### PR TITLE
Print unhandled RPC errors which bubble up to CLI

### DIFF
--- a/packages/truffle-core/cli.js
+++ b/packages/truffle-core/cli.js
@@ -47,7 +47,7 @@ command.run(inputArguments, options, function(err) {
         process.exit(err);
       } else {
         // Bubble up all other unexpected errors.
-        console.log(err.stack || err.toString());
+        console.log(err.stack || err.message || err.toString());
       }
     }
     process.exit(1);


### PR DESCRIPTION
When using a provider created from the `web3-provider-engine` I get an error printed as `[Object object]`. This is because an RPC error response payload is being propagated all  the way back to the top-level error handler. This change makes those types of errors print correctly.