### PR TITLE
Update publish for web3 1.0

### DIFF
--- a/packages/truffle-blockchain-utils/index.js
+++ b/packages/truffle-blockchain-utils/index.js
@@ -2,7 +2,7 @@ var Blockchain = {
 
   getBlockByNumber: function(blockNumber, provider, callback){
     var params = [blockNumber, true];
-    provider.sendAsync({
+    provider.send({
       jsonrpc: '2.0',
       method: 'eth_getBlockByNumber',
       params: params,
@@ -12,7 +12,7 @@ var Blockchain = {
 
   getBlockByHash: function(blockHash, provider, callback){
     var params = [blockHash, true];
-    provider.sendAsync({
+    provider.send({
       jsonrpc: '2.0',
       method: 'eth_getBlockByHash',
       params: params,

--- a/packages/truffle-core/lib/package.js
+++ b/packages/truffle-core/lib/package.js
@@ -13,7 +13,7 @@ var fs = require('fs');
 var OS = require("os");
 
 var Package = {
-  install: function(options, callback) {
+  install: async function(options, callback) {
     expect.options(options, [
       "working_directory",
       "ethpm"
@@ -47,7 +47,7 @@ var Package = {
     var registry = options.ethpm.registry;
 
     if (typeof registry == "string") {
-      registry = EthPMRegistry.use(options.ethpm.registry, fakeAddress, provider);
+      registry = await EthPMRegistry.use(options.ethpm.registry, fakeAddress, provider);
     }
 
     var pkg = new EthPM(options.working_directory, host, registry);
@@ -124,8 +124,8 @@ var Package = {
     self.publishable_artifacts(options, function(err, artifacts) {
       if (err) return callback(err);
 
-      web3.eth.getAccounts().then(accs => {
-        var registry = EthPMRegistry.use(options.ethpm.registry, accs[0], provider);
+      web3.eth.getAccounts().then(async (accs) => {
+        var registry = await EthPMRegistry.use(options.ethpm.registry, accs[0], provider);
         var pkg = new EthPM(options.working_directory, host, registry);
 
         fs.access(path.join(options.working_directory, "ethpm.json"), fs.constants.R_OK, function(err) {

--- a/packages/truffle-core/package.json
+++ b/packages/truffle-core/package.json
@@ -12,7 +12,7 @@
     "del": "^2.2.0",
     "diff": "1.4.0",
     "ethpm": "0.0.16",
-    "ethpm-registry": "0.0.10",
+    "ethpm-registry": "0.1.0-next.0",
     "fs-extra": "6.0.1",
     "ganache-cli": "6.1.6",
     "lodash": "4.17.10",

--- a/packages/truffle-core/package.json
+++ b/packages/truffle-core/package.json
@@ -12,7 +12,7 @@
     "del": "^2.2.0",
     "diff": "1.4.0",
     "ethpm": "0.0.16",
-    "ethpm-registry": "0.1.0-next.0",
+    "ethpm-registry": "0.1.0-next.1",
     "fs-extra": "6.0.1",
     "ganache-cli": "6.1.6",
     "lodash": "4.17.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1031,10 +1031,6 @@ bignumber.js@^7.2.1:
   version "2.0.7"
   resolved "git+https://github.com/debris/bignumber.js#c7a38de919ed75e6fb6ba38051986e294b328df9"
 
-"bignumber.js@git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2":
-  version "2.0.7"
-  resolved "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
-
 "bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git":
   version "2.0.7"
   resolved "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
@@ -3493,17 +3489,17 @@ ethjs-util@^0.1.3:
     is-hex-prefixed "1.0.0"
     strip-hex-prefix "1.0.0"
 
-ethpm-registry@0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/ethpm-registry/-/ethpm-registry-0.0.10.tgz#54f3c12f9c26588a241b008f696888cf29cac58e"
+ethpm-registry@0.1.0-next.0:
+  version "0.1.0-next.0"
+  resolved "https://registry.yarnpkg.com/ethpm-registry/-/ethpm-registry-0.1.0-next.0.tgz#19ab5324818ce5e9aba2b03ef1ffd836d4257ef4"
   dependencies:
     fs-extra "^2.0.0"
     left-pad "^1.1.3"
     semver "^5.3.0"
     solidity-sha3 "^0.4.1"
     truffle-artifactor "^2.1.2"
-    truffle-contract "^1.1.6"
-    web3 "^0.18.2"
+    truffle-contract "4.0.0-next.0"
+    web3 "1.0.0-beta.35"
 
 ethpm-spec@^1.0.1:
   version "1.0.1"
@@ -9410,12 +9406,6 @@ truffle-artifactor@^2.1.2:
     truffle-contract "^2.0.3"
     truffle-contract-schema "^0.0.5"
 
-truffle-blockchain-utils@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/truffle-blockchain-utils/-/truffle-blockchain-utils-0.0.1.tgz#07a58e55bb0555a64208c9119c0b04ffe1464aa4"
-  dependencies:
-    web3 "^0.18.0"
-
 truffle-blockchain-utils@^0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/truffle-blockchain-utils/-/truffle-blockchain-utils-0.0.3.tgz#ae8a111ec124d96504f0e042c6f205c0b3817e29"
@@ -9432,20 +9422,34 @@ truffle-config@^1.0.1:
     truffle-error "^0.0.3"
     truffle-provider "^0.0.6"
 
-truffle-contract-schema@0.0.5, truffle-contract-schema@^0.0.5:
+truffle-contract-schema@^0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/truffle-contract-schema/-/truffle-contract-schema-0.0.5.tgz#5e9d20bd0bf2a27fe94310748249d484eee49961"
   dependencies:
     crypto-js "^3.1.9-1"
 
-truffle-contract@^1.1.6:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/truffle-contract/-/truffle-contract-1.1.11.tgz#ce1fa787f797758aff572f45e8b1174527f6edaa"
+truffle-contract-schema@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/truffle-contract-schema/-/truffle-contract-schema-2.0.1.tgz#9bf821d32e26e674ba15eb5d40f96b10b1c9d568"
   dependencies:
+    ajv "^5.1.1"
+    crypto-js "^3.1.9-1"
+    debug "^3.1.0"
+
+truffle-contract@4.0.0-next.0:
+  version "4.0.0-next.0"
+  resolved "https://registry.yarnpkg.com/truffle-contract/-/truffle-contract-4.0.0-next.0.tgz#717b5921331ec70ca4f58a3d29ae955db80163fe"
+  dependencies:
+    ethereumjs-util "^5.2.0"
     ethjs-abi "0.1.8"
-    truffle-blockchain-utils "0.0.1"
-    truffle-contract-schema "0.0.5"
-    web3 "^0.16.0"
+    truffle-blockchain-utils "^0.0.5"
+    truffle-contract-schema "^2.0.1"
+    truffle-error "^0.0.3"
+    uglify-es "^3.3.9"
+    web3 "1.0.0-beta.35"
+    web3-core-promievent "1.0.0-beta.35"
+    web3-eth-abi "1.0.0-beta.35"
+    web3-utils "1.0.0-beta.35"
 
 truffle-contract@^2.0.3:
   version "2.0.5"
@@ -10279,16 +10283,6 @@ web3@^0.16.0:
     bignumber.js "git+https://github.com/debris/bignumber.js#master"
     crypto-js "^3.1.4"
     utf8 "^2.1.1"
-    xmlhttprequest "*"
-
-web3@^0.18.0, web3@^0.18.2:
-  version "0.18.4"
-  resolved "https://registry.yarnpkg.com/web3/-/web3-0.18.4.tgz#81ec1784145491f2eaa8955b31c06049e07c5e7d"
-  dependencies:
-    bignumber.js "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
-    crypto-js "^3.1.4"
-    utf8 "^2.1.1"
-    xhr2 "*"
     xmlhttprequest "*"
 
 web3@^1.0.0-beta.34:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3489,9 +3489,9 @@ ethjs-util@^0.1.3:
     is-hex-prefixed "1.0.0"
     strip-hex-prefix "1.0.0"
 
-ethpm-registry@0.1.0-next.0:
-  version "0.1.0-next.0"
-  resolved "https://registry.yarnpkg.com/ethpm-registry/-/ethpm-registry-0.1.0-next.0.tgz#19ab5324818ce5e9aba2b03ef1ffd836d4257ef4"
+ethpm-registry@0.1.0-next.1:
+  version "0.1.0-next.1"
+  resolved "https://registry.yarnpkg.com/ethpm-registry/-/ethpm-registry-0.1.0-next.1.tgz#7bbea911cf37386b46e606507a3bd6757e39f249"
   dependencies:
     fs-extra "^2.0.0"
     left-pad "^1.1.3"


### PR DESCRIPTION
#1209 

This goes with some changes in the EthPM registry package updating it to web3 1.0 as well. We don't really have any working tests for `truffle publish` at the moment unfortunately. The installation tests broke when the manifest work was done. And the publish test has always been weird, trying to claw through as much of the logic as possible before it errors out without publishing....

I *think* this is a fix though.
