### PR TITLE
Pluggable Config Packages

### DIFF
--- a/packages/truffle-config/index.js
+++ b/packages/truffle-config/index.js
@@ -327,6 +327,7 @@ Config.default = function() {
   return new Config();
 };
 
+
 Config.detect = function(options, filename) {
   var search;
 
@@ -344,14 +345,19 @@ Config.detect = function(options, filename) {
 };
 
 Config.load = function(file, options) {
-  var config = new Config();
+  var static_config = originalrequire(file);
+
+  var config = static_config.config
+    ? static_config.config
+    : require("truffle-config");
+
+  config = new config();
 
   config.working_directory = path.dirname(path.resolve(file));
 
   // The require-nocache module used to do this for us, but
   // it doesn't bundle very well. So we've pulled it out ourselves.
   delete require.cache[Module._resolveFilename(file, module)];
-  var static_config = originalrequire(file);
 
   config.merge(static_config);
   config.merge(options);

--- a/packages/truffle-core/cli.js
+++ b/packages/truffle-core/cli.js
@@ -11,7 +11,6 @@ if (nodeMajorVersion < 8) {
   process.exit(1);
 }
 
-const Config = require("truffle-config");
 const Command = require("./lib/command");
 
 const command = new Command(require("./lib/commands"));


### PR DESCRIPTION
## Feature

One small step towards pluggability...

Now users can bring their own config packages to return their own custom config objects and (theoretically) add support for non-native truffle commands and features.

Example:

```
module.exports = {
  config: require("advanced-truffle-config"),
  ...
};
```

Potentially overkill, but mainly added to test out making workflows pluggable.