### PR TITLE
Make prerelease publishing script wizard-ish.

### DIFF
--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -38,8 +38,8 @@
     "build": "npm run build-cli",
     "build-cli": "webpack --config ./cli.webpack.config.js",
     "test": "npm run build-cli && mocha --colors",
-    "version:byoc-safe": "node ./scripts/prereleaseVersion.js byoc-safe byoc",
-    "version:next": "node ./scripts/prereleaseVersion.js next next"
+    "publish:byoc": "node ./scripts/prereleaseVersion.js byoc-safe byoc",
+    "publish:next": "node ./scripts/prereleaseVersion.js next next"
   },
   "repository": {
     "type": "git",

--- a/packages/truffle/scripts/prereleaseVersion.js
+++ b/packages/truffle/scripts/prereleaseVersion.js
@@ -22,8 +22,6 @@ const semver = require('semver');
 const readline = require('readline');
 
 const args = process.argv.slice(2);
-
-// Example command node ./version.js byoc-safe byoc
 const branch = args[0];
 const tag = args[1];
 const premajor = 'premajor';
@@ -35,15 +33,14 @@ if (!branch || !tag ){
   const help =
   `** You forgot to pass in some arguments **\n\n` +
   `USAGE:\n` +
-  `   node ./publishPrerelase <branch> <tag>\n\n` +
+  `   node ./scripts/prereleaseVersion.js <branch> <tag>\n\n` +
 
-  `Ex: node ./publishPrerelease next next\n` +
+  `Ex: node ./scripts/prereleaseVersion.js next next\n` +
   `>>  truffle@4.1.12-next.0  truffle@next\n`;
 
   console.log(help);
   return;
 }
-
 
 // Checkout branch
 exec(`git checkout ${branch}`, opts);
@@ -62,6 +59,7 @@ let version;
 
 version = semver.inc(version, prerelease, tag);
 
+// Describe actions:
 const warn = `You are about to:\n` +
              `  + increment the package version to ${version}\n` +
              `  + publish the package on npm at tag: '${tag}'\n` +
@@ -78,6 +76,7 @@ const input = readline.createInterface({
   output: process.stdout
 });
 
+// Confirm
 input.question(warn + quest, (answer) => {
   const reminder = `\n` +
   `** Remember: don't overwrite this version in the 'package.json' when you merge develop in. **\n`;
@@ -97,6 +96,8 @@ input.question(warn + quest, (answer) => {
     input.close();
     return;
   }
+
+  // Exit doing nothing.
   console.log(exit);
   input.close();
 });

--- a/packages/truffle/scripts/prereleaseVersion.js
+++ b/packages/truffle/scripts/prereleaseVersion.js
@@ -1,19 +1,25 @@
 #!/usr/bin/env node
 
 /**
- * This script checks out the specified branch and runs:
- *    `npm version <version-tag>`
- * where <version-tag> is a pre-release increment with the tag id.
- * **********************************************************************
- * NB: It updates the package version and makes a commit.
- * **********************************************************************
+ * This script checks out the specified branch, tags and publishes truffle at
+ * <version-tag> where <version-tag> is a pre-release increment with the tag id.
+ * It asks you if you're sure you want to do this. It also commits the version
+ * update and pushes to the branch. If you exit, it leaves everything alone.
+ * *****************************************************************************
+ * NB: It updates the package version, publishes, makes a commit and pushes.
+ * *****************************************************************************
  * USAGE:
- *   node ./version.js <branch> <tag>
+ *   node ./scripts/prereleaseVersion.js <branch> <tag>
+ *
+ * ALSO:
+ *   npm run publish:byoc
+ *   npm run publish:next
  */
 const fs = require('fs');
 const path = require('path');
 const exec = require('child_process').execSync
 const semver = require('semver');
+const readline = require('readline');
 
 const args = process.argv.slice(2);
 
@@ -22,21 +28,32 @@ const branch = args[0];
 const tag = args[1];
 const premajor = 'premajor';
 const prerelease = 'prerelease';
+const opts = {stdio:[0,1,2]};
+
+// Validate args
+if (!branch || !tag ){
+  const help =
+  `** You forgot to pass in some arguments **\n\n` +
+  `USAGE:\n` +
+  `   node ./publishPrerelase <branch> <tag>\n\n` +
+
+  `Ex: node ./publishPrerelease next next\n` +
+  `>>  truffle@4.1.12-next.0  truffle@next\n`;
+
+  console.log(help);
+  return;
+}
+
 
 // Checkout branch
-exec(`git checkout ${branch}`, {stdio:[0,1,2]});
+exec(`git checkout ${branch}`, opts);
 console.log();
 
 // Read package
-console.log('Loading package');
 let pkg = fs.readFileSync('./package.json');
 pkg = JSON.parse(pkg);
 
-// Get semver increment string.
-// This bumps to 5.0.0-tag.0 the first time we do it
-// and increments the final number each time after.
-// As we merge develop into these branches we should prefer
-// the branch versioning (until they're mergeable).
+// Get semver increment string
 let version;
 
 (!pkg.version.includes(tag))
@@ -45,7 +62,41 @@ let version;
 
 version = semver.inc(version, prerelease, tag);
 
-// Updates the package and commits
-console.log(`Running: npm version ${version}`)
-exec(`npm version ${version}`);
+const warn = `You are about to:\n` +
+             `  + increment the package version to ${version}\n` +
+             `  + publish the package on npm at tag: '${tag}'\n` +
+             `  + commit and push this change to branch: '${branch}'\n\n` +
+             `  ------------------------------------------\n` +
+             '  Version'.padEnd(25) + '| Tag\n' +
+             `  ------------------------------------------\n` +
+             `  truffle@${version}`.padEnd(25) + `| truffle@${tag}\n\n`
 
+const quest = `Are you sure you want to publish: (y/n) >> `;
+
+const input = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout
+});
+
+input.question(warn + quest, (answer) => {
+  const reminder = `\n` +
+  `** Remember: don't overwrite this version in the 'package.json' when you merge develop in. **\n`;
+
+  const affirmations = [
+    'y', 'yes', 'YES', 'Yes', 'OK', 'Ok', 'ok', 'peace', 'np', 'almost'
+  ];
+
+  const exit = `Exiting without publishing.`
+
+  // npm version updates the package and commits
+  if (affirmations.includes(answer.trim())){
+    exec(`npm version ${version}`, opts);
+    exec(`npm publish --tag ${tag}`, opts);
+    exec(`git push`);
+    console.log(reminder);
+    input.close();
+    return;
+  }
+  console.log(exit);
+  input.close();
+});

--- a/packages/truffle/scripts/prereleaseVersion.js
+++ b/packages/truffle/scripts/prereleaseVersion.js
@@ -82,7 +82,7 @@ input.question(warn + quest, (answer) => {
   `** Remember: don't overwrite this version in the 'package.json' when you merge develop in. **\n`;
 
   const affirmations = [
-    'y', 'yes', 'YES', 'Yes', 'OK', 'Ok', 'ok', 'peace', 'np', 'almost'
+    'y', 'yes', 'YES', 'Yes', 'OK', 'Ok', 'ok', 'peace', 'almost'
   ];
 
   const exit = `Exiting without publishing.`


### PR DESCRIPTION
+ Adds a prompt
+ Adds warnings, info and a 'usage' when there are missing `argv`s.

**Output**
(Tested this on a mock repo [here](https://github.com/cgewecke/npm-beta-test)).
```shell
npm-beta-test cgewecke$ npm run prerelease byoc-safe byoc

> npm-beta-test@2.0.0-byoc.2 prerelease /Users/cgewecke/code/consensys/npm-beta-test
> node ./publish.js "byoc-safe" "byoc"

Already on 'byoc-safe'
Your branch is up to date with 'origin/byoc-safe'.

You are about to:
  + increment the package version to 2.0.0-byoc.3
  + publish the package on npm at tag: 'byoc'
  + commit and push this change to branch: 'byoc-safe'

  ------------------------------------------
  Version                | Tag
  ------------------------------------------
  truffle@2.0.0-byoc.3   | truffle@byoc

Are you sure you want to publish: (y/n) >> y
v2.0.0-byoc.3
npm notice 
npm notice 📦  npm-beta-test@2.0.0-byoc.3
npm notice === Tarball Contents === 
npm notice 646B  package.json
npm notice 1.1kB LICENSE     
npm notice 3.0kB publish.js  
npm notice 110B  README.md   
npm notice === Tarball Details === 
npm notice name:          npm-beta-test                           
npm notice version:       2.0.0-byoc.3                            
npm notice package size:  2.4 kB                                  
npm notice unpacked size: 4.9 kB                                  
npm notice shasum:        82676c7218d943097408db5ff63f509f3df562af
npm notice integrity:     sha512-M8Vh5MXHKc7o9[...]dZP9nblQayhAA==
npm notice total files:   4                                       
npm notice 
+ npm-beta-test@2.0.0-byoc.3
To https://github.com/cgewecke/npm-beta-test.git
   ffd17a4..41df059  byoc-safe -> byoc-safe

** Remember: don't overwrite this version in the 'package.json' when you merge develop in. **

npm-beta-test cgewecke$ npm view npm-beta-test

npm-beta-test@2.0.0-next.0 | ISC | deps: 1 | versions: 7
Repo to test a script that manages tagged releases of branches at an arbitary prerelease tag.

...etc...

dist-tags:
byoc: 2.0.0-byoc.3    latest: 2.0.0-next.0  next: 2.0.0-next.2    

published 32 minutes ago by cgewecke <christophergewecke@gmail.com>
npm-beta-test cgewecke$
```
 