### PR TITLE
Adds .gitattributes to recognize *.sol files in GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity


### PR DESCRIPTION
A minor update to add syntax highlighting to *.sol files when viewed on GitHub