### PR TITLE
add missing bignumber.js dependency

### DIFF
--- a/packages/truffle-contract/package.json
+++ b/packages/truffle-contract/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/trufflesuite/truffle-contract#readme",
   "dependencies": {
+    "bignumber.js": "^7.2.1",
     "ethereumjs-util": "^5.2.0",
     "ethjs-abi": "0.1.8",
     "truffle-blockchain-utils": "^0.0.5",


### PR DESCRIPTION
Hi.

I stumbled upon another missing dependency. This time in `truffle-contract`. It needs `bignumber.js` since af7d5ae3366aae10cdd96bc8e29686738fd8545e

Cheers,
Fabian