### PR TITLE
Fix CI env variable that breaks downstream CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
 env:
   global:
     - TEST=repo
+    - MAIN_REPO_CI=true
   matrix:
     - GANACHE=true
     - GETH=true

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "build-cli": "webpack --config ./cli.webpack.config.js",
     "test": "npm run build-cli && mocha",
     "test:ci": "./scripts/test.sh",
-    "test:geth": "CI=true npm test"
+    "test:geth": "MAIN_REPO_CI=true npm test"
   },
   "repository": {
     "type": "git",

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -29,7 +29,7 @@ run_geth_test() {
     -e TRAVIS_BRANCH \
     -e TEST \
     -e GETH \
-    -e CI \
+    -e MAIN_REPO_CI \
   truffle/ci:latest run_tests
 }
 
@@ -42,7 +42,7 @@ run_ganache_test() {
     -e TRAVIS_BRANCH \
     -e TEST \
     -e GANACHE \
-    -e CI \
+    -e MAIN_REPO_CI \
   truffle/ci:latest run_tests
 }
 

--- a/test/scenarios/server.js
+++ b/test/scenarios/server.js
@@ -5,7 +5,7 @@ var server = null;
 module.exports = {
   start: function(done) {
     this.stop(function(err) {
-      if (!process.env.CI || process.env.GANACHE){
+      if (!process.env.MAIN_REPO_CI || process.env.GANACHE){
         server = TestRPC.server({gasLimit: 6721975});
         server.listen(8545, done);
       } else {


### PR DESCRIPTION
Fix for #856. There are four execution contexts for truffle's main repo scenario tests:
+ locally against ganache
+ locally against geth
+ in CI at `truffle` main repo (geth is installed). 
+ in CI at any other module (geth is *not* installed).

`CI` is a Travis global so we're not adequately disambiguating case 3 and 4 above. 