### PR TITLE
Bump solc to 0.4.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "mocha": "^3.4.2",
     "original-require": "^1.0.1",
-    "solc": "0.4.19"
+    "solc": "0.4.21"
   },
   "devDependencies": {
     "clean-webpack-plugin": "^0.1.16",


### PR DESCRIPTION
Upgrades solc to `0.4.21`. 

Release notes [link](https://github.com/ethereum/solidity/releases/tag/v0.4.21)