### PR TITLE
Dereference stack/memory pointers to storage vars

### DIFF
--- a/packages/truffle-debugger/lib/data/decode/index.js
+++ b/packages/truffle-debugger/lib/data/decode/index.js
@@ -278,11 +278,16 @@ export function decodeStorageReference(definition, pointer, info) {
         ? definition.typeName.referencedDeclaration
         : definition.referencedDeclaration;
 
-      const { variables } = (scopes[referencedDeclaration] || {});
+      const variables = (scopes[referencedDeclaration] || {}).variables || [];
 
-      const allocation = utils.allocateDeclarations(
-        variables || [], scopes, pointer.storage.from.slot
-      );
+      let slot;
+      if (pointer.storage != undefined) {
+        slot = pointer.storage.from.slot;
+      } else {
+        slot = utils.normalizeSlot(utils.toBigNumber(read(pointer, state)));
+      }
+
+      const allocation = utils.allocateDeclarations(variables, scopes, slot);
 
       return Object.assign(
         {}, ...Object.entries(allocation.children)

--- a/packages/truffle-debugger/lib/data/sagas/index.js
+++ b/packages/truffle-debugger/lib/data/sagas/index.js
@@ -120,9 +120,6 @@ function *tickSaga() {
       debug("baseAssignment %O", baseAssignment);
 
       let baseDefinition = definitions[baseDeclarationId].definition;
-      if (utils.typeClass(baseDefinition) !== "mapping") {
-        break;
-      }
 
       const indexAssignment = (currentAssignments[indexId] || {}).ref;
       debug("indexAssignment %O", indexAssignment);


### PR DESCRIPTION
So that intermediary variables can be used, e.g. when grabbing a struct variable from a mapping.

For instance:
```solidity
Record storage record = someMapping[i];
```

Previously, the debugger couldn't decode `record` because the storage location was kept on the stack. This PR adds support for this.