### PR TITLE
Throw batch deprecation error correctly

### DIFF
--- a/packages/truffle-deployer/index.js
+++ b/packages/truffle-deployer/index.js
@@ -45,14 +45,6 @@ class Deployer extends Deployment {
   deploy() {
     const args = Array.prototype.slice.call(arguments);
     const contract = args.shift();
-
-    if (Array.isArray(contract)){
-      const msg = 'Support for batch deployments is no longer supported. ' +
-                  'Please deploy each contract individually.'
-
-      throw new Error(msg);
-    }
-
     return this.queueOrExec(this.executeDeployment(contract, args, this));
   }
 

--- a/packages/truffle-deployer/src/deployment.js
+++ b/packages/truffle-deployer/src/deployment.js
@@ -160,6 +160,17 @@ class Deployment {
    * @return {Promise}         throws on error
    */
   async _preFlightCheck(contract){
+
+    // Check that contract is not array
+    if (Array.isArray(contract)){
+      const message = await this.emitter.emit('error', {
+        type: 'noBatches',
+        contract: null,
+      })
+
+      throw new Error(message);
+    }
+
     // Check bytecode
     if(contract.bytecode === '0x') {
       const message = await this.emitter.emit('error', {
@@ -270,14 +281,14 @@ class Deployment {
     const self = this;
 
     return async function() {
+      await self._preFlightCheck(contract);
+
       let instance;
       let eventArgs;
       let shouldDeploy = true;
       let state = {
         contractName: contract.contractName
       };
-
-      await self._preFlightCheck(contract);
 
       const isDeployed = contract.isDeployed();
       const newArgs = await Promise.all(args);

--- a/packages/truffle-reporters/reporters/migrations-V5/messages.js
+++ b/packages/truffle-reporters/reporters/migrations-V5/messages.js
@@ -64,6 +64,10 @@ class MigrationsMessages{
         `is an abstract contract or an interface and cannot be deployed\n` +
         `   * Hint: just import the contract into the '.sol' file that uses it.\n`,
 
+      noBatches: () =>
+        `Support for batch deployments (array syntax) is deprecated. ` +
+        `Please deploy each contract individually.`,
+
       intWithGas: () =>
         `${prefix}"${data.contract.contractName}" ran out of gas ` +
         `(using a value you set in your network config or deployment parameters.)\n` +

--- a/packages/truffle/test/scenarios/migrations/errors.js
+++ b/packages/truffle/test/scenarios/migrations/errors.js
@@ -124,7 +124,20 @@ describe("migration errors", function() {
       assert(output.includes('Balance'));
       done();
     });
-
   });
+
+  it("should error if user tries to use batch syntax", function(done){
+    this.timeout(70000);
+
+    CommandRunner.run("migrate -f 7", config, err => {
+      const output = logger.contents();
+      assert(err);
+      console.log(output);
+      assert(output.includes('7_batch_deployments.js'));
+      assert(output.includes("batch deployments"));
+      assert(output.includes("deprecated"));
+      done();
+    });
+  })
 });
 

--- a/packages/truffle/test/sources/migrations/error/migrations/7_batch_deployments.js
+++ b/packages/truffle/test/sources/migrations/error/migrations/7_batch_deployments.js
@@ -1,0 +1,5 @@
+const Example = artifacts.require("Example");
+
+module.exports = async function(deployer, network, accounts) {
+  await deployer.deploy([Example]);
+};


### PR DESCRIPTION
#1136 

This error was in the wrong place / not throwing. 

+ moves array syntax check into the pre-flight validation at `executeDeployment`
+ puts the messaging in the reporter, 
+ adds a test.