### PR TITLE
Allow newer versions of solidity 0.4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "mocha": "^3.4.2",
     "original-require": "^1.0.1",
-    "solc": "0.4.18"
+    "solc": "^0.4.18"
   },
   "devDependencies": {
     "clean-webpack-plugin": "^0.1.16",


### PR DESCRIPTION
Issue #762: support solc 0.4.19.

Truffle should not restrict Solidity to version 0.4.18 because [semantic versioning](http://solidity.readthedocs.io/en/develop/layout-of-source-files.html#version-pragma) specifies that only non-breaking changes will be included in the 0.4.x series.  Locking it to 0.4.18 means that users of Truffle cannot use Solidity 0.4.19 with its bug fixes.