### PR TITLE
Ensure truffle-debugger targets Node 6

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -5,5 +5,6 @@
   ],
   "version": "independent",
   "npmClient": "yarn",
+  "npmClientArgs": ["--ignore-engines"],
   "useWorkspaces": true
 }

--- a/packages/truffle-debugger/package.json
+++ b/packages/truffle-debugger/package.json
@@ -23,7 +23,6 @@
     "bignumber.js": "^6.0.0",
     "debug": "^3.1.0",
     "json-pointer": "^0.6.0",
-    "node-interval-tree": "^1.3.3",
     "redux": "^3.7.2",
     "redux-cli-logger": "^2.0.1",
     "redux-saga": "^0.16.0",
@@ -37,6 +36,7 @@
   },
   "devDependencies": {
     "async": "2.6.1",
+    "node-interval-tree": "^1.3.3",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",

--- a/packages/truffle-debugger/webpack/webpack.config-common.js
+++ b/packages/truffle-debugger/webpack/webpack.config-common.js
@@ -10,7 +10,12 @@ module.exports = {
       test: /\.js$/,
       loader: "babel-loader",
       query: {
-        presets: ['babel-preset-env'],
+        presets: [
+          [
+            'babel-preset-env',
+            { targets: { "node": "6.14" } }
+          ]
+        ],
         plugins: ['transform-object-rest-spread', 'transform-runtime'],
       },
       include: [

--- a/packages/truffle-debugger/webpack/webpack.config-common.js
+++ b/packages/truffle-debugger/webpack/webpack.config-common.js
@@ -44,6 +44,9 @@ module.exports = {
   // in order to ignore all modules in node_modules folder
   externals: [nodeExternals({
     modulesFromFile: true,
+    whitelist: [
+      "node-interval-tree"
+    ]
   })],
 
   devtool: "inline-cheap-module-source-map",

--- a/packages/truffle-debugger/webpack/webpack.config-test.js
+++ b/packages/truffle-debugger/webpack/webpack.config-test.js
@@ -11,7 +11,12 @@ module.exports = merge(commonConfig, {
       test: /\.js$/,
       loader: "babel-loader",
       query: {
-        presets: ['babel-preset-env'],
+        presets: [
+          [
+            'babel-preset-env',
+            { targets: { "node": "6.14" } }
+          ]
+        ],
         plugins: ['transform-object-rest-spread', 'transform-runtime'],
       },
       include: [


### PR DESCRIPTION
Via babel preset-env's `targets` directive.