### PR TITLE
Use `noVMErrorsOnRPCResponse` for built in ganache

### DIFF
--- a/packages/truffle-core/lib/commands/develop.js
+++ b/packages/truffle-core/lib/commands/develop.js
@@ -94,7 +94,8 @@ var command = {
       port: 9545,
       network_id: 4447,
       mnemonic: mnemonic,
-      gasLimit: config.gas
+      gasLimit: config.gas,
+      noVMErrorsOnRPCResponse: true,
     };
 
     Develop.connectOrStart(ipcOptions, testrpcOptions, function(started) {

--- a/packages/truffle-core/lib/commands/test.js
+++ b/packages/truffle-core/lib/commands/test.js
@@ -106,7 +106,8 @@ var command = {
             port: 7545,
             network_id: 4447,
             mnemonic: "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat",
-            gasLimit: config.gas
+            gasLimit: config.gas,
+            noVMErrorsOnRPCResponse: true,
           };
 
           Develop.connectOrStart(ipcOptions, testrpcOptions, function(started, disconnect) {


### PR DESCRIPTION
#1159

This will produce a nicer error message that contains the tx hash. People will be able to modify their tests to run a single test or contract suite using the `.only` prefix, grab the hash out of the error and pull up the debugger. 

It's possible we should add that flow as some kind of pro-tip thing in the error itself. Currently looks something like this:
```
Error: Transaction: 0x794b7eced61292f319cc8bbe9f293ea5777ef7adfb8e27ad24971e38ebebfc90 exited with an error (status 0). 
Please check that the transaction:
  - satisfies all conditions set by Solidity `require` statements.
  - does not trigger a Solidity `revert` statement.

at StatusError.ExtendableError (node_modules/truffle/build/webpack:/packages/truffle-error/index.js:10:1)
at new StatusError (node_modules/truffle/build/webpack:/packages/truffle-contract/lib/statuserror.js:32:1)
at Promise.receipt (node_modules/truffle/build/webpack:/packages/truffle-contract/lib/handlers.js:109:1)
at <anonymous>
at process._tickCallback (internal/process/next_tick.js:182:7)
```