### PR TITLE
Fix broken compilers config options

### DIFF
--- a/packages/truffle-compile/index.js
+++ b/packages/truffle-compile/index.js
@@ -39,6 +39,9 @@ var compile = function(sources, options, callback) {
     "compilers"
   ]);
 
+  expect.options(options.compilers, ["solc"]);
+  expect.options(options.compilers.solc, ["settings"]);
+
   // Grandfather in old solc config
   if (options.solc){
     compilers.solc.settings.evmVersion = options.solc.evmVersion;

--- a/packages/truffle-config/index.js
+++ b/packages/truffle-config/index.js
@@ -19,6 +19,11 @@ function Config(truffle_directory, working_directory, network) {
     from: null,
   };
 
+  // This is a list of multi-level keys with defaults
+  // we need to _.merge. Using this list for safety
+  // vs. just merging all objects.
+  this._deepCopy = ['compilers'];
+
   this._values = {
     truffle_directory: truffle_directory || path.resolve(path.join(__dirname, "../")),
     working_directory: working_directory || process.cwd(),
@@ -258,7 +263,11 @@ Config.prototype.merge = function(obj) {
   // Only set keys for values that don't throw.
   Object.keys(obj).forEach(function(key) {
     try {
-      self[key] = clone[key];
+      if (typeof clone[key] === 'object' && self._deepCopy.includes(key)){
+        self[key] = _.merge(self[key], clone[key])
+      } else {
+        self[key] = clone[key];
+      }
     } catch (e) {
       // Do nothing.
     }

--- a/packages/truffle/test/sources/inheritance/truffle.js
+++ b/packages/truffle/test/sources/inheritance/truffle.js
@@ -1,2 +1,7 @@
 module.exports = {
+  compilers: {
+    solc: {
+      version: "0.4.24"
+    }
+  }
 };


### PR DESCRIPTION
The compilers key change in #1083 broke that feature because `truffle-config` does not merge the defaults (which are a multi-level object) with the user defined config (which may not include all the necessary settings). We were missing a test for this in the scenarios. 

+ Makes it possible merge complex config objects into complex defaults if their top level keys are declared in a `deepCopy` array in `truffle-config`
+ Deep merges the `compilers` key (when declared as an object) into the config defaults
+ Uses a solcjs compiler for the compiler scenario tests. The happy path tests use the default so we have both of these cases covered from the `truffle.js` side now.
+ Adds options sanity checks to the `compile` function, making sure we have at least `compilers.solc.settings` 