### PR TITLE
Stop expecting `constant` and `payable` in ABIs

### DIFF
--- a/packages/truffle-contract-schema/spec/abi.spec.json
+++ b/packages/truffle-contract-schema/spec/abi.spec.json
@@ -65,7 +65,7 @@
         "constant": { "type": "boolean" },
         "payable": { "type": "boolean", "default": false }
       },
-      "required": ["name", "inputs", "constant"],
+      "required": ["name", "inputs", "stateMutability"],
       "additionalProperties": false
     },
 
@@ -80,9 +80,13 @@
           "type": "array",
           "items": { "$ref": "#/definitions/Parameter" }
         },
+        "stateMutability": {
+          "$ref": "#/definitions/StateMutability"
+        },
+        "constant": { "type": "boolean" },
         "payable": { "type": "boolean", "default": false }
       },
-      "required": ["type", "inputs"],
+      "required": ["type", "inputs", "stateMutability"],
       "additionalProperties": false
     },
 
@@ -93,10 +97,13 @@
           "type": "string",
           "enum": ["fallback"]
         },
+        "stateMutability": {
+          "$ref": "#/definitions/StateMutability"
+        },
         "constant": { "type": "boolean" },
         "payable": { "type": "boolean", "default": false }
       },
-      "required": ["type"],
+      "required": ["type", "stateMutability"],
       "additionalProperties": false
     },
 

--- a/packages/truffle-contract-schema/test/MetaCoin.json
+++ b/packages/truffle-contract-schema/test/MetaCoin.json
@@ -2,7 +2,6 @@
   "contractName": "MetaCoin",
   "abi": [
     {
-      "constant": false,
       "inputs": [
         {
           "name": "addr",
@@ -16,11 +15,10 @@
           "type": "uint256"
         }
       ],
-      "payable": false,
+      "stateMutability": "nonpayable",
       "type": "function"
     },
     {
-      "constant": false,
       "inputs": [
         {
           "name": "receiver",
@@ -38,11 +36,10 @@
           "type": "bool"
         }
       ],
-      "payable": false,
+      "stateMutability": "nonpayable",
       "type": "function"
     },
     {
-      "constant": false,
       "inputs": [
         {
           "name": "addr",
@@ -56,12 +53,12 @@
           "type": "uint256"
         }
       ],
-      "payable": false,
+      "stateMutability": "nonpayable",
       "type": "function"
     },
     {
       "inputs": [],
-      "payable": false,
+      "stateMutability": "nonpayable",
       "type": "constructor"
     },
     {

--- a/packages/truffle-contract-schema/test/abi-schema.js
+++ b/packages/truffle-contract-schema/test/abi-schema.js
@@ -80,19 +80,19 @@ describe("ABI Schema", function() {
     });
   });
   describe("normal function definition", function() {
-    it("can omit type, outputs, and payable", function() {
+    it("can omit type, outputs, constant, and payable", function() {
       var abi = [{
         "name": "press",
         "inputs": [{
           "name": "button",
           "type": "uint256"
         }],
-        "constant": false
+        "stateMutability": "nonpayable"
       }];
 
       assert(validate(abi));
       assert.equal(abi[0].type, "function");
-      assert.equal(abi[0].payable, false);
+      assert.equal(abi[0].stateMutability, "nonpayable");
       assert.deepEqual(abi[0].outputs, []);
     });
 
@@ -100,9 +100,8 @@ describe("ABI Schema", function() {
       var abi = [{
         "type": "function",
         "outputs": [],
-        "payable": true,
         "inputs": [],
-        "constant": false
+        "stateMutability": "nonpayable"
       }];
 
       assert(!validate(abi));
@@ -113,20 +112,7 @@ describe("ABI Schema", function() {
         "name": "pressButton",
         "type": "function",
         "outputs": [],
-        "payable": true,
-        "constant": false
-      }];
-
-      assert(!validate(abi));
-    });
-
-    it("cannot omit constant", function() {
-      var abi = [{
-        "name": "pressButton",
-        "type": "function",
-        "inputs": [],
-        "outputs": [],
-        "payable": true
+        "stateMutability": "nonpayable"
       }];
 
       assert(!validate(abi));
@@ -134,18 +120,20 @@ describe("ABI Schema", function() {
   });
 
   describe("constructor function definition", function() {
-    it("can omit payable", function() {
+    it("can omit constant, and payable", function() {
       var abi = [{
         "type": "constructor",
         "inputs": [{
           "name": "button",
           "type": "uint256"
-        }]
+        }],
+        "stateMutability": "nonpayable"
       }];
 
-      var valid = validate(abi);
-      assert(valid);
-      assert.equal(abi[0].payable, false);
+      assert(validate(abi));
+      assert.equal(abi[0].type, "constructor");
+      assert.equal(abi[0].stateMutability, "nonpayable");
+      assert.deepEqual(abi[0].outputs, []);
     });
 
     it("cannot include name", function() {
@@ -155,7 +143,8 @@ describe("ABI Schema", function() {
         "inputs": [{
           "name": "button",
           "type": "uint256"
-        }]
+        }],
+        "stateMutability": "nonpayable"
       }];
 
       assert(!validate(abi));
@@ -173,7 +162,8 @@ describe("ABI Schema", function() {
         "outputs": [{
           "name": "amount",
           "type": "uint256"
-        }]
+        }],
+        "stateMutability": "nonpayable"
       }];
       assert(!validate(abi));
 
@@ -183,7 +173,8 @@ describe("ABI Schema", function() {
           "name": "button",
           "type": "uint256"
         }],
-        "outputs": []
+        "outputs": [],
+        "stateMutability": "nonpayable"
       }];
       assert(!validate(abi));
     });
@@ -191,42 +182,30 @@ describe("ABI Schema", function() {
     it("cannot omit inputs", function() {
       var abi = [{
         "type": "constructor",
-        "payable": true
+        "stateMutability": "nonpayable"
       }];
 
-      assert(!validate(abi));
-    });
-
-    it("cannot include constant", function() {
-      var abi = [{
-        "type": "constructor",
-        "inputs": [{
-          "name": "button",
-          "type": "uint256"
-        }],
-        "constant": false
-      }];
       assert(!validate(abi));
     });
   });
 
   describe("fallback function definition", function() {
-    it("can omit payable", function() {
+    it("can omit constant and payable", function() {
       var abi = [{
         "type": "fallback",
-        "constant": false
+        "stateMutability": "nonpayable"
       }];
 
       var valid = validate(abi);
       assert(valid);
-      assert.equal(abi[0].payable, false);
+      assert.equal(abi[0].stateMutability, "nonpayable");
     });
 
     it("cannot include name", function() {
       var abi = [{
         "type": "fallback",
-        "constant": false,
         "name": "default",
+        "stateMutability": "nonpayable"
       }];
 
       assert(!validate(abi));
@@ -237,7 +216,7 @@ describe("ABI Schema", function() {
 
       abi = [{
         "type": "fallback",
-        "constant": false,
+        "stateMutability": "nonpayable",
         "outputs": [{
           "name": "amount",
           "type": "uint256"
@@ -247,7 +226,7 @@ describe("ABI Schema", function() {
 
       abi = [{
         "type": "fallback",
-        "constant": false,
+        "stateMutability": "nonpayable",
         "outputs": []
       }];
       assert(!validate(abi));
@@ -256,7 +235,7 @@ describe("ABI Schema", function() {
     it("cannot include inputs", function() {
       var abi = [{
         "type": "fallback",
-        "payable": true,
+        "stateMutability": "payable",
         "inputs": [{
           "name": "arg",
           "type": "uint256"
@@ -264,15 +243,6 @@ describe("ABI Schema", function() {
       }];
 
       assert(!validate(abi));
-    });
-
-    it("can omit constant", function() {
-      var abi = [{
-        "type": "fallback",
-        "payable": true
-      }];
-
-      assert(validate(abi));
     });
   });
 });

--- a/packages/truffle-contract-schema/test/solc.js
+++ b/packages/truffle-contract-schema/test/solc.js
@@ -4,7 +4,21 @@ var Schema = require("../");
 var debug = require("debug")("test:solc");
 
 describe("solc", function() {
-  var exampleSolidity = "contract A { function doStuff() {} } \n\n contract B { function somethingElse() {} }";
+  var exampleSolidity = `pragma solidity ^0.4.24;
+pragma experimental "v0.5.0";
+
+contract A {
+  uint x;
+
+  function doStuff() public {
+    x = 5;
+  }
+}
+
+contract B {
+  function somethingElse() public pure {}
+}
+`;
 
   it("processes solc compile output correctly", function(done) {
     this.timeout(10000);

--- a/packages/truffle-contract/README.md
+++ b/packages/truffle-contract/README.md
@@ -206,7 +206,7 @@ contract MyContract {
     value = val;
     ValueSet(value);
   }
-  function getValue() constant returns (uint) {
+  function getValue() view returns (uint) {
     return value;
   }
 }
@@ -277,7 +277,7 @@ instance.getValue.call().then(function(val) {
 });
 ```
 
-Even more helpful, however is we *don't even need* to use `.call` when a function is marked as `constant`, because `truffle-contract` will automatically know that that function can only be interacted with via a call:
+Even more helpful, however is we *don't even need* to use `.call` when a function is marked as `view` or `pure`, because `truffle-contract` will automatically know that that function can only be interacted with via a call:
 
 ```javascript
 instance.getValue().then(function(val) {

--- a/packages/truffle-contract/lib/contract.js
+++ b/packages/truffle-contract/lib/contract.js
@@ -38,7 +38,10 @@ var contract = (function(module) {
 
       switch(item.type) {
         case "function":
-          var isConstant = item.constant === true;
+          var isConstant =
+            ["pure", "view"].includes(item.stateMutability) ||  // new form
+            item.constant;  // deprecated case
+
           var signature = webUtils._jsonInterfaceMethodToString(item);
 
           var method = function(constant, web3Method){


### PR DESCRIPTION
Ref: #1093 

Solidity is moving away from usage of `constant` and `payable` properties in the ABI. This PR removes those fields as being any kind of required, and instead now relies on the `stateMutability` property.

- Update schema accordingly
- Change tests to reflect new requirements
- Also (for good measure) put `pragma experimental "v0.5.0"` in the schema `solc` tests
- Fix a readme