### PR TITLE
[WIP] V5 release notes

### DIFF
--- a/release.md
+++ b/release.md
@@ -396,6 +396,8 @@ This new configuration supports two main use cases:
 - Your compilation command outputs Truffle JSON artifacts directly
 - Your compilation command outputs individual parts of an artifact, and you want Truffle to generate the artifacts for you.
 
+Credit to @axic for the idea and for helping to hone our requirements as we implemented it. Thank you!
+
 <a href="#" id="target-generated-artifacts"></a>
 #### Target generated artifacts
 

--- a/release.md
+++ b/release.md
@@ -1,0 +1,187 @@
+⚠️ **This is an early draft. Details subject to change.** ⚠️
+
+# 🐘 🐘 V5 🐘 🐘  🐘
+
+## 1. All SOLC.
+
+It's now possible to have truffle compile with:
++ any solc-js version listed at [solc-bin](http://solc-bin.ethereum.org/bin/list.json). Specify the one you want and truffle will get it for you.
++ a natively compiled solc binary (you'll need to install this yourself, links to help below).
++ dockerized solc from one of images published [here](https://hub.docker.com/r/ethereum/solc/tags/). (You'll also need to pull down the docker image yourself but it's really easy.)
+
+### List available versions at the command line
+```shell
+$ truffle compile --list                   # Recent stable releases from solc-bin (JS)
+$ truffle compile --list prereleases       # Recent prereleases from solc-bin (JS)
+$ truffle compile --list docker            # Recent docker tags from hub.docker.com
+$ truffle compile --list releases --all    # Complete list of stable releases.
+```
+
+### Specify a solcjs version in `truffle.js`
+
+Set the compiler solc key to the version you'd like. Truffle will fetch it from the solc-bin server and cache it in your local evironment.
+```javascript
+module.exports = {
+  networks: {
+    ... etc ...
+  },
+  compilers: {
+     solc: {
+       version: <string>  // ex:  "0.4.20". (Default: truffle's installed solc)
+     }
+  }
+};
+```
+
+### Using docker / natively built binaries
+
+Solc docker images should be installed locally by running:
+```shell
+$ docker pull ethereum/solc:0.4.22  // Example image
+```
+**truffle.js**
+```javascript
+// Native binary
+compilers: {
+  solc: {
+    version: "native"
+  }
+}
+
+// Docker
+compilers: {
+  solc: {
+    version: "0.4.22",   // Any published image name
+    docker: true
+  }
+}
+```
+
+### Speed comparison
+Docker and native binary compilers process large contract sets much faster than solcjs. If you're just compiling a few contracts at a time, the speedup isn't significant relative to the overhead of running a command (see below). The first time truffle uses a docker version there's some extra overhead as it caches the solc version string and a solcjs companion compiler. All subsequent runs should be at full speed.
+
+Times to `truffle compile` on a MacBook Air 1.8GHz, Node 8.11.1
+
+| Project              | # files | solcjs | docker | bin |
+|----------------------|---------:| ------:|--------:|-----------:|
+| truffle/metacoin-box |       3 |   4.4s |   4.4s |      4.7s |
+| gnosis/pm-contracts  |      34 |  21.7s |  10.9s |     10.2s |
+| zeppelin-solidity    |     107 |  36.7s |  11.7s |     11.1s |
+
+
+For help installing a natively built compiler, see the Solidity docs [here](https://solidity.readthedocs.io/en/v0.4.23/installing-solidity.html#binary-packages).
+
+### Contract Profiling.
+Truffle has long tried to figure out which contracts changed recently and selectively compile the smallest set necessary, with varying degrees of success. It now *actually* does this. So if you're often writing a test suite and switching back and forth between JS and Solidity changes, you might get some time savings by setting up an `npm` convenience script that looks like this:
+```
+"test": "truffle compile && truffle test"
+```
+
+Many thanks to the Solidity team for making all of the above possible, and for their helpful advice over the last year.
+
+
+# 2. Web3 1.0.  🏎  🏎
+
+`truffle-contract` now uses Web3 1.0 under the hood.  It's nice! The error handling (especially the parameter checking) is great. And there's lots of new work happening over there  - ENS support is being added and EthPrize is funding an API to make contract packages published to EthPM easily available as well.
+
+We've tried to minimize the number of changes that will be necessary to transition an existing test suite from Web3 0.x to 1.0, but unfortunately some things **will** break, because there have been a number of changes to library's outputs.
+
+First, here's a list things that are new and better:
+
+### Methods / `.new` have an EventEmitter interface *and*  return a promise.
+```javascript
+example
+  .setValue(123)
+  .on('transactionHash', hash => {} )
+  .on('receipt', receipt => {})
+  .on('error', error => {})
+  .on('confirmation', (num, receipt) => {} )
+  .then( receipt => {} )
+```
+
+### Events have an EventEmitter interface
+```javascript
+example
+  .ExampleEvent()
+  .on('data', event => ... etc ... )
+
+example
+  .ExampleEvent()
+  .once('data', event => ... etc ... )
+```
+### Reason strings!! Find out the reason.
+```javascript
+# In a Solidity file
+require(msg.sender == owner, 'not authorized');
+
+// In JS
+try {
+  await Example.transferToSelf({from: nonOwner})
+} catch (err) {
+  assert(err.reason === 'not authorized');
+  assert(err.message.includes('not authorized');
+}
+```
+
+### Overloaded Solidity methods (credit to @rudolfix and @mcdee)
+```javascript
+example.methods['setValue(uint256)'](123);
+example.methods['setValue(uint256,uint256)'](11,55);
+```
+
+### Call methods at any block using the `defaultBlock` parameter.
+```javascript
+const oldBlock = 777;
+const valueInThePast = await example.getBalance("0xabc..545", oldBlock);
+```
+
+### Automated fueling for method calls and deployments.
+```javascript
+Example.autoGas = true;   // Defaults to true
+Example.gasMultiplier(1.5) // Defaults to 1.25
+const instance = await Example.new();
+await instance.callExpensiveMethod();
+```
+
+### Contract deployments & transactions allowed to take as long as they take:
+```javascript
+Example.timeoutBlocks = 10000;
+const example = await Example.new(1);
+// Later....
+await example.setValue(5)
+```
+
+### Gas estimation for `.new`:
+```javascript
+const deploymentCost = await Example.new.estimateGas();
+```
+
+### Config
+To take advantage of the `confirmations` listener and to hear Events using `.on` or `.once`, you'll need to explicitly enable websockets in your network config as below.
+```js
+module.exports = {
+  networks: {
+    development: {
+      host: "127.0.0.1",
+      port: 8545,
+      network_id: "*",
+      websockets: true
+    }
+  }
+};
+```
+
+### ⚠️ Breaking Changes ⚠️
+
+| Category | Web3 0.0 | Web3 1.0 |
+| ------ | ---- | ------- |
+| addresses (return value) | lower-case | check-summed (mixed-case) |
+| numbers  (return value)  | BigNumber/BN | string |
+| tuples (return value)       | Array | Object w/ named & indexed keys |
+| `.contract` | same as now | completely different |
+|`.at` | sync / then-able | async |
+
+
+## Migrations
+
+[Coming]

--- a/release.md
+++ b/release.md
@@ -30,7 +30,7 @@ Or keep reading for more information!
   + [Advanced](#advanced)
   + [Speed comparison](#speed-comparison)
   + [Contract Profiling](#contract-profiling)
-* [🐇 🐇 Web3.js 1.0 🐇 🐇](#------web3js-10------)
+* [🐇 🐇 Web3.js 1.0 🐇 🐇](#--web3js-10--)
   + [⚠️ Breaking Changes ⚠️](#️-breaking-changes-️)
   + [🍨 Features 🍨](#-features-)
   + [Methods / `.new` have an EventEmitter interface *and*  return a promise.](#methods--new-have-an-eventemitter-interface-and--return-a-promise)
@@ -40,8 +40,8 @@ Or keep reading for more information!
   + [Configure number return format](#configure-number-return-format)
   + [Call methods at any block using the `defaultBlock` parameter.](#call-methods-at-any-block-using-the-defaultblock-parameter)
   + [Automated fueling for method calls and deployments.](#automated-fueling-for-method-calls-and-deployments)
-  + [Contract deployments & transactions allowed to take as long as they take:](#contract-deployments--transactions-allowed-to-take-as-long-as-they-take)
-  + [Gas estimation for `.new`:](#gas-estimation-for-new)
+  + [Contract deployments & transactions allowed to take as long as they take](#contract-deployments--transactions-allowed-to-take-as-long-as-they-take)
+  + [Gas estimation for `.new`](#gas-estimation-for-new)
   + [Config](#config)
 * [🐦 🐦  New Migrations 🐦 🐦](#---new-migrations--)
     - [Features](#features)
@@ -255,7 +255,7 @@ const instance = await Example.new();
 await instance.callExpensiveMethod();
 ```
 
-### Contract deployments & transactions allowed to take as long as they take:
+### Contract deployments & transactions allowed to take as long as they take
 ```javascript
 Example.timeoutBlocks = 10000;
 const example = await Example.new(1);
@@ -263,7 +263,7 @@ const example = await Example.new(1);
 await example.setValue(5)
 ```
 
-### Gas estimation for `.new`:
+### Gas estimation for `.new`
 ```javascript
 const deploymentCost = await Example.new.estimateGas();
 ```

--- a/release.md
+++ b/release.md
@@ -4,6 +4,24 @@
 
 # 🐘 🐘 V5 🐘 🐘  🐘
 
+Good day! We're pleased to announce the first beta release of Truffle v5.
+With this release, we're excited to bring you some new features and
+improvements that will make your life easier. What's included, you ask?
+Well, get ready to use whatever Solidity version you want (Truffle will even
+automatically download it for you.) Or how about an improved migrations system,
+which dry-runs by default and provides lots of information to understand what
+is going right or wrong. Or maybe you've been waiting for Web3.js 1.0. Or
+maybe you're sick of typing `.then()` in console and want to use `await`
+instead. Truffle v5 has all of this, and more.
+
+If you're as excited as we are and can't wait, here's how to upgrade:
+```bash
+npm uninstall -g truffle
+npm install -g truffle
+```
+
+Or keep reading for more information!
+
 - [Bring your own compiler](#Bring-your-own-compiler)
 - [Web3.js 1.0](#Web3.js-1.0)
 - [New Migrations](#New-Migrations)

--- a/release.md
+++ b/release.md
@@ -4,10 +4,15 @@
 
 # 🐘 🐘 V5 🐘 🐘  🐘
 
-## 1. All SOLC.
+- [Bring your own compiler](#Bring-your-own-compiler)
+- [Web3.js 1.0](#Web3.js-1.0)
+- [New Migrations](#New-Migrations)
+- [More](#Even-More!)
 
-It's now possible to have truffle compile with:
-+ any solc-js version listed at [solc-bin](http://solc-bin.ethereum.org/bin/list.json). Specify the one you want and truffle will get it for you.
+## Bring your own compiler
+
+It's now possible to have Truffle compile with:
++ any solc-js version listed at [solc-bin](http://solc-bin.ethereum.org/bin/list.json). Specify the one you want and Truffle will get it for you.
 + a natively compiled solc binary (you'll need to install this yourself, links to help below).
 + dockerized solc from one of images published [here](https://hub.docker.com/r/ethereum/solc/tags/). (You'll also need to pull down the docker image yourself but it's really easy.)
 
@@ -29,7 +34,7 @@ module.exports = {
   },
   compilers: {
      solc: {
-       version: <string>  // ex:  "0.4.20". (Default: truffle's installed solc)
+       version: <string>  // ex:  "0.4.20". (Default: Truffle's installed solc)
      }
   }
 };
@@ -84,7 +89,7 @@ compilers: {
 ```
 
 ### Speed comparison
-Docker and native binary compilers process large contract sets faster than solcjs. If you're just compiling a few contracts at a time, the speedup isn't significant relative to the overhead of running a command (see below). The first time `truffle` uses a docker version there's some extra overhead as it caches the solc version string and a solcjs companion compiler. All subsequent runs should be at full speed.
+Docker and native binary compilers process large contract sets faster than solcjs. If you're just compiling a few contracts at a time, the speedup isn't significant relative to the overhead of running a command (see below). The first time Truffle uses a docker version there's a small delay as it caches the solc version string and a solcjs companion compiler. All subsequent runs should be at full speed.
 
 Times to `truffle compile` on a MacBook Air 1.8GHz, Node 8.11.1
 
@@ -106,28 +111,28 @@ Truffle has always tried figure out which contracts changed recently and compile
 Many thanks to the Solidity team for making all of the above possible and for their helpful advice over the last year.  🙌 🙌
 
 
-# 2. 🐇 🐇  Web3 1.0  🐇 🐇
+## 🐇 🐇 Web3.js 1.0 🐇 🐇
 
-`truffle-contract` now uses Web3 1.0 under the hood.  It's nice! The error handling (especially the parameter checking) is really good. And there's lots of new work happening over there  - ENS support is being added and [EthPrize](http://ethprize.io/) is funding an API to make contract packages published to EthPM easily available as well.
+**truffle-contract** now uses Web3.js 1.0 under the hood.  It's nice! The error handling (especially the parameter checking) is really good. And there's lots of new work happening over there  - ENS support is being added and [EthPrize](http://ethprize.io/) is funding an API to make contract packages published to EthPM easily available as well.
 
-We've tried to minimize the number of changes required to transition an existing test suite from Web3 0.x to 1.0. Unfortunately there are some breaking changes due to differences in the way Web3 1.0 formats outputs (see chart below).
+We've tried to minimize the inconvenience involved in transitioning an existing test suite from Web3 0.x to 1.0. Unfortunately there are some breaking changes due to differences in the way Web3 1.0 formats outputs (see chart below).
 
-The biggest change is that `truffle-contract` now returns numbers as [BN](https://github.com/indutny/bn.js/) by default instead of BigNumber. This is necessary - BigNumber doesn't have the precision required by the EVM. The number libraries share some methods (notably `.toNumber()`) but their arithmetic operations are quite different.
+The biggest of these is that **truffle-contract** now returns numbers as [BN](https://github.com/indutny/bn.js/) by default instead of [BigNumber](https://github.com/MikeMcl/bignumber.js). This is necessary - BigNumber doesn't have the precision required by the EVM. The number libraries share some methods (notably `.toNumber()`) but their arithmetic operations are quite different.
 
-**Important**: If you receive a number directly from web3 (e.g. *not* from a truffle-contract instance)  you'll get a **string**. Luckily there's a helpful BN conversion method in the web3 utils.
+**Important**: If you receive a number directly from Web3 (e.g. *not* from a **truffle-contract** instance)  you'll get a **string**. Luckily there's a helpful BN conversion method in the Web3 utils.
 ```javascript
 const stringBalance = await web3.eth.getBalance('0xabc..');
 const bnBalance = web3.utils.toBN(stringBalance);
 ```
 
 **Helpful Resources**
-+  Web3 1.0's documentation. Well worth taking a look - lots of differences in their new API.
++  Web3 1.0's [documentation](https://web3js.readthedocs.io/en/1.0/). Well worth taking a look - lots of differences in their new API.
 + EthWork's [bn-chai](https://github.com/EthWorks/bn-chai) library: BN helpers for your tests. (💡 ProTip courtesy elenadimitrova)
 
 ------------
 ### ⚠️ Breaking Changes ⚠️
 
-| Category | V4 (Web3 0.0) |  V5 (Web3 1.0) |
+| Category | v4 (Web3 0.0) |  v5 (Web3 1.0) |
 | ------ | ---- | ------- |
 | addresses (return value) | lower-case | check-summed (mixed-case) |
 | numbers  (return value)  | BigNumber | BN (configurable) |
@@ -140,8 +145,10 @@ const bnBalance = web3.utils.toBN(stringBalance);
 
 ### Methods / `.new` have an EventEmitter interface *and*  return a promise.
 ```javascript
+const example = await artifacts.require("Example").deployed();
+
 example
-  .setValue(123)
+  .setValue(45)
   .on('transactionHash', hash => {} )
   .on('receipt', receipt => {})
   .on('error', error => {})
@@ -160,11 +167,14 @@ example
   .once('data', event => ... etc ... )
 ```
 ### Reason strings!! Find out the reason.
-```javascript
-# In a Solidity file
-require(msg.sender == owner, 'not authorized');
 
-// In JS
+**Solidity**
+```solidity
+require(msg.sender == owner, 'not authorized');
+```
+
+**Javascript**
+```javascript
 try {
   await example.transferToSelf({from: nonOwner})
 } catch (err) {
@@ -179,8 +189,8 @@ example.methods['setValue(uint256)'](123);
 example.methods['setValue(uint256,uint256)'](11,55);
 ```
 
-### Configure format of number return values
-As mentioned above - `truffle-contract` now returns BN. We've made this configurable so if you have an existing test suite you'd prefer to gradually transition from BigNumber to BN, it's possible to configure a contract's number format as below.
+### Configure number return format
+As mentioned above - **truffle-contract** now returns [BN](https://github.com/indutny/bn.js). We've made this configurable so if you have an existing test suite you'd prefer to gradually transition from [BigNumber](https://github.com/MikeMcl/bignumber.js) to BN, it's possible to configure a contract's number format as below.
 ```javascript
 // Choices are:  `["BigNumber", "BN", "String"].
 const Example = artifacts.require('Example');
@@ -233,18 +243,20 @@ module.exports = {
 
 Deploying contracts to public networks is hard ... 🙂 The topic dominates our 10 most visited GitHub issues.  On the bright side, those discussion threads are a rich trove of advice and brilliant insight from experienced Truffle users. V5 includes a rewrite of the `migrations` command that tries to integrate all their hard won knowledge into an easier to use deployment manager.
 
-**Highlights**
-+ **Improved error messaging.**  If Truffle can guess why a deployment might have failed it tells you and suggests some possible solutions.
+#### Features
++ **Improved error messaging.**  If Truffle can guess why a deployment failed it tells you and suggests some possible solutions.
 + **More information** about what's going on as you deploy, including cost summaries and real-time status updates about how long transactions have been pending. (See GIF below)
 + **Improved dry run** deployment simulations. This feature has had it's kinks worked out and now runs automatically if you're deploying to a known public network.  You can also use the `--interactive` flag at the command line to get a prompt between your dry run and real deployment.
 + Configure the number of block **confirmations** to wait between deployments. This is helpful when deploying to Infura because their load balancer sometimes executes back-to-back transactions out of sequence and  noncing can go awry.
 + Specify how many **blocks to wait** before timing out a pending deployment. Web3 hardcodes this value at 50 blocks which can be a problem if you're trying to deploy large contracts at the lower end of the gas price range.
 + A deployer interface that works seamlessly with ES6 **async/await** syntax. (Also backward compatible with Truffle V4's then-able pattern.)
 
-⚠️  **Important** ⚠️  If you're using `truffle-hdwallet-provider` with Truffle V5 you **must** install the Web3 1.0 enabled version:
+⚠️  **Important** ⚠️  If you're using **truffle-hdwallet-provider** with Truffle v5 you **must** install the Web3 1.0 enabled version:
 ```shell
 $ npm install --save truffle-hdwallet-provider@web3-one
 ```
+
+#### Configuration and use
 
 **Example network config**
 ```javascript
@@ -284,7 +296,7 @@ module.exports = async function(deployer) {
 
 ## Even More!
 
-### truffle-console now supports async/await
+### **truffle-console** now supports async/await
 
 A small but decisive improvement that should make the console much easier to use.
 **Example**

--- a/release.md
+++ b/release.md
@@ -1,5 +1,6 @@
+Good day! We're pleased to announce the first beta release of Truffle v5. With this release, we're excited to bring you some new features and improvements that will make your life easier. 
 
-Good day! We're pleased to announce the first beta release of Truffle v5. With this release, we're excited to bring you some new features and improvements that will make your life easier. What's included, you ask? Well, get ready to use whatever Solidity version you want (Truffle will even automatically download it for you.) Or how about an improved migrations system, which dry-runs by default and provides lots of information to understand what is going right or wrong. Or maybe you've been waiting for Web3.js 1.0. Or maybe you're sick of typing `.then()` in console and want to use `await` instead. Truffle v5 has all of this, and more.
+What's included, you ask? Well, get ready to use **whatever Solidity version you want** (Truffle will even automatically download it for you.) Or how about an **improved migrations system**, which dry-runs by default and provides lots of information to understand what is going right or wrong. Maybe you've been waiting for **Web3.js 1.0**. Perhaps you're sick of typing `.then()` and want to use **`await` in the console**. Truffle v5 has all of this, and more!
 
 If you're as excited as we are and can't wait, here's how to upgrade:
 ```bash

--- a/release.md
+++ b/release.md
@@ -26,28 +26,28 @@ Or keep reading for more information!
 
 * [Bring your own compiler](#bring-your-own-compiler)
   + [List available versions at the command line](#list-available-versions-at-the-command-line)
-  + [Specify a solcjs version in `truffle.js`](#specify-a-solcjs-version-in--trufflejs-)
+  + [Specify a solcjs version](#specify-a-solcjs-version)
   + [Advanced](#advanced)
   + [Speed comparison](#speed-comparison)
   + [Contract Profiling](#contract-profiling)
 * [🐇 🐇 Web3.js 1.0 🐇 🐇](#------web3js-10------)
-  + [⚠️ Breaking Changes ⚠️](#---breaking-changes---)
-  + [🍨 Features 🍨](#---features---)
-  + [Methods / `.new` have an EventEmitter interface *and*  return a promise.](#methods----new--have-an-eventemitter-interface--and---return-a-promise)
+  + [⚠️ Breaking Changes ⚠️](#️-breaking-changes-️)
+  + [🍨 Features 🍨](#-features-)
+  + [Methods / `.new` have an EventEmitter interface *and*  return a promise.](#methods--new-have-an-eventemitter-interface-and--return-a-promise)
   + [Events have an EventEmitter interface](#events-have-an-eventemitter-interface)
-  + [Reason strings!! Find out the reason.](#reason-strings---find-out-the-reason)
-  + [Overloaded Solidity methods (credit to @rudolfix and @mcdee)](#overloaded-solidity-methods--credit-to--rudolfix-and--mcdee-)
+  + [Reason strings!! Find out the reason.](#reason-strings-find-out-the-reason)
+  + [Overloaded Solidity methods (credit to @rudolfix and @mcdee)](#overloaded-solidity-methods-credit-to-rudolfix-and-mcdee)
   + [Configure number return format](#configure-number-return-format)
-  + [Call methods at any block using the `defaultBlock` parameter.](#call-methods-at-any-block-using-the--defaultblock--parameter)
+  + [Call methods at any block using the `defaultBlock` parameter.](#call-methods-at-any-block-using-the-defaultblock-parameter)
   + [Automated fueling for method calls and deployments.](#automated-fueling-for-method-calls-and-deployments)
-  + [Contract deployments & transactions allowed to take as long as they take:](#contract-deployments---transactions-allowed-to-take-as-long-as-they-take-)
-  + [Gas estimation for `.new`:](#gas-estimation-for--new--)
+  + [Contract deployments & transactions allowed to take as long as they take:](#contract-deployments--transactions-allowed-to-take-as-long-as-they-take)
+  + [Gas estimation for `.new`:](#gas-estimation-for-new)
   + [Config](#config)
-* [🐦 🐦  New Migrations 🐦 🐦](#-------new-migrations------)
+* [🐦 🐦  New Migrations 🐦 🐦](#---new-migrations--)
     - [Features](#features)
     - [Configuration and use](#configuration-and-use)
-* [Even More!](#even-more-)
-  + [**truffle-console** now supports async/await](#--truffle-console---now-supports-async-await)
+* [Even More!](#even-more)
+  + [**truffle-console** now supports async/await](#truffle-console-now-supports-asyncawait)
   + [External compiler support](#external-compiler-support)
     - [Target generated artifacts](#target-generated-artifacts)
       * [Post-processing artifacts](#post-processing-artifacts)
@@ -68,7 +68,7 @@ $ truffle compile --list docker            # Recent docker tags from hub.docker.
 $ truffle compile --list releases --all    # Complete list of stable releases.
 ```
 
-### Specify a solcjs version in `truffle.js`
+### Specify a solcjs version
 
 Set the compilers solc `version` key to the one you'd like. Truffle will fetch it from the solc-bin server and cache it in your local evironment.
 ```javascript

--- a/release.md
+++ b/release.md
@@ -52,6 +52,8 @@ Or keep reading for more information!
     - [Target generated artifacts](#target-generated-artifacts)
       * [Post-processing artifacts](#post-processing-artifacts)
     - [Target individual artifact properties](#target-individual-artifact-properties)
+  + [Debugger mapping support](#debugger-mapping-support)
+* [Acknowledgements](#acknowledgements)
 
 ## Bring your own compiler
 
@@ -469,3 +471,19 @@ values when building the artifacts.
 
 These two approaches aim to provide flexibility, aiming to meet whatever your
 compilation needs may be.
+
+### Debugger mapping support
+
+Mappings are now supported in **truffle-debugger**. Truffle will keep track
+of known mapping keys and let you inspect your contract's `mapping` variables
+with the `v` command. What's more, this means you can inspect `mapping`s of
+`struct`s and `struct`s of `mapping`s, etc.!
+
+## Acknowledgements
+
+We'd like to extend a huge thank you to our community, our users, and our
+contributors, who have all been instrumental in helping us get this this
+point. We hope you enjoy this beta and all of Truffle's new features.
+
+Please let us know if you find any problems or have any suggestions for
+making this release better. 🙇

--- a/release.md
+++ b/release.md
@@ -22,10 +22,36 @@ npm install -g truffle
 
 Or keep reading for more information!
 
-- [Bring your own compiler](#Bring-your-own-compiler)
-- [Web3.js 1.0](#Web3.js-1.0)
-- [New Migrations](#New-Migrations)
-- [More](#Even-More!)
+## Release Contents
+
+* [Bring your own compiler](#bring-your-own-compiler)
+  + [List available versions at the command line](#list-available-versions-at-the-command-line)
+  + [Specify a solcjs version in `truffle.js`](#specify-a-solcjs-version-in--trufflejs-)
+  + [Advanced](#advanced)
+  + [Speed comparison](#speed-comparison)
+  + [Contract Profiling](#contract-profiling)
+* [🐇 🐇 Web3.js 1.0 🐇 🐇](#------web3js-10------)
+  + [⚠️ Breaking Changes ⚠️](#---breaking-changes---)
+  + [🍨 Features 🍨](#---features---)
+  + [Methods / `.new` have an EventEmitter interface *and*  return a promise.](#methods----new--have-an-eventemitter-interface--and---return-a-promise)
+  + [Events have an EventEmitter interface](#events-have-an-eventemitter-interface)
+  + [Reason strings!! Find out the reason.](#reason-strings---find-out-the-reason)
+  + [Overloaded Solidity methods (credit to @rudolfix and @mcdee)](#overloaded-solidity-methods--credit-to--rudolfix-and--mcdee-)
+  + [Configure number return format](#configure-number-return-format)
+  + [Call methods at any block using the `defaultBlock` parameter.](#call-methods-at-any-block-using-the--defaultblock--parameter)
+  + [Automated fueling for method calls and deployments.](#automated-fueling-for-method-calls-and-deployments)
+  + [Contract deployments & transactions allowed to take as long as they take:](#contract-deployments---transactions-allowed-to-take-as-long-as-they-take-)
+  + [Gas estimation for `.new`:](#gas-estimation-for--new--)
+  + [Config](#config)
+* [🐦 🐦  New Migrations 🐦 🐦](#-------new-migrations------)
+    - [Features](#features)
+    - [Configuration and use](#configuration-and-use)
+* [Even More!](#even-more-)
+  + [**truffle-console** now supports async/await](#--truffle-console---now-supports-async-await)
+  + [External compiler support](#external-compiler-support)
+    - [Target generated artifacts](#target-generated-artifacts)
+      * [Post-processing artifacts](#post-processing-artifacts)
+    - [Target individual artifact properties](#target-individual-artifact-properties)
 
 ## Bring your own compiler
 
@@ -58,7 +84,7 @@ module.exports = {
 };
 ```
 
-### Advanced:
+### Advanced
 + docker
 + native binary
 + `path/to/solc`

--- a/release.md
+++ b/release.md
@@ -1,23 +1,10 @@
-**DO NOT MERGE** - this is here so people can do review stuff to it if they want to.
 
-⚠️ **Early draft. Details subject to change.** ⚠️
-
-# 🐘 🐘 V5 🐘 🐘  🐘
-
-Good day! We're pleased to announce the first beta release of Truffle v5.
-With this release, we're excited to bring you some new features and
-improvements that will make your life easier. What's included, you ask?
-Well, get ready to use whatever Solidity version you want (Truffle will even
-automatically download it for you.) Or how about an improved migrations system,
-which dry-runs by default and provides lots of information to understand what
-is going right or wrong. Or maybe you've been waiting for Web3.js 1.0. Or
-maybe you're sick of typing `.then()` in console and want to use `await`
-instead. Truffle v5 has all of this, and more.
+Good day! We're pleased to announce the first beta release of Truffle v5. With this release, we're excited to bring you some new features and improvements that will make your life easier. What's included, you ask? Well, get ready to use whatever Solidity version you want (Truffle will even automatically download it for you.) Or how about an improved migrations system, which dry-runs by default and provides lots of information to understand what is going right or wrong. Or maybe you've been waiting for Web3.js 1.0. Or maybe you're sick of typing `.then()` in console and want to use `await` instead. Truffle v5 has all of this, and more.
 
 If you're as excited as we are and can't wait, here's how to upgrade:
 ```bash
 npm uninstall -g truffle
-npm install -g truffle
+npm install -g truffle@beta
 ```
 
 Or keep reading for more information!
@@ -30,21 +17,21 @@ Or keep reading for more information!
   + [Advanced](#advanced)
   + [Speed comparison](#speed-comparison)
   + [Contract Profiling](#contract-profiling)
-* [🐇 🐇 Web3.js 1.0 🐇 🐇](#--web3js-10--)
-  + [⚠️ Breaking Changes ⚠️](#️-breaking-changes-️)
-  + [🍨 Features 🍨](#-features-)
-  + [Methods / `.new` have an EventEmitter interface *and*  return a promise.](#methods--new-have-an-eventemitter-interface-and--return-a-promise)
-  + [Events have an EventEmitter interface](#events-have-an-eventemitter-interface)
-  + [Reason strings!! Find out the reason.](#reason-strings-find-out-the-reason)
-  + [Overloaded Solidity methods (credit to @rudolfix and @mcdee)](#overloaded-solidity-methods-credit-to-rudolfix-and-mcdee)
+* [🐇 🐇 Web3.js 1.0 🐇 🐇](#web3js-1.0)
+  + [⚠️ Breaking Changes ⚠️](#breaking-changes)
+  + [🍨 Features 🍨](#web3-features)
+  + [Methods / `.new` have an EventEmitter interface *and*  return a promise.](#methods-eventemitter)
+  + [Events have an EventEmitter interface](#events-eventemitter)
+  + [Reason strings!! Find out the reason.](#reason-strings)
+  + [Overloaded Solidity methods (credit to @rudolfix and @mcdee)](#overloaded-solidity-methods)
   + [Configure number return format](#configure-number-return-format)
-  + [Call methods at any block using the `defaultBlock` parameter.](#call-methods-at-any-block-using-the-defaultblock-parameter)
-  + [Automated fueling for method calls and deployments.](#automated-fueling-for-method-calls-and-deployments)
-  + [Contract deployments & transactions allowed to take as long as they take](#contract-deployments--transactions-allowed-to-take-as-long-as-they-take)
+  + [Call methods at any block using the `defaultBlock` parameter.](#default-block)
+  + [Automated fueling for method calls and deployments.](#automated-fueling)
+  + [Contract deployments & transactions allowed to take as long as they take](#contract-deployments-transactions)
   + [Gas estimation for `.new`](#gas-estimation-for-new)
   + [Config](#config)
-* [🐦 🐦  New Migrations 🐦 🐦](#---new-migrations--)
-    - [Features](#features)
+* [🐦 🐦  New Migrations 🐦 🐦](#new-migrations)
+    - [Features](#new-migrations-features)
     - [Configuration and use](#configuration-and-use)
 * [Even More!](#even-more)
   + [**truffle-console** now supports async/await](#truffle-console-now-supports-asyncawait)
@@ -55,6 +42,7 @@ Or keep reading for more information!
   + [Debugger mapping support](#debugger-mapping-support)
 * [Acknowledgements](#acknowledgements)
 
+<a href="#" id="bring-your-own-compiler"></a>
 ## Bring your own compiler
 
 It's now possible to have Truffle compile with:
@@ -62,6 +50,7 @@ It's now possible to have Truffle compile with:
 + a natively compiled solc binary (you'll need to install this yourself, links to help below).
 + dockerized solc from one of images published [here](https://hub.docker.com/r/ethereum/solc/tags/). (You'll also need to pull down the docker image yourself but it's really easy.)
 
+<a href="#" id="list-available-versions-at-the-command-line"></a>
 ### List available versions at the command line
 ```shell
 $ truffle compile --list                   # Recent stable releases from solc-bin (JS)
@@ -70,6 +59,7 @@ $ truffle compile --list docker            # Recent docker tags from hub.docker.
 $ truffle compile --list releases --all    # Complete list of stable releases.
 ```
 
+<a href="#" id="specify-a-solcjs-version"></a>
 ### Specify a solcjs version
 
 Set the compilers solc `version` key to the one you'd like. Truffle will fetch it from the solc-bin server and cache it in your local evironment.
@@ -86,6 +76,7 @@ module.exports = {
 };
 ```
 
+<a href="#" id="advanced"></a>
 ### Advanced
 + docker
 + native binary
@@ -134,6 +125,7 @@ compilers: {
 }
 ```
 
+<a href="#" id="speed-comparison"></a>
 ### Speed comparison
 Docker and native binary compilers process large contract sets faster than solcjs. If you're just compiling a few contracts at a time, the speedup isn't significant relative to the overhead of running a command (see below). The first time Truffle uses a docker version there's a small delay as it caches the solc version string and a solcjs companion compiler. All subsequent runs should be at full speed.
 
@@ -148,6 +140,7 @@ Times to `truffle compile` on a MacBook Air 1.8GHz, Node 8.11.1
 
 For help installing a natively built compiler, see the Solidity docs [here](https://solidity.readthedocs.io/en/v0.4.23/installing-solidity.html#binary-packages).
 
+<a href="#" id="contract-profiling"></a>
 ### Contract Profiling
 Truffle has always tried figure out which contracts changed recently and compile the smallest set necessary (with varying degrees of success). It now does this reliably so you may benefit from setting up an `npm` convenience script that looks like this:
 ```
@@ -156,7 +149,7 @@ Truffle has always tried figure out which contracts changed recently and compile
 
 Many thanks to the Solidity team for making all of the above possible and for their helpful advice over the last year.  🙌 🙌
 
-
+<a href="#" id="web3js-1.0"></a>
 ## 🐇 🐇 Web3.js 1.0 🐇 🐇
 
 **truffle-contract** now uses Web3.js 1.0 under the hood.  It's nice! The error handling (especially the parameter checking) is really good. And there's lots of new work happening over there  - ENS support is being added and [EthPrize](http://ethprize.io/) is funding an API to make contract packages published to EthPM easily available as well.
@@ -176,6 +169,7 @@ const bnBalance = web3.utils.toBN(stringBalance);
 + EthWork's [bn-chai](https://github.com/EthWorks/bn-chai) library: BN helpers for your tests. (💡 ProTip courtesy elenadimitrova)
 
 ------------
+<a href="#" id="breaking-changes"></a>
 ### ⚠️ Breaking Changes ⚠️
 
 | Category | v4 (Web3 0.0) |  v5 (Web3 1.0) |
@@ -187,8 +181,10 @@ const bnBalance = web3.utils.toBN(stringBalance);
 |`.at` (TruffleContract method)| sync / then-able | async |
 
 -----------
+<a href="#" id="web3-features"></a>
 ### 🍨 Features 🍨
 
+<a href="#" id="methods-eventemitter"></a>
 ### Methods / `.new` have an EventEmitter interface *and*  return a promise.
 ```javascript
 const example = await artifacts.require("Example").deployed();
@@ -202,6 +198,7 @@ example
   .then( receipt => {} )
 ```
 
+<a href="#" id="events-eventemitter"></a>
 ### Events have an EventEmitter interface
 ```javascript
 example
@@ -212,6 +209,7 @@ example
   .ExampleEvent()
   .once('data', event => ... etc ... )
 ```
+<a href="#" id="reason-strings"></a>
 ### Reason strings!! Find out the reason.
 
 **Solidity**
@@ -229,12 +227,14 @@ try {
 }
 ```
 
+<a href="#" id="overloaded-solidity-methods"></a>
 ### Overloaded Solidity methods (credit to @rudolfix and @mcdee)
 ```javascript
 example.methods['setValue(uint256)'](123);
 example.methods['setValue(uint256,uint256)'](11,55);
 ```
 
+<a href="#" id="configure-number-return-format"></a>
 ### Configure number return format
 As mentioned above - **truffle-contract** now returns [BN](https://github.com/indutny/bn.js). We've made this configurable so if you have an existing test suite you'd prefer to gradually transition from [BigNumber](https://github.com/MikeMcl/bignumber.js) to BN, it's possible to configure a contract's number format as below.
 ```javascript
@@ -243,12 +243,14 @@ const Example = artifacts.require('Example');
 Example.numberFormat = 'BigNumber';
 ```
 
+<a href="#" id="default-block"></a>
 ### Call methods at any block using the `defaultBlock` parameter.
 ```javascript
 const oldBlock = 777;
 const valueInThePast = await example.getBalance("0xabc..545", oldBlock);
 ```
 
+<a href="#" id="automated-fueling"></a>
 ### Automated fueling for method calls and deployments.
 ```javascript
 Example.autoGas = true;   // Defaults to true
@@ -257,6 +259,7 @@ const instance = await Example.new();
 await instance.callExpensiveMethod();
 ```
 
+<a href="#" id="contract-deployments-transactions"></a>
 ### Contract deployments & transactions allowed to take as long as they take
 ```javascript
 Example.timeoutBlocks = 10000;
@@ -265,11 +268,13 @@ const example = await Example.new(1);
 await example.setValue(5)
 ```
 
+<a href="#" id="gas-estimation-for-new"></a>
 ### Gas estimation for `.new`
 ```javascript
 const deploymentCost = await Example.new.estimateGas();
 ```
 
+<a href="#" id="config"></a>
 ### Config
 To take advantage of the `confirmations` listener and to hear Events using `.on` or `.once`, you'll need to enable websockets in your network config as below.
 ```js
@@ -285,10 +290,12 @@ module.exports = {
 };
 ```
 
+<a href="#" id="new-migrations"></a>
 ## 🐦 🐦  New Migrations 🐦 🐦
 
 Deploying contracts to public networks is hard ... 🙂 The topic dominates our 10 most visited GitHub issues.  On the bright side, those discussion threads are a rich trove of advice and brilliant insight from experienced Truffle users. V5 includes a rewrite of the `migrations` command that tries to integrate all their hard won knowledge into an easier to use deployment manager.
 
+<a href="#" id="new-migrations-features"></a>
 #### Features
 + **Improved error messaging.**  If Truffle can guess why a deployment failed it tells you and suggests some possible solutions.
 + **More information** about what's going on as you deploy, including cost summaries and real-time status updates about how long transactions have been pending. (See GIF below)
@@ -302,6 +309,7 @@ Deploying contracts to public networks is hard ... 🙂 The topic dominates our 
 $ npm install --save truffle-hdwallet-provider@web3-one
 ```
 
+<a href="#" id="configuration-and-use"></a>
 #### Configuration and use
 
 **Example network config**
@@ -340,8 +348,10 @@ module.exports = async function(deployer) {
 + cag from Gnosis has written a really nice addition to the Migrations module that will automatically deploy contract dependencies you've installed with `npm` along with your own contracts.
 + Under the hood, the `migrations` command is now completely evented and managed by a reporter module. Those hooks will be exposed so anyone can write a UI for it and hopefully you'll be plugging into ever more sophisticated deployment script managers soon. Work on the default UI to make it more interactive and colorful is ongoing.
 
+<a href="#" id="even-more"></a>
 ## Even More!
 
+<a href="#" id="truffle-console-now-supports-asyncawait"></a>
 ### **truffle-console** now supports async/await
 
 A small but decisive improvement that should make the console much easier to use.
@@ -355,17 +365,12 @@ truffle(development)> balance.toNumber()
 truffle(development)>
 ```
 
+<a href="#" id="external-compiler-support"></a>
 ### External compiler support
 
-For more advanced use cases, let's say your smart contract development workflow
-involves more than just compiling Solidity contracts. Maybe you're writing
-[eWASM precompiles](https://github.com/ewasm/ewasm-precompiles/tree/ecadd-truffle-tests/ecadd)
-or making a [two-dimensional `delegatecall` proxy](https://github.com/GNSPS/2DProxy).
-Or maybe you would just rather use [@pubkey's solidity-cli](https://github.com/pubkey/solidity-cli)
-instead of Truffle's `solc` configuration.
+For more advanced use cases, let's say your smart contract development workflow involves more than just compiling Solidity contracts. Maybe you're writing [eWASM precompiles](https://github.com/ewasm/ewasm-precompiles/tree/ecadd-truffle-tests/ecadd) or making a [two-dimensional `delegatecall` proxy](https://github.com/GNSPS/2DProxy). Or maybe you would just rather use [@pubkey's solidity-cli](https://github.com/pubkey/solidity-cli) instead of Truffle's `solc` configuration.
 
-This is now supported by adding a `compilers.external` object to your Truffle
-config:
+This is now supported by adding a `compilers.external` object to your Truffle config:
 ```javascript
 {
   /* ... */
@@ -385,19 +390,16 @@ config:
 }
 ```
 
-When you run `truffle compile`, Truffle will run the configured `command` and
-look for contract artifacts specified by `targets`.
+When you run `truffle compile`, Truffle will run the configured `command` and look for contract artifacts specified by `targets`.
 
 This new configuration supports two main use cases:
 - Your compilation command outputs Truffle JSON artifacts directly
-- Your compilation command outputs individual parts of an artifact, and you
-  want Truffle to generate the artifacts for you.
+- Your compilation command outputs individual parts of an artifact, and you want Truffle to generate the artifacts for you.
 
+<a href="#" id="target-generated-artifacts"></a>
 #### Target generated artifacts
 
-If your compilation command generates artifacts directly, or generates output
-that contains all the information for an artifact, configure a target as
-follows:
+If your compilation command generates artifacts directly, or generates output that contains all the information for an artifact, configure a target as follows:
 ```javascript
 {
   compilers: {
@@ -411,13 +413,12 @@ follows:
 }
 ```
 
-Truffle will expand the glob (`*`) and find all `.json` files in the listed
-path and copy those over as artifacts in the `build/contracts/` directory.
+Truffle will expand the glob (`*`) and find all `.json` files in the listed path and copy those over as artifacts in the `build/contracts/` directory.
 
+<a href="#" id="post-processing-artifacts"></a>
 ##### Post-processing artifacts
 
-The above use case might not be sufficient for all use cases. You can configure
-your target to run an arbitrary post-processing command:
+The above use case might not be sufficient for all use cases. You can configure your target to run an arbitrary post-processing command:
 ```javascript
 {
   compilers: {
@@ -432,19 +433,14 @@ your target to run an arbitrary post-processing command:
 }
 ```
 
-This will run `./process-artifact` for each matched `.json` file, piping
-the contents of that file as stdin. Your `./process-artifact` command is then
-expected to output a complete Truffle artifact as stdout.
+This will run `./process-artifact` for each matched `.json` file, piping the contents of that file as stdin. Your `./process-artifact` command is then expected to output a complete Truffle artifact as stdout.
 
-Want to provide the path as a filename instead? Add `stdin: false` to your
-target configuration.
+Want to provide the path as a filename instead? Add `stdin: false` to your target configuration.
 
-
+<a href="#" id="target-individual-artifact-properties"></a>
 #### Target individual artifact properties
 
-The other way to configure your external compilation is to specify the
-individual properties of your contracts and have Truffle generate the
-artifacts itself:
+The other way to configure your external compilation is to specify the individual properties of your contracts and have Truffle generate the artifacts itself:
 ```javascript
 {
   compilers: {
@@ -466,24 +462,18 @@ artifacts itself:
 }
 ```
 
-Specify `properties` and/or `fileProperties`, and Truffle will look for those
-values when building the artifacts.
+Specify `properties` and/or `fileProperties`, and Truffle will look for those values when building the artifacts.
 
-These two approaches aim to provide flexibility, aiming to meet whatever your
-compilation needs may be.
+These two approaches aim to provide flexibility, aiming to meet whatever your compilation needs may be.
 
+<a href="#" id="debugger-mapping-support"></a>
 ### Debugger mapping support
 
-Mappings are now supported in **truffle-debugger**. Truffle will keep track
-of known mapping keys and let you inspect your contract's `mapping` variables
-with the `v` command. What's more, this means you can inspect `mapping`s of
-`struct`s and `struct`s of `mapping`s, etc.!
+Mappings are now supported in **truffle-debugger**. Truffle will keep track of known mapping keys and let you inspect your contract's `mapping` variables with the `v` command. What's more, this means you can inspect `mapping`s of `struct`s and `struct`s of `mapping`s, etc.!
 
+<a href="#" id="acknowledgements"></a>
 ## Acknowledgements
 
-We'd like to extend a huge thank you to our community, our users, and our
-contributors, who have all been instrumental in helping us get this this
-point. We hope you enjoy this beta and all of Truffle's new features.
+We'd like to extend a huge thank you to our community, our users, and our contributors, who have all been instrumental in helping us get this this point. We hope you enjoy this beta and all of Truffle's new features.
 
-Please let us know if you find any problems or have any suggestions for
-making this release better. 🙇
+Please let us know if you find any problems or have any suggestions for making this release better. 🙇


### PR DESCRIPTION
**DO NOT MERGE** - this is here so people can do review stuff to it if they want to.
Good day! We're pleased to announce the first beta release of Truffle v5. With this release, we're excited to bring you some new features and improvements that will make your life easier. 

What's included, you ask? Well, get ready to use **whatever Solidity version you want** (Truffle will even automatically download it for you.) Or how about an **improved migrations system**, which dry-runs by default and provides lots of information to understand what is going right or wrong. Maybe you've been waiting for **Web3.js 1.0**. Perhaps you're sick of typing `.then()` and want to use **`await` in the console**. Truffle v5 has all of this, and more!

If you're as excited as we are and can't wait, here's how to upgrade:
```bash
npm uninstall -g truffle
npm install -g truffle@beta
```

Or keep reading for more information!

## Release Contents

* [Bring your own compiler](#bring-your-own-compiler)
  + [List available versions at the command line](#list-available-versions-at-the-command-line)
  + [Specify a solcjs version](#specify-a-solcjs-version)
  + [Advanced](#advanced)
  + [Speed comparison](#speed-comparison)
  + [Contract Profiling](#contract-profiling)
* [🐇 🐇 Web3.js 1.0 🐇 🐇](#web3js-1.0)
  + [⚠️ Breaking Changes ⚠️](#breaking-changes)
  + [🍨 Features 🍨](#web3-features)
  + [Methods / `.new` have an EventEmitter interface *and*  return a promise.](#methods-eventemitter)
  + [Events have an EventEmitter interface](#events-eventemitter)
  + [Reason strings!! Find out the reason.](#reason-strings)
  + [Overloaded Solidity methods (credit to @rudolfix and @mcdee)](#overloaded-solidity-methods)
  + [Configure number return format](#configure-number-return-format)
  + [Call methods at any block using the `defaultBlock` parameter.](#default-block)
  + [Automated fueling for method calls and deployments.](#automated-fueling)
  + [Contract deployments & transactions allowed to take as long as they take](#contract-deployments-transactions)
  + [Gas estimation for `.new`](#gas-estimation-for-new)
  + [Config](#config)
* [🐦 🐦  New Migrations 🐦 🐦](#new-migrations)
    - [Features](#new-migrations-features)
    - [Configuration and use](#configuration-and-use)
* [Even More!](#even-more)
  + [**truffle-console** now supports async/await](#truffle-console-now-supports-asyncawait)
  + [External compiler support](#external-compiler-support)
    - [Target generated artifacts](#target-generated-artifacts)
      * [Post-processing artifacts](#post-processing-artifacts)
    - [Target individual artifact properties](#target-individual-artifact-properties)
  + [Debugger mapping support](#debugger-mapping-support)
* [Acknowledgements](#acknowledgements)

<a href="#" id="bring-your-own-compiler"></a>
## Bring your own compiler

It's now possible to have Truffle compile with:
+ any solc-js version listed at [solc-bin](http://solc-bin.ethereum.org/bin/list.json). Specify the one you want and Truffle will get it for you.
+ a natively compiled solc binary (you'll need to install this yourself, links to help below).
+ dockerized solc from one of images published [here](https://hub.docker.com/r/ethereum/solc/tags/). (You'll also need to pull down the docker image yourself but it's really easy.)

<a href="#" id="list-available-versions-at-the-command-line"></a>
### List available versions at the command line
```shell
$ truffle compile --list                   # Recent stable releases from solc-bin (JS)
$ truffle compile --list prereleases       # Recent prereleases from solc-bin (JS)
$ truffle compile --list docker            # Recent docker tags from hub.docker.com
$ truffle compile --list releases --all    # Complete list of stable releases.
```

<a href="#" id="specify-a-solcjs-version"></a>
### Specify a solcjs version

Set the compilers solc `version` key to the one you'd like. Truffle will fetch it from the solc-bin server and cache it in your local evironment.
```javascript
module.exports = {
  networks: {
    ... etc ...
  },
  compilers: {
     solc: {
       version: <string>  // ex:  "0.4.20". (Default: Truffle's installed solc)
     }
  }
};
```

<a href="#" id="advanced"></a>
### Advanced
+ docker
+ native binary
+ `path/to/solc`
+ solc settings

Docker images should be installed locally by running:
```shell
$ docker pull ethereum/solc:0.4.22  // Example image
```
**truffle.js**
```javascript
// Native binary
compilers: {
  solc: {
    version: "native"
  }
}

// Docker
compilers: {
  solc: {
    version: "0.4.22",   // Any published image name
    docker: true
  }
}

// Relative or absolute path to an npm installed solc-js
compilers: {
  solc: {
    version: "/Users/axic/.nvm/versions/node/v8.9.4/lib/node_modules/solc"
  }
}

// Optimization and EVM version settings
compilers: {
  solc: {
    settings: {
      optimizer: {
        enabled: true, // Default: false
        runs: 1000     // Default: 200
      },
      evmVersion: "homestead"  // Default: "byzantium"
    }
  }
}
```

<a href="#" id="speed-comparison"></a>
### Speed comparison
Docker and native binary compilers process large contract sets faster than solcjs. If you're just compiling a few contracts at a time, the speedup isn't significant relative to the overhead of running a command (see below). The first time Truffle uses a docker version there's a small delay as it caches the solc version string and a solcjs companion compiler. All subsequent runs should be at full speed.

Times to `truffle compile` on a MacBook Air 1.8GHz, Node 8.11.1

| Project              | # files | solcjs | docker | bin |
|----------------------|---------:| ------:|--------:|-----------:|
| truffle/metacoin-box |       3 |   4.4s |   4.4s |      4.7s |
| gnosis/pm-contracts  |      34 |  21.7s |  10.9s |     10.2s |
| zeppelin-solidity    |     107 |  36.7s |  11.7s |     11.1s |


For help installing a natively built compiler, see the Solidity docs [here](https://solidity.readthedocs.io/en/v0.4.23/installing-solidity.html#binary-packages).

<a href="#" id="contract-profiling"></a>
### Contract Profiling
Truffle has always tried figure out which contracts changed recently and compile the smallest set necessary (with varying degrees of success). It now does this reliably so you may benefit from setting up an `npm` convenience script that looks like this:
```
"test": "truffle compile && truffle test"
```

Many thanks to the Solidity team for making all of the above possible and for their helpful advice over the last year.  🙌 🙌

<a href="#" id="web3js-1.0"></a>
## 🐇 🐇 Web3.js 1.0 🐇 🐇

**truffle-contract** now uses Web3.js 1.0 under the hood.  It's nice! The error handling (especially the parameter checking) is really good. And there's lots of new work happening over there  - ENS support is being added and [EthPrize](http://ethprize.io/) is funding an API to make contract packages published to EthPM easily available as well.

We've tried to minimize the inconvenience involved in transitioning an existing test suite from Web3 0.x to 1.0. Unfortunately there are some breaking changes due to differences in the way Web3 1.0 formats outputs (see chart below).

The biggest of these is that **truffle-contract** now returns numbers as [BN](https://github.com/indutny/bn.js/) by default instead of [BigNumber](https://github.com/MikeMcl/bignumber.js). This is necessary - BigNumber doesn't have the precision required by the EVM. The number libraries share some methods (notably `.toNumber()`) but their arithmetic operations are quite different.

**Important**: If you receive a number directly from Web3 (e.g. *not* from a **truffle-contract** instance)  you'll get a **string**. Luckily there's a helpful BN conversion method in the Web3 utils.
```javascript
const stringBalance = await web3.eth.getBalance('0xabc..');
const bnBalance = web3.utils.toBN(stringBalance);
```

**Helpful Resources**
+  Web3 1.0's [documentation](https://web3js.readthedocs.io/en/1.0/). Well worth taking a look - lots of differences in their new API.
+ EthWork's [bn-chai](https://github.com/EthWorks/bn-chai) library: BN helpers for your tests. (💡 ProTip courtesy elenadimitrova)

------------
<a href="#" id="breaking-changes"></a>
### ⚠️ Breaking Changes ⚠️

| Category | v4 (Web3 0.0) |  v5 (Web3 1.0) |
| ------ | ---- | ------- |
| addresses (return value) | lower-case | check-summed (mixed-case) |
| numbers  (return value)  | BigNumber | BN (configurable) |
| tuples (return value)       | Array | Object w/ named & indexed keys |
| `.contract` (underlying Web3 abstraction)| same as now | completely [different](https://web3js.readthedocs.io/en/1.0/web3-eth-contract.html) |
|`.at` (TruffleContract method)| sync / then-able | async |

-----------
<a href="#" id="web3-features"></a>
### 🍨 Features 🍨

<a href="#" id="methods-eventemitter"></a>
### Methods / `.new` have an EventEmitter interface *and*  return a promise.
```javascript
const example = await artifacts.require("Example").deployed();

example
  .setValue(45)
  .on('transactionHash', hash => {} )
  .on('receipt', receipt => {})
  .on('error', error => {})
  .on('confirmation', (num, receipt) => {} )
  .then( receipt => {} )
```

<a href="#" id="events-eventemitter"></a>
### Events have an EventEmitter interface
```javascript
example
  .ExampleEvent()
  .on('data', event => ... etc ... )

example
  .ExampleEvent()
  .once('data', event => ... etc ... )
```
<a href="#" id="reason-strings"></a>
### Reason strings!! Find out the reason.

**Solidity**
```solidity
require(msg.sender == owner, 'not authorized');
```

**Javascript**
```javascript
try {
  await example.transferToSelf({from: nonOwner})
} catch (err) {
  assert(err.reason === 'not authorized');
  assert(err.message.includes('not authorized');
}
```

<a href="#" id="overloaded-solidity-methods"></a>
### Overloaded Solidity methods (credit to @rudolfix and @mcdee)
```javascript
example.methods['setValue(uint256)'](123);
example.methods['setValue(uint256,uint256)'](11,55);
```

<a href="#" id="configure-number-return-format"></a>
### Configure number return format
As mentioned above - **truffle-contract** now returns [BN](https://github.com/indutny/bn.js). We've made this configurable so if you have an existing test suite you'd prefer to gradually transition from [BigNumber](https://github.com/MikeMcl/bignumber.js) to BN, it's possible to configure a contract's number format as below.
```javascript
// Choices are:  `["BigNumber", "BN", "String"].
const Example = artifacts.require('Example');
Example.numberFormat = 'BigNumber';
```

<a href="#" id="default-block"></a>
### Call methods at any block using the `defaultBlock` parameter.
```javascript
const oldBlock = 777;
const valueInThePast = await example.getBalance("0xabc..545", oldBlock);
```

<a href="#" id="automated-fueling"></a>
### Automated fueling for method calls and deployments.
```javascript
Example.autoGas = true;   // Defaults to true
Example.gasMultiplier(1.5) // Defaults to 1.25
const instance = await Example.new();
await instance.callExpensiveMethod();
```

<a href="#" id="contract-deployments-transactions"></a>
### Contract deployments & transactions allowed to take as long as they take
```javascript
Example.timeoutBlocks = 10000;
const example = await Example.new(1);
// Later....
await example.setValue(5)
```

<a href="#" id="gas-estimation-for-new"></a>
### Gas estimation for `.new`
```javascript
const deploymentCost = await Example.new.estimateGas();
```

<a href="#" id="config"></a>
### Config
To take advantage of the `confirmations` listener and to hear Events using `.on` or `.once`, you'll need to enable websockets in your network config as below.
```js
module.exports = {
  networks: {
    development: {
      host: "127.0.0.1",
      port: 8545,
      network_id: "*",
      websockets: true
    }
  }
};
```

<a href="#" id="new-migrations"></a>
## 🐦 🐦  New Migrations 🐦 🐦

Deploying contracts to public networks is hard ... 🙂 The topic dominates our 10 most visited GitHub issues.  On the bright side, those discussion threads are a rich trove of advice and brilliant insight from experienced Truffle users. V5 includes a rewrite of the `migrations` command that tries to integrate all their hard won knowledge into an easier to use deployment manager.

<a href="#" id="new-migrations-features"></a>
#### Features
+ **Improved error messaging.**  If Truffle can guess why a deployment failed it tells you and suggests some possible solutions.
+ **More information** about what's going on as you deploy, including cost summaries and real-time status updates about how long transactions have been pending. (See GIF below)
+ **Improved dry run** deployment simulations. This feature has had it's kinks worked out and now runs automatically if you're deploying to a known public network.  You can also use the `--interactive` flag at the command line to get a prompt between your dry run and real deployment.
+ Configure the number of block **confirmations** to wait between deployments. This is helpful when deploying to Infura because their load balancer sometimes executes back-to-back transactions out of sequence and  noncing can go awry.
+ Specify how many **blocks to wait** before timing out a pending deployment. Web3 hardcodes this value at 50 blocks which can be a problem if you're trying to deploy large contracts at the lower end of the gas price range.
+ A deployer interface that works seamlessly with ES6 **async/await** syntax. (Also backward compatible with Truffle V4's then-able pattern.)

⚠️  **Important** ⚠️  If you're using **truffle-hdwallet-provider** with Truffle v5 you **must** install the Web3 1.0 enabled version:
```shell
$ npm install --save truffle-hdwallet-provider@web3-one
```

<a href="#" id="configuration-and-use"></a>
#### Configuration and use

**Example network config**
```javascript
ropsten: {
  provider: () => new HDWalletProvider(mnemonic, `https://ropsten.infura.io`),
  network_id: 3,
  gas: 5500000,           // Default gas to send per transaction
  gasPrice: 10000000000,  // 10 gwei (default: 20 gwei)
  confirmations: 2,       // # of confs to wait between deployments. (default: 0)
  timeoutBlocks: 200,     // # of blocks before a deployment times out  (minimum/default: 50)
  skipDryRun: true        // Skip dry run before migrations? (default: false for public nets )
},
```

**Example Migration using async / await**
```javascript
const One = artifacts.require("One");
const Two = artifacts.require("Two");

module.exports = async function(deployer) {
  await deployer.deploy(One);

  const one = await One.deployed();
  const value = await one.value();

  await deployer.deploy(Two, value);
};
```
**Deploying to Rinkeby...**


![migrate-rinkeby](https://user-images.githubusercontent.com/7332026/43867960-3499922c-9b20-11e8-8553-589308a6cd61.gif)

**More migrations improvements are coming soon...**.
+ cag from Gnosis has written a really nice addition to the Migrations module that will automatically deploy contract dependencies you've installed with `npm` along with your own contracts.
+ Under the hood, the `migrations` command is now completely evented and managed by a reporter module. Those hooks will be exposed so anyone can write a UI for it and hopefully you'll be plugging into ever more sophisticated deployment script managers soon. Work on the default UI to make it more interactive and colorful is ongoing.

<a href="#" id="even-more"></a>
## Even More!

<a href="#" id="truffle-console-now-supports-asyncawait"></a>
### **truffle-console** now supports async/await

A small but decisive improvement that should make the console much easier to use.
**Example**
```shell
truffle(development)> let instance = await MetaCoin.deployed()
truffle(development)> let accounts = await web3.eth.getAccounts()
truffle(development)> let balance = await instance.getBalanceInEth(accounts[0])
truffle(development)> balance.toNumber()
20000
truffle(development)>
```

<a href="#" id="external-compiler-support"></a>
### External compiler support

For more advanced use cases, let's say your smart contract development workflow involves more than just compiling Solidity contracts. Maybe you're writing [eWASM precompiles](https://github.com/ewasm/ewasm-precompiles/tree/ecadd-truffle-tests/ecadd) or making a [two-dimensional `delegatecall` proxy](https://github.com/GNSPS/2DProxy). Or maybe you would just rather use [@pubkey's solidity-cli](https://github.com/pubkey/solidity-cli) instead of Truffle's `solc` configuration.

This is now supported by adding a `compilers.external` object to your Truffle config:
```javascript
{
  /* ... */

  compilers: {
    /* ... */

    external: {
      command: "./compile-contracts",
      targets: [{
        /* compilation output */
      }]
    }
  }

  /* ... */
}
```

When you run `truffle compile`, Truffle will run the configured `command` and look for contract artifacts specified by `targets`.

This new configuration supports two main use cases:
- Your compilation command outputs Truffle JSON artifacts directly
- Your compilation command outputs individual parts of an artifact, and you want Truffle to generate the artifacts for you.

Credit to @axic for the idea and for helping to hone our requirements as we implemented it. Thank you!

<a href="#" id="target-generated-artifacts"></a>
#### Target generated artifacts

If your compilation command generates artifacts directly, or generates output that contains all the information for an artifact, configure a target as follows:
```javascript
{
  compilers: {
    external: {
      command: "./compile-contracts",
      targets: [{
        path: "./path/to/artifacts/*.json"
      }]
    }
  }
}
```

Truffle will expand the glob (`*`) and find all `.json` files in the listed path and copy those over as artifacts in the `build/contracts/` directory.

<a href="#" id="post-processing-artifacts"></a>
##### Post-processing artifacts

The above use case might not be sufficient for all use cases. You can configure your target to run an arbitrary post-processing command:
```javascript
{
  compilers: {
    external: {
      command: "./compile-contracts",
      targets: [{
        path: "./path/to/preprocessed-artifacts/*.json",
        command: "./process-artifact"
      }]
    }
  }
}
```

This will run `./process-artifact` for each matched `.json` file, piping the contents of that file as stdin. Your `./process-artifact` command is then expected to output a complete Truffle artifact as stdout.

Want to provide the path as a filename instead? Add `stdin: false` to your target configuration.

<a href="#" id="target-individual-artifact-properties"></a>
#### Target individual artifact properties

The other way to configure your external compilation is to specify the individual properties of your contracts and have Truffle generate the artifacts itself:
```javascript
{
  compilers: {
    external: {
      command: "./compile-contracts",
      targets: [{
        properties: {
          contractName: "MyContract",
          /* other literal properties */
        },
        fileProperties: {
          abi: "./output/contract.abi",
          bytecode: "./output/contract.bytecode",
          /* other properties encoded in output files */
        }
      }]
    }
  }
}
```

Specify `properties` and/or `fileProperties`, and Truffle will look for those values when building the artifacts.

These two approaches aim to provide flexibility, aiming to meet whatever your compilation needs may be.

<a href="#" id="debugger-mapping-support"></a>
### Debugger mapping support

Mappings are now supported in **truffle-debugger**. Truffle will keep track of known mapping keys and let you inspect your contract's `mapping` variables with the `v` command. What's more, this means you can inspect `mapping`s of `struct`s and `struct`s of `mapping`s, etc.!

<a href="#" id="acknowledgements"></a>
## Acknowledgements

We'd like to extend a huge thank you to our community, our users, and our contributors, who have all been instrumental in helping us get this this point. We hope you enjoy this beta and all of Truffle's new features.

Please let us know if you find any problems or have any suggestions for making this release better. 🙇