### PR TITLE
Make overloaded function tests multivariable

### DIFF
--- a/packages/truffle-contract/test/methods.js
+++ b/packages/truffle-contract/test/methods.js
@@ -182,20 +182,29 @@ describe("Methods", function() {
     });
 
     it("should execute overloaded solidity fn sends", async function() {
+      let hash;
       let value;
       const example = await Example.new(1);
 
       value = await example.value.call();
       assert.equal(parseInt(value), 1, "Starting value should be 1");
 
-      await example.methods['overloadedSet(uint256)'](5);
+      let helloHash = web3.utils.soliditySha3('hello');
+      await example.methods['overloadedSet(bytes32,uint256)'](helloHash, 5);
 
+      hash = await example.hash.call();
       value = await example.value.call();
+
+      assert.equal(hash, helloHash)
       assert.equal(parseInt(value), 5, "Ending value should be five");
 
-      await example.methods['overloadedSet(uint256,uint256)'](5, 5);
+      goodbyeHash = web3.utils.soliditySha3('goodbye');
+      await example.methods['overloadedSet(bytes32,uint256,uint256)'](goodbyeHash, 5, 5);
 
+      hash = await example.hash.call();
       value = await example.value.call();
+
+      assert.equal(hash, goodbyeHash);
       assert.equal(parseInt(value), 25, "Ending value should be twenty five");
     });
 

--- a/packages/truffle-contract/test/sources/Example.sol
+++ b/packages/truffle-contract/test/sources/Example.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.4.22;
 
 contract Example {
+  bytes32 public hash;
   uint public value;
   uint public counter;
   bool public fallbackTriggered;
@@ -54,11 +55,13 @@ contract Example {
     return value * multiplier;
   }
 
-  function overloadedSet(uint val) {
+  function overloadedSet(bytes32 h, uint val) {
+    hash = h;
     value = val;
   }
 
-  function overloadedSet(uint val, uint multiplier) {
+  function overloadedSet(bytes32 h, uint val, uint multiplier) {
+    hash = h;
     value = val * multiplier;
   }
 


### PR DESCRIPTION
Makes the overloaded function tests at `truffle-contract` use bytes32 as well as uint to make sure this kind of signature works. 