### PR TITLE
Suppress web3 MaxListenersExceededWarning

### DIFF
--- a/packages/truffle-core/cli.js
+++ b/packages/truffle-core/cli.js
@@ -10,6 +10,12 @@ var OS = require("os");
 
 var command = new Command(require("./lib/commands"));
 
+// Hack to suppress web3 MaxListenersExceededWarning
+// This should be removed when issue is resolved upstream:
+// https://github.com/ethereum/web3.js/issues/1648
+var listeners = process.listeners('warning');
+listeners.forEach(listener => process.removeListener('warning', listener));
+
 var options = {
   logger: console
 };


### PR DESCRIPTION
+ Underlying issue described at web3 is [here](https://github.com/ethereum/web3.js/issues/1648). 
+ Rejected [PR](https://github.com/ethereum/web3.js/pull/1494) at web3 to end-run warning.

Suggests this isn't obviously the result of negligence cleaning up emitters here. Also not proof of a lack of negligence, although have tried hard not to neglect this.

Also looks like it's not possible to manually set these limits on the PromiEvent since that part of the EventEmitter interface [isn't exposed](https://github.com/ethereum/web3.js/blob/1.0/packages/web3-core-promievent/src/index.js#L52-L60).

Warning looks like this:
```shell
(node:60858) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 data listeners added. Use emitter.setMaxListeners() to increase limit
```

Believe this will also need to be done for the console/develop but a different approach might be possible there. Mocha implements it's `--no-warnings` option by passing it as node flag to the process when they [shell out](https://github.com/mochajs/mocha/blob/1d486155e37743e1ba3ea6384268911d7e922cd0/bin/mocha#L42-L74).
