### PR TITLE
Make send accept txParams and prefer user-defined send

### DIFF
--- a/packages/truffle-contract/lib/contract.js
+++ b/packages/truffle-contract/lib/contract.js
@@ -74,7 +74,14 @@ var contract = (function(module) {
 
     // sendTransaction / send
     instance.sendTransaction = execute.send.call(constructor, null, instance.address);
-    instance.send = (value) => instance.sendTransaction({value: value});
+
+    // Prefer user defined `send`
+    if (!instance.send){
+      instance.send = (value, txParams={}) => {
+        const packet = Object.assign({value: value}, txParams);
+        return instance.sendTransaction(packet)
+      };
+    }
 
     // Other events
     instance.allEvents = execute.allEvents.call(constructor, contract);

--- a/packages/truffle-contract/test/methods.js
+++ b/packages/truffle-contract/test/methods.js
@@ -367,5 +367,26 @@ describe("Methods", function() {
       const balance = await web3.eth.getBalance(example.address);
       assert(balance == web3.utils.toWei("1", "ether"));
     });
+
+    it("should accept tx params (send)", async function(){
+      const example = await Example.new(1);
+      const eth = web3.utils.toWei("1", "ether");
+      const sender = accounts[1];
+      const initialSenderBalance = await web3.eth.getBalance(sender);
+
+      await example.send(eth, {from: sender});
+
+      const finalSenderBalance = await web3.eth.getBalance(sender);
+      const contractBalance = await web3.eth.getBalance(example.address);
+
+      assert(contractBalance === eth, 'Contract should receive eth');
+
+      const initialBN = new web3.utils.BN(initialSenderBalance);
+      const finalBN = new web3.utils.BN(finalSenderBalance);
+      const ethBN = new web3.utils.BN(eth);
+      const expectedBN = initialBN.sub(ethBN);
+      assert(finalBN.lte(expectedBN), 'send should send from the specified address');
+    });
   })
 });
+


### PR DESCRIPTION
Addresses #1030.  `instance.send` should accept tx params so you can set the `from`, etc. 

Also added a conditional to skip definition of this method if user has already defined it in their contract. Believe this was problematic for [ERC-721](https://github.com/ethereum/eips/issues/721) although now I can't find any reference to a `send` method in the interface. 