### PR TITLE
Default Console & Migration network settings to GanacheUI

### DIFF
--- a/packages/truffle-core/lib/commands/console.js
+++ b/packages/truffle-core/lib/commands/console.js
@@ -1,42 +1,33 @@
 var command = {
-  command: 'console',
-  description: 'Run a console with contract abstractions and commands available',
+  command: "console",
+  description:
+    "Run a console with contract abstractions and commands available",
   builder: {},
   help: {
     usage: "truffle console [--network <name>] [--verbose-rpc]",
     options: [
       {
         option: "--network <name>",
-        description: "Specify the network to use. Network name must exist in the configuration.",
-      },{
-        option: "--verbose-rpc",
-        description: "Log communication between Truffle and the Ethereum client.",
+        description:
+          "Specify the network to use. Network name must exist in the configuration."
       },
+      {
+        option: "--verbose-rpc",
+        description:
+          "Log communication between Truffle and the Ethereum client."
+      }
     ]
   },
-  run: function (options, done) {
+  run: function(options, done) {
     var Config = require("truffle-config");
     var Console = require("../console");
     var Environment = require("../environment");
-    var TruffleError = require("truffle-error");
 
     var config = Config.detect(options);
 
-    if (!config.network && !config.networks.development) {
-      return done(new TruffleError(
-        "No network available. Use `truffle develop` " +
-          "or add network to truffle.js config."
-      ));
-    }
-
     // This require a smell?
     var commands = require("./index");
-    var excluded = [
-      "console",
-      "init",
-      "watch",
-      "develop"
-    ];
+    var excluded = ["console", "init", "watch", "develop"];
 
     var available_commands = Object.keys(commands).filter(function(name) {
       return excluded.indexOf(name) == -1;
@@ -50,9 +41,12 @@ var command = {
     Environment.detect(config, function(err) {
       if (err) return done(err);
 
-      var c = new Console(console_commands, config.with({
-        noAliases: true
-      }));
+      var c = new Console(
+        console_commands,
+        config.with({
+          noAliases: true
+        })
+      );
       c.start(done);
     });
   }

--- a/packages/truffle-core/lib/environment.js
+++ b/packages/truffle-core/lib/environment.js
@@ -18,18 +18,17 @@ var Environment = {
       config.artifactor = new Artifactor(config.contracts_build_directory);
     }
 
-    if (!config.network && config.networks["development"]) {
-      config.network = "development";
-    }
-
     if (!config.network) {
-      config.network = "ganache";
-      config.networks[config.network] = {
-        host: "127.0.0.1",
-        port: 7545,
-        network_id: 5777
-      };
-      //return callback(new Error("No network specified. Cannot determine current network."));
+      if (config.networks["development"]) {
+        config.network = "development";
+      } else {
+        config.network = "ganache";
+        config.networks[config.network] = {
+          host: "127.0.0.1",
+          port: 7545,
+          network_id: 5777
+        };
+      }
     }
 
     var network_config = config.networks[config.network];

--- a/packages/truffle-core/lib/environment.js
+++ b/packages/truffle-core/lib/environment.js
@@ -8,9 +8,7 @@ var TestRPC = require("ganache-cli");
 var Environment = {
   // It's important config is a Config object and not a vanilla object
   detect: function(config, callback) {
-    expect.options(config, [
-      "networks"
-    ]);
+    expect.options(config, ["networks"]);
 
     if (!config.resolver) {
       config.resolver = new Resolver(config);
@@ -25,19 +23,37 @@ var Environment = {
     }
 
     if (!config.network) {
-      return callback(new Error("No network specified. Cannot determine current network."));
+      config.network = "ganache";
+      config.networks[config.network] = {
+        host: "127.0.0.1",
+        port: 7545,
+        network_id: 5777
+      };
+      //return callback(new Error("No network specified. Cannot determine current network."));
     }
 
     var network_config = config.networks[config.network];
 
     if (!network_config) {
-      return callback(new TruffleError("Unknown network \"" + config.network + "\". See your Truffle configuration file for available networks."));
+      return callback(
+        new TruffleError(
+          'Unknown network "' +
+            config.network +
+            '". See your Truffle configuration file for available networks.'
+        )
+      );
     }
 
     var network_id = config.networks[config.network].network_id;
 
     if (network_id == null) {
-      return callback(new Error("You must specify a network_id in your '" + config.network + "' configuration in order to use this network."));
+      return callback(
+        new Error(
+          "You must specify a network_id in your '" +
+            config.network +
+            "' configuration in order to use this network."
+        )
+      );
     }
 
     var web3 = new Web3(config.provider);
@@ -49,13 +65,14 @@ var Environment = {
 
       // We have a "*" network. Get the current network and replace it with the real one.
       // TODO: Should we replace this with the blockchain uri?
-      web3.eth.net.getId().then(id => {
-
-        network_id = id;
-        config.networks[config.network].network_id = network_id;
-        done(null, network_id);
-
-      }).catch(callback);
+      web3.eth.net
+        .getId()
+        .then(id => {
+          network_id = id;
+          config.networks[config.network].network_id = network_id;
+          done(null, network_id);
+        })
+        .catch(callback);
     }
 
     function detectFromAddress(done) {
@@ -63,12 +80,13 @@ var Environment = {
         return done();
       }
 
-      web3.eth.getAccounts().then(accounts => {
-
-        config.networks[config.network].from = accounts[0];
-        done();
-
-      }).catch(done);
+      web3.eth
+        .getAccounts()
+        .then(accounts => {
+          config.networks[config.network].from = accounts[0];
+          done();
+        })
+        .catch(done);
     }
 
     detectNetworkId(function(err) {
@@ -79,15 +97,13 @@ var Environment = {
 
   // Ensure you call Environment.detect() first.
   fork: async function(config, callback) {
-    expect.options(config, [
-      "from"
-    ]);
+    expect.options(config, ["from"]);
 
     var web3 = new Web3(config.provider);
 
     try {
       var accounts = await web3.eth.getAccounts();
-      var block = await web3.eth.getBlock('latest');
+      var block = await web3.eth.getBlock("latest");
 
       var upstreamNetwork = config.network;
       var upstreamConfig = config.networks[upstreamNetwork];
@@ -107,18 +123,13 @@ var Environment = {
       config.network = forkedNetwork;
 
       callback();
-
-    } catch(err){
+    } catch (err) {
       callback(err);
-    };
+    }
   },
 
   develop: function(config, testrpcOptions, callback) {
-    var self = this;
-
-    expect.options(config, [
-      "networks",
-    ]);
+    expect.options(config, ["networks"]);
 
     var network = config.network || "develop";
     var url = `http://${testrpcOptions.host}:${testrpcOptions.port}/`;


### PR DESCRIPTION
## Feature

Default `truffle console` & `truffle migrate` to use GanacheUI network settings when no network configuration is defined. The network will be defined as `ganache`.

To override the default settings, `truffle migrate --network ganache` or `truffle console --network ganache` will need to be specified with modified `networks.ganache` network settings defined in `truffle-config.js`.

Example of overriding `networks.ganache` to use ganache-cli instead of GanacheUI:

```
module.exports = {
  networks: {
    ganache: {
      host: "127.0.0.1",
      port: 8545,
      network_id: "*"
    }
  }
};
```

Steps to Test:

Run `truffle migrate` or `truffle console` in a truffle project directory with GanacheUI running in the background.