### PR TITLE
Add string number reformatting for .call return values

### DIFF
--- a/packages/truffle-contract/lib/contract.js
+++ b/packages/truffle-contract/lib/contract.js
@@ -48,10 +48,10 @@ var contract = (function(module) {
             var fn;
 
             (constant)
-              ? fn = execute.call.call(constructor, web3Method, item.inputs, instance.address)
+              ? fn = execute.call.call(constructor, web3Method, item, instance.address)
               : fn = execute.send.call(constructor, web3Method, instance.address);
 
-            fn.call = execute.call.call(constructor, web3Method, item.inputs, instance.address);
+            fn.call = execute.call.call(constructor, web3Method, item, instance.address);
             fn.sendTransaction = execute.send.call(constructor, web3Method, instance.address);
             fn.estimateGas = execute.estimate.call(constructor, web3Method, instance.address);
             fn.request = execute.request.call(constructor, web3Method, instance.address);

--- a/packages/truffle-contract/lib/contract.js
+++ b/packages/truffle-contract/lib/contract.js
@@ -458,6 +458,28 @@ var contract = (function(module) {
         this._json.autoGas = val;
       }
     },
+    numberFormat: {
+      get: function() {
+        if (this._json.numberFormat === undefined){
+          this._json.numberFormat = 'bignumber';
+        }
+        return this._json.numberFormat;
+      },
+      set: function(val) {
+        const allowedFormats = [
+          'bignumber',
+          'bn',
+          'string'
+        ];
+
+        const msg = `Invalid number format setting: ${val}: ` +
+                    `valid formats are: ${allowedFormats}.`;
+
+        if (!allowedFormats.includes(val)) throw new Error(mg);
+
+        this._json.numberFormat = val;
+      }
+    },
     abi: {
       get: function() {
         return this._json.abi;

--- a/packages/truffle-contract/lib/contract.js
+++ b/packages/truffle-contract/lib/contract.js
@@ -472,10 +472,10 @@ var contract = (function(module) {
           'string'
         ];
 
-        const msg = `Invalid number format setting: ${val}: ` +
-                    `valid formats are: ${allowedFormats}.`;
+        const msg = `Invalid number format setting: "${val}": ` +
+                    `valid formats are: ${JSON.stringify(allowedFormats)}.`;
 
-        if (!allowedFormats.includes(val)) throw new Error(mg);
+        if (!allowedFormats.includes(val)) throw new Error(msg);
 
         this._json.numberFormat = val;
       }

--- a/packages/truffle-contract/lib/execute.js
+++ b/packages/truffle-contract/lib/execute.js
@@ -86,7 +86,7 @@ var execute = {
   /**
    * Executes method as .call and processes optional `defaultBlock` argument.
    * @param  {Function} fn         method
-   * @param  {Array}    methodABI  ABI segment defining the methods inputs.
+   * @param  {Object}   methodABI  function ABI segment w/ inputs & outputs keys.
    * @return {Promise}             Return value of the call.
    */
   call: function(fn, methodABI, address) {

--- a/packages/truffle-contract/lib/reformat.js
+++ b/packages/truffle-contract/lib/reformat.js
@@ -1,0 +1,90 @@
+/**
+ * Utilities for reformatting web3 outputs
+ */
+const BigNumber = require('bignumber.js');
+const web3Utils = require('web3-utils');
+
+/**
+ * Converts from string to other number format
+ * @param  {String} val    number string returned by web3
+ * @param  {String} format name of format to convert to
+ * @return {Object|String} converted value
+ */
+const _convertNumber = function(val, format){
+  const badFormatMsg = `Attempting to convert to unknown number format: ${format}`;
+
+  switch(format){
+    case 'bignumber': return new BigNumber(val);
+    case 'bn':        return web3Utils.toBN(val);
+    case 'string':    return val;
+    default:          throw new Error(badFormatMsg);
+  }
+}
+
+/**
+ * Converts arrays of number strings to other number formats
+ * @param  {String[]} arr       number string array returned by web3
+ * @param  {String}   format    name of format to convert to
+ * @return {Object[]|String[]}  array of converted values
+ */
+const _convertNumberArray = function(arr, format){
+  return arr.map((item => _convertNumber(item, format)));
+}
+
+/**
+ * Reformats numbers in the result/result-object of a web3 call.
+ * Possible forms of `result` are:
+ *   - object (with index keys and optionally, named keys)
+ *   - array
+ *   - single primitive
+ * @param  {String|Object|Array} result  web3 call result
+ * @param  {Array}               outputs ABI outputs array
+ * @return {String|Object|Array} reformatted result
+ */
+const callOutput = function(result, outputs){
+  const format = this.numberFormat;
+
+  outputs.forEach((output, i) => {
+
+    // output is a number type (uint || int);
+    if (output.type.includes('int')){
+
+      // output is an array type
+      if(output.type.includes('[')){
+
+        // result is array
+        if (Array.isArray(result)){
+          result = _convertNumberArray(result, format);
+
+        // result is object
+        } else {
+          // output has name
+          if (output.name.length){
+            result[output.name] = _convertNumberArray(result[output.name], format);
+          }
+          // output will always have an index key
+          result[i] = _convertNumberArray(result[i], format);
+        }
+      //
+      } else if (typeof result === 'object'){
+
+        // output has name
+          if (output.name.length){
+            result[output.name] = _convertNumber(result[output.name], format);
+          }
+
+          // output will always have an index key
+          result[i] = _convertNumber(result[i], format);
+
+      } else {
+        result = _convertNumber(result, format)
+      }
+    }
+  });
+  return result;
+}
+
+module.exports = {
+  callOutput: callOutput
+}
+

--- a/packages/truffle-contract/package.json
+++ b/packages/truffle-contract/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/trufflesuite/truffle-contract#readme",
   "dependencies": {
+    "bignumber.js": "^7.2.1",
     "ethereumjs-util": "^5.2.0",
     "ethjs-abi": "0.1.8",
     "truffle-blockchain-utils": "^0.0.5",
@@ -41,7 +42,6 @@
     "babel-core": "^6.26.0",
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.1",
-    "bignumber.js": "^6.0.0",
     "browserify": "^14.0.0",
     "chai": "4.1.2",
     "debug": "^3.1.0",

--- a/packages/truffle-contract/package.json
+++ b/packages/truffle-contract/package.json
@@ -26,7 +26,6 @@
   },
   "homepage": "https://github.com/trufflesuite/truffle-contract#readme",
   "dependencies": {
-    "bignumber.js": "^7.2.1",
     "ethereumjs-util": "^5.2.0",
     "ethjs-abi": "0.1.8",
     "truffle-blockchain-utils": "^0.0.5",

--- a/packages/truffle-contract/test/deploy.js
+++ b/packages/truffle-contract/test/deploy.js
@@ -211,7 +211,7 @@ describe("Deployments", function() {
     // Constructor in this test consumes ~6437823 (ganache) vs blockLimit of 6721975.
     it('should not multiply past the blockLimit', async function(){
       this.timeout(50000);
-      let iterations = 1200; // # of times to set a uint in a loop, consuming gas.
+      let iterations = 1000; // # of times to set a uint in a loop, consuming gas.
 
       const estimate = await Example.new.estimateGas(iterations);
       const block = await web3.eth.getBlock('latest');

--- a/packages/truffle-contract/test/methods.js
+++ b/packages/truffle-contract/test/methods.js
@@ -136,30 +136,91 @@ describe("Methods", function() {
       assert.equal(parseInt(value), 865, "Parrotted value should equal 865")
     });
 
-    it.only("should output uint tuples as BigNumber by default (call)", async function(){
+    it("should output uint tuples as BigNumber by default (call)", async function(){
       let value;
       const example = await Example.new(1)
 
       value = await example.returnsNamedTuple();
+
+      assert(web3.utils.isBigNumber(value[0]));
+      assert(typeof value[1] === 'string');
+      assert(web3.utils.isBigNumber(value[2]));
+
+      assert(web3.utils.isBigNumber(value.hello));
+      assert(typeof value.black === 'string');
+      assert(web3.utils.isBigNumber(value.goodbye));
+
       value = await example.returnsUnnamedTuple();
+
+      assert(typeof value[0] === 'string');
+      assert(web3.utils.isBigNumber(value[1]));
+
+      // uint sub-array
+      assert(Array.isArray(value[2]));
+      assert(web3.utils.isBigNumber(value[2][0]));
+      assert(web3.utils.isBigNumber(value[2][1]));
     });
 
-    it.only("should output uint array values as BigNumber by default (call)", async function(){
+    it("should output uint array values as BigNumber by default (call)", async function(){
       let value;
-      Example.numberFormat = 'bn';
       const example = await Example.new(1)
 
       value = await example.returnsNamedStaticArray();
+      assert(Array.isArray(value));
+      assert(web3.utils.isBigNumber(value[0]));
+      assert(web3.utils.isBigNumber(value[1]));
+
       value = await example.returnsUnnamedStaticArray();
+
+      assert(Array.isArray(value));
+      assert(web3.utils.isBigNumber(value[0]));
+      assert(web3.utils.isBigNumber(value[1]));
     });
 
     it("should output int values as BigNumber by default (call)", async function(){
       let value;
-      Example.numberFormat = 'bn';
       const example = await Example.new(1)
 
       value = await example.returnsInt();
+      assert(web3.utils.isBigNumber(value));
+    });
 
+    it("should output uint tuples as BN when set to 'bn' (call)", async function(){
+      let value;
+      Example.numberFormat = 'bn';
+      const example = await Example.new(1)
+
+      value = await example.returnsNamedTuple();
+
+      assert(web3.utils.isBN(value[0]));
+      assert(typeof value[1] === 'string');
+      assert(web3.utils.isBN(value[2]));
+
+      assert(web3.utils.isBN(value.hello));
+      assert(typeof value.black === 'string');
+      assert(web3.utils.isBN(value.goodbye));
+
+      value = await example.returnsUnnamedTuple();
+
+      assert(typeof value[0] === 'string');
+      assert(web3.utils.isBN(value[1]));
+
+      // uint sub-array
+      assert(Array.isArray(value[2]));
+      assert(web3.utils.isBN(value[2][0]));
+      assert(web3.utils.isBN(value[2][1]));
+
+      Example.numberFormat = 'bignumber';
+    });
+
+    it("should output int values as string when set to 'string' (call)", async function(){
+      let value;
+      Example.numberFormat = 'string';
+      const example = await Example.new(1)
+
+      value = await example.returnsInt();
+      assert(typeof value === 'string');
+      Example.numberFormat = 'bignumber';
     });
 
     it("should emit a transaction hash", function(done){
@@ -335,19 +396,14 @@ describe("Methods", function() {
       }
     });
 
-    it("errors if constructor `numberFormat` is unknown", async function(){
-      let value;
-      Example.numberFormat = undefined;
-      const example = await Example.new(1)
-
+    it("errors when setting `numberFormat` to invalid value", async function(){
       try {
-        await example.returnsNamedTuple();
+        Example.numberFormat = undefined;
         assert.fail()
       } catch(err){
-        assert(err.message.includes('unknown number format'));
+        assert(err.message.includes('Invalid number format'));
+        assert(Example.numberFormat === 'bignumber');
       }
-
-      Example.numberFormat = 'bignumber';
     });
   });
 

--- a/packages/truffle-contract/test/methods.js
+++ b/packages/truffle-contract/test/methods.js
@@ -136,6 +136,32 @@ describe("Methods", function() {
       assert.equal(parseInt(value), 865, "Parrotted value should equal 865")
     });
 
+    it.only("should output uint tuples as BigNumber by default (call)", async function(){
+      let value;
+      const example = await Example.new(1)
+
+      value = await example.returnsNamedTuple();
+      value = await example.returnsUnnamedTuple();
+    });
+
+    it.only("should output uint array values as BigNumber by default (call)", async function(){
+      let value;
+      Example.numberFormat = 'bn';
+      const example = await Example.new(1)
+
+      value = await example.returnsNamedStaticArray();
+      value = await example.returnsUnnamedStaticArray();
+    });
+
+    it("should output int values as BigNumber by default (call)", async function(){
+      let value;
+      Example.numberFormat = 'bn';
+      const example = await Example.new(1)
+
+      value = await example.returnsInt();
+
+    });
+
     it("should emit a transaction hash", function(done){
       Example.new(5).then(function(instance) {
         instance.setValue(25).on('transactionHash', function(hash){
@@ -307,6 +333,21 @@ describe("Methods", function() {
         assert(e.message.includes('invalid opcode'));
         assert(parseInt(e.receipt.status, 16) == 0)
       }
+    });
+
+    it("errors if constructor `numberFormat` is unknown", async function(){
+      let value;
+      Example.numberFormat = undefined;
+      const example = await Example.new(1)
+
+      try {
+        await example.returnsNamedTuple();
+        assert.fail()
+      } catch(err){
+        assert(err.message.includes('unknown number format'));
+      }
+
+      Example.numberFormat = 'bignumber';
     });
   });
 

--- a/packages/truffle-contract/test/sources/Example.sol
+++ b/packages/truffle-contract/test/sources/Example.sol
@@ -110,11 +110,29 @@ contract Example {
     }
   }
 
-  function returnsTuple () view returns (uint256 hello, uint8 goodbye){
-    return (5, 5);
+  function returnsNamedTuple () view returns (uint256 hello, string black, uint8 goodbye){
+    return (5, 'black', 5);
   }
 
-  function returnsStaticArray () view returns (uint[2]){
+  function returnsUnnamedTuple() view returns (string, uint, uint[2]){
+    uint[2] arr;
+    arr[0] = 5;
+    arr[1] = 5;
+    return ('hello', 5, arr);
+  }
+
+  function returnsInt() view returns (int){
+    return 5;
+  }
+
+  function returnsNamedStaticArray() view returns (uint[2] named ){
+    uint[2] arr;
+    arr[0] = 5;
+    arr[1] = 5;
+    return arr;
+  }
+
+  function returnsUnnamedStaticArray () view returns (uint[2]){
     uint[2] arr;
     arr[0] = 5;
     arr[1] = 5;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1027,10 +1027,6 @@ big.js@^3.1.3:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
 
-bignumber.js@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-6.0.0.tgz#bbfa047644609a5af093e9cbd83b0461fa3f6002"
-
 bignumber.js@^7.2.1:
   version "7.2.1"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-7.2.1.tgz#80c048759d826800807c4bfd521e50edbba57a5f"


### PR DESCRIPTION
#1126, [relevant suggestion](https://github.com/trufflesuite/truffle/pull/1129#issuecomment-406517580) 

+ Adds logic to transform Web3 1.0's string number outputs to BigNumber|BN|string before returning value from a `.call`. Defaults to BigNumber  for backwards compatibility with Web3 0.x
+ Adds a `numberFormat` setting to the contract abstraction that allows you to configure this at the costructor level
+ Adds tests for these return cases:
  + primitive
  + number array
  + tuple (named and unnamed elements)
  + tuple with a number array as an element

I will add event return value reformatting in a second PR, after this one is reviewed.


