### PR TITLE
fix mnemonic tests to not actually hit the user config

### DIFF
--- a/packages/truffle-core/lib/mnemonics/mnemonic.js
+++ b/packages/truffle-core/lib/mnemonics/mnemonic.js
@@ -1,44 +1,44 @@
 /**
-* @module mnemonic;
-* @requires module:truffle-config
-* @requires module:seedrandom
-* @requires module:bip39
-* @requires module:ethereumjs-wallet/hdkey
-* @requires module:crypto
-*/
+ * @module mnemonic;
+ * @requires module:truffle-config
+ * @requires module:seedrandom
+ * @requires module:bip39
+ * @requires module:ethereumjs-wallet/hdkey
+ * @requires module:crypto
+ */
 
-const Config = require('truffle-config');
+const Config = require("truffle-config");
 const defaultUserConfig = Config.getUserConfig();
-const bip39 = require('bip39'); 
-const hdkey = require('ethereumjs-wallet/hdkey');
-const crypto = require('crypto');
+const bip39 = require("bip39");
+const hdkey = require("ethereumjs-wallet/hdkey");
+const crypto = require("crypto");
 
 const mnemonic = {
-
   /**
-  * gets user-level mnemonic from user config, and if missing generates a new mnemonic
-  * @returns {String} mnemonic
-  */
-  getOrGenerateMnemonic: function () {
+   * gets user-level mnemonic from user config, and if missing generates a new mnemonic
+   * @returns {String} mnemonic
+   */
+  getOrGenerateMnemonic: function() {
     let mnemonic;
     const userMnemonicExists = defaultUserConfig.get("mnemonic");
-    if(!userMnemonicExists) {
-      mnemonic = bip39.entropyToMnemonic(crypto.randomBytes(16).toString('hex'));
-      defaultUserConfig.set({"mnemonic": mnemonic});
+    if (!userMnemonicExists) {
+      mnemonic = bip39.entropyToMnemonic(
+        crypto.randomBytes(16).toString("hex")
+      );
+      defaultUserConfig.set({ mnemonic: mnemonic });
     } else {
-      mnemonic = defaultUserConfig.get("mnemonic");
+      mnemonic = userMnemonicExists;
     }
 
     return mnemonic;
   },
 
   /**
-  * gets accounts object using mnemonic
-  * @param {String}
-  * @returns {Object} mnemonicObject
-  */
-  getAccountsInfo: function (numAddresses) {
-
+   * gets accounts object using mnemonic
+   * @param {String}
+   * @returns {Object} mnemonicObject
+   */
+  getAccountsInfo: function(numAddresses) {
     let mnemonic = this.getOrGenerateMnemonic();
     let accounts = [];
     let privateKeys = [];
@@ -49,8 +49,8 @@ const mnemonic = {
 
     for (let i = addressIndex; i < addressIndex + numAddresses; i++) {
       let wallet = hdwallet.derivePath(walletHdpath + i).getWallet();
-      let addr = '0x' + wallet.getAddress().toString('hex');
-      let privKey = wallet.getPrivateKey().toString('hex');
+      let addr = "0x" + wallet.getAddress().toString("hex");
+      let privKey = wallet.getPrivateKey().toString("hex");
       accounts.push(addr);
       privateKeys.push(privKey);
     }
@@ -58,7 +58,7 @@ const mnemonic = {
     return {
       mnemonic,
       accounts,
-      privateKeys,
+      privateKeys
     };
   }
 };

--- a/packages/truffle-core/test/mnemonic.js
+++ b/packages/truffle-core/test/mnemonic.js
@@ -1,19 +1,31 @@
 const assert = require("chai").assert;
+const sinon = require("sinon");
 const accountsInfo = require("../lib/mnemonics/mnemonic");
-const Config = require('truffle-config');
-const defaultUserConfig = Config.getUserConfig();
-
+const Configstore = require("configstore");
 
 describe("mnemonic", function() {
-  describe("#getOrGenerateMnemonic", function(){
+  beforeEach(() => {
+    sinon
+      .stub(Configstore.prototype, "get")
+      .returns(
+        "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat"
+      );
+    sinon.stub(Configstore.prototype, "set");
+  });
+  afterEach(() => {
+    Configstore.prototype.get.restore();
+    Configstore.prototype.set.restore();
+  });
+  describe("#getOrGenerateMnemonic", function() {
     it("checks user-level configuration for mnemonic and creates one if one is not present", function() {
       let mnemonic = accountsInfo.getOrGenerateMnemonic();
+      sinon.assert.calledOnce(Configstore.prototype.get);
       assert.exists(mnemonic);
       assert.isString(mnemonic);
-      assert.equal(mnemonic, defaultUserConfig.get('mnemonic'));
+      assert.equal(mnemonic, Configstore.prototype.get("mnemonic"));
     });
   });
-  describe("#getAccountsInfo", function(){
+  describe("#getAccountsInfo", function() {
     it("returns public keys, private keys, and mnemonic for default user account", function() {
       let defaultNumAddresses = 10;
       let accounts = accountsInfo.getAccountsInfo(defaultNumAddresses);
@@ -23,6 +35,7 @@ describe("mnemonic", function() {
       assert.lengthOf(accounts.accounts, defaultNumAddresses);
       assert.isArray(accounts.privateKeys);
       assert.isString(accounts.mnemonic);
+      sinon.assert.calledOnce(Configstore.prototype.get);
     });
   });
 });


### PR DESCRIPTION
Previous tests for the mnemonics user config code were actually hitting the user config directly, which is not ideal. This fix stubs that bit of code so that the user config is left out of it while testing. 

When running npm test in truffle-core, tests should pass, and the mnemonic used is just a default, "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat", rather than the actual mnemonic in the user config. Also, if a mnemonic is not set in the user config, one will not be set by the test (this was not likely to happen anyway, just being extra cautious). 