### PR TITLE
Fix typo in GettingStarted/testing.md

### DIFF
--- a/docs/getting_started/testing.md
+++ b/docs/getting_started/testing.md
@@ -20,7 +20,7 @@ Truffle uses the [Mocha](https://mochajs.org/) testing framework for automated t
 
 # Location
 
-All test files should be located in the `./tests` directory. Truffle will only run test files with the following file extensions: `.js`, `.es`, `.es6`, and `.jsx`. All other files are ignored.
+All test files should be located in the `./test` directory. Truffle will only run test files with the following file extensions: `.js`, `.es`, `.es6`, and `.jsx`. All other files are ignored.
 
 # Writing Tests
 


### PR DESCRIPTION
in the docs it states that `tests` dir should be used while the correct one would be `test`