### PR TITLE
Add geth client in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ before_install:
 env:
   global:
     - TEST=repo
-    - GETH_CONTAINER=geth
   matrix:
     - GANACHE=true
     - GETH=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,19 @@ services:
 
 before_install:
   - docker pull truffle/ci
+  - docker pull ethereum/client-go:latest
 
 env:
-  - TEST=repo
+  global:
+    - TEST=repo
+    - GETH_CONTAINER=geth
+  matrix:
+    - GANACHE=true
+    - GETH=true
+
+matrix:
+  allow_failures:
+    - env: GETH=true
 
 script:
-  - >
-    docker run -it --rm --name ${TEST} \
-        -e TRAVIS_REPO_SLUG \
-        -e TRAVIS_PULL_REQUEST \
-        -e TRAVIS_PULL_REQUEST_SLUG \
-        -e TRAVIS_PULL_REQUEST_BRANCH \
-        -e TRAVIS_BRANCH \
-        -e TEST \
-      truffle/ci:latest run_tests
+  - npm run test:ci

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   "scripts": {
     "build": "npm run build-cli",
     "build-cli": "webpack --config ./cli.webpack.config.js",
-    "test": "npm run build-cli && mocha"
+    "test": "npm run build-cli && mocha",
+    "test:ci": "./scripts/test.sh"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "build": "npm run build-cli",
     "build-cli": "webpack --config ./cli.webpack.config.js",
     "test": "npm run build-cli && mocha",
-    "test:ci": "./scripts/test.sh"
+    "test:ci": "./scripts/test.sh",
+    "test:geth": "CI=true npm test"
   },
   "repository": {
     "type": "git",

--- a/scripts/geth-accounts.js
+++ b/scripts/geth-accounts.js
@@ -1,0 +1,33 @@
+/**
+ * @author  cpurta <cpurta@gmail.com>
+ * @github https://github.com/cpurta/geth-devnet
+ * This code comes from Christopher Purta's `geth-devnet` project.
+ * geth --dev seeds with a single account so we need to spin
+ * up more accounts and short-circuit account auto-locking to get multi-account
+ * tests passing.
+ */
+
+function createAccounts() {
+  for (var i = 0; i < 10; i++) {
+    acc = personal.newAccount("");
+    personal.unlockAccount(acc, "");
+    eth.sendTransaction({from: eth.accounts[0], to: acc, value: web3.toWei(1000, "ether")});
+  }
+}
+
+function unlockAccounts() {
+  eth.accounts.forEach(function (account) {
+    console.log('Unlocking ' + account + '...');
+    personal.unlockAccount(account, '', 86400);
+  });
+}
+
+function setupDevNode() {
+  // keep accounts unlocked
+  while (true) {
+      unlockAccounts()
+  }
+}
+
+createAccounts();
+setupDevNode();

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+run_geth() {
+  docker run \
+    -v /$PWD/scripts:/scripts \
+    -d \
+    --net="host" \
+    -p 8545:8545 \
+    -p 30303:30303 \
+    ethereum/client-go:latest \
+    --rpc \
+    --rpcaddr '0.0.0.0' \
+    --rpcport 8545 \
+    --rpccorsdomain '*' \
+    --nodiscover \
+    --dev \
+    --dev.period 1 \
+    --targetgaslimit '7000000' \
+    js ./scripts/geth-accounts.js \
+    > /dev/null &
+}
+
+run_geth_test() {
+  docker run -it --rm --name ${TEST} --net="host" \
+    -e TRAVIS_REPO_SLUG \
+    -e TRAVIS_PULL_REQUEST \
+    -e TRAVIS_PULL_REQUEST_SLUG \
+    -e TRAVIS_PULL_REQUEST_BRANCH \
+    -e TRAVIS_BRANCH \
+    -e TEST \
+    -e GETH \
+  truffle/ci:latest run_tests
+}
+
+run_ganache_test() {
+  docker run -it --rm --name ${TEST} \
+    -e TRAVIS_REPO_SLUG \
+    -e TRAVIS_PULL_REQUEST \
+    -e TRAVIS_PULL_REQUEST_SLUG \
+    -e TRAVIS_PULL_REQUEST_BRANCH \
+    -e TRAVIS_BRANCH \
+    -e TEST \
+    -e GANACHE \
+  truffle/ci:latest run_tests
+}
+
+
+if [ "$GETH" = true ]; then
+  run_geth
+  run_geth_test
+else
+  run_ganache_test
+fi
+
+
+
+
+

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -29,6 +29,7 @@ run_geth_test() {
     -e TRAVIS_BRANCH \
     -e TEST \
     -e GETH \
+    -e CI \
   truffle/ci:latest run_tests
 }
 
@@ -41,6 +42,7 @@ run_ganache_test() {
     -e TRAVIS_BRANCH \
     -e TEST \
     -e GANACHE \
+    -e CI \
   truffle/ci:latest run_tests
 }
 

--- a/test/scenarios/happy_path/happypath.js
+++ b/test/scenarios/happy_path/happypath.js
@@ -75,7 +75,7 @@ describe("Happy path (truffle unbox)", function() {
   });
 
   it("will run tests", function(done) {
-    this.timeout(40000);
+    this.timeout(70000);
     CommandRunner.run("test", config, function(err) {
       if (err) return done(err);
 

--- a/test/scenarios/migrations/parameters.js
+++ b/test/scenarios/migrations/parameters.js
@@ -50,7 +50,7 @@ describe("Migration Parameters", function() {
   });
 
   it("will migrate and save the correct output data", function(done) {
-    this.timeout(20000);
+    this.timeout(50000);
 
     var expected_file = path.join(config.migrations_directory, "output.json");
 

--- a/test/scenarios/server.js
+++ b/test/scenarios/server.js
@@ -5,7 +5,7 @@ var server = null;
 module.exports = {
   start: function(done) {
     this.stop(function(err) {
-      if (process.env.GANACHE){
+      if (!process.env.CI || process.env.GANACHE){
         server = TestRPC.server({gasLimit: 6721975});
         server.listen(8545, done);
       } else {

--- a/test/scenarios/server.js
+++ b/test/scenarios/server.js
@@ -5,8 +5,12 @@ var server = null;
 module.exports = {
   start: function(done) {
     this.stop(function(err) {
-      server = TestRPC.server({gasLimit: 6721975});
-      server.listen(8545, done);
+      if (process.env.GANACHE){
+        server = TestRPC.server({gasLimit: 6721975});
+        server.listen(8545, done);
+      } else {
+        done();
+      }
     });
   },
   stop: function(done) {


### PR DESCRIPTION
Adds `geth:latest` to the list of clients we scenario test against. It's set up as an 'allowed failure' because . . . that's our current position? As such this test is more a notice of breaking changes upstream rather than a verification that we haven't broken anything.  

Another (possibly more rational) approach might be to test against `geth:stable` and require that we pass. We should discuss this. 

Also: have looted @cpurta's excellent [geth-dev-net](https://github.com/cpurta/geth-devnet) for logic and technique, especially for generating geth accounts on launch. Reaching out to him on gitter to ask if this is ok and make sure we are crediting him appropriately in the file. 

