### PR TITLE
Add support for STATICCALL

### DIFF
--- a/packages/truffle-debugger/lib/evm/selectors/index.js
+++ b/packages/truffle-debugger/lib/evm/selectors/index.js
@@ -1,14 +1,12 @@
 import debugModule from "debug";
-const debug = debugModule("debugger:evm:selectors");
+const debug = debugModule("debugger:evm:selectors"); // eslint-disable-line no-unused-vars
 
 import { createSelectorTree, createLeaf } from "reselect-tree";
 import levenshtein from "fast-levenshtein";
 
-import * as decodeUtils from "lib/data/decode/utils";
-
 import trace from "lib/trace/selectors";
 
-const WORD_SIZE = 0x20;
+import { isCallMnemonic } from "lib/helpers";
 
 /**
  * create EVM-level selectors for a given trace step selector
@@ -21,24 +19,19 @@ function createStepSelectors(step, state = null) {
      *
      * trace step info related to operation
      */
-    trace: createLeaf(
-      [step], ({gasCost, op, pc}) => ({gasCost, op, pc})
-    ),
+    trace: createLeaf([step], ({ gasCost, op, pc }) => ({ gasCost, op, pc })),
 
     /**
      * .programCounter
      */
-    programCounter: createLeaf(
-      ["./trace"], (step) => step.pc
-    ),
+    programCounter: createLeaf(["./trace"], step => step.pc),
 
     /**
      * .isJump
      */
     isJump: createLeaf(
-      ["./trace"], (step) => (
-        step.op != "JUMPDEST" && step.op.indexOf("JUMP") == 0
-      )
+      ["./trace"],
+      step => step.op != "JUMPDEST" && step.op.indexOf("JUMP") == 0
     ),
 
     /**
@@ -46,16 +39,12 @@ function createStepSelectors(step, state = null) {
      *
      * whether the opcode will switch to another calling context
      */
-    isCall: createLeaf(
-      ["./trace"], (step) => step.op == "CALL" || step.op == "DELEGATECALL"
-    ),
+    isCall: createLeaf(["./trace"], step => isCallMnemonic(step.op)),
 
     /**
      * .isCreate
      */
-    isCreate: createLeaf(
-      ["./trace"], (step) => step.op == "CREATE"
-    ),
+    isCreate: createLeaf(["./trace"], step => step.op == "CREATE"),
 
     /**
      * .isHalting
@@ -63,16 +52,15 @@ function createStepSelectors(step, state = null) {
      * whether the instruction halts or returns from a calling context
      */
     isHalting: createLeaf(
-      ["./trace"], (step) => step.op == "STOP" || step.op == "RETURN"
+      ["./trace"],
+      step => step.op == "STOP" || step.op == "RETURN"
     )
   };
 
   if (state) {
-    const isRelative = (path) => (
-      typeof path == "string" && (
-        path.startsWith("./") || path.startsWith("../")
-      )
-    );
+    const isRelative = path =>
+      typeof path == "string" &&
+      (path.startsWith("./") || path.startsWith("../"));
 
     if (isRelative(state)) {
       state = `../${state}`;
@@ -87,7 +75,7 @@ function createStepSelectors(step, state = null) {
       callAddress: createLeaf(
         ["./isCall", "./trace", state],
 
-        (matches, step, {stack}) => {
+        (matches, step, { stack }) => {
           if (!matches) return null;
 
           let address = stack[stack.length - 2];
@@ -104,7 +92,7 @@ function createStepSelectors(step, state = null) {
       createBinary: createLeaf(
         ["./isCreate", "./trace", state],
 
-        (matches, step, {stack, memory}) => {
+        (matches, step, { stack, memory }) => {
           if (!matches) return null;
 
           // Get the code that's going to be created from memory.
@@ -125,7 +113,7 @@ const evm = createSelectorTree({
   /**
    * evm.state
    */
-  state: (state) => state.evm,
+  state: state => state.evm,
 
   /**
    * evm.info
@@ -134,56 +122,54 @@ const evm = createSelectorTree({
     /**
      * evm.info.contexts
      */
-    contexts: createLeaf(['/state'], (state) => state.info.contexts.byContext),
+    contexts: createLeaf(["/state"], state => state.info.contexts.byContext),
 
     /**
      * evm.info.instances
      */
-    instances: createLeaf(['/state'], (state) => state.info.instances.byAddress),
+    instances: createLeaf(["/state"], state => state.info.instances.byAddress),
 
     /**
      * evm.info.binaries
      */
     binaries: {
-      _: createLeaf(['/state'], (state) => state.info.contexts.byBinary),
+      _: createLeaf(["/state"], state => state.info.contexts.byBinary),
 
       /**
        * evm.info.binaries.search
        *
        * returns function (binary) => context
        */
-      search: createLeaf(['./_'], (binaries) =>
-        (binary) => {
-          // search for a given binary based on levenshtein distances to
-          // existing (known) context binaries.
-          //
-          // levenshtein distance is the number of textual modifications
-          // (insert, change, delete) required to convert string a to b
-          //
-          // filter by a percentage threshold
-          const threshold = 0.25;
+      search: createLeaf(["./_"], binaries => binary => {
+        // search for a given binary based on levenshtein distances to
+        // existing (known) context binaries.
+        //
+        // levenshtein distance is the number of textual modifications
+        // (insert, change, delete) required to convert string a to b
+        //
+        // filter by a percentage threshold
+        const threshold = 0.25;
 
-          // skip levenshtein check for undefined binaries
-          if (!binary || binary == "0x0") {
-            return {};
-          }
-
-          const results = Object.entries(binaries)
-            .map( ([ knownBinary, { context } ]) => ({
-              context,
-              distance: levenshtein.get(knownBinary, binary)
-            }))
-            .filter( ({ distance }) => distance <= binary.length * threshold )
-            .sort( ({distance: a}, {distance: b}) => a - b );
-
-          if (results[0]) {
-            const { context } = results[0];
-            return { context };
-          }
-
+        // skip levenshtein check for undefined binaries
+        if (!binary || binary == "0x0") {
           return {};
         }
-      )
+
+        const results = Object.entries(binaries)
+          .map(([knownBinary, { context }]) => ({
+            context,
+            distance: levenshtein.get(knownBinary, binary)
+          }))
+          .filter(({ distance }) => distance <= binary.length * threshold)
+          .sort(({ distance: a }, { distance: b }) => a - b);
+
+        if (results[0]) {
+          const { context } = results[0];
+          return { context };
+        }
+
+        return {};
+      })
     }
   },
 
@@ -191,11 +177,10 @@ const evm = createSelectorTree({
    * evm.current
    */
   current: {
-
     /**
      * evm.current.callstack
      */
-    callstack: (state) => state.evm.proc.callstack,
+    callstack: state => state.evm.proc.callstack,
 
     /**
      * evm.current.call
@@ -203,7 +188,7 @@ const evm = createSelectorTree({
     call: createLeaf(
       ["./callstack"],
 
-      (stack) => stack.length ? stack[stack.length - 1] : {}
+      stack => (stack.length ? stack[stack.length - 1] : {})
     ),
 
     /**
@@ -213,7 +198,7 @@ const evm = createSelectorTree({
     creationDepth: createLeaf(
       ["./callstack"],
 
-      (stack) => stack.filter((call) => call.address === undefined).length
+      stack => stack.filter(call => call.address === undefined).length
     ),
 
     /**
@@ -222,7 +207,7 @@ const evm = createSelectorTree({
     context: createLeaf(
       ["./call", "/info/instances", "/info/binaries/search", "/info/contexts"],
 
-      ({address, binary}, instances, search, contexts) => {
+      ({ address, binary }, instances, search, contexts) => {
         let record;
         if (address) {
           record = instances[address];
@@ -248,18 +233,12 @@ const evm = createSelectorTree({
      *
      * evm state info: as of last operation, before op defined in step
      */
-    state: Object.assign({}, ...(
-      [
-        "depth",
-        "error",
-        "gas",
-        "memory",
-        "stack",
-        "storage"
-      ].map( (param) => ({
-        [param]: createLeaf([trace.step], (step) => step[param])
+    state: Object.assign(
+      {},
+      ...["depth", "error", "gas", "memory", "stack", "storage"].map(param => ({
+        [param]: createLeaf([trace.step], step => step[param])
       }))
-    )),
+    ),
 
     /**
      * evm.current.step
@@ -271,24 +250,17 @@ const evm = createSelectorTree({
    * evm.next
    */
   next: {
-
     /**
      * evm.next.state
      *
      * evm state as a result of next step operation
      */
-    state: Object.assign({}, ...(
-      [
-        "depth",
-        "error",
-        "gas",
-        "memory",
-        "stack",
-        "storage"
-      ].map( (param) => ({
-        [param]: createLeaf([trace.next], (step) => step[param])
+    state: Object.assign(
+      {},
+      ...["depth", "error", "gas", "memory", "stack", "storage"].map(param => ({
+        [param]: createLeaf([trace.next], step => step[param])
       }))
-    )),
+    ),
 
     step: createStepSelectors(trace.next, "./state")
   }

--- a/packages/truffle-debugger/lib/helpers/index.js
+++ b/packages/truffle-debugger/lib/helpers/index.js
@@ -3,7 +3,7 @@ import { keccak256 as _keccak256, toHexString } from "lib/data/decode/utils";
 const stringify = require("json-stable-stringify");
 
 export function prefixName(prefix, fn) {
-  Object.defineProperty(fn, 'name', {
+  Object.defineProperty(fn, "name", {
     value: `${prefix}.${fn.name}`,
     configurable: true
   });
@@ -24,4 +24,13 @@ export function keccak256(...args) {
  */
 export function stableKeccak256(obj) {
   return keccak256(stringify(obj));
+}
+
+/*
+ * Given a mmemonic, determine whether it's the mnemonic of a calling
+ * instruction (does NOT include creation instructions)
+ */
+export function isCallMnemonic(op) {
+  const calls = ["CALL", "DELEGATECALL", "STATICCALL", "CALLCODE"];
+  return calls.includes(op);
 }

--- a/packages/truffle-debugger/lib/trace/sagas/index.js
+++ b/packages/truffle-debugger/lib/trace/sagas/index.js
@@ -2,7 +2,7 @@ import debugModule from "debug";
 const debug = debugModule("debugger:trace:sagas");
 
 import { take, takeEvery, put, select } from "redux-saga/effects";
-import { prefixName } from "lib/helpers";
+import { prefixName, isCallMnemonic } from "lib/helpers";
 
 import * as actions from "../actions";
 
@@ -14,7 +14,7 @@ function* waitForTrace() {
   let addresses = [
     ...new Set(
       steps
-        .filter(({ op }) => op == "CALL" || op == "DELEGATECALL")
+        .filter(({ op }) => isCallMnemonic(op))
         .map(({ stack }) => "0x" + stack[stack.length - 2].substring(24))
     )
   ];


### PR DESCRIPTION
This pull requests adds support for `STATICCALL`; both places in the code that check whether an opcode is a `CALL` or `DELEGATECALL` now also check for `STATICCALL`.  Note that rather than just updating both of these separately, I factored out the check into a new function in `helpers` so we can just update that if further calling opcodes are added in later versions of Ethereum.

I also added `CALLCODE` as well as `STATICCALL`; `CALLCODE` is of course disallowed in Solidity 0.5.0, and obviously it's deprecated even in older versions, but, hey, maybe you encounter it debugging some historical contract, I don't know.  I figured may as well be prepared for the past as well as the future, so I put it in.

There are of course also some minor unrelated changes to satisfy `eslint`.