### PR TITLE
Support external compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - docker pull ethereum/solc:0.4.22
   - sudo add-apt-repository --yes ppa:ethereum/ethereum
   - sudo apt-get update
-  - sudo apt-get install solc
+  - sudo apt-get install solc jq
 
 matrix:
   fast_finish: true

--- a/packages/truffle-contract-sources/index.js
+++ b/packages/truffle-contract-sources/index.js
@@ -1,15 +1,20 @@
-var dir = require("node-dir");
-var path = require("path");
+const debug = require("debug")("contract-sources");
 
-module.exports = function(directory, callback) {
-  dir.files(directory, function(err, files) {
-    if (err) return callback(err);
+const path = require("path");
+const glob = require("glob");
 
-    files = files.filter(function(file) {
-      // Ignore any files that aren't solidity files.
-      return path.extname(file) == ".sol" && path.basename(file)[0] != ".";
-    });
+const DEFAULT_PATTERN = "**/*.sol";
 
-    callback(null, files);
-  })
+module.exports = function(pattern, callback) {
+  // pattern is either a directory (contracts directory), or an absolute path
+  // with a glob expression
+  if (!glob.hasMagic(pattern)) {
+    pattern = path.join(pattern, DEFAULT_PATTERN);
+  }
+
+  const globOptions = {
+    follow: true  // follow symlinks
+  };
+
+  glob(pattern, globOptions, callback);
 };

--- a/packages/truffle-contract-sources/package.json
+++ b/packages/truffle-contract-sources/package.json
@@ -21,7 +21,8 @@
   },
   "homepage": "https://github.com/trufflesuite/truffle-contract-sources#readme",
   "dependencies": {
-    "node-dir": "0.1.17"
+    "debug": "^3.1.0",
+    "glob": "^7.1.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/truffle-core/lib/commands/compile.js
+++ b/packages/truffle-core/lib/commands/compile.js
@@ -8,6 +8,10 @@ var command = {
       type: "boolean",
       default: false
     },
+    compiler: {
+      type: "string",
+      default: null
+    },
     list: {
       type: "string",
     },

--- a/packages/truffle-core/lib/test.js
+++ b/packages/truffle-core/lib/test.js
@@ -164,8 +164,9 @@ var Test = {
           resolver: test_resolver,
           quiet: false,
           quietWrite: true
-        }), function(err, abstractions, paths) {
+        }), function(err, result) {
           if (err) return reject(err);
+          const paths = result.outputs.solc;
           accept(paths);
         });
       });

--- a/packages/truffle-core/lib/test.js
+++ b/packages/truffle-core/lib/test.js
@@ -11,7 +11,6 @@ var TestResolver = require("./testing/testresolver");
 var TestSource = require("./testing/testsource");
 var SolidityTest = require("./testing/soliditytest");
 var expect = require("truffle-expect");
-var find_contracts = require("truffle-contract-sources");
 var Migrate = require("truffle-migrate");
 var Profiler = require("truffle-compile/profiler.js");
 var async = require("async");

--- a/packages/truffle-core/test/compile.js
+++ b/packages/truffle-core/test/compile.js
@@ -52,8 +52,9 @@ describe("compile", function() {
     Contracts.compile(config.with({
       all: false,
       quiet: true
-    }), function(err, contracts) {
+    }), function(err, result) {
       if (err) return done(err);
+      let { contracts } = result;
 
       assert.equal(Object.keys(contracts).length, 3, "Didn't compile the expected number of contracts");
       done();
@@ -66,8 +67,9 @@ describe("compile", function() {
     Contracts.compile(config.with({
       all: false,
       quiet: true
-    }), function(err, contracts) {
+    }), function(err, result) {
       if (err) return done(err);
+      let { contracts } = result;
 
       assert.equal(Object.keys(contracts).length, 0, "Compiled a contract even though we weren't expecting it");
       done();
@@ -87,8 +89,9 @@ describe("compile", function() {
     Contracts.compile(config.with({
       all: false,
       quiet: true
-    }), function(err, contracts) {
+    }), function(err, result) {
       if (err) return done(err);
+      let { contracts } = result;
 
       assert.equal(Object.keys(contracts).length, 2, "Expected MetaCoin and ConvertLib to be compiled");
 

--- a/packages/truffle-core/test/ethpm.js
+++ b/packages/truffle-core/test/ethpm.js
@@ -155,8 +155,9 @@ describe.skip('EthPM integration', function() {
       Contracts.compile(config.with({
         all: true,
         quiet: true
-      }), function(err, contracts) {
+      }), function(err, result) {
         if (err) return done(err);
+        let { contracts } = result;
 
         assert.isNotNull(contracts["owned"]);
         assert.isNotNull(contracts["transferable"]);

--- a/packages/truffle-core/test/migrate.js
+++ b/packages/truffle-core/test/migrate.js
@@ -78,8 +78,9 @@ describe("migrate", function() {
     Contracts.compile(config.with({
       all: false,
       quiet: true
-    }), function(err, contracts) {
+    }), function(err, result) {
       if (err) return done(err);
+      let { contracts } = result;
 
       Migrate.run(config.with({
         quiet: true

--- a/packages/truffle-core/test/npm.js
+++ b/packages/truffle-core/test/npm.js
@@ -77,8 +77,9 @@ describe('NPM integration', function() {
 
     Contracts.compile(config.with({
       quiet: true
-    }), function(err, contracts) {
+    }), function(err, result) {
       if (err) return done(err);
+      let { contracts } = result;
 
       var contractNames = Object.keys(contracts);
 

--- a/packages/truffle-debugger/test/helpers.js
+++ b/packages/truffle-debugger/test/helpers.js
@@ -132,9 +132,11 @@ export async function compile(config) {
     Contracts.compile(config.with({
       all: true,
       quiet: true
-    }), function(err, contracts, files) {
+    }), function(err, result) {
       if (err) return reject(err);
-      return accept({contracts, files});
+      const { contracts, outputs } = result;
+      debug("result %O", result);
+      return accept({ contracts, files: outputs.solc });
     });
   });
 }

--- a/packages/truffle-external-compile/README.md
+++ b/packages/truffle-external-compile/README.md
@@ -10,9 +10,10 @@ In your Truffle config (`truffle.js`):
 module.exports = {
   compilers: {
     external: {
-      command: "<command-to-run>",
+      command: "<compilation-command>",
       targets: [{
-        path: "relative/globbed/path/to/artifacts/*.json"
+        path: "<relative/globbed/path/to/outputs/*.output>",
+        command: "<artifact-generation-command>"
       }]
     }
   }

--- a/packages/truffle-external-compile/README.md
+++ b/packages/truffle-external-compile/README.md
@@ -1,0 +1,20 @@
+# `truffle-external-compile`
+
+Package to enable Truffle to run arbitrary commands as part of compilation.
+
+## Configuration
+
+In your Truffle config (`truffle.js`):
+
+```javascript
+module.exports = {
+  compilers: {
+    external: {
+      command: "<command-to-run>",
+      targets: [{
+        path: "relative/globbed/path/to/artifacts/*.json"
+      }]
+    }
+  }
+}
+```

--- a/packages/truffle-external-compile/index.js
+++ b/packages/truffle-external-compile/index.js
@@ -42,18 +42,20 @@ const runCommand = promisify(function (command, options, callback) {
 });
 
 function decodeContents (contents) {
-  // HACK to test if contents has binary data
-  // from https://stackoverflow.com/a/49773659
-  if (/\ufffd/.test(contents.toString())) {
-    return web3.utils.bytesToHex(contents);
-  }
+  // accepts JSON, a hex string, or raw binary
 
+  // JSON
   try {
     return JSON.parse(contents);
-  } catch (e) {
-    return contents;
+  } catch (e) { /* no-op */ }
+
+  // hex string
+  if (contents.toString().startsWith("0x")) {
+    return contents.toString();
   }
 
+  // raw binary
+  return web3.utils.bytesToHex(contents);
 }
 
 async function processTargets (targets, cwd) {

--- a/packages/truffle-external-compile/index.js
+++ b/packages/truffle-external-compile/index.js
@@ -8,6 +8,12 @@ const fs = require("fs");
 const expect = require("truffle-expect");
 const debug = require("debug")("external-compile");
 
+const DEFAULT_ABI = [{
+  payable: true,
+  stateMutability: "payable",
+  type: "fallback"
+}];
+
 const runCommand = promisify(function (command, options, callback) {
   const { cwd, logger, input } = options;
   const child = exec(command, { cwd, input });
@@ -119,6 +125,11 @@ async function processTarget (target, cwd) {
     if (!contract.contractName) {
       throw new Error("External compilation target must specify contractName");
     }
+
+    if (!contract.abi) {
+      contract.abi = DEFAULT_ABI;
+    }
+
     return { [contract.contractName]: contract };
   }
 }
@@ -148,7 +159,12 @@ const compile = callbackify(async function(options) {
   return await processTargets(targets, cwd);
 });
 
+// required public interface
 compile.all = compile;
 compile.necessary = compile;
+
+// specific exports
+compile.DEFAULT_ABI = DEFAULT_ABI;
+compile.processTarget = processTarget;
 
 module.exports = compile;

--- a/packages/truffle-external-compile/index.js
+++ b/packages/truffle-external-compile/index.js
@@ -21,12 +21,12 @@ const runCommand = promisify(function (command, options, callback) {
   const child = exec(command, { cwd, input });
 
   child.stdout.on('data', function(data) {
-    data = data.toString().replace(/\n$/, '');
+    data = data.toString().replace(/(\r|\n)+$/, '');
     logger.log(data);
   });
 
   child.stderr.on('data', function(data) {
-    data = data.toString().replace(/\n$/, '');
+    data = data.toString().replace(/(\r|\n)+$/, '');
     logger.log(data);
   });
 

--- a/packages/truffle-external-compile/index.js
+++ b/packages/truffle-external-compile/index.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const exec = require('child_process').exec;
+const path = require("path");
+const { callbackify, promisify } = require("util");
+const glob = promisify(require("glob"));
+const fs = require("fs");
+const expect = require("truffle-expect");
+const debug = require("debug")("external-compile");
+
+const runCompile = promisify(function (command, cwd, logger, callback) {
+  const child = exec(command, { cwd });
+
+  child.stdout.on('data', function(data) {
+    data = data.toString().replace(/\n$/, '');
+    logger.log(data);
+  });
+
+  child.stderr.on('data', function(data) {
+    data = data.toString().replace(/\n$/, '');
+    logger.log(data);
+  });
+
+  child.on('close', function(code) {
+    // If the command didn't exit properly, show the output and throw.
+    if (code !== 0) {
+      var err = new Error("Unknown exit code: " + code);
+      return callback(err);
+    }
+
+    callback();
+  });
+});
+
+const compile = callbackify(async function(options) {
+  if (options.logger == null) {
+    options.logger = console;
+  }
+
+  expect.options(options, [
+    "compilers",
+    "working_directory"
+  ]);
+  expect.options(options.compilers, ["external"]);
+  expect.options(options.compilers.external, [
+    "command",
+    "targets"
+  ]);
+
+  const { command, targets } = options.compilers.external;
+
+  debug("running compile command: %s", command);
+  await runCompile(command, options.working_directory, options.logger);
+
+  const contracts = {};
+  for (let target of targets) {
+    const pattern = path.join(options.working_directory, target.path);
+    for (let artifact of await glob( pattern, { follow: true })) {
+      debug("processing artifact: %s", artifact);
+
+      let contract = JSON.parse(fs.readFileSync(artifact));
+      contracts[contract.contractName] = contract;
+    }
+  }
+
+  return contracts;
+});
+
+compile.all = compile;
+compile.necessary = compile;
+
+module.exports = compile;

--- a/packages/truffle-external-compile/index.js
+++ b/packages/truffle-external-compile/index.js
@@ -57,15 +57,23 @@ const compile = callbackify(async function(options) {
 
   const contracts = {};
   for (let target of targets) {
-    const pattern = path.join(cwd, target.path);
+    expect.one(target, [ "path", "command" ]);  // also allows both
 
-    for (let preprocessed of await glob( pattern, { follow: true })) {
-      debug("processing target: %s", preprocessed);
-      const input = fs.readFileSync(preprocessed).toString();
+    if (target.path != undefined) {
+      const pattern = path.join(cwd, target.path);
 
-      const output = (target.command)
-        ? execSync(target.command, { cwd, input })
-        : input;
+      for (let preprocessed of await glob( pattern, { follow: true })) {
+        debug("processing target: %s", preprocessed);
+        const input = fs.readFileSync(preprocessed).toString();
+
+        const output = (target.command)
+          ? execSync(target.command, { cwd, input })
+          : input;
+        const contract = JSON.parse(output);
+        contracts[contract.contractName] = contract;
+      }
+    } else {
+      const output = execSync(target.command, { cwd });
       const contract = JSON.parse(output);
       contracts[contract.contractName] = contract;
     }

--- a/packages/truffle-external-compile/index.js
+++ b/packages/truffle-external-compile/index.js
@@ -7,6 +7,7 @@ const { callbackify, promisify } = require("util");
 const glob = promisify(require("glob"));
 const fs = require("fs");
 const expect = require("truffle-expect");
+const Schema = require("truffle-contract-schema");
 const web3 = {};
 web3.utils = require("web3-utils");
 
@@ -63,7 +64,7 @@ async function processTargets (targets, cwd, logger) {
   for (let target of targets) {
     let targetContracts = await processTarget(target, cwd, logger);
     for (let [name, contract] of Object.entries(targetContracts)) {
-      contracts[name] = contract;
+      contracts[name] = Schema.validate(contract);
     }
   }
 

--- a/packages/truffle-external-compile/index.js
+++ b/packages/truffle-external-compile/index.js
@@ -17,21 +17,104 @@ const DEFAULT_ABI = [{
   type: "fallback"
 }];
 
+/**
+ * buffer a line of data, yielding each full line
+ *
+ * returned generator alternates between two states:
+ * 1. reset
+ * 2. read/write
+ *
+ * usage:
+ *
+ *   let gen = bufferLines();
+ *
+ *   // first reset
+ *   gen.next(); // reset
+ *
+ *   // pass string data with zero or more new lines
+ *   // or pass `null` to signal EOF
+ *   let { value, done } = gen.next(data);
+ *
+ *   // if done, value possibly contains string value with unterminated output
+ *   // otherwise, value contains any/all complete lines
+ */
+function *bufferLines() {
+  let buffer = [];
+
+  while (true) {
+    // read input string or null as eof
+    const input = yield;
+
+    // eof returns buffer
+    if (input == null) {
+      const unterminated = buffer.join("");
+
+      return (unterminated)
+        ? [ `${unterminated}%` ]
+        : [];
+    }
+
+    // split lines
+    // last element is always partial line
+    const data = input.split("\n");
+
+    // add first element to buffer
+    let [ first ] = data.slice(0);
+    buffer.push(first);
+
+    if (data.length > 1) {
+      // split off partial line to save as new buffer
+      const [ last ] = data.slice(-1);
+      const [ ...middle ] = data.slice(1, -1);
+
+      // use buffer as first element (now complete line)
+      // and yield all complete lines
+      const lines = [ buffer.join(""),  ...middle ];
+      yield lines;
+
+      // reset buffer
+      buffer = [last];
+
+    } else {
+      // nothing to see yet
+      yield [];
+    }
+  }
+}
+
+/**
+ * run a command, forwarding data to arbitrary logger.
+ * invokes callback when process exits, error on nonzero exit code.
+ */
 const runCommand = promisify(function (command, options, callback) {
   const { cwd, logger, input } = options;
   const child = exec(command, { cwd, input });
 
-  child.stdout.on('data', function(data) {
-    data = data.toString().replace(/(\r|\n)+$/, '');
-    logger.log(data);
-  });
+  // wrap buffer generator for easy use
+  const buffer = (func) => {
+    const gen = bufferLines();
 
-  child.stderr.on('data', function(data) {
-    data = data.toString().replace(/(\r|\n)+$/, '');
-    logger.log(data);
-  });
+    return (data) => {
+      gen.next();
+
+      let { value: lines } = gen.next(data);
+      for (let line of lines) {
+        func(line);
+      }
+    }
+  };
+
+  const log = buffer(logger.log);
+  const warn = buffer(logger.warn || logger.log);
+
+  child.stdout.on('data', data => log(data.toString()));
+  child.stderr.on('data', data => warn(data.toString()));
 
   child.on('close', function(code) {
+    // close streams to flush unterminated lines
+    log(null);
+    warn(null);
+
     // If the command didn't exit properly, show the output and throw.
     if (code !== 0) {
       var err = new Error("Unknown exit code: " + code);
@@ -42,9 +125,13 @@ const runCommand = promisify(function (command, options, callback) {
   });
 });
 
+/**
+ * identify and process contents as one of:
+ * 1. JSON literal
+ * 2. Hex string
+ * 3. Raw binary data
+ */
 function decodeContents (contents) {
-  // accepts JSON, a hex string, or raw binary
-
   // JSON
   try {
     return JSON.parse(contents);

--- a/packages/truffle-external-compile/package.json
+++ b/packages/truffle-external-compile/package.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "debug": "^3.1.0",
     "glob": "^7.1.2",
-    "truffle-expect": "^0.0.4"
+    "truffle-expect": "^0.0.4",
+    "web3-utils": "1.0.0-beta.33"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/packages/truffle-external-compile/package.json
+++ b/packages/truffle-external-compile/package.json
@@ -15,7 +15,9 @@
     "type": "git",
     "url": "git+https://github.com/trufflesuite/truffle.git"
   },
-  "scripts": {},
+  "scripts": {
+    "test": "mocha"
+  },
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"
   },
@@ -23,5 +25,10 @@
     "debug": "^3.1.0",
     "glob": "^7.1.2",
     "truffle-expect": "^0.0.4"
+  },
+  "devDependencies": {
+    "chai": "^4.1.2",
+    "mocha": "5.2.0",
+    "temp": "^0.8.3"
   }
 }

--- a/packages/truffle-external-compile/package.json
+++ b/packages/truffle-external-compile/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "truffle-external-compile",
+  "version": "1.0.0",
+  "description": "Wrapper to compile Truffle contracts with arbitrary shell command",
+  "keywords": [
+    "truffle",
+    "ethereum",
+    "smart-contract"
+  ],
+  "author": "g. nicholas d'andrea <gnidan@users.noreply.github.com>",
+  "homepage": "https://github.com/trufflesuite/truffle#readme",
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/trufflesuite/truffle.git"
+  },
+  "scripts": {},
+  "bugs": {
+    "url": "https://github.com/trufflesuite/truffle/issues"
+  },
+  "dependencies": {
+    "debug": "^3.1.0",
+    "glob": "^7.1.2",
+    "truffle-expect": "^0.0.4"
+  }
+}

--- a/packages/truffle-external-compile/package.json
+++ b/packages/truffle-external-compile/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "debug": "^3.1.0",
     "glob": "^7.1.2",
+    "truffle-contract-schema": "^2.0.1",
     "truffle-expect": "^0.0.4",
     "web3-utils": "1.0.0-beta.33"
   },

--- a/packages/truffle-external-compile/test/test_targets.js
+++ b/packages/truffle-external-compile/test/test_targets.js
@@ -83,7 +83,7 @@ describe("Compilation Targets", () => {
     it("reads UTF-8 file properties", async () => {
       const contractName = "My😀Contract";
       const contractNameFile = "contractName";
-      const fileContents = contractName;
+      const fileContents = JSON.stringify(contractName);
 
       fs.writeFileSync(path.join(cwd, contractNameFile), fileContents);
 

--- a/packages/truffle-external-compile/test/test_targets.js
+++ b/packages/truffle-external-compile/test/test_targets.js
@@ -1,0 +1,34 @@
+const { promisify } = require("util");
+const temp = require("temp").track();
+const assert = require("chai").assert;
+
+const { processTarget, DEFAULT_ABI } = require("..");
+
+describe("Compilation Targets", () => {
+  let outputDir;
+
+  before("make temporary directory", async () => {
+    outputDir = await promisify(temp.mkdir)("external-targets");
+  });
+
+  describe("Property outputs", () => {
+    it("includes default ABI when not specified", async () => {
+      const contractName = "MyContract";
+      const abi = DEFAULT_ABI;
+
+      const target = {
+        properties: {
+          contractName
+        }
+      };
+
+      const expected = {
+        [contractName]: { contractName, abi },
+      };
+
+      const actual = await processTarget(target, outputDir);
+
+      assert.deepEqual(expected, actual);
+    });
+  });
+});

--- a/packages/truffle-external-compile/test/test_targets.js
+++ b/packages/truffle-external-compile/test/test_targets.js
@@ -59,7 +59,7 @@ describe("Compilation Targets", () => {
       assert.equal(processed[contractName].bytecode, bytecode);
     });
 
-    it("reads UTF-8 string file properties", async () => {
+    it("reads hex-string file properties", async () => {
       const bytecode = "0x603160008181600b";
       const bytecodeFile = "bytecode";
       const fileContents = bytecode;
@@ -78,6 +78,24 @@ describe("Compilation Targets", () => {
       const processed = await processTarget(target, cwd);
 
       assert.equal(processed[contractName].bytecode, bytecode);
+    });
+
+    it("reads UTF-8 file properties", async () => {
+      const contractName = "My😀Contract";
+      const contractNameFile = "contractName";
+      const fileContents = contractName;
+
+      fs.writeFileSync(path.join(cwd, contractNameFile), fileContents);
+
+      const target = {
+        fileProperties: {
+          contractName: contractNameFile
+        }
+      };
+
+      const processed = await processTarget(target, cwd);
+
+      assert.equal(processed[contractName].contractName, contractName);
     });
 
     it("reads raw binary file properties", async () => {

--- a/packages/truffle-workflow-compile/index.js
+++ b/packages/truffle-workflow-compile/index.js
@@ -65,24 +65,27 @@ var Contracts = {
   compile: callbackify(async function(options) {
     const config = prepareConfig(options);
 
+    const compilers = (config.compiler)
+      ? [config.compiler]
+      : Object.keys(config.compilers);
+
     // convert to promise to compile+write
-    const compilations = Object.keys(config.compilers)
-      .map(async (compiler) => {
-        const compile = SUPPORTED_COMPILERS[compiler];
-        if (!compile) throw new Error("Unsupported compiler: " + name);
+    const compilations = compilers.map(async (compiler) => {
+      const compile = SUPPORTED_COMPILERS[compiler];
+      if (!compile) throw new Error("Unsupported compiler: " + compiler);
 
-        const compileFunc = (config.all === true || config.compileAll === true)
-          ? compile.all
-          : compile.necessary;
+      const compileFunc = (config.all === true || config.compileAll === true)
+        ? compile.all
+        : compile.necessary;
 
-        let [contracts, output] = await multiPromisify(compileFunc)(config);
+      let [contracts, output] = await multiPromisify(compileFunc)(config);
 
-        if (contracts && Object.keys(contracts).length > 0) {
-          await this.writeContracts(contracts, config)
-        }
+      if (contracts && Object.keys(contracts).length > 0) {
+        await this.writeContracts(contracts, config)
+      }
 
-        return { compiler, contracts, output };
-      });
+      return { compiler, contracts, output };
+    });
 
     const collect = async (compilations) => {
       let result = {

--- a/packages/truffle-workflow-compile/index.js
+++ b/packages/truffle-workflow-compile/index.js
@@ -7,6 +7,7 @@ var path = require("path");
 var { callbackify, promisify } = require("util");
 var Config = require("truffle-config");
 var solcCompile = require("truffle-compile");
+var externalCompile = require("truffle-external-compile");
 var expect = require("truffle-expect");
 var _ = require("lodash");
 var Resolver = require("truffle-resolver");
@@ -15,6 +16,7 @@ var OS = require("os");
 
 const SUPPORTED_COMPILERS = {
   "solc": solcCompile,
+  "external": externalCompile,
 };
 
 function prepareConfig(options) {

--- a/packages/truffle-workflow-compile/package.json
+++ b/packages/truffle-workflow-compile/package.json
@@ -4,6 +4,7 @@
   "description": "Core workflow behavior for `truffle compile` command",
   "dependencies": {
     "async": "2.6.1",
+    "debug": "^3.1.0",
     "lodash": "4.17.10",
     "mkdirp": "^0.5.1",
     "truffle-artifactor": "^3.0.7",

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -39,6 +39,7 @@
     "build-cli": "webpack --config ./cli.webpack.config.js",
     "test": "./scripts/test.sh",
     "publish:byoc": "node ./scripts/prereleaseVersion.js byoc-safe byoc",
+    "publish:external-compiler": "node ./scripts/prereleaseVersion.js external-compiler external-compiler",
     "publish:next": "node ./scripts/prereleaseVersion.js next next",
     "test:raw": "NO_BUILD=true mocha"
   },

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -1,7 +1,7 @@
 {
   "name": "truffle",
   "namespace": "consensys",
-  "version": "5.0.0-external-compiler.2",
+  "version": "5.0.0-external-compiler.3",
   "description": "Truffle - Simple development framework for Ethereum",
   "dependencies": {
     "mocha": "^4.1.0",

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -1,7 +1,7 @@
 {
   "name": "truffle",
   "namespace": "consensys",
-  "version": "5.0.0-external-compiler.1",
+  "version": "5.0.0-external-compiler.2",
   "description": "Truffle - Simple development framework for Ethereum",
   "dependencies": {
     "mocha": "^4.1.0",

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -1,7 +1,7 @@
 {
   "name": "truffle",
   "namespace": "consensys",
-  "version": "5.0.0-next.7",
+  "version": "5.0.0-external-compiler.0",
   "description": "Truffle - Simple development framework for Ethereum",
   "dependencies": {
     "mocha": "^4.1.0",

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -1,7 +1,7 @@
 {
   "name": "truffle",
   "namespace": "consensys",
-  "version": "5.0.0-external-compiler.0",
+  "version": "5.0.0-external-compiler.1",
   "description": "Truffle - Simple development framework for Ethereum",
   "dependencies": {
     "mocha": "^4.1.0",

--- a/packages/truffle/scripts/test.sh
+++ b/packages/truffle/scripts/test.sh
@@ -3,7 +3,7 @@
 set -o errexit
 
 if [ "$GETH" == true ]; then
-  npm run build-cli && mocha --timeout 50000 --grep @ganache --invert --colors
+  npm run build-cli && mocha --timeout 50000 --grep @ganache --invert --colors $@
 else
-  npm run build-cli && mocha --no-warnings --timeout 7000 --grep @geth --invert --colors
+  npm run build-cli && mocha --no-warnings --timeout 7000 --grep @geth --invert --colors $@
 fi

--- a/packages/truffle/test/scenarios/external_compilers/truffle-compile.js
+++ b/packages/truffle/test/scenarios/external_compilers/truffle-compile.js
@@ -1,0 +1,99 @@
+var MemoryLogger = require("../memorylogger");
+var CommandRunner = require("../commandrunner");
+var contract = require("truffle-contract");
+var fs = require("fs");
+var path = require("path");
+var assert = require("assert");
+var sandbox = require("../sandbox");
+var Server = require("../server");
+var Reporter = require("../reporter");
+
+describe("`truffle compile` as external", function() {
+  var config;
+  var project = path.join(__dirname, '../../sources/external_compile');
+  var logger = new MemoryLogger();
+
+  before("set up the server", function(done) {
+    Server.start(done);
+  });
+
+  after("stop server", function(done) {
+    Server.stop(done);
+  });
+
+  before("set up sandbox", function() {
+    this.timeout(10000);
+    return sandbox.create(project).then(conf => {
+      config = conf;
+      config.network = "development";
+      config.logger = logger;
+      config.mocha = {
+        reporter: new Reporter(logger)
+      }
+    });
+  });
+
+  it("will compile", function(done) {
+    this.timeout(20000);
+
+    CommandRunner.run("compile --compiler=external", config, function(err) {
+      var output = logger.contents();
+      if (err) {
+        console.log(output);
+        return done(err);
+      }
+
+      assert(fs.existsSync(path.join(config.contracts_build_directory, "MetaCoin.json")));
+      assert(fs.existsSync(path.join(config.contracts_build_directory, "ConvertLib.json")));
+      assert(fs.existsSync(path.join(config.contracts_build_directory, "Migrations.json")));
+
+      done();
+    });
+  });
+
+  it("will migrate", function(done) {
+    this.timeout(50000);
+
+    CommandRunner.run("migrate", config, function(err) {
+      var output = logger.contents();
+      if (err) {
+        console.log(output);
+        return done(err);
+      }
+
+      var MetaCoin = contract(require(path.join(config.contracts_build_directory, "MetaCoin.json")));
+      var ConvertLib = contract(require(path.join(config.contracts_build_directory, "ConvertLib.json")));
+      var Migrations = contract(require(path.join(config.contracts_build_directory, "Migrations.json")));
+
+      var promises = [];
+
+      [MetaCoin, ConvertLib, Migrations].forEach(function(abstraction) {
+        abstraction.setProvider(config.provider);
+
+        promises.push(abstraction.deployed().then(function(instance) {
+          assert.notEqual(instance.address, null, instance.contract_name + " didn't have an address!")
+        }));
+      });
+
+      Promise.all(promises).then(function() {
+        done();
+      }).catch(done);
+    });
+  });
+
+  it("will run tests", function(done) {
+    this.timeout(70000);
+    CommandRunner.run("test", config, function(err) {
+      var output = logger.contents();
+      if (err) {
+        console.log(output);
+        return done(err);
+      }
+
+      assert(output.indexOf("3 passing") >= 0);
+      done();
+    });
+  });
+
+
+});

--- a/packages/truffle/test/scenarios/external_compilers/truffle-compile.js
+++ b/packages/truffle/test/scenarios/external_compilers/truffle-compile.js
@@ -46,6 +46,7 @@ describe("`truffle compile` as external", function() {
       assert(fs.existsSync(path.join(config.contracts_build_directory, "MetaCoin.json")));
       assert(fs.existsSync(path.join(config.contracts_build_directory, "ConvertLib.json")));
       assert(fs.existsSync(path.join(config.contracts_build_directory, "Migrations.json")));
+      assert(fs.existsSync(path.join(config.contracts_build_directory, "ExtraMetaCoin.json")));
 
       done();
     });
@@ -64,10 +65,11 @@ describe("`truffle compile` as external", function() {
       var MetaCoin = contract(require(path.join(config.contracts_build_directory, "MetaCoin.json")));
       var ConvertLib = contract(require(path.join(config.contracts_build_directory, "ConvertLib.json")));
       var Migrations = contract(require(path.join(config.contracts_build_directory, "Migrations.json")));
+      var ExtraMetaCoin = contract(require(path.join(config.contracts_build_directory, "ExtraMetaCoin.json")));
 
       var promises = [];
 
-      [MetaCoin, ConvertLib, Migrations].forEach(function(abstraction) {
+      [MetaCoin, ConvertLib, Migrations, ExtraMetaCoin].forEach(function(abstraction) {
         abstraction.setProvider(config.provider);
 
         promises.push(abstraction.deployed().then(function(instance) {

--- a/packages/truffle/test/sources/external_compile/compile-external
+++ b/packages/truffle/test/sources/external_compile/compile-external
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+truffle compile --compiler=solc --contracts_build_directory=external
+
+cat ./external/MetaCoin.json | jq '.abi' > ./external/MetaCoin.abi
+cat ./external/MetaCoin.json | jq '.bytecode' > ./external/MetaCoin.bytecode

--- a/packages/truffle/test/sources/external_compile/contracts/.placeholder
+++ b/packages/truffle/test/sources/external_compile/contracts/.placeholder
@@ -1,0 +1,1 @@
+This is a placeholder file to ensure the parent directory in the git repository. Feel free to remove.

--- a/packages/truffle/test/sources/external_compile/contracts/ConvertLib.sol
+++ b/packages/truffle/test/sources/external_compile/contracts/ConvertLib.sol
@@ -1,0 +1,8 @@
+pragma solidity ^0.4.4;
+
+library ConvertLib{
+	function convert(uint amount,uint conversionRate) public pure returns (uint convertedAmount)
+	{
+		return amount * conversionRate;
+	}
+}

--- a/packages/truffle/test/sources/external_compile/contracts/MetaCoin.sol
+++ b/packages/truffle/test/sources/external_compile/contracts/MetaCoin.sol
@@ -1,0 +1,34 @@
+pragma solidity ^0.4.18;
+
+import "./ConvertLib.sol";
+
+// This is just a simple example of a coin-like contract.
+// It is not standards compatible and cannot be expected to talk to other
+// coin/token contracts. If you want to create a standards-compliant
+// token, see: https://github.com/ConsenSys/Tokens. Cheers!
+
+contract MetaCoin {
+	mapping (address => uint) balances;
+
+	event Transfer(address indexed _from, address indexed _to, uint256 _value);
+
+	constructor() public {
+		balances[tx.origin] = 10000;
+	}
+
+	function sendCoin(address receiver, uint amount) public returns(bool sufficient) {
+		if (balances[msg.sender] < amount) return false;
+		balances[msg.sender] -= amount;
+		balances[receiver] += amount;
+		emit Transfer(msg.sender, receiver, amount);
+		return true;
+	}
+
+	function getBalanceInEth(address addr) public view returns(uint){
+		return ConvertLib.convert(getBalance(addr),2);
+	}
+
+	function getBalance(address addr) public view returns(uint) {
+		return balances[addr];
+	}
+}

--- a/packages/truffle/test/sources/external_compile/contracts/Migrations.sol
+++ b/packages/truffle/test/sources/external_compile/contracts/Migrations.sol
@@ -1,0 +1,23 @@
+pragma solidity ^0.4.2;
+
+contract Migrations {
+  address public owner;
+  uint public last_completed_migration;
+
+  modifier restricted() {
+    if (msg.sender == owner) _;
+  }
+
+  constructor() public {
+    owner = msg.sender;
+  }
+
+  function setCompleted(uint completed) public restricted {
+    last_completed_migration = completed;
+  }
+
+  function upgrade(address new_address) public restricted {
+    Migrations upgraded = Migrations(new_address);
+    upgraded.setCompleted(last_completed_migration);
+  }
+}

--- a/packages/truffle/test/sources/external_compile/migrations/1_initial_migration.js
+++ b/packages/truffle/test/sources/external_compile/migrations/1_initial_migration.js
@@ -1,0 +1,5 @@
+var Migrations = artifacts.require("./Migrations.sol");
+
+module.exports = function(deployer) {
+  deployer.deploy(Migrations);
+};

--- a/packages/truffle/test/sources/external_compile/migrations/2_deploy_contracts.js
+++ b/packages/truffle/test/sources/external_compile/migrations/2_deploy_contracts.js
@@ -1,0 +1,8 @@
+var ConvertLib = artifacts.require("./ConvertLib.sol");
+var MetaCoin = artifacts.require("./MetaCoin.sol");
+
+module.exports = function(deployer) {
+  deployer.deploy(ConvertLib);
+  deployer.link(ConvertLib, MetaCoin);
+  deployer.deploy(MetaCoin);
+};

--- a/packages/truffle/test/sources/external_compile/migrations/2_deploy_contracts.js
+++ b/packages/truffle/test/sources/external_compile/migrations/2_deploy_contracts.js
@@ -1,8 +1,11 @@
-var ConvertLib = artifacts.require("./ConvertLib.sol");
-var MetaCoin = artifacts.require("./MetaCoin.sol");
+var ConvertLib = artifacts.require("ConvertLib");
+var MetaCoin = artifacts.require("MetaCoin");
+var ExtraMetaCoin = artifacts.require("ExtraMetaCoin");
 
 module.exports = function(deployer) {
   deployer.deploy(ConvertLib);
   deployer.link(ConvertLib, MetaCoin);
+  deployer.link(ConvertLib, ExtraMetaCoin);
   deployer.deploy(MetaCoin);
+  deployer.deploy(ExtraMetaCoin);
 };

--- a/packages/truffle/test/sources/external_compile/test/.placeholder
+++ b/packages/truffle/test/sources/external_compile/test/.placeholder
@@ -1,0 +1,1 @@
+This is a placeholder file to ensure the parent directory in the git repository. Feel free to remove.

--- a/packages/truffle/test/sources/external_compile/test/metacoin.js
+++ b/packages/truffle/test/sources/external_compile/test/metacoin.js
@@ -1,0 +1,63 @@
+var MetaCoin = artifacts.require("./MetaCoin.sol");
+
+contract('MetaCoin', function(accounts) {
+  it("should put 10000 MetaCoin in the first account", function() {
+    return MetaCoin.deployed().then(function(instance) {
+      return instance.getBalance.call(accounts[0]);
+    }).then(function(balance) {
+      assert.equal(balance.valueOf(), 10000, "10000 wasn't in the first account");
+    });
+  });
+  it("should call a function that depends on a linked library", function() {
+    var meta;
+    var metaCoinBalance;
+    var metaCoinEthBalance;
+
+    return MetaCoin.deployed().then(function(instance) {
+      meta = instance;
+      return meta.getBalance.call(accounts[0]);
+    }).then(function(outCoinBalance) {
+      metaCoinBalance = outCoinBalance.toNumber();
+      return meta.getBalanceInEth.call(accounts[0]);
+    }).then(function(outCoinBalanceEth) {
+      metaCoinEthBalance = outCoinBalanceEth.toNumber();
+    }).then(function() {
+      assert.equal(metaCoinEthBalance, 2 * metaCoinBalance, "Library function returned unexpected function, linkage may be broken");
+    });
+  });
+  it("should send coin correctly", function() {
+    var meta;
+
+    // Get initial balances of first and second account.
+    var account_one = accounts[0];
+    var account_two = accounts[1];
+
+    var account_one_starting_balance;
+    var account_two_starting_balance;
+    var account_one_ending_balance;
+    var account_two_ending_balance;
+
+    var amount = 10;
+
+    return MetaCoin.deployed().then(function(instance) {
+      meta = instance;
+      return meta.getBalance.call(account_one);
+    }).then(function(balance) {
+      account_one_starting_balance = balance.toNumber();
+      return meta.getBalance.call(account_two);
+    }).then(function(balance) {
+      account_two_starting_balance = balance.toNumber();
+      return meta.sendCoin(account_two, amount, {from: account_one});
+    }).then(function() {
+      return meta.getBalance.call(account_one);
+    }).then(function(balance) {
+      account_one_ending_balance = balance.toNumber();
+      return meta.getBalance.call(account_two);
+    }).then(function(balance) {
+      account_two_ending_balance = balance.toNumber();
+
+      assert.equal(account_one_ending_balance, account_one_starting_balance - amount, "Amount wasn't correctly taken from the sender");
+      assert.equal(account_two_ending_balance, account_two_starting_balance + amount, "Amount wasn't correctly sent to the receiver");
+    });
+  });
+});

--- a/packages/truffle/test/sources/external_compile/truffle.js
+++ b/packages/truffle/test/sources/external_compile/truffle.js
@@ -5,7 +5,8 @@ module.exports = {
         "--compiler=solc " +
         "--contracts_build_directory=external",
       targets: [{
-        path: "external/*.json"
+        path: "external/*.json",
+        command: "cat"
       }]
     }
   },

--- a/packages/truffle/test/sources/external_compile/truffle.js
+++ b/packages/truffle/test/sources/external_compile/truffle.js
@@ -1,0 +1,21 @@
+module.exports = {
+  compilers: {
+    external: {
+      command: "truffle compile " +
+        "--compiler=solc " +
+        "--contracts_build_directory=external",
+      targets: [{
+        path: "external/*.json"
+      }]
+    }
+  },
+  networks: {
+    development: {
+      host: "127.0.0.1",
+      port: 8545,
+      network_id: '*',
+      gas: 4700000,
+      gasPrice: 20000000000,
+    },
+  },
+};

--- a/packages/truffle/test/sources/external_compile/truffle.js
+++ b/packages/truffle/test/sources/external_compile/truffle.js
@@ -1,12 +1,22 @@
 module.exports = {
   compilers: {
     external: {
-      command: "truffle compile " +
-        "--compiler=solc " +
-        "--contracts_build_directory=external",
+      command: "./compile-external",
       targets: [{
-        path: "external/*.json",
-        command: "cat"
+        path: "external/M*.json",  // MetaCoin and Migrations
+        command: "cat -"
+      }, {
+        path: "external/ConvertLib.json",
+        command: "cat",
+        stdin: false
+      }, {
+        properties: {
+          contractName: "ExtraMetaCoin"
+        },
+        fileProperties: {
+          abi: "external/MetaCoin.abi",
+          bytecode: "external/MetaCoin.bytecode"
+        }
       }]
     }
   },


### PR DESCRIPTION
Ref: #1134 

# Support external compilers

## Motivation

It'd be nice to use Truffle for workflows that don't operate nicely in the context of the current `truffle compile` solc pipeline. This compilation step can be greatly generalized by way of offering configuration for two components:
- Allow specifying arbitrary command to run, for compilation
- Allow specifying targets, with optional arbitrary command to process those targets into Truffle artifacts.

This PR makes changes to `truffle-workflow-compile` to support multiple compilers (at all), and defines a new package `truffle-external-compile`, which implements the above.

## Approach

In `truffle-workflow-compile`:

- Define `SUPPORTED_COMPILERS`, mapping name to node module

- Detect keys included in `config.compilers` (NOTE: solc is defaulted!)

- Run all compile modules for detected supported compilers

- Add `--compiler` option to the `truffle compile` command, to specify a particular compiler instead.

- Update truffle-workflow-compile's interface to return an object of the form:
  ```javascript
  {
    contracts, // aggregate of all contracts by name
    outputs: {
      compilerName: compilerSpecificResult
      /* for instance: */
      solc: paths
    }
  }
  ``` 
  This is instead of having multiple return values via `callback(err, contracts, paths)`.

New package `truffle-external-compile`:

- See [Configuration Example](https://github.com/trufflesuite/truffle/blob/d6b957ba9d7a7468de3559bf5e387e9b2e483b06/packages/truffle/test/sources/external_compile/truffle.js#L2-L22)

- Define method for processing compilation targets via arbitrary commands:

  1. Run `compilers.external.command`, expect some target output

  2. For each defined target, glob-expand `target.path` and pipe to `target.command` via stdin.

  3. Use stdout from each `target.command` as JSON description of artifact

- Define method for processing compilation targets via explicit property listing.

### re: globbing in first commit
The first commit here changes the way `truffle-contract-sources` works, so that compiler configuration can do things like:
```javascript
compilers: {
  solc: {
    sources: "**/*.sol",
    /* ... */
  }
}
```

## Dependent on `truffle-workflow-compile`'s external interface

These have all been updated:

- `truffle-core/lib/test` - resolves `contracts` and `paths` in `compileContractsWithTestFilesIfNeeded`
- `truffle-debugger/test/helpers` - resolves `contracts` and `paths` in `compile`
- `truffle-core/test/compile` - resolves `contracts` in three tests
- `truffle-core/test/migrate` - resolves `contracts` in one test
- `truffle-core/test/ethpm` - resolves `contracts` in one test
- `truffle-core/test/npm` - resolves `contracts` in one test

## Known Limitations

- Solidity tests currently don't work properly when using `truffle compile` as external