### PR TITLE
Upgrade web3 to beta.36

### DIFF
--- a/packages/truffle-artifactor/package.json
+++ b/packages/truffle-artifactor/package.json
@@ -21,7 +21,7 @@
     "solc": "0.4.24",
     "temp": "^0.8.3",
     "truffle-blockchain-utils": "^0.0.5",
-    "web3": "1.0.0-beta.35"
+    "web3": "1.0.0-beta.36"
   },
   "dependencies": {
     "async": "2.6.1",

--- a/packages/truffle-contract/lib/execute.js
+++ b/packages/truffle-contract/lib/execute.js
@@ -53,6 +53,8 @@ var execute = {
     var args = Array.prototype.slice.call(_arguments);
     var params = utils.getTxParams.call(constructor, args);
 
+    args = utils.convertToEthersBN(args);
+
     return constructor
       .detectNetwork()
       .then(() => {return {args: args, params: params}});
@@ -116,6 +118,7 @@ var execute = {
         try {
 
           await constructor.detectNetwork();
+          args = utils.convertToEthersBN(args);
           result = await fn(...args).call(params, defaultBlock);
           result = reformat.numbers.call(constructor, result, methodABI.outputs);
           resolve(result);
@@ -151,6 +154,7 @@ var execute = {
       }
 
       constructor.detectNetwork().then(network => {
+        args = utils.convertToEthersBN(args);
         params.to = address;
         params.data = fn ? fn(...args).encodeABI() : undefined;
 
@@ -187,7 +191,7 @@ var execute = {
 
     var options = {
       data: constructor.binary,
-      arguments: args
+      arguments: utils.convertToEthersBN(args)
     };
 
     var contract = new web3.eth.Contract(abi);

--- a/packages/truffle-contract/lib/utils.js
+++ b/packages/truffle-contract/lib/utils.js
@@ -1,4 +1,5 @@
 var Web3 = require('web3');
+var ethers = require('ethers');
 var abi = require("web3-eth-abi");
 var reformat = require('./reformat');
 
@@ -160,6 +161,26 @@ var Utils = {
       throw new Error(error);
     }
   },
+
+  convertToEthersBN: function(original){
+    const converted = [];
+    original.forEach(item => {
+
+      // Recurse for arrays
+      if (Array.isArray(item)){
+        converted.push(Utils.convertToEthersBN(item));
+
+      // Convert Web3 BN / BigNumber
+      } else if (Utils.is_big_number(item)){
+        const ethersBN = ethers.utils.bigNumberify(item.toString())
+        converted.push(ethersBN);
+
+      } else {
+        converted.push(item);
+      }
+    })
+    return converted;
+  }
 };
 
 module.exports = Utils;

--- a/packages/truffle-contract/package.json
+++ b/packages/truffle-contract/package.json
@@ -37,7 +37,7 @@
     "uglify-es": "^3.3.9",
     "web3": "1.0.0-beta.36",
     "web3-core-promievent": "1.0.0-beta.36",
-    "web3-eth-abi": "1.0.0-beta.35",
+    "web3-eth-abi": "1.0.0-beta.36",
     "web3-utils": "1.0.0-beta.35"
   },
   "devDependencies": {

--- a/packages/truffle-contract/package.json
+++ b/packages/truffle-contract/package.json
@@ -36,7 +36,7 @@
     "truffle-error": "^0.0.3",
     "uglify-es": "^3.3.9",
     "web3": "1.0.0-beta.36",
-    "web3-core-promievent": "1.0.0-beta.35",
+    "web3-core-promievent": "1.0.0-beta.36",
     "web3-eth-abi": "1.0.0-beta.35",
     "web3-utils": "1.0.0-beta.35"
   },

--- a/packages/truffle-contract/package.json
+++ b/packages/truffle-contract/package.json
@@ -35,7 +35,7 @@
     "truffle-contract-schema": "^3.0.0-beta.0",
     "truffle-error": "^0.0.3",
     "uglify-es": "^3.3.9",
-    "web3": "1.0.0-beta.35",
+    "web3": "1.0.0-beta.36",
     "web3-core-promievent": "1.0.0-beta.35",
     "web3-eth-abi": "1.0.0-beta.35",
     "web3-utils": "1.0.0-beta.35"

--- a/packages/truffle-contract/package.json
+++ b/packages/truffle-contract/package.json
@@ -38,7 +38,7 @@
     "web3": "1.0.0-beta.36",
     "web3-core-promievent": "1.0.0-beta.36",
     "web3-eth-abi": "1.0.0-beta.36",
-    "web3-utils": "1.0.0-beta.35"
+    "web3-utils": "1.0.0-beta.36"
   },
   "devDependencies": {
     "async": "2.6.1",

--- a/packages/truffle-contract/test/methods.js
+++ b/packages/truffle-contract/test/methods.js
@@ -236,6 +236,13 @@ describe("Methods", function() {
       Example.numberFormat = 'BigNumber';
     });
 
+    it.skip('should represent zero bytes as `0x`', async function(){
+      const example = await Example.new(1)
+      await example.setBytesDataToZero();
+      const data = await example.data();
+      assert(data === '0x');
+    });
+
     it("should output int values as string when set to 'String' (call)", async function(){
       let value;
       Example.numberFormat = 'String';

--- a/packages/truffle-contract/test/methods.js
+++ b/packages/truffle-contract/test/methods.js
@@ -2,6 +2,7 @@ var assert = require("chai").assert;
 var BigNumber = require("bignumber.js");
 var util = require('./util');
 var contract = require("../");
+var ethers = require('ethers');
 
 describe("Methods", function() {
   var Example;
@@ -106,7 +107,7 @@ describe("Methods", function() {
 
     it("should allow BigNumbers as input params, not treat them as tx objects", async function() {
       let value;
-      const example = await Example.new( new BigNumber(30))
+      const example = await Example.new(new BigNumber(30))
 
       value = await example.value.call();
       assert.equal(value.valueOf(), 30, "Starting value should be 30");
@@ -118,11 +119,22 @@ describe("Methods", function() {
 
       value = await example.parrot.call(new BigNumber(865));
       assert.equal(parseInt(value), 865, "Parrotted value should equal 865")
+
+      // Arrays
+      const numArray = [
+        new BigNumber(1),
+        new BigNumber(2)
+      ];
+
+      await example.setNumbers(numArray);
+      const numbers = await example.getNumbers();
+      assert(numbers[0].toNumber() === 1);
+      assert(numbers[1].toNumber() === 2);
     });
 
-    it("should allow BN's as input paramss, not treat them as tx objects", async function() {
+    it("should allow BN's as input params, not treat them as tx objects", async function() {
       let value;
-      const example = await Example.new( new web3.utils.BN(30))
+      const example = await Example.new(new web3.utils.BN(30))
 
       value = await example.value.call();
       assert.equal(value.valueOf(), 30, "Starting value should be 30");
@@ -133,7 +145,18 @@ describe("Methods", function() {
       assert.equal(value.valueOf(), 25, "Ending value should be twenty-five");
 
       value = await example.parrot.call(new web3.utils.BN(865));
-      assert.equal(parseInt(value), 865, "Parrotted value should equal 865")
+      assert.equal(parseInt(value), 865, "Parrotted value should equal 865");
+
+      // Arrays
+      const numArray = [
+        web3.utils.toBN(1),
+        web3.utils.toBN(2)
+      ];
+
+      await example.setNumbers(numArray);
+      const numbers = await example.getNumbers();
+      assert(numbers[0].toNumber() === 1);
+      assert(numbers[1].toNumber() === 2);
     });
 
     it("should output uint tuples as BN by default (call)", async function(){

--- a/packages/truffle-contract/test/sources/Example.sol
+++ b/packages/truffle-contract/test/sources/Example.sol
@@ -1,10 +1,12 @@
 pragma solidity ^0.4.22;
 
 contract Example {
+
   bytes32 public hash;
   uint public value;
   uint public counter;
   bool public fallbackTriggered;
+  uint[] public numbers;
 
   event ExampleEvent(address indexed _from, uint num);
   event ContractAddressEvent(address _contract);
@@ -30,6 +32,14 @@ contract Example {
 
   function setValue(uint val) public {
     value = val;
+  }
+
+  function setNumbers(uint[] vals) public {
+    numbers = vals;
+  }
+
+  function getNumbers() public view returns (uint [] vals){
+    return numbers;
   }
 
   function isDeployed() public view returns (address){

--- a/packages/truffle-contract/test/sources/Example.sol
+++ b/packages/truffle-contract/test/sources/Example.sol
@@ -7,6 +7,7 @@ contract Example {
   uint public counter;
   bool public fallbackTriggered;
   uint[] public numbers;
+  bytes public data;
 
   event ExampleEvent(address indexed _from, uint num);
   event ContractAddressEvent(address _contract);
@@ -40,6 +41,10 @@ contract Example {
 
   function getNumbers() public view returns (uint [] vals){
     return numbers;
+  }
+
+  function setBytesDataToZero() public {
+    data = new bytes(0);
   }
 
   function isDeployed() public view returns (address){

--- a/packages/truffle-core/package.json
+++ b/packages/truffle-core/package.json
@@ -44,7 +44,7 @@
     "truffle-resolver": "^5.0.0-beta.0",
     "truffle-solidity-utils": "^1.1.2",
     "truffle-workflow-compile": "^2.0.0-beta.0",
-    "web3": "1.0.0-beta.35",
+    "web3": "1.0.0-beta.36",
     "yargs": "^8.0.2"
   },
   "bin": {

--- a/packages/truffle-debugger/package.json
+++ b/packages/truffle-debugger/package.json
@@ -33,7 +33,7 @@
     "truffle-expect": "^0.0.4",
     "truffle-solidity-utils": "^1.1.2",
     "web3": "1.0.0-beta.36",
-    "web3-eth-abi": "1.0.0-beta.35"
+    "web3-eth-abi": "1.0.0-beta.36"
   },
   "devDependencies": {
     "async": "2.6.1",

--- a/packages/truffle-debugger/package.json
+++ b/packages/truffle-debugger/package.json
@@ -32,7 +32,7 @@
     "truffle-code-utils": "^1.1.1",
     "truffle-expect": "^0.0.4",
     "truffle-solidity-utils": "^1.1.2",
-    "web3": "1.0.0-beta.35",
+    "web3": "1.0.0-beta.36",
     "web3-eth-abi": "1.0.0-beta.35"
   },
   "devDependencies": {

--- a/packages/truffle-deployer/package.json
+++ b/packages/truffle-deployer/package.json
@@ -33,7 +33,7 @@
     "mocha": "5.2.0",
     "truffle-reporters": "^1.0.0-beta.0",
     "truffle-workflow-compile": "^2.0.0-beta.0",
-    "web3": "1.0.0-beta.35"
+    "web3": "1.0.0-beta.36"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/truffle-external-compile/package.json
+++ b/packages/truffle-external-compile/package.json
@@ -26,7 +26,7 @@
     "glob": "^7.1.2",
     "truffle-contract-schema": "^3.0.0-beta.0",
     "truffle-expect": "^0.0.4",
-    "web3-utils": "1.0.0-beta.35"
+    "web3-utils": "1.0.0-beta.36"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/packages/truffle-migrate/package.json
+++ b/packages/truffle-migrate/package.json
@@ -28,7 +28,7 @@
     "truffle-expect": "^0.0.4",
     "truffle-reporters": "^1.0.0-beta.0",
     "truffle-require": "^2.0.0-beta.0",
-    "web3": "1.0.0-beta.35"
+    "web3": "1.0.0-beta.36"
   },
   "devDependencies": {
     "mocha": "5.2.0"

--- a/packages/truffle-provider/package.json
+++ b/packages/truffle-provider/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/trufflesuite/truffle-provider#readme",
   "dependencies": {
     "truffle-error": "^0.0.3",
-    "web3": "1.0.0-beta.35"
+    "web3": "1.0.0-beta.36"
   },
   "devDependencies": {
     "ganache-cli": "6.1.8",

--- a/packages/truffle-reporters/package.json
+++ b/packages/truffle-reporters/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "ora": "^2.1.0",
-    "web3-utils": "1.0.0-beta.35"
+    "web3-utils": "1.0.0-beta.36"
   },
   "gitHead": "07967b472112f1c771ebbc90319781454cf9331b"
 }

--- a/packages/truffle-require/package.json
+++ b/packages/truffle-require/package.json
@@ -29,7 +29,7 @@
     "original-require": "1.0.1",
     "truffle-config": "^1.1.0-beta.0",
     "truffle-expect": "^0.0.4",
-    "web3": "1.0.0-beta.35"
+    "web3": "1.0.0-beta.36"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -25,7 +25,7 @@
     "tmp": "0.0.33",
     "truffle-box": "^1.0.8-beta.0",
     "truffle-contract": "^4.0.0-beta.0",
-    "web3": "1.0.0-beta.35",
+    "web3": "1.0.0-beta.36",
     "webpack": "^2.5.1",
     "yargs": "^8.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,7 +26,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*":
+"@types/node@*", "@types/node@^10.3.2":
   version "10.9.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.9.4.tgz#0f4cb2dc7c1de6096055357f70179043c33e9897"
 
@@ -145,6 +145,10 @@ add-stream@^1.0.0:
 adm-zip@~0.4.3:
   version "0.4.11"
   resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.4.11.tgz#2aa54c84c4b01a9d0fb89bb11982a51f13e3d62a"
+
+aes-js@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-3.0.0.tgz#e21df10ad6c2053295bcbb8dab40b09dbea87e4d"
 
 aes-js@^3.1.1:
   version "3.1.1"
@@ -398,7 +402,7 @@ async-eventemitter@^0.2.2:
   dependencies:
     async "^2.4.0"
 
-"async-eventemitter@github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c":
+async-eventemitter@ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c:
   version "0.2.3"
   resolved "https://codeload.github.com/ahultgren/async-eventemitter/tar.gz/fa06e39e56786ba541c180061dbf2c0a5bbf951c"
   dependencies:
@@ -1057,9 +1061,9 @@ bignumber.js@^7.2.1:
   version "7.2.1"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-7.2.1.tgz#80c048759d826800807c4bfd521e50edbba57a5f"
 
-"bignumber.js@git+https://github.com/debris/bignumber.js.git#master":
+"bignumber.js@git+https://github.com/debris/bignumber.js#master":
   version "2.0.7"
-  resolved "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
+  resolved "git+https://github.com/debris/bignumber.js#c7a38de919ed75e6fb6ba38051986e294b328df9"
 
 "bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git":
   version "2.0.7"
@@ -2818,6 +2822,15 @@ electron-to-chromium@^1.3.47:
   version "1.3.62"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.62.tgz#2e8e2dc070c800ec8ce23ff9dfcceb585d6f9ed8"
 
+elliptic@6.3.3:
+  version "6.3.3"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.3.3.tgz#5482d9646d54bcb89fd7d994fc9e2e9568876e3f"
+  dependencies:
+    bn.js "^4.4.0"
+    brorand "^1.0.1"
+    hash.js "^1.0.0"
+    inherits "^2.0.1"
+
 elliptic@^6.0.0, elliptic@^6.2.3, elliptic@^6.4.0:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.1.tgz#c2d0b7776911b86722c632c3c06c60f2f819939a"
@@ -3301,6 +3314,13 @@ eth-block-tracker@^3.0.0:
     pify "^2.3.0"
     tape "^4.6.3"
 
+eth-ens-namehash@2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/eth-ens-namehash/-/eth-ens-namehash-2.0.8.tgz#229ac46eca86d52e0c991e7cb2aef83ff0f68bcf"
+  dependencies:
+    idna-uts46-hx "^2.3.1"
+    js-sha3 "^0.5.7"
+
 eth-json-rpc-infura@^3.1.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/eth-json-rpc-infura/-/eth-json-rpc-infura-3.1.2.tgz#04c5d0cee98619e93ba8a9842492b771b316e83a"
@@ -3521,6 +3541,21 @@ ethereumjs-wallet@~0.6.0:
     scrypt.js "^0.2.0"
     utf8 "^3.0.0"
     uuid "^3.3.2"
+
+ethers@4.0.0-beta.1:
+  version "4.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.0-beta.1.tgz#0648268b83e0e91a961b1af971c662cdf8cbab6d"
+  dependencies:
+    "@types/node" "^10.3.2"
+    aes-js "3.0.0"
+    bn.js "^4.4.0"
+    elliptic "6.3.3"
+    hash.js "1.1.3"
+    js-sha3 "0.5.7"
+    scrypt-js "2.0.3"
+    setimmediate "1.0.4"
+    uuid "2.0.1"
+    xmlhttprequest "1.8.0"
 
 ethjs-abi@0.1.8:
   version "0.1.8"
@@ -4661,6 +4696,13 @@ hash-base@^3.0.0:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
+hash.js@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.3.tgz#340dedbe6290187151c1ea1d777a3448935df846"
+  dependencies:
+    inherits "^2.0.3"
+    minimalistic-assert "^1.0.0"
+
 hash.js@^1.0.0, hash.js@^1.0.3:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.5.tgz#e38ab4b85dfb1e0c40fe9265c0e9b54854c23812"
@@ -4808,6 +4850,12 @@ iconv-lite@^0.4.17, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+idna-uts46-hx@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/idna-uts46-hx/-/idna-uts46-hx-2.3.1.tgz#a1dc5c4df37eee522bf66d969cc980e00e8711f9"
+  dependencies:
+    punycode "2.1.0"
 
 ieee754@^1.1.4:
   version "1.1.12"
@@ -5405,6 +5453,10 @@ js-scrypt@^0.2.0:
 js-sha3@0.5.5:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.5.5.tgz#baf0c0e8c54ad5903447df96ade7a4a1bca79a4a"
+
+js-sha3@0.5.7, js-sha3@^0.5.7:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.5.7.tgz#0d4ffd8002d5333aabaf4a23eed2f6374c9f28e7"
 
 js-sha3@^0.3.1:
   version "0.3.1"
@@ -7698,6 +7750,10 @@ punycode@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
 
+punycode@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
+
 punycode@^1.2.4, punycode@^1.3.2, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -8423,6 +8479,10 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
+scrypt-js@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-2.0.3.tgz#bb0040be03043da9a012a2cea9fc9f852cfc87d4"
+
 scrypt.js@0.2.0, scrypt.js@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/scrypt.js/-/scrypt.js-0.2.0.tgz#af8d1465b71e9990110bedfc593b9479e03a8ada"
@@ -8554,6 +8614,10 @@ set-value@^2.0.0:
     is-extendable "^0.1.1"
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
+
+setimmediate@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.4.tgz#20e81de622d4a02588ce0c8da8973cbcf1d3138f"
 
 "setimmediate@>= 1.0.1 < 2", "setimmediate@>= 1.0.2 < 2", setimmediate@^1.0.4, setimmediate@^1.0.5:
   version "1.0.5"
@@ -9987,6 +10051,14 @@ web3-bzz@1.0.0-beta.35:
     swarm-js "0.1.37"
     underscore "1.8.3"
 
+web3-bzz@1.0.0-beta.36:
+  version "1.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/web3-bzz/-/web3-bzz-1.0.0-beta.36.tgz#adb3fe7a70053eb7843e32b106792b01b482ef41"
+  dependencies:
+    got "7.1.0"
+    swarm-js "0.1.37"
+    underscore "1.8.3"
+
 web3-core-helpers@1.0.0-beta.35:
   version "1.0.0-beta.35"
   resolved "https://registry.yarnpkg.com/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.35.tgz#d681d218a0c6e3283ee1f99a078ab9d3eef037f1"
@@ -9994,6 +10066,14 @@ web3-core-helpers@1.0.0-beta.35:
     underscore "1.8.3"
     web3-eth-iban "1.0.0-beta.35"
     web3-utils "1.0.0-beta.35"
+
+web3-core-helpers@1.0.0-beta.36:
+  version "1.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.36.tgz#6f618e80f1a6588d846efbfdc28f92ae0477f8d2"
+  dependencies:
+    underscore "1.8.3"
+    web3-eth-iban "1.0.0-beta.36"
+    web3-utils "1.0.0-beta.36"
 
 web3-core-method@1.0.0-beta.35:
   version "1.0.0-beta.35"
@@ -10005,9 +10085,26 @@ web3-core-method@1.0.0-beta.35:
     web3-core-subscriptions "1.0.0-beta.35"
     web3-utils "1.0.0-beta.35"
 
+web3-core-method@1.0.0-beta.36:
+  version "1.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/web3-core-method/-/web3-core-method-1.0.0-beta.36.tgz#855c0365ae7d0ead394d973ea9e28828602900e0"
+  dependencies:
+    underscore "1.8.3"
+    web3-core-helpers "1.0.0-beta.36"
+    web3-core-promievent "1.0.0-beta.36"
+    web3-core-subscriptions "1.0.0-beta.36"
+    web3-utils "1.0.0-beta.36"
+
 web3-core-promievent@1.0.0-beta.35:
   version "1.0.0-beta.35"
   resolved "https://registry.yarnpkg.com/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.35.tgz#4f1b24737520fa423fee3afee110fbe82bcb8691"
+  dependencies:
+    any-promise "1.3.0"
+    eventemitter3 "1.1.1"
+
+web3-core-promievent@1.0.0-beta.36:
+  version "1.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.36.tgz#3a5127787fff751be6de272722cbc77dc9523fd5"
   dependencies:
     any-promise "1.3.0"
     eventemitter3 "1.1.1"
@@ -10022,6 +10119,16 @@ web3-core-requestmanager@1.0.0-beta.35:
     web3-providers-ipc "1.0.0-beta.35"
     web3-providers-ws "1.0.0-beta.35"
 
+web3-core-requestmanager@1.0.0-beta.36:
+  version "1.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.36.tgz#70c8eead84da9ed1cf258e6dde3f137116d0691b"
+  dependencies:
+    underscore "1.8.3"
+    web3-core-helpers "1.0.0-beta.36"
+    web3-providers-http "1.0.0-beta.36"
+    web3-providers-ipc "1.0.0-beta.36"
+    web3-providers-ws "1.0.0-beta.36"
+
 web3-core-subscriptions@1.0.0-beta.35:
   version "1.0.0-beta.35"
   resolved "https://registry.yarnpkg.com/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.35.tgz#c1b76a2ad3c6e80f5d40b8ba560f01e0f4628758"
@@ -10029,6 +10136,14 @@ web3-core-subscriptions@1.0.0-beta.35:
     eventemitter3 "1.1.1"
     underscore "1.8.3"
     web3-core-helpers "1.0.0-beta.35"
+
+web3-core-subscriptions@1.0.0-beta.36:
+  version "1.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.36.tgz#20f1f20c85d5b40f1e5a49b070ba977a142621f3"
+  dependencies:
+    eventemitter3 "1.1.1"
+    underscore "1.8.3"
+    web3-core-helpers "1.0.0-beta.36"
 
 web3-core@1.0.0-beta.35:
   version "1.0.0-beta.35"
@@ -10039,6 +10154,15 @@ web3-core@1.0.0-beta.35:
     web3-core-requestmanager "1.0.0-beta.35"
     web3-utils "1.0.0-beta.35"
 
+web3-core@1.0.0-beta.36:
+  version "1.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/web3-core/-/web3-core-1.0.0-beta.36.tgz#86182f2456c2cf1cd6e7654d314e195eac211917"
+  dependencies:
+    web3-core-helpers "1.0.0-beta.36"
+    web3-core-method "1.0.0-beta.36"
+    web3-core-requestmanager "1.0.0-beta.36"
+    web3-utils "1.0.0-beta.36"
+
 web3-eth-abi@1.0.0-beta.35:
   version "1.0.0-beta.35"
   resolved "https://registry.yarnpkg.com/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.35.tgz#2eb9c1c7c7233db04010defcb192293e0db250e6"
@@ -10047,6 +10171,14 @@ web3-eth-abi@1.0.0-beta.35:
     underscore "1.8.3"
     web3-core-helpers "1.0.0-beta.35"
     web3-utils "1.0.0-beta.35"
+
+web3-eth-abi@1.0.0-beta.36:
+  version "1.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.36.tgz#21c0f222701db827a8a269accb9cd18bbd8f70f9"
+  dependencies:
+    ethers "4.0.0-beta.1"
+    underscore "1.8.3"
+    web3-utils "1.0.0-beta.36"
 
 web3-eth-accounts@1.0.0-beta.35:
   version "1.0.0-beta.35"
@@ -10063,6 +10195,21 @@ web3-eth-accounts@1.0.0-beta.35:
     web3-core-method "1.0.0-beta.35"
     web3-utils "1.0.0-beta.35"
 
+web3-eth-accounts@1.0.0-beta.36:
+  version "1.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.36.tgz#8aea37df9b038ef2c6cda608856ffd861b39eeef"
+  dependencies:
+    any-promise "1.3.0"
+    crypto-browserify "3.12.0"
+    eth-lib "0.2.7"
+    scrypt.js "0.2.0"
+    underscore "1.8.3"
+    uuid "2.0.1"
+    web3-core "1.0.0-beta.36"
+    web3-core-helpers "1.0.0-beta.36"
+    web3-core-method "1.0.0-beta.36"
+    web3-utils "1.0.0-beta.36"
+
 web3-eth-contract@1.0.0-beta.35:
   version "1.0.0-beta.35"
   resolved "https://registry.yarnpkg.com/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.35.tgz#5276242d8a3358d9f1ce92b71575c74f9015935c"
@@ -10076,12 +10223,45 @@ web3-eth-contract@1.0.0-beta.35:
     web3-eth-abi "1.0.0-beta.35"
     web3-utils "1.0.0-beta.35"
 
+web3-eth-contract@1.0.0-beta.36:
+  version "1.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.36.tgz#c0c366c4e4016896142208cee758a2ff2a31be2a"
+  dependencies:
+    underscore "1.8.3"
+    web3-core "1.0.0-beta.36"
+    web3-core-helpers "1.0.0-beta.36"
+    web3-core-method "1.0.0-beta.36"
+    web3-core-promievent "1.0.0-beta.36"
+    web3-core-subscriptions "1.0.0-beta.36"
+    web3-eth-abi "1.0.0-beta.36"
+    web3-utils "1.0.0-beta.36"
+
+web3-eth-ens@1.0.0-beta.36:
+  version "1.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/web3-eth-ens/-/web3-eth-ens-1.0.0-beta.36.tgz#c7440b42b597fd74f64bc402f03ad2e832f423d8"
+  dependencies:
+    eth-ens-namehash "2.0.8"
+    underscore "1.8.3"
+    web3-core "1.0.0-beta.36"
+    web3-core-helpers "1.0.0-beta.36"
+    web3-core-promievent "1.0.0-beta.36"
+    web3-eth-abi "1.0.0-beta.36"
+    web3-eth-contract "1.0.0-beta.36"
+    web3-utils "1.0.0-beta.36"
+
 web3-eth-iban@1.0.0-beta.35:
   version "1.0.0-beta.35"
   resolved "https://registry.yarnpkg.com/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.35.tgz#5aa10327a9abb26bcfc4ba79d7bad18a002b332c"
   dependencies:
     bn.js "4.11.6"
     web3-utils "1.0.0-beta.35"
+
+web3-eth-iban@1.0.0-beta.36:
+  version "1.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.36.tgz#00cb3aba7a5aeb15d02b07421042e263d7b2e01b"
+  dependencies:
+    bn.js "4.11.6"
+    web3-utils "1.0.0-beta.36"
 
 web3-eth-personal@1.0.0-beta.35:
   version "1.0.0-beta.35"
@@ -10092,6 +10272,16 @@ web3-eth-personal@1.0.0-beta.35:
     web3-core-method "1.0.0-beta.35"
     web3-net "1.0.0-beta.35"
     web3-utils "1.0.0-beta.35"
+
+web3-eth-personal@1.0.0-beta.36:
+  version "1.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.36.tgz#95545998a8ee377e3bb71e27c8d1a5dc1d7d5a21"
+  dependencies:
+    web3-core "1.0.0-beta.36"
+    web3-core-helpers "1.0.0-beta.36"
+    web3-core-method "1.0.0-beta.36"
+    web3-net "1.0.0-beta.36"
+    web3-utils "1.0.0-beta.36"
 
 web3-eth@1.0.0-beta.35:
   version "1.0.0-beta.35"
@@ -10110,6 +10300,24 @@ web3-eth@1.0.0-beta.35:
     web3-net "1.0.0-beta.35"
     web3-utils "1.0.0-beta.35"
 
+web3-eth@1.0.0-beta.36:
+  version "1.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/web3-eth/-/web3-eth-1.0.0-beta.36.tgz#04a8c748d344c1accaa26d7d5d0eac0da7127f14"
+  dependencies:
+    underscore "1.8.3"
+    web3-core "1.0.0-beta.36"
+    web3-core-helpers "1.0.0-beta.36"
+    web3-core-method "1.0.0-beta.36"
+    web3-core-subscriptions "1.0.0-beta.36"
+    web3-eth-abi "1.0.0-beta.36"
+    web3-eth-accounts "1.0.0-beta.36"
+    web3-eth-contract "1.0.0-beta.36"
+    web3-eth-ens "1.0.0-beta.36"
+    web3-eth-iban "1.0.0-beta.36"
+    web3-eth-personal "1.0.0-beta.36"
+    web3-net "1.0.0-beta.36"
+    web3-utils "1.0.0-beta.36"
+
 web3-net@1.0.0-beta.35:
   version "1.0.0-beta.35"
   resolved "https://registry.yarnpkg.com/web3-net/-/web3-net-1.0.0-beta.35.tgz#5c6688e0dea71fcd910ee9dc5437b94b7f6b3354"
@@ -10117,6 +10325,14 @@ web3-net@1.0.0-beta.35:
     web3-core "1.0.0-beta.35"
     web3-core-method "1.0.0-beta.35"
     web3-utils "1.0.0-beta.35"
+
+web3-net@1.0.0-beta.36:
+  version "1.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/web3-net/-/web3-net-1.0.0-beta.36.tgz#396cd35cb40934ed022a1f44a8a642d3908c41eb"
+  dependencies:
+    web3-core "1.0.0-beta.36"
+    web3-core-method "1.0.0-beta.36"
+    web3-utils "1.0.0-beta.36"
 
 web3-provider-engine@^13.3.2:
   version "13.8.0"
@@ -10175,6 +10391,13 @@ web3-providers-http@1.0.0-beta.35:
     web3-core-helpers "1.0.0-beta.35"
     xhr2-cookies "1.1.0"
 
+web3-providers-http@1.0.0-beta.36:
+  version "1.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/web3-providers-http/-/web3-providers-http-1.0.0-beta.36.tgz#c1937a2e64f8db7cd30f166794e37cf0fcca1131"
+  dependencies:
+    web3-core-helpers "1.0.0-beta.36"
+    xhr2-cookies "1.1.0"
+
 web3-providers-ipc@1.0.0-beta.35:
   version "1.0.0-beta.35"
   resolved "https://registry.yarnpkg.com/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.35.tgz#031afeb10fade2ebb0ef2fb82f5e58c04be842d9"
@@ -10183,12 +10406,28 @@ web3-providers-ipc@1.0.0-beta.35:
     underscore "1.8.3"
     web3-core-helpers "1.0.0-beta.35"
 
+web3-providers-ipc@1.0.0-beta.36:
+  version "1.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.36.tgz#0c78efb4ed6b0305ec830e1e0b785e61217ee605"
+  dependencies:
+    oboe "2.1.3"
+    underscore "1.8.3"
+    web3-core-helpers "1.0.0-beta.36"
+
 web3-providers-ws@1.0.0-beta.35:
   version "1.0.0-beta.35"
   resolved "https://registry.yarnpkg.com/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.35.tgz#5d38603fd450243a26aae0ff7f680644e77fa240"
   dependencies:
     underscore "1.8.3"
     web3-core-helpers "1.0.0-beta.35"
+    websocket "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
+
+web3-providers-ws@1.0.0-beta.36:
+  version "1.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.36.tgz#27b74082c7adfa0cb5a65535eb312e49008c97c3"
+  dependencies:
+    underscore "1.8.3"
+    web3-core-helpers "1.0.0-beta.36"
     websocket "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
 
 web3-shh@1.0.0-beta.35:
@@ -10200,9 +10439,30 @@ web3-shh@1.0.0-beta.35:
     web3-core-subscriptions "1.0.0-beta.35"
     web3-net "1.0.0-beta.35"
 
+web3-shh@1.0.0-beta.36:
+  version "1.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/web3-shh/-/web3-shh-1.0.0-beta.36.tgz#6ff297594480edefc710d9d287765a0c4a5d5af1"
+  dependencies:
+    web3-core "1.0.0-beta.36"
+    web3-core-method "1.0.0-beta.36"
+    web3-core-subscriptions "1.0.0-beta.36"
+    web3-net "1.0.0-beta.36"
+
 web3-utils@1.0.0-beta.35:
   version "1.0.0-beta.35"
   resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.0.0-beta.35.tgz#ced9e1df47c65581c441c5f2af76b05a37a273d7"
+  dependencies:
+    bn.js "4.11.6"
+    eth-lib "0.1.27"
+    ethjs-unit "0.1.6"
+    number-to-bn "1.7.0"
+    randomhex "0.1.5"
+    underscore "1.8.3"
+    utf8 "2.1.1"
+
+web3-utils@1.0.0-beta.36:
+  version "1.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.0.0-beta.36.tgz#dc19c9aeec009b1816cc91ef64d7fe9f8ee344c9"
   dependencies:
     bn.js "4.11.6"
     eth-lib "0.1.27"
@@ -10233,6 +10493,18 @@ web3@1.0.0-beta.35, web3@^1.0.0-beta.34:
     web3-net "1.0.0-beta.35"
     web3-shh "1.0.0-beta.35"
     web3-utils "1.0.0-beta.35"
+
+web3@1.0.0-beta.36:
+  version "1.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/web3/-/web3-1.0.0-beta.36.tgz#2954da9e431124c88396025510d840ba731c8373"
+  dependencies:
+    web3-bzz "1.0.0-beta.36"
+    web3-core "1.0.0-beta.36"
+    web3-eth "1.0.0-beta.36"
+    web3-eth-personal "1.0.0-beta.36"
+    web3-net "1.0.0-beta.36"
+    web3-shh "1.0.0-beta.36"
+    web3-utils "1.0.0-beta.36"
 
 web3@^0.16.0:
   version "0.16.0"
@@ -10549,7 +10821,7 @@ xhr@^2.0.4, xhr@^2.2.0, xhr@^2.3.3:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
 
-xmlhttprequest@*, xmlhttprequest@^1.8.0:
+xmlhttprequest@*, xmlhttprequest@1.8.0, xmlhttprequest@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz#67fe075c5c24fef39f9d65f5f7b7fe75171968fc"
 


### PR DESCRIPTION
Upgrade web3 to beta.36 which has several very useful [features/improvements](https://github.com/ethereum/web3.js/releases/tag/v1.0.0-beta.36). 

+ [ethers](https://github.com/ethers-io/ethers.js) is now being used to encode/decode params. PR includes some logic to convert incoming BN / BigNumbers to the ethers big number format because it looks like they're not compatible. 
+ adds some tests for the foregoing as well as a (skipped) regression test for #1229.

This needs to be run E2E at wild-truffle before publication to see if there are other decoding problems.

[EDIT - I'm seeing crashes on ~80% of Colony's tests because they [reach into](https://github.com/JoinColony/colonyNetwork/blob/develop/helpers/test-data-generator.js#L31) the underlying web3 contract to do their own `encodeABI` in some cases. This is really common (#1230 for example). Have opened an [issue](https://github.com/ethereum/web3.js/issues/1920) at web3. We might have to close this and wait for a fix...)   