### PR TITLE
Fix "Error: Expected parameter 'contracts_build_directory' not passed to function." 

### DIFF
--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -94,6 +94,7 @@ var Actions = {
       if (path.isAbsolute(file) == false) {
         file = path.resolve(path.join(deployer.basePath, file));
       }
+
       deployer.logger.log("Running " + file + "...");
       // Evaluate any arguments if they're promises
       return new Promise(function(accept, reject) {

--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -94,12 +94,12 @@ var Actions = {
       if (path.isAbsolute(file) == false) {
         file = path.resolve(path.join(deployer.basePath, file));
       }
-
       deployer.logger.log("Running " + file + "...");
       // Evaluate any arguments if they're promises
       return new Promise(function(accept, reject) {
         Require.exec({
           file: file,
+          contracts_build_directory: path.join(deployer.basePath, "..", "build/contracts"),
           contracts: Object.keys(deployer.known_contracts).map(function(key) {
             return deployer.known_contracts[key];
           }),


### PR DESCRIPTION
When truffle migrate, I got this error:

`Contract: Test "before all" hook: prepare suite:
     Error: Expected parameter 'contracts_build_directory' not passed to function.
      at /home/chris/.nvm/versions/node/v5.12.0/lib/node_modules/truffle/lib/expect.js:5:15
      at Array.forEach (native)
      at Object.Expect.options (/home/chris/.nvm/versions/node/v5.12.0/lib/node_modules/truffle/lib/expect.js:3:19)
      at Object.Require.exec (/home/chris/.nvm/versions/node/v5.12.0/lib/node_modules/truffle/lib/require.js:89:12)
      at /home/chris/.nvm/versions/node/v5.12.0/lib/node_modules/truffle/lib/deployer.js:101:17
      at new Promise (/home/chris/.nvm/versions/node/v5.12.0/lib/node_modules/truffle/node_modules/core-js/modules/es6.promise.js:191:7)
      at /home/chris/.nvm/versions/node/v5.12.0/lib/node_modules/truffle/lib/deployer.js:100:14
      at /home/chris/.nvm/versions/node/v5.12.0/lib/node_modules/truffle/lib/deferredchain.js:20:15
      at run (/home/chris/.nvm/versions/node/v5.12.0/lib/node_modules/truffle/node_modules/core-js/modules/es6.promise.js:87:22)
      at /home/chris/.nvm/versions/node/v5.12.0/lib/node_modules/truffle/node_modules/core-js/modules/es6.promise.js:100:28
      at flush (/home/chris/.nvm/versions/node/v5.12.0/lib/node_modules/truffle/node_modules/core-js/modules/_microtask.js:18:9)
      at _combinedTickCallback (internal/process/next_tick.js:67:7)
      at process._tickDomainCallback (internal/process/next_tick.js:122:9)`


This is caused because 'contracts_build_directory' is not set in deploy.js library.