### PR TITLE
Add original-fs to list of nils

### DIFF
--- a/cli.webpack.config.js
+++ b/cli.webpack.config.js
@@ -85,6 +85,7 @@ module.exports = {
       // It doesn't pack well, and is OS X specific, so let's get rid of it.
       "fsevents": path.join(__dirname, "./nil.js"),
       "ws": path.join(__dirname, "./nil.js"),
+      "original-fs": path.join(__dirname, "./nil.js"),
       "scrypt": "js-scrypt",
       "secp256k1": path.join(__dirname, "node_modules", "secp256k1", "elliptic.js")
     }


### PR DESCRIPTION
This might be OSX specific because Travis is running clean, but have been getting an annoying build error because of an electron related  conditional require that webpack can't deal with. Also reported as an issue a couple months ago at webpack [here](https://github.com/webpack/webpack/issues/6504).
```shell
 WARNING in ./~/promisify-node/index.js
157:14-27 Critical dependency: the request of a dependency is an expression

ERROR in ./~/adm-zip/util/fileSystem.js
Module not found: Error: Can't resolve 'original-fs' in '/Users/cgewecke/code/consensys/byoc-opti/truffle/node_modules/adm-zip/util'
 @ ./~/adm-zip/util/fileSystem.js 2:9-69
 @ ./~/adm-zip/util/index.js
 @ ./~/adm-zip/adm-zip.js
 @ ./~/github-download/lib/zip.js
 @ ./~/github-download/lib/github-download.js
 @ ./~/truffle-box/lib/utils/unbox.js
 @ ./~/truffle-box/lib/utils/index.js
 @ ./~/truffle-box/box.js
 @ ./~/truffle-core/lib/commands/unbox.js
 @ ./~/truffle-core/lib/commands/index.js
 @ ./~/truffle-core/cli.js
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! truffle@4.1.7 build-cli: `webpack --config ./cli.webpack.config.js`
```