### PR TITLE
use web3 instance of TestRunner instead of global

### DIFF
--- a/packages/truffle-core/lib/testing/testrunner.js
+++ b/packages/truffle-core/lib/testing/testrunner.js
@@ -67,7 +67,7 @@ TestRunner.prototype.initialize = function(callback) {
         abis.map(function(abi) {
           if (abi.type == "event") {
             var signature = abi.name + "(" + _.map(abi.inputs, "type").join(",") + ")";
-            self.known_events[web3.sha3(signature)] = {
+            self.known_events[self.web3.sha3(signature)] = {
               signature: signature,
               abi_entry: abi
             };
@@ -127,7 +127,7 @@ TestRunner.prototype.startTest = function(mocha, callback) {
   this.web3.eth.getBlockNumber(function(err, result) {
     if (err) return callback(err);
 
-    result = web3.toBigNumber(result);
+    result = self.web3.toBigNumber(result);
 
     // Add one in base 10
     self.currentTestStartBlock = result.plus(1, 10);


### PR DESCRIPTION
Hi

while trying to come up with a possible solution for #500, and #403 I noticed that the TestRunner relies on the global web3 instance which is exposed to the unit tests. I think it would be better to reuse the web3 instance of the TestRunner instance.

Cheers,
Fabian