### PR TITLE
add dependency to truffle-external-compile package

### DIFF
--- a/packages/truffle-workflow-compile/package.json
+++ b/packages/truffle-workflow-compile/package.json
@@ -11,6 +11,7 @@
     "truffle-compile": "^4.0.0-beta.0",
     "truffle-config": "^1.1.0-beta.0",
     "truffle-expect": "^0.0.4",
+    "truffle-external-compile": "^1.0.0-beta.0",
     "truffle-resolver": "^5.0.0-beta.0"
   },
   "main": "index.js",


### PR DESCRIPTION
Hi, 

`truffle-workflow-compile` depends on `truffle-external-compile` since commit https://github.com/trufflesuite/truffle/commit/66ae42c291d8f52f67ef362cd6680f4e18a9ac88. This PR add the missing dependency to the package.json.

Noted while running `npm install truffle-workflow-compile@beta`.

Cheers,
Fabian