### PR TITLE
Upgrade ethpm to 0.0.16

### DIFF
--- a/packages/truffle-core/package.json
+++ b/packages/truffle-core/package.json
@@ -12,7 +12,7 @@
     "debug": "^3.1.0",
     "del": "^2.2.0",
     "diff": "1.4.0",
-    "ethpm": "0.0.15",
+    "ethpm": "0.0.16",
     "ethpm-registry": "0.0.10",
     "finalhandler": "^0.4.0",
     "fs-extra": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -329,10 +329,6 @@ arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
-asap@~2.0.3:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
-
 asn1.js@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-1.0.3.tgz#281ba3ec1f2448fe765f92a4eecf883fe1364b54"
@@ -404,7 +400,7 @@ async-eventemitter@^0.2.2:
   dependencies:
     async "^2.4.0"
 
-"async-eventemitter@github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c":
+async-eventemitter@ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c:
   version "0.2.3"
   resolved "https://codeload.github.com/ahultgren/async-eventemitter/tar.gz/fa06e39e56786ba541c180061dbf2c0a5bbf951c"
   dependencies:
@@ -1194,13 +1190,13 @@ bignumber.js@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-6.0.0.tgz#bbfa047644609a5af093e9cbd83b0461fa3f6002"
 
+"bignumber.js@git+https://github.com/debris/bignumber.js#master":
+  version "2.0.7"
+  resolved "git+https://github.com/debris/bignumber.js#c7a38de919ed75e6fb6ba38051986e294b328df9"
+
 "bignumber.js@git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2":
   version "2.0.7"
   resolved "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
-
-"bignumber.js@git+https://github.com/debris/bignumber.js.git#master":
-  version "2.0.7"
-  resolved "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
 
 "bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git":
   version "2.0.7"
@@ -3586,19 +3582,18 @@ ethpm-spec@^1.0.1:
   dependencies:
     json-schema-to-markdown "^1.0.3"
 
-ethpm@0.0.15:
-  version "0.0.15"
-  resolved "https://registry.yarnpkg.com/ethpm/-/ethpm-0.0.15.tgz#ed04dec48fed3e0cf09e699c57f481226e266d3e"
+ethpm@0.0.16:
+  version "0.0.16"
+  resolved "https://registry.yarnpkg.com/ethpm/-/ethpm-0.0.16.tgz#c06b3eb3d969180f4fb2a49700b178457f9b6c94"
   dependencies:
     async "^2.1.2"
     ethpm-spec "^1.0.1"
-    fs-extra "^1.0.0"
+    fs-extra "^6.0.1"
     glob "^7.1.1"
     ipfs-mini "^1.1.2"
     jsonschema "^1.1.1"
     lodash "^4.17.1"
     node-dir "^0.1.16"
-    promisify-node "^0.4.0"
     semver "^5.3.0"
     wget-improved "^1.4.0"
 
@@ -4117,6 +4112,14 @@ fs-extra@^3.0.1:
 fs-extra@^4.0.0, fs-extra@^4.0.1, fs-extra@^4.0.2:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs-extra@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-6.0.1.tgz#8abc128f7946e310135ddc93b98bddb410e7a34b"
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
@@ -7356,12 +7359,6 @@ node-uuid@^1.4.0:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.8.tgz#b040eb0923968afabf8d32fb1f17f1167fdab907"
 
-nodegit-promise@~4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/nodegit-promise/-/nodegit-promise-4.0.0.tgz#5722b184f2df7327161064a791d2e842c9167b34"
-  dependencies:
-    asap "~2.0.3"
-
 nodeify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/nodeify/-/nodeify-1.0.1.tgz#64ab69a7bdbaf03ce107b4f0335c87c0b9e91b1d"
@@ -8022,13 +8019,6 @@ promise@~1.3.0:
 promisify-es6@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/promisify-es6/-/promisify-es6-1.0.3.tgz#b012668c4df3c965ce13daac2b3a4d1726a96346"
-
-promisify-node@^0.4.0:
-  version "0.4.0"
-  resolved "http://registry.npmjs.org/promisify-node/-/promisify-node-0.4.0.tgz#32803874ec411784e4786c339902a87a179a469c"
-  dependencies:
-    nodegit-promise "~4.0.0"
-    object-assign "^4.0.1"
 
 prompt-sync@^4.1.5:
   version "4.1.6"


### PR DESCRIPTION
Addresses #985. More detail at [ethpm 9](https://github.com/trufflesuite/ethpm-js/pull/9), where `node-promisify` was removed. 

This issue affects people running Node 10 - tested this fix locally on `10.4.0`.