### PR TITLE
Add better cleanup for truffle-box sandbox()

### DIFF
--- a/packages/truffle-box/box.js
+++ b/packages/truffle-box/box.js
@@ -4,43 +4,82 @@ var path = require("path");
 
 var Config = require("truffle-config");
 
+function parseSandboxOptions(options) {
+  if (typeof options === "function") {
+    return {
+      name: "default",
+      unsafeCleanup: false,
+      setGracefulCleanup: false
+    };
+  } else if (typeof options === "string") {
+    // back compatibility for when `options` used to be `name`
+    return {
+      name: options,
+      unsafeCleanup: false,
+      setGracefulCleanup: false
+    };
+  } else if (typeof options === "object") {
+    return {
+      name: options.name || "default",
+      unsafeCleanup: options.unsafeCleanup || false,
+      setGracefulCleanup: options.setGracefulCleanup || false
+    };
+  }
+}
+
 var Box = {
   unbox: function(url, destination, options) {
     options = options || {};
-    options.logger = options.logger || { log: () => {} };
+    options.logger = options.logger || {log: () => {}};
     const downloadBoxOptions = {
-      force: options.force,
+      force: options.force
     };
 
     return Promise.resolve()
       .then(() => {
         options.logger.log("Downloading...");
+
         return utils.downloadBox(url, destination, downloadBoxOptions);
       })
       .then(() => {
         options.logger.log("Unpacking...");
+
         return utils.unpackBox(destination);
       })
       .then((boxConfig) => {
         options.logger.log("Setting up...");
+
         return utils.setupBox(boxConfig, destination);
       })
       .then((boxConfig) => boxConfig);
   },
 
-  sandbox: function(name, callback) {
+  // options.unsafeCleanup
+  //   Recursively removes the created temporary directory, even when it's not empty. default is false
+  // options.setGracefulCleanup
+  //   Cleanup temporary files even when an uncaught exception occurs
+  sandbox: function(options, callback) {
     var self = this;
-    if (typeof name === "function") {
-      callback = name;
-      name = "default";
+
+    const {name, unsafeCleanup, setGracefulCleanup} = parseSandboxOptions(
+      options
+    );
+
+    if (typeof options === "function") {
+      callback = options;
     }
 
-    tmp.dir(function(err, dir, cleanupCallback) {
+    if (setGracefulCleanup) {
+      tmp.setGracefulCleanup();
+    }
+
+    tmp.dir({unsafeCleanup}, function(err, dir) {
       if (err) {
         return callback(err);
       }
 
-      self.unbox("https://github.com/trufflesuite/truffle-init-" + name, dir)
+      self
+        .unbox("https://github.com/trufflesuite/truffle-init-" + name, dir)
         .then(function() {
           var config = Config.load(path.join(dir, "truffle.js"), {});
           callback(null, config);

--- a/packages/truffle-debugger/test/helpers.js
+++ b/packages/truffle-debugger/test/helpers.js
@@ -3,7 +3,6 @@ const debug = debugModule("test:helpers");
 
 import path from "path";
 import fs from "fs-extra";
-import async from "async";
 import Contracts from "truffle-workflow-compile";
 import Debug from "truffle-debug-utils";
 import Artifactor from "truffle-artifactor";
@@ -11,7 +10,6 @@ import Web3 from "web3";
 import Migrate from "truffle-migrate";
 import Box from "truffle-box";
 import Resolver from "truffle-resolver";
-import expect from "truffle-expect";
 
 export async function prepareContracts(provider, sources = {}, migrations) {
   let config = await createSandbox();
@@ -37,10 +35,10 @@ export async function prepareContracts(provider, sources = {}, migrations) {
   await migrate(config);
 
   let artifacts = await gatherArtifacts(config);
-  debug("artifacts: %o", artifacts.map((a) => a.contractName));
+  debug("artifacts: %o", artifacts.map(a => a.contractName));
 
   let abstractions = {};
-  contractNames.forEach( (name) => {
+  contractNames.forEach(name => {
     abstractions[name] = config.resolver.require(name);
   });
 
@@ -64,7 +62,10 @@ export function getAccounts(provider) {
 
 export async function createSandbox() {
   let config = await new Promise(function(accept, reject) {
-    Box.sandbox(function(err, result) {
+    Box.sandbox({ unsafeCleanup: true, setGracefulCleanup: true }, function(
+      err,
+      result
+    ) {
       if (err) return reject(err);
       result.resolver = new Resolver(result);
       result.artifactor = new Artifactor(result.contracts_build_directory);
@@ -76,7 +77,9 @@ export async function createSandbox() {
 
   await fs.remove(path.join(config.contracts_directory, "MetaCoin.sol"));
   await fs.remove(path.join(config.contracts_directory, "ConvertLib.sol"));
-  await fs.remove(path.join(config.migrations_directory, "2_deploy_contracts.js"));
+  await fs.remove(
+    path.join(config.migrations_directory, "2_deploy_contracts.js")
+  );
 
   return config;
 }
@@ -106,12 +109,12 @@ export async function addMigrations(config, migrations = {}) {
 }
 
 export async function defaultMigrations(contractNames) {
-  contractNames = contractNames.filter((name) => name != "Migrations");
+  contractNames = contractNames.filter(name => name != "Migrations");
 
   let migrations = {};
 
-  contractNames.forEach( (contractName, i) => {
-    let index = i + 2;  // start at 2 cause Migrations migration
+  contractNames.forEach((contractName, i) => {
+    let index = i + 2; // start at 2 cause Migrations migration
     let filename = `${index}_migrate_${contractName}.js`;
     let source = `
       var ${contractName} = artifacts.require("${contractName}");
@@ -129,26 +132,32 @@ export async function defaultMigrations(contractNames) {
 
 export async function compile(config) {
   return new Promise(function(accept, reject) {
-    Contracts.compile(config.with({
-      all: true,
-      quiet: true
-    }), function(err, result) {
-      if (err) return reject(err);
-      const { contracts, outputs } = result;
-      debug("result %O", result);
-      return accept({ contracts, files: outputs.solc });
-    });
+    Contracts.compile(
+      config.with({
+        all: true,
+        quiet: true
+      }),
+      function(err, result) {
+        if (err) return reject(err);
+        const { contracts, outputs } = result;
+        debug("result %O", result);
+        return accept({ contracts, files: outputs.solc });
+      }
+    );
   });
 }
 
 export async function migrate(config) {
   return new Promise(function(accept, reject) {
-    Migrate.run(config.with({
-      quiet: true
-    }), function(err, contracts) {
-      if (err) return reject(err);
-      accept(contracts);
-    });
+    Migrate.run(
+      config.with({
+        quiet: true
+      }),
+      function(err, contracts) {
+        if (err) return reject(err);
+        accept(contracts);
+      }
+    );
   });
 }
 


### PR DESCRIPTION
This PR changes the `sandbox` interface to accept an argument `options` instead of `name` to allow some extra options such as `unsafeCleanup` and `setGracefulCleanup` that interface with the `tmp` module. There is back compatibility where if `options` is a `string`, then it will use it as the `name` directly

You can find an example of using these changes, as well as the motivation for these changes in `packages/truffle-debugger/test/helpers.js` to cleanup the sandboxes when mocha finishes the tests for the debugger.

Here are some comments on the the options:
```
// options.unsafeCleanup
//   Recursively removes the created temporary directory, even when it's not empty. default is false
// options.setGracefulCleanup
//   Cleanup temporary files even when an uncaught exception occurs
```