### PR TITLE
Extract reasons on error only

### DIFF
--- a/packages/truffle-contract/lib/reason.js
+++ b/packages/truffle-contract/lib/reason.js
@@ -1,0 +1,55 @@
+/**
+ * Methods to fetch and decode reason string from ganache when a tx errors.
+ */
+
+const reason = {
+  /**
+   * Extracts a reason string from `eth_call` response
+   * @param  {Object}           res  response from `eth_call` to extract reason
+   * @param  {Web3}             web3 a helpful friend
+   * @return {String|Undefined}      decoded reason string
+   */
+  _extract: function(res, web3){
+    if (!res || (!res.error && !res.result)) return;
+
+    const errorStringHash = '0x08c379a0';
+
+    const isObject = res && typeof res === 'object' && res.error && res.error.data;
+    const isString = res && typeof res === 'object' && typeof res.result === 'string';
+
+    if (isObject) {
+      const data = res.error.data;
+      const hash = Object.keys(data)[0];
+
+      if (data[hash].return && data[hash].return.includes(errorStringHash)){
+        return web3.eth.abi.decodeParameter('string', data[hash].return.slice(10))
+      }
+
+    } else if (isString && res.result.includes(errorStringHash)){
+      return web3.eth.abi.decodeParameter('string', res.result.slice(10))
+    }
+  },
+
+  /**
+   * Runs tx via `eth_call` and resolves a reason string if it exists on the response.
+   * @param  {Object} web3
+   * @return {String|Undefined}
+   */
+  get: function(params, web3){
+    const packet = {
+      jsonrpc: "2.0",
+      method: "eth_call",
+      params: [params],
+      id: new Date().getTime(),
+    }
+
+    return new Promise(resolve => {
+      web3.currentProvider.send(packet, (err, response) => {
+        const reasonString = reason._extract(response, web3);
+        resolve(reasonString);
+      })
+    })
+  },
+};
+
+module.exports = reason;


### PR DESCRIPTION
#1102 

+ Makes reason string fetching an error triggered post-fetch rather than a tx triggered pre-fetch 
+ Restores logic that only run gas estimation if no other values have been specified (e.g in the tx params or network config)
+ Moves reason string logic to its own file.

We discussed running these calls using the `defaultBlock` param - haven't added that here - in many cases it would require that we make another call to get the blockNumber. Even that value might not be correct post-call if ganache is auto-mining or something, and we don't want to do it pre-call because it obviates the performance gains we need here. 

Also just think its not worth it to manage this given the rarity of the edge cases that would suffer from a post-tx call and how temporary this logic is anyway - as soon as the main clients work out their strategy for this feature ganache should mirror their approach and this won't be problem. 

