### PR TITLE
Fix coverage & CompilerSupplier Method

### DIFF
--- a/packages/truffle-artifactor/test/contracts.js
+++ b/packages/truffle-artifactor/test/contracts.js
@@ -22,22 +22,24 @@ describe("artifactor + require", function() {
   web3.setProvider(provider);
 
   before(function() {
-    return web3
-      .eth
-      .net
-      .getId()
-      .then(id => network_id = id);
+    return web3.eth.net.getId().then(id => (network_id = id));
   });
 
   before(function(done) {
-    this.timeout(10000);
+    this.timeout(20000);
 
     // Compile first
-    var result = solc.compile(fs.readFileSync("./test/Example.sol", {encoding: "utf8"}), 1);
+    var result = solc.compile(
+      fs.readFileSync("./test/Example.sol", { encoding: "utf8" }),
+      1
+    );
 
     // Clean up after solidity. Only remove solidity's listener,
     // which happens to be the first.
-    process.removeListener("uncaughtException", process.listeners("uncaughtException")[0] || function(){});
+    process.removeListener(
+      "uncaughtException",
+      process.listeners("uncaughtException")[0] || function() {}
+    );
 
     var compiled = Schema.normalize(result.contracts[":Example"]);
     abi = compiled.abi;
@@ -46,37 +48,38 @@ describe("artifactor + require", function() {
     // Setup
     var dirPath = temp.mkdirSync({
       dir: path.resolve("./"),
-      prefix: 'tmp-test-contract-'
+      prefix: "tmp-test-contract-"
     });
 
     var expected_filepath = path.join(dirPath, "Example.json");
 
     artifactor = new Artifactor(dirPath);
 
-    artifactor.save({
-      contractName: "Example",
-      abi: abi,
-      binary: binary,
-      address: "0xe6e1652a0397e078f434d6dda181b218cfd42e01",
-      network_id: network_id
-    }).then(function() {
-      var json = requireNoCache(expected_filepath);
-      Example = contract(json);
-      Example.setProvider(provider);
-    }).then(done).catch(done);
+    artifactor
+      .save({
+        contractName: "Example",
+        abi: abi,
+        binary: binary,
+        address: "0xe6e1652a0397e078f434d6dda181b218cfd42e01",
+        network_id: network_id
+      })
+      .then(function() {
+        var json = requireNoCache(expected_filepath);
+        Example = contract(json);
+        Example.setProvider(provider);
+      })
+      .then(done)
+      .catch(done);
   });
 
   before(function() {
-    return web3
-      .eth
-      .getAccounts()
-      .then(accs => {
-        accounts = accs;
+    return web3.eth.getAccounts().then(accs => {
+      accounts = accs;
 
-        Example.defaults({
-          from: accounts[0]
-        });
+      Example.defaults({
+        from: accounts[0]
       });
+    });
   });
 
   after(function(done) {
@@ -85,118 +88,171 @@ describe("artifactor + require", function() {
   });
 
   it("should set the transaction hash of contract instantiation", function() {
-    return Example.new(1, {gas: 3141592}).then(function(example) {
+    return Example.new(1, { gas: 3141592 }).then(function(example) {
       assert(example.transactionHash, "transactionHash should be non-empty");
     });
   });
 
   it("should get and set values via methods and get values via .call", function(done) {
     var example;
-    Example.new(1, {gas: 3141592}).then(function(instance) {
-      example = instance;
-      return example.value.call();
-    }).then(function(value) {
-      assert.equal(value.valueOf(), 1, "Starting value should be 1");
-      return example.setValue(5);
-    }).then(function(tx) {
-      return example.value.call();
-    }).then(function(value) {
-      assert.equal(parseInt(value), 5, "Ending value should be five");
-    }).then(done).catch(done);
+    Example.new(1, { gas: 3141592 })
+      .then(function(instance) {
+        example = instance;
+        return example.value.call();
+      })
+      .then(function(value) {
+        assert.equal(value.valueOf(), 1, "Starting value should be 1");
+        return example.setValue(5);
+      })
+      .then(() => {
+        return example.value.call();
+      })
+      .then(function(value) {
+        assert.equal(parseInt(value), 5, "Ending value should be five");
+      })
+      .then(done)
+      .catch(done);
   });
 
   it("shouldn't synchronize constant functions", function(done) {
     var example;
-    Example.new(5, {gas: 3141592}).then(function(instance) {
-      example = instance;
-      return example.getValue();
-    }).then(function(value) {
-      assert.equal(value.valueOf(), 5, "Value should have been retrieved without explicitly calling .call()");
-    }).then(done).catch(done);
+    Example.new(5, { gas: 3141592 })
+      .then(function(instance) {
+        example = instance;
+        return example.getValue();
+      })
+      .then(function(value) {
+        assert.equal(
+          value.valueOf(),
+          5,
+          "Value should have been retrieved without explicitly calling .call()"
+        );
+      })
+      .then(done)
+      .catch(done);
   });
 
   it("should allow BigNumbers as input parameters, and not confuse them as transaction objects", function(done) {
     // BigNumber passed on new()
     var example = null;
-    Example.new('30', {gas: 3141592}).then(function(instance) {
-      example = instance;
-      return example.value.call();
-    }).then(function(value) {
-      assert.equal(parseInt(value), 30, "Starting value should be 30");
-      // BigNumber passed in a transaction.
-      return example.setValue('25', {gas: 3141592});
-    }).then(function(tx) {
-      return example.value.call();
-    }).then(function(value) {
-      assert.equal(parseInt(value), 25, "Ending value should be twenty-five");
-      // BigNumber passed in a call.
-      return example.parrot.call(865);
-    }).then(function(parrot_value) {
-      assert.equal(parseInt(parrot_value), 865, "Parrotted value should equal 865");
-    }).then(done).catch(done);
+    Example.new("30", { gas: 3141592 })
+      .then(function(instance) {
+        example = instance;
+        return example.value.call();
+      })
+      .then(function(value) {
+        assert.equal(parseInt(value), 30, "Starting value should be 30");
+        // BigNumber passed in a transaction.
+        return example.setValue("25", { gas: 3141592 });
+      })
+      .then(() => {
+        return example.value.call();
+      })
+      .then(function(value) {
+        assert.equal(parseInt(value), 25, "Ending value should be twenty-five");
+        // BigNumber passed in a call.
+        return example.parrot.call(865);
+      })
+      .then(function(parrot_value) {
+        assert.equal(
+          parseInt(parrot_value),
+          865,
+          "Parrotted value should equal 865"
+        );
+      })
+      .then(done)
+      .catch(done);
   });
 
   it("should return transaction hash, logs and receipt when using synchronised transactions", function(done) {
     var example = null;
-    Example.new('1', {gas: 3141592}).then(function(instance) {
-      example = instance;
-      return example.triggerEvent();
-    }).then(function(result) {
-      assert.isDefined(result.tx, "transaction hash wasn't returned");
-      assert.isDefined(result.logs, "synchronized transaction didn't return any logs");
-      assert.isDefined(result.receipt, "synchronized transaction didn't return a receipt");
-      assert.isOk(result.tx.length > 42, "Unexpected transaction hash"); // There has to be a better way to do this.
-      assert.equal(result.tx, result.receipt.transactionHash, "Transaction had different hash than receipt");
-      assert.equal(result.logs.length, 1, "logs array expected to be 1");
+    Example.new("1", { gas: 3141592 })
+      .then(function(instance) {
+        example = instance;
+        return example.triggerEvent();
+      })
+      .then(function(result) {
+        assert.isDefined(result.tx, "transaction hash wasn't returned");
+        assert.isDefined(
+          result.logs,
+          "synchronized transaction didn't return any logs"
+        );
+        assert.isDefined(
+          result.receipt,
+          "synchronized transaction didn't return a receipt"
+        );
+        assert.isOk(result.tx.length > 42, "Unexpected transaction hash"); // There has to be a better way to do this.
+        assert.equal(
+          result.tx,
+          result.receipt.transactionHash,
+          "Transaction had different hash than receipt"
+        );
+        assert.equal(result.logs.length, 1, "logs array expected to be 1");
 
-      var log = result.logs[0];
+        var log = result.logs[0];
 
-      assert.equal("ExampleEvent", log.event);
-      assert.equal(accounts[0], log.args._from);
-      assert.equal(8, log.args.num); // 8 is a magic number inside Example.sol
-    }).then(done).catch(done);
+        assert.equal("ExampleEvent", log.event);
+        assert.equal(accounts[0], log.args._from);
+        assert.equal(8, log.args.num); // 8 is a magic number inside Example.sol
+      })
+      .then(done)
+      .catch(done);
   });
 
   it("should trigger the fallback function when calling sendTransaction()", function() {
     var example = null;
-    return Example.new('1', {gas: 3141592}).then(function(instance) {
-      example = instance;
-      return example.fallbackTriggered();
-    }).then(function(triggered) {
-      assert(triggered == false, "Fallback should not have been triggered yet");
-      return example.sendTransaction({
-        value: web3.utils.toWei('1', "ether")
-      });
-    }).then(function(results) {
-      return new Promise(function(accept, reject) {
-        return web3.eth.getBalance(example.address, function(err, balance) {
-          if (err) return reject(err);
-          accept(balance);
+    return Example.new("1", { gas: 3141592 })
+      .then(function(instance) {
+        example = instance;
+        return example.fallbackTriggered();
+      })
+      .then(function(triggered) {
+        assert(
+          triggered == false,
+          "Fallback should not have been triggered yet"
+        );
+        return example.sendTransaction({
+          value: web3.utils.toWei("1", "ether")
         });
+      })
+      .then(() => {
+        return new Promise(function(accept, reject) {
+          return web3.eth.getBalance(example.address, function(err, balance) {
+            if (err) return reject(err);
+            accept(balance);
+          });
+        });
+      })
+      .then(function(balance) {
+        assert(balance == web3.utils.toWei("1", "ether"));
       });
-    }).then(function(balance) {
-      assert(balance == web3.utils.toWei('1', "ether"));
-    });
   });
 
   it("should trigger the fallback function when calling send() (shorthand notation)", function() {
     var example = null;
-    return Example.new('1', {gas: 3141592}).then(function(instance) {
-      example = instance;
-      return example.fallbackTriggered();
-    }).then(function(triggered) {
-      assert(triggered == false, "Fallback should not have been triggered yet");
-      return example.send(web3.utils.toWei('1', "ether"));
-    }).then(function(results) {
-      return new Promise(function(accept, reject) {
-        return web3.eth.getBalance(example.address, function(err, balance) {
-          if (err) return reject(err);
-          accept(balance);
+    return Example.new("1", { gas: 3141592 })
+      .then(function(instance) {
+        example = instance;
+        return example.fallbackTriggered();
+      })
+      .then(function(triggered) {
+        assert(
+          triggered == false,
+          "Fallback should not have been triggered yet"
+        );
+        return example.send(web3.utils.toWei("1", "ether"));
+      })
+      .then(() => {
+        return new Promise(function(accept, reject) {
+          return web3.eth.getBalance(example.address, function(err, balance) {
+            if (err) return reject(err);
+            accept(balance);
+          });
         });
+      })
+      .then(function(balance) {
+        assert(balance == web3.utils.toWei("1", "ether"));
       });
-    }).then(function(balance) {
-      assert(balance == web3.utils.toWei('1', "ether"));
-    });
   });
 
   it("errors when setting an invalid provider", function(done) {
@@ -222,50 +278,55 @@ describe("artifactor + require", function() {
 
     assert.equal(NewExample.network_id, null);
 
-    NewExample.new(1, {gas: 3141592}).then(function(instance) {
-      // We have a network id in this case, with new(), since it was detected,
-      // but no further configuration.
-      assert.equal(NewExample.network_id, network_id);
-      assert.equal(NewExample.toJSON().networks[network_id], null);
+    NewExample.new(1, { gas: 3141592 })
+      .then(function(instance) {
+        // We have a network id in this case, with new(), since it was detected,
+        // but no further configuration.
+        assert.equal(NewExample.network_id, network_id);
+        assert.equal(NewExample.toJSON().networks[network_id], null);
 
-      NewExample.address = instance.address;
+        NewExample.address = instance.address;
 
-      assert.equal(NewExample.toJSON().networks[network_id].address, instance.address);
+        assert.equal(
+          NewExample.toJSON().networks[network_id].address,
+          instance.address
+        );
 
-      done();
-    }).catch(done);
+        done();
+      })
+      .catch(done);
   });
 
   it("doesn't error when calling .links() or .events() with no network configuration", function(done) {
     var event_abi = {
-      "anonymous": false,
-      "inputs": [
+      anonymous: false,
+      inputs: [
         {
-          "indexed": true,
-          "name": "nameHash",
-          "type": "bytes32"
+          indexed: true,
+          name: "nameHash",
+          type: "bytes32"
         },
         {
-          "indexed": true,
-          "name": "releaseHash",
-          "type": "bytes32"
+          indexed: true,
+          name: "releaseHash",
+          type: "bytes32"
         }
       ],
-      "name": "PackageRelease",
-      "type": "event"
+      name: "PackageRelease",
+      type: "event"
     };
 
     var MyContract = contract({
       contractName: "MyContract",
-      abi: [
-        event_abi
-      ],
-      binary: "0x12345678",
+      abi: [event_abi],
+      binary: "0x12345678"
     });
 
     MyContract.setNetwork(5);
 
-    var expected_event_topic = web3.utils.sha3("PackageRelease(bytes32,bytes32)");
+    var expected_event_topic = web3.utils.sha3(
+      "PackageRelease(bytes32,bytes32)"
+    );
 
     // We want to make sure these don't throw when a network configuration doesn't exist.
     // While we're at it, lets make sure we still get the event we expect.

--- a/packages/truffle-deployer/test/await.js
+++ b/packages/truffle-deployer/test/await.js
@@ -3,7 +3,7 @@ const Web3 = require("web3");
 const assert = require("assert");
 
 const Deployer = require("../index");
-const utils = require('./helpers/utils');
+const utils = require("./helpers/utils");
 
 describe("Deployer (async / await)", function() {
   let owner;
@@ -13,13 +13,14 @@ describe("Deployer (async / await)", function() {
   const web3 = new Web3(provider);
 
   beforeEach(async function() {
+    this.timeout(20000);
     networkId = await web3.eth.net.getId();
     const accounts = await web3.eth.getAccounts();
 
     owner = accounts[0];
     options = {
       contracts: null,
-      network: 'test',
+      network: "test",
       network_id: networkId,
       provider: provider
     };
@@ -31,12 +32,12 @@ describe("Deployer (async / await)", function() {
   afterEach(() => deployer.finish());
 
   it("single deploy()", async function() {
-    const Example = utils.getContract('Example', provider, networkId, owner);
-    options.contracts = [ Example ];
+    const Example = utils.getContract("Example", provider, networkId, owner);
+    options.contracts = [Example];
 
     deployer = new Deployer(options);
 
-    const migrate = async function(){
+    const migrate = async function() {
       await deployer.deploy(Example);
     };
 
@@ -47,18 +48,23 @@ describe("Deployer (async / await)", function() {
     assert(Example.transactionHash !== null);
 
     example = await Example.deployed();
-    assert(await example.id() === 'Example' );
+    assert((await example.id()) === "Example");
   });
 
-  it('deploy() with interdependent contracts', async function(){
-    const Example = utils.getContract('Example', provider, networkId, owner);
-    const UsesExample = utils.getContract('UsesExample', provider, networkId, owner);
+  it("deploy() with interdependent contracts", async function() {
+    const Example = utils.getContract("Example", provider, networkId, owner);
+    const UsesExample = utils.getContract(
+      "UsesExample",
+      provider,
+      networkId,
+      owner
+    );
 
-    options.contracts = [ Example, UsesExample ];
+    options.contracts = [Example, UsesExample];
 
     deployer = new Deployer(options);
 
-    const migrate = async function(){
+    const migrate = async function() {
       await deployer.deploy(Example);
       await deployer.deploy(UsesExample, Example.address);
     };
@@ -71,19 +77,29 @@ describe("Deployer (async / await)", function() {
 
     assert(Example.address !== null);
 
-    assert(await example.id() === 'Example' );
-    assert(await usesExample.id() === 'UsesExample' );
-    assert(await usesExample.other() === Example.address);
+    assert((await example.id()) === "Example");
+    assert((await usesExample.id()) === "UsesExample");
+    assert((await usesExample.other()) === Example.address);
   });
 
-  it('deployer.link', async function(){
-    const UsesLibrary = utils.getContract('UsesLibrary', provider, networkId, owner);
-    const IsLibrary = utils.getContract('IsLibrary', provider, networkId, owner);
-    options.contracts = [ UsesLibrary, IsLibrary ];
+  it("deployer.link", async function() {
+    const UsesLibrary = utils.getContract(
+      "UsesLibrary",
+      provider,
+      networkId,
+      owner
+    );
+    const IsLibrary = utils.getContract(
+      "IsLibrary",
+      provider,
+      networkId,
+      owner
+    );
+    options.contracts = [UsesLibrary, IsLibrary];
 
     deployer = new Deployer(options);
 
-    const migrate = async function(){
+    const migrate = async function() {
       await deployer.deploy(IsLibrary);
       deployer.link(IsLibrary, UsesLibrary);
       await deployer.deploy(UsesLibrary);
@@ -99,11 +115,10 @@ describe("Deployer (async / await)", function() {
     await usesLibrary.fireIsLibraryEvent(5);
     await usesLibrary.fireUsesLibraryEvent(7);
 
-    eventOptions = {fromBlock: 0, toBlock: 'latest'};
+    eventOptions = { fromBlock: 0, toBlock: "latest" };
     const events = await usesLibrary.getPastEvents("allEvents", eventOptions);
 
     assert(events[0].args.eventID.toNumber() === 5);
     assert(events[1].args.eventID.toNumber() === 7);
   });
 });
-

--- a/packages/truffle/test/scenarios/commands/build.js
+++ b/packages/truffle/test/scenarios/commands/build.js
@@ -11,39 +11,46 @@ describe("truffle build", () => {
   describe("when there is no build script in config", () => {
     beforeEach("set up sandbox", function() {
       this.timeout(10000);
-      project = path.join(__dirname, '../../sources/build/projectWithoutBuildScript');
+      project = path.join(
+        __dirname,
+        "../../sources/build/projectWithoutBuildScript"
+      );
       return sandbox.create(project).then(conf => {
         config = conf;
         config.logger = logger;
       });
     });
 
-    it("should not error", (done) => {
-      CommandRunner.run("build", config, (error) => {
+    it("should not error", done => {
+      CommandRunner.run("build", config, error => {
         assert(typeof error === "undefined");
         done();
       });
-    });
-    it("whines about having no build config", (done) => {
-      CommandRunner.run("build", config, (error) => {
+    }).timeout(20000);
+
+    it("whines about having no build config", done => {
+      CommandRunner.run("build", config, () => {
         const output = logger.contents();
         assert(output.includes("No build configuration found."));
         done();
       });
-    });
+    }).timeout(10000);
   });
 
   describe("when there is a proper build config", () => {
     beforeEach("set up sandbox", function() {
       this.timeout(10000);
-      project = path.join(__dirname, '../../sources/build/projectWithBuildScript');
+      project = path.join(
+        __dirname,
+        "../../sources/build/projectWithBuildScript"
+      );
       return sandbox.create(project).then(conf => {
         config = conf;
         config.logger = logger;
       });
     });
     it("runs the build script", function(done) {
-      CommandRunner.run("build", config, (error) => {
+      CommandRunner.run("build", config, () => {
         const output = logger.contents();
         assert(output.includes("'this is the build script'"));
         done();
@@ -54,16 +61,23 @@ describe("truffle build", () => {
   describe("when there is an object in the build config", () => {
     beforeEach("set up sandbox", function() {
       this.timeout(10000);
-      project = path.join(__dirname, '../../sources/build/projectWithObjectInBuildScript');
+      project = path.join(
+        __dirname,
+        "../../sources/build/projectWithObjectInBuildScript"
+      );
       return sandbox.create(project).then(conf => {
         config = conf;
         config.logger = logger;
       });
     });
     it("tells the user it shouldn't use an object", function(done) {
-      CommandRunner.run("build", config, (error) => {
+      CommandRunner.run("build", config, () => {
         const output = logger.contents();
-        assert(output.includes("Build configuration can no longer be specified as an object."));
+        assert(
+          output.includes(
+            "Build configuration can no longer be specified as an object."
+          )
+        );
         done();
       });
     });


### PR DESCRIPTION
## Bug Fix

The Travis Coverage build was failing due to timeouts. In the process of fixing the build, it was discovered that a CompilerSupplier method was missing a conditional check.

New expected Behavior:

Coverage build should pass on the current `next` branch and users should be able to successfully specify a cached version of solc to compile with.