### PR TITLE
Native .ts support for truffle tests

### DIFF
--- a/packages/truffle-config/index.js
+++ b/packages/truffle-config/index.js
@@ -2,10 +2,10 @@ var _ = require("lodash");
 var path = require("path");
 var Provider = require("truffle-provider");
 var TruffleError = require("truffle-error");
-var Module = require('module');
+var Module = require("module");
 var findUp = require("find-up");
 var originalrequire = require("original-require");
-const Configstore = require('configstore');
+const Configstore = require("configstore");
 
 var DEFAULT_CONFIG_FILENAME = "truffle.js";
 var BACKUP_CONFIG_FILENAME = "truffle-config.js"; // For Windows + Command Prompt
@@ -17,18 +17,23 @@ function Config(truffle_directory, working_directory, network) {
   var default_tx_values = {
     gas: 6721975,
     gasPrice: 20000000000, // 20 gwei,
-    from: null,
+    from: null
   };
 
-  const defaultUserConfig = new Configstore(DEFAULT_USER_CONFIG, {}, { globalConfigPath: true });
+  const defaultUserConfig = new Configstore(
+    DEFAULT_USER_CONFIG,
+    {},
+    { globalConfigPath: true }
+  );
 
   // This is a list of multi-level keys with defaults
   // we need to _.merge. Using this list for safety
   // vs. just merging all objects.
-  this._deepCopy = ['compilers'];
+  this._deepCopy = ["compilers"];
 
   this._values = {
-    truffle_directory: truffle_directory || path.resolve(path.join(__dirname, "../")),
+    truffle_directory:
+      truffle_directory || path.resolve(path.join(__dirname, "../")),
     working_directory: working_directory || process.cwd(),
     network: network,
     networks: {},
@@ -62,12 +67,11 @@ function Config(truffle_directory, working_directory, network) {
       vyper: {}
     },
     logger: {
-      log: function() {},
+      log: function() {}
     }
   };
 
-  const resolveDirectory = (value) =>
-    path.resolve(self.working_directory, value);
+  const resolveDirectory = value => path.resolve(self.working_directory, value);
 
   var props = {
     // These are already set.
@@ -104,7 +108,7 @@ function Config(truffle_directory, working_directory, network) {
       transform: resolveDirectory
     },
     test_file_extension_regexp: function() {
-      return /.*\.(js|es|es6|jsx|sol)$/;
+      return /.*\.(js|ts|es|es6|jsx|sol)$/;
     },
     example_project_directory: {
       default: () => path.join(self.truffle_directory, "example"),
@@ -119,7 +123,9 @@ function Config(truffle_directory, working_directory, network) {
         }
       },
       set: function(val) {
-        throw new Error("Do not set config.network_id. Instead, set config.networks and then config.networks[<network name>].network_id");
+        throw new Error(
+          "Do not set config.network_id. Instead, set config.networks and then config.networks[<network name>].network_id"
+        );
       }
     },
     network_config: {
@@ -141,7 +147,9 @@ function Config(truffle_directory, working_directory, network) {
         return conf;
       },
       set: function(val) {
-        throw new Error("Don't set config.network_config. Instead, set config.networks with the desired values.");
+        throw new Error(
+          "Don't set config.network_config. Instead, set config.networks with the desired values."
+        );
       }
     },
     from: {
@@ -153,7 +161,9 @@ function Config(truffle_directory, working_directory, network) {
         }
       },
       set: function(val) {
-        throw new Error("Don't set config.from directly. Instead, set config.networks and then config.networks[<network name>].from");
+        throw new Error(
+          "Don't set config.from directly. Instead, set config.networks and then config.networks[<network name>].from"
+        );
       }
     },
     gas: {
@@ -165,7 +175,9 @@ function Config(truffle_directory, working_directory, network) {
         }
       },
       set: function(val) {
-        throw new Error("Don't set config.gas directly. Instead, set config.networks and then config.networks[<network name>].gas");
+        throw new Error(
+          "Don't set config.gas directly. Instead, set config.networks and then config.networks[<network name>].gas"
+        );
       }
     },
     gasPrice: {
@@ -177,7 +189,9 @@ function Config(truffle_directory, working_directory, network) {
         }
       },
       set: function(val) {
-        throw new Error("Don't set config.gasPrice directly. Instead, set config.networks and then config.networks[<network name>].gasPrice");
+        throw new Error(
+          "Don't set config.gasPrice directly. Instead, set config.networks and then config.networks[<network name>].gasPrice"
+        );
       }
     },
     provider: {
@@ -191,7 +205,9 @@ function Config(truffle_directory, working_directory, network) {
         return Provider.create(options);
       },
       set: function(val) {
-        throw new Error("Don't set config.provider directly. Instead, set config.networks and then set config.networks[<network name>].provider");
+        throw new Error(
+          "Don't set config.provider directly. Instead, set config.networks and then set config.networks[<network name>].provider"
+        );
       }
     },
     confirmations: {
@@ -203,7 +219,9 @@ function Config(truffle_directory, working_directory, network) {
         }
       },
       set: function(val) {
-        throw new Error("Don't set config.confirmations directly. Instead, set config.networks and then config.networks[<network name>].confirmations");
+        throw new Error(
+          "Don't set config.confirmations directly. Instead, set config.networks and then config.networks[<network name>].confirmations"
+        );
       }
     },
     production: {
@@ -215,11 +233,13 @@ function Config(truffle_directory, working_directory, network) {
         }
       },
       set: function(val) {
-        throw new Error("Don't set config.production directly. Instead, set config.networks and then config.networks[<network name>].production");
+        throw new Error(
+          "Don't set config.production directly. Instead, set config.networks and then config.networks[<network name>].production"
+        );
       }
     },
     timeoutBlocks: {
-      get: function(){
+      get: function() {
         try {
           return self.network_config.timeoutBlocks;
         } catch (e) {
@@ -227,11 +247,13 @@ function Config(truffle_directory, working_directory, network) {
         }
       },
       set: function(val) {
-        throw new Error("Don't set config.timeoutBlocks directly. Instead, set config.networks and then config.networks[<network name>].timeoutBlocks");
+        throw new Error(
+          "Don't set config.timeoutBlocks directly. Instead, set config.networks and then config.networks[<network name>].timeoutBlocks"
+        );
       }
     },
     skipDryRun: {
-      get: function(){
+      get: function() {
         try {
           return self.network_config.skipDryRun;
         } catch (e) {
@@ -239,16 +261,17 @@ function Config(truffle_directory, working_directory, network) {
         }
       },
       set: function(val) {
-        throw new Error("Don't set config.skipDryRun directly. Instead, set config.networks and then config.networks[<network name>].skipDryRun");
+        throw new Error(
+          "Don't set config.skipDryRun directly. Instead, set config.networks and then config.networks[<network name>].skipDryRun"
+        );
       }
     }
-
   };
 
   Object.keys(props).forEach(function(prop) {
     self.addProp(prop, props[prop]);
   });
-};
+}
 
 Config.prototype.addProp = function(propertyName, descriptor) {
   // possible property descriptors
@@ -259,25 +282,29 @@ Config.prototype.addProp = function(propertyName, descriptor) {
   // transform: specify function to transform value when (used by set)
   Object.defineProperty(this, propertyName, {
     // retrieve config property value
-    get: descriptor.get || function() {
-      // value is specified
-      if (propertyName in this._values) {
-        return this._values[propertyName];
-      }
+    get:
+      descriptor.get ||
+      function() {
+        // value is specified
+        if (propertyName in this._values) {
+          return this._values[propertyName];
+        }
 
-      // default getter is specified
-      if (descriptor.default) {
-        return descriptor.default();
-      };
+        // default getter is specified
+        if (descriptor.default) {
+          return descriptor.default();
+        }
 
-      // descriptor is a function
-      return descriptor();
-    },
-    set: descriptor.set || function(value) {
-      this._values[propertyName] = (descriptor.transform)
-        ? descriptor.transform(value)
-        : value;
-    },
+        // descriptor is a function
+        return descriptor();
+      },
+    set:
+      descriptor.set ||
+      function(value) {
+        this._values[propertyName] = descriptor.transform
+          ? descriptor.transform(value)
+          : value;
+      },
     configurable: true,
     enumerable: true
   });
@@ -309,7 +336,7 @@ Config.prototype.merge = function(obj) {
   // Only set keys for values that don't throw.
   Object.keys(obj).forEach(function(key) {
     try {
-      if (typeof clone[key] === 'object' && self._deepCopy.includes(key)){
+      if (typeof clone[key] === "object" && self._deepCopy.includes(key)) {
         self[key] = _.merge(self[key], clone[key]);
       } else {
         self[key] = clone[key];
@@ -329,11 +356,13 @@ Config.default = function() {
 Config.detect = function(options, filename) {
   var search;
 
-  (!filename)
-    ? search = [DEFAULT_CONFIG_FILENAME, BACKUP_CONFIG_FILENAME]
-    : search = filename;
+  !filename
+    ? (search = [DEFAULT_CONFIG_FILENAME, BACKUP_CONFIG_FILENAME])
+    : (search = filename);
 
-  var file = findUp.sync(search, {cwd: options.working_directory || options.workingDirectory});
+  var file = findUp.sync(search, {
+    cwd: options.working_directory || options.workingDirectory
+  });
 
   if (file == null) {
     throw new TruffleError("Could not find suitable configuration file.");
@@ -359,7 +388,7 @@ Config.load = function(file, options) {
 };
 
 Config.getUserConfig = function() {
-  return new Configstore('truffle', {}, { globalConfigPath: true });
+  return new Configstore("truffle", {}, { globalConfigPath: true });
 };
 
 module.exports = Config;

--- a/packages/truffle/test/scenarios/typescript_testing/typescriptTests.js
+++ b/packages/truffle/test/scenarios/typescript_testing/typescriptTests.js
@@ -1,0 +1,56 @@
+const Box = require("truffle-box");
+const MemoryLogger = require("../memorylogger");
+const CommandRunner = require("../commandrunner");
+const assert = require("assert");
+const Reporter = require("../reporter");
+const Server = require("../server");
+
+describe("Typescript Tests", () => {
+  const logger = new MemoryLogger();
+  let config;
+
+  function processErr(err, output) {
+    if (err) {
+      console.log(output);
+      throw new Error(err);
+    }
+  }
+
+  before(done => Server.start(done));
+  after(done => Server.stop(done));
+
+  before("set up sandbox", function(done) {
+    this.timeout(10000);
+
+    Box.sandbox("default#typescript", (err, conf) => {
+      if (err) return done(err);
+      config = conf;
+      config.logger = logger;
+      config.network = "development";
+      config.mocha = {
+        reporter: new Reporter(logger)
+      };
+      done();
+    });
+  });
+
+  describe("testing contract behavior", () => {
+    it("will run .ts tests and have the correct behavior", done => {
+      CommandRunner.run("test test/metacoin.ts", config, err => {
+        const output = logger.contents();
+        processErr(err, output);
+        assert(output.includes("3 passing"));
+        done();
+      });
+    }).timeout(70000);
+
+    it("will detect and run .sol, .ts, & .js test files", done => {
+      CommandRunner.run("test", config, err => {
+        const output = logger.contents();
+        processErr(err, output);
+        assert(output.includes("8 passing"));
+        done();
+      });
+    }).timeout(70000);
+  });
+});


### PR DESCRIPTION
## Feature

Allows native .ts support for truffle tests.

Currently, users have to add a workaround to their config file in order to support .ts test files.

For example:

```
module.exports = {
  test_file_extension_regexp: /.*\.ts$/,
  ....
};
```

Steps to Test:

https://github.com/ethereum-ts/truffle-typechain-example#setup (minus the config workaround)