### PR TITLE
Ensure commit in prerelease publish script

### DIFF
--- a/packages/truffle/scripts/prereleaseVersion.js
+++ b/packages/truffle/scripts/prereleaseVersion.js
@@ -91,7 +91,18 @@ input.question(warn + quest, (answer) => {
   if (affirmations.includes(answer.trim())){
     exec(`npm version ${version}`, opts);
     exec(`npm publish --tag ${tag}`, opts);
-    exec(`git push`);
+
+    // NPM version sometimes executes the commit, sometimes not.
+    // This might be related to having yarn as the npm client?
+    // If there's nothing to commit, that's fine
+    // and this is just a noop that errors exec.
+    try {
+      exec(`git commit -a -m 'Upgrade version to ${version}'`, opts);
+    } catch(err){
+      // ignore
+    }
+
+    exec(`git push`, opts);
     console.log(reminder);
     input.close();
     return;


### PR DESCRIPTION
Fixes a weird issue where `npm version` does not consistently commit the version upgrade. I can't isolate why this happens but it might be `nvm`, might be `yarn`. . . This fix just makes double-sure it happens. Running `git commit` in a repo with no changes is a no-op. 