### PR TITLE
Adding ability to change RPC protocol

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -33,11 +33,12 @@ module.exports = {
 
   create: function(options) {
     var provider;
+    var protocol = options.protocol || 'http';
 
     if (options.provider) {
       provider = options.provider;
     } else {
-      provider = new Web3.providers.HttpProvider("http://" + options.host + ":" + options.port);
+      provider = new Web3.providers.HttpProvider(protocol + "://" + options.host + ":" + options.port);
     }
 
     return this.wrap(provider, options);


### PR DESCRIPTION
Needed to switch RPC to HTTPS and thought this might be beneficial for the public package.
- `protocol` can be added to RPC options. If none is provided, `http` is used.
