### PR TITLE
Fix build for truffle-contract package version change

### DIFF
--- a/packages/truffle-artifactor/package.json
+++ b/packages/truffle-artifactor/package.json
@@ -28,7 +28,7 @@
     "debug": "^3.1.0",
     "fs-extra": "6.0.1",
     "lodash": "4.17.10",
-    "truffle-contract": "4.0.0-next.0",
+    "truffle-contract": "^4.0.0-next.0",
     "truffle-contract-schema": "^2.0.1",
     "truffle-expect": "^0.0.4"
   },

--- a/packages/truffle-artifactor/package.json
+++ b/packages/truffle-artifactor/package.json
@@ -28,7 +28,7 @@
     "debug": "^3.1.0",
     "fs-extra": "6.0.1",
     "lodash": "4.17.10",
-    "truffle-contract": "^3.0.6",
+    "truffle-contract": "4.0.0-next.0",
     "truffle-contract-schema": "^2.0.1",
     "truffle-expect": "^0.0.4"
   },

--- a/packages/truffle-core/package.json
+++ b/packages/truffle-core/package.json
@@ -29,7 +29,7 @@
     "truffle-box": "^1.0.7",
     "truffle-compile": "^3.0.13",
     "truffle-config": "^1.0.6",
-    "truffle-contract": "4.0.0-next.0",
+    "truffle-contract": "^4.0.0-next.0",
     "truffle-contract-sources": "^0.0.2",
     "truffle-debug-utils": "^1.0.6",
     "truffle-debugger": "^4.0.3",

--- a/packages/truffle-core/package.json
+++ b/packages/truffle-core/package.json
@@ -29,7 +29,7 @@
     "truffle-box": "^1.0.7",
     "truffle-compile": "^3.0.13",
     "truffle-config": "^1.0.6",
-    "truffle-contract": "^3.0.6",
+    "truffle-contract": "4.0.0-next.0",
     "truffle-contract-sources": "^0.0.2",
     "truffle-debug-utils": "^1.0.6",
     "truffle-debugger": "^4.0.3",

--- a/packages/truffle-deployer/package.json
+++ b/packages/truffle-deployer/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/trufflesuite/truffle-deployer#readme",
   "dependencies": {
     "emittery": "^0.3.0",
-    "truffle-contract": "4.0.0-next.0",
+    "truffle-contract": "^4.0.0-next.0",
     "truffle-expect": "^0.0.4"
   },
   "devDependencies": {

--- a/packages/truffle-deployer/package.json
+++ b/packages/truffle-deployer/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/trufflesuite/truffle-deployer#readme",
   "dependencies": {
     "emittery": "^0.3.0",
-    "truffle-contract": "^3.0.5",
+    "truffle-contract": "4.0.0-next.0",
     "truffle-expect": "^0.0.4"
   },
   "devDependencies": {

--- a/packages/truffle-resolver/package.json
+++ b/packages/truffle-resolver/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/trufflesuite/truffle-resolver#readme",
   "dependencies": {
     "async": "2.6.1",
-    "truffle-contract": "4.0.0-next.0",
+    "truffle-contract": "^4.0.0-next.0",
     "truffle-expect": "^0.0.4",
     "truffle-provisioner": "^0.1.1"
   },

--- a/packages/truffle-resolver/package.json
+++ b/packages/truffle-resolver/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/trufflesuite/truffle-resolver#readme",
   "dependencies": {
     "async": "2.6.1",
-    "truffle-contract": "^3.0.6",
+    "truffle-contract": "4.0.0-next.0",
     "truffle-expect": "^0.0.4",
     "truffle-provisioner": "^0.1.1"
   },

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -24,7 +24,7 @@
     "stream-buffers": "^3.0.1",
     "tmp": "0.0.33",
     "truffle-box": "^1.0.7",
-    "truffle-contract": "^3.0.6",
+    "truffle-contract": "3.0.6",
     "web3": "1.0.0-beta.35",
     "webpack": "^2.5.1",
     "yargs": "^8.0.2"

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -24,7 +24,7 @@
     "stream-buffers": "^3.0.1",
     "tmp": "0.0.33",
     "truffle-box": "^1.0.7",
-    "truffle-contract": "3.0.6",
+    "truffle-contract": "^4.0.0-next.0",
     "web3": "1.0.0-beta.35",
     "webpack": "^2.5.1",
     "yargs": "^8.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9199,16 +9199,6 @@ truffle-contract-schema@0.0.5, truffle-contract-schema@^0.0.5:
   dependencies:
     crypto-js "^3.1.9-1"
 
-truffle-contract@3.0.6:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/truffle-contract/-/truffle-contract-3.0.6.tgz#2ef6fc32d7faafa9f4aed8e50001a9fdea342192"
-  dependencies:
-    ethjs-abi "0.1.8"
-    truffle-blockchain-utils "^0.0.5"
-    truffle-contract-schema "^2.0.1"
-    truffle-error "^0.0.3"
-    web3 "0.20.6"
-
 truffle-contract@^1.1.6:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/truffle-contract/-/truffle-contract-1.1.11.tgz#ce1fa787f797758aff572f45e8b1174527f6edaa"
@@ -10010,16 +10000,6 @@ web3-utils@1.0.0-beta.35:
     underscore "1.8.3"
     utf8 "2.1.1"
 
-web3@0.20.6, web3@^0.20.1:
-  version "0.20.6"
-  resolved "https://registry.yarnpkg.com/web3/-/web3-0.20.6.tgz#3e97306ae024fb24e10a3d75c884302562215120"
-  dependencies:
-    bignumber.js "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
-    crypto-js "^3.1.4"
-    utf8 "^2.1.1"
-    xhr2 "*"
-    xmlhttprequest "*"
-
 web3@1.0.0-beta.35:
   version "1.0.0-beta.35"
   resolved "https://registry.yarnpkg.com/web3/-/web3-1.0.0-beta.35.tgz#6475095bd451a96e50a32b997ddee82279292f11"
@@ -10046,6 +10026,16 @@ web3@^0.18.0, web3@^0.18.2:
   resolved "https://registry.yarnpkg.com/web3/-/web3-0.18.4.tgz#81ec1784145491f2eaa8955b31c06049e07c5e7d"
   dependencies:
     bignumber.js "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
+    crypto-js "^3.1.4"
+    utf8 "^2.1.1"
+    xhr2 "*"
+    xmlhttprequest "*"
+
+web3@^0.20.1:
+  version "0.20.6"
+  resolved "https://registry.yarnpkg.com/web3/-/web3-0.20.6.tgz#3e97306ae024fb24e10a3d75c884302562215120"
+  dependencies:
+    bignumber.js "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
     crypto-js "^3.1.4"
     utf8 "^2.1.1"
     xhr2 "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9199,6 +9199,16 @@ truffle-contract-schema@0.0.5, truffle-contract-schema@^0.0.5:
   dependencies:
     crypto-js "^3.1.9-1"
 
+truffle-contract@3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/truffle-contract/-/truffle-contract-3.0.6.tgz#2ef6fc32d7faafa9f4aed8e50001a9fdea342192"
+  dependencies:
+    ethjs-abi "0.1.8"
+    truffle-blockchain-utils "^0.0.5"
+    truffle-contract-schema "^2.0.1"
+    truffle-error "^0.0.3"
+    web3 "0.20.6"
+
 truffle-contract@^1.1.6:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/truffle-contract/-/truffle-contract-1.1.11.tgz#ce1fa787f797758aff572f45e8b1174527f6edaa"
@@ -10000,6 +10010,16 @@ web3-utils@1.0.0-beta.35:
     underscore "1.8.3"
     utf8 "2.1.1"
 
+web3@0.20.6, web3@^0.20.1:
+  version "0.20.6"
+  resolved "https://registry.yarnpkg.com/web3/-/web3-0.20.6.tgz#3e97306ae024fb24e10a3d75c884302562215120"
+  dependencies:
+    bignumber.js "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
+    crypto-js "^3.1.4"
+    utf8 "^2.1.1"
+    xhr2 "*"
+    xmlhttprequest "*"
+
 web3@1.0.0-beta.35:
   version "1.0.0-beta.35"
   resolved "https://registry.yarnpkg.com/web3/-/web3-1.0.0-beta.35.tgz#6475095bd451a96e50a32b997ddee82279292f11"
@@ -10026,16 +10046,6 @@ web3@^0.18.0, web3@^0.18.2:
   resolved "https://registry.yarnpkg.com/web3/-/web3-0.18.4.tgz#81ec1784145491f2eaa8955b31c06049e07c5e7d"
   dependencies:
     bignumber.js "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
-    crypto-js "^3.1.4"
-    utf8 "^2.1.1"
-    xhr2 "*"
-    xmlhttprequest "*"
-
-web3@^0.20.1:
-  version "0.20.6"
-  resolved "https://registry.yarnpkg.com/web3/-/web3-0.20.6.tgz#3e97306ae024fb24e10a3d75c884302562215120"
-  dependencies:
-    bignumber.js "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
     crypto-js "^3.1.4"
     utf8 "^2.1.1"
     xhr2 "*"


### PR DESCRIPTION
Changing the package version at `truffle-contract` [broke](https://travis-ci.org/trufflesuite/truffle/builds/416480241) the lerna installation.

Ran lernaupdate for TC as a dep. Then I floated the changes on a caret - I think this correct based on this description of [lerna link](https://github.com/lerna/lerna/tree/master/commands/link#readme) which suggests that linking checks the version range of the packages. Not 100% sure about this needless to say.

Also checked the release build and it's fine - it has the most recent changes in it. Tests that failed on Travis were passing locally for me when I did the release - I guess everything was linked correctly from before the change.