### PR TITLE
[docs] Install abi-decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Truffle is a development environment, testing framework and asset pipeline for E
 ### Install
 
 ```
-$ npm install -g truffle
+$ npm install -g abi-decoder truffle
 ```
 
 ### Quick Usage


### PR DESCRIPTION

#### Changes
This modifies the installation instructions in the readme so that new users install the required dependency `abi-decoder`.
Without `abi-decoder`, I get the following error:
```
module.js:549
    throw err;
    ^
Error: Cannot find module 'abi-decoder'
    at Function.Module._resolveFilename (module.js:547:15)
    at Function.Module._load (module.js:474:25)
    at Module.require (module.js:596:17)
    at require (internal/module.js:11:18)
    at require (/Users/will/.nvm/versions/node/v8.11.3/lib/node_modules/truffle/build/cli.bundled.js:101620:20)
    ...
```
Reviewers @gnidan