### PR TITLE
Update Solidity sources to the latest constructor syntax (requires Solidity 0.4.22)

### DIFF
--- a/packages/truffle-compile/test/ComplexOrdered.sol
+++ b/packages/truffle-compile/test/ComplexOrdered.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.22;
 
 import "./InheritB.sol";
 
@@ -7,7 +7,7 @@ import "./InheritB.sol";
 contract InheritA is InheritB {
   event LogB();
   event LogA();
-  function InheritA() public {}
+  constructor() public {}
 }
 
 contract ComplexOrdered is InheritA {

--- a/packages/truffle-compile/test/InheritB.sol
+++ b/packages/truffle-compile/test/InheritB.sol
@@ -1,9 +1,9 @@
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.22;
 
 // These are out of alphabetic order
 // Solc will alphabetize them, we should restore source-order.
 contract InheritB {
   event LogD();
   event LogC();
-  function InheritB() public {}
+  constructor() public {}
 }

--- a/packages/truffle-contract/test/Example.sol
+++ b/packages/truffle-contract/test/Example.sol
@@ -1,10 +1,12 @@
+pragma solidity ^0.4.22;
+
 contract Example {
   uint public value;
   uint public counter;
   bool public fallbackTriggered;
   event ExampleEvent(address indexed _from, uint num);
 
-  function Example(uint val) {
+  constructor(uint val) {
     value = val;
     fallbackTriggered = false;
   }

--- a/packages/truffle-core/lib/templates/Example.sol
+++ b/packages/truffle-core/lib/templates/Example.sol
@@ -1,8 +1,7 @@
-pragma solidity ^0.4.4;
+pragma solidity ^0.4.22;
 
 
 contract Example {
-  function Example() {
-    // constructor
+  constructor() {
   }
 }

--- a/packages/truffle-core/lib/testing/SafeSend.sol
+++ b/packages/truffle-core/lib/testing/SafeSend.sol
@@ -1,9 +1,9 @@
-pragma solidity ^0.4.8;
+pragma solidity ^0.4.22;
 
 contract SafeSend {
   address public recipient;
   
-  function SafeSend(address _recipient) payable {
+  constructor(address _recipient) payable {
     recipient = _recipient;
   }
 


### PR DESCRIPTION
`SafeSend` found by @bit-shift.