### PR TITLE
Add wallet version warning to Migrations output

### DIFF
--- a/packages/truffle-reporters/package.json
+++ b/packages/truffle-reporters/package.json
@@ -10,6 +10,7 @@
     "access": "public"
   },
   "dependencies": {
+    "node-emoji": "^1.8.1",
     "ora": "^2.1.0",
     "web3-utils": "1.0.0-beta.35"
   },

--- a/packages/truffle-reporters/reporters/migrations-V5/messages.js
+++ b/packages/truffle-reporters/reporters/migrations-V5/messages.js
@@ -1,3 +1,5 @@
+const emoji = require('node-emoji')
+
 /**
  *  A module that formats output for the Migrations reporter.
  *  This is where all the strings go.
@@ -7,6 +9,7 @@ class MigrationsMessages{
   constructor(reporter){
     this.reporter = reporter;
   }
+
 
   // ----------------------------------- Utilities -------------------------------------------------
 
@@ -19,6 +22,11 @@ class MigrationsMessages{
   doubleline(msg){
     const ul = '='.repeat(msg.length);
     return `\n${msg}\n${ul}`;
+  }
+
+  // Emoji alternative
+  onMissing(name){
+    return "**";
   }
 
   // ----------------------------------- Interactions ----------------------------------------------
@@ -243,10 +251,16 @@ class MigrationsMessages{
         `\n   * Saving migration`,
 
       firstMigrate: () => {
-        let output;
+        let output = emoji.emojify(
+          `:warning:  Important :warning:\nIf you're using an HDWalletProvider, ` +
+          `it must be Web3 1.0 enabled or your migration will hang.\n` +
+          `Try: npm install --save truffle-hdwallet-provider@web3-one\n\n`,
+          this.onMissing
+        );
+
         (reporter.migration.dryRun)
-          ? output = self.doubleline(`Migrations dry-run (simulation)`) + '\n'
-          : output = self.doubleline(`Starting migrations...`) + '\n';
+          ? output += self.doubleline(`Migrations dry-run (simulation)`) + '\n'
+          : output += self.doubleline(`Starting migrations...`) + '\n';
 
         output +=
           `> Network name:    '${data.network}'\n` +

--- a/yarn.lock
+++ b/yarn.lock
@@ -398,7 +398,7 @@ async-eventemitter@^0.2.2:
   dependencies:
     async "^2.4.0"
 
-"async-eventemitter@github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c":
+async-eventemitter@ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c:
   version "0.2.3"
   resolved "https://codeload.github.com/ahultgren/async-eventemitter/tar.gz/fa06e39e56786ba541c180061dbf2c0a5bbf951c"
   dependencies:
@@ -1057,9 +1057,9 @@ bignumber.js@^7.2.1:
   version "7.2.1"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-7.2.1.tgz#80c048759d826800807c4bfd521e50edbba57a5f"
 
-"bignumber.js@git+https://github.com/debris/bignumber.js.git#master":
+"bignumber.js@git+https://github.com/debris/bignumber.js#master":
   version "2.0.7"
-  resolved "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
+  resolved "git+https://github.com/debris/bignumber.js#c7a38de919ed75e6fb6ba38051986e294b328df9"
 
 "bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git":
   version "2.0.7"


### PR DESCRIPTION
Using the older wallet will be a common problem. Warning looks like:


![screen shot 2018-08-31 at 6 21 02 pm](https://user-images.githubusercontent.com/7332026/44941062-8a585f80-ad4b-11e8-95cc-7b96095a50ea.png)
