### PR TITLE
Explicit proccess.exit after successful command run

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -34,5 +34,7 @@ command.run(process.argv.slice(2), options, function(err) {
       }
     }
     process.exit(1);
+  } else {
+    process.exit(0);
   }
 });


### PR DESCRIPTION
Why it needs explicitly execute proccess.exit ? Because truffle loads its configuration file. Somebody can put in his config some code which prevent finishing execution. For instance, if we use custom web3-provider-engine it will run timer to track new blocks.