### PR TITLE
Throw link errors

### DIFF
--- a/packages/truffle-deployer/test/errors.js
+++ b/packages/truffle-deployer/test/errors.js
@@ -94,6 +94,23 @@ describe("Error cases", function() {
     }
   });
 
+  it('unlinked library', async function(){
+    const migrate = function(){
+      deployer.deploy(UsesLibrary);
+    };
+
+    migrate();
+
+    try {
+      await deployer.start();
+      assert.fail();
+    } catch( err ) {
+      assert(err.message.includes('Deployment Failed'));
+      assert(err.message.includes('UsesLibrary'));
+      assert(err.message.includes('unresolved libraries'));
+    }
+  })
+
   it('contract has no bytecode', async function(){
     const migrate = function(){
       deployer.deploy(Abstract);

--- a/packages/truffle-reporters/reporters/migrations-V5/reporter.js
+++ b/packages/truffle-reporters/reporters/migrations-V5/reporter.js
@@ -149,7 +149,7 @@ class Reporter {
 
     const errors = {
       ETH: error.message.includes('funds'),
-      OOG: error.message.includes('out of gas') || (data.gas === data.blockLimit),
+      OOG: error.message.includes('out of gas'),
       INT: error.message.includes('base fee') || error.message.includes('intrinsic'),
       RVT: error.message.includes('revert'),
       BLK: error.message.includes('block gas limit'),


### PR DESCRIPTION
+ Removes a bad conditional check in the reporter dispatcher.
+ Adds a regression test for library link errors that were being swallowed.