### PR TITLE
Make debugger fail less hard

### DIFF
--- a/packages/truffle-debugger/lib/controller/sagas/index.js
+++ b/packages/truffle-debugger/lib/controller/sagas/index.js
@@ -69,10 +69,15 @@ function* stepNext () {
     yield* advance();
 
     // and check the next source range
-    upcoming = yield select(controller.current.location);
+    try {
+      upcoming = yield select(controller.current.location);
+    } catch (e) {
+      upcoming = null;
+    }
 
     // if the next step's source range is still the same, keep going
   } while (
+    !upcoming ||
     !upcoming.node ||
     SKIPPED_TYPES.has(upcoming.node.nodeType) ||
 

--- a/packages/truffle-debugger/lib/evm/selectors/index.js
+++ b/packages/truffle-debugger/lib/evm/selectors/index.js
@@ -201,6 +201,9 @@ const evm = createSelectorTree({
         let record;
         if (address) {
           record = instances[address];
+          if (!record) {
+            return { address };
+          }
           binary = record.binary
         } else {
           record = search(binary);

--- a/packages/truffle-debugger/lib/solidity/sagas/index.js
+++ b/packages/truffle-debugger/lib/solidity/sagas/index.js
@@ -17,24 +17,26 @@ export function *addSourceMap(binary, sourceMap) {
   yield put(actions.addSourceMap(binary, sourceMap));
 }
 
-function* functionDepthSaga () {
+function *tickSaga() {
   while (true) {
     yield take(TICK);
     debug("got TICK");
-    let instruction = yield select(solidity.current.instruction);
-    debug("instruction: %o", instruction);
 
-    if (yield select(solidity.current.willJump)) {
-      let jumpDirection = yield select(solidity.current.jumpDirection);
+    yield *functionDepthSaga();
+  }
+}
+
+function* functionDepthSaga () {
+  if (yield select(solidity.current.willJump)) {
+    let jumpDirection = yield select(solidity.current.jumpDirection);
 
 
-      yield put(actions.jump(jumpDirection));
-    }
+    yield put(actions.jump(jumpDirection));
   }
 }
 
 export function* saga () {
-  yield call(functionDepthSaga);
+  yield call(tickSaga);
 }
 
 export default prefixName("solidity", saga);

--- a/packages/truffle-debugger/lib/solidity/selectors/index.js
+++ b/packages/truffle-debugger/lib/solidity/selectors/index.js
@@ -69,6 +69,10 @@ let solidity = createSelectorTree({
       ["/info/sources", evm.current.context, "./sourceMap"],
 
       (sources, {binary}, {sourceMap}) => {
+        if (!binary) {
+          return [];
+        }
+
         let instructions = CodeUtils.parseCode(binary);
 
         if (!sourceMap) {


### PR DESCRIPTION
Might fix some problems in trufflesuite/truffle-debugger#75

- Continue stepping through Solidity code if `controller.current.location` causes an error
- Use more defaults to prevent unhandled "cannot read whatever of undefined" exceptions