### PR TITLE
Add debugger support for precompiled contracts

### DIFF
--- a/packages/truffle-debugger/lib/evm/actions/index.js
+++ b/packages/truffle-debugger/lib/evm/actions/index.js
@@ -1,8 +1,16 @@
 export const ADD_CONTEXT = "EVM_ADD_CONTEXT";
-export function addContext(contractName, binary) {
+export function addContext(contractName, raw) {
   return {
     type: ADD_CONTEXT,
-    contractName, binary
+    contractName, raw
+  }
+}
+
+export const ADD_BINARY = "EVM_ADD_BINARY";
+export function addBinary(context, binary) {
+  return {
+    type: ADD_BINARY,
+    context, binary
   }
 }
 

--- a/packages/truffle-debugger/lib/evm/reducers.js
+++ b/packages/truffle-debugger/lib/evm/reducers.js
@@ -14,27 +14,55 @@ function contexts(state = DEFAULT_CONTEXTS, action) {
      * Adding a new context
      */
     case actions.ADD_CONTEXT:
-      let { contractName, binary } = action;
+      const addContext = ({ contractName, raw }) => {
+        let context = keccak256(raw);
 
-      if (state.byBinary[binary]) {
-        return state;
+        return {
+          ...state,
+
+          byContext: {
+            ...state.byContext,
+
+            [context]: {
+              ...(state.byContext[context] || {}),
+
+              contractName, context
+            }
+          },
+        };
       }
 
-      let context = keccak256(binary);
+      return addContext(action);
 
-      return {
-        byContext: {
-          ...state.byContext,
-
-          [context]: { context, binary, contractName }
-        },
-
-        byBinary: {
-          ...state.byBinary,
-
-          [binary]: { context: context }
+    /*
+     * Adding binary for a context
+     */
+    case actions.ADD_BINARY:
+      const addBinary = ({ context, binary }) => {
+        if (state.byBinary[binary]) {
+          return state;
         }
-      };
+
+        return {
+          byContext: {
+            ...state.byContext,
+
+            [context]: {
+              ...state.byContext[context],
+
+              binary
+            }
+          },
+
+          byBinary: {
+            ...state.byBinary,
+
+            [binary]: { context: context }
+          }
+        };
+      }
+
+      return addBinary(action);
 
     /*
      * Default case

--- a/packages/truffle-debugger/lib/evm/reducers.js
+++ b/packages/truffle-debugger/lib/evm/reducers.js
@@ -93,7 +93,7 @@ function instances(state = DEFAULT_INSTANCES, action) {
         byAddress: {
           ...state.byAddress,
 
-          [address]: { context, binary }
+          [address]: { address, context, binary }
         },
 
         byContext: {

--- a/packages/truffle-debugger/lib/evm/selectors/index.js
+++ b/packages/truffle-debugger/lib/evm/selectors/index.js
@@ -173,6 +173,8 @@ const evm = createSelectorTree({
             const { context } = results[0];
             return { context };
           }
+
+          return {};
         }
       )
     }

--- a/packages/truffle-debugger/lib/evm/selectors/index.js
+++ b/packages/truffle-debugger/lib/evm/selectors/index.js
@@ -161,6 +161,11 @@ const evm = createSelectorTree({
           // filter by a percentage threshold
           const threshold = 0.25;
 
+          // skip levenshtein check for undefined binaries
+          if (!binary || binary == "0x0") {
+            return {};
+          }
+
           const results = Object.entries(binaries)
             .map( ([ knownBinary, { context }]) => ({
               context,

--- a/packages/truffle-debugger/lib/session/sagas/index.js
+++ b/packages/truffle-debugger/lib/session/sagas/index.js
@@ -98,7 +98,7 @@ function* fetchTx(txHash, provider) {
 
 function* recordContexts(...contexts) {
   for (let { contractName, binary, sourceMap } of contexts) {
-    yield *evm.addContext(contractName, binary);
+    yield *evm.addContext(contractName, { binary });
 
     if (sourceMap) {
       yield *solidity.addSourceMap(binary, sourceMap);

--- a/packages/truffle-debugger/lib/session/selectors/index.js
+++ b/packages/truffle-debugger/lib/session/selectors/index.js
@@ -21,6 +21,8 @@ const session = createSelectorTree({
       (instances, contexts, sources, sourceMaps) => Object.assign({},
         ...Object.entries(instances).map(
           ([address, {context}]) => {
+            debug("instances %O", instances);
+            debug("contexts %O", contexts);
             let { contractName, binary } = contexts[context];
             let { sourceMap } = sourceMaps[context];
 

--- a/packages/truffle-debugger/lib/session/selectors/index.js
+++ b/packages/truffle-debugger/lib/session/selectors/index.js
@@ -24,7 +24,7 @@ const session = createSelectorTree({
             debug("instances %O", instances);
             debug("contexts %O", contexts);
             let { contractName, binary } = contexts[context];
-            let { sourceMap } = sourceMaps[context];
+            let { sourceMap } = sourceMaps[context] || {};
 
             let { source } = sourceMap ?
               // look for source ID between second and third colons (HACK)

--- a/packages/truffle-debugger/test/evm.js
+++ b/packages/truffle-debugger/test/evm.js
@@ -11,7 +11,6 @@ import Debugger from "lib/debugger";
 
 import evm from "lib/evm/selectors";
 
-
 const __OUTER = `
 pragma solidity ^0.4.18;
 
@@ -49,17 +48,10 @@ const __MIGRATION = `
 let Outer = artifacts.require("Outer");
 let Inner = artifacts.require("Inner");
 
-module.exports = function(deployer) {
-  return deployer
-    .then(function() {
-      return deployer.deploy(Inner);
-    })
-    .then(function() {
-      return Inner.deployed();
-    })
-    .then(function(inner) {
-      return deployer.deploy(Outer, inner.address);
-    });
+module.exports = async function(deployer) {
+  await deployer.deploy(Inner);
+  const inner = await Inner.deployed();
+  await deployer.deploy(Outer, inner.address);
 };
 `;
 

--- a/packages/truffle-debugger/test/evm.js
+++ b/packages/truffle-debugger/test/evm.js
@@ -1,5 +1,5 @@
 import debugModule from "debug";
-const debug = debugModule("test:solidity");
+const debug = debugModule("test:evm");
 
 import { assert } from "chai";
 

--- a/packages/truffle-debugger/test/precompiles.js
+++ b/packages/truffle-debugger/test/precompiles.js
@@ -1,0 +1,152 @@
+import debugModule from "debug";
+const debug = debugModule("test:precompiles");
+
+import { assert } from "chai";
+
+import Ganache from "ganache-cli";
+import Web3 from "web3";
+
+import { prepareContracts } from "./helpers";
+import Debugger from "lib/debugger";
+
+import evm from "lib/evm/selectors";
+import trace from "lib/trace/selectors";
+import solidity from "lib/solidity/selectors";
+
+const __PRECOMPILE = `
+pragma solidity ^0.4.18;
+
+contract HasPrecompile {
+  event Called();
+
+  function run() public {
+    sha256("hello world");
+
+    emit Called();
+  }
+}
+`;
+
+let sources = {
+  "HasPrecompile.sol": __PRECOMPILE,
+}
+
+const TEST_CASES = [{
+  name: "trace.step",
+  selector: trace.step
+}, {
+  name: "evm.current.context",
+  selector: evm.current.context
+}, {
+  name: "solidity.current.sourceRange",
+  selector: solidity.current.sourceRange
+}];
+
+describe("Precompiled Contracts", () => {
+  let provider;
+  let web3;
+
+  let abstractions;
+  let artifacts;
+  let files;
+
+  // object where key is selector name, value is list of results at step
+  let results = {};
+
+  before("Create Provider", async function() {
+    provider = Ganache.provider({seed: "debugger", gasLimit: 7000000});
+    web3 = new Web3(provider);
+  });
+
+  before("Prepare contracts and artifacts", async function() {
+    this.timeout(30000);
+
+    let prepared = await prepareContracts(provider, sources)
+    abstractions = prepared.abstractions;
+    artifacts = prepared.artifacts;
+    files = prepared.files;
+  });
+
+  before("Initialize results", () => {
+    // initialize results as mapping of selector to step results list
+    for (let { name } of TEST_CASES) {
+      results[name] = [];
+    }
+  });
+
+  before("Step through debugger", async function() {
+    let instance = await abstractions.HasPrecompile.deployed();
+    let receipt = await instance.run();
+    let txHash = receipt.tx;
+
+    let bugger = await Debugger.forTx(txHash, {
+      provider,
+      files,
+      contracts: artifacts
+    });
+
+    let session = bugger.connect();
+    var stepped;  // session steppers return false when done
+
+    do {
+      for (let { name, selector } of TEST_CASES) {
+        let stepResult;
+
+        try {
+          stepResult = { value: session.view(selector) };
+        } catch (e) {
+          stepResult = { error: e };
+        }
+
+        results[name].push(stepResult);
+      }
+
+      stepped = session.advance();
+    } while(stepped);
+  });
+
+  before("remove final step results", () => {
+    // since these include one step past end of trace
+    for (let { name } of TEST_CASES) {
+      results[name].pop();
+    }
+  });
+
+  it("never fails to know the trace step", async () => {
+    // remove last item (known to be undefined)
+    const result = results["trace.step"];
+
+    for (let step of result) {
+      if (step.error) {
+        throw step.error;
+      }
+
+      assert.isOk(step.value);
+    }
+  });
+
+  it("never fails to know EVM context", async () => {
+    const result = results["evm.current.context"];
+
+    for (let step of result) {
+      if (step.error) {
+        throw step.error;
+      }
+
+      assert.isOk(step.value);
+      assert.property(step.value, "context");
+    }
+  });
+
+  it("never throws an exception for missing source range", async () => {
+    const result = results["solidity.current.sourceRange"];
+
+    for (let step of result) {
+      if (step.error) {
+        throw step.error;
+      }
+
+      assert.isOk(step.value);
+    }
+  });
+});


### PR DESCRIPTION
This prevents the debugger from failing when a contract uses an EVM precompile.

Roughly, this includes:
- Allowing the debugger to track EVM "contexts" that don't have a binary
- Fixing a bunch of `undefined` return values that should be objects
- Change missing binary behavior in `*evm.addInstance` saga (so it adds both binary-less context and instance)
- Add special case handling of CALLs to precompiles