### PR TITLE
Restore option to listen for event with callback

### DIFF
--- a/packages/truffle-contract/test/events.js
+++ b/packages/truffle-contract/test/events.js
@@ -53,6 +53,20 @@ describe("Events [ @geth ]", function() {
     });
   })
 
+  it('should be possible to listen for events with a callback', function(done){
+    const callback = (err, data) => {
+      assert.equal("ExampleEvent", data.event);
+      assert.equal(accounts[0], data.args._from);
+      assert.equal(8, data.args.num);
+      done();
+    }
+
+    Example.new(1).then(example => {
+      example.ExampleEvent(callback);
+      example.triggerEvent();
+    })
+  });
+
   it('should fire repeatedly (without duplicates)', async function(){
     let emitter;
     let counter = 0;


### PR DESCRIPTION
#1105 

+ Adds logic to enable listening to an event via callback
+ Adds a test for same

I pulled this logic out of the original web3 1.0 draft  assuming that it's a new day and the sun's rays are websocket-enabled. 

This is true for `ganache` but geth is having some teething problems with it.  There are many reports over at web3 that the geth websocket channel is prone to random disconnection which web3 cannot recover from. Additionally large data sends cause the geth client to disconnect - it might not be possible for everyone to use the new feature.

