### PR TITLE
Work around an obnoxious issue in aleth JSON RPC [WIP]

### DIFF
--- a/packages/truffle-provider/wrapper.js
+++ b/packages/truffle-provider/wrapper.js
@@ -74,6 +74,9 @@ module.exports = {
         options.logger.log(" <   " + JSON.stringify(result, null, 2).split("\n").join("\n <   "));
       }
 
+      // aleth sometimes does these horrible things to us
+      if (result.result === '0x') result.result = '';
+
       return [payload, error, result];
     };
   },


### PR DESCRIPTION
I'm opening this PR not for it to be merged immediately but rather to flag an issue and initiate dialog about how to fix it.

This change allows me to use truffle with aleth. Without this change, I get the below error. Note that I have not tested this change with geth or any other client.

```
Error: Couldn't decode uint256 from ABI: 0x
    at SolidityTypeUInt.formatOutputUInt (/Users/lanerettig/.nvm/versions/node/v8.6.0/lib/node_modules/truffle/build/webpack:/~/web3-eth-abi/src/formatters.js:174:1)
    at SolidityTypeUInt.SolidityType.decode (/Users/lanerettig/.nvm/versions/node/v8.6.0/lib/node_modules/truffle/build/webpack:/~/web3-eth-abi/src/type.js:252:1)
    at /Users/lanerettig/.nvm/versions/node/v8.6.0/lib/node_modules/truffle/build/webpack:/~/web3-eth-abi/src/index.js:327:1
    at Array.forEach (<anonymous>)
    at ABICoder.decodeParameters (/Users/lanerettig/.nvm/versions/node/v8.6.0/lib/node_modules/truffle/build/webpack:/~/web3-eth-abi/src/index.js:326:1)
    at Contract._decodeMethodReturn (/Users/lanerettig/.nvm/versions/node/v8.6.0/lib/node_modules/truffle/build/webpack:/~/web3-eth-contract/src/index.js:459:1)
    at Method.outputFormatter (/Users/lanerettig/.nvm/versions/node/v8.6.0/lib/node_modules/truffle/build/webpack:/~/web3-eth-contract/src/index.js:812:1)
    at Method.formatOutput (/Users/lanerettig/.nvm/versions/node/v8.6.0/lib/node_modules/truffle/build/webpack:/~/web3-core-method/src/index.js:163:1)
    at sendTxCallback (/Users/lanerettig/.nvm/versions/node/v8.6.0/lib/node_modules/truffle/build/webpack:/~/web3-core-method/src/index.js:467:1)
    at /Users/lanerettig/.nvm/versions/node/v8.6.0/lib/node_modules/truffle/build/webpack:/~/web3-core-requestmanager/src/index.js:147:1
    at /Users/lanerettig/.nvm/versions/node/v8.6.0/lib/node_modules/truffle/build/webpack:/packages/truffle-provider/wrapper.js:101:1
    at XMLHttpRequest.request.onreadystatechange (/Users/lanerettig/.nvm/versions/node/v8.6.0/lib/node_modules/truffle/build/webpack:/~/web3-providers-http/src/index.js:77:1)
    at XMLHttpRequestEventTarget.dispatchEvent (/Users/lanerettig/.nvm/versions/node/v8.6.0/lib/node_modules/truffle/build/webpack:/~/xhr2/lib/xhr2.js:64:1)
    at XMLHttpRequest._setReadyState (/Users/lanerettig/.nvm/versions/node/v8.6.0/lib/node_modules/truffle/build/webpack:/~/xhr2/lib/xhr2.js:354:1)
    at XMLHttpRequest._onHttpResponseEnd (/Users/lanerettig/.nvm/versions/node/v8.6.0/lib/node_modules/truffle/build/webpack:/~/xhr2/lib/xhr2.js:509:1)
    at IncomingMessage.<anonymous> (/Users/lanerettig/.nvm/versions/node/v8.6.0/lib/node_modules/truffle/build/webpack:/~/xhr2/lib/xhr2.js:469:1)
    at emitNone (events.js:110:20)
    at IncomingMessage.emit (events.js:207:7)
    at endReadableNT (_stream_readable.js:1059:12)
    at _combinedTickCallback (internal/process/next_tick.js:138:11)
    at process._tickCallback (internal/process/next_tick.js:180:9)
```