### PR TITLE
Add integration tests for minimized compilation

### DIFF
--- a/test/scenarios/compile/compile.js
+++ b/test/scenarios/compile/compile.js
@@ -1,0 +1,286 @@
+var MemoryLogger = require("../memorylogger");
+var CommandRunner = require("../commandrunner");
+var fs = require("fs");
+var path = require("path");
+var assert = require("assert");
+var Server = require("../server");
+var Reporter = require("../reporter");
+var sandbox = require("../sandbox");
+var log = console.log;
+
+describe("Repeated compilation of contracts with inheritance", function() {
+  var config;
+  var contracts;
+  var contractPaths;
+  var artifactPaths;
+  var initialTimes;
+  var finalTimes;
+  var output;
+  var mapping = {};
+
+  var project = path.join(__dirname, '../../sources/inheritance');
+  var names = ["Root", "Branch", "LeafA", "LeafB", "LeafC", "SameFile1", "SameFile2", "LibraryA"];
+  var logger = new MemoryLogger();
+
+  // ----------------------- Utils -----------------------------
+  function processErr(err, output){
+    if (err){
+      log(output);
+      throw new Error(err);
+    }
+  }
+
+  function waitSecond() {
+    return new Promise((resolve, reject) => setTimeout(() => resolve(), 1250));
+  }
+
+  function getContract(key) {
+    return fs.readFileSync(mapping[key].contractPath);
+  }
+
+  function getArtifact(key) {
+    return fs.readFileSync(mapping[key].artifactPath);
+  }
+
+  function getArtifactStats() {
+    const stats = {};
+    names.forEach(key => {
+      const mDate = fs.statSync(mapping[key].artifactPath).mtime.getTime();
+      stats[key] = mDate;
+    });
+    return stats;
+  }
+
+  function touchContract(key, file) {
+    fs.writeFileSync(mapping[key].contractPath, file);
+  }
+
+  // ----------------------- Setup -----------------------------
+
+  before("set up the server", function(done) {
+    Server.start(done);
+  });
+
+  after("stop server", function(done) {
+    Server.stop(done);
+  });
+
+  beforeEach("set up sandbox and do initial compile", function(done) {
+    this.timeout(10000);
+
+    sandbox.create(project).then(conf => {
+      config = conf;
+      config.network = "development";
+      config.logger = logger;
+      config.mocha = {
+        reporter: new Reporter(logger),
+      }
+
+      contracts = names.map(name => name + '.sol');
+      artifactPaths = names.map(name => path.join(config.contracts_build_directory, name + '.json'));
+      contractPaths = contracts.map(contract => path.join(config.contracts_directory, contract));
+
+      names.forEach((name, i) => {
+        mapping[name] = {};
+        mapping[name].contract = contracts[i];
+        mapping[name].artifactPath = artifactPaths[i];
+        mapping[name].contractPath = contractPaths[i];
+      })
+
+      CommandRunner.run("compile", config, function(err) {
+        output = logger.contents();
+        processErr(err, output);
+
+        initialTimes = getArtifactStats();
+
+        // mTime resolution on 6.9.1 is 1 sec.
+        waitSecond().then(done);
+      })
+    });
+  });
+
+  // -------------Inheritance Graph -----------------------------
+  //                                      |
+  //      LibA         LeafA              |    SameFile1 - LeafC
+  //     /           /       \            |
+  // Root* - Branch -           - LeafC   |    SameFile2
+  //                 \       /            |
+  //                   LeafB              |
+  // ------------------------------------------------------------
+
+  it("Updates only Root when Root is touched", function(done) {
+    this.timeout(30000);
+
+    touchContract('Root', getContract('Root'));
+
+    CommandRunner.run("compile", config, function(err) {
+      output = logger.contents();
+      processErr(err, output);
+
+      finalTimes = getArtifactStats();
+
+      try {
+        assert(initialTimes['Root'] < finalTimes['Root'], 'Should update root');
+        assert(initialTimes['Branch'] === finalTimes['Branch'], 'Should not update Branch');
+        assert(initialTimes['LeafA'] === finalTimes['LeafA'], 'Should not update LeafA');
+        assert(initialTimes['LeafB'] === finalTimes['LeafB'], 'Should not update LeafB');
+        assert(initialTimes['LeafC'] === finalTimes['LeafC'], 'Should not update LeafC');
+        assert(initialTimes['LibraryA'] === finalTimes['LibraryA'], 'Should not update LibraryA');
+        assert(initialTimes['SameFile1'] === finalTimes['SameFile1'], 'Should not update SameFile1');
+        assert(initialTimes['SameFile2'] === finalTimes['SameFile2'], 'Should not update SameFile2');
+        done();
+      } catch(err) {
+        err.message += '\n\n' + output;
+        throw new Error(err);
+      }
+    });
+  });
+
+  // -------------Inheritance Graph -----------------------------
+  //                                      |
+  //      LibA*        LeafA              |    SameFile1 - LeafC
+  //     /           /       \            |
+  // Root* - Branch -           - LeafC   |    SameFile2
+  //                 \       /            |
+  //                   LeafB              |
+  // ------------------------------------------------------------
+
+  it("Updates Root and Library when Library is touched", function(done) {
+    this.timeout(30000);
+
+    touchContract('LibraryA', getContract('LibraryA'));
+
+    CommandRunner.run("compile", config, function(err) {
+      output = logger.contents();
+      processErr(err, output);
+
+      finalTimes = getArtifactStats();
+
+      try {
+        assert(initialTimes['Root'] < finalTimes['Root'], 'Should update root');
+        assert(initialTimes['Branch'] === finalTimes['Branch'], 'Should not update Branch');
+        assert(initialTimes['LeafA'] === finalTimes['LeafA'], 'Should not update LeafA');
+        assert(initialTimes['LeafB'] === finalTimes['LeafB'], 'Should not update LeafB');
+        assert(initialTimes['LeafC'] === finalTimes['LeafC'], 'Should not update LeafC');
+        assert(initialTimes['LibraryA'] < finalTimes['LibraryA'], 'Should update LibraryA');
+        assert(initialTimes['SameFile1'] === finalTimes['SameFile1'], 'Should not update SameFile1');
+        assert(initialTimes['SameFile2'] === finalTimes['SameFile2'], 'Should not update SameFile2');
+        done();
+      } catch(err) {
+        err.message += '\n\n' + output;
+        throw new Error(err);
+      }
+    });
+  });
+
+  // -------------Inheritance Graph -----------------------------
+  //                                      |
+  //      LibA         LeafA              |    SameFile1 - LeafC
+  //     /           /       \            |
+  // Root* - Branch* -           - LeafC  |    SameFile2
+  //                 \       /            |
+  //                   LeafB              |
+  // ------------------------------------------------------------
+
+  it("Updates Branch and Root when Branch is touched", function(done) {
+    this.timeout(30000);
+
+    touchContract('Branch', getContract('Branch'));
+
+    CommandRunner.run("compile", config, function(err) {
+      output = logger.contents();
+      processErr(err, output);
+
+      finalTimes = getArtifactStats();
+
+      try {
+        assert(initialTimes['Root'] < finalTimes['Root'], 'Should update root');
+        assert(initialTimes['Branch'] < finalTimes['Branch'], 'Should update Branch');
+        assert(initialTimes['LeafA'] === finalTimes['LeafA'], 'Should not update LeafA');
+        assert(initialTimes['LeafB'] === finalTimes['LeafB'], 'Should not update LeafB');
+        assert(initialTimes['LeafC'] === finalTimes['LeafC'], 'Should not update LeafC');
+        assert(initialTimes['LibraryA'] === finalTimes['LibraryA'], 'Should not update LibraryA');
+        assert(initialTimes['SameFile1'] === finalTimes['SameFile1'], 'Should not update SameFile1');
+        assert(initialTimes['SameFile2'] === finalTimes['SameFile2'], 'Should not update SameFile2');
+        done();
+      } catch(err) {
+        err.message += '\n\n' + output;
+        throw new Error(err);
+      }
+    });
+  });
+
+  // -------------Inheritance Graph -----------------------------
+  //                                       |
+  //      LibA          LeafA*             |    SameFile1 - LeafC
+  //     /            /       \            |
+  // Root* - Branch* -           - LeafC   |    SameFile2
+  //                  \       /            |
+  //                    LeafB              |
+  // ------------------------------------------------------------
+
+  it("Updates LeafA, Branch and Root when LeafA is touched", function(done) {
+    this.timeout(30000);
+
+    touchContract('LeafA', getContract('LeafA'));
+
+    CommandRunner.run("compile", config, function(err) {
+      output = logger.contents();
+      processErr(err, output);
+
+      finalTimes = getArtifactStats();
+
+      try {
+        assert(initialTimes['Root'] < finalTimes['Root'], 'Should update root');
+        assert(initialTimes['Branch'] < finalTimes['Branch'], 'Should update Branch');
+        assert(initialTimes['LeafA'] < finalTimes['LeafA'], 'Should update LeafA');
+        assert(initialTimes['LeafB'] === finalTimes['LeafB'], 'Should not update LeafB');
+        assert(initialTimes['LeafC'] === finalTimes['LeafC'], 'Should not update LeafC');
+        assert(initialTimes['LibraryA'] === finalTimes['LibraryA'], 'Should not update LibraryA');
+        assert(initialTimes['SameFile1'] === finalTimes['SameFile1'], 'Should not update SameFile1');
+        assert(initialTimes['SameFile2'] === finalTimes['SameFile2'], 'Should not update SameFile2');
+        done();
+      } catch(err) {
+        err.message += '\n\n' + output;
+        throw new Error(err);
+      }
+    });
+  });
+
+  // -------------Inheritance Graph -----------------------------
+  //                                       |
+  //      LibA         LeafA*              |  SameFile1* - LeafC*
+  //     /           /        \            |
+  // Root* - Branch* -           - LeafC*  |  SameFile2*
+  //                 \        /            |
+  //                   LeafB*              |
+  // ------------------------------------------------------------
+
+  it("Updates everything except LibraryA and SameFile2 when LeafC is touched", function(done) {
+    this.timeout(30000);
+
+    touchContract('LeafC', getContract('LeafC'));
+
+    CommandRunner.run("compile", config, function(err) {
+      output = logger.contents();
+      processErr(err, output);
+
+      finalTimes = getArtifactStats();
+
+      try {
+        assert(initialTimes['Root'] < finalTimes['Root'], 'Should update root');
+        assert(initialTimes['Branch'] < finalTimes['Branch'], 'Should update Branch');
+        assert(initialTimes['LeafA'] < finalTimes['LeafA'], 'Should update LeafA');
+        assert(initialTimes['LeafB'] < finalTimes['LeafB'], 'Should update LeafB');
+        assert(initialTimes['LeafC'] < finalTimes['LeafC'], 'Should update LeafC');
+        assert(initialTimes['LibraryA'] === finalTimes['LibraryA'], 'Should not update LibraryA');
+        assert(initialTimes['SameFile1'] < finalTimes['SameFile1'], 'Should update SameFile1');
+        assert(initialTimes['SameFile2'] < finalTimes['SameFile2'], 'Should update SameFile2');
+        done();
+      } catch(err) {
+        err.message += '\n\n' + output;
+        throw new Error(err);
+      }
+    });
+  });
+});

--- a/test/scenarios/compile/compile.js
+++ b/test/scenarios/compile/compile.js
@@ -256,7 +256,7 @@ describe("Repeated compilation of contracts with inheritance", function() {
   //                   LeafB*              |
   // ------------------------------------------------------------
 
-  it("Updates everything except LibraryA and SameFile2 when LeafC is touched", function(done) {
+  it("Updates everything except LibraryA when LeafC is touched", function(done) {
     this.timeout(30000);
 
     touchContract('LeafC', getContract('LeafC'));

--- a/test/scenarios/compile/compile.js
+++ b/test/scenarios/compile/compile.js
@@ -10,8 +10,8 @@ var log = console.log;
 
 describe("Repeated compilation of contracts with inheritance", function() {
   var config;
-  var contracts;
-  var contractPaths;
+  var sources;
+  var sourcePaths;
   var artifactPaths;
   var initialTimes;
   var finalTimes;
@@ -34,8 +34,8 @@ describe("Repeated compilation of contracts with inheritance", function() {
     return new Promise((resolve, reject) => setTimeout(() => resolve(), 1250));
   }
 
-  function getContract(key) {
-    return fs.readFileSync(mapping[key].contractPath);
+  function getSource(key) {
+    return fs.readFileSync(mapping[key].sourcePath);
   }
 
   function getArtifact(key) {
@@ -51,8 +51,9 @@ describe("Repeated compilation of contracts with inheritance", function() {
     return stats;
   }
 
-  function touchContract(key, file) {
-    fs.writeFileSync(mapping[key].contractPath, file);
+  function touchSource(key) {
+    const source = getSource(key);
+    fs.writeFileSync(mapping[key].sourcePath, source);
   }
 
   // ----------------------- Setup -----------------------------
@@ -76,15 +77,15 @@ describe("Repeated compilation of contracts with inheritance", function() {
         reporter: new Reporter(logger),
       }
 
-      contracts = names.map(name => name + '.sol');
+      sources = names.map(name => name + '.sol');
       artifactPaths = names.map(name => path.join(config.contracts_build_directory, name + '.json'));
-      contractPaths = contracts.map(contract => path.join(config.contracts_directory, contract));
+      sourcePaths = sources.map(source => path.join(config.contracts_directory, source));
 
       names.forEach((name, i) => {
         mapping[name] = {};
-        mapping[name].contract = contracts[i];
+        mapping[name].source = sources[i];
         mapping[name].artifactPath = artifactPaths[i];
-        mapping[name].contractPath = contractPaths[i];
+        mapping[name].sourcePath = sourcePaths[i];
       })
 
       CommandRunner.run("compile", config, function(err) {
@@ -111,7 +112,7 @@ describe("Repeated compilation of contracts with inheritance", function() {
   it("Updates only Root when Root is touched", function(done) {
     this.timeout(30000);
 
-    touchContract('Root', getContract('Root'));
+    touchSource('Root');
 
     CommandRunner.run("compile", config, function(err) {
       output = logger.contents();
@@ -148,7 +149,7 @@ describe("Repeated compilation of contracts with inheritance", function() {
   it("Updates Root and Library when Library is touched", function(done) {
     this.timeout(30000);
 
-    touchContract('LibraryA', getContract('LibraryA'));
+    touchSource('LibraryA');
 
     CommandRunner.run("compile", config, function(err) {
       output = logger.contents();
@@ -185,7 +186,7 @@ describe("Repeated compilation of contracts with inheritance", function() {
   it("Updates Branch and Root when Branch is touched", function(done) {
     this.timeout(30000);
 
-    touchContract('Branch', getContract('Branch'));
+    touchSource('Branch');
 
     CommandRunner.run("compile", config, function(err) {
       output = logger.contents();
@@ -222,7 +223,7 @@ describe("Repeated compilation of contracts with inheritance", function() {
   it("Updates LeafA, Branch and Root when LeafA is touched", function(done) {
     this.timeout(30000);
 
-    touchContract('LeafA', getContract('LeafA'));
+    touchSource('LeafA');
 
     CommandRunner.run("compile", config, function(err) {
       output = logger.contents();
@@ -259,7 +260,7 @@ describe("Repeated compilation of contracts with inheritance", function() {
   it("Updates everything except LibraryA when LeafC is touched", function(done) {
     this.timeout(30000);
 
-    touchContract('LeafC', getContract('LeafC'));
+    touchSource('LeafC');
 
     CommandRunner.run("compile", config, function(err) {
       output = logger.contents();

--- a/test/scenarios/ethpm/ethpm.js
+++ b/test/scenarios/ethpm/ethpm.js
@@ -43,8 +43,8 @@ describe("EthPM commands", function() {
         log(logger.contents());
         return done(err);
       }
+
       assert(fs.existsSync(path.join(config.contracts_build_directory, "PLCRVoting.json")));
-      assert(fs.existsSync(path.join(config.contracts_build_directory, "EIP20.json")));
       assert(fs.existsSync(path.join(config.contracts_build_directory, "Local.json")));
 
       CommandRunner.run("publish", config, function(err) {
@@ -57,6 +57,7 @@ describe("EthPM commands", function() {
           log(output);
           done(err);
         }
+
         assert(output.includes('Uploading sources and publishing'), 'Should have found sources');
         done();
       })

--- a/test/sources/inheritance/contracts/Branch.sol
+++ b/test/sources/inheritance/contracts/Branch.sol
@@ -1,0 +1,8 @@
+pragma solidity ^0.4.8;
+
+import "./LeafA.sol";
+import "./LeafB.sol";
+
+contract Branch is LeafA, LeafB {
+  uint branch;
+}

--- a/test/sources/inheritance/contracts/LeafA.sol
+++ b/test/sources/inheritance/contracts/LeafA.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.4.8;
+
+import "./LeafC.sol";
+
+contract LeafA is LeafC {
+  uint leafA;
+}

--- a/test/sources/inheritance/contracts/LeafB.sol
+++ b/test/sources/inheritance/contracts/LeafB.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.4.8;
+
+import "./LeafC.sol";
+
+contract LeafB is LeafC {
+  uint leafB;
+}

--- a/test/sources/inheritance/contracts/LeafC.sol
+++ b/test/sources/inheritance/contracts/LeafC.sol
@@ -1,0 +1,5 @@
+pragma solidity ^0.4.8;
+
+contract LeafC {
+  uint leafC;
+}

--- a/test/sources/inheritance/contracts/LibraryA.sol
+++ b/test/sources/inheritance/contracts/LibraryA.sol
@@ -1,0 +1,9 @@
+pragma solidity ^0.4.8;
+
+
+library LibraryA {
+
+  function add(uint a, uint b) public pure returns (uint) {
+    return a + b;
+  }
+}

--- a/test/sources/inheritance/contracts/Migrations.sol
+++ b/test/sources/inheritance/contracts/Migrations.sol
@@ -1,0 +1,23 @@
+pragma solidity ^0.4.4;
+
+contract Migrations {
+  address public owner;
+  uint public last_completed_migration;
+
+  modifier restricted() {
+    if (msg.sender == owner) _;
+  }
+
+  function Migrations() public {
+    owner = msg.sender;
+  }
+
+  function setCompleted(uint completed) restricted public {
+    last_completed_migration = completed;
+  }
+
+  function upgrade(address new_address) restricted public {
+    Migrations upgraded = Migrations(new_address);
+    upgraded.setCompleted(last_completed_migration);
+  }
+}

--- a/test/sources/inheritance/contracts/Root.sol
+++ b/test/sources/inheritance/contracts/Root.sol
@@ -1,0 +1,14 @@
+pragma solidity ^0.4.8;
+
+import "./Branch.sol";
+import "./LeafC.sol";
+import "./LibraryA.sol";
+
+contract Root is Branch {
+  uint root;
+
+  function addToRoot(uint a, uint b) public {
+    root = LibraryA.add(a, b);
+  }
+}
+

--- a/test/sources/inheritance/contracts/SameFile.sol
+++ b/test/sources/inheritance/contracts/SameFile.sol
@@ -1,0 +1,11 @@
+pragma solidity ^0.4.8;
+
+import "./LeafC.sol";
+
+contract SameFile1 is LeafC {
+  uint samefile1;
+}
+
+contract SameFile2 {
+  uint samefile2;
+}

--- a/test/sources/inheritance/migrations/1_initial_migrations.js
+++ b/test/sources/inheritance/migrations/1_initial_migrations.js
@@ -1,0 +1,7 @@
+/* global artifacts */
+
+const Migrations = artifacts.require('./Migrations.sol');
+
+module.exports = function (deployer) {
+  deployer.deploy(Migrations);
+};

--- a/test/sources/inheritance/test/inheritance.js
+++ b/test/sources/inheritance/test/inheritance.js
@@ -1,0 +1,8 @@
+const Root = artifacts.require('Root');
+
+contract('Root', function(accounts){
+
+  it('runs', function(){
+    return Root.new();
+  })
+})

--- a/test/sources/inheritance/truffle.js
+++ b/test/sources/inheritance/truffle.js
@@ -1,0 +1,2 @@
+module.exports = {
+};


### PR DESCRIPTION
+ Adds a set of integration tests for [truffle-compile 53](https://github.com/trufflesuite/truffle-compile/pull/53).
+ Adds a small suite of contracts we can use to test inheritance cases. 