### PR TITLE
Add startTransaction / endTransaction reporter hooks

### DIFF
--- a/packages/truffle-migrate/migration.js
+++ b/packages/truffle-migrate/migration.js
@@ -94,7 +94,7 @@ class Migration {
       const Migrations = resolver.require("./Migrations.sol");
 
       if (Migrations && Migrations.isDeployed()) {
-        const message = `Saving migration (#${self.number}) to chain.`;
+        const message = `Saving migration to chain.`;
 
         if (!this.dryRun){
           const data = { message: message }

--- a/packages/truffle-migrate/migration.js
+++ b/packages/truffle-migrate/migration.js
@@ -94,9 +94,20 @@ class Migration {
       const Migrations = resolver.require("./Migrations.sol");
 
       if (Migrations && Migrations.isDeployed()) {
-        await self.emitter.emit('saveMigration', self.number);
+        const message = `Saving migration (#${self.number}) to chain.`;
+
+        if (!this.dryRun){
+          const data = { message: message }
+          await self.emitter.emit('startTransaction', data);
+        }
+
         const migrations = await Migrations.deployed();
-        await migrations.setCompleted(self.number);
+        const receipt = await migrations.setCompleted(self.number);
+
+        if (!this.dryRun){
+          const data = {receipt: receipt, message: message };
+          await self.emitter.emit('endTransaction', data);
+        }
       }
 
       await self.emitter.emit('postMigrate', self.isLast);

--- a/packages/truffle-reporters/reporters/migrations-V5/messages.js
+++ b/packages/truffle-reporters/reporters/migrations-V5/messages.js
@@ -204,6 +204,12 @@ class MigrationsMessages{
         return output;
       },
 
+      // Transactions
+      endTransaction: () => {
+        if(reporter.blockSpinner) reporter.blockSpinner.stop();
+
+        return `   > ${data.message}`;
+      },
 
       // Libraries
       linking: () => {

--- a/packages/truffle-reporters/reporters/migrations-V5/messages.js
+++ b/packages/truffle-reporters/reporters/migrations-V5/messages.js
@@ -256,9 +256,10 @@ class MigrationsMessages{
 
       postMigrate: () => {
         let output = '';
+        let deployments = reporter.summary[reporter.currentFileIndex].deployments;
 
-        if (!reporter.migration.dryRun)
-          output += `   * Saving artifacts\n`;
+        if (!reporter.migration.dryRun && deployments.length)
+          output += `   > Saving artifacts\n`;
 
         output += self.underline(37) + '\n' +
           `   > ${'Total cost:'.padEnd(15)} ${data.cost.padStart(15)} ETH\n`;

--- a/packages/truffle-reporters/reporters/migrations-V5/reporter.js
+++ b/packages/truffle-reporters/reporters/migrations-V5/reporter.js
@@ -64,7 +64,8 @@ class Reporter {
 
     // Migration
     this.migration.emitter.on('preMigrate',          this.preMigrate.bind(this));
-    this.migration.emitter.on('saveMigration',       this.saveMigrate.bind(this));
+    this.migration.emitter.on('startTransaction',    this.startTransaction.bind(this));
+    this.migration.emitter.on('endTransaction',      this.endTransaction.bind(this));
     this.migration.emitter.on('postMigrate',         this.postMigrate.bind(this));
     this.migration.emitter.on('error',               this.error.bind(this));
 
@@ -77,6 +78,8 @@ class Reporter {
     this.deployer.emitter.on('transactionHash',      this.hash.bind(this));
     this.deployer.emitter.on('confirmation',         this.confirmation.bind(this));
     this.deployer.emitter.on('block',                this.block.bind(this));
+    this.deployer.emitter.on('startTransaction',     this.startTransaction.bind(this));
+    this.deployer.emitter.on('endTransaction',       this.endTransaction.bind(this));
   }
 
   /**
@@ -238,18 +241,6 @@ class Reporter {
   }
 
   /**
-   * Run when a migrations file deployment sequence has completed,
-   * before the migrations is saved to chain via Migrations.sol
-   * @param  {Object} data
-   */
-  async saveMigrate(data){
-    if (this.migration.dryRun) return;
-
-    const message = this.messages.steps('saving', data);
-    this.deployer.logger.log(message);
-  }
-
-  /**
    * Run after a migrations file has completed and the migration has been saved.
    * @param  {Boolean} isLast  true if this the last file in the sequence.
    */
@@ -360,6 +351,36 @@ class Reporter {
     return (data.log)
       ? this.deployer.logger.error(message)
       : message;
+  }
+
+  /**
+   * Run on `startTransaction` event. This is fired by migrations on save
+   * but could also be fired within a migrations script by a user.
+   * @param  {Object} data
+   */
+  async startTransaction(data){
+    const message = data.message || 'Starting unknown transaction...';
+    this.deployer.logger.log();
+
+    this.blockSpinner = new ora({
+      text: message,
+      spinner: indentedSpinner,
+      color: 'red'
+    });
+
+    this.blockSpinner.start();
+  }
+
+  // ----------------------------  Library Event Handlers ------------------------------------------
+
+  /**
+   * Run after a start transaction
+   * @param  {Object} data
+   */
+  async endTransaction(data){
+    data.message = data.message || 'Ending unknown transaction....';
+    const message = this.messages.steps('endTransaction', data);
+    this.deployer.logger.log(message);
   }
 
   // ----------------------------  Library Event Handlers ------------------------------------------

--- a/packages/truffle-reporters/reporters/migrations-V5/reporter.js
+++ b/packages/truffle-reporters/reporters/migrations-V5/reporter.js
@@ -353,6 +353,8 @@ class Reporter {
       : message;
   }
 
+  // --------------------------  Transaction Handlers  ------------------------------------------
+
   /**
    * Run on `startTransaction` event. This is fired by migrations on save
    * but could also be fired within a migrations script by a user.
@@ -370,8 +372,6 @@ class Reporter {
 
     this.blockSpinner.start();
   }
-
-  // ----------------------------  Library Event Handlers ------------------------------------------
 
   /**
    * Run after a start transaction

--- a/packages/truffle/test/scenarios/migrations/migrate.js
+++ b/packages/truffle/test/scenarios/migrations/migrate.js
@@ -57,6 +57,8 @@ describe("migrate (success)", function() {
       assert(output.includes("Replacing 'UsesExample'"))
       assert(output.includes("PayableExample"));
       assert(output.includes("1 ETH"));
+      assert(output.includes("Saving migration"));
+      assert(output.includes("Saving artifacts"));
 
       const location = path.join(config.contracts_build_directory, "UsesExample.json");
       const artifact = require(location);


### PR DESCRIPTION
Targets #1123

These have a really simple implementation at the moment - they just start/stop a spinner with a message. They should be expanded to aggregate gas data.

+ Integrated them into the "Saving Migrations" step so that doesn't seem like it's hanging
+ Also: stopped printing `Saving artifacts` when script doesn't actually deploy any contracts. It's not uncommon for people to use a migration file to run setup and initialization logic separately from the actual deployments.