### PR TITLE
Fix error when migrating to mining Geth client

### DIFF
--- a/packages/truffle-contract/lib/execute.js
+++ b/packages/truffle-contract/lib/execute.js
@@ -203,7 +203,7 @@ var execute = {
         handlers.setup(deferred, context);
 
         deferred.then(async (receipt) => {
-          if (!receipt.status){
+          if (receipt.status !== undefined && !receipt.status){
             var reason = await Reason.get(params, web3);
 
             var error = new StatusError(

--- a/packages/truffle-contract/lib/handlers.js
+++ b/packages/truffle-contract/lib/handlers.js
@@ -102,7 +102,7 @@ var handlers = {
     }
 
     // .method(): resolve/reject receipt in handler
-    if (!receipt.status){
+    if (receipt.status !== undefined && receipt.status){
       var reason = await Reason.get(context.params, context.contract.web3);
 
       var error = new StatusError(

--- a/packages/truffle-contract/lib/handlers.js
+++ b/packages/truffle-contract/lib/handlers.js
@@ -102,7 +102,7 @@ var handlers = {
     }
 
     // .method(): resolve/reject receipt in handler
-    if (receipt.status !== undefined && receipt.status){
+    if (receipt.status !== undefined && !receipt.status){
       var reason = await Reason.get(context.params, context.contract.web3);
 
       var error = new StatusError(


### PR DESCRIPTION
Resolves #1241 

There's a small issue with Truffle's handling of transaction receipts which prevents deployment to some Geth clients.

According to the JSON RPC spec for `eth_getTransactionReceipt`:

>[the receipt] also returns either :
> 
>     root : DATA 32 bytes of post-transaction stateroot (pre Byzantium)
>     status: QUANTITY either 1 (success) or 0 (failure)

Truffle assumes that a status is always returned. When the Geth receipt instead has a root specified, Truffle thinks it has failed. This PR resolves that bug by first checking whether a status field exists before throwing an error.

