### PR TITLE
Upgrade ganache cli to 6.1.6

### DIFF
--- a/packages/truffle-artifactor/package.json
+++ b/packages/truffle-artifactor/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "devDependencies": {
     "chai": "4.1.2",
-    "ganache-cli": "6.1.4",
+    "ganache-cli": "6.1.6",
     "mocha": "5.2.0",
     "require-nocache": "^1.0.0",
     "solc": "0.4.24",

--- a/packages/truffle-core/package.json
+++ b/packages/truffle-core/package.json
@@ -16,7 +16,7 @@
     "ethpm-registry": "0.0.10",
     "finalhandler": "^0.4.0",
     "fs-extra": "6.0.1",
-    "ganache-cli": "6.1.4",
+    "ganache-cli": "6.1.6",
     "lodash": "4.17.10",
     "mkdirp": "^0.5.1",
     "mocha": "5.2.0",

--- a/packages/truffle-debugger/package.json
+++ b/packages/truffle-debugger/package.json
@@ -50,7 +50,7 @@
     "express": "^4.16.2",
     "faker": "^4.1.0",
     "fs-extra": "6.0.1",
-    "ganache-cli": "6.1.4",
+    "ganache-cli": "6.1.6",
     "mocha": "5.2.0",
     "mocha-webpack": "^1.1.0",
     "node-interval-tree": "^1.3.3",

--- a/packages/truffle-deployer/package.json
+++ b/packages/truffle-deployer/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "fs-extra": "^6.0.1",
-    "ganache-cli": "6.1.4",
+    "ganache-cli": "6.1.6",
     "memorystream": "^0.3.1",
     "mocha": "5.2.0",
     "truffle-reporters": "^1.0.0",

--- a/packages/truffle-provider/package.json
+++ b/packages/truffle-provider/package.json
@@ -27,7 +27,7 @@
     "web3": "1.0.0-beta.33"
   },
   "devDependencies": {
-    "ganache-cli": "6.1.4",
+    "ganache-cli": "6.1.6",
     "mocha": "5.2.0"
   },
   "publishConfig": {

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -12,7 +12,7 @@
     "clean-webpack-plugin": "^0.1.16",
     "copy-webpack-plugin": "^4.0.1",
     "fs-extra": "6.0.1",
-    "ganache-cli": "6.1.4",
+    "ganache-cli": "6.1.6",
     "glob": "^7.1.2",
     "js-scrypt": "^0.2.0",
     "meta-npm": "^0.0.22",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4014,9 +4014,9 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
 
-ganache-cli@6.1.4:
-  version "6.1.4"
-  resolved "https://registry.yarnpkg.com/ganache-cli/-/ganache-cli-6.1.4.tgz#23a9b90a2d3abb136968193f5bade15d32c520bc"
+ganache-cli@6.1.6:
+  version "6.1.6"
+  resolved "https://registry.yarnpkg.com/ganache-cli/-/ganache-cli-6.1.6.tgz#99b500a25f571271a6978ef3f9c9c53e1a3854f0"
   dependencies:
     source-map-support "^0.5.3"
 


### PR DESCRIPTION
#1122 

This should resolve an issue in the dry-run migrations where the account balance is reported incorrectly because of a number conversion bug in `6.1.4`