### PR TITLE
Extract Supplier base class from CompilerSupplier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - docker pull ethereum/solc:0.4.22
   - sudo add-apt-repository --yes ppa:ethereum/ethereum
   - sudo apt-get update
-  - sudo apt-get install solc
+  - sudo apt-get install solc --allow-unauthenticated
 
 env:
   - INTEGRATION=true

--- a/packages/truffle-box/package.json
+++ b/packages/truffle-box/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "fs-extra": "6.0.1",
     "github-download": "^0.5.0",
-    "request": "^2.83.0",
+    "request": "2.87.0",
     "tmp": "0.0.33",
     "vcsurl": "^0.1.1"
   },

--- a/packages/truffle-compile/package.json
+++ b/packages/truffle-compile/package.json
@@ -7,21 +7,18 @@
     "async": "2.6.1",
     "colors": "^1.1.2",
     "debug": "^3.1.0",
-    "find-cache-dir": "^1.0.0",
-    "original-require": "^1.0.1",
-    "request": "^2.85.0",
-    "request-promise": "^4.2.2",
-    "require-from-string": "^2.0.2",
     "solc": "0.4.24",
     "truffle-config": "^1.0.5",
     "truffle-contract-sources": "^0.0.2",
     "truffle-error": "^0.0.3",
-    "truffle-expect": "^0.0.4"
+    "truffle-expect": "^0.0.4",
+    "truffle-supplier": "^0.1.0"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.1",
+    "find-cache-dir": "^1.0.0",
     "mocha": "5.2.0",
     "truffle-resolver": "^4.0.4"
   },

--- a/packages/truffle-compile/package.json
+++ b/packages/truffle-compile/package.json
@@ -18,7 +18,7 @@
     "babel-core": "^6.26.0",
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.1",
-    "find-cache-dir": "^1.0.0",
+    "find-cache-dir": "2.0.0",
     "mocha": "5.2.0",
     "truffle-resolver": "^4.0.4"
   },

--- a/packages/truffle-compile/scripts/test.sh
+++ b/packages/truffle-compile/scripts/test.sh
@@ -3,7 +3,7 @@
 set -o errexit
 
 if [ "$CI" = true ]; then
-  mocha --timeout 5000
+  mocha --timeout 5000 $@
 else
-  mocha --invert --grep native --timeout 5000
+  mocha --invert --grep native --timeout 5000 $@
 fi

--- a/packages/truffle-compile/test/test_supplier.js
+++ b/packages/truffle-compile/test/test_supplier.js
@@ -105,7 +105,7 @@ describe('CompilerSupplier', function(){
     it('compiles w/ remote solc when options specify release (pinned)', function(done){
       options.compiler = {
         cache: false,
-        solc: "0.4.15"
+        version: "0.4.15"
       };
 
       compile(oldPragmaPinSource, options, (err, result) => {
@@ -120,7 +120,7 @@ describe('CompilerSupplier', function(){
       // An 0.4.16 prerelease for 0.4.15
       options.compiler = {
         cache: false,
-        solc: "0.4.16-nightly.2017.8.9+commit.81887bc7"
+        version: "0.4.16-nightly.2017.8.9+commit.81887bc7"
       };
 
       compile(oldPragmaFloatSource, options, (err, result) => {
@@ -134,7 +134,7 @@ describe('CompilerSupplier', function(){
     it('errors when specified release does not exist', function(done){
       options.compiler = {
         cache: false,
-        solc: "0.4.55.77-fantasy-solc"
+        version: "0.4.55.77-fantasy-solc"
       };
 
       compile(newPragmaSource, options, (err, result) => {
@@ -148,7 +148,7 @@ describe('CompilerSupplier', function(){
 
       options.compiler = {
         cache: false,
-        solc: pathToSolc
+        version: pathToSolc
       };
 
       compile(newPragmaSource, options, (err, result) => {
@@ -163,7 +163,7 @@ describe('CompilerSupplier', function(){
       const pathToSolc = path.join(__dirname, "../solidity-warehouse/solc/index.js");
       options.compiler = {
         cache: false,
-        solc: pathToSolc
+        version: pathToSolc
       };
 
       compile(newPragmaSource, options, (err, result) => {
@@ -176,7 +176,11 @@ describe('CompilerSupplier', function(){
       let initialAccessTime;
       let finalAccessTime;
 
-      const thunk = findCacheDir({name: 'truffle', thunk: true});
+      const thunk = findCacheDir({
+        name: 'truffle',
+        cwd: CompilerSupplier.prototype.cacheRoot,
+        thunk: true
+      });
       const expectedCache = thunk('soljson-v0.4.21+commit.dfe3193c.js');
 
       // Delete if it's already there.
@@ -184,7 +188,7 @@ describe('CompilerSupplier', function(){
 
       options.compiler = {
         cache: true,
-        solc: "0.4.21"
+        version: "0.4.21"
       };
 
       // Run compiler, expecting solc to be downloaded and cached.
@@ -222,7 +226,7 @@ describe('CompilerSupplier', function(){
 
       it('compiles with native solc', function(done){
         options.compiler = {
-          solc: "native"
+          version: "native"
         };
 
         compile(newPragmaSource, options, (err, result) => {
@@ -236,7 +240,7 @@ describe('CompilerSupplier', function(){
 
       it('compiles with dockerized solc', function(done){
         options.compiler = {
-          solc: "0.4.22",
+          version: "0.4.22",
           docker: true
         };
 
@@ -258,7 +262,7 @@ describe('CompilerSupplier', function(){
 
         let options = {
           compiler : {
-            solc: "0.4.22",
+            version: "0.4.22",
             docker: true
           },
           quiet: true,
@@ -282,7 +286,7 @@ describe('CompilerSupplier', function(){
 
       it('errors if running dockerized solc without specifying an image', function(done){
         options.compiler = {
-          solc: undefined,
+          version: undefined,
           docker: true
         };
 
@@ -296,7 +300,7 @@ describe('CompilerSupplier', function(){
         const imageName = 'fantasySolc.7777555';
 
         options.compiler = {
-          solc: imageName,
+          version: imageName,
           docker: true
         };
 

--- a/packages/truffle-contract/package.json
+++ b/packages/truffle-contract/package.json
@@ -32,7 +32,7 @@
     "truffle-error": "^0.0.3",
     "web3": "1.0.0-beta.33",
     "web3-core-promievent": "1.0.0-beta.33",
-    "web3-eth-abi": "1.0.0-beta.33",
+    "web3-eth-abi": "1.0.0-beta.34",
     "web3-utils": "1.0.0-beta.33"
   },
   "devDependencies": {

--- a/packages/truffle-debugger/package.json
+++ b/packages/truffle-debugger/package.json
@@ -43,7 +43,7 @@
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.1",
     "babel-runtime": "^6.26.0",
-    "chai": "^4.1.2",
+    "chai": "4.1.2",
     "esdoc": "^1.0.4",
     "esdoc-ecmascript-proposal-plugin": "^1.0.0",
     "esdoc-standard-plugin": "^1.0.0",

--- a/packages/truffle-debugger/package.json
+++ b/packages/truffle-debugger/package.json
@@ -33,7 +33,7 @@
     "truffle-expect": "^0.0.4",
     "truffle-solidity-utils": "^1.1.2",
     "web3": "1.0.0-beta.33",
-    "web3-eth-abi": "^1.0.0-beta.29"
+    "web3-eth-abi": "1.0.0-beta.34"
   },
   "devDependencies": {
     "async": "2.6.1",

--- a/packages/truffle-supplier/README.md
+++ b/packages/truffle-supplier/README.md
@@ -1,0 +1,11 @@
+# `truffle-dynamics`
+
+> TODO: description
+
+## Usage
+
+```
+const truffleDynamics = require('truffle-dynamics');
+
+// TODO: DEMONSTRATE API
+```

--- a/packages/truffle-supplier/index.js
+++ b/packages/truffle-supplier/index.js
@@ -1,0 +1,450 @@
+const child = require('child_process');
+const expect = require("truffle-expect");
+const findCacheDir = require('find-cache-dir');
+const fs = require('fs');
+const originalRequire = require("original-require");
+const path = require('path');
+const request = require('request-promise');
+const requireFromString = require('require-from-string');
+const debug = require("debug")("supplier");
+
+
+//------------------------------ Constructor/Config ------------------------------------------------
+
+/**
+ * Constructor
+ */
+function Supplier(_config) {
+  _config = _config || {};
+  this.config = Object.assign(this.config, this.baseConfig, _config);
+
+  // must be provided via defaults or specified via end-user override
+  expect.options(this.config, [
+    "componentName",
+    "versionsUrl",
+    "urlRoot",
+    "dockerTagsUrl",
+    "dockerImageName",
+    "packageName",
+    "commandBin",
+    "commandArgs"
+  ]);
+}
+
+Supplier.prototype.baseConfig = {
+  version: null,
+  cache: true
+};
+
+// The path to the cache root depends on whether or not we're running in the
+// bundled version.
+if (typeof BUNDLE_CHAIN_FILENAME != "undefined") {
+  // Remember: In the bundled version, __dirname refers to the
+  // build directory where cli.bundled.js lives
+  Supplier.prototype.cacheRoot = path.join(__dirname, "..");
+} else {
+  // Otherwise, this file is inside truffle-supplier, so let's get back to
+  // truffle
+  Supplier.prototype.cacheRoot = path.join(__dirname, "..", "truffle");
+}
+
+debug("cache root: %s", Supplier.prototype.cacheRoot);
+
+
+//----------------------------------- Interface  ---------------------------------------------------
+
+/**
+ * Loads a JS module component from four possible locations:
+ * - local node_modules            (config.version = <undefined>)
+ * - absolute path to a local      (config.version = <path>)
+ * - the cache                     (config.version = <version-string> && cache contains version)
+ * - a remote source               (config.version = <version-string> && version not cached)
+ *
+ * OR specify that a wrapper should wrap an external program:
+ * - Docker image                  (config.version = "<image-name>" && config.docker: true)
+ * - shell-default binary          (cofing.version = "native")
+ *
+ * @return {Module|Object}         supplied component
+ */
+Supplier.prototype.load = function(){
+  const self = this;
+  const version = self.config.version;
+  const isNative = version === 'native';
+
+  return new Promise((accept, reject) => {
+    const useDocker =  self.config.docker;
+    const useDefault = !version;
+    const useLocal =   !useDefault && self.isLocal(version);
+    const useNative =  !useLocal && isNative;
+    const useRemote =  !useNative
+
+    if (useDocker)  {
+      debug("using docker");
+      return accept(self.getBuilt("docker"));
+    }
+
+    if (useNative) {
+      debug("using native");
+      return accept(self.getBuilt("native"));
+    }
+
+    if (useDefault) {
+      debug("using default");
+      return accept(self.getDefault());
+    }
+
+    if (useLocal) {
+      debug("using local");
+      return accept(self.getLocal(version));
+    }
+
+    if (useRemote) {
+      debug("using remote");
+      return accept(self.getByUrl(version)); // Tries cache first, then remote.
+    }
+  });
+}
+
+/**
+ * Returns keys that can be used to specify which remote version to fetch
+ * ```
+ *   latestRelease:  "0.4.21",
+ *   releases: ["0.4.21", ...],
+ *   prereleases: ["0.4.22-nightly.2018.4.10+commit.27385d6d", ...]
+ * ```
+ * @abstract
+ * @return {Object} See above
+ */
+Supplier.prototype.getReleases = function(){
+  throw new Error(
+    "Attempted to invoke abstract method Supplier.prototype.getReleases()"
+  );
+}
+
+/**
+ * Fetches the first page of docker tags for the component's image
+ * @return {Object} tags
+ */
+Supplier.prototype.getDockerTags = function(){
+  const self = this;
+
+  return request(self.config.dockerTagsUrl)
+    .then(list =>
+      JSON
+        .parse(list)
+        .results
+        .map(item => item.name)
+    )
+    .catch(err => {throw self.errors('noRequest', url, err)});
+}
+
+
+//------------------------------------ Getters -----------------------------------------------------
+
+/**
+ * Gets local version from `node_modules`.`
+ * @return {Module} Component
+ */
+Supplier.prototype.getDefault = function(){
+  return require(this.config.packageName);
+}
+
+/**
+ * Gets an npm installed component from specified path.
+ * @param  {String} localPath
+ * @return {Module}
+ */
+Supplier.prototype.getLocal = function(localPath){
+  const self = this;
+  let component;
+
+  try {
+    component = originalRequire(localPath)
+  } catch (err) {
+    throw self.errors('noPath', localPath);
+  }
+
+  return component;
+}
+
+
+/**
+ * Fetches component versions object from remote URL. This includes an array of
+ * buildobjects with detailed version info, an array of release version numbers
+ * and their terminal url segment strings, and a latest version key with the
+ * same.
+ * @return {Object} versions
+ */
+Supplier.prototype.getVersions = function(){
+  const self = this;
+
+  return request(self.config.versionsUrl)
+    .then(list => JSON.parse(list))
+    .catch(err => {throw self.errors('noRequest', url, err)});
+}
+
+
+/**
+ * Returns terminal url segment for `version` from the versions object
+ * generated  by `getVersions`.
+ * @param  {String} version         ex: "0.4.1", "0.4.16-nightly.2017.8.9+commit.81887bc7"
+ * @param  {Object} allVersions     (see `getVersions`)
+ * @return {String} url             ex: "soljson-v0.4.21+commit.dfe3193c.js"
+ */
+Supplier.prototype.getVersionUrlSegment = function(version, allVersions){
+  throw new Error("Attempted to call abstract method Supplier.prototype.formatVersionURL");
+}
+
+/**
+ * Downloads component specified by `version` after attempting retrieve it from cache on local machine,
+ * @param  {String} version ex: "0.4.1", "0.4.16-nightly.2017.8.9+commit.81887bc7"
+ * @return {Module}         solc
+ */
+Supplier.prototype.getByUrl = function(version){
+  const self = this;
+
+  return self
+    .getVersions(self.config.versionsUrl)
+    .then(allVersions => {
+      const file = self.getVersionUrlSegment(version, allVersions);
+
+      if (!file)               throw self.errors('noVersion', version);
+
+      if (self.isCached(file)) return self.getFromCache(file);
+
+      const url = self.config.urlRoot + file;
+
+      return request
+        .get(url)
+        .then(response => {
+          self.addToCache(response, file);
+          return self.componentFromString(response);
+        })
+        .catch(err => { throw self.errors('noRequest', url, err)});
+    });
+}
+
+/**
+ * Returns a default JS wrapper for a component. Should be overridden to match
+ * concrete component class JS interface (e.g. define `compileStandard`
+ * for native `solc`)
+ * @param {String} command - command to run
+ * @param {String} version - raw version string
+ * @return {Promise<Object>} - promise for wrapped component
+ */
+Supplier.prototype.getCommandWrapper = function (command, version) {
+  return Promise.resolve({
+    execute: (options) => String(child.execSync(command, {input: options})),
+    version: () => version
+  });
+}
+
+/**
+ * Returns a JS interface wrapping a child process invocation of dockerized or
+ * natively available command.
+ * @return {Promise<Object>} promise for a wrapped JS component
+ */
+Supplier.prototype.getBuilt = function(buildType){
+  let version;
+  let command;
+
+  switch (buildType) {
+    case "native":
+      version = this.validateNative();
+      command = `${this.config.commandBin} ${this.config.commandArgs}`;
+      break;
+    case "docker":
+      version = this.validateDocker();
+      command = `docker run -i ${this.config.dockerImageName}:${this.config.version} ${this.config.commandArgs}`;
+      break;
+  }
+
+  return this.getCommandWrapper(command, version);
+}
+
+//------------------------------------ Utils -------------------------------------------------------
+
+/**
+ * Returns true if file exists or `localPath` is an absolute path.
+ * @param  {String}  localPath
+ * @return {Boolean}
+ */
+Supplier.prototype.isLocal = function(localPath){
+  return fs.existsSync(localPath) || path.isAbsolute(localPath);
+}
+
+/**
+ * Checks to make sure image is specified in the config, that docker exists and that
+ * the image exists locally. If the last condition isn't true, docker will try to pull
+ * it down and this breaks everything.
+ * @return {String}  solc version string
+ * @throws {Error}
+ */
+Supplier.prototype.validateDocker = function(){
+  const image = this.config.version;
+  const fileName = image + '.version';
+
+  // Skip validation if they've validated for this image before.
+  if (this.isCached(fileName)){
+    const cachePath = this.resolveCache(fileName);
+    return fs.readFileSync(cachePath, 'utf-8');
+  }
+
+  // Image specified
+  if (!image) throw this.errors('noString', image);
+
+  // Docker exists locally
+  try {
+    child.execSync('docker -v');
+  } catch(err){
+    throw this.errors('noDocker');
+  }
+
+  // Image exists locally
+  try {
+    child.execSync(
+      `docker inspect --type=image ${this.config.dockerImageName}:${image}`
+    );
+  } catch(err){
+    debug("err %O", err)
+    throw this.errors('noImage', image);
+  }
+
+  // Get version & cache.
+  const version = child.execSync(
+    `docker run ${this.config.dockerImageName}:${image} --version`
+  );
+  const normalized = this.normalizeVersion(version);
+  this.addToCache(normalized, fileName);
+  return normalized;
+}
+
+/**
+ * Checks to make sure image is specified in the config, that docker exists and that
+ * the image exists locally. If the last condition isn't true, docker will try to pull
+ * it down and this breaks everything.
+ * @return {String}  solc version string
+ * @throws {Error}
+ */
+Supplier.prototype.validateNative = function(){
+  let version;
+  try {
+    version = child.execSync(`${this.config.commandBin} --version`);
+  } catch(err){
+    throw this.errors('noNative', null, err);
+  }
+
+  return this.normalizeVersion(version);
+}
+
+/**
+ * Converts shell exec'd component version from buffer to string and strips out
+ * human readable description.
+ * @param  {Buffer} version result of childprocess
+ * @return {String}         normalized version string: e.g 0.4.22+commit.4cb486ee.Linux.g++
+ */
+Supplier.prototype.normalizeVersion = function(version){
+  version = String(version);
+  return version.split(':')[1].trim();
+}
+
+
+/**
+ * Returns path to cached component version
+ * @param  {String} fileName ex: "soljson-v0.4.21+commit.dfe3193c.js"
+ * @return {String}          path
+ */
+Supplier.prototype.resolveCache = function(fileName){
+  const thunk = findCacheDir({
+    name: 'truffle',
+    cwd: Supplier.prototype.cacheRoot,
+    thunk: true
+  });
+  return thunk(fileName);
+}
+
+/**
+ * Returns true if `fileName` exists in the cache.
+ * @param  {String}  fileName   ex: "soljson-v0.4.21+commit.dfe3193c.js"
+ * @return {Boolean}
+ */
+Supplier.prototype.isCached = function(fileName){
+  const file = this.resolveCache(fileName);
+  return fs.existsSync(file);
+}
+
+/**
+ * Write  to the cache at `config.cachePath`. Creates `cachePath` directory if
+ * does not exist.
+ * @param {String} code       JS code string downloaded from solc-bin
+ * @param {String} fileName   ex: "soljson-v0.4.21+commit.dfe3193c.js"
+ */
+Supplier.prototype.addToCache = function(code, fileName){
+  if (!this.config.cache) return;
+
+  const filePath = this.resolveCache(fileName);
+  fs.writeFileSync(filePath, code);
+}
+
+/**
+ * Returns a default wrapper for JS module component. Override for performance
+ * or interface reasons.
+ *
+ * @param {Module} underlying module
+ * @param {String} version - raw version string
+ * @return {Promise<Object>} - promise for wrapped component
+ */
+Supplier.prototype.getModuleWrapper = function (module, version) {
+  return Promise.resolve({
+    execute: (options) => module.call(null, options),
+    version: () => version
+  });
+}
+/**
+ * Retrieves usable solc module from cache
+ * @param  {String} file  ex: "soljson-v0.4.21+commit.dfe3193c.js"
+ * @return {Module}       solc
+ */
+Supplier.prototype.getFromCache = function(fileName){
+  const filePath = this.resolveCache(fileName);
+  const loaded = originalRequire(filePath);
+  return this.getModuleWrapper(loaded);
+}
+
+/**
+ * Converts the JS code string obtained from solc-bin to usable node module.
+ * @param  {String} code JS code
+ * @return {Module}      solc
+ */
+Supplier.prototype.componentFromString = function(code){
+  const loaded = requireFromString(code);
+  return this.getModuleWrapper(loaded);
+}
+
+/**
+ * Error formatter
+ * @param  {String} kind  descriptive key
+ * @param  {String} input contextual info for error
+ * @param  {Object} err   [optional] additional error associated with this error
+ * @return {Error}
+ */
+Supplier.prototype.errors = function(kind, input, err){
+  const component = this.config.componentName;
+
+  const kinds = {
+
+    noPath:    `Could not find ${component} at: ${input}`,
+    noVersion: `Could not find ${component} version:\n${input}.`,
+    noRequest: `Failed to complete request to: ${input}.\n\n${err}`,
+    noDocker:  `You are trying to run dockerized version of ${component}, but docker is not installed.`,
+    noImage:   `Please pull ${input} from docker before trying to compile with it.`,
+    noNative:  `Could not execute local ${component} binary: ${err}`,
+
+    // Lists
+    noString:  `Invalid version specified. Received: ${input}`
+  }
+
+  return new Error(kinds[kind]);
+}
+
+module.exports = Supplier;

--- a/packages/truffle-supplier/package.json
+++ b/packages/truffle-supplier/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "debug": "^3.1.0",
     "find-cache-dir": "^2.0.0",
-    "original-require": "^1.0.1",
+    "original-require": "1.0.1",
     "request": "2.87.0",
     "request-promise": "^4.2.2",
     "require-from-string": "^2.0.2",

--- a/packages/truffle-supplier/package.json
+++ b/packages/truffle-supplier/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "truffle-supplier",
+  "version": "0.1.0",
+  "description": "Dynamic component fetching for Truffle",
+  "keywords": [
+    "truffle",
+    "ethereum",
+    "smart-contracts"
+  ],
+  "author": "g. nicholas d'andrea <gnidan@users.noreply.github.com>",
+  "homepage": "https://github.com/trufflesuite/truffle#readme",
+  "license": "MIT",
+  "main": "index.js",
+  "directories": {
+    "lib": "lib",
+    "test": "test"
+  },
+  "files": [
+    "lib"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/trufflesuite/truffle.git"
+  },
+  "scripts": {
+    "test": "mocha"
+  },
+  "bugs": {
+    "url": "https://github.com/trufflesuite/truffle/issues"
+  },
+  "dependencies": {
+    "debug": "^3.1.0",
+    "find-cache-dir": "^2.0.0",
+    "original-require": "^1.0.1",
+    "request-promise": "^4.2.2",
+    "require-from-string": "^2.0.2",
+    "truffle-expect": "^0.0.4"
+  },
+  "devDependencies": {
+    "mocha": "^5.2.0"
+  }
+}

--- a/packages/truffle-supplier/package.json
+++ b/packages/truffle-supplier/package.json
@@ -32,6 +32,7 @@
     "debug": "^3.1.0",
     "find-cache-dir": "^2.0.0",
     "original-require": "^1.0.1",
+    "request": "^2.87.0",
     "request-promise": "^4.2.2",
     "require-from-string": "^2.0.2",
     "truffle-expect": "^0.0.4"

--- a/packages/truffle-supplier/package.json
+++ b/packages/truffle-supplier/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "debug": "^3.1.0",
-    "find-cache-dir": "^2.0.0",
+    "find-cache-dir": "2.0.0",
     "original-require": "1.0.1",
     "request": "2.87.0",
     "request-promise": "^4.2.2",

--- a/packages/truffle-supplier/package.json
+++ b/packages/truffle-supplier/package.json
@@ -32,7 +32,7 @@
     "debug": "^3.1.0",
     "find-cache-dir": "^2.0.0",
     "original-require": "^1.0.1",
-    "request": "^2.87.0",
+    "request": "2.87.0",
     "request-promise": "^4.2.2",
     "require-from-string": "^2.0.2",
     "truffle-expect": "^0.0.4"

--- a/packages/truffle-supplier/package.json
+++ b/packages/truffle-supplier/package.json
@@ -38,6 +38,6 @@
     "truffle-expect": "^0.0.4"
   },
   "devDependencies": {
-    "mocha": "^5.2.0"
+    "mocha": "5.2.0"
   }
 }

--- a/packages/truffle-supplier/test/supplier.test.js
+++ b/packages/truffle-supplier/test/supplier.test.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const Supplier = require('..');
+
+describe('Supplier', () => {
+    it('needs tests');
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -7563,7 +7563,7 @@ ora@^0.2.3:
     cli-spinners "^0.1.2"
     object-assign "^4.0.1"
 
-original-require@1.0.1, original-require@^1.0.1:
+original-require@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/original-require/-/original-require-1.0.1.tgz#0f130471584cd33511c5ec38c8d59213f9ac5e20"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1737,7 +1737,7 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chai@4.1.2, chai@^4.1.2:
+chai@4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.1.2.tgz#0f64584ba642f0f2ace2806279f4f06ca23ad73c"
   dependencies:
@@ -8593,7 +8593,7 @@ request-promise@^4.2.2:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.3"
 
-request@^2.12.0, request@^2.55.0, request@^2.67.0, request@^2.79.0, request@^2.81.0, request@^2.83.0:
+request@^2.12.0, request@^2.55.0, request@^2.67.0, request@^2.79.0, request@^2.81.0, request@^2.83.0, request@^2.87.0:
   version "2.87.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -6955,7 +6955,7 @@ mocha-webpack@^1.1.0:
     toposort "^1.0.0"
     yargs "^4.8.0"
 
-mocha@5.2.0, mocha@^5.2.0:
+mocha@5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-5.2.0.tgz#6d8ae508f59167f940f2b5b3c4a612ae50c90ae6"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3910,6 +3910,14 @@ finalhandler@^0.4.0:
     on-finished "~2.3.0"
     unpipe "~1.0.0"
 
+find-cache-dir@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.0.0.tgz#4c1faed59f45184530fb9d7fa123a4d04a98472d"
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^1.0.0"
+    pkg-dir "^3.0.0"
+
 find-cache-dir@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-1.0.0.tgz#9288e3e9e3cc3748717d39eade17cf71fc30ee6f"
@@ -3917,14 +3925,6 @@ find-cache-dir@^1.0.0:
     commondir "^1.0.1"
     make-dir "^1.0.0"
     pkg-dir "^2.0.0"
-
-find-cache-dir@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.0.0.tgz#4c1faed59f45184530fb9d7fa123a4d04a98472d"
-  dependencies:
-    commondir "^1.0.1"
-    make-dir "^1.0.0"
-    pkg-dir "^3.0.0"
 
 find-module-bin@^0.0.2:
   version "0.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8593,7 +8593,7 @@ request-promise@^4.2.2:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.3"
 
-request@^2.12.0, request@^2.55.0, request@^2.67.0, request@^2.79.0, request@^2.81.0, request@^2.83.0, request@^2.87.0:
+request@2.87.0, request@^2.12.0, request@^2.55.0, request@^2.67.0, request@^2.79.0, request@^2.81.0:
   version "2.87.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -10664,7 +10664,7 @@ web3-eth-abi@1.0.0-beta.33:
     web3-core-helpers "1.0.0-beta.33"
     web3-utils "1.0.0-beta.33"
 
-web3-eth-abi@1.0.0-beta.34, web3-eth-abi@^1.0.0-beta.29:
+web3-eth-abi@1.0.0-beta.34:
   version "1.0.0-beta.34"
   resolved "https://registry.yarnpkg.com/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.34.tgz#034533e3aa2f7e59ff31793eaea685c0ed5af67a"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3918,6 +3918,14 @@ find-cache-dir@^1.0.0:
     make-dir "^1.0.0"
     pkg-dir "^2.0.0"
 
+find-cache-dir@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.0.0.tgz#4c1faed59f45184530fb9d7fa123a4d04a98472d"
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^1.0.0"
+    pkg-dir "^3.0.0"
+
 find-module-bin@^0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/find-module-bin/-/find-module-bin-0.0.2.tgz#99ef84fb548aedae3bfe4da14b61846cd9888666"
@@ -3937,6 +3945,12 @@ find-up@^2.0.0, find-up@^2.1.0:
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   dependencies:
     locate-path "^2.0.0"
+
+find-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+  dependencies:
+    locate-path "^3.0.0"
 
 findup-sync@^2.0.0:
   version "2.0.0"
@@ -6272,6 +6286,13 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+locate-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
+  dependencies:
+    p-locate "^3.0.0"
+    path-exists "^3.0.0"
+
 lodash-es@^4.2.1:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.10.tgz#62cd7104cdf5dd87f235a837f0ede0e8e5117e05"
@@ -6934,7 +6955,7 @@ mocha-webpack@^1.1.0:
     toposort "^1.0.0"
     yargs "^4.8.0"
 
-mocha@5.2.0:
+mocha@5.2.0, mocha@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-5.2.0.tgz#6d8ae508f59167f940f2b5b3c4a612ae50c90ae6"
   dependencies:
@@ -7627,11 +7648,23 @@ p-limit@^1.0.0, p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
+p-limit@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.0.0.tgz#e624ed54ee8c460a778b3c9f3670496ff8a57aec"
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
   dependencies:
     p-limit "^1.1.0"
+
+p-locate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
+  dependencies:
+    p-limit "^2.0.0"
 
 p-map@^1.1.1:
   version "1.2.0"
@@ -7656,6 +7689,10 @@ p-timeout@^2.0.1:
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+
+p-try@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.0.0.tgz#85080bb87c64688fa47996fe8f7dfbe8211760b1"
 
 package-json@^4.0.1:
   version "4.0.1"
@@ -7891,6 +7928,12 @@ pkg-dir@^2.0.0:
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
   dependencies:
     find-up "^2.1.0"
+
+pkg-dir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-3.0.0.tgz#2749020f239ed990881b1f71210d51eb6523bea3"
+  dependencies:
+    find-up "^3.0.0"
 
 pluralize@^7.0.0:
   version "7.0.0"
@@ -8550,7 +8593,7 @@ request-promise@^4.2.2:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.3"
 
-request@^2.12.0, request@^2.55.0, request@^2.67.0, request@^2.79.0, request@^2.81.0, request@^2.83.0, request@^2.85.0:
+request@^2.12.0, request@^2.55.0, request@^2.67.0, request@^2.79.0, request@^2.81.0, request@^2.83.0:
   version "2.87.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
   dependencies:


### PR DESCRIPTION
Defines new package `truffle-supplier` for `Supplier` class, to be inherited from for specific components. Much of the code in `CompilerSupplier` has been moved, except for solc specifics.

Suppliers are defined to fetch/provide a core component from one of several sources:
- Bundled in Truffle
- Locally installed via NPM
- Docker
- Native shell binary

**Note**: This renames the `compiler.solc` setting to `compiler.version`