### PR TITLE
Support configuring relative paths in `_directory` properties

### DIFF
--- a/packages/truffle-config/index.js
+++ b/packages/truffle-config/index.js
@@ -243,12 +243,32 @@ function Config(truffle_directory, working_directory, network) {
 };
 
 Config.prototype.addProp = function(key, obj) {
+  // possible property descriptors
+  //
+  // supports `default` and `transform` in addition to `get` and `set`
+  //
+  // default: specify function to retrieve default value (used by get)
+  // transform: specify function to transform value when (used by set)
   Object.defineProperty(this, key, {
+    // retrieve config property value
     get: obj.get || function() {
-      return this._values[key] || obj();
+      // value is specified
+      if (key in this._values) {
+        return this._values[key];
+      }
+
+      // default getter is specified
+      if (obj.default) {
+        return obj.default()
+      };
+
+      // obj is a function
+      return obj();
     },
     set: obj.set || function(val) {
-      this._values[key] = val;
+      this._values[key] = (obj.transform)
+        ? obj.transform(val)
+        : val;
     },
     configurable: true,
     enumerable: true

--- a/packages/truffle-config/index.js
+++ b/packages/truffle-config/index.js
@@ -67,6 +67,9 @@ function Config(truffle_directory, working_directory, network) {
     }
   };
 
+  const resolveDirectory = (value) =>
+    path.resolve(self.working_directory, value);
+
   var props = {
     // These are already set.
     truffle_directory: function() {},

--- a/packages/truffle-config/index.js
+++ b/packages/truffle-config/index.js
@@ -251,33 +251,33 @@ function Config(truffle_directory, working_directory, network) {
   });
 };
 
-Config.prototype.addProp = function(key, obj) {
+Config.prototype.addProp = function(propertyName, descriptor) {
   // possible property descriptors
   //
   // supports `default` and `transform` in addition to `get` and `set`
   //
   // default: specify function to retrieve default value (used by get)
   // transform: specify function to transform value when (used by set)
-  Object.defineProperty(this, key, {
+  Object.defineProperty(this, propertyName, {
     // retrieve config property value
-    get: obj.get || function() {
+    get: descriptor.get || function() {
       // value is specified
-      if (key in this._values) {
-        return this._values[key];
+      if (propertyName in this._values) {
+        return this._values[propertyName];
       }
 
       // default getter is specified
-      if (obj.default) {
-        return obj.default()
+      if (descriptor.default) {
+        return descriptor.default()
       };
 
-      // obj is a function
-      return obj();
+      // descriptor is a function
+      return descriptor();
     },
-    set: obj.set || function(val) {
-      this._values[key] = (obj.transform)
-        ? obj.transform(val)
-        : val;
+    set: descriptor.set || function(value) {
+      this._values[propertyName] = (descriptor.transform)
+        ? descriptor.transform(value)
+        : value;
     },
     configurable: true,
     enumerable: true

--- a/packages/truffle-config/index.js
+++ b/packages/truffle-config/index.js
@@ -84,26 +84,32 @@ function Config(truffle_directory, working_directory, network) {
     logger: function() {},
     compilers: function() {},
 
-    build_directory: function() {
-      return path.join(self.working_directory, "build");
+    build_directory: {
+      default: () => path.join(self.working_directory, "build"),
+      transform: resolveDirectory
     },
-    contracts_directory: function() {
-      return path.join(self.working_directory, "contracts");
+    contracts_directory: {
+      default: () => path.join(self.working_directory, "contracts"),
+      transform: resolveDirectory
     },
-    contracts_build_directory: function() {
-      return path.join(self.build_directory, "contracts");
+    contracts_build_directory: {
+      default: () => path.join(self.build_directory, "contracts"),
+      transform: resolveDirectory
     },
-    migrations_directory: function() {
-      return path.join(self.working_directory, "migrations");
+    migrations_directory: {
+      default: () => path.join(self.working_directory, "migrations"),
+      transform: resolveDirectory
     },
-    test_directory: function() {
-      return path.join(self.working_directory, "test");
+    test_directory: {
+      default: () => path.join(self.working_directory, "test"),
+      transform: resolveDirectory
     },
     test_file_extension_regexp: function() {
       return /.*\.(js|es|es6|jsx|sol)$/
     },
-    example_project_directory: function() {
-      return path.join(self.truffle_directory, "example");
+    example_project_directory: {
+      default: () => path.join(self.truffle_directory, "example"),
+      transform: resolveDirectory
     },
     network_id: {
       get: function() {


### PR DESCRIPTION
#862 (among others)

This PR expands the capability for truffle-config's property descriptions, to enable preprocessing config values. In addition to the normal Node `get` and `set`:
  - Define `default` option for specifying default value
  - Define `transform` option for preprocessing set values

`default` is necessary because existing directory properties are getting their default values via a function literal.