### PR TITLE
Allow `await` keyword in console

### DIFF
--- a/packages/truffle-core/lib/console.js
+++ b/packages/truffle-core/lib/console.js
@@ -160,16 +160,72 @@ Console.prototype.interpret = function(cmd, context, filename, callback) {
   }
 
   var result;
+
+  // Much of the following code is from here, though spruced up:
+  // https://github.com/nfcampos/await-outside
+
+  /*
+  - allow whitespace before everything else
+  - optionally capture `var|let|const <varname> = `
+    - varname only matches if it starts with a-Z or _ or $
+      and if contains only those chars or numbers
+    - this is overly restrictive but is easier to maintain
+  - capture `await <anything that follows it>`
+  */
+  let includesAwait = /^\s*((?:(?:var|const|let)\s+)?[a-zA-Z_$][0-9a-zA-Z_$]*\s*=\s*)?(\(?\s*await[\s\S]*)/;
+
+  var match = cmd.match(includesAwait);
+  var newSource = cmd;
+  var assignment = null;
+
+  // If our code includes an await, add special processing to ensure it's evaluated properly.
+  if (match) {
+    var assign = match[1];
+    var expression = match[2];
+  
+    var RESULT = "__await_outside_result";
+
+    // Wrap the await inside an async function.
+    // Strange indentation keeps column offset correct in stack traces
+    newSource = `(async function() { try { ${assign ? `global.${RESULT} =` : "return"} (
+${expression.trim()}
+); } catch(e) { global.ERROR = e; throw e; } }())`;
+
+    assignment = assign
+      ? `${assign.trim()} global.${RESULT}; void delete global.${RESULT};`
+      : null;
+  } else {
+    // No await? Just process the source as normal.
+    newSource = cmd;
+  }
+
+  var runScript = function(s) {
+    const options = { displayErrors: true, breakOnSigint: true, filename: filename };
+    return s.runInContext(context, options);
+  };
+
   try {
-    result = vm.runInContext(cmd, context, {
-      displayErrors: false
-    });
+    const options = { displayErrors: true, lineOffset: -1 };
+    var script = vm.createScript(newSource, options);
   } catch (e) {
+    // If syntax error, or similar, bail.
     return callback(e);
   }
 
-  // Resolve all promises. This will leave non-promises alone.
-  Promise.resolve(result).then(function(res) { callback(null, res) }).catch(callback);
+  // Ensure our script returns a promise whether we're using an
+  // async function or not. If our script is an async function,
+  // this will ensure the console waits until that await is finished.
+  Promise.resolve(runScript(script)).then(function(value) {
+    // If there's an assignment to run, run that.
+    if (assignment) { 
+      return runScript(vm.createScript(assignment));
+    } else {
+      return value;
+    }
+  }).then(function(value) {
+    // All good? Return the value (e.g., eval'd script or assignment)
+    callback(null, value);
+  }).catch(callback);
 }
 
 module.exports = Console;

--- a/packages/truffle-core/lib/console.js
+++ b/packages/truffle-core/lib/console.js
@@ -175,7 +175,7 @@ Console.prototype.interpret = function(cmd, context, filename, callback) {
   let includesAwait = /^\s*((?:(?:var|const|let)\s+)?[a-zA-Z_$][0-9a-zA-Z_$]*\s*=\s*)?(\(?\s*await[\s\S]*)/;
 
   var match = cmd.match(includesAwait);
-  var newSource = cmd;
+  var source = cmd;
   var assignment = null;
 
   // If our code includes an await, add special processing to ensure it's evaluated properly.
@@ -187,17 +187,14 @@ Console.prototype.interpret = function(cmd, context, filename, callback) {
 
     // Wrap the await inside an async function.
     // Strange indentation keeps column offset correct in stack traces
-    newSource = `(async function() { try { ${assign ? `global.${RESULT} =` : "return"} (
+    source = `(async function() { try { ${assign ? `global.${RESULT} =` : "return"} (
 ${expression.trim()}
 ); } catch(e) { global.ERROR = e; throw e; } }())`;
 
     assignment = assign
       ? `${assign.trim()} global.${RESULT}; void delete global.${RESULT};`
       : null;
-  } else {
-    // No await? Just process the source as normal.
-    newSource = cmd;
-  }
+  } 
 
   var runScript = function(s) {
     const options = { displayErrors: true, breakOnSigint: true, filename: filename };
@@ -206,7 +203,7 @@ ${expression.trim()}
 
   try {
     const options = { displayErrors: true, lineOffset: -1 };
-    var script = vm.createScript(newSource, options);
+    var script = vm.createScript(source, options);
   } catch (e) {
     // If syntax error, or similar, bail.
     return callback(e);


### PR DESCRIPTION
Allow the use of the `await` keyword in the console. This is only available if the user's node version supports it.

![image 1](https://user-images.githubusercontent.com/92629/41626353-dadc8364-73d0-11e8-8518-a55b8c53eadd.png)

Big thanks to https://github.com/nfcampos/await-outside for the reference implementation.