### PR TITLE
Run test command if --tests flag is specified on watch

### DIFF
--- a/lib/commands/watch.js
+++ b/lib/commands/watch.js
@@ -1,3 +1,5 @@
+var testCommand = require('./test');
+
 var command = {
   command: 'watch',
   description: 'Watch filesystem for changes and rebuild the project automatically',
@@ -38,6 +40,10 @@ var command = {
       path.join(config.working_directory, "truffle.js")
     ];
 
+    if(config.tests) {
+      watchPaths.push(path.join(config.working_directory, "test/**/*"));
+    }
+
     chokidar.watch(watchPaths, {
       ignored: /[\/\\]\./, // Ignore files prefixed with "."
       cwd: config.working_directory,
@@ -60,6 +66,17 @@ var command = {
         return;
       }
 
+      if(config.tests && (needs_rebuild || needs_recompile)){
+        needs_rebuild = false;
+        needs_recompile = false;
+        working = true;
+
+        testCommand.run(options,function(err){
+          if(err) printFailure(err);
+          working = false;
+        });
+      }
+      
       if (needs_rebuild == true) {
         needs_rebuild = false;
 


### PR DESCRIPTION
In issue 269 people were expecting --tests to run tests after a rebuild.  I've added this.  Note it diverts to the test task rather than rebuilding then passing to tests (where we would have to tell it not to rebuild), so that's up for discussion.  