### PR TITLE
Edit test for null build config

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm](https://img.shields.io/npm/v/truffle.svg)](https://www.npmjs.com/package/truffle)
 [![npm](https://img.shields.io/npm/dm/truffle.svg)](https://www.npmjs.com/package/truffle)
 [![Join the chat at https://gitter.im/consensys/truffle](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/consensys/truffle?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Build Status](https://travis-ci.org/trufflesuite/truffle.svg?branch=develop)](https://travis-ci.org/trufflesuite/truffle)
+[![Build Status](https://travis-ci.org/trufflesuite/truffle.svg?branch=next)](https://travis-ci.org/trufflesuite/truffle)
 [![Coverage Status](https://coveralls.io/repos/github/trufflesuite/truffle/badge.svg?branch=next)](https://coveralls.io/github/trufflesuite/truffle?branch=next)
 
 -----------------------

--- a/packages/truffle-core/lib/build.js
+++ b/packages/truffle-core/lib/build.js
@@ -74,7 +74,7 @@ const Build = {
     // Duplicate build directory for legacy purposes
     options.destination_directory = options.build_directory;
 
-    if (builder === null) {
+    if (builder === null || typeof builder === "undefined") {
       logger.log("No build configuration found. Preparing to compile contracts.");
     } else if (typeof builder === "string") {
       builder = new CommandBuilder(builder);

--- a/packages/truffle-core/lib/build.js
+++ b/packages/truffle-core/lib/build.js
@@ -74,7 +74,7 @@ const Build = {
     // Duplicate build directory for legacy purposes
     options.destination_directory = options.build_directory;
 
-    if (typeof builder === "undefined") {
+    if (builder === null) {
       logger.log("No build configuration found. Preparing to compile contracts.");
     } else if (typeof builder === "string") {
       builder = new CommandBuilder(builder);


### PR DESCRIPTION
Change the way truffle checks for a lack of build configuration.  The config now returns a `null` value instead of `undefined` when it is not set in the config.

Also update the travis build badge to indicate the build status of `next` and not `develop`.