### PR TITLE
Process exit(0) at cli.js

### DIFF
--- a/packages/truffle-core/cli.js
+++ b/packages/truffle-core/cli.js
@@ -43,19 +43,5 @@ command.run(process.argv.slice(2), options, function(err) {
     process.exit(1);
   }
 
-  // Don't exit if no error; if something is keeping the process open,
-  // like `truffle console`, then let it.
-
-  // Clear any polling or open sockets - `provider-engine` in HDWallet
-  // and `web3 1.0 confirmations` both leave interval timers etc wide open.
-  const handles = process._getActiveHandles();
-  handles.forEach(handle => {
-    if (typeof handle.close === 'function'){
-      handle.close();
-    } else if (handle.readable && !handle._isStdio){
-      //This is causing problems over RPC
-      //with hd-wallet-provider V5
-      //handle.destroy();
-    }
-  });
+  process.exit(0);
 });


### PR DESCRIPTION
What *is* [this comment](https://github.com/trufflesuite/truffle/blob/develop/packages/truffle-core/cli.js#L40-L41) about?
> // Don't exit if no error; if something is keeping the process open,
  // like `truffle console`, then let it.

Commands launched in`truffle console` do not appear to exit through this callback. It's only run when a terminal launched command exits - e.g. it will only run when you type `.exit` into the repl. 

There's some back and forth in the blame here a year ago and it's not clear what the underlying issue was. 

We need this to `process.exit` now because websockets and eth-block-tracker are a tangle of open interval handlers and unclosed sockets within their own codebases. We're either getting hanging or crashing and strategies for managing one vs. the other are not obviously reconcilable. 

NB: these problems *only* appear to affect the terminal launched command. I can run a websockets enabled config within the console and have commands complete without hanging. 