### PR TITLE
Fix Truffle Develop Undefined Bug

### DIFF
--- a/packages/truffle-core/lib/commands/develop.js
+++ b/packages/truffle-core/lib/commands/develop.js
@@ -19,11 +19,7 @@ var command = {
     var Environment = require("../environment");
 
     var commands = require("./index");
-    var excluded = [
-      "console",
-      "init",
-      "develop"
-    ];
+    var excluded = ["console", "init", "develop"];
 
     var available_commands = Object.keys(commands).filter(function(name) {
       return excluded.indexOf(name) == -1;
@@ -56,16 +52,17 @@ var command = {
 
     var config = Config.detect(options);
     var customConfig = config.networks.develop;
+    let numAddresses = 10;
+    let defaultEtherBalance = 100;
+    let bTime = 0;
 
-    var numAddresses = customConfig.accounts
-      ? customConfig.accounts
-      : 10;
-    var defaultEtherBalance = customConfig.defaultEtherBalance
-      ? customConfig.defaultEtherBalance
-      : 100;
-    var bTime = customConfig.blockTime
-      ? customConfig.blockTime
-      : 0;
+    if (customConfig) {
+      numAddresses = customConfig.accounts ? customConfig.accounts : 10;
+      defaultEtherBalance = customConfig.defaultEtherBalance
+        ? customConfig.defaultEtherBalance
+        : 100;
+      bTime = customConfig.blockTime ? customConfig.blockTime : 0;
+    }
 
     const { mnemonic, accounts, privateKeys } = mnemonicInfo.getAccountsInfo(
       numAddresses


### PR DESCRIPTION
## Bug Fix

Truffle develop broke on next because of a failed conditional check.

Calling `truffle develop` would return something like:

```
TypeError: Cannot read property 'accounts' of undefined
    at Object.run (/truffle-projects/truffle/packages/truffle-core/lib/commands/develop.js:60:18)
    at Command.run (/truffle-projects/truffle/packages/truffle-core/lib/command.js:103:20)
    at Object.<anonymous> (/truffle-projects/truffle/packages/truffle-core/cli.js:40:9)
    ...
```

New expected Behavior:

```
truffle develop
Truffle Develop started at http://127.0.0.1:9545/

Accounts:
(0) 0xb21c7f82d974f7fb83651b7b3a3e6631c0c4028b
(1) 0xb10152e844cf7e5d3983b91cb6c347761fe506f1
(2) 0x38a7dea9500c193478f72a8fa66ec10f2304c689
(3) 0xbf65982f7c3949833c6ca7560eb3cbc4533b22a2
(4) 0x54ec0c29a5f2a251a28b4ed4361f50d6c2ba9e25
(5) 0x8e889e03b973e2a4ee0923f7054eb0891ae4e0e9
...

```