### PR TITLE
Wrap getAddress function in provider

### DIFF
--- a/packages/truffle-migrate/index.js
+++ b/packages/truffle-migrate/index.js
@@ -224,6 +224,19 @@ var Migrate = {
 
           callback(err, result);
         });
+      },
+      getAddress: function() {
+        var result = "";
+
+        if (provider.getAddress === undefined) return result;
+
+        if (arguments.length === 1) {
+          result = provider.getAddress(arguments[0]);
+        } else {
+          result = provider.getAddress();
+        }
+
+        return result;
       }
     };
   },


### PR DESCRIPTION
Due to truffle can use another provider like [truffle-hdwallet-provider](https://github.com/trufflesuite/truffle-hdwallet-provider) or [truffle-wallet-provider](https://github.com/crypedit/truffle-wallet-provider), user can call getAddres() in provider but not in wrapped provider.

I try to add `getAddress()` in wrapped provider that user can call `deployer.getAddress()` to get provider address.
