### PR TITLE
Improved breakpoint functionality

### DIFF
--- a/packages/truffle-core/lib/commands/debug.js
+++ b/packages/truffle-core/lib/commands/debug.js
@@ -38,6 +38,7 @@ var command = {
     var trace = selectors.trace;
     var solidity = selectors.solidity;
     var evm = selectors.evm;
+    var controller = selectors.controller;
 
     var config = Config.detect(options);
 
@@ -187,7 +188,9 @@ var command = {
         };
 
         function printWatchExpressions() {
-          if (enabledExpressions.size == 0) {
+          let source = session.view(solidity.current.source);
+
+          if (enabledExpressions.size === 0) {
             config.logger.log("No watch expressions added.");
             return;
           }
@@ -196,7 +199,6 @@ var command = {
           enabledExpressions.forEach(function(expression) {
             config.logger.log("  " + expression);
           });
-          config.logger.log("");
         }
 
         function printWatchExpressionsResults() {
@@ -303,46 +305,179 @@ var command = {
           }
         }
 
-        function toggleBreakpoint() {
-          var currentCall = session.view(evm.current.call);
-          var currentNode = session.view(ast.current.node).id;
+        function setOrClearBreakpoint(args,setOrClear) {
+          //setOrClear: true for set, false for clear
+          var currentLocation = session.view(controller.current.location);
+          var breakpoints = session.view(controller.breakpoints);
 
-          // Try to find the breakpoint in the list
-          var found = false;
-          for (var index = 0; index < breakpoints.length; index++) {
-            var breakpoint = breakpoints[index];
+          var currentNode = currentLocation.node.id;
+          var currentLine = currentLocation.sourceRange.lines.start.line;
+          var currentSource = currentLocation.source;
 
-            if (_.isEqual(currentCall, breakpoint.call) && currentNode == breakpoint.node) {
-              found = true;
-              // Remove the breakpoint
-              breakpoints.splice(index, 1);
-              break;
+          var breakpoint = {};
+
+          debug("args %O",args);
+
+          if(args.length === 0) //no arguments, want currrent node
+          {
+            debug("node case");
+            breakpoint.node = currentNode;
+            breakpoint.line = currentLine;
+            breakpoint.source = currentSource;
+          }
+
+          //if the argument starts with a "+" or "-", we have a relative
+          //line number
+          else if(args[0][0] === "+" || args[0][0] === "-")
+          {
+            debug("relative case");
+            let delta = parseInt(args[0],10); //want an integer
+            debug("delta %d",delta);
+
+            if(isNaN(delta))
+            {
+              config.logger.log("Offset must be an integer");
+              return;
+            }
+
+            breakpoint.source = currentSource;
+            breakpoint.line = currentLine + delta;
+          }
+
+          //if it contains a colon, it's in the form source:line
+          else if(args[0].includes(":"))
+          {
+            debug("source case")
+            let sourceArgs = args[0].split(":");
+            let sourceArg = sourceArgs[0];
+            let lineArg = sourceArgs[1];
+            debug("sourceArgs %O",sourceArgs);
+
+            //first let's get the line number as usual
+            let line = parseInt(lineArg,10); //want an integer
+            if(isNaN(line))
+            {
+              config.logger.log("Line number must be an integer");
+              return;
+            }
+
+            //search sources for given string
+            let sources = session.view(solidity.info.sources);
+
+            let matchingSources = sources.filter(
+              (source) => source.sourcePath.includes(sourceArg)
+            );
+
+            if(matchingSources.length === 0)
+            {
+              config.logger.log(`No source file found matching ${sourceArg}.`)
+              return;
+            }
+            else if(matchingSources.length > 1)
+            {
+              config.logger.log(`Multiple source files found matching ${sourceArg}.  Which did you mean?`)
+              matchingSources.forEach(
+                (source) => config.logger.log(source.sourcePath));
+              return;
+            }
+
+            //otherwise, we found it!
+            breakpoint.source = matchingSources[0];
+            breakpoint.line = line;
+          }
+
+          //otherwise, it's a simple line number
+          else
+          {
+            debug("absolute case");
+            let line = parseInt(args[0],10); //want an integer
+            debug("line %d",line);
+
+            if(isNaN(line))
+            {
+              config.logger.log("Line number must be an integer");
+              return;
+            }
+
+            breakpoint.source = currentSource;
+            breakpoint.line = line;
+          }
+
+          //having constructed the breakpoint, here's now a usable-readable
+          //message describing its location
+          let locationMessage;
+          if(breakpoint.node !== undefined)
+          {
+            locationMessage = `this point in line ${breakpoint.line}`;
+          }
+          else if(breakpoint.source !== currentSource)
+          {
+            locationMessage = `line ${breakpoint.line} in source ${sourceArg}`;
+          }
+          else
+          {
+            locationMessage = `line ${breakpoint.line}`
+          }
+
+          //one last check -- does this breakpoint already exist?
+          let alreadyExists = breakpoints.filter(
+              (existingBreakpoint) =>
+              existingBreakpoint.source === breakpoint.source &&
+              existingBreakpoint.line === breakpoint.line &&
+              existingBreakpoint.node === breakpoint.node //may be undefined
+          ).length > 0;
+
+          //NOTE: in the "set breakpoint" case, the above check is somewhat
+          //redundant, as we're going to check again when we actually make the
+          //call to add or remove the breakpoint!  But we need to check here so
+          //that we can display the appropriate message.  Hopefully we can find
+          //some way to avoid this redundant check in the future.
+
+          //if it already exists and is being set, or doesn't and is being
+          //cleared, report back that we can't do that
+          if(setOrClear === alreadyExists)
+          {
+            if(setOrClear)
+            {
+              config.logger.log(`Breakpoint at ${locationMessage} already exists.`);
+              return;
+            }
+            else
+            {
+              config.logger.log(`No breakpoint at ${locationMessage} to remove.`);
+              return;
             }
           }
+         
+          //finally, if we've reached this point, do it!
+          session.setOrClearBreakpoint(breakpoint,setOrClear);
 
-          if (found) {
-            config.logger.log("Breakpoint removed.");
-            return;
+          //finally, report back to the user on what happened
+          if(setOrClear)
+          {
+            config.logger.log(`Breakpoint added at ${locationMessage}.`);
           }
-
-          // No breakpoint? Add it.
-          breakpoints.push({
-            call: currentCall,
-            node: currentNode
-          });
-
-          config.logger.log("Breakpoint added.");
+          else
+          {
+            config.logger.log(`Breakpoint removed at ${locationMessage}.`);
+          }
+          return;
         }
 
         function interpreter(cmd, replContext, filename, callback) {
           cmd = cmd.trim();
-          var cmdArgs;
+          var cmdArgs, splitArgs;
           debug("cmd %s", cmd);
 
           if (cmd == ".exit") {
             cmd = "q";
           }
 
+          //split arguments for commands that want that; split on runs of spaces
+          splitArgs=cmd.trim().split(/ +/).slice(1);
+          debug("splitArgs %O",splitArgs);
+
+          //warning: this bit *alters* cmd!
           if (cmd.length > 0) {
             cmdArgs = cmd.slice(1).trim();
             cmd = cmd[0];
@@ -370,7 +505,7 @@ var command = {
               session.advance();
               break;
             case "c":
-              session.continueUntil.apply(session, breakpoints);
+              session.continueUntilBreakpoint();
               break;
             case "q":
               return repl.stop(callback);
@@ -412,7 +547,10 @@ var command = {
               evalAndPrintExpression(cmdArgs);
               break;
             case "b":
-              toggleBreakpoint();
+              setOrClearBreakpoint(splitArgs,true);
+              break;
+            case "B":
+              setOrClearBreakpoint(splitArgs,false);
               break;
             case ";":
             case "p":

--- a/packages/truffle-core/lib/commands/debug.js
+++ b/packages/truffle-core/lib/commands/debug.js
@@ -338,7 +338,7 @@ var command = {
 
             if(isNaN(delta))
             {
-              config.logger.log("Offset must be an integer");
+              config.logger.log("Offset must be an integer.\n");
               return;
             }
 
@@ -359,7 +359,7 @@ var command = {
             let line = parseInt(lineArg,10); //want an integer
             if(isNaN(line))
             {
-              config.logger.log("Line number must be an integer");
+              config.logger.log("Line number must be an integer.\n");
               return;
             }
 
@@ -372,7 +372,7 @@ var command = {
 
             if(matchingSources.length === 0)
             {
-              config.logger.log(`No source file found matching ${sourceArg}.`)
+              config.logger.log(`No source file found matching ${sourceArg}.\n`)
               return;
             }
             else if(matchingSources.length > 1)
@@ -380,6 +380,7 @@ var command = {
               config.logger.log(`Multiple source files found matching ${sourceArg}.  Which did you mean?`)
               matchingSources.forEach(
                 (source) => config.logger.log(source.sourcePath));
+              config.logger.log("");
               return;
             }
 
@@ -398,7 +399,7 @@ var command = {
 
             if(isNaN(line))
             {
-              config.logger.log("Line number must be an integer");
+              config.logger.log("Line number must be an integer.\n");
               return;
             }
 
@@ -406,7 +407,7 @@ var command = {
             breakpoint.line = line-1; //adjust for zero-indexing!
           }
 
-          //having constructed the breakpoint, here's now a usable-readable
+          //having constructed the breakpoint, here's now a user-readable
           //message describing its location
           let locationMessage;
           if(breakpoint.node !== undefined)
@@ -416,7 +417,6 @@ var command = {
           }
           else if(breakpoint.sourceId !== currentSourceId)
           {
-            //name the source as the user entered it
             //note: we should only be in this case if a source was entered!
             //if no source as entered and we are here, something is wrong
             locationMessage = `line ${breakpoint.line+1} in ${sourceName}`;
@@ -448,27 +448,27 @@ var command = {
           {
             if(setOrClear)
             {
-              config.logger.log(`Breakpoint at ${locationMessage} already exists.`);
+              config.logger.log(`Breakpoint at ${locationMessage} already exists.\n`);
               return;
             }
             else
             {
-              config.logger.log(`No breakpoint at ${locationMessage} to remove.`);
+              config.logger.log(`No breakpoint at ${locationMessage} to remove.\n`);
               return;
             }
           }
          
           //finally, if we've reached this point, do it!
-          session.setOrClearBreakpoint(breakpoint,setOrClear);
-
-          //finally, report back to the user on what happened
+          //also report back to the user on what happened
           if(setOrClear)
           {
-            config.logger.log(`Breakpoint added at ${locationMessage}.`);
+            session.addBreakpoint(breakpoint);
+            config.logger.log(`Breakpoint added at ${locationMessage}.\n`);
           }
           else
           {
-            config.logger.log(`Breakpoint removed at ${locationMessage}.`);
+            session.removeBreakpoint(breakpoint);
+            config.logger.log(`Breakpoint removed at ${locationMessage}.\n`);
           }
           return;
         }

--- a/packages/truffle-debug-utils/index.js
+++ b/packages/truffle-debug-utils/index.js
@@ -17,7 +17,8 @@ var commandReference = {
   "+": "add watch expression (`+:<expr>`)",
   "-": "remove watch expression (-:<expr>)",
   "?": "list existing watch expressions",
-  "b": "toggle breakpoint",
+  "b": "add breakpoint",
+  "B": "remove breakpoint",
   "c": "continue until breakpoint",
   "q": "quit"
 };
@@ -115,7 +116,7 @@ var DebugUtils = {
     var commandSections = [
       ["o", "i", "u", "n"],
       [";", "p", "h", "q"],
-      ["b", "c"],
+      ["b", "B", "c"],
       ["+", "-"],
       ["?"],
       ["v", ":"]

--- a/packages/truffle-debugger/lib/controller/actions/index.js
+++ b/packages/truffle-debugger/lib/controller/actions/index.js
@@ -32,15 +32,23 @@ export function stepOut() {
 }
 
 export const INTERRUPT = "INTERRUPT";
-export function interrupt () {
+export function interrupt() {
   return {type: INTERRUPT};
 }
 
+export const CONTINUE = "CONTINUE";
+export function continueUntilBreakpoint() { //"continue" is not a legal name
+  return { type: CONTINUE};
+}
 
-export const CONTINUE_UNTIL = "CONTINUE_UNTIL";
-export function continueUntil(...breakpoints) {
-  return {
-    type: CONTINUE_UNTIL,
-    breakpoints
-  };
+export const ADD_BREAKPOINT = "ADD_BREAKPOINT";
+export function addBreakpoint(breakpoint) {
+  return { type: ADD_BREAKPOINT,
+    breakpoint};
+}
+
+export const REMOVE_BREAKPOINT = "REMOVE_BREAKPOINT";
+export function removeBreakpoint(breakpoint) {
+  return { type: REMOVE_BREAKPOINT,
+    breakpoint};
 }

--- a/packages/truffle-debugger/lib/controller/reducers.js
+++ b/packages/truffle-debugger/lib/controller/reducers.js
@@ -7,10 +7,11 @@ import * as actions from "./actions";
 
 function breakpoints(state = [], action) {
   switch (action.type) {
+
     case actions.ADD_BREAKPOINT:
       //check for any existing identical breakpoints to avoid redundancy
       if(state.filter((breakpoint)=>
-        breakpoint.source===action.breakpoint.source &&
+        breakpoint.sourceId===action.breakpoint.sourceId &&
         breakpoint.line===action.breakpoint.line &&
         breakpoint.node===action.breakpoint.node //may be undefined
       ).length>0)
@@ -24,13 +25,15 @@ function breakpoints(state = [], action) {
         return state.concat([action.breakpoint]);
       }
       break;
+
     case actions.REMOVE_BREAKPOINT:
       return state.filter((breakpoint)=>
-        breakpoint.source===action.breakpoint.source &&
-        breakpoint.line===action.breakpoint.line &&
-        breakpoint.node===action.breakpoint.node //may be undefined
+        breakpoint.sourceId!==action.breakpoint.sourceId ||
+        breakpoint.line!==action.breakpoint.line ||
+        breakpoint.node!==action.breakpoint.node //may be undefined
       );
       break;
+
     default:
       return state;
   }

--- a/packages/truffle-debugger/lib/controller/reducers.js
+++ b/packages/truffle-debugger/lib/controller/reducers.js
@@ -1,0 +1,43 @@
+import debugModule from "debug";
+const debug = debugModule("debugger:controller:reducers");
+
+import { combineReducers } from "redux";
+
+import * as actions from "./actions";
+
+function breakpoints(state = [], action) {
+  switch (action.type) {
+    case actions.ADD_BREAKPOINT:
+      //check for any existing identical breakpoints to avoid redundancy
+      if(state.filter((breakpoint)=>
+        breakpoint.source===action.breakpoint.source &&
+        breakpoint.line===action.breakpoint.line &&
+        breakpoint.node===action.breakpoint.node //may be undefined
+      ).length>0)
+      {
+        //if it's already there, do nothing
+	return state;
+      }
+      else
+      {
+        //otherwise add it
+        return state.concat([action.breakpoint]);
+      }
+      break;
+    case actions.REMOVE_BREAKPOINT:
+      return state.filter((breakpoint)=>
+        breakpoint.source===action.breakpoint.source &&
+        breakpoint.line===action.breakpoint.line &&
+        breakpoint.node===action.breakpoint.node //may be undefined
+      );
+      break;
+    default:
+      return state;
+  }
+}
+
+const reducer = combineReducers({
+  breakpoints
+});
+
+export default reducer;

--- a/packages/truffle-debugger/lib/controller/sagas/index.js
+++ b/packages/truffle-debugger/lib/controller/sagas/index.js
@@ -194,56 +194,44 @@ function* stepOver () {
  * continueUntilBreakpoint - step through execution until a breakpoint
  */
 function *continueUntilBreakpoint () {
-  var currentLocation, currentNode, currentLine, currentSource;
-  var previousLine, previousSource;
+  var currentLocation, currentNode, currentLine, currentSourceId;
+  var previousLine, previousSourceId;
 
   let breakpoints = yield select(controller.breakpoints);
 
   let breakpointHit = false;
 
   currentLocation = yield select(controller.current.location);
+  currentNode = currentLocation.node.id;
   currentLine = currentLocation.sourceRange.lines.start.line;
-  currentSource = currentLocation.source.id;
+  currentSourceId = currentLocation.source.id;
 
   do {
     yield* stepNext();
 
     previousLine = currentLine;
-    previousSource = currentSource;
+    previousSourceId = currentSourceId;
 
     currentLocation = yield select(controller.current.location);
+    currentNode = currentLocation.node.id;
     currentLine = currentLocation.sourceRange.lines.start.line;
-    currentSource = currentLocation.source.id;
+    currentSourceId = currentLocation.source.id;
 
     breakpointHit = breakpoints
-      .filter( ({source, line, node}) =>
+      .filter( ({sourceId, line, node}) =>
         {
           if(node !== undefined)
           {
-            return source === currentSource && node === currentNode;
+            debug("node %d currentNode %d",node,currentNode);
+            return sourceId === currentSourceId && node === currentNode;
           }
           //otherwise, we have a line-style breakpoint; we want to stop at the
           //*first* point on the line
-          return source === currentSource && line === currentLine
-          && (currentSource !== previousSource || currentLine !== previousLine);
+          return sourceId === currentSourceId && line === currentLine
+          && (currentSourceId !== previousSourceId || currentLine !== previousLine);
         }
       )
       .length > 0;
     
   } while(!breakpointHit);
-
-  debug("breakpoints %O",breakpoints);
-  debug("currentCall %O",currentCall);
-  debug("currentCall.address %s",currentCall.address);
-  debug("address %s",breakpoints[0].address);
-  debug("address == currentCall.address %s",
-    breakpoints[0].address == currentCall.address ? 'true' : 'false');
-  debug("address === currentCall.address %s",
-    breakpoints[0].address === currentCall.address ? 'true' : 'false');
-  debug("currentCall.binary %s",currentCall.binary);
-  debug("binary %s",breakpoints[0].binary);
-  debug("binary == currentCall.binary %s",
-    breakpoints[0].binary == currentCall.binary ? 'true' : 'false');
-  debug("binary === currentCall.binary %s",
-    breakpoints[0].binary === currentCall.binary ? 'true' : 'false');
 }

--- a/packages/truffle-debugger/lib/controller/selectors/index.js
+++ b/packages/truffle-debugger/lib/controller/selectors/index.js
@@ -18,6 +18,10 @@ const identity = (x) => x
 const controller = createSelectorTree({
 
   /**
+   * controller.state
+   */
+  state: ((state) => state.controller),
+  /**
    * controller.current
    */
   current: {
@@ -46,6 +50,11 @@ const controller = createSelectorTree({
       sourceRange: createLeaf([solidity.current.sourceRange], identity),
 
       /**
+       * controller.current.location.source
+       */
+      source: createLeaf([solidity.current.source], identity),
+
+      /**
        * controller.current.location.node
        */
       node: createLeaf([ast.current.node], identity),
@@ -55,7 +64,11 @@ const controller = createSelectorTree({
        */
       isMultiline: createLeaf([solidity.current.isMultiline], identity),
     }
-  }
+  },
+  /**
+   * controller.breakpoints
+   */
+  breakpoints: createLeaf(["./state"], (state) => state.breakpoints)
 });
 
 export default controller;

--- a/packages/truffle-debugger/lib/debugger.js
+++ b/packages/truffle-debugger/lib/debugger.js
@@ -11,6 +11,7 @@ import traceSelector from "./trace/selectors";
 import evmSelector from "./evm/selectors";
 import soliditySelector from "./solidity/selectors";
 import sessionSelector from "./session/selectors";
+import controllerSelector from "./controller/selectors";
 
 const debug = debugModule("debugger");
 
@@ -94,6 +95,7 @@ export default class Debugger {
       evm: evmSelector,
       solidity: soliditySelector,
       session: sessionSelector,
+      controller: controllerSelector,
     });
   }
 }

--- a/packages/truffle-debugger/lib/session/index.js
+++ b/packages/truffle-debugger/lib/session/index.js
@@ -160,7 +160,18 @@ export default class Session {
     return this.dispatch(controller.stepOut());
   }
 
-  continueUntil(...breakpoints) {
-    return this.dispatch(controller.continueUntil(...breakpoints));
+  continueUntilBreakpoint() {
+    return this.dispatch(controller.continueUntilBreakpoint());
+  }
+
+  setOrClearBreakpoint(breakpoint,setOrClear){
+    if(setOrClear)
+    {
+      return this.dispatch(controller.addBreakpoint(breakpoint));
+    }
+    else
+    {
+      return this.dispatch(controller.removeBreakpoint(breakpoint));
+    }
   }
 }

--- a/packages/truffle-debugger/lib/session/index.js
+++ b/packages/truffle-debugger/lib/session/index.js
@@ -164,14 +164,12 @@ export default class Session {
     return this.dispatch(controller.continueUntilBreakpoint());
   }
 
-  setOrClearBreakpoint(breakpoint,setOrClear){
-    if(setOrClear)
-    {
-      return this.dispatch(controller.addBreakpoint(breakpoint));
-    }
-    else
-    {
-      return this.dispatch(controller.removeBreakpoint(breakpoint));
-    }
+  addBreakpoint(breakpoint)
+  {
+    return this.dispatch(controller.addBreakpoint(breakpoint));
+  }
+
+  removeBreakpoint(breakpoint){
+    return this.dispatch(controller.removeBreakpoint(breakpoint));
   }
 }

--- a/packages/truffle-debugger/lib/session/reducers.js
+++ b/packages/truffle-debugger/lib/session/reducers.js
@@ -4,6 +4,7 @@ import data from "lib/data/reducers";
 import evm from "lib/evm/reducers";
 import solidity from "lib/solidity/reducers";
 import trace from "lib/trace/reducers";
+import controller from "lib/controller/reducers";
 
 import * as actions from "./actions";
 
@@ -34,6 +35,7 @@ const reduceState = combineReducers({
   evm,
   solidity,
   trace,
+  controller
 });
 
 export default reduceState;

--- a/packages/truffle-debugger/test/data/decode/helpers.js
+++ b/packages/truffle-debugger/test/data/decode/helpers.js
@@ -80,7 +80,7 @@ async function prepareDebugger(testName, sources) {
     line: lastStatementLine(source)
   };
 
-  session.setOrClearBreakpoint(breakpoint,true);
+  session.addBreakpoint(breakpoint,true);
 
   session.continueUntilBreakpoint();
 

--- a/packages/truffle-debugger/test/solidity.js
+++ b/packages/truffle-debugger/test/solidity.js
@@ -107,7 +107,7 @@ describe("Solidity Debugging", function() {
     let breakpoint = { sourceId: source.id, line: 16 }
     let breakpointStopped = false;
 
-    session.setOrClearBreakpoint(breakpoint,true);
+    session.addBreakpoint(breakpoint);
 
     do {
       session.continueUntilBreakpoint();

--- a/packages/truffle-debugger/test/solidity.js
+++ b/packages/truffle-debugger/test/solidity.js
@@ -103,11 +103,14 @@ describe("Solidity Debugging", function() {
     let session = bugger.connect();
 
     // at `second();`
-    let breakpoint = { "address": instance.address, line: 16 }
+    let source = await session.view(solidity.current.source);
+    let breakpoint = { sourceId: source.id, line: 16 }
     let breakpointStopped = false;
 
+    session.setOrClearBreakpoint(breakpoint,true);
+
     do {
-      session.continueUntil(breakpoint);
+      session.continueUntilBreakpoint();
 
       if (!session.finished) {
         let range = await session.view(solidity.current.sourceRange);


### PR DESCRIPTION
This branch expands the functionality of breakpoints as requested in #1276.  Breakpoints can now be set on a line of the user's choice in a source file of their choice; they can also be set at the current location as before.  Breakpoints are no longer toggled with `b` but rather set with `b` and cleared with `B`.  A breakpoint set with `b` with no arguments is set at the current location; this is the current location *within* the line, like the old breakpoints.  Breakpoints may also be set at a given line (including in another source file), which may also be specified relative to the current line; these breakpoints will stop execution at the *first* encountered location within that line.  Breakpoints in another source file need only have enough of the filename specified to unambiguously identify it; if what's given is ambiguous, the user will be prompted with a list of possibilities.

This branch does not include expanded functionality for `?`.