### PR TITLE
don't try to set the from address

### DIFF
--- a/packages/truffle-core/lib/test.js
+++ b/packages/truffle-core/lib/test.js
@@ -87,10 +87,6 @@ var Test = {
     web3.eth.getAccounts().then(function(accs) {
       accounts = accs;
 
-      if (!config.from) {
-        config.from = accounts[0];
-      }
-
       if (!config.resolver) {
         config.resolver = new Resolver(config);
       }


### PR DESCRIPTION
Hi.

The `config.from` property is readonly since some time. 
The from address will either be set through the network configuration or 
will be loaded by Environment.detect.

I think we can remove this statement here.

Cheers, 
Fabian