### PR TITLE
Stop testing error message in EthPM test

### DIFF
--- a/test/scenarios/commands/ethpm.js
+++ b/test/scenarios/commands/ethpm.js
@@ -49,11 +49,9 @@ describe("truffle publish", function() {
 
       CommandRunner.run("publish", config, function(err) {
         var output = logger.contents();
-        var expected = output.includes('not a contract') || output.includes('previously published');
 
         // We expect publication to be rejected by the client.
-        // Ganache and Geth trigger diff errs.
-        if (!err || !expected) {
+        if (!err) {
           log(output);
           done(err);
         }


### PR DESCRIPTION
Fixes an ill-conceived test for `truffle publish` that tries to validate an error message which changed in the last week. 

This test is a little weak anyway - it doesn't expect to publish anything - just verify that all the pre-publication steps execute correctly. 