### PR TITLE
Add "public" to Example.sol constructor

### DIFF
--- a/packages/truffle-core/lib/templates/Example.sol
+++ b/packages/truffle-core/lib/templates/Example.sol
@@ -2,6 +2,6 @@ pragma solidity ^0.4.22;
 
 
 contract Example {
-  constructor() {
+  constructor() public {
   }
 }


### PR DESCRIPTION
To suppress the following warning:
```
C:\Users\username\projectname\contracts\MyContract.sol:5:3: Warning: No visibility specified.
Defaulting to "public".
  constructor() {
  ^ (Relevant source part starts here and spans across multiple lines).
```
