### PR TITLE
Upgrade dependency: fs-extra@6.0.1

### DIFF
--- a/packages/truffle-artifactor/package.json
+++ b/packages/truffle-artifactor/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "async": "2.6.1",
     "debug": "^3.1.0",
-    "fs-extra": "^1.0.0",
+    "fs-extra": "6.0.1",
     "lodash": "4.17.10",
     "truffle-contract": "^3.0.6",
     "truffle-contract-schema": "^2.0.1",

--- a/packages/truffle-box/package.json
+++ b/packages/truffle-box/package.json
@@ -21,7 +21,7 @@
     "truffle-config": "^1.0.5"
   },
   "dependencies": {
-    "fs-extra": "^3.0.1",
+    "fs-extra": "6.0.1",
     "github-download": "^0.5.0",
     "request": "^2.83.0",
     "tmp": "0.0.33",

--- a/packages/truffle-core/package.json
+++ b/packages/truffle-core/package.json
@@ -15,7 +15,7 @@
     "ethpm": "0.0.16",
     "ethpm-registry": "0.0.10",
     "finalhandler": "^0.4.0",
-    "fs-extra": "^2.0.0",
+    "fs-extra": "6.0.1",
     "ganache-cli": "6.1.3",
     "lodash": "4.17.10",
     "mkdirp": "^0.5.1",

--- a/packages/truffle-debugger/package.json
+++ b/packages/truffle-debugger/package.json
@@ -47,7 +47,7 @@
     "esdoc-ecmascript-proposal-plugin": "^1.0.0",
     "esdoc-standard-plugin": "^1.0.0",
     "express": "^4.16.2",
-    "fs-extra": "^4.0.2",
+    "fs-extra": "6.0.1",
     "ganache-cli": "6.1.3",
     "mocha": "5.2.0",
     "mocha-webpack": "^1.1.0",

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "clean-webpack-plugin": "^0.1.16",
     "copy-webpack-plugin": "^4.0.1",
-    "fs-extra": "^4.0.0",
+    "fs-extra": "6.0.1",
     "ganache-cli": "6.1.3",
     "glob": "^7.1.2",
     "js-scrypt": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4088,6 +4088,14 @@ fs-extra@5.0.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@6.0.1, fs-extra@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-6.0.1.tgz#8abc128f7946e310135ddc93b98bddb410e7a34b"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-extra@^0.24.0:
   version "0.24.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.24.0.tgz#d4e4342a96675cb7846633a6099249332b539952"
@@ -4114,25 +4122,9 @@ fs-extra@^2.0.0, fs-extra@^2.1.2:
     graceful-fs "^4.1.2"
     jsonfile "^2.1.0"
 
-fs-extra@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-3.0.1.tgz#3794f378c58b342ea7dbbb23095109c4b3b62291"
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^3.0.0"
-    universalify "^0.1.0"
-
-fs-extra@^4.0.0, fs-extra@^4.0.1, fs-extra@^4.0.2:
+fs-extra@^4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
-
-fs-extra@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-6.0.1.tgz#8abc128f7946e310135ddc93b98bddb410e7a34b"
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
@@ -5893,12 +5885,6 @@ json5@^0.5.0, json5@^0.5.1:
 jsonfile@^2.1.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
-  optionalDependencies:
-    graceful-fs "^4.1.6"
-
-jsonfile@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-3.0.1.tgz#a5ecc6f65f53f662c4415c7675a0331d0992ec66"
   optionalDependencies:
     graceful-fs "^4.1.6"
 


### PR DESCRIPTION
Fixes #1044 

* truffle: ^4.0.0 →  6.0.1
* truffle-artifactor: ^1.0.0 →  6.0.1
* truffle-box: ^3.0.1 →  6.0.1
* truffle-core: ^2.0.0 →  6.0.1
* truffle-debugger: ^4.0.2 →  6.0.1