### PR TITLE
Allow Migrations.sol to migrate alone

### DIFF
--- a/packages/truffle-migrate/index.js
+++ b/packages/truffle-migrate/index.js
@@ -198,7 +198,7 @@ const Migrate = {
           migrations.shift();
         }
 
-        callback(null, migrations.length > 1);
+        callback(null, migrations.length > 1 || (migrations.length && number === 0));
       });
     });
   }

--- a/packages/truffle/test/scenarios/migrations/init.js
+++ b/packages/truffle/test/scenarios/migrations/init.js
@@ -1,0 +1,71 @@
+const MemoryLogger = require("../memorylogger");
+const CommandRunner = require("../commandrunner");
+const fs = require("fs");
+const path = require("path");
+const assert = require("assert");
+const Server = require("../server");
+const Reporter = require("../reporter");
+const sandbox = require("../sandbox");
+const Web3 = require('web3');
+
+const log = console.log;
+
+const util = require('util');
+
+function processErr(err, output){
+  if (err){
+    log(output);
+    throw new Error(err);
+  }
+}
+
+describe("solo migration", function() {
+  let config;
+  let web3;
+  let networkId;
+  const project = path.join(__dirname, '../../sources/migrations/init');
+  const logger = new MemoryLogger();
+
+  before(done => Server.start(done));
+  after(done => Server.stop(done));
+
+  before(async function() {
+    this.timeout(10000);
+    config = await sandbox.create(project)
+    config.network = "development";
+    config.logger = logger;
+    config.mocha = {
+      reporter: new Reporter(logger)
+    }
+
+    const provider = new Web3.providers.HttpProvider('http://localhost:8545')
+    web3 = new Web3(provider);
+    networkId = await web3.eth.net.getId();
+  });
+
+  it("runs a migration with just Migrations.sol ", function(done) {
+    this.timeout(70000);
+
+    CommandRunner.run("migrate", config, err => {
+      const output = logger.contents();
+      processErr(err, output);
+
+      const location = path.join(config.contracts_build_directory, "Migrations.json");
+      const artifact = require(location);
+      const network = artifact.networks[networkId];
+
+      assert(output.includes(network.transactionHash));
+      assert(output.includes(network.address));
+
+      console.log(output)
+
+      // Make sure it doesn't re-migrate the solo
+      CommandRunner.run("migrate", config, err => {
+        const output = logger.contents();
+        processErr(err, output);
+        assert(output.includes('Network up to date.'))
+        done();
+      })
+    })
+  });
+});

--- a/packages/truffle/test/sources/migrations/init/contracts/Migrations.sol
+++ b/packages/truffle/test/sources/migrations/init/contracts/Migrations.sol
@@ -1,0 +1,23 @@
+pragma solidity ^0.4.23;
+
+contract Migrations {
+  address public owner;
+  uint public last_completed_migration;
+
+  constructor() public {
+    owner = msg.sender;
+  }
+
+  modifier restricted() {
+    if (msg.sender == owner) _;
+  }
+
+  function setCompleted(uint completed) public restricted {
+    last_completed_migration = completed;
+  }
+
+  function upgrade(address new_address) public restricted {
+    Migrations upgraded = Migrations(new_address);
+    upgraded.setCompleted(last_completed_migration);
+  }
+}

--- a/packages/truffle/test/sources/migrations/init/migrations/1_initial_migration.js
+++ b/packages/truffle/test/sources/migrations/init/migrations/1_initial_migration.js
@@ -1,0 +1,5 @@
+var Migrations = artifacts.require("./Migrations.sol");
+
+module.exports = function(deployer) {
+  deployer.deploy(Migrations);
+};

--- a/packages/truffle/test/sources/migrations/init/truffle.js
+++ b/packages/truffle/test/sources/migrations/init/truffle.js
@@ -1,0 +1,14 @@
+module.exports = {
+  // See <http://truffleframework.com/docs/advanced/configuration>
+  // to customize your Truffle configuration!
+  networks: {
+    development: {
+      host: "127.0.0.1",
+      port: 8545,
+      network_id: '*',
+      gas: 4700000,
+      gasPrice: 20000000000,
+    },
+  },
+};
+


### PR DESCRIPTION
#1111 and #777 

+ Lets this edge case execute as expected - e.g as long as there is a migration file and there are no previous migrations, we should migrate.
+ Adds a test which also verifies Migrations.sol doesn't unnecessarily re-migrate.

