### PR TITLE
Fix Deployer.exec()

### DIFF
--- a/lib/expect.js
+++ b/lib/expect.js
@@ -22,15 +22,11 @@ var Expect = {
       return t + value;
     });
 
-    if (total == 1) return;
+    // If this doesn't work in all cases, perhaps we should
+    // create an expect.onlyOne() function.
+    if (total >= 1) return;
 
-    var amount = total;
-
-    if (total == 0) {
-      amount = "none"
-    }
-
-    throw new Error("Expected one of the following parameters, but found " + amount + ": " + expected_keys.join(", "));
+    throw new Error("Expected one of the following parameters, but found none: " + expected_keys.join(", "));
   }
 }
 

--- a/lib/expect.js
+++ b/lib/expect.js
@@ -5,6 +5,32 @@ var Expect = {
         throw new Error("Expected parameter '" + key + "' not passed to function.");
       }
     });
+  },
+
+  one: function(options, expected_keys) {
+    var found = [];
+
+    expected_keys.forEach(function(key) {
+      if (options[key] != null) {
+        found.push(1);
+      } else {
+        found.push(0);
+      }
+    });
+
+    var total = found.reduce(function(t, value) {
+      return t + value;
+    });
+
+    if (total == 1) return;
+
+    var amount = total;
+
+    if (total == 0) {
+      amount = "none"
+    }
+
+    throw new Error("Expected one of the following parameters, but found " + amount + ": " + expected_keys.join(", "));
   }
 }
 

--- a/lib/require.js
+++ b/lib/require.js
@@ -99,7 +99,7 @@ var Require = {
     ]);
 
     var provision = function(callback) {
-      if (options.contracts != null) {
+      if (options.contracts) {
         callback(null, options.contracts);
       } else {
         Contracts.provision(options, callback);

--- a/lib/require.js
+++ b/lib/require.js
@@ -87,11 +87,15 @@ var Require = {
     var self = this;
 
     expect.options(options, [
-      "contracts_build_directory",
       "file",
       "provider",
       "network",
       "network_id"
+    ]);
+
+    expect.one(options, [
+      "contracts",
+      "contracts_build_directory"
     ]);
 
     var provision = function(callback) {


### PR DESCRIPTION
Here is what I believe to be the correct fix to the attempted `Deployer.exec()` fixes in #299 and #311.

When `Require.exec()` is called via `Deployer.exec()`, it will be supplied a contracts options that contains the list of contracts known to the Deployer. If not, then the contracts_build_directory is expected to specify where the contract artifacts exist. This PR makes that behavior explicit and restores the `Deployer.exec()` function.