### PR TITLE
Update contracts for compatibility with solidity 0.5.0

### DIFF
--- a/packages/truffle-artifactor/test/Example.sol
+++ b/packages/truffle-artifactor/test/Example.sol
@@ -3,28 +3,28 @@ contract Example {
   bool public fallbackTriggered;
   event ExampleEvent(address indexed _from, uint num);
 
-  function Example(uint val) {
+  constructor(uint val) public {
     value = val;
     fallbackTriggered = false;
   }
 
-  function setValue(uint val) {
+  function setValue(uint val) public {
     value = val;
   }
 
-  function getValue() constant returns(uint) {
+  function getValue() public view returns(uint) {
     return value;
   }
 
-  function parrot(uint val) returns(uint) {
+  function parrot(uint val) public returns(uint) {
     return val;
   }
 
-  function triggerEvent() {
-    ExampleEvent(msg.sender, 8);
+  function triggerEvent() public {
+    emit ExampleEvent(msg.sender, 8);
   }
 
-  function() payable {
+  function() external payable {
     fallbackTriggered = true;
   }
 }

--- a/packages/truffle-artifactor/test/ExampleLibrary.sol
+++ b/packages/truffle-artifactor/test/ExampleLibrary.sol
@@ -1,7 +1,7 @@
 library ExampleLibrary {
   event LibraryEvent();
 
-  function triggerLibraryEvent() {
-    LibraryEvent();
+  function triggerLibraryEvent() public {
+    emit LibraryEvent();
   }
 }

--- a/packages/truffle-artifactor/test/ExampleLibraryConsumer.sol
+++ b/packages/truffle-artifactor/test/ExampleLibraryConsumer.sol
@@ -1,7 +1,7 @@
 import "./ExampleLibrary.sol";
 
 contract ExampleLibraryConsumer {
-  function triggerLibraryEvent() {
+  function triggerLibraryEvent() public {
     ExampleLibrary.triggerLibraryEvent();
   }
 }

--- a/packages/truffle-artifactor/test/contracts.js
+++ b/packages/truffle-artifactor/test/contracts.js
@@ -37,7 +37,7 @@ describe("artifactor + require", function() {
 
     // Clean up after solidity. Only remove solidity's listener,
     // which happens to be the first.
-    process.removeListener("uncaughtException", process.listeners("uncaughtException")[0]);
+    process.removeListener("uncaughtException", process.listeners("uncaughtException")[0] || function(){});
 
     var compiled = Schema.normalize(result.contracts[":Example"]);
     abi = compiled.abi;

--- a/packages/truffle-contract/test/cloning.js
+++ b/packages/truffle-contract/test/cloning.js
@@ -5,7 +5,7 @@ var solc = require("solc");
 
 // Clean up after solidity. Only remove solidity's listener,
 // which happens to be the first.
-process.removeListener("uncaughtException", process.listeners("uncaughtException")[0]);
+process.removeListener("uncaughtException", process.listeners("uncaughtException")[0] || function() {});
 
 var fs = require("fs");
 var requireNoCache = require("require-nocache")(module);

--- a/packages/truffle-contract/test/sources/Example.sol
+++ b/packages/truffle-contract/test/sources/Example.sol
@@ -10,7 +10,7 @@ contract Example {
   event ContractAddressEvent(address _contract);
   event SpecialEvent();
 
-  constructor(uint val) {
+  constructor(uint val) public {
     // Constructor revert
     require(val != 13);
     require(val != 2001, 'reasonstring');
@@ -27,122 +27,122 @@ contract Example {
     fallbackTriggered = false;
   }
 
-  function setValue(uint val) {
+  function setValue(uint val) public {
     value = val;
   }
 
-  function isDeployed() constant returns (address){
+  function isDeployed() public view returns (address){
     return address(this);
   }
 
-  function viewSender() view returns(address){
+  function viewSender() public view returns(address){
     return msg.sender;
   }
 
-  function getValue() constant returns(uint) {
+  function getValue() public view returns(uint) {
     return value;
   }
 
-  function getValuePlus(uint toAdd) constant returns(uint) {
+  function getValuePlus(uint toAdd) public view returns(uint) {
     return value + toAdd;
   }
 
-  function overloadedGet() constant returns(uint){
+  function overloadedGet() public view returns(uint){
     return value;
   }
 
-  function overloadedGet(uint multiplier) constant returns(uint){
+  function overloadedGet(uint multiplier) public view returns(uint){
     return value * multiplier;
   }
 
-  function overloadedSet(bytes32 h, uint val) {
+  function overloadedSet(bytes32 h, uint val) public {
     hash = h;
     value = val;
   }
 
-  function overloadedSet(bytes32 h, uint val, uint multiplier) {
+  function overloadedSet(bytes32 h, uint val, uint multiplier) public {
     hash = h;
     value = val * multiplier;
   }
 
-  function parrot(uint val) returns(uint) {
+  function parrot(uint val) public returns(uint) {
     return val;
   }
 
-  function triggerEvent() {
-    ExampleEvent(msg.sender, 8);
+  function triggerEvent() public {
+    emit ExampleEvent(msg.sender, 8);
   }
 
-  function triggerEventWithArgument(uint arg) {
-    ExampleEvent(msg.sender, arg);
+  function triggerEventWithArgument(uint arg) public {
+    emit ExampleEvent(msg.sender, arg);
   }
 
-  function triggerSpecialEvent() {
-    SpecialEvent();
+  function triggerSpecialEvent() public {
+    emit SpecialEvent();
   }
 
-  function triggerContractAddressEvent(){
-    ContractAddressEvent(address(this));
+  function triggerContractAddressEvent() public {
+    emit ContractAddressEvent(address(this));
   }
 
-  function triggerRequireError() {
+  function triggerRequireError() public {
     require(false);
   }
 
-  function triggerAssertError() {
+  function triggerAssertError() public {
     assert(false);
   }
 
-  function triggerRequireWithReasonError(){
+  function triggerRequireWithReasonError() public {
     require(false, 'reasonstring');
   }
 
-  function runsOutOfGas() {
+  function runsOutOfGas() public {
     consumesGas();
   }
 
-  function isExpensive(uint val){
+  function isExpensive(uint val) public {
     for(uint i = 0; i < val; i++){
       counter = i;
     }
   }
 
-  function consumesGas() {
+  function consumesGas() public {
     for(uint i = 0; i < 10000; i++){
       counter = i;
     }
   }
 
-  function returnsNamedTuple () view returns (uint256 hello, string black, uint8 goodbye){
+  function returnsNamedTuple () public view returns (uint256 hello, string black, uint8 goodbye){
     return (5, 'black', 5);
   }
 
-  function returnsUnnamedTuple() view returns (string, uint, uint[2]){
-    uint[2] arr;
+  function returnsUnnamedTuple() public view returns (string, uint, uint[2]){
+    uint[2] memory arr;
     arr[0] = 5;
     arr[1] = 5;
     return ('hello', 5, arr);
   }
 
-  function returnsInt() view returns (int){
+  function returnsInt() public view returns (int){
     return 5;
   }
 
-  function returnsNamedStaticArray() view returns (uint[2] named ){
-    uint[2] arr;
+  function returnsNamedStaticArray() public view returns (uint[2] named ){
+    uint[2] memory arr;
     arr[0] = 5;
     arr[1] = 5;
     return arr;
   }
 
-  function returnsUnnamedStaticArray () view returns (uint[2]){
-    uint[2] arr;
+  function returnsUnnamedStaticArray () public view returns (uint[2]){
+    uint[2] memory arr;
     arr[0] = 5;
     arr[1] = 5;
     return arr;
   }
 
-  function() payable {
+  function() external payable {
     fallbackTriggered = true;
   }
 }

--- a/packages/truffle-contract/test/sources/ExampleLibrary.sol
+++ b/packages/truffle-contract/test/sources/ExampleLibrary.sol
@@ -1,7 +1,7 @@
 library ExampleLibrary {
   event LibraryEvent(address indexed _from, uint num);
 
-  function triggerLibraryEvent() {
-    LibraryEvent(msg.sender, 8);
+  function triggerLibraryEvent() public {
+    emit LibraryEvent(msg.sender, 8);
   }
 }

--- a/packages/truffle-contract/test/sources/ExampleLibraryConsumer.sol
+++ b/packages/truffle-contract/test/sources/ExampleLibraryConsumer.sol
@@ -1,7 +1,7 @@
 import "./ExampleLibrary.sol";
 
 contract ExampleLibraryConsumer {
-  function triggerLibraryEvent() {
+  function triggerLibraryEvent() public {
     ExampleLibrary.triggerLibraryEvent();
   }
 }

--- a/packages/truffle-debugger/test/ast.js
+++ b/packages/truffle-debugger/test/ast.js
@@ -31,7 +31,7 @@ contract Variables {
 
     qux = baz;
 
-    Result(baz);
+    emit Result(baz);
 
     return baz;
   }

--- a/packages/truffle-debugger/test/context.js
+++ b/packages/truffle-debugger/test/context.js
@@ -22,14 +22,14 @@ contract OuterContract {
 
   InnerContract inner;
 
-  function OuterContract(address _inner) public {
+  constructor(address _inner) public {
     inner = InnerContract(_inner);
   }
 
   function run() public {
     inner.run();
 
-    Outer();
+    emit Outer();
   }
 }
 `;
@@ -41,7 +41,7 @@ contract InnerContract {
   event Inner();
 
   function run() public {
-    Inner();
+    emit Inner();
   }
 }
 `;

--- a/packages/truffle-debugger/test/evm.js
+++ b/packages/truffle-debugger/test/evm.js
@@ -22,7 +22,7 @@ contract Outer {
 
   Inner inner;
 
-  function Outer(address _inner) {
+  constructor(address _inner) public {
     inner = Inner(_inner);
   }
 

--- a/packages/truffle-debugger/test/solidity.js
+++ b/packages/truffle-debugger/test/solidity.js
@@ -19,7 +19,7 @@ contract SingleCall {
   event Called();
 
   function run() public {
-    Called();
+    emit Called();
   }
 }
 `;
@@ -49,11 +49,11 @@ contract NestedCall {
   }
 
   function inner() public {
-    First();
+    emit First();
   }
 
   function second() public {
-    Second();
+    emit Second();
   }
 
 }

--- a/packages/truffle/test/sources/ethpm/contracts/Local.sol
+++ b/packages/truffle/test/sources/ethpm/contracts/Local.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.4.8;
 contract Local {
   uint local;
 
-  function Local() public {
+  constructor() public {
 
   }
 }

--- a/packages/truffle/test/sources/ethpm/contracts/PLCRVoting.sol
+++ b/packages/truffle/test/sources/ethpm/contracts/PLCRVoting.sol
@@ -5,7 +5,7 @@ import "./Local.sol";
 
 contract PLCRVoting is EIP20, Local {
 
-    function isExpired(uint _terminationDate) constant public returns (bool expired) {
+    function isExpired(uint _terminationDate) view public returns (bool expired) {
         return (block.timestamp > _terminationDate);
     }
 

--- a/packages/truffle/test/sources/ethpm/installed_contracts/tokens/contracts/Migrations.sol
+++ b/packages/truffle/test/sources/ethpm/installed_contracts/tokens/contracts/Migrations.sol
@@ -8,7 +8,7 @@ contract Migrations {
     if (msg.sender == owner) _;
   }
 
-  function Migrations() public {
+  constructor() public {
     owner = msg.sender;
   }
 

--- a/packages/truffle/test/sources/ethpm/installed_contracts/tokens/contracts/eip20/EIP20.sol
+++ b/packages/truffle/test/sources/ethpm/installed_contracts/tokens/contracts/eip20/EIP20.sol
@@ -19,7 +19,7 @@ contract EIP20 is EIP20Interface {
     uint8 public decimals;                //How many decimals to show.
     string public symbol;                 //An identifier: eg SBX
 
-     function EIP20(
+     constructor(
         uint256 _initialAmount,
         string _tokenName,
         uint8 _decimalUnits,

--- a/packages/truffle/test/sources/ethpm/installed_contracts/tokens/contracts/eip20/EIP20Factory.sol
+++ b/packages/truffle/test/sources/ethpm/installed_contracts/tokens/contracts/eip20/EIP20Factory.sol
@@ -8,7 +8,7 @@ contract EIP20Factory {
     mapping(address => bool) public isEIP20; //verify without having to do a bytecode check.
     bytes public EIP20ByteCode;
 
-    function EIP20Factory() public {
+    constructor() public {
       //upon creation of the factory, deploy a EIP20 (parameters are meaningless) and store the bytecode provably.
       address verifiedToken = createEIP20(10000, "Verify Token", 3, "VTX");
       EIP20ByteCode = codeAt(verifiedToken);

--- a/packages/truffle/test/sources/ethpm/installed_contracts/tokens/contracts/eip20/EIP20Interface.sol
+++ b/packages/truffle/test/sources/ethpm/installed_contracts/tokens/contracts/eip20/EIP20Interface.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.4.8;
 
 contract EIP20Interface {
     /* This is a slight change to the ERC20 base standard.
-    function totalSupply() constant returns (uint256 supply);
+    function totalSupply() view returns (uint256 supply);
     is replaced with:
     uint256 public totalSupply;
     This automatically creates a getter function for the totalSupply.

--- a/packages/truffle/test/sources/inheritance/contracts/Migrations.sol
+++ b/packages/truffle/test/sources/inheritance/contracts/Migrations.sol
@@ -8,7 +8,7 @@ contract Migrations {
     if (msg.sender == owner) _;
   }
 
-  function Migrations() public {
+  constructor() public {
     owner = msg.sender;
   }
 


### PR DESCRIPTION
This PR *almost* makes it possible to replace ``soljson.js`` with the current nightly build (that is to become solidity 0.5.0) while still having the truffle test suite pass.

What still needs to be adjusted is ``packages/truffle-compile/test/test_supplier.js``, resp. ``packages/truffle-compile/test/sources/NewPragma.sol``, but this is tested against different versions of solidity, so some more involved logic is needed here.

Apart from that ``packages/truffle/test/scenarios/contract_names/test_imports.js``, ``packages/truffle/test/scenarios/happy_path/happypath.js`` and ``packages/truffle/test/scenarios/solidity_testing/with_balances.js`` pull some solidity files (presumably from a truffle box) that still use outdated syntax, but I don't really know where those files are coming from (``https://github.com/trufflesuite/truffle-init-default`` seems to be up to date - maybe a fixed commit or another branch or an entirely different repo is used here?)

The changes are backwards compatible in the sense that the tests still pass without updating ``soljson.js``.