### PR TITLE
Use levenshtein distance for context binary search

### DIFF
--- a/packages/truffle-debugger/lib/evm/selectors/index.js
+++ b/packages/truffle-debugger/lib/evm/selectors/index.js
@@ -2,6 +2,7 @@ import debugModule from "debug";
 const debug = debugModule("debugger:evm:selectors");
 
 import { createSelectorTree, createLeaf } from "reselect-tree";
+import levenshtein from "fast-levenshtein";
 
 import trace from "lib/trace/selectors";
 
@@ -149,26 +150,31 @@ const evm = createSelectorTree({
        *
        * returns function (binary) => context
        */
-      search: createLeaf(['./_'], (binaries) => {
-        // HACK ignore link references for search
-        // link references come in two forms: with underscores or all zeroes
-        // the underscore format is used by Truffle to reference links by name
-        // zeroes are used by solc directly, as libraries inject their own
-        // address at CREATE-time
-        const toRegExp = (binary) =>
-          new RegExp(`^${binary.replace(/__.{38}|0{40}/g, ".{40}")}`)
+      search: createLeaf(['./_'], (binaries) =>
+        (binary) => {
+          // search for a given binary based on levenshtein distances to
+          // existing (known) context binaries.
+          //
+          // levenshtein distance is the number of textual modifications
+          // (insert, change, delete) required to convert string a to b
+          //
+          // filter by a percentage threshold
+          const threshold = 0.25;
 
-        let matchers = Object.entries(binaries)
-          .map( ([binary, {context}]) => ({
-            context,
-            regex: toRegExp(binary)
-          }))
+          const results = Object.entries(binaries)
+            .map( ([ knownBinary, { context }]) => ({
+              context,
+              distance: levenshtein.get(knownBinary, binary)
+            }))
+            .filter( ({ distance }) => distance <= binary.length * threshold )
+            .sort( ({distance: a}, {distance: b}) => a - b );
 
-        return (binary) => matchers
-          .filter( ({ context, regex }) => binary.match(regex) )
-          .map( ({ context }) => ({ context }) )
-          [0] || null;
-      })
+          if (results[0]) {
+            const { context } = results[0];
+            return { context };
+          }
+        }
+      )
     }
   },
 

--- a/packages/truffle-debugger/package.json
+++ b/packages/truffle-debugger/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "bignumber.js": "^7.2.1",
     "debug": "^3.1.0",
+    "fast-levenshtein": "^2.0.6",
     "json-pointer": "^0.6.0",
     "redux": "^3.7.2",
     "redux-cli-logger": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3642,7 +3642,7 @@ fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
 
-fast-levenshtein@~2.0.4:
+fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 


### PR DESCRIPTION
Since context binary searching has been a problem, this sidesteps the problem a bit by finding the closest matching binary string.

Instead of attempting to remove link-references and whatnot, just use the levenshtein distance to determine the number of inserts/deletes/character changes required to change sought binary to possible found binary. Return the closest match as the result.

Filter the results so that a result is only returned in the case where the distance is <=25% the length of the sought binary.

Wikipedia: [Levenshtein Distance](https://en.wikipedia.org/wiki/Levenshtein_distance)