### PR TITLE
Use constructor in Migrations.sol:11:3:

### DIFF
--- a/test/sources/ethpm/installed_contracts/tokens/contracts/Migrations.sol
+++ b/test/sources/ethpm/installed_contracts/tokens/contracts/Migrations.sol
@@ -8,7 +8,7 @@ contract Migrations {
     if (msg.sender == owner) _;
   }
 
-  function Migrations() public {
+  constructor() public {
     owner = msg.sender;
   }
 


### PR DESCRIPTION
This pull request solves this issue: https://github.com/trufflesuite/truffle/issues/981 which is about compilation failure due to this warning:
```
/Users/noel/petshop/contracts/Migrations.sol:11:3: Warning: Defining constructors as functions with the same name as the contract is deprecated. Use "constructor(...) { ... }" instead.
  function Migrations() public {
  ^ (Relevant source part starts here and spans across multiple lines).
```

## Solution
Fix Migrations.sol:11:3: 
from this
```
function Migrations() public {
```
to this
```
constructor() public {
```
