### PR TITLE
Add toNumber method to String prototype in test

### DIFF
--- a/packages/truffle-core/lib/test.js
+++ b/packages/truffle-core/lib/test.js
@@ -207,6 +207,10 @@ var Test = {
         }
       };
 
+      // Hack to give web3 1.0 string numbers a convenience method
+      // that BigNumber has - widely used in truffle tests prior to V5.
+      String.prototype.toNumber = function() { return parseInt(this) };
+
       var template = function(tests) {
         this.timeout(runner.TEST_TIMEOUT);
 


### PR DESCRIPTION
Not expecting this PR to get a warm reception FWIW 🙂 

Motivation is detailed in #1126. It would make transitioning from V4 to V5 significantly less tedious for people who have hundreds of `toNumber()` calls in their test suites.

Don't have a great place to put a test for this but it works. Running `parseInt` on a huge number string converts it to exponential notation, otherwise normal.

Drawbacks:
+  it muddies the water around whether the return value is a BN or not, although we could address this by being super clear in the release notes that this was added as an expedient.
+ It's being done for the `test` command only, so behavior in other contexts will be variant. Would like to minimize the pain while encouraging a transition to a new order? 

Weigh in!

