### PR TITLE
Add lerna publishConfigs

### DIFF
--- a/packages/truffle-artifactor/package.json
+++ b/packages/truffle-artifactor/package.json
@@ -31,5 +31,8 @@
     "truffle-contract": "^3.0.5",
     "truffle-contract-schema": "^2.0.0",
     "truffle-expect": "^0.0.3"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/truffle-box/package.json
+++ b/packages/truffle-box/package.json
@@ -26,5 +26,8 @@
     "request": "^2.83.0",
     "tmp": "^0.0.31",
     "vcsurl": "^0.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/truffle-code-utils/package.json
+++ b/packages/truffle-code-utils/package.json
@@ -6,5 +6,8 @@
   "scripts": {
   },
   "author": "",
-  "license": "MIT"
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/truffle-compile/package.json
+++ b/packages/truffle-compile/package.json
@@ -36,5 +36,8 @@
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle-compile/issues"
   },
-  "homepage": "https://github.com/trufflesuite/truffle-compile#readme"
+  "homepage": "https://github.com/trufflesuite/truffle-compile#readme",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/truffle-config/package.json
+++ b/packages/truffle-config/package.json
@@ -26,5 +26,8 @@
     "original-require": "^1.0.0",
     "truffle-error": "^0.0.2",
     "truffle-provider": "^0.0.4"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/truffle-contract-sources/package.json
+++ b/packages/truffle-contract-sources/package.json
@@ -23,5 +23,8 @@
   "homepage": "https://github.com/trufflesuite/truffle-contract-sources#readme",
   "dependencies": {
     "node-dir": "^0.1.16"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/truffle-contract/package.json
+++ b/packages/truffle-contract/package.json
@@ -44,5 +44,8 @@
     "temp": "^0.8.3",
     "uglify": "^0.1.5",
     "uglify-js": "^2.7.5"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/truffle-core/package.json
+++ b/packages/truffle-core/package.json
@@ -77,5 +77,8 @@
   "devDependencies": {
     "ipfsd-ctl": "^0.21.0",
     "truffle-blockchain-utils": "^0.0.4"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/truffle-debug-utils/package.json
+++ b/packages/truffle-debug-utils/package.json
@@ -19,5 +19,8 @@
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle-debug-utils/issues"
   },
-  "homepage": "https://github.com/trufflesuite/truffle-debug-utils#readme"
+  "homepage": "https://github.com/trufflesuite/truffle-debug-utils#readme",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/truffle-debugger/package.json
+++ b/packages/truffle-debugger/package.json
@@ -71,5 +71,8 @@
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle-debugger/issues"
   },
-  "homepage": "https://github.com/trufflesuite/truffle-debugger#readme"
+  "homepage": "https://github.com/trufflesuite/truffle-debugger#readme",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/truffle-deployer/package.json
+++ b/packages/truffle-deployer/package.json
@@ -31,5 +31,8 @@
     "ganache-cli": "6.0.3",
     "mocha": "^3.2.0",
     "web3": "^0.20.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/truffle-expect/package.json
+++ b/packages/truffle-expect/package.json
@@ -19,5 +19,8 @@
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle-expect/issues"
   },
-  "homepage": "https://github.com/trufflesuite/truffle-expect#readme"
+  "homepage": "https://github.com/trufflesuite/truffle-expect#readme",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/truffle-migrate/package.json
+++ b/packages/truffle-migrate/package.json
@@ -31,5 +31,8 @@
   },
   "devDependencies": {
     "mocha": "^3.2.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/truffle-provider/package.json
+++ b/packages/truffle-provider/package.json
@@ -29,5 +29,8 @@
   "devDependencies": {
     "ganache-cli": "6.1.0-beta.4",
     "mocha": "^3.3.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/truffle-provisioner/package.json
+++ b/packages/truffle-provisioner/package.json
@@ -21,5 +21,8 @@
     "url": "https://github.com/trufflesuite/truffle-provisioner/issues"
   },
   "homepage": "https://github.com/trufflesuite/truffle-provisioner#readme",
-  "dependencies": {}
+  "dependencies": {},
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/truffle-require/package.json
+++ b/packages/truffle-require/package.json
@@ -30,5 +30,8 @@
     "truffle-config": "^1.0.4",
     "truffle-expect": "^0.0.3",
     "web3": "^0.20.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/truffle-resolver/package.json
+++ b/packages/truffle-resolver/package.json
@@ -29,5 +29,8 @@
   },
   "devDependencies": {
     "mocha": "^3.2.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/truffle-solidity-utils/package.json
+++ b/packages/truffle-solidity-utils/package.json
@@ -22,5 +22,8 @@
   },
   "homepage": "https://github.com/trufflesuite/truffle-solidity-utils#readme",
   "dependencies": {},
-  "devDependencies": {}
+  "devDependencies": {},
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/truffle-workflow-compile/package.json
+++ b/packages/truffle-workflow-compile/package.json
@@ -24,5 +24,8 @@
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle-workflow-compile/issues"
   },
-  "homepage": "https://github.com/trufflesuite/truffle-workflow-compile#readme"
+  "homepage": "https://github.com/trufflesuite/truffle-workflow-compile#readme",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -55,5 +55,8 @@
       "email": "tim@timothyjcoulter.com",
       "url": "https://github.com/tcoulter"
     }
-  ]
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
 }


### PR DESCRIPTION
Adds to all package.jsons within `packages`
```javascript
"publishConfig": {
    "access": "public"
  }
```
This  is what lerna uses to identify publication candidates. More in their docs [here](https://github.com/lerna/lerna#publish).

Do we want to publish all of this? 