### PR TITLE
new Buffer is deprecated and unsafe

### DIFF
--- a/packages/truffle-code-utils/index.js
+++ b/packages/truffle-code-utils/index.js
@@ -18,7 +18,7 @@ module.exports = {
     code.splice(-43);
 
     // Convert to Buffer
-    code = new Buffer(code.join("").replace("0x", ""), "hex");
+    code = Buffer.from(code.join("").replace("0x", ""), "hex");
 
     var instructions = []
     for (var pc = 0; pc < code.length; pc++) {


### PR DESCRIPTION
#### What does it do?
This PR replaces all `new Buffer` with `Buffer.from`. We should not use Buffer constructor which is deprecated and unsafe.

#### Any helpful background information?
The behavior of new Buffer() is different depending on the type of the first argument, security and reliability issues can be inadvertently introduced into applications when argument validation or Buffer initialization is not performed.

To make the creation of Buffer instances more reliable and less error-prone, the various forms of the new Buffer() constructor have been deprecated and replaced by separate Buffer.from(), Buffer.alloc(), and Buffer.allocUnsafe() methods.

Check this out: 
* https://nodejs.org/api/buffer.html#buffer_buffer_from_buffer_alloc_and_buffer_allocunsafe
* https://github.com/nodejs/Release#end-of-life-releases