### PR TITLE
fix: prevent sending deduped (false) events downstream.

### DIFF
--- a/packages/truffle-contract/lib/execute.js
+++ b/packages/truffle-contract/lib/execute.js
@@ -252,9 +252,9 @@ var execute = {
       // As callback
       if (callback !== undefined){
         var intermediary = function(err, e){
-          if (err) callback(err);
-          var event = dedupe(e.id) && decode.call(constructor, e, true)[0];
-          callback(null, event);
+          if (err) return callback(err);
+          if (!dedupe(e.id)) return;
+          callback(null, decode.call(constructor, e, true)[0]);
         };
 
         return constructor.detectNetwork()


### PR DESCRIPTION
When using truffle-contract on websocket enabled geth nodes, duplicated events got passed as `false` to the application callback handler.

I dont think this was intended behaviour, otherwise it should be documented that callbacks may occasionally be called with just `false` instead of a parsed message.