### PR TITLE
Fix grandfathering of `solc` key

### DIFF
--- a/packages/truffle-compile/index.js
+++ b/packages/truffle-compile/index.js
@@ -44,8 +44,8 @@ var compile = function(sources, options, callback) {
 
   // Grandfather in old solc config
   if (options.solc){
-    compilers.solc.settings.evmVersion = options.solc.evmVersion;
-    compilers.solc.settings.optimizer = options.solc.optimizer;
+    options.compilers.solc.settings.evmVersion = options.solc.evmVersion;
+    options.compilers.solc.settings.optimizer = options.solc.optimizer;
   }
 
   // Ensure sources have operating system independent paths


### PR DESCRIPTION
#1137 

Fixes old `solc` settings not getting assigned to the new compilers key.
