### PR TITLE
Configurable Truffle Develop

### DIFF
--- a/packages/truffle-core/chain.js
+++ b/packages/truffle-core/chain.js
@@ -29,7 +29,7 @@ if (args.length == 2) {
   options = args[0];
 } else {
   ipcNetwork = "develop";
-  options = "{}";
+  options = process.argv || "{}";
 }
 
 try {
@@ -41,6 +41,9 @@ try {
 options.host = options.host || "127.0.0.1";
 options.port = options.port || 9545;
 options.network_id = options.network_id || 4447;
+options.total_accounts = options.total_accounts;
+options.default_ether_balance = options.default_ether_balance;
+options.blockTime = options.blockTime;
 options.mnemonic = options.mnemonic || "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat";
 options.gasLimit = options.gasLimit || 0x47e7c4;
 

--- a/packages/truffle-core/lib/commands/develop.js
+++ b/packages/truffle-core/lib/commands/develop.js
@@ -1,9 +1,9 @@
-var emoji = require('node-emoji');
-const mnemonicInfo = require('truffle-core/lib/mnemonics/mnemonic');
+var emoji = require("node-emoji");
+const mnemonicInfo = require("truffle-core/lib/mnemonics/mnemonic");
 
 var command = {
-  command: 'develop',
-  description: 'Open a console with a local development blockchain',
+  command: "develop",
+  description: "Open a console with a local development blockchain",
   builder: {
     log: {
       type: "boolean",
@@ -12,19 +12,14 @@ var command = {
   },
   help: {
     usage: "truffle develop",
-    options: [],
+    options: []
   },
   runConsole: function(config, testrpcOptions, done) {
     var Console = require("../console");
     var Environment = require("../environment");
 
-    var commands = require("./index")
-    var excluded = [
-      "console",
-      "init",
-      "watch",
-      "develop"
-    ];
+    var commands = require("./index");
+    var excluded = ["console", "init", "watch", "develop"];
 
     var available_commands = Object.keys(commands).filter(function(name) {
       return excluded.indexOf(name) == -1;
@@ -38,9 +33,12 @@ var command = {
     Environment.develop(config, testrpcOptions, function(err) {
       if (err) return done(err);
 
-      var c = new Console(console_commands, config.with({
-        noAliases: true
-      }));
+      var c = new Console(
+        console_commands,
+        config.with({
+          noAliases: true
+        })
+      );
 
       c.start(done);
       c.on("exit", function() {
@@ -48,16 +46,30 @@ var command = {
       });
     });
   },
-  run: function (options, done) {
+  run: function(options, done) {
     var Config = require("truffle-config");
     var Develop = require("../develop");
 
     var config = Config.detect(options);
+    var customConfig = config.networks.develop;
 
-    const { mnemonic, accounts, privateKeys } = mnemonicInfo.getAccountsInfo();
+    var numAddresses = customConfig.accounts
+      ? customConfig.accounts
+      : 10;
+    var defaultEtherBalance = customConfig.defaultEtherBalance
+      ? customConfig.defaultEtherBalance
+      : 100;
+    var bTime = customConfig.blockTime
+      ? customConfig.blockTime
+      : 0;
 
+    const { mnemonic, accounts, privateKeys } = mnemonicInfo.getAccountsInfo(
+      numAddresses
+    );
 
-    var onMissing = function(name){ return "**"};
+    var onMissing = function(name) {
+      return "**";
+    };
 
     var warning =
       ":warning:  Important :warning:  : " +
@@ -72,9 +84,12 @@ var command = {
       host: "127.0.0.1",
       port: 9545,
       network_id: 4447,
+      total_accounts: numAddresses,
+      default_balance_ether: defaultEtherBalance,
+      blockTime: bTime,
       mnemonic: mnemonic,
       gasLimit: config.gas,
-      noVMErrorsOnRPCResponse: true,
+      noVMErrorsOnRPCResponse: true
     };
 
     Develop.connectOrStart(ipcOptions, testrpcOptions, function(started) {
@@ -103,7 +118,9 @@ var command = {
         config.logger.log(emoji.emojify(warning, onMissing));
         config.logger.log();
       } else {
-        config.logger.log(`Connected to existing Truffle Develop session at ${url}`);
+        config.logger.log(
+          `Connected to existing Truffle Develop session at ${url}`
+        );
         config.logger.log();
       }
 
@@ -112,6 +129,6 @@ var command = {
       }
     });
   }
-}
+};
 
 module.exports = command;

--- a/packages/truffle-core/lib/environment.js
+++ b/packages/truffle-core/lib/environment.js
@@ -6,7 +6,6 @@ var Artifactor = require("truffle-artifactor");
 var TestRPC = require("ganache-cli");
 var spawn = require("child_process").spawn;
 var path = require("path");
-var Develop = require("./develop");
 
 var Environment = {
   // It's important config is a Config object and not a vanilla object

--- a/packages/truffle-core/lib/mnemonics/mnemonic.js
+++ b/packages/truffle-core/lib/mnemonics/mnemonic.js
@@ -10,7 +10,7 @@
 const Config = require('truffle-config');
 const defaultUserConfig = Config.getUserConfig();
 const seedrandom = require('seedrandom');
-const bip39 = require('bip39'); 
+const bip39 = require('bip39');
 const hdkey = require('ethereumjs-wallet/hdkey');
 const crypto = require('crypto');
 
@@ -34,11 +34,11 @@ const mnemonic = {
   },
 
   /**
-  * gets accounts object using mnemonic 
-  * @param {String}   
+  * gets accounts object using mnemonic
+  * @param {String}
   * @returns {Object} mnemonicObject
   */
-  getAccountsInfo: function () {
+  getAccountsInfo: function (numAddresses) {
 
     let mnemonic = this.getOrGenerateMnemonic();
     let accounts = [];
@@ -46,7 +46,6 @@ const mnemonic = {
 
     let hdwallet = hdkey.fromMasterSeed(bip39.mnemonicToSeed(mnemonic));
     let addressIndex = 0;
-    let numAddresses = 10;
     let walletHdpath = "m/44'/60'/0'/0/";
 
     for (let i = addressIndex; i < addressIndex + numAddresses; i++) {

--- a/packages/truffle-core/test/mnemonic.js
+++ b/packages/truffle-core/test/mnemonic.js
@@ -15,10 +15,12 @@ describe("mnemonic", function() {
   });
   describe("#getAccountsInfo", function(){
     it("returns public keys, private keys, and mnemonic for default user account", function() {
-      let accounts = accountsInfo.getAccountsInfo();
+      let defaultNumAddresses = 10;
+      let accounts = accountsInfo.getAccountsInfo(defaultNumAddresses);
       assert.exists(accounts);
       assert.isObject(accounts);
       assert.isArray(accounts.accounts);
+      assert.lengthOf(accounts.accounts, defaultNumAddresses);
       assert.isArray(accounts.privateKeys);
       assert.isString(accounts.mnemonic);
     });


### PR DESCRIPTION
## Feature

Addresses Feature Request #1090.

Now users can configure the number of accounts generated at startup (`accounts`), amount of ether assigned to each account on startup (`defaultEtherBalance`), and specify the block time in seconds for automatic mining (`blockTime`) for `truffle develop` in their `truffle.js` or `truffle-config.js` file.

Example:

```
module.exports = {
  networks: {
    develop: {
      accounts: 5,
      defaultEtherBalance: 500,
      blockTime: 3
    }
  }
};
```