### PR TITLE
Add configstore dependency to package.json

### DIFF
--- a/packages/truffle-config/package.json
+++ b/packages/truffle-config/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/trufflesuite/truffle-config#readme",
   "dependencies": {
+    "configstore": "^4.0.0",
     "find-up": "^2.1.0",
     "lodash": "4.17.10",
     "original-require": "1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2943,6 +2943,7 @@ config-chain@^1.1.11:
 configstore@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/configstore/-/configstore-4.0.0.tgz#5933311e95d3687efb592c528b922d9262d227e7"
+  integrity sha512-CmquAXFBocrzaSM8mtGPMM/HiWmyIpr4CcJl/rgY2uCObZ/S7cKU0silxslqJejl+t/T9HS8E0PUNQD81JGUEQ==
   dependencies:
     dot-prop "^4.1.0"
     graceful-fs "^4.1.2"


### PR DESCRIPTION
This dependency (https://github.com/trufflesuite/truffle/blob/next/packages/truffle-config/index.js#L8) was not in the `package.json`. This PR adds it.