### PR TITLE
Rename testrpc to ganache-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ $ truffle init
 
 From there, you can run `truffle compile`, `truffle migrate` and `truffle test` to compile your contracts, deploy those contracts to the network, and run their associated unit tests.
 
-Be sure you're connected to an ethereum client before running these commands. If you're new, install [ganache-cli](https://github.com/rufflesuite/ganache-cli) to run a local blockchain RPC server. After that, simply run `ganache-cli` in a new tab.
+Truffle comes bundled with a local development blockchain server that launches automatically when you invoke the commands above. If you're interested in configuring the blockchain server or would like a user-friendly UI for it, check out:
+
++  [ganache-cli](https://github.com/trufflesuite/ganache-cli): a command-line version of Truffle's blockchain server.
++  [ganache](http://truffleframework.com/ganache/): A GUI for the server that displays your transaction history and chain state.
 
 See [the documentation](http://truffleframework.com/docs/) for more details.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ truffle init
 
 From there, you can run `truffle compile`, `truffle migrate` and `truffle test` to compile your contracts, deploy those contracts to the network, and run their associated unit tests.
 
-Be sure you're connected to an ethereum client before running these commands. If you're new, install [testrpc](https://github.com/ethereumjs/testrpc) to run a local blockchain RPC server. After that, simply run `testrpc` in a new tab.
+Be sure you're connected to an ethereum client before running these commands. If you're new, install [ganache-cli](https://github.com/rufflesuite/ganache-cli) to run a local blockchain RPC server. After that, simply run `ganache-cli` in a new tab.
 
 See [the documentation](http://truffleframework.com/docs/) for more details.
 


### PR DESCRIPTION
Update the Readme since `testrpc` has been renamed to `ganache-cli`.