### PR TITLE
Upgrade mocha to 4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "4.1.8",
   "description": "Truffle - Simple development framework for Ethereum",
   "dependencies": {
-    "mocha": "^3.4.2",
+    "mocha": "^4.1.0",
     "original-require": "^1.0.1",
     "solc": "0.4.23"
   },
@@ -17,7 +17,7 @@
     "js-scrypt": "^0.2.0",
     "meta-npm": "^0.0.22",
     "meta-pkgs": "^0.2.0",
-    "mocha": "^3.4.2",
+    "mocha": "^4.1.0",
     "prepend-file": "^1.3.1",
     "shebang-loader": "0.0.1",
     "stream-buffers": "^3.0.1",


### PR DESCRIPTION
This should address the security vulnerability reported in #941 (for Truffle).

+ [Issue at mocha](https://github.com/mochajs/mocha/issues/2791) and [confirmed fix](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#401--2017-10-05).
+ List of [breaking changes](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#400--2017-10-02) at mocha for v4 - seems ok. . . . .

Incidentally, this issue was found using a new command that comes with NPM 6
```shell
npm audit
```
 