### PR TITLE
Ensure not-null binary before adding instance

### DIFF
--- a/packages/truffle-debugger/lib/evm/sagas/index.js
+++ b/packages/truffle-debugger/lib/evm/sagas/index.js
@@ -27,11 +27,13 @@ export function *addContext(contractName, binary) {
  */
 export function *addInstance(address, binary) {
   let search = yield select(evm.info.binaries.search);
-  let { context } = search(binary);
+  if (binary != "0x0") {
+    let { context } = search(binary);
 
-  yield put(actions.addInstance(address, context, binary));
+    yield put(actions.addInstance(address, context, binary));
 
-  return context;
+    return context;
+  }
 }
 
 export function* begin({ address, binary }) {


### PR DESCRIPTION
This is for issue #1051 

Simple check that ensures binary is not equal to "0x0" before searching for it and adding the instance to an address.