### PR TITLE
Add `skipDryRun` option

### DIFF
--- a/packages/truffle-config/index.js
+++ b/packages/truffle-config/index.js
@@ -36,6 +36,7 @@ function Config(truffle_directory, working_directory, network) {
     confirmations: 0,
     timeoutBlocks: 0,
     production: false,
+    skipDryRun: false,
     build: null,
     resolver: null,
     artifactor: null,
@@ -214,6 +215,18 @@ function Config(truffle_directory, working_directory, network) {
       },
       set: function(val) {
         throw new Error("Don't set config.timeoutBlocks directly. Instead, set config.networks and then config.networks[<network name>].timeoutBlocks")
+      }
+    },
+    skipDryRun: {
+      get: function(){
+        try {
+          return self.network_config.skipDryRun;
+        } catch (e) {
+          return false;
+        }
+      },
+      set: function(val) {
+        throw new Error("Don't set config.skipDryRun directly. Instead, set config.networks and then config.networks[<network name>].skipDryRun")
       }
     }
 

--- a/packages/truffle-core/lib/commands/migrate.js
+++ b/packages/truffle-core/lib/commands/migrate.js
@@ -157,7 +157,7 @@ var command = {
           };
 
         // Production: dry-run then real run
-        } else if (production) {
+        } else if (production && !conf.skipDryRun) {
 
           const currentBuild = conf.contracts_build_directory;
           conf.dryRun = true;

--- a/packages/truffle/test/scenarios/migrations/production.js
+++ b/packages/truffle/test/scenarios/migrations/production.js
@@ -19,60 +19,111 @@ function processErr(err, output){
   }
 }
 
-describe("production migrations [ @geth ]", function() {
-  if (!process.env.GETH) return;
+describe('production', function() {
 
-  let config;
-  let web3;
-  let networkId;
-  const project = path.join(__dirname, '../../sources/migrations/production');
-  const logger = new MemoryLogger();
+  describe("{production: true, confirmations: 2 } [ @geth ]", function() {
+    if (!process.env.GETH) return;
 
-  before(done => Server.start(done));
-  after(done => Server.stop(done));
+    let config;
+    let web3;
+    let networkId;
+    const project = path.join(__dirname, '../../sources/migrations/production');
+    const logger = new MemoryLogger();
 
-  before(async function() {
-    this.timeout(10000);
-    config = await sandbox.create(project)
-    config.network = "ropsten";
-    config.logger = logger;
-    config.mocha = {
-      reporter: new Reporter(logger)
-    }
-
-    const provider = new Web3.providers.HttpProvider('http://localhost:8545')
-    web3 = new Web3(provider);
-    networkId = await web3.eth.net.getId();
-  });
-
-  it("runs migrations (sync & async/await)", function(done) {
-    this.timeout(70000);
-
-    CommandRunner.run("migrate --network ropsten", config, err => {
-
-      const output = logger.contents();
-      processErr(err, output);
-
-      assert(output.includes('2_migrations_conf.js'));
-      assert(output.includes("Deploying 'Example'"))
-
-      const location = path.join(config.contracts_build_directory, "Example.json");
-      const artifact = require(location);
-      const network = artifact.networks[networkId];
-
-      assert(output.includes(network.transactionHash));
-      assert(output.includes(network.address));
-      assert(output.includes('2 confirmations'));
-
-      // Geth automines too quickly for the 4 sec resolution we set
-      // to trigger the output.
-      if (!process.env.GETH){
-        assert(output.includes('confirmation number: 1'));
-        assert(output.includes('confirmation number: 2'));
+    before(async function() {
+      this.timeout(10000);
+      config = await sandbox.create(project)
+      config.network = "ropsten";
+      config.logger = logger;
+      config.mocha = {
+        reporter: new Reporter(logger)
       }
 
-      console.log(output)
-      done();
-    })
+      const provider = new Web3.providers.HttpProvider('http://localhost:8545')
+      web3 = new Web3(provider);
+      networkId = await web3.eth.net.getId();
+    });
+
+    it("auto dry-runs and honors confirmations option", function(done) {
+      this.timeout(70000);
+
+      CommandRunner.run("migrate --network ropsten", config, err => {
+
+        const output = logger.contents();
+        processErr(err, output);
+
+        assert(output.includes('dry-run'));
+
+        assert(output.includes('2_migrations_conf.js'));
+        assert(output.includes("Deploying 'Example'"))
+
+        const location = path.join(config.contracts_build_directory, "Example.json");
+        const artifact = require(location);
+        const network = artifact.networks[networkId];
+
+        assert(output.includes(network.transactionHash));
+        assert(output.includes(network.address));
+        assert(output.includes('2 confirmations'));
+
+        // Geth automines too quickly for the 4 sec resolution we set
+        // to trigger the output.
+        if (!process.env.GETH){
+          assert(output.includes('confirmation number: 1'));
+          assert(output.includes('confirmation number: 2'));
+        }
+
+        console.log(output)
+        done();
+      })
+    });
   });
+
+  describe("{production: true, skipDryRun: true } [ @geth ]", function() {
+    if (!process.env.GETH) return;
+
+    let config;
+    let web3;
+    let networkId;
+    const project = path.join(__dirname, '../../sources/migrations/production');
+    const logger = new MemoryLogger();
+
+    before(async function() {
+      this.timeout(10000);
+      config = await sandbox.create(project)
+      config.network = "fakeRopsten";
+      config.logger = logger;
+      config.mocha = {
+        reporter: new Reporter(logger)
+      }
+
+      const provider = new Web3.providers.HttpProvider('http://localhost:8545')
+      web3 = new Web3(provider);
+      networkId = await web3.eth.net.getId();
+    });
+
+    it("migrates without dry-run", function(done) {
+      this.timeout(70000);
+
+      CommandRunner.run("migrate --network fakeRopsten", config, err => {
+
+        const output = logger.contents();
+        processErr(err, output);
+
+        assert(!output.includes('dry-run'));
+
+        assert(output.includes('2_migrations_conf.js'));
+        assert(output.includes("Deploying 'Example'"))
+
+        const location = path.join(config.contracts_build_directory, "Example.json");
+        const artifact = require(location);
+        const network = artifact.networks[networkId];
+
+        assert(output.includes(network.transactionHash));
+        assert(output.includes(network.address));
+
+        console.log(output)
+        done();
+      })
+    });
+  })
 });

--- a/packages/truffle/test/sources/migrations/production/truffle.js
+++ b/packages/truffle/test/sources/migrations/production/truffle.js
@@ -10,5 +10,16 @@ module.exports = {
       production: true,
       timeoutBlocks: 70,
     },
+    fakeRopsten: {
+      host: "127.0.0.1",
+      port: 8545,
+      network_id: "*",
+      gas: 4700000,
+      gasPrice: 20000000000,
+      confirmations: 2,
+      production: true,
+      timeoutBlocks: 70,
+      skipDryRun: true
+    }
   },
 };


### PR DESCRIPTION
Adds option that lets you bypass the auto dry-run on networks we've flagged as auto dry-run. Also overrides the `production` flag (which auto dry-runs). 

The colony migrations targeting a parity client fail on dry-run, reason unknown. This definitely needs to be something people can turn off.

