### PR TITLE
Only select migrations files that end in .js

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -121,6 +121,10 @@ var Migrate = {
     dir.files(options.migrations_directory, function(err, files) {
       if (err) return callback(err);
 
+      files = files.filter(function(file) {
+        return path.extname(file) === ".js";
+      });
+
       var migrations = files.map(function(file) {
         return new Migration(file, options.network);
       });


### PR DESCRIPTION
I'm using VIM with default swap file behavior. I was getting tired of running into migration failures when Truffle picked up the .swp files for processing. Hence, filtering for .js files.