### PR TITLE
Inherit synchronization_timeout=0 during deployments

### DIFF
--- a/packages/truffle-migrate/resolverintercept.js
+++ b/packages/truffle-migrate/resolverintercept.js
@@ -24,7 +24,7 @@ ResolverIntercept.prototype.require = function(import_path) {
   // During migrations, we could be on a network that takes a long time to accept
   // transactions (i.e., contract deployment close to block size). Because successful
   // migration is more important than wait time in those cases, we'll synchronize "forever".
-  resolved.synchronization_timeout = 0;
+  resolved.prototype.synchronization_timeout = 0;
 
   return resolved;
 };


### PR DESCRIPTION
`synchronization_timeout` is set on the base class, but is not inherited by instances from `new()` and `at()`.
Therefore, later calls remain subject to the low default timeout.

Fix using the prototype inheritance of JavaScript.