### PR TITLE
Make it easier to get env info when filing issues

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -21,7 +21,7 @@ What actually happened. Please give examples and support it with screenshots, co
 ## Environment
 
 * Operating System: 
-* Truffle version:
 * Ethereum client:
-* node version:
-* npm version: 
+* Truffle version (`truffle version`):
+* node version (`node --version`):
+* npm version (`npm --version`): 


### PR DESCRIPTION
Partially addresses Issue #780.  I considered adding a line for the Solidity version since that's also output in `truffle version` but thought it might've been excluded intentionally.  I also swapped two lines' order to keep those with tips together for better visual harmony.