### PR TITLE
Stackframes

### DIFF
--- a/packages/truffle-debugger/lib/data/actions/index.js
+++ b/packages/truffle-debugger/lib/data/actions/index.js
@@ -26,6 +26,6 @@ export const MAP_KEY = "MAP_KEY";
 export function mapKey(id, key) {
   return {
     type: MAP_KEY,
-    id, key //mappings are never local to a function
+    id, key
   };
 }

--- a/packages/truffle-debugger/lib/data/actions/index.js
+++ b/packages/truffle-debugger/lib/data/actions/index.js
@@ -26,6 +26,6 @@ export const MAP_KEY = "MAP_KEY";
 export function mapKey(id, key) {
   return {
     type: MAP_KEY,
-    id, key
+    id, key //mappings are never local to a function
   };
 }

--- a/packages/truffle-debugger/lib/data/decode/index.js
+++ b/packages/truffle-debugger/lib/data/decode/index.js
@@ -314,7 +314,7 @@ export function decodeMapping(definition, pointer, info) {
 
   debug("mapping %O", pointer);
   debug("mapping definition %O", definition);
-  let keys = mappingKeys["0:"+definition.id] || [];
+  let keys = mappingKeys[utils.augmentWithDepth(definition.id)] || [];
   debug("known keys %o", keys);
 
   let keyDefinition = definition.typeName.keyType;

--- a/packages/truffle-debugger/lib/data/decode/index.js
+++ b/packages/truffle-debugger/lib/data/decode/index.js
@@ -314,7 +314,7 @@ export function decodeMapping(definition, pointer, info) {
 
   debug("mapping %O", pointer);
   debug("mapping definition %O", definition);
-  let keys = mappingKeys[definition.id] || [];
+  let keys = mappingKeys["0:"+definition.id] || [];
   debug("known keys %o", keys);
 
   let keyDefinition = definition.typeName.keyType;

--- a/packages/truffle-debugger/lib/data/decode/utils.js
+++ b/packages/truffle-debugger/lib/data/decode/utils.js
@@ -352,9 +352,9 @@ export function augmentWithDepth(id, depth = 0) {
 }
 
 export function idFromAugmented(augmentedId) {
-    return augmentedId.split(":")[1];
+    return Number(augmentedId.split(":")[1]);
 }
 
 export function depthFromAugmented(augmentedId) {
-    return augmentedId.split(":")[0];
+    return Number(augmentedId.split(":")[0]);
 }

--- a/packages/truffle-debugger/lib/data/decode/utils.js
+++ b/packages/truffle-debugger/lib/data/decode/utils.js
@@ -344,3 +344,17 @@ export function keccak256(...args) {
   debug("sha %o", sha);
   return toBigNumber(sha);
 }
+
+export function augmentWithDepth(id, depth = 0) {
+    //depth 0 indicates not a local variable; real depths start from 1
+    //both arguments are numeric, so a colon should occur in neither
+    return `${depth}:${id}`;
+}
+
+export function idFromAugmented(augmentedId) {
+    return augmentedId.split(":")[1];
+}
+
+export function depthFromAugmented(augmentedId) {
+    return augmentedId.split(":")[0];
+}

--- a/packages/truffle-debugger/lib/data/reducers.js
+++ b/packages/truffle-debugger/lib/data/reducers.js
@@ -77,7 +77,7 @@ function assignments(state = DEFAULT_ASSIGNMENTS, action) {
             ...Object.entries(action.assignments).map(
               ([id, ref]) => ({
                 [id]: {
-                  ...state.byId[id],
+                  ...state.byId[id], //note: id here includes depth
                   ref
                 }
               })

--- a/packages/truffle-debugger/lib/data/sagas/index.js
+++ b/packages/truffle-debugger/lib/data/sagas/index.js
@@ -113,7 +113,7 @@ function *tickSaga() {
       debug("currentAssignments %O", currentAssignments);
       debug("currentDepth %d varId %d", currentDepth, varId);
       yield put(actions.assign(treeId, {
-        [utils.augmentWithDepth(currentDepth,  varId)]: {"stack": top}
+        [utils.augmentWithDepth(varId, currentDepth)]: {"stack": top}
       }));
       break;
 
@@ -130,7 +130,7 @@ function *tickSaga() {
       //augment declaration Id w/0 to indicate storage
       let augmentedDeclarationId = utils.augmentWithDepth(baseDeclarationId);
       //indices, meanwhile, use depth as usual
-      let augmentedIndexId = utils.augmentWithDepth(currentDepth, indexId);
+      let augmentedIndexId = utils.augmentWithDepth(indexId, currentDepth);
       debug("Index access case");
       debug("currentAssignments %O", currentAssignments);
       debug("augmentedDeclarationId %s", augmentedDeclarationId)
@@ -180,7 +180,7 @@ function *tickSaga() {
       debug("currentAssignments %O", currentAssignments);
       debug("currentDepth %d node.id %d", currentDepth, node.id);
       yield put(actions.assign(treeId, {
-        [utils.augmentWithDepth(currentDepth, node.id)]: { literal }
+        [utils.augmentWithDepth(node.id, currentDepth)]: { literal }
       }));
       break;
   }

--- a/packages/truffle-debugger/lib/data/selectors/index.js
+++ b/packages/truffle-debugger/lib/data/selectors/index.js
@@ -235,10 +235,11 @@ const data = createSelectorTree({
       refs: createLeaf(
         [
           "/proc/assignments",
-          "./_"
+          "./_",
+          solidity.current.functionDepth //for pruning things too deep on stack
         ],
 
-        (assignments, identifiers) => Object.assign({},
+        (assignments, identifiers, curDepth) => Object.assign({},
           ...Object.entries(identifiers)
             .map( ([identifier, id]) => {
               let matchIds = Object.keys(assignments).filter(
@@ -246,9 +247,10 @@ const data = createSelectorTree({
                   ).map(
                   (longId) => longId.split(":")[0] //get just the stack frame
                   );
-              let maxMatch=Math.max(...matchIds); //want innermost
-		    //note: if no matches, will return -Infinity
-		    //however the return value in this case is irrelevant
+              //want innermost but not beyond current depth
+              let maxMatch=Math.min(curDepth,Math.max(...matchIds));
+                  //note: if no matches, will return -Infinity
+                  //however the return value in this case is irrelevant
               let { ref } = (assignments[maxMatch+":"+id] || {});
               if (!ref) { return undefined };
 

--- a/packages/truffle-debugger/lib/data/selectors/index.js
+++ b/packages/truffle-debugger/lib/data/selectors/index.js
@@ -246,11 +246,9 @@ const data = createSelectorTree({
                   ).map(
                   (longId) => longId.split(":")[0] //get just the stack frame
                   );
-              let maxMatch; //default undefined; if nothing found value irrel
-              if( matchIds.length > 0)
-              {
-                maxMatch=Math.max(...matchIds); //want innermost
-              }
+              let maxMatch=Math.max(...matchIds); //want innermost
+		    //note: if no matches, will return -Infinity
+		    //however the return value in this case is irrelevant
               let { ref } = (assignments[maxMatch+":"+id] || {});
               if (!ref) { return undefined };
 

--- a/packages/truffle-debugger/lib/data/selectors/index.js
+++ b/packages/truffle-debugger/lib/data/selectors/index.js
@@ -241,7 +241,17 @@ const data = createSelectorTree({
         (assignments, identifiers) => Object.assign({},
           ...Object.entries(identifiers)
             .map( ([identifier, id]) => {
-              let { ref } = (assignments[id] || {})
+              let matchIds = Object.keys(assignments).filter(
+                  (longId) => longId.endsWith(":"+id) //get cases of that var
+                  ).map(
+                  (longId) => longId.split(":")[0] //get just the stack frame
+                  );
+              let maxMatch; //default undefined; if nothing found value irrel
+              if( matchIds.length > 0)
+              {
+                maxMatch=Math.max(...matchIds); //want innermost
+              }
+              let { ref } = (assignments[maxMatch+":"+id] || {});
               if (!ref) { return undefined };
 
               return {


### PR DESCRIPTION
Augments variable id's with a stack depth so that if a function appears more than once in the call stack you will see the variables for the appropriate stack frame (more specifically, `data.current.identifiers.refs` will point to the appropriate copy of the variable).  (This augmenting is only done in certain contexts -- specifically, contexts that feed into `data.current.identifiers.refs`, so be aware that there are both augmented and non-augmented IDs still used.)  Variables that are not local to a function get depth 0; depths are started counting from 1 (since that is what the existing code already does).  There is a slight potential bug in that, if `f` (at depth `d`) calls `f` (at depth `d+1`) and then later calls `f` (at depth `d+1`) again, the last of these may see the values from the earlier call to `f` at depth `d+1` for variables that have not been declared yet.  Note that support for mappings required making an alteration to the `decodeMapping` function in `decode`; this does not feed into `data.current.identifiers.refs`, but does feed into `data.current.identifiers.decoded`; without this change, mappings had the correct refs yet would not be correctly display to the user.