### PR TITLE
Add compilers key to config

### DIFF
--- a/packages/truffle-compile/index.js
+++ b/packages/truffle-compile/index.js
@@ -41,8 +41,8 @@ var compile = function(sources, options, callback) {
 
   // Grandfather in old solc config
   if (options.solc){
-    compilers.solc.evmVersion = options.solc.evmVersion;
-    compilers.solc.optimizer = options.solc.optimizer;
+    compilers.solc.settings.evmVersion = options.solc.evmVersion;
+    compilers.solc.settings.optimizer = options.solc.optimizer;
   }
 
   // Ensure sources have operating system independent paths
@@ -102,8 +102,8 @@ var compile = function(sources, options, callback) {
     language: "Solidity",
     sources: {},
     settings: {
-      evmVersion: options.compilers.solc.evmVersion,
-      optimizer: options.compilers.solc.optimizer,
+      evmVersion: options.compilers.solc.settings.evmVersion,
+      optimizer: options.compilers.solc.settings.optimizer,
       outputSelection: outputSelection,
     }
   };

--- a/packages/truffle-compile/index.js
+++ b/packages/truffle-compile/index.js
@@ -36,10 +36,14 @@ var compile = function(sources, options, callback) {
 
   expect.options(options, [
     "contracts_directory",
-    "solc"
+    "compilers"
   ]);
 
-
+  // Grandfather in old solc config
+  if (options.solc){
+    compilers.solc.evmVersion = options.solc.evmVersion;
+    compilers.solc.optimizer = options.solc.optimizer;
+  }
 
   // Ensure sources have operating system independent paths
   // i.e., convert backslashes to forward slashes; things like C: are left intact.
@@ -98,8 +102,8 @@ var compile = function(sources, options, callback) {
     language: "Solidity",
     sources: {},
     settings: {
-      evmVersion: options.solc.evmVersion,
-      optimizer: options.solc.optimizer,
+      evmVersion: options.compilers.solc.evmVersion,
+      optimizer: options.compilers.solc.optimizer,
       outputSelection: outputSelection,
     }
   };
@@ -116,7 +120,7 @@ var compile = function(sources, options, callback) {
   });
 
   // Load solc module only when compilation is actually required.
-  var supplier = new CompilerSupplier(options.compiler);
+  var supplier = new CompilerSupplier(options.compilers.solc);
 
   supplier.load().then(solc => {
     var result = solc.compileStandard(JSON.stringify(solcStandardInput));

--- a/packages/truffle-compile/profiler.js
+++ b/packages/truffle-compile/profiler.js
@@ -189,7 +189,7 @@ module.exports = {
       var compilationTargets = [];
 
       // Load compiler
-      var supplier = new CompilerSupplier(options.compilers)
+      var supplier = new CompilerSupplier(options.compilers.solc)
       supplier.load().then(solc => {
 
         // Get all the source code

--- a/packages/truffle-compile/profiler.js
+++ b/packages/truffle-compile/profiler.js
@@ -189,7 +189,7 @@ module.exports = {
       var compilationTargets = [];
 
       // Load compiler
-      var supplier = new CompilerSupplier(options.compiler)
+      var supplier = new CompilerSupplier(options.compilers)
       supplier.load().then(solc => {
 
         // Get all the source code

--- a/packages/truffle-compile/test/test_ordering.js
+++ b/packages/truffle-compile/test/test_ordering.js
@@ -9,7 +9,7 @@ describe("Compile", function() {
   var simpleOrderedSource = null;
   var complexOrderedSource = null;
   var inheritedSource = null;
-  var compileOptions = { contracts_directory: '', solc: '', quiet: true};
+  var compileOptions = { contracts_directory: '', compilers: {solc: {}}, quiet: true};
 
   describe("ABI Ordering", function(){
     before("get code", function() {

--- a/packages/truffle-compile/test/test_ordering.js
+++ b/packages/truffle-compile/test/test_ordering.js
@@ -9,7 +9,15 @@ describe("Compile", function() {
   var simpleOrderedSource = null;
   var complexOrderedSource = null;
   var inheritedSource = null;
-  var compileOptions = { contracts_directory: '', compilers: {solc: {}}, quiet: true};
+
+  var compileOptions = {
+    contracts_directory: '',
+    compilers: {
+      solc: {
+        settings: {},
+      }
+    }, quiet: true
+  };
 
   describe("ABI Ordering", function(){
     before("get code", function() {

--- a/packages/truffle-compile/test/test_supplier.js
+++ b/packages/truffle-compile/test/test_supplier.js
@@ -94,7 +94,8 @@ describe('CompilerSupplier', function(){
     it('compiles w/ default solc if no compiler specified (float)', function(done){
       options.compilers = {
         solc: {
-          cache: false
+          cache: false,
+          settings: {},
         }
       };
 
@@ -110,7 +111,8 @@ describe('CompilerSupplier', function(){
       options.compilers = {
         solc: {
           cache: false,
-          version: "0.4.15"
+          version: "0.4.15",
+          settings: {},
         }
       };
 
@@ -127,7 +129,8 @@ describe('CompilerSupplier', function(){
       options.compilers = {
         solc: {
           cache: false,
-          version: "0.4.16-nightly.2017.8.9+commit.81887bc7"
+          version: "0.4.16-nightly.2017.8.9+commit.81887bc7",
+          settings: {},
         }
       };
 
@@ -143,7 +146,8 @@ describe('CompilerSupplier', function(){
       options.compilers = {
         solc: {
           cache: false,
-          version: "0.4.55.77-fantasy-solc"
+          version: "0.4.55.77-fantasy-solc",
+          settings: {},
         }
       };
 
@@ -159,7 +163,8 @@ describe('CompilerSupplier', function(){
       options.compilers = {
         solc: {
           cache: false,
-          version: pathToSolc
+          version: pathToSolc,
+          settings: {},
         }
       };
 
@@ -176,7 +181,8 @@ describe('CompilerSupplier', function(){
       options.compilers = {
         solc: {
           cache: false,
-          version: pathToSolc
+          version: pathToSolc,
+          settings: {},
         }
       };
 
@@ -199,7 +205,8 @@ describe('CompilerSupplier', function(){
       options.compilers = {
         solc: {
           cache: true,
-          version: "0.4.21"
+          version: "0.4.21",
+          settings: {},
         }
       };
 
@@ -239,7 +246,8 @@ describe('CompilerSupplier', function(){
       it('compiles with native solc', function(done){
         options.compilers = {
           solc: {
-            version: "native"
+            version: "native",
+            settings: {},
           }
         };
 
@@ -256,7 +264,8 @@ describe('CompilerSupplier', function(){
         options.compilers = {
           solc: {
             version: "0.4.22",
-            docker: true
+            docker: true,
+            settings: {},
           }
         };
 
@@ -280,7 +289,8 @@ describe('CompilerSupplier', function(){
           compilers : {
             solc: {
               version: "0.4.22",
-              docker: true
+              docker: true,
+              settings: {},
             }
           },
           quiet: true,
@@ -306,7 +316,8 @@ describe('CompilerSupplier', function(){
         options.compilers = {
           solc: {
             version: undefined,
-            docker: true
+            docker: true,
+            settings: {},
           }
         };
 
@@ -322,7 +333,8 @@ describe('CompilerSupplier', function(){
         options.compilers = {
           solc: {
             version: imageName,
-            docker: true
+            docker: true,
+            settings: {},
           }
         };
 

--- a/packages/truffle-compile/test/test_supplier.js
+++ b/packages/truffle-compile/test/test_supplier.js
@@ -92,7 +92,11 @@ describe('CompilerSupplier', function(){
 
 
     it('compiles w/ default solc if no compiler specified (float)', function(done){
-      options.compiler = { cache: false };
+      options.compilers = {
+        solc: {
+          cache: false
+        }
+      };
 
       compile(newPragmaSource, options, (err, result) => {
         if (err) return done(err);
@@ -103,9 +107,11 @@ describe('CompilerSupplier', function(){
     });
 
     it('compiles w/ remote solc when options specify release (pinned)', function(done){
-      options.compiler = {
-        cache: false,
-        solc: "0.4.15"
+      options.compilers = {
+        solc: {
+          cache: false,
+          version: "0.4.15"
+        }
       };
 
       compile(oldPragmaPinSource, options, (err, result) => {
@@ -118,9 +124,11 @@ describe('CompilerSupplier', function(){
 
     it('compiles w/ remote solc when options specify prerelease (float)', function(done){
       // An 0.4.16 prerelease for 0.4.15
-      options.compiler = {
-        cache: false,
-        solc: "0.4.16-nightly.2017.8.9+commit.81887bc7"
+      options.compilers = {
+        solc: {
+          cache: false,
+          version: "0.4.16-nightly.2017.8.9+commit.81887bc7"
+        }
       };
 
       compile(oldPragmaFloatSource, options, (err, result) => {
@@ -132,9 +140,11 @@ describe('CompilerSupplier', function(){
     });
 
     it('errors when specified release does not exist', function(done){
-      options.compiler = {
-        cache: false,
-        solc: "0.4.55.77-fantasy-solc"
+      options.compilers = {
+        solc: {
+          cache: false,
+          version: "0.4.55.77-fantasy-solc"
+        }
       };
 
       compile(newPragmaSource, options, (err, result) => {
@@ -146,9 +156,11 @@ describe('CompilerSupplier', function(){
     it('compiles w/ local path solc when options specify path', function(done){
       const pathToSolc = path.join(__dirname, "../../../node_modules/solc/index.js");
 
-      options.compiler = {
-        cache: false,
-        solc: pathToSolc
+      options.compilers = {
+        solc: {
+          cache: false,
+          version: pathToSolc
+        }
       };
 
       compile(newPragmaSource, options, (err, result) => {
@@ -161,9 +173,11 @@ describe('CompilerSupplier', function(){
 
     it('errors when specified path does not exist', function(done){
       const pathToSolc = path.join(__dirname, "../solidity-warehouse/solc/index.js");
-      options.compiler = {
-        cache: false,
-        solc: pathToSolc
+      options.compilers = {
+        solc: {
+          cache: false,
+          version: pathToSolc
+        }
       };
 
       compile(newPragmaSource, options, (err, result) => {
@@ -182,9 +196,11 @@ describe('CompilerSupplier', function(){
       // Delete if it's already there.
       if (fs.existsSync(expectedCache)) fs.unlinkSync(expectedCache);
 
-      options.compiler = {
-        cache: true,
-        solc: "0.4.21"
+      options.compilers = {
+        solc: {
+          cache: true,
+          version: "0.4.21"
+        }
       };
 
       // Run compiler, expecting solc to be downloaded and cached.
@@ -221,8 +237,10 @@ describe('CompilerSupplier', function(){
     describe('native / docker [ @native ]', function() {
 
       it('compiles with native solc', function(done){
-        options.compiler = {
-          solc: "native"
+        options.compilers = {
+          solc: {
+            version: "native"
+          }
         };
 
         compile(newPragmaSource, options, (err, result) => {
@@ -235,9 +253,11 @@ describe('CompilerSupplier', function(){
       });
 
       it('compiles with dockerized solc', function(done){
-        options.compiler = {
-          solc: "0.4.22",
-          docker: true
+        options.compilers = {
+          solc: {
+            version: "0.4.22",
+            docker: true
+          }
         };
 
         const expectedVersion = '0.4.22+commit.4cb486ee.Linux.g++';
@@ -257,9 +277,11 @@ describe('CompilerSupplier', function(){
         paths.push(path.join(__dirname, "./sources/InheritB.sol"));
 
         let options = {
-          compiler : {
-            solc: "0.4.22",
-            docker: true
+          compilers : {
+            solc: {
+              version: "0.4.22",
+              docker: true
+            }
           },
           quiet: true,
           solc: '',
@@ -281,9 +303,11 @@ describe('CompilerSupplier', function(){
       })
 
       it('errors if running dockerized solc without specifying an image', function(done){
-        options.compiler = {
-          solc: undefined,
-          docker: true
+        options.compilers = {
+          solc: {
+            version: undefined,
+            docker: true
+          }
         };
 
         compile(newPragmaSource, options, (err, result) => {
@@ -295,9 +319,11 @@ describe('CompilerSupplier', function(){
       it('errors if running dockerized solc when image does not exist locally', function(done){
         const imageName = 'fantasySolc.7777555';
 
-        options.compiler = {
-          solc: imageName,
-          docker: true
+        options.compilers = {
+          solc: {
+            version: imageName,
+            docker: true
+          }
         };
 
         compile(newPragmaSource, options, (err, result) => {

--- a/packages/truffle-config/index.js
+++ b/packages/truffle-config/index.js
@@ -39,11 +39,13 @@ function Config(truffle_directory, working_directory, network) {
     },
     compilers: {
       solc: {
-        optimizer: {
-          enabled: false,
-          runs: 200
-        },
-        evmVersion: "byzantium"
+        settings: {
+          optimizer: {
+            enabled: false,
+            runs: 200
+          },
+          evmVersion: "byzantium"
+        }
       }
     },
     logger: {

--- a/packages/truffle-config/index.js
+++ b/packages/truffle-config/index.js
@@ -37,12 +37,14 @@ function Config(truffle_directory, working_directory, network) {
       registry: "0x8011df4830b4f696cd81393997e5371b93338878",
       install_provider_uri: "https://ropsten.infura.io/truffle"
     },
-    solc: {
-      optimizer: {
-        enabled: false,
-        runs: 200
-      },
-      evmVersion: "byzantium"
+    compilers: {
+      solc: {
+        optimizer: {
+          enabled: false,
+          runs: 200
+        },
+        evmVersion: "byzantium"
+      }
     },
     logger: {
       log: function() {},
@@ -60,8 +62,8 @@ function Config(truffle_directory, working_directory, network) {
     resolver: function() {},
     artifactor: function() {},
     ethpm: function() {},
-    solc: function() {},
     logger: function() {},
+    compilers: function() {},
 
     build_directory: function() {
       return path.join(self.working_directory, "build");
@@ -168,6 +170,7 @@ function Config(truffle_directory, working_directory, network) {
         throw new Error("Don't set config.provider directly. Instead, set config.networks and then set config.networks[<network name>].provider")
       }
     }
+
   };
 
   Object.keys(props).forEach(function(prop) {


### PR DESCRIPTION
+ modifies config key to support multiple compilers
+ moves existing solc defaults there
+ grandfathers in the old solc key at `truffle-compile`

**Example** (updated)
```javascript
compilers: {
  solc: {
    version: "0.4.24",
    docker: true,
    settings: {
      optimizer: {
        enabled: true,
        runs: 1000
      }
    }
  },
  vyper: {
    version: "0.1.0-beta.1",
    snap: true
  }
}
```
         