### PR TITLE
Re-order migrations error / use 20gwei default

### DIFF
--- a/packages/truffle-config/index.js
+++ b/packages/truffle-config/index.js
@@ -15,7 +15,7 @@ function Config(truffle_directory, working_directory, network) {
 
   var default_tx_values = {
     gas: 6721975,
-    gasPrice: 100000000000, // 100 Shannon,
+    gasPrice: 20000000000, // 20 gwei,
     from: null,
   };
 

--- a/packages/truffle-reporters/reporters/migrations-V5/reporter.js
+++ b/packages/truffle-reporters/reporters/migrations-V5/reporter.js
@@ -148,10 +148,10 @@ class Reporter {
     data.reason = (data.error) ? data.error.reason : null;
 
     const errors = {
+      ETH: error.message.includes('funds'),
       OOG: error.message.includes('out of gas') || (data.gas === data.blockLimit),
       INT: error.message.includes('base fee') || error.message.includes('intrinsic'),
       RVT: error.message.includes('revert'),
-      ETH: error.message.includes('funds'),
       BLK: error.message.includes('block gas limit'),
       NCE: error.message.includes('nonce'),
       INV: error.message.includes('invalid opcode'),


### PR DESCRIPTION
Couple tiny fixes for the migrations:

+ Re-orders the insufficient balance message in the reporter because it fulfills two conditions in the error management switch, but we really want the first one.
+ Sets the default gasPrice to 20 gwei. This is still pretty high. Too high?

Note: we aren't really gas estimating when we run commands even though all the logic works on this side. Tried to remove the default config setting in this PR but ganache estimates are not reliable enough for our own unit tests. There are failed transactions when value is sent during the solidity tests for example. 

There's WIP for estimation at ganache right now. Even when it's fixed it will likely be a breaking change for us to remove the defaults if people are using an older ganache version. 

