### PR TITLE
Download spinner

### DIFF
--- a/packages/truffle-compile/compilerSupplier.js
+++ b/packages/truffle-compile/compilerSupplier.js
@@ -82,27 +82,27 @@ CompilerSupplier.prototype.load = function(){
  * ```
  * @return {Object} See above
  */
- CompilerSupplier.prototype.getReleases = function(){
-   return this
-     .getVersions()
-     .then(list => {
+CompilerSupplier.prototype.getReleases = function() {
+  return this
+    .getVersions()
+    .then(list => {
 
-       // Prereleases
-       const prereleases = list
-           .builds
-           .filter(build => build['prerelease'])
-           .map(build => build['longVersion']);
+      // Prereleases
+      const prereleases = list
+          .builds
+          .filter(build => build['prerelease'])
+          .map(build => build['longVersion']);
 
-       // Releases
-       const releases = Object.keys(list.releases);
+      // Releases
+      const releases = Object.keys(list.releases);
 
-       return {
-         prereleases: prereleases,
-         releases: releases,
-         latestRelease: list.latestRelease,
-       }
-     });
- }
+      return {
+        prereleases: prereleases,
+        releases: releases,
+        latestRelease: list.latestRelease,
+      }
+    });
+}
 
 /**
  * Fetches the first page of docker tags for the the ethereum/solc image

--- a/packages/truffle-compile/compilerSupplier.js
+++ b/packages/truffle-compile/compilerSupplier.js
@@ -6,7 +6,7 @@ const requireFromString = require('require-from-string');
 const findCacheDir = require('find-cache-dir');
 const originalRequire = require('original-require');
 const solcWrap = require('./solcWrap.js');
-
+const ora = require('ora');
 
 //------------------------------ Constructor/Config ------------------------------------------------
 
@@ -82,27 +82,27 @@ CompilerSupplier.prototype.load = function(){
  * ```
  * @return {Object} See above
  */
-CompilerSupplier.prototype.getReleases = function(){
-  return this
-    .getVersions()
-    .then(list => {
+ CompilerSupplier.prototype.getReleases = function(){
+   return this
+     .getVersions()
+     .then(list => {
 
-      // Prereleases
-      const prereleases = list
-          .builds
-          .filter(build => build['prerelease'])
-          .map(build => build['longVersion']);
+       // Prereleases
+       const prereleases = list
+           .builds
+           .filter(build => build['prerelease'])
+           .map(build => build['longVersion']);
 
-      // Releases
-      const releases = Object.keys(list.releases);
+       // Releases
+       const releases = Object.keys(list.releases);
 
-      return {
-        prereleases: prereleases,
-        releases: releases,
-        latestRelease: list.latestRelease,
-      }
-    });
-}
+       return {
+         prereleases: prereleases,
+         releases: releases,
+         latestRelease: list.latestRelease,
+       }
+     });
+ }
 
 /**
  * Fetches the first page of docker tags for the the ethereum/solc image
@@ -165,14 +165,23 @@ CompilerSupplier.prototype.getLocal = function(localPath){
  * same.
  * @return {Object} versions
  */
-CompilerSupplier.prototype.getVersions = function(){
+CompilerSupplier.prototype.getVersions = function() {
   const self = this;
+  const spinner = ora({
+    text: 'Fetching solc version list from solc-bin',
+    color: 'yellow'
+  }).start();
 
   return request(self.config.versionsUrl)
-    .then(list => JSON.parse(list))
-    .catch(err => {throw self.errors('noRequest', self.config.versionsUrl, err)});
+    .then(list => {
+      spinner.stop();
+      return JSON.parse(list);
+    })
+    .catch(err => {
+      spinner.stop();
+      throw self.errors('noRequest', self.config.versionsUrl, err);
+    });
 }
-
 
 /**
  * Returns terminal url segment for `version` from the versions object
@@ -218,14 +227,22 @@ CompilerSupplier.prototype.getByUrl = function(version){
       if (self.isCached(file)) return self.getFromCache(file);
 
       const url = self.config.compilerUrlRoot + file;
+      const spinner = ora({
+        text: 'Downloading compiler',
+        color: 'red',
+      }).start();
 
       return request
         .get(url)
         .then(response => {
+          spinner.stop();
           self.addToCache(response, file);
           return self.compilerFromString(response);
         })
-        .catch(err => { throw self.errors('noRequest', url, err)});
+        .catch(err => {
+          spinner.stop();
+          throw self.errors('noRequest', url, err);
+        });
     });
 }
 

--- a/packages/truffle-compile/package.json
+++ b/packages/truffle-compile/package.json
@@ -8,6 +8,7 @@
     "colors": "^1.1.2",
     "debug": "^3.1.0",
     "find-cache-dir": "^1.0.0",
+    "ora": "^3.0.0",
     "original-require": "^1.0.1",
     "request": "^2.85.0",
     "request-promise": "^4.2.2",

--- a/packages/truffle-reporters/package.json
+++ b/packages/truffle-reporters/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "node-emoji": "^1.8.1",
-    "ora": "^2.1.0",
+    "ora": "^3.0.0",
     "web3-utils": "1.0.0-beta.35"
   },
   "gitHead": "07967b472112f1c771ebbc90319781454cf9331b"


### PR DESCRIPTION
This adds ora to the truffle-compile package.  It provides the user with a status update while downloading the solc version list and whenever it needs to download a compiler from solc-bin.

Inspired by issue #1274 