### PR TITLE
Use exact version of mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "3.4.11",
   "description": "Truffle - Simple development framework for Ethereum",
   "dependencies": {
-    "mocha": "^3.4.2",
+    "mocha": "3.4.2",
     "original-require": "^1.0.1",
     "solc": "0.4.15"
   },


### PR DESCRIPTION
I've noticed some of the dependencies of `mocha` have been adding new contributors with publish rights.

For security purposes, it would probably be best to ensure `truffle` is using a semver of `mocha` which is fixed.