### PR TITLE
Throw real Error instead of list for schema errors

### DIFF
--- a/packages/truffle-contract-schema/index.js
+++ b/packages/truffle-contract-schema/index.js
@@ -1,6 +1,7 @@
 var sha3 = require("crypto-js/sha3");
 var pkgVersion = require("./package.json").version;
 var Ajv = require("ajv");
+var util = require("util");
 
 var contractObjectSchema = require("./spec/contract-object.spec.json");
 var networkObjectSchema = require("./spec/network-object.spec.json");
@@ -169,7 +170,32 @@ var TruffleContractSchema = {
     if (ajv.validate("contract-object.spec.json", contractObj)) {
       return contractObj;
     } else {
-      throw ajv.errors;
+      const message = `Schema validation failed. Errors:\n\n${
+        ajv.errors
+          .map( ({
+            keyword,
+            dataPath,
+            schemaPath,
+            params,
+            message,
+            data,
+            schema,
+            parentSchema
+          }) => util.format(
+            "%s (%s):\n%s\n",
+            message, keyword, util.inspect({
+              dataPath,
+              schemaPath,
+              params,
+              data,
+              parentSchema
+            }, { depth: 5 })
+          ))
+          .join("\n")
+      }`;
+      const error = new Error(message);
+      error.errors = ajv.errors;
+      throw error;
     }
   },
 

--- a/packages/truffle-contract-schema/index.js
+++ b/packages/truffle-contract-schema/index.js
@@ -162,7 +162,7 @@ var TruffleContractSchema = {
   // - Resolves as validated `contractObj`
   // - Rejects with list of errors from schema validator
   validate: function(contractObj) {
-    var ajv = new Ajv({ useDefaults: true });
+    var ajv = new Ajv({ verbose: true });
     ajv.addSchema(abiSchema);
     ajv.addSchema(networkObjectSchema);
     ajv.addSchema(contractObjectSchema);

--- a/packages/truffle-contract-schema/test/schema.js
+++ b/packages/truffle-contract-schema/test/schema.js
@@ -16,8 +16,8 @@ describe("Schema", function() {
 
     try {
       Schema.validate(invalid)
-    } catch (errors) {
-      var abiErrors = errors.filter(function(error) {
+    } catch (err) {
+      var abiErrors = err.errors.filter(function(error) {
         return error.dataPath === ".abi"
       });
       assert(abiErrors);


### PR DESCRIPTION
Currently, truffle-contract-schema's `validate()` function throws a list of objects representing validation errors.

This PR:
- Converts that exception to a real `Error` object, with lightly formatted message text.
- Appends the original `errors` list as a property on the Error object
- Removes the `useDefaults` option from the validation, since it mutates the input object. This was causing problems with the polymorphic ABI item schema.
- Use `verbose` when validating, to ensure that the errors contain the original data value.