### PR TITLE
Throw message even when migrations reporter not enabled

### DIFF
--- a/packages/truffle-deployer/src/deployment.js
+++ b/packages/truffle-deployer/src/deployment.js
@@ -349,7 +349,14 @@ class Deployment {
 
           self._stopBlockPolling();
           eventArgs.error = err.error || err;
-          const message = await self.emitter.emit('deployFailed', eventArgs);
+          let message = await self.emitter.emit('deployFailed', eventArgs);
+
+          // Reporter might not be enabled (via Migrate.launchReporter) so
+          // message is a (potentially empty) array of results from the emitter
+          if (!message.length){
+            message = `while migrating ${contract.contractName}: ${eventArgs.error.message}`
+          }
+
           self.close();
           throw new Error(message);
         }


### PR DESCRIPTION
This fixes the blank error message axic found while testing the external compiler. The reporter (which generates the message) isn't launched during the test migrations because we want silence. 

With this change, when running `truffle test`  with an underfunded migration we get:
```
Error: while migrating ConvertLib: Returned error: base fee exceeds gas limit
```

When running `truffle migrate` we get:
```
"ConvertLib" ran out of gas (using a value you set in your network config or deployment parameters.)
   * Block limit:  6721975
   * Gas sent:     10
```