### PR TITLE
Add show-events option to test command

### DIFF
--- a/packages/truffle-core/lib/commands/test.js
+++ b/packages/truffle-core/lib/commands/test.js
@@ -1,7 +1,13 @@
 var command = {
   command: 'test',
   description: 'Run JavaScript and Solidity tests',
-  builder: {},
+  builder: {
+    "show-events": {
+      describe: "Show all test logs",
+      type: "boolean",
+      default: false
+    },
+  },
   run: function (options, done) {
     var OS = require("os");
     var dir = require("node-dir");


### PR DESCRIPTION
PR https://github.com/trufflesuite/truffle/pull/1232 adds `--show-events` flag, correspondingly this PR is to add this flag to command options.

Original Issue https://github.com/trufflesuite/truffle/issues/186