### PR TITLE
Skip external compile tests locally

### DIFF
--- a/packages/truffle/test/scenarios/external_compilers/truffle-compile.js
+++ b/packages/truffle/test/scenarios/external_compilers/truffle-compile.js
@@ -9,6 +9,11 @@ var Server = require("../server");
 var Reporter = require("../reporter");
 
 describe("`truffle compile` as external", function() {
+
+  // These tests rely on a solc jq dependency installed with apt-get
+  // You can run them locally with `CI=true npm test`
+  if (!process.env.CI) return;
+
   var config;
   var project = path.join(__dirname, '../../sources/external_compile');
   var logger = new MemoryLogger();


### PR DESCRIPTION
These fail locally if you don't have the `jq` installed. We have the same problem with the solc native compiler tests and run those conditionally in CI as well. 

PR  skips out of the scenario test unless `process.env.CI`  