### PR TITLE
Upgrade solc to 0.4.16 and node to 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
   - "6"
-  - "7"
+  - "8"
 
 addons:
   apt:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "mocha": "^3.4.2",
     "original-require": "^1.0.1",
-    "solc": "0.4.15"
+    "solc": "0.4.16"
   },
   "devDependencies": {
     "clean-webpack-plugin": "^0.1.16",

--- a/test/scenarios/contract_names/test_imports.js
+++ b/test/scenarios/contract_names/test_imports.js
@@ -21,7 +21,7 @@ describe("Contract names", function() {
   });
 
   before("set up sandbox", function(done) {
-    this.timeout(10000);
+    this.timeout(20000);
     Box.sandbox("bare", function(err, conf) {
       if (err) return done(err);
       config = conf;
@@ -40,7 +40,7 @@ describe("Contract names", function() {
   });
 
   it("will compile if file names do not match contract names", function(done) {
-    this.timeout(20000);
+    this.timeout(40000);
 
     CommandRunner.run("compile", config, function(err) {
       if (err) return done(err);
@@ -55,7 +55,7 @@ describe("Contract names", function() {
   });
 
   it("will migrate when artifacts.require() doesn't have an extension and names do not match", function(done) {
-    this.timeout(20000);
+    this.timeout(40000);
 
     CommandRunner.run("migrate", config, function(err) {
       if (err) return done(err);
@@ -79,7 +79,7 @@ describe("Contract names", function() {
   });
 
   it("will compile and migrate with relative imports (using filename)", function(done) {
-    this.timeout(20000);
+    this.timeout(40000);
 
     fs.copySync(path.join(__dirname, "relative_import.sol"), path.join(config.contracts_directory, "relative_import.sol"));
     fs.copySync(path.join(__dirname, "3_deploy_relative_import.js.template"), path.join(config.migrations_directory, "3_deploy_relative_import.js"));

--- a/test/scenarios/cyclic_dependencies/compiles.js
+++ b/test/scenarios/cyclic_dependencies/compiles.js
@@ -13,7 +13,7 @@ describe("Cyclic Dependencies", function() {
   var logger = new MemoryLogger();
 
   before("set up sandbox", function(done) {
-    this.timeout(10000);
+    this.timeout(20000);
     Box.sandbox("default", function(err, conf) {
       if (err) return done(err);
       config = conf;
@@ -32,7 +32,7 @@ describe("Cyclic Dependencies", function() {
   });
 
   it("will compile cyclic dependencies that Solidity is fine with (no `new`'s)", function(done) {
-    this.timeout(20000);
+    this.timeout(40000);
 
     CommandRunner.run("compile", config, function(err) {
       if (err) return done(err);

--- a/test/scenarios/happy_path/happypath.js
+++ b/test/scenarios/happy_path/happypath.js
@@ -21,7 +21,7 @@ describe("Happy path (truffle unbox)", function() {
   });
 
   before("set up sandbox", function(done) {
-    this.timeout(10000);
+    this.timeout(20000);
     Box.sandbox("default", function(err, conf) {
       if (err) return done(err);
       config = conf;
@@ -35,7 +35,7 @@ describe("Happy path (truffle unbox)", function() {
   });
 
   it("will compile", function(done) {
-    this.timeout(20000);
+    this.timeout(40000);
 
     CommandRunner.run("compile", config, function(err) {
       if (err) return done(err);
@@ -49,7 +49,7 @@ describe("Happy path (truffle unbox)", function() {
   });
 
   it("will migrate", function(done) {
-    this.timeout(20000);
+    this.timeout(40000);
 
     CommandRunner.run("migrate", config, function(err) {
       if (err) return done(err);
@@ -75,7 +75,7 @@ describe("Happy path (truffle unbox)", function() {
   });
 
   it("will run tests", function(done) {
-    this.timeout(20000);
+    this.timeout(40000);
     CommandRunner.run("test", config, function(err) {
       if (err) return done(err);
 

--- a/test/scenarios/migrations/parameters.js
+++ b/test/scenarios/migrations/parameters.js
@@ -23,7 +23,7 @@ describe("Migration Parameters", function() {
   });
 
   before("set up sandbox", function(done) {
-    this.timeout(10000);
+    this.timeout(20000);
     Box.sandbox("default", function(err, conf) {
       if (err) return done(err);
       config = conf;
@@ -50,7 +50,7 @@ describe("Migration Parameters", function() {
   });
 
   it("will migrate and save the correct output data", function(done) {
-    this.timeout(20000);
+    this.timeout(40000);
 
     var expected_file = path.join(config.migrations_directory, "output.json");
 

--- a/test/scenarios/solidity_testing/with_balances.js
+++ b/test/scenarios/solidity_testing/with_balances.js
@@ -20,7 +20,7 @@ describe("Solidity Tests with balances", function() {
   });
 
   before("set up sandbox", function(done) {
-    this.timeout(5000);
+    this.timeout(10000);
     Box.sandbox("bare", function(err, conf) {
       if (err) return done(err);
       config = conf;
@@ -44,7 +44,7 @@ describe("Solidity Tests with balances", function() {
   // It'll test that its balance equals what it expect. We'll check the log to
   // ensure everything worked out fine.
   it("will run the test and have the correct balance", function(done) {
-    this.timeout(20000);
+    this.timeout(40000);
 
     CommandRunner.run("test", config, function(err) {
       if (err) return done(err);


### PR DESCRIPTION
- Upgrade solidity compiler to the latest version
- Upgrade node to v8 in travis CI. Node 8 is the next LTS version in October 2017. ([Node LTS schedule](https://github.com/nodejs/LTS))
- Increase test timeouts to avoid issues with slower executions in Travis CI

I can create different PRs if necessary.