### PR TITLE
Upgrade ethpm

### DIFF
--- a/lib/package.js
+++ b/lib/package.js
@@ -36,7 +36,7 @@ var Package = {
     var host = options.ethpm.ipfs_host;
 
     if ((host instanceof EthPM.hosts.IPFS) == false) {
-      host = new EthPM.hosts.IPFS(options.ethpm.ipfs_host, options.ethpm.ipfs_port, options.ethpm.ipfs_protocol);
+      host = new EthPM.hosts.IPFSWithLocalReader(options.ethpm.ipfs_host, options.ethpm.ipfs_port, options.ethpm.ipfs_protocol);
     }
 
     // When installing, we use infura to make a bunch of eth_call's.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "cpr": "^0.4.3",
     "del": "^2.2.0",
     "diff": "1.4.0",
-    "ethpm": "0.0.10",
+    "ethpm": "0.0.13",
     "ethpm-registry": "0.0.9",
     "finalhandler": "^0.4.0",
     "fs-extra": "^2.0.0",


### PR DESCRIPTION
This upgrades the version of EthPM Truffle uses. We now use a different host during installation that downloads files from a separate API, which is much faster. This is a stop gap until we/Infura can figure out why IPFS requests are so slow over the normal IPFS api.