### PR TITLE
Add pre-release script

### DIFF
--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -37,8 +37,8 @@
     "build": "npm run build-cli",
     "build-cli": "webpack --config ./cli.webpack.config.js",
     "test": "npm run build-cli && mocha --colors",
-    "test:ci": "./scripts/test.sh",
-    "test:geth": "MAIN_REPO_CI=true npm test"
+    "version:byoc-safe": "node ./scripts/prereleaseVersion.js byoc-safe byoc",
+    "version:next": "node node ./scripts/prereleaseVersion.js next next"
   },
   "repository": {
     "type": "git",

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -19,6 +19,7 @@
     "meta-pkgs": "^0.2.0",
     "mocha": "5.2.0",
     "prepend-file": "^1.3.1",
+    "semver": "^5.5.0",
     "shebang-loader": "0.0.1",
     "stream-buffers": "^3.0.1",
     "tmp": "0.0.33",

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -39,7 +39,7 @@
     "build-cli": "webpack --config ./cli.webpack.config.js",
     "test": "npm run build-cli && mocha --colors",
     "version:byoc-safe": "node ./scripts/prereleaseVersion.js byoc-safe byoc",
-    "version:next": "node node ./scripts/prereleaseVersion.js next next"
+    "version:next": "node ./scripts/prereleaseVersion.js next next"
   },
   "repository": {
     "type": "git",

--- a/packages/truffle/scripts/prereleaseVersion.js
+++ b/packages/truffle/scripts/prereleaseVersion.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+/**
+ * This script checks out the specified branch and runs:
+ *    `npm version <version-tag>`
+ * where <version-tag> is a pre-release increment with the tag id.
+ * **********************************************************************
+ * NB: It updates the package version and makes a commit.
+ * **********************************************************************
+ * USAGE:
+ *   node ./version.js <branch> <tag>
+ */
+const fs = require('fs');
+const path = require('path');
+const exec = require('child_process').execSync
+const semver = require('semver');
+
+const args = process.argv.slice(2);
+
+// Example command node ./version.js byoc-safe byoc
+const branch = args[0];
+const tag = args[1];
+const step = 'prerelease';
+
+// Checkout branch
+exec(`git checkout ${branch}`, {stdio:[0,1,2]});
+console.log();
+
+// Read package
+console.log('Loading package');
+let pkg = fs.readFileSync('./package.json');
+pkg = JSON.parse(pkg);
+
+// Get semver increment string
+const version = semver.inc(pkg.version, step, tag);
+
+// npm version: this updates the package and commits
+console.log(`Running: npm version ${version}`)
+exec(`npm version ${version}`);

--- a/packages/truffle/scripts/prereleaseVersion.js
+++ b/packages/truffle/scripts/prereleaseVersion.js
@@ -20,7 +20,8 @@ const args = process.argv.slice(2);
 // Example command node ./version.js byoc-safe byoc
 const branch = args[0];
 const tag = args[1];
-const step = 'prerelease';
+const premajor = 'premajor';
+const prerelease = 'prerelease';
 
 // Checkout branch
 exec(`git checkout ${branch}`, {stdio:[0,1,2]});
@@ -31,9 +32,20 @@ console.log('Loading package');
 let pkg = fs.readFileSync('./package.json');
 pkg = JSON.parse(pkg);
 
-// Get semver increment string
-const version = semver.inc(pkg.version, step, tag);
+// Get semver increment string.
+// This bumps to 5.0.0-tag.0 the first time we do it
+// and increments the final number each time after.
+// As we merge develop into these branches we should prefer
+// the branch versioning (until they're mergeable).
+let version;
 
-// npm version: this updates the package and commits
+(!pkg.version.includes(tag))
+  ? version = semver.inc(pkg.version, premajor)
+  : version = pkg.version;
+
+version = semver.inc(version, prerelease, tag);
+
+// Updates the package and commits
 console.log(`Running: npm version ${version}`)
 exec(`npm version ${version}`);
+


### PR DESCRIPTION
We'd like to publish experimental builds - e.g. webpacks of `packages/truffle` checked out to a branch. Lerna doesn't let you publish a single scoped package. 

This adds a script to `packages/truffle` which checks out a branch and runs `npm version <version-tag>` where <version-tag> is a tagged prerelease increment of the current version. e.g
```shell
4.1.13-next.0
```
Command is:
```shell
node ./scripts/prereleaseVersion.js <branch> <tag>
```
Needs `npm publish` and `git push` added to the end of it. Those are left out so it can be evaluated without causing damage.