### PR TITLE
Update truffle debug error handling

### DIFF
--- a/packages/truffle-core/lib/commands/debug.js
+++ b/packages/truffle-core/lib/commands/debug.js
@@ -46,7 +46,7 @@ var command = {
       if (err) return done(err);
 
       if (config._.length == 0) {
-        return callback(new Error(
+        return done(new Error(
           "Please specify a transaction hash as the first parameter in order to " +
           "debug that transaction. i.e., truffle debug 0x1234..."
         ));


### PR DESCRIPTION
## The Issue

As noted in #1302, calling `truffle debug` by itself (without a transaction hash) would return:

```
ReferenceError: callback is not defined
    at /[my project folder]/node_modules/truffle-core/lib/commands/debug.js:49:9
    at web3.eth.getAccounts.then.accounts (/[my project folder]/node_modules/truffle-core/lib/environment.js:72:9)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```

Now it should return a more helpful error 😎 

## Steps to Test

`truffle debug`

## Expected Outcome

```
Error: Please specify a transaction hash as the first parameter in order to debug that transaction. i.e., truffle debug 0x1234...
    at /[my project folder]/node_modules/truffle-core/lib/commands/debug.js:49:21
    at web3.eth.getAccounts.then.accounts (/[my project folder]/node_modules/truffle-core/lib/environment.js:72:9)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```