### PR TITLE
Make filter for js files sharp

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -63,7 +63,7 @@ var Test = {
     var mocha = this.createMocha(config);
 
     var js_tests = config.test_files.filter(function(file) {
-      return path.extname(file) != ".sol";
+      return path.extname(file) == ".js";
     });
 
     var sol_tests = config.test_files.filter(function(file) {


### PR DESCRIPTION
Generally good practice to make switch structures sharp, i.e. don't assume anything not a .sol file is a .js file. Probably not a security risk here, but this sort of error is a common exploit vector.