### PR TITLE
Support debugging mappings of structs of mappings of structs...

### DIFF
--- a/packages/truffle-debugger/lib/data/actions/index.js
+++ b/packages/truffle-debugger/lib/data/actions/index.js
@@ -21,3 +21,11 @@ export function assign(context, assignments) {
     context, assignments
   };
 }
+
+export const MAP_KEY = "MAP_KEY";
+export function mapKey(id, key) {
+  return {
+    type: MAP_KEY,
+    id, key
+  };
+}

--- a/packages/truffle-debugger/lib/data/decode/index.js
+++ b/packages/truffle-debugger/lib/data/decode/index.js
@@ -116,7 +116,15 @@ export function decodeMemoryReference(definition, pointer, info) {
 
     case "struct":
       const { scopes } = info;
-      let structDefinition = scopes[definition.typeName.referencedDeclaration];
+
+      // Declaration reference usually appears in `typeName`, but for
+      // { nodeType: "FunctionCall", kind: "structConstructorCall" }, this
+      // reference appears to live in `expression`
+      const referencedDeclaration = (definition.typeName)
+        ? definition.typeName.referencedDeclaration
+        : definition.expression.referencedDeclaration;
+
+      let structDefinition = scopes[referencedDeclaration];
       let structVariables = structDefinition.variables || [];
 
       return Object.assign(

--- a/packages/truffle-debugger/lib/data/decode/index.js
+++ b/packages/truffle-debugger/lib/data/decode/index.js
@@ -124,11 +124,10 @@ export function decodeMemoryReference(definition, pointer, info) {
         ? definition.typeName.referencedDeclaration
         : definition.expression.referencedDeclaration;
 
-      let structDefinition = scopes[referencedDeclaration];
-      let structVariables = structDefinition.variables || [];
+      let { variables } = (scopes[referencedDeclaration] || {});
 
       return Object.assign(
-        {}, ...structVariables
+        {}, ...(variables || [])
           .map(
             ({name, id}, i) => {
               let memberDefinition = scopes[id].definition;
@@ -275,8 +274,18 @@ export function decodeStorageReference(definition, pointer, info) {
     case "struct":
       const { scopes } = info;
 
+      const referencedDeclaration = (definition.typeName)
+        ? definition.typeName.referencedDeclaration
+        : definition.referencedDeclaration;
+
+      const { variables } = (scopes[referencedDeclaration] || {});
+
+      const allocation = utils.allocateDeclarations(
+        variables || [], scopes, pointer.storage.from.slot
+      );
+
       return Object.assign(
-        {}, ...Object.entries(pointer.storage.children)
+        {}, ...Object.entries(allocation.children)
           .map( ([id, childPointer]) => ({
             [childPointer.name]: decode(
               scopes[id].definition, { storage: childPointer }, info

--- a/packages/truffle-debugger/lib/data/decode/index.js
+++ b/packages/truffle-debugger/lib/data/decode/index.js
@@ -48,6 +48,10 @@ export function decodeValue(definition, pointer, info) {
 
     case "bytes":
       debug("typeIdentifier %s %o", utils.typeIdentifier(definition), bytes);
+      // HACK bytes may be getting passed in as a literal hexstring
+      if (typeof bytes == "string") {
+        return bytes;
+      }
       let length = utils.specifiedSize(definition);
       return utils.toHexString(bytes, length);
 
@@ -329,7 +333,7 @@ export function decodeMapping(definition, pointer, info) {
 
 
 export default function decode(definition, pointer, info) {
-  if (pointer.literal) {
+  if (pointer.literal != undefined) {
     return decodeValue(definition, pointer, info);
   }
 

--- a/packages/truffle-debugger/lib/data/decode/index.js
+++ b/packages/truffle-debugger/lib/data/decode/index.js
@@ -209,21 +209,23 @@ export function decodeStorageReference(definition, pointer, info) {
         return position * baseSize;
       }
 
+      let from = {
+        slot: utils.normalizeSlot(pointer.storage.from.slot),
+        index: pointer.storage.from.index
+      };
+
       debug("pointer: %o", pointer);
       return [...Array(length).keys()]
         .map( (i) => {
-          let childFrom = pointer.storage.from.offset != undefined ?
-            {
-              slot: ["0x" + utils.toBigNumber(
-                utils.keccak256(...pointer.storage.from.slot)
-              ).plus(pointer.storage.from.offset).toString(16)],
+          let childFrom = {
+            slot: {
+              path: (from.slot.path instanceof Array)
+                ? from.slot.path
+                : [from.slot],
               offset: offset(i),
-              index: index(i)
-            } : {
-              slot: [pointer.storage.from.slot],
-              offset: offset(i),
-              index: index(i)
-            };
+            },
+            index: index(i)
+          };
           return childFrom;
         })
         .map( (childFrom, idx) => {

--- a/packages/truffle-debugger/lib/data/decode/index.js
+++ b/packages/truffle-debugger/lib/data/decode/index.js
@@ -281,10 +281,12 @@ export function decodeMapping(definition, pointer, info) {
     // attempting to decode reference to mapping, thus missing valid pointer
     return undefined;
   }
+
+  const { mappingKeys } = info;
+
   debug("mapping %O", pointer);
   debug("mapping definition %O", definition);
-  let { keys } = pointer;
-  keys = keys || [];
+  let keys = mappingKeys[definition.id] || [];
   debug("known keys %o", keys);
 
   let keyDefinition = definition.typeName.keyType;

--- a/packages/truffle-debugger/lib/data/decode/index.js
+++ b/packages/truffle-debugger/lib/data/decode/index.js
@@ -21,7 +21,8 @@ export function read(pointer, state) {
 }
 
 
-export function decodeValue(definition, pointer, state, ...args) {
+export function decodeValue(definition, pointer, info) {
+  const { state } = info;
   debug(
     "decoding value, pointer: %o, typeClass: %s",
     pointer, utils.typeClass(definition)
@@ -68,7 +69,8 @@ export function decodeValue(definition, pointer, state, ...args) {
   }
 }
 
-export function decodeMemoryReference(definition, pointer, state, ...args) {
+export function decodeMemoryReference(definition, pointer, info) {
+  const { state } = info
   debug("pointer %o", pointer);
   let rawValue = read(pointer, state)
   if (rawValue == undefined) {
@@ -86,9 +88,11 @@ export function decodeMemoryReference(definition, pointer, state, ...args) {
         memory: { start: rawValue, length: WORD_SIZE}
       }, state); // bytes contain length
 
-      return decodeValue(definition, {
+      let childPointer = {
         memory: { start: rawValue + WORD_SIZE, length: bytes }
-      }, state, ...args);
+      }
+
+      return decodeValue(definition, childPointer, info);
 
     case "array":
       bytes = utils.toBigNumber(read({
@@ -103,19 +107,19 @@ export function decodeMemoryReference(definition, pointer, state, ...args) {
         .map(
           (chunk) => decode(utils.baseDefinition(definition), {
             literal: chunk
-          }, state, ...args)
+          }, info)
         )
 
     case "struct":
-      let [refs] = args;
-      let structDefinition = refs[definition.typeName.referencedDeclaration];
+      const { scopes } = info;
+      let structDefinition = scopes[definition.typeName.referencedDeclaration];
       let structVariables = structDefinition.variables || [];
 
       return Object.assign(
         {}, ...structVariables
           .map(
             ({name, id}, i) => {
-              let memberDefinition = refs[id].definition;
+              let memberDefinition = scopes[id].definition;
               let memberPointer = {
                 memory: { start: rawValue + i * WORD_SIZE, length: WORD_SIZE }
               };
@@ -136,7 +140,7 @@ export function decodeMemoryReference(definition, pointer, state, ...args) {
 
               return {
                 [name]: decode(
-                  memberDefinition, memberPointer, state, ...args
+                  memberDefinition, memberPointer, info
                 )
               };
             }
@@ -152,11 +156,13 @@ export function decodeMemoryReference(definition, pointer, state, ...args) {
 
 }
 
-export function decodeStorageReference(definition, pointer, state, ...args) {
+export function decodeStorageReference(definition, pointer, info) {
   var data;
   var bytes;
   var length;
   var slot;
+
+  const { state } = info;
 
   switch (utils.typeClass(definition)) {
     case "array":
@@ -213,7 +219,7 @@ export function decodeStorageReference(definition, pointer, state, ...args) {
           return decode(utils.baseDefinition(definition), { storage: {
             from: childFrom,
             length: baseSize
-          }}, state, ...args);
+          }}, info);
         });
 
     case "bytes":
@@ -240,7 +246,7 @@ export function decodeStorageReference(definition, pointer, state, ...args) {
         return decodeValue(definition, { storage: {
           from: { slot: pointer.storage.from.slot, index: 0 },
           to: { slot: pointer.storage.from.slot, index: length - 1}
-        }}, state, ...args);
+        }}, info);
 
       } else {
         length = utils.toBigNumber(data).minus(1).div(2).toNumber();
@@ -249,17 +255,17 @@ export function decodeStorageReference(definition, pointer, state, ...args) {
         return decodeValue(definition, { storage: {
           from: { slot: [pointer.storage.from.slot], index: 0 },
           length
-        }}, state, ...args);
+        }}, info);
       }
 
     case "struct":
-      let [refs] = args;
+      const { scopes } = info;
 
       return Object.assign(
         {}, ...Object.entries(pointer.storage.children)
           .map( ([id, childPointer]) => ({
             [childPointer.name]: decode(
-              refs[id].definition, { storage: childPointer }, state, ...args
+              scopes[id].definition, { storage: childPointer }, info
             )
           }))
       );
@@ -270,7 +276,7 @@ export function decodeStorageReference(definition, pointer, state, ...args) {
   }
 }
 
-export function decodeMapping(definition, pointer, ...args) {
+export function decodeMapping(definition, pointer, info) {
   if (definition.referencedDeclaration) {
     // attempting to decode reference to mapping, thus missing valid pointer
     return undefined;
@@ -308,11 +314,11 @@ export function decodeMapping(definition, pointer, ...args) {
     debug("keyPointer %o", keyPointer);
 
     // NOTE mapping keys are potentially lossy because JS only likes strings
-    let keyValue = decode(keyDefinition, keyPointer, ...args);
+    let keyValue = decode(keyDefinition, keyPointer, info);
     debug("keyValue %o", keyValue);
     if (keyValue != undefined) {
       mapping[keyValue.toString()] =
-        decode(valueDefinition, valuePointer, ...args);
+        decode(valueDefinition, valuePointer, info);
     }
   }
 
@@ -320,9 +326,9 @@ export function decodeMapping(definition, pointer, ...args) {
 }
 
 
-export default function decode(definition, pointer, ...args) {
+export default function decode(definition, pointer, info) {
   if (pointer.literal) {
-    return decodeValue(definition, pointer, ...args);
+    return decodeValue(definition, pointer, info);
   }
 
   const identifier = utils.typeIdentifier(definition);
@@ -330,10 +336,10 @@ export default function decode(definition, pointer, ...args) {
     switch (utils.referenceType(definition)) {
       case "memory":
         debug("decoding memory reference, type: %s", identifier);
-        return decodeMemoryReference(definition, pointer, ...args);
+        return decodeMemoryReference(definition, pointer, info);
       case "storage":
         debug("decoding storage reference, type: %s", identifier);
-        return decodeStorageReference(definition, pointer, ...args);
+        return decodeStorageReference(definition, pointer, info);
       default:
         debug("Unknown reference category: %s", utils.typeIdentifier(definition));
         return undefined;
@@ -342,9 +348,9 @@ export default function decode(definition, pointer, ...args) {
 
   if (utils.isMapping(definition)) {
     debug("decoding mapping, type: %s", identifier);
-    return decodeMapping(definition, pointer, ...args);
+    return decodeMapping(definition, pointer, info);
   }
 
   debug("decoding value, type: %s", identifier);
-  return decodeValue(definition, pointer, ...args);
+  return decodeValue(definition, pointer, info);
 }

--- a/packages/truffle-debugger/lib/data/decode/storage.js
+++ b/packages/truffle-debugger/lib/data/decode/storage.js
@@ -15,6 +15,9 @@ import * as utils from "./utils";
 export function slotAddress(slot) {
   if (slot instanceof Array) {
     return utils.keccak256(...slot.map(slotAddress));
+  } else if (typeof slot == "object" && slot.path != undefined) {
+    let { path, offset } = slot;
+    return utils.toBigNumber(slotAddress(path)).plus(offset);
   } else if (typeof slot == "string" && slot.slice(0,2) == "0x") {
     return utils.toBigNumber(slot);
   } else {
@@ -28,8 +31,8 @@ export function slotAddress(slot) {
  * @param slot - big number or array of regular numbers
  * @param offset - for array, offset from the keccak determined location
  */
-export function read(storage, slot, offset = 0) {
-  const address = utils.toBigNumber(slotAddress(slot)).plus(offset);
+export function read(storage, slot) {
+  const address = slotAddress(slot);
 
   debug("reading slot: %o", utils.toHexString(address));
 
@@ -45,15 +48,18 @@ export function read(storage, slot, offset = 0) {
  *
  * parameters `from` and `to` are objects with the following properties:
  *
- *   slot - (required) either a bignumber or a "path" array of integer offsets
+ *   slot - (required) one of the following:
+ *     - a literal value referring to a slot (a number, a bytestring, etc.)
  *
- *     path array values get converted into keccak256 hash as per solidity
- *     storage allocation method
+ *     - a "path" array of literal values
+ *       path array values get converted into keccak256 hash as per solidity
+ *       storage allocation method, after recursing.
+ *
+ *     - an object { path, offset }, where path is one of the above ^
+ *       offset values indicate sequential address offset, post-keccak
  *
  *     ref: https://solidity.readthedocs.io/en/v0.4.23/miscellaneous.html#layout-of-state-variables-in-storage
  *     (search "concatenation")
- *
- *  offset - (default: 0) slot offset
  *
  *  index - (default: 0) byte index in word
  *
@@ -61,39 +67,45 @@ export function read(storage, slot, offset = 0) {
  * @param to - location (see ^). inclusive.
  * @param length - instead of `to`, number of bytes after `from`
  */
-export function readRange(storage, {from, to, length}) {
+export function readRange(storage, range) {
+  debug("readRange %o", range);
+
+  let { from, to, length } = range;
   if (!length && !to || length && to) {
     throw new Error("must specify exactly one `to`|`length`");
   }
 
   from = {
-    ...from,
-    offset: from.offset || 0
+    slot: utils.normalizeSlot(from.slot),
+    index: from.index || 0
   };
 
   if (length) {
     to = {
-      slot: from.slot,
-      offset: from.offset + Math.floor((from.index + length - 1) / WORD_SIZE),
+      slot: {
+        path: from.slot.path,
+        offset: from.slot.offset +
+          Math.floor((from.index + length - 1) / WORD_SIZE)
+      },
       index: (from.index + length - 1) % WORD_SIZE
     };
   } else {
     to = {
-      ...to,
-      offset: to.offset || 0
+      slot: utils.normalizeSlot(to.slot),
+      index: to.index
     }
   }
 
-  debug("readRange %o", {from,to});
+  debug("normalized readRange %o", {from,to});
 
-  const totalWords = to.offset - from.offset + 1;
+  const totalWords = to.slot.offset - from.slot.offset + 1;
   debug("totalWords %o", totalWords);
 
   let data = new Uint8Array(totalWords * WORD_SIZE);
 
   for (let i = 0; i < totalWords; i++) {
-    let offset = i + from.offset;
-    data.set(read(storage, from.slot, offset), i * WORD_SIZE);
+    let offset = i + from.slot.offset;
+    data.set(read(storage, { ...from.slot, offset }), i * WORD_SIZE);
   }
   debug("words %o", data);
 

--- a/packages/truffle-debugger/lib/data/decode/storage.js
+++ b/packages/truffle-debugger/lib/data/decode/storage.js
@@ -15,6 +15,8 @@ import * as utils from "./utils";
 export function slotAddress(slot) {
   if (slot instanceof Array) {
     return utils.keccak256(...slot.map(slotAddress));
+  } else if (typeof slot == "string" && slot.slice(0,2) == "0x") {
+    return utils.toBigNumber(slot);
   } else {
     return slot;
   }

--- a/packages/truffle-debugger/lib/data/decode/utils.js
+++ b/packages/truffle-debugger/lib/data/decode/utils.js
@@ -92,15 +92,29 @@ export function allocateDeclarations(
 }
 
 function allocateValue(slot, index, bytes) {
-  let from = index - bytes + 1 >= 0 ?
-    { slot, index: index - bytes + 1 } :
-    { slot: slot + 1, index: WORD_SIZE - bytes };
+  slot = normalizeSlot(slot);
+
+  let from = (index - bytes + 1 >= 0)
+    ? { slot, index: index - bytes + 1 }
+    : {
+        slot: {
+          path: slot.path,
+          offset: slot.offset + 1
+        },
+        index: WORD_SIZE - bytes
+      };
 
   let to = { slot: from.slot, index: from.index + bytes - 1 };
 
-  let next = from.index == 0 ?
-    { slot: from.slot + 1, index: WORD_SIZE - 1 } :
-    { slot: from.slot, index: from.index - 1 };
+  let next = (from.index == 0)
+    ? {
+        slot: {
+          path: from.slot.path,
+          offset: from.slot.offset + 1
+        },
+        index: WORD_SIZE - 1
+      }
+    : { slot: from.slot, index: from.index - 1 };
 
   return { from, to, next };
 }
@@ -120,6 +134,24 @@ function allocateDeclaration(declaration, refs, slot, index) {
   debug("struct result %o", result);
   return result;
 }
+
+/**
+ * Convert polymorphic slot value into canonical { path, offset } pair.
+ */
+export function normalizeSlot(slot) {
+  if (typeof slot == "object" && slot.path != undefined) {
+    return {
+      path: slot.path,
+      offset: slot.offset || 0
+    };
+  }
+
+  return {
+    path: slot,
+    offset: 0
+  };
+}
+
 
 /**
  * e.g. uint48 -> 6

--- a/packages/truffle-debugger/lib/data/decode/utils.js
+++ b/packages/truffle-debugger/lib/data/decode/utils.js
@@ -53,8 +53,13 @@ export function allocateDeclarations(
   slot = 0,
   index = WORD_SIZE - 1,
 ) {
+  slot = normalizeSlot(slot);
+
   if (index < WORD_SIZE - 1) {  // starts a new slot
-    slot++;
+    slot = {
+      path: slot,
+      offset: 1
+    };
     index = WORD_SIZE - 1;
   }
 
@@ -78,7 +83,10 @@ export function allocateDeclarations(
   }
 
   if (index < WORD_SIZE - 1) {
-    slot++;
+    slot = {
+      path: slot,
+      offset: 1
+    };
     index = WORD_SIZE - 1;
   }
 
@@ -91,8 +99,6 @@ export function allocateDeclarations(
 }
 
 function allocateValue(slot, index, bytes) {
-  slot = normalizeSlot(slot);
-
   let from = (index - bytes + 1 >= 0)
     ? { slot, index: index - bytes + 1 }
     : {

--- a/packages/truffle-debugger/lib/data/decode/utils.js
+++ b/packages/truffle-debugger/lib/data/decode/utils.js
@@ -52,7 +52,6 @@ export function allocateDeclarations(
   refs,
   slot = 0,
   index = WORD_SIZE - 1,
-  path = []
 ) {
   if (index < WORD_SIZE - 1) {  // starts a new slot
     slot++;

--- a/packages/truffle-debugger/lib/data/reducers.js
+++ b/packages/truffle-debugger/lib/data/reducers.js
@@ -91,8 +91,34 @@ function assignments(state = DEFAULT_ASSIGNMENTS, action) {
   }
 };
 
+const DEFAULT_MAPPING_KEYS = {
+  byId: {}
+}
+
+function mappingKeys(state = DEFAULT_MAPPING_KEYS, action) {
+  switch (action.type) {
+    case actions.MAP_KEY:
+      let { id, key } = action;
+      return {
+        byId: {
+          ...state.byId,
+
+          // add new key to set of keys already defined
+          [id]: [...new Set([
+            ...(state.byId[id] || []),
+            key
+          ])]
+        }
+      };
+
+    default:
+      return state;
+  }
+}
+
 const proc = combineReducers({
-  assignments
+  assignments,
+  mappingKeys
 });
 
 const reducer = combineReducers({

--- a/packages/truffle-debugger/lib/data/sagas/index.js
+++ b/packages/truffle-debugger/lib/data/sagas/index.js
@@ -136,25 +136,10 @@ function *tickSaga() {
             });
 
       debug("index value %O", indexValue);
-      if (indexValue == undefined) {
-        break;
+      if (indexValue != undefined) {
+        yield put(actions.mapKey(baseDeclarationId, indexValue));
       }
 
-      assignments = {
-        [baseDeclarationId]: {
-          ...baseAssignment,
-          keys: [
-            ...new Set([
-              ...(baseAssignment.keys || []),
-              indexValue
-            ])
-          ]
-        }
-      }
-
-      debug("mapping assignments %O", assignments);
-      yield put(actions.assign(treeId, assignments));
-      debug("new assignments %O", yield select(data.proc.assignments));
       break;
 
     case "Assignment":

--- a/packages/truffle-debugger/lib/data/sagas/index.js
+++ b/packages/truffle-debugger/lib/data/sagas/index.js
@@ -145,14 +145,13 @@ function *tickSaga() {
     case "Assignment":
       break;
 
-
     default:
       if (node.typeDescriptions == undefined) {
         break;
       }
 
       debug("decoding expression value %O", node.typeDescriptions);
-      let literal = decode(node, { "stack": top });
+      let literal = stack[top];
 
       yield put(actions.assign(treeId, {
         [node.id]: { literal }

--- a/packages/truffle-debugger/lib/data/sagas/index.js
+++ b/packages/truffle-debugger/lib/data/sagas/index.js
@@ -125,15 +125,18 @@ function *tickSaga() {
       }
 
       const indexAssignment = (currentAssignments[indexId] || {}).ref;
+      debug("indexAssignment %O", indexAssignment);
       // HACK because string literal AST nodes are not sourcemapped to directly
       // value appears to be available in `node.indexExpression.hexValue`
       // [observed with solc v0.4.24]
-      const indexValue = (indexAssignment)
-        ? decode(node.indexExpression, indexAssignment)
-        : utils.typeClass(node.indexExpression) == "stringliteral" &&
-            decode(node.indexExpression, {
-              "literal": utils.toBytes(node.indexExpression.hexValue)
-            });
+      let indexValue;
+      if (indexAssignment) {
+        indexValue = decode(node.indexExpression, indexAssignment)
+      } else if (utils.typeClass(node.indexExpression) == "stringliteral") {
+        indexValue = decode(node.indexExpression, {
+          "literal": utils.toBytes(node.indexExpression.hexValue)
+        })
+      }
 
       debug("index value %O", indexValue);
       if (indexValue != undefined) {

--- a/packages/truffle-debugger/lib/data/selectors/index.js
+++ b/packages/truffle-debugger/lib/data/selectors/index.js
@@ -106,11 +106,12 @@ const data = createSelectorTree({
      * selector returns (ast node definition, data reference) => value
      */
     decoder: createLeaf(
-      ["/views/scopes/inlined", "/next/state"],
+      ["/views/scopes/inlined", "/next/state", "/proc/mappingKeys"],
 
-      (scopes, state) => {
-        return (definition, ref) => decode(definition, ref, { state, scopes })
-      }
+      (scopes, state, mappingKeys) =>
+        (definition, ref) => decode(definition, ref, {
+          scopes, state, mappingKeys
+        })
     )
   },
 
@@ -133,7 +134,18 @@ const data = createSelectorTree({
     /**
      * data.proc.assignments
      */
-    assignments: createLeaf(["/state"], (state) => state.proc.assignments.byId)
+    assignments: createLeaf(
+      ["/state"], (state) => state.proc.assignments.byId
+    ),
+
+    /**
+     * data.proc.mappingKeys
+     *
+     * known keys for each mapping (identified by node ID)
+     */
+    mappingKeys: createLeaf(
+      ["/state"], (state) => state.proc.mappingKeys.byId
+    )
   },
 
   /**

--- a/packages/truffle-debugger/lib/data/selectors/index.js
+++ b/packages/truffle-debugger/lib/data/selectors/index.js
@@ -109,7 +109,7 @@ const data = createSelectorTree({
       ["/views/scopes/inlined", "/next/state"],
 
       (scopes, state) => {
-        return (definition, ref) => decode(definition, ref, state, scopes)
+        return (definition, ref) => decode(definition, ref, { state, scopes })
       }
     )
   },


### PR DESCRIPTION
Sequel to #1108 

This supports nested mappings by updating calculation of storage slots and struct allocations.

- Update `slot` data type to encode offset natively, to represent arbitrarily nested storage variable declarations. When computing recursively described slots, respect offset values in the inner-slot.
- Move known mapping keys outside assignments state and into separate field.
- Pass known mapping keys as info to decode functions
- Compress decode function signatures and remove annoying `...args` splats.