### PR TITLE
Fix broken exec command

### DIFF
--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -100,7 +100,7 @@ var Actions = {
       return new Promise(function(accept, reject) {
         Require.exec({
           file: file,
-          contracts: Object.keys(deployer.known_contracts).map(function(key) {
+          contracts_build_directory: Object.keys(deployer.known_contracts).map(function(key) {
             return deployer.known_contracts[key];
           }),
           network: deployer.network,


### PR DESCRIPTION
## Issue

Running `truffle migrate` produces error

## Steps to reproduce

1. Create a script according to https://truffle.readthedocs.io/en/latest/getting_started/scripts/
2. Add `deployer.exec` command to migration jobs

```
module.exports = function(deployer) {
  deployer.exec('path/to/script');
}
```
3. Run `truffle migrate`

## Expected behavior

Script runs and exits successfully

## Actual behavior

```
Error encountered, bailing. Network state unknown. Review successful transactions manually.
Error: Expected parameter 'contracts_build_directory' not passed to function.
    at /Users/teddy/Projects/btl/truffle-webpack-demo-clone/node_modules/truffle/lib/expect.js:5:15
    at Array.forEach (native)
    at Object.options (/Users/teddy/Projects/btl/truffle-webpack-demo-clone/node_modules/truffle/lib/expect.js:3:19)
    at Object.exec (/Users/teddy/Projects/btl/truffle-webpack-demo-clone/node_modules/truffle/lib/require.js:89:12)
    at /Users/teddy/Projects/btl/truffle-webpack-demo-clone/node_modules/truffle/lib/deployer.js:101:17
    at /Users/teddy/Projects/btl/truffle-webpack-demo-clone/node_modules/truffle/lib/deployer.js:100:14
    at /Users/teddy/Projects/btl/truffle-webpack-demo-clone/node_modules/truffle/lib/deferredchain.js:20:15
```

## Environment

- Truffle 2.1.1
- Node 7.0.0
- TestRPC 3.0.0
- macOS Sierra
- npm 3.10.8