### PR TITLE
Throw js errors from sync migrations correctly

### DIFF
--- a/packages/truffle-migrate/migration.js
+++ b/packages/truffle-migrate/migration.js
@@ -58,8 +58,12 @@ class Migration {
 
         // `migrateFn` might be sync or async. We negotiate that difference in
         // `execute` through the deployer API.
-        const migrateFn = fn(deployer, options.network, accounts);
-        await self._deploy(options, deployer, resolver, migrateFn, callback);
+        try {
+          const migrateFn = fn(deployer, options.network, accounts);
+          await self._deploy(options, deployer, resolver, migrateFn, callback);
+        } catch (err){
+          callback(err);
+        }
       });
 
     } catch(err){

--- a/packages/truffle-reporters/reporters/migrations-V5/messages.js
+++ b/packages/truffle-reporters/reporters/migrations-V5/messages.js
@@ -61,8 +61,10 @@ class MigrationsMessages{
 
       noBytecode: () =>
         `${prefix}"${data.contract.contractName}" ` +
-        `is an abstract contract or an interface and cannot be deployed\n` +
-        `   * Hint: just import the contract into the '.sol' file that uses it.\n`,
+        `is an abstract contract or an interface and cannot be deployed.\n` +
+        `   * Import abstractions into the '.sol' file that uses them instead of deploying them separately.\n` +
+        `   * Contracts that inherit an abstraction must implement all its method signatures exactly.\n` +
+        `   * A contract that only implements part of an inherited abstraction is also considered abstract.\n`,
 
       noBatches: () =>
         `Support for batch deployments (array syntax) is deprecated. ` +

--- a/packages/truffle/test/scenarios/migrations/errors.js
+++ b/packages/truffle/test/scenarios/migrations/errors.js
@@ -19,7 +19,7 @@ function processErr(err, output){
   }
 }
 
-describe.only("migration errors", function() {
+describe("migration errors", function() {
   let config;
   let web3;
   let networkId;

--- a/packages/truffle/test/scenarios/migrations/errors.js
+++ b/packages/truffle/test/scenarios/migrations/errors.js
@@ -19,7 +19,7 @@ function processErr(err, output){
   }
 }
 
-describe("migration errors", function() {
+describe.only("migration errors", function() {
   let config;
   let web3;
   let networkId;
@@ -136,6 +136,32 @@ describe("migration errors", function() {
       assert(output.includes('7_batch_deployments.js'));
       assert(output.includes("batch deployments"));
       assert(output.includes("deprecated"));
+      done();
+    });
+  })
+
+  it("should error if there are js errors in the migrations script (sync)", function(done){
+    this.timeout(70000);
+
+    CommandRunner.run("migrate -f 8", config, err => {
+      const output = logger.contents();
+      assert(err);
+      console.log(output);
+      assert(output.includes('8_js_error_sync.js'));
+      assert(output.includes("ReferenceError"));
+      done();
+    });
+  })
+
+  it("should error if there are js errors in the migrations script (async)", function(done){
+    this.timeout(70000);
+
+    CommandRunner.run("migrate -f 9", config, err => {
+      const output = logger.contents();
+      assert(err);
+      console.log(output);
+      assert(output.includes('9_js_error_async.js'));
+      assert(output.includes("ReferenceError"));
       done();
     });
   })

--- a/packages/truffle/test/sources/migrations/error/migrations/8_js_error_sync.js
+++ b/packages/truffle/test/sources/migrations/error/migrations/8_js_error_sync.js
@@ -1,0 +1,5 @@
+const Example = artifacts.require("Example");
+
+module.exports = function(deployer, network, accounts) {
+  deployer.deploy(Hello);
+};

--- a/packages/truffle/test/sources/migrations/error/migrations/9_js_error_async.js
+++ b/packages/truffle/test/sources/migrations/error/migrations/9_js_error_async.js
@@ -1,0 +1,5 @@
+const Example = artifacts.require("Example");
+
+module.exports = async function(deployer, network, accounts) {
+  await deployer.deploy(Hello);
+};


### PR DESCRIPTION
#1208, #1207.

+ Stop swallowing runtime js errors (like ReferenceError) in sync migrations script.
+ (Sneaking this in) Improve migration error output when for case when contract has no bytecode.