### PR TITLE
Adds step counter display to the debugger output

### DIFF
--- a/packages/truffle-core/lib/commands/debug.js
+++ b/packages/truffle-core/lib/commands/debug.js
@@ -54,6 +54,7 @@ var command = {
 
       var txHash = config._[0];
 
+      var jumpCount = 0;
       var lastCommand = "n";
       var enabledExpressions = new Set();
       var breakpoints = [];
@@ -151,7 +152,7 @@ var command = {
           var lines = splitLines(source);
 
           config.logger.log("");
-
+          config.logger.log("Jump Count #"+jumpCount++);
           config.logger.log(
             DebugUtils.formatRangeLines(lines, range.lines)
           );


### PR DESCRIPTION
* Helps keeping track of how far the debugger is into the execution.
* Helps out for finding a good place to put breakpoints after hitting a
  revert.