### PR TITLE
Fix Import Regex For Named Imports

### DIFF
--- a/packages/truffle-compile/parser.js
+++ b/packages/truffle-compile/parser.js
@@ -78,7 +78,7 @@ module.exports = {
     var imports = errors.filter(function(solidity_error) {
       return solidity_error.message.indexOf(failingImportFileName) < 0;
     }).map(function(solidity_error) {
-      var matches = solidity_error.formattedMessage.match(/import[^'"]+("|')([^'"]+)("|');/);
+      var matches = solidity_error.formattedMessage.match(/import[^'"]+("|')([^'"]+)("|')/);
 
       // Return the item between the quotes.
       return matches[2];


### PR DESCRIPTION
## Bug Fix

As noted in #1271, trying to compile a contract with named imports (`import "./item.sol" as Item;`) would return:

`TypeError: Error parsing /Projects/vpod/artemis/contracts/item.sol: Cannot read property '2' of null`

Now the truffle-compile's `parser.js` file should parse and compile the contract successfully.

## Steps to Test

Call `truffle compile` on a truffle project with a .sol smart contract inheriting another .sol smart contract as a named import.

## Expected Outcome

```
truffle compile
Compiling ./contracts/Example.sol...
Writing artifacts to ./build/contracts
```