### PR TITLE
Get coverage reading for scenario tests

### DIFF
--- a/packages/truffle/scripts/test.sh
+++ b/packages/truffle/scripts/test.sh
@@ -4,6 +4,8 @@ set -o errexit
 
 if [ "$GETH" == true ]; then
   npm run build-cli && mocha --timeout 50000 --grep @ganache --invert --colors $@
+elif [ "$COVERAGE" == true ]; then
+  NO_BUILD=true mocha --no-warnings --timeout 7000 --grep @geth --invert --colors $@
 else
   npm run build-cli && mocha --no-warnings --timeout 7000 --grep @geth --invert --colors $@
 fi

--- a/packages/truffle/test/scenarios/commands/exec.js
+++ b/packages/truffle/test/scenarios/commands/exec.js
@@ -41,7 +41,7 @@ describe("truffle exec", function() {
   }
 
   it("runs script after compiling", function(done) {
-    this.timeout(20000);
+    this.timeout(30000);
 
     CommandRunner.run("compile", config, function(err) {
       processErr(err);


### PR DESCRIPTION
Routes execution through the repo instead of the bundle when running the scenario tests for coverage.