### PR TITLE
Fix npm test for Node 10

### DIFF
--- a/packages/truffle-core/test/npm.js
+++ b/packages/truffle-core/test/npm.js
@@ -28,7 +28,8 @@ describe('NPM integration', function() {
       };
       config.network = "development";
 
-      fs.writeFile(path.join(config.contracts_directory, "Parent.sol"), parentContractSource, {encoding: "utf8"}, done());
+      fs.writeFileSync(path.join(config.contracts_directory, "Parent.sol"), parentContractSource, {encoding: "utf8"});
+      done();
     });
   });
 


### PR DESCRIPTION
Another Node 10 crash - something is different about `fs` and it's not happy with the old callbacks. Example error:
```shell
1) NPM integration
       "before all" hook: Create a sandbox:
     TypeError [ERR_INVALID_CALLBACK]: Callback must be a function
      at maybeCallback (fs.js:159:9)
      at Object.fs.writeFile (fs.js:1278:14)
      at test/npm.js:31:10
      at /Users/cgewecke/code/consensys/truffle/packages/truffle-box/box.js:47:11

```