### PR TITLE
Adding truffle solidity loader to truffle

### DIFF
--- a/packages/truffle-solidity-loader/.gitignore
+++ b/packages/truffle-solidity-loader/.gitignore
@@ -1,0 +1,3 @@
+.tern-port
+node_modules/
+.DS_Store

--- a/packages/truffle-solidity-loader/ISSUE_TEMPLATE.md
+++ b/packages/truffle-solidity-loader/ISSUE_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Issue
+
+What the issue is, in broad strokes.
+
+## Steps to Reproduce
+
+Please provide the shortest amount of steps to reproduce your issue.
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Results
+
+What actually happened. Please give examples and support it with screenshots, copied output or error messages.
+
+## Environment
+
+* Operating System:
+* Truffle version:
+* Testrpc version:
+* Ethereum client:
+* node version:
+* npm version:

--- a/packages/truffle-solidity-loader/README.md
+++ b/packages/truffle-solidity-loader/README.md
@@ -1,0 +1,41 @@
+## truffle-solidity-loader
+
+A Webpack loader that will parse and provision Solidity files to Javascript using Truffle for compilation, and utilising Truffle's migrations. This allows you to develop your contracts with Hot Reloading support, and have your migrations automatically re-run on change.
+
+A project by ConsenSys and @johnmcdowall.
+
+## Installation
+
+`$ npm install --save-dev truffle-solidity-loader`
+
+Add the appropriate config to your `loaders` section of your Webpack config:
+
+```javascript
+{
+  test: /\.sol/, loader: 'truffle-solidity?web3_rpc_uri='+process.env.WEB3_RPC_LOCATION+'&migrations_directory='+path.resolve(__dirname, '../migrations' )
+}
+```
+
+### Loader Query string config
+
+  - `web3_rpc_uri`: The URI of the Web3 RPC endpoint with which to provision your contracts (Required)
+  - `migrations_directory`: The path to a directory containing your Truffle migrations (Required)
+  - `network`: A network name to use (optional: defaults to `default`)
+  - `network_id`: A network id to use (optional: defaults to `default`)
+
+## Contributing
+
+- Write issue in the Issue Tracker.
+- Submit PRs.
+- Respect the project coding style: StandardJS.
+
+[![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)
+
+## License
+Copyright (c) Consensys LLC, and authors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/truffle-solidity-loader/README.md
+++ b/packages/truffle-solidity-loader/README.md
@@ -6,6 +6,8 @@ Each time you change a Solidity contract, Webpack will detect the change, recomp
 
 When you run a production build, the contracts will be bundled into your main bundle for easy deployment.
 
+You can see this plugin in operation in the [Truffle+Webpack Demo App](https://github.com/ConsenSys/truffle-webpack-demo)
+
 A project by ConsenSys and @johnmcdowall.
 
 ## Installation

--- a/packages/truffle-solidity-loader/README.md
+++ b/packages/truffle-solidity-loader/README.md
@@ -2,6 +2,10 @@
 
 A Webpack loader that will parse and provision Solidity files to Javascript using Truffle for compilation, and utilising Truffle's migrations. This allows you to develop your contracts with Hot Reloading support, and have your migrations automatically re-run on change.
 
+Each time you change a Solidity contract, Webpack will detect the change, recompile the Solidity files, and re-run your Truffle migrations. The updated Solidity contract will be Hot updated in teh browser if enabled.
+
+When you run a production build, the contracts will be bundled into your main bundle for easy deployment.
+
 A project by ConsenSys and @johnmcdowall.
 
 ## Installation
@@ -12,16 +16,33 @@ Add the appropriate config to your `loaders` section of your Webpack config:
 
 ```javascript
 {
-  test: /\.sol/, loader: 'truffle-solidity?web3_rpc_uri='+process.env.WEB3_RPC_LOCATION+'&migrations_directory='+path.resolve(__dirname, '../migrations' )
+  test: /\.sol/,
+  loader: 'truffle-solidity'
+}
+```
+
+### `truffle.js` integration
+
+The loader will detect a `truffle.js` (or `truffle-config.js` for Windows users) config file in your project and use that for configuration.
+
+Importantly, you will need to specify the location of your `migrations` directory in the `truffle.js` file like so:
+
+`"migrations_directory": "./migrations"`
+
+You can also override the Truffle config using a loader querystring as outlined below:
+
+```javascript
+{
+  test: /\.sol/,
+  loader: 'truffle-solidity?migrations_directory='+path.resolve(__dirname, '../migrations' )
 }
 ```
 
 ### Loader Query string config
 
-  - `web3_rpc_uri`: The URI of the Web3 RPC endpoint with which to provision your contracts (Required)
-  - `migrations_directory`: The path to a directory containing your Truffle migrations (Required)
-  - `network`: A network name to use (optional: defaults to `default`)
-  - `network_id`: A network id to use (optional: defaults to `default`)
+  - `migrations_directory`: The path to a directory containing your Truffle migrations
+  - `network`: A network name to use
+  - `network_id`: A network id to use
 
 ## Contributing
 

--- a/packages/truffle-solidity-loader/index.js
+++ b/packages/truffle-solidity-loader/index.js
@@ -5,28 +5,14 @@ var Pudding                 = require('ether-pudding')
 var Web3                    = require('web3')
 var temp                    = require('temp')
 
+/* Internal Module Dependencies */
+var Logger                  = require('./lib/logger_decorator')
+var BuildOptionNormalizer   = require('./lib/build_option_normalizer')
+
 /* Native Node Imports */
 var path                    = require('path')
 var fs                      = require('fs')
 
-// Convert a Query String into an object of key value pairs.
-function parseQueryString(query) {
-    var queryString = {};
-
-    query.replace(
-      new RegExp("([^?=&]+)(=([^&]*))?", "g"),
-      function($0, $1, $2, $3) { queryString[$1] = $3; }
-    );
-
-    return queryString;
-}
-
-// Custom Logger
-var Logger = {
-  log: function(msg) {
-    console.log("[TRUFFLE SOLIDITY] " + msg)
-  }
-}
 
 module.exports = function (source) {
   this.cacheable && this.cacheable()
@@ -39,24 +25,7 @@ module.exports = function (source) {
 
   var buildOpts    = {}
   buildOpts.logger = Logger
-
-  if (typeof this.query !== "undefined") {
-    buildOpts = parseQueryString(this.query)
-  }
-
-  if(!buildOpts.network) {
-    buildOpts.network = "default"
-    Logger.log("Setting network to 'default' for compilation and contract provisioning")
-  }
-
-  if(!buildOpts.network_id) {
-    buildOpts.network_id = "default"
-    Logger.log("Setting network_id to 'default' for compilation and contract provisioning")
-  }
-
-  if(!buildOpts.migrations_directory) {
-    throw new Error("You must specify the location of the Truffle migrations directory in the loader query string. (migrations_directory)")
-  }
+  buildOpts        = BuildOptionNormalizer.normalize(buildOpts, this.query)
 
   temp.mkdir('webpack-truffle', function(err, dirPath){
     if(!err) {

--- a/packages/truffle-solidity-loader/index.js
+++ b/packages/truffle-solidity-loader/index.js
@@ -1,0 +1,102 @@
+/* External Module Dependencies */
+var TruffleContractCompiler = require('truffle/lib/contracts')
+var TruffleContractMigrator = require('truffle/lib/migrate')
+var Pudding                 = require('ether-pudding')
+var Web3                    = require('web3')
+var temp                    = require('temp')
+
+/* Native Node Imports */
+var path                    = require('path')
+var fs                      = require('fs')
+
+// Convert a Query String into an object of key value pairs.
+function parseQueryString(query) {
+    var queryString = {};
+
+    query.replace(
+      new RegExp("([^?=&]+)(=([^&]*))?", "g"),
+      function($0, $1, $2, $3) { queryString[$1] = $3; }
+    );
+
+    return queryString;
+}
+
+// Custom Logger
+var Logger = {
+  log: function(msg) {
+    console.log("[TRUFFLE SOLIDITY] " + msg)
+  }
+}
+
+module.exports = function (source) {
+  this.cacheable && this.cacheable()
+
+  var compilationFinished = this.async()
+  var contractPath        = this.context
+  var contractFilePath    = this.resourcePath
+  var contractFileName    = path.basename(contractFilePath)
+  var contractName        = contractFileName.charAt(0).toUpperCase() + contractFileName.slice(1, contractFileName.length-4)
+
+  var buildOpts    = {}
+  buildOpts.logger = Logger
+
+  if (typeof this.query !== "undefined") {
+    buildOpts = parseQueryString(this.query)
+  }
+
+  if(!buildOpts.network) {
+    buildOpts.network = "default"
+    Logger.log("Setting network to 'default' for compilation and contract provisioning")
+  }
+
+  if(!buildOpts.network_id) {
+    buildOpts.network_id = "default"
+    Logger.log("Setting network_id to 'default' for compilation and contract provisioning")
+  }
+
+  if(!buildOpts.migrations_directory) {
+    throw new Error("You must specify the location of the Truffle migrations directory in the loader query string. (migrations_directory)")
+  }
+
+  temp.mkdir('webpack-truffle', function(err, dirPath){
+    if(!err) {
+      var compilerOpts = {};
+      compilerOpts.contracts_directory       = contractPath
+      compilerOpts.contracts_build_directory = dirPath
+      compilerOpts.network                   = buildOpts.network
+      compilerOpts.network_id                = buildOpts.network_id
+      compilerOpts.logger                    = Logger
+
+      var provisionOpts = {}
+      provisionOpts.provider                  = new Web3.providers.HttpProvider(buildOpts.web3_rpc_uri)
+      provisionOpts.contracts_build_directory = dirPath
+
+      TruffleContractCompiler.compile( compilerOpts, function(err, contracts){
+        var migrationOpts = {}
+        migrationOpts.migrations_directory      = buildOpts.migrations_directory
+        migrationOpts.contracts_build_directory = dirPath
+        migrationOpts.provider                  = provisionOpts.provider
+        migrationOpts.network                   = compilerOpts.network
+        migrationOpts.network_id                = compilerOpts.network_id
+        migrationOpts.logger                    = Logger
+
+        TruffleContractMigrator.run( migrationOpts, function( err, result ) {
+          if(err) {
+            Logger.error(err);
+            return compilationFinished(err, null);
+          }
+
+          fs.readFile( path.resolve(dirPath, contractFileName+'.js'), 'utf8', function(err, solJsFile) {
+            if(err) {
+              Logger.error(err);
+              return compilationFinished(err, null);
+            }
+
+            compilationFinished(err, solJsFile)
+          })
+        })
+      })
+    }
+  })
+
+}

--- a/packages/truffle-solidity-loader/index.js
+++ b/packages/truffle-solidity-loader/index.js
@@ -82,11 +82,9 @@ module.exports = function (source) {
     Logger.log(`Writing temporary contract build artifacts to ${buildPath}`)
     isCompilingContracts = true
 
-    var compilerOpts = {}
+    var compilerOpts = buildOpts
     compilerOpts.contracts_directory = contractPath
     compilerOpts.contracts_build_directory = buildPath
-    compilerOpts.network = buildOpts.network
-    compilerOpts.network_id = buildOpts.network_id
     compilerOpts.logger = Logger
     compilerOpts.all = false
 
@@ -104,12 +102,10 @@ module.exports = function (source) {
       Logger.log('COMPILATION FINISHED')
       Logger.log('RUNNING MIGRATIONS')
 
-      var migrationOpts = {}
+      var migrationOpts = compilerOpts
       migrationOpts.migrations_directory = buildOpts.migrations_directory
       migrationOpts.contracts_build_directory = buildPath
       migrationOpts.provider = provisionOpts.provider
-      migrationOpts.network = compilerOpts.network
-      migrationOpts.network_id = compilerOpts.network_id
       migrationOpts.logger = Logger
 
       // Once all of the contracts have been compiled, we know we can immediately

--- a/packages/truffle-solidity-loader/index.js
+++ b/packages/truffle-solidity-loader/index.js
@@ -107,6 +107,7 @@ module.exports = function (source) {
       migrationOpts.contracts_build_directory = buildPath
       migrationOpts.provider = provisionOpts.provider
       migrationOpts.logger = Logger
+      migrationOpts.reset = true                                 // Force the migrations to re-run
 
       // Once all of the contracts have been compiled, we know we can immediately
       // try to run the migrations safely.
@@ -115,7 +116,7 @@ module.exports = function (source) {
           Logger.error(err)
           return compilationFinished(err, null)
         }
-
+        console.log('here', result)
         // Finally return the contract source we were originally asked for.
         returnContractAsSource(compiledContractPath, compilationFinished)
       })

--- a/packages/truffle-solidity-loader/index.js
+++ b/packages/truffle-solidity-loader/index.js
@@ -1,71 +1,137 @@
 /* External Module Dependencies */
 var TruffleContractCompiler = require('truffle/lib/contracts')
 var TruffleContractMigrator = require('truffle/lib/migrate')
-var Pudding                 = require('ether-pudding')
-var Web3                    = require('web3')
-var temp                    = require('temp')
+var SolidityParser = require('solidity-parser')
+var Web3 = require('web3')
 
 /* Internal Module Dependencies */
-var Logger                  = require('./lib/logger_decorator')
-var BuildOptionNormalizer   = require('./lib/build_option_normalizer')
+var Logger = require('./lib/logger_decorator')
+var BuildOptionNormalizer = require('./lib/build_option_normalizer')
+var ScratchDir = require('./lib/scratch_dir')
 
 /* Native Node Imports */
-var path                    = require('path')
-var fs                      = require('fs')
+var path = require('path')
+var fs = require('fs')
 
+// Synchronus file existence check helper
+function compiledContractExists (filePath) {
+  try {
+    fs.statSync(filePath)
+  } catch (err) {
+    if (err.code === 'ENOENT') return false
+  }
+  return true
+}
+
+// Read the contract source file and pass it to the `compilationFinished` callback
+function returnContractAsSource (filePath, compilationFinished) {
+  fs.readFile(filePath, 'utf8', function (err, solJsFile) {
+    if (err) {
+      Logger.error(err)
+      return compilationFinished(err, null)
+    }
+
+    compilationFinished(err, solJsFile)
+  })
+}
+
+// This acts as a mutex to prevent multiple compilation runs
+var isCompilingContracts = false
 
 module.exports = function (source) {
   this.cacheable && this.cacheable()
 
+  var scratchPath = new ScratchDir()
+  scratchPath.createIfMissing()
+
+  var buildPath = scratchPath.path()
+
   var compilationFinished = this.async()
-  var contractPath        = this.context
-  var contractFilePath    = this.resourcePath
-  var contractFileName    = path.basename(contractFilePath)
-  var contractName        = contractFileName.charAt(0).toUpperCase() + contractFileName.slice(1, contractFileName.length-4)
+  var contractPath = this.context
+  var contractFilePath = this.resourcePath
+  var contractFileName = path.basename(contractFilePath)
+  var contractName = contractFileName.charAt(0).toUpperCase() + contractFileName.slice(1, contractFileName.length - 4)
+  var compiledContractPath = path.resolve(buildPath, contractFileName + '.js')
 
-  var buildOpts    = {}
-  buildOpts.logger = Logger
-  buildOpts        = BuildOptionNormalizer.normalize(buildOpts, this.query)
+  var imports = SolidityParser.parseFile(contractFilePath, 'imports')
 
-  temp.mkdir('webpack-truffle', function(err, dirPath){
-    if(!err) {
-      var compilerOpts = {};
-      compilerOpts.contracts_directory       = contractPath
-      compilerOpts.contracts_build_directory = dirPath
-      compilerOpts.network                   = buildOpts.network
-      compilerOpts.network_id                = buildOpts.network_id
-      compilerOpts.logger                    = Logger
+  imports.forEach(function (solidityImport) {
+    var dependencyPath = path.resolve(contractPath, solidityImport)
+    Logger.log('adding ' + dependencyPath + ' as dependency of ' + contractFileName)
+    this.addDependency(dependencyPath)
 
-      var provisionOpts = {}
-      provisionOpts.provider                  = new Web3.providers.HttpProvider(buildOpts.web3_rpc_uri)
-      provisionOpts.contracts_build_directory = dirPath
-
-      TruffleContractCompiler.compile( compilerOpts, function(err, contracts){
-        var migrationOpts = {}
-        migrationOpts.migrations_directory      = buildOpts.migrations_directory
-        migrationOpts.contracts_build_directory = dirPath
-        migrationOpts.provider                  = provisionOpts.provider
-        migrationOpts.network                   = compilerOpts.network
-        migrationOpts.network_id                = compilerOpts.network_id
-        migrationOpts.logger                    = Logger
-
-        TruffleContractMigrator.run( migrationOpts, function( err, result ) {
-          if(err) {
-            Logger.error(err);
-            return compilationFinished(err, null);
-          }
-
-          fs.readFile( path.resolve(dirPath, contractFileName+'.js'), 'utf8', function(err, solJsFile) {
-            if(err) {
-              Logger.error(err);
-              return compilationFinished(err, null);
-            }
-
-            compilationFinished(err, solJsFile)
-          })
-        })
-      })
+    if (compiledContractExists(compiledContractPath)) {
+      fs.unlinkSync(compiledContractPath)
     }
-  })
+  }.bind(this))
 
+  var buildOpts = {}
+  buildOpts.logger = Logger
+  buildOpts = BuildOptionNormalizer.normalize(buildOpts, this.query)
+
+  function waitForContractCompilation () {
+    setTimeout(function () {
+      if (compiledContractExists(compiledContractPath)) {
+        returnContractAsSource(compiledContractPath, compilationFinished)
+      } else {
+        waitForContractCompilation()
+      }
+    }.bind(this), 500)
+  }
+
+  if (!isCompilingContracts) {
+    Logger.log(`Writing temporary contract build artifacts to ${buildPath}`)
+    isCompilingContracts = true
+
+    var compilerOpts = {}
+    compilerOpts.contracts_directory = contractPath
+    compilerOpts.contracts_build_directory = buildPath
+    compilerOpts.network = buildOpts.network
+    compilerOpts.network_id = buildOpts.network_id
+    compilerOpts.logger = Logger
+    compilerOpts.all = false
+
+    var provisionOpts = {}
+    provisionOpts.provider = new Web3.providers.HttpProvider(buildOpts.web3_rpc_uri)
+    provisionOpts.contracts_build_directory = buildPath
+
+    TruffleContractCompiler.compile(compilerOpts, function (err, contracts) {
+      if (err) {
+        Logger.error(err)
+        return compilationFinished(err, null)
+      }
+
+      isCompilingContracts = false
+      Logger.log('COMPILATION FINISHED')
+      Logger.log('RUNNING MIGRATIONS')
+
+      var migrationOpts = {}
+      migrationOpts.migrations_directory = buildOpts.migrations_directory
+      migrationOpts.contracts_build_directory = buildPath
+      migrationOpts.provider = provisionOpts.provider
+      migrationOpts.network = compilerOpts.network
+      migrationOpts.network_id = compilerOpts.network_id
+      migrationOpts.logger = Logger
+
+      // Once all of the contracts have been compiled, we know we can immediately
+      // try to run the migrations safely.
+      TruffleContractMigrator.run(migrationOpts, function (err, result) {
+        if (err) {
+          Logger.error(err)
+          return compilationFinished(err, null)
+        }
+
+        // Finally return the contract source we were originally asked for.
+        returnContractAsSource(compiledContractPath, compilationFinished)
+      })
+    })
+
+    return
+  }
+
+  if (compiledContractExists(compiledContractPath)) {
+    returnContractAsSource(compiledContractPath, compilationFinished)
+  } else {
+    waitForContractCompilation()
+  }
 }

--- a/packages/truffle-solidity-loader/index.js
+++ b/packages/truffle-solidity-loader/index.js
@@ -57,7 +57,6 @@ module.exports = function (source) {
 
   imports.forEach(function (solidityImport) {
     var dependencyPath = path.resolve(contractPath, solidityImport)
-    Logger.log('adding ' + dependencyPath + ' as dependency of ' + contractFileName)
     this.addDependency(dependencyPath)
 
     if (compiledContractExists(compiledContractPath)) {

--- a/packages/truffle-solidity-loader/lib/build_option_normalizer.js
+++ b/packages/truffle-solidity-loader/lib/build_option_normalizer.js
@@ -1,0 +1,39 @@
+var merge                   = require('lodash.merge')
+var Logger                  = require('./logger_decorator')
+
+var QueryStringParser       = require('./query_string_parser')
+var TruffleConfigLocator    = require('./truffle_config_locator')
+
+var BuildOptionNormalizer = {
+  normalize: function(buildOpts, query) {
+    var truffleConfig = TruffleConfigLocator.find()
+
+    if(truffleConfig) {
+      var config = require(truffleConfig)
+      merge(buildOpts, config)
+    }
+
+    if (query !== "undefined") {
+      var config = QueryStringParser.parse(query)
+      merge(buildOpts, config)
+    }
+
+    if(!buildOpts.network) {
+      buildOpts.network = "default"
+      Logger.log("Setting network to 'default' for compilation and contract provisioning")
+    }
+
+    if(!buildOpts.network_id) {
+      buildOpts.network_id = "default"
+      Logger.log("Setting network_id to 'default' for compilation and contract provisioning")
+    }
+
+    if(!buildOpts.migrations_directory) {
+      throw new Error("You must specify the location of the Truffle migrations directory in the loader query string. (migrations_directory)")
+    }
+
+    return buildOpts
+  }
+}
+
+module.exports = BuildOptionNormalizer

--- a/packages/truffle-solidity-loader/lib/build_option_normalizer.js
+++ b/packages/truffle-solidity-loader/lib/build_option_normalizer.js
@@ -11,7 +11,7 @@ var BuildOptionNormalizer = {
 
     if(truffleConfig) {
       var config = TruffleConfig.load(truffleConfig)
-      merge(buildOpts, config)
+      config = merge(buildOpts, config)
     }
 
     if (query !== "undefined") {

--- a/packages/truffle-solidity-loader/lib/build_option_normalizer.js
+++ b/packages/truffle-solidity-loader/lib/build_option_normalizer.js
@@ -3,13 +3,14 @@ var Logger                  = require('./logger_decorator')
 
 var QueryStringParser       = require('./query_string_parser')
 var TruffleConfigLocator    = require('./truffle_config_locator')
+var TruffleConfig           = require('truffle/lib/config.js');
 
 var BuildOptionNormalizer = {
   normalize: function(buildOpts, query) {
     var truffleConfig = TruffleConfigLocator.find()
 
     if(truffleConfig) {
-      var config = require(truffleConfig)
+      var config = TruffleConfig.load(truffleConfig)
       merge(buildOpts, config)
     }
 

--- a/packages/truffle-solidity-loader/lib/logger_decorator.js
+++ b/packages/truffle-solidity-loader/lib/logger_decorator.js
@@ -1,0 +1,12 @@
+var chalk = require('chalk')
+
+var Logger = {
+  log: function(msg) {
+    console.log("[TRUFFLE SOLIDITY] " + msg)
+  },
+  error: function(msg) {
+    console.log(chalk.red("[! TRUFFLE SOLIDITY ERROR] " + msg))
+  }
+}
+
+module.exports = Logger;

--- a/packages/truffle-solidity-loader/lib/query_string_parser.js
+++ b/packages/truffle-solidity-loader/lib/query_string_parser.js
@@ -1,0 +1,15 @@
+// Convert a Query String into an object of key value pairs.
+var QueryStringParser = {
+  parse: function(query) {
+    var queryString = {};
+
+    query.replace(
+      new RegExp("([^?=&]+)(=([^&]*))?", "g"),
+      function($0, $1, $2, $3) { queryString[$1] = $3; }
+    );
+
+    return queryString;
+  }
+}
+
+module.exports = QueryStringParser;

--- a/packages/truffle-solidity-loader/lib/scratch_dir.js
+++ b/packages/truffle-solidity-loader/lib/scratch_dir.js
@@ -1,0 +1,39 @@
+var path                    = require('path')
+var fs                      = require('fs')
+
+/* ScratchDir - Handles the creation and path resolution of the
+ * webpack loader build artifacts directory.
+ */
+var ScratchDir = function ScratchDir () { }
+
+ScratchDir.prototype = {
+  createIfMissing: function() {
+    if(!this.dirExists()) {
+      fs.mkdirSync(this.path());
+    }
+  },
+
+  dirExists: function() {
+    return this.isDirSync( this.path() )
+  },
+
+  path: function() {
+    var cwd = process.cwd()
+    var scratchDir = '.truffle-solidity-loader'
+    return path.resolve( cwd, scratchDir)
+  },
+
+  isDirSync: function(aPath) {
+    try {
+      return fs.statSync(aPath).isDirectory();
+    } catch (e) {
+      if (e.code === 'ENOENT') {
+        return false;
+      } else {
+        throw e;
+      }
+    }
+  }
+}
+
+module.exports = ScratchDir

--- a/packages/truffle-solidity-loader/lib/truffle_config_locator.js
+++ b/packages/truffle-solidity-loader/lib/truffle_config_locator.js
@@ -1,0 +1,26 @@
+var findUp = require('find-up')
+var Logger = require('./logger_decorator')
+
+var TruffleConfigLocator = {
+  find: function() {
+    var isWin = /^win/.test(process.platform)
+    var file
+
+    if(isWin) {
+      Logger.log("Searching for truffle-config.js")
+      file = findUp.sync('truffle-config.js')
+    } else {
+      Logger.log('Searching for truffle.js')
+      file = findUp.sync('truffle.js')
+    }
+
+    if(file) {
+      Logger.log("Found Truffle config at: " + file)
+      return file
+    }
+
+    Logger.log("No Truffle config file found.")
+  }
+}
+
+module.exports = TruffleConfigLocator

--- a/packages/truffle-solidity-loader/lib/truffle_config_locator.js
+++ b/packages/truffle-solidity-loader/lib/truffle_config_locator.js
@@ -7,15 +7,12 @@ var TruffleConfigLocator = {
     var file
 
     if(isWin) {
-      Logger.log("Searching for truffle-config.js")
       file = findUp.sync('truffle-config.js')
     } else {
-      Logger.log('Searching for truffle.js')
       file = findUp.sync('truffle.js')
     }
 
     if(file) {
-      Logger.log("Found Truffle config at: " + file)
       return file
     }
 

--- a/packages/truffle-solidity-loader/package.json
+++ b/packages/truffle-solidity-loader/package.json
@@ -10,8 +10,14 @@
   "license": "MIT",
   "devDependencies": {
     "ether-pudding": "^3.1.2",
+    "findup": "^0.1.5",
     "temp": "^0.8.3",
     "truffle": "^2.0.8",
-    "web3": "^0.17.0-alpha"
+    "web3": "^0.17.0-alpha",
+    "lodash.merge": "^4.6.0"
+  },
+  "dependencies": {
+    "chalk": "^1.1.3",
+    "find-up": "^1.1.2"
   }
 }

--- a/packages/truffle-solidity-loader/package.json
+++ b/packages/truffle-solidity-loader/package.json
@@ -3,9 +3,7 @@
   "version": "0.0.8",
   "description": "A Webpack loader that uses Truffle to load and provision solidity contracts, with Truffle migrations.",
   "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
+  "scripts": {},
   "author": "John McDowall <john@kantan.io>",
   "license": "MIT",
   "dependencies": {

--- a/packages/truffle-solidity-loader/package.json
+++ b/packages/truffle-solidity-loader/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "truffle-solidity-loader",
+  "version": "0.0.1",
+  "description": "A Webpack loader that uses Truffle to load and provision solidity contracts, with Truffle migrations.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "John McDowall <john@kantan.io>",
+  "license": "MIT",
+  "devDependencies": {
+    "ether-pudding": "^3.1.2",
+    "temp": "^0.8.3",
+    "truffle": "^2.0.8",
+    "web3": "^0.17.0-alpha"
+  }
+}

--- a/packages/truffle-solidity-loader/package.json
+++ b/packages/truffle-solidity-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truffle-solidity-loader",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "A Webpack loader that uses Truffle to load and provision solidity contracts, with Truffle migrations.",
   "main": "index.js",
   "scripts": {

--- a/packages/truffle-solidity-loader/package.json
+++ b/packages/truffle-solidity-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truffle-solidity-loader",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "A Webpack loader that uses Truffle to load and provision solidity contracts, with Truffle migrations.",
   "main": "index.js",
   "scripts": {

--- a/packages/truffle-solidity-loader/package.json
+++ b/packages/truffle-solidity-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truffle-solidity-loader",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A Webpack loader that uses Truffle to load and provision solidity contracts, with Truffle migrations.",
   "main": "index.js",
   "scripts": {

--- a/packages/truffle-solidity-loader/package.json
+++ b/packages/truffle-solidity-loader/package.json
@@ -13,9 +13,10 @@
     "find-up": "^1.1.2",
     "ether-pudding": "^3.1.2",
     "findup": "^0.1.5",
-    "temp": "^0.8.3",
     "truffle": "^2.0.8",
     "web3": "^0.17.0-alpha",
-    "lodash.merge": "^4.6.0"
+    "temp": "^0.8.3",
+    "lodash.merge": "^4.6.0",
+    "find-up": "^1.1.2"
   }
 }

--- a/packages/truffle-solidity-loader/package.json
+++ b/packages/truffle-solidity-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truffle-solidity-loader",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A Webpack loader that uses Truffle to load and provision solidity contracts, with Truffle migrations.",
   "main": "index.js",
   "scripts": {
@@ -10,13 +10,13 @@
   "license": "MIT",
   "dependencies": {
     "chalk": "^1.1.3",
+    "ether-pudding": "^3.2.0",
     "find-up": "^1.1.2",
-    "ether-pudding": "^3.1.2",
     "findup": "^0.1.5",
-    "truffle": "^2.0.8",
-    "web3": "^0.17.0-alpha",
-    "temp": "^0.8.3",
     "lodash.merge": "^4.6.0",
-    "find-up": "^1.1.2"
+    "solidity-parser": "^0.1.0",
+    "temp": "^0.8.3",
+    "truffle": "^2.0.8",
+    "web3": "^0.17.0-alpha"
   }
 }

--- a/packages/truffle-solidity-loader/package.json
+++ b/packages/truffle-solidity-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truffle-solidity-loader",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A Webpack loader that uses Truffle to load and provision solidity contracts, with Truffle migrations.",
   "main": "index.js",
   "scripts": {
@@ -8,16 +8,14 @@
   },
   "author": "John McDowall <john@kantan.io>",
   "license": "MIT",
-  "devDependencies": {
+  "dependencies": {
+    "chalk": "^1.1.3",
+    "find-up": "^1.1.2",
     "ether-pudding": "^3.1.2",
     "findup": "^0.1.5",
     "temp": "^0.8.3",
     "truffle": "^2.0.8",
     "web3": "^0.17.0-alpha",
     "lodash.merge": "^4.6.0"
-  },
-  "dependencies": {
-    "chalk": "^1.1.3",
-    "find-up": "^1.1.2"
   }
 }

--- a/packages/truffle-solidity-loader/package.json
+++ b/packages/truffle-solidity-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truffle-solidity-loader",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "A Webpack loader that uses Truffle to load and provision solidity contracts, with Truffle migrations.",
   "main": "index.js",
   "scripts": {

--- a/packages/truffle-solidity-loader/package.json
+++ b/packages/truffle-solidity-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truffle-solidity-loader",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A Webpack loader that uses Truffle to load and provision solidity contracts, with Truffle migrations.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This pull request will add the original `truffle-solidity-loader` to the truffle mono repo. No code changes were added, only a direct `lerna import ./dir/truffle-solidity-loader --flatten` was used.

The reason this is being added is because this has a direct dependency to `truffle-core` to run. 