### PR TITLE
Upgrade test contracts to 0.5.0 and fix all resulting problems

### DIFF
--- a/packages/truffle-debugger/test/ast.js
+++ b/packages/truffle-debugger/test/ast.js
@@ -4,7 +4,6 @@ const debug = debugModule("test:ast");
 import { assert } from "chai";
 
 import Ganache from "ganache-cli";
-import Web3 from "web3";
 
 import { prepareContracts } from "./helpers";
 import Debugger from "lib/debugger";
@@ -13,10 +12,10 @@ import ast from "lib/ast/selectors";
 import solidity from "lib/solidity/selectors";
 import trace from "lib/trace/selectors";
 
-import { getRange, findRange, rangeNodes } from "lib/ast/map";
+import { getRange } from "lib/ast/map";
 
 const __VARIABLES = `
-pragma solidity ^0.4.18;
+pragma solidity ~0.5;
 
 contract Variables {
   event Result(uint256 result);
@@ -44,22 +43,19 @@ contract Variables {
 }
 `;
 
-
 let sources = {
   "Variables.sol": __VARIABLES
 };
 
 describe("AST", function() {
   var provider;
-  var web3;
 
   var abstractions;
   var artifacts;
   var files;
 
   before("Create Provider", async function() {
-    provider = Ganache.provider({seed: "debugger", gasLimit: 7000000});
-    web3 = new Web3(provider);
+    provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
   });
 
   before("Prepare contracts and artifacts", async function() {
@@ -93,23 +89,24 @@ describe("AST", function() {
 
         let node = session.view(ast.current.node);
 
-        let [ nodeStart, nodeLength ] = getRange(node);
+        let [nodeStart, nodeLength] = getRange(node);
         let nodeEnd = nodeStart + nodeLength;
 
         let pointer = session.view(ast.current.pointer);
 
         assert.isAtMost(
-          nodeStart, start,
+          nodeStart,
+          start,
           `Node ${pointer} at should not begin after instruction source range`
         );
         assert.isAtLeast(
-          nodeEnd, end,
+          nodeEnd,
+          end,
           `Node ${pointer} should not end after source`
         );
 
         session.stepNext();
-      } while(!session.view(trace.finished));
-
+      } while (!session.view(trace.finished));
     });
   });
 });

--- a/packages/truffle-debugger/test/context.js
+++ b/packages/truffle-debugger/test/context.js
@@ -76,6 +76,7 @@ describe("Contexts", function() {
 
   var abstractions;
   var artifacts;
+  var files;
 
   before("Create Provider", async function() {
     provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
@@ -87,6 +88,7 @@ describe("Contexts", function() {
     let prepared = await prepareContracts(provider, sources, migrations);
     abstractions = prepared.abstractions;
     artifacts = prepared.artifacts;
+    files = prepared.files;
   });
 
   it("returns view of addresses affected", async function() {
@@ -102,6 +104,7 @@ describe("Contexts", function() {
 
     let bugger = await Debugger.forTx(txHash, {
       provider,
+      files,
       contracts: artifacts
     });
     debug("debugger ready");

--- a/packages/truffle-debugger/test/context.js
+++ b/packages/truffle-debugger/test/context.js
@@ -11,7 +11,7 @@ import Debugger from "lib/debugger";
 import sessionSelector from "lib/session/selectors";
 
 const __OUTER = `
-pragma solidity ^0.4.18;
+pragma solidity ~0.5;
 
 import "./InnerContract.sol";
 
@@ -33,7 +33,7 @@ contract OuterContract {
 `;
 
 const __INNER = `
-pragma solidity ^0.4.18;
+pragma solidity ~0.5;
 
 contract InnerContract {
   event Inner();

--- a/packages/truffle-debugger/test/data/decode/decoding.js
+++ b/packages/truffle-debugger/test/data/decode/decoding.js
@@ -5,136 +5,155 @@ import faker from "faker";
 
 import evm from "lib/evm/selectors";
 
-import {
-  generateUints, describeDecoding
-} from "./helpers";
-
+import { generateUints, describeDecoding } from "./helpers";
 
 const uints = generateUints();
 
 function generateArray(length) {
-  return [...Array(length)]
-    .map(() => uints.next().value);
+  return [...Array(length)].map(() => uints.next().value);
 }
 
-const commonFixtures = [{
-  name: "multipleFullWordArray",
-  type: "uint[]",
-  value: generateArray(3)  // takes up 3 whole words
-}, {
-  name: "withinWordArray",
-  type: "uint16[]",
-  value: generateArray(10)  // takes up >1/2 word
-}, {
-  name: "multiplePartWordArray",
-  type: "uint64[]",
-  value: generateArray(9)  // takes up 2.25 words
-}, {
-  name: "inconvenientlyWordOffsetArray",
-  type: "uint240[]",
-  value: generateArray(3)  // takes up ~2.8 words
-}, {
-  name: "shortString",
-  type: "string",
-  value: "hello world"
-}, {
-  name: "longString",
-  type: "string",
-  value: "solidity allocation is a fun lesson in endianness"
-}];
+const commonFixtures = [
+  {
+    name: "multipleFullWordArray",
+    type: "uint[]",
+    value: generateArray(3) // takes up 3 whole words
+  },
+  {
+    name: "withinWordArray",
+    type: "uint16[]",
+    value: generateArray(10) // takes up >1/2 word
+  },
+  {
+    name: "multiplePartWordArray",
+    type: "uint64[]",
+    value: generateArray(9) // takes up 2.25 words
+  },
+  {
+    name: "inconvenientlyWordOffsetArray",
+    type: "uint240[]",
+    value: generateArray(3) // takes up ~2.8 words
+  },
+  {
+    name: "shortString",
+    type: "string",
+    value: "hello world"
+  },
+  {
+    name: "longString",
+    type: "string",
+    value: "solidity allocation is a fun lesson in endianness"
+  }
+];
 
-const mappingFixtures = [{
-  name: "simpleMapping",
-  type: {
-    from: "uint256",
-    to: "uint256"
+const mappingFixtures = [
+  {
+    name: "simpleMapping",
+    type: {
+      from: "uint256",
+      to: "uint256"
+    },
+    value: {
+      ...Object.assign(
+        {},
+        ...generateArray(5).map((value, idx) => ({ [idx]: value }))
+      )
+    }
   },
-  value: {
-    ...Object.assign({}, ...generateArray(5).map(
-      (value, idx) => ({ [idx]: value })
-    ))
-  }
-}, {
-  name: "numberedStrings",
-  type: {
-    from: "uint256",
-    to: "string"
+  {
+    name: "numberedStrings",
+    type: {
+      from: "uint256",
+      to: "string"
+    },
+    value: {
+      ...Object.assign(
+        {},
+        ...generateArray(7).map((value, idx) => ({
+          [value]: faker.lorem.slug(idx)
+        }))
+      )
+    }
   },
-  value: {
-    ...Object.assign({}, ...generateArray(7).map(
-      (value, idx) => ({ [value]: faker.lorem.slug(idx) })
-    ))
+  {
+    name: "stringsToStrings",
+    type: {
+      from: "string",
+      to: "string"
+    },
+    value: {
+      ...Object.assign(
+        {},
+        ...[0, 1, 2, 3, 4].map(idx => ({
+          [faker.lorem.slug(idx)]: faker.lorem.slug(idx)
+        }))
+      )
+    }
   }
-}, {
-  name: "stringsToStrings",
-  type: {
-    from: "string",
-    to: "string"
-  },
-  value: {
-    ...Object.assign({}, ...[0,1,2,3,4].map(
-      (idx) => ({ [faker.lorem.slug(idx)]: faker.lorem.slug(idx) })
-    ))
-  }
-}];
+];
 
 debug("mappingFixtures %O", mappingFixtures);
 
 describe("Decoding", function() {
-
   /*
    * Storage Tests
    */
   describeDecoding(
-    "Storage Variables", commonFixtures, evm.current.state.storage,
+    "Storage Variables",
+    commonFixtures,
+    evm.current.state.storage,
 
     (contractName, fixtures) => {
-      return `pragma solidity ^0.4.23;
+      return `pragma solidity ~0.5;
 
 contract ${contractName} {
 
   event Done();
 
   // declarations
-  ${fixtures
-    .map( ({type, name}) => `${type} ${name};` )
-    .join("\n  ")}
+  ${fixtures.map(({ type, name }) => `${type} ${name};`).join("\n  ")}
 
   function run() public {
     ${fixtures
-      .map( ({name, value}) => `${name} = ${JSON.stringify(value)};` )
+      .map(({ name, value }) => `${name} = ${JSON.stringify(value)};`)
       .join("\n    ")}
 
     emit Done();
   }
 }
-`;   }
+`;
+    }
   );
 
   describeDecoding(
-    "Mapping Variables", mappingFixtures, evm.current.state.storage,
+    "Mapping Variables",
+    mappingFixtures,
+    evm.current.state.storage,
 
     (contractName, fixtures) => {
-      return `pragma solidity ^0.4.24;
+      return `pragma solidity ~0.5;
 
 contract ${contractName} {
   event Done();
 
   // declarations
   ${fixtures
-    .map( ({name, type: {from, to}}) => `mapping (${from} => ${to}) ${name};` )
+    .map(
+      ({ name, type: { from, to } }) => `mapping (${from} => ${to}) ${name};`
+    )
     .join("\n  ")}
 
   function run() public {
     ${fixtures
-      .map(
-        ({name, type: {from}, value}) =>
-          Object.entries(value)
-            .map( ([k, v]) => (from === "string")
-              ? `${name}["${k}"] = ${JSON.stringify(v)};`
-              : `${name}[${k}] = ${JSON.stringify(v)};`
-            )
-            .join("\n    ")
+      .map(({ name, type: { from }, value }) =>
+        Object.entries(value)
+          .map(
+            ([k, v]) =>
+              from === "string"
+                ? `${name}["${k}"] = ${JSON.stringify(v)};`
+                : `${name}[${k}] = ${JSON.stringify(v)};`
+          )
+          .join("\n    ")
       )
       .join("\n\n    ")}
 
@@ -149,12 +168,14 @@ contract ${contractName} {
    * Memory Tests
    */
   describeDecoding(
-    "Memory Variables", commonFixtures, evm.current.state.memory,
+    "Memory Variables",
+    commonFixtures,
+    evm.current.state.memory,
 
     (contractName, fixtures) => {
       const separator = ";\n    ";
 
-      function declareAssign({name, type, value}) {
+      function declareAssign({ name, type, value }) {
         if (type.indexOf("[]") != -1) {
           // array, must `new`
           let declare = `${type} memory ${name} = new ${type}(${value.length})`;
@@ -165,7 +186,7 @@ contract ${contractName} {
         }
       }
 
-      return `pragma solidity ^0.4.23;
+      return `pragma solidity ~0.5;
 
 contract ${contractName} {
 

--- a/packages/truffle-debugger/test/data/decode/helpers.js
+++ b/packages/truffle-debugger/test/data/decode/helpers.js
@@ -2,7 +2,6 @@ import debugModule from "debug";
 const debug = debugModule("test:data:decode");
 
 import Ganache from "ganache-cli";
-import Web3 from "web3";
 import { assert } from "chai";
 import changeCase from "change-case";
 
@@ -15,7 +14,7 @@ import { cleanBigNumbers } from "lib/data/decode/utils";
 import data from "lib/data/selectors";
 import solidity from "lib/solidity/selectors";
 
-export function *generateUints() {
+export function* generateUints() {
   let x = 0;
   while (true) {
     yield x;
@@ -31,12 +30,11 @@ function fileName(testName) {
   return `${contractName(testName)}.sol`;
 }
 
-
 function generateTests(fixtures) {
   for (let { name, value: expected } of fixtures) {
-    it(`correctly decodes ${name}`,
-      () => { assert.deepEqual(this.decode(name), expected); }
-    );
+    it(`correctly decodes ${name}`, () => {
+      assert.deepEqual(this.decode(name), expected);
+    });
   }
 }
 
@@ -50,13 +48,13 @@ function lastStatementLine(source) {
   }
 }
 
-
 async function prepareDebugger(testName, sources) {
-  const provider = Ganache.provider({seed: "debugger", gasLimit: 7000000});
-  const web3 = new Web3(provider);
+  const provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
 
-  let { abstractions, artifacts: contracts, files } =
-    await prepareContracts(provider, sources);
+  let { abstractions, artifacts: contracts, files } = await prepareContracts(
+    provider,
+    sources
+  );
 
   let instance = await abstractions[contractName(testName)].deployed();
   let receipt = await instance.run();
@@ -67,12 +65,12 @@ async function prepareDebugger(testName, sources) {
   let session = bugger.connect();
 
   let source = sources[fileName(testName)];
-  
+
   //we'll need the debugger-internal ID of this source
   let debuggerSources = session.view(solidity.info.sources);
-  let matchingSources = Object.values(debuggerSources)
-    .filter((sourceObject) =>
-      sourceObject.sourcePath.includes(contractName(testName)));
+  let matchingSources = Object.values(debuggerSources).filter(sourceObject =>
+    sourceObject.sourcePath.includes(contractName(testName))
+  );
   let sourceId = matchingSources[0].id;
 
   let breakpoint = {
@@ -80,7 +78,7 @@ async function prepareDebugger(testName, sources) {
     line: lastStatementLine(source)
   };
 
-  session.addBreakpoint(breakpoint,true);
+  session.addBreakpoint(breakpoint);
 
   session.continueUntilBreakpoint();
 
@@ -92,9 +90,7 @@ async function getDecode(session) {
   const refs = session.view(data.current.identifiers.refs);
 
   const decode = session.view(data.views.decoder);
-  return (name) => cleanBigNumbers(
-    decode(definitions[name], refs[name])
-  );
+  return name => cleanBigNumbers(decode(definitions[name], refs[name]));
 }
 
 export function describeDecoding(testName, fixtures, selector, generateSource) {

--- a/packages/truffle-debugger/test/data/ids.js
+++ b/packages/truffle-debugger/test/data/ids.js
@@ -192,6 +192,7 @@ describe("Variable IDs", function() {
 
     let bugger = await Debugger.forTx(txHash, {
       provider,
+      files,
       contracts: artifacts
     });
 
@@ -221,6 +222,7 @@ describe("Variable IDs", function() {
 
     let bugger = await Debugger.forTx(txHash, {
       provider,
+      files,
       contracts: artifacts
     });
 
@@ -244,6 +246,7 @@ describe("Variable IDs", function() {
 
     let bugger = await Debugger.forTx(txHash, {
       provider,
+      files,
       contracts: artifacts
     });
 

--- a/packages/truffle-debugger/test/data/ids.js
+++ b/packages/truffle-debugger/test/data/ids.js
@@ -13,7 +13,7 @@ import trace from "lib/trace/selectors";
 import solidity from "lib/solidity/selectors";
 
 const __FACTORIAL = `
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 
 contract FactorialTest {
 
@@ -40,7 +40,7 @@ contract FactorialTest {
 `;
 
 const __ADDRESS = `
-pragma solidity ^0.4.25;
+pragma solidity ^0.5.0;
 
 contract AddressTest {
 
@@ -78,7 +78,7 @@ contract SecretByte {
 `;
 
 const __INTERVENING = `
-pragma solidity ^0.4.25;
+pragma solidity ^0.5.0;
 
 import "./InterveningLib.sol";
 
@@ -110,13 +110,13 @@ contract Intervening {
 }
 
 contract Inner {
-  
+
   uint8 flag;
 
   constructor() public {
     flag = 0;
   }
-  
+
   function run() public returns (uint8) {
     flag = 1;
     return 2;
@@ -126,10 +126,10 @@ contract Inner {
 `;
 
 const __INTERVENINGLIB = `
-pragma solidity ^0.4.25;
+pragma solidity ^0.5.0;
 
 library InterveningLib {
-  
+
   function run() pure external returns (uint8) {
     return 2;
   }

--- a/packages/truffle-debugger/test/endstate.js
+++ b/packages/truffle-debugger/test/endstate.js
@@ -1,5 +1,5 @@
 import debugModule from "debug";
-const debug = debugModule("test:endstate");
+const debug = debugModule("test:endstate"); // eslint-disable-line no-unused-vars
 
 import { assert } from "chai";
 
@@ -12,21 +12,21 @@ import sessionSelector from "lib/session/selectors";
 import data from "lib/data/selectors";
 
 const __FAILURE = `
-pragma solidity ^0.4.24;
+pragma solidity ~0.5;
 
 contract FailureTest {
-  function run() {
+  function run() public {
     revert();
   }
 }
 `;
 
 const __SUCCESS = `
-pragma solidity ^0.4.24;
+pragma solidity ~0.5;
 
 contract SuccessTest {
 uint x;
-  function run() {
+  function run() public {
     x = 107;
   }
 }

--- a/packages/truffle-debugger/test/endstate.js
+++ b/packages/truffle-debugger/test/endstate.js
@@ -42,6 +42,7 @@ describe("End State", function() {
 
   var abstractions;
   var artifacts;
+  var files;
 
   before("Create Provider", async function() {
     provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
@@ -53,6 +54,7 @@ describe("End State", function() {
     let prepared = await prepareContracts(provider, sources);
     abstractions = prepared.abstractions;
     artifacts = prepared.artifacts;
+    files = prepared.files;
   });
 
   it("correctly marks a failed transaction as failed", async function() {
@@ -69,6 +71,7 @@ describe("End State", function() {
 
     let bugger = await Debugger.forTx(txHash, {
       provider,
+      files,
       contracts: artifacts
     });
 
@@ -84,6 +87,7 @@ describe("End State", function() {
 
     let bugger = await Debugger.forTx(txHash, {
       provider,
+      files,
       contracts: artifacts
     });
 

--- a/packages/truffle-debugger/test/evm.js
+++ b/packages/truffle-debugger/test/evm.js
@@ -1,10 +1,9 @@
 import debugModule from "debug";
-const debug = debugModule("test:evm");
+const debug = debugModule("test:evm"); // eslint-disable-line no-unused-vars
 
 import { assert } from "chai";
 
 import Ganache from "ganache-cli";
-import Web3 from "web3";
 
 import { prepareContracts } from "./helpers";
 import Debugger from "lib/debugger";
@@ -13,7 +12,7 @@ import evm from "lib/evm/selectors";
 import trace from "lib/trace/selectors";
 
 const __OUTER = `
-pragma solidity ^0.4.18;
+pragma solidity ~0.5;
 
 import "./Inner.sol";
 
@@ -35,9 +34,8 @@ contract Outer {
 }
 `;
 
-
 const __INNER = `
-pragma solidity ^0.4.18;
+pragma solidity ~0.5;
 
 contract Inner {
   function run() public {
@@ -58,24 +56,22 @@ module.exports = async function(deployer) {
 
 let sources = {
   "Inner.sol": __INNER,
-  "Outer.sol": __OUTER,
+  "Outer.sol": __OUTER
 };
 
 let migrations = {
-  "2_deploy_contracts.js": __MIGRATION,
+  "2_deploy_contracts.js": __MIGRATION
 };
 
 describe("EVM Debugging", function() {
   var provider;
-  var web3;
 
   var abstractions;
   var artifacts;
   var files;
 
   before("Create Provider", async function() {
-    provider = Ganache.provider({seed: "debugger", gasLimit: 7000000});
-    web3 = new Web3(provider);
+    provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
   });
 
   before("Prepare contracts and artifacts", async function() {
@@ -102,7 +98,7 @@ describe("EVM Debugging", function() {
       });
 
       let session = bugger.connect();
-      var finished;  // is the trace finished?
+      var finished; // is the trace finished?
 
       do {
         session.stepNext();
@@ -111,9 +107,7 @@ describe("EVM Debugging", function() {
         let actual = session.view(evm.current.callstack).length;
 
         assert.isAtMost(actual, maxExpected);
-
-      } while(!finished);
-
+      } while (!finished);
     });
 
     it("tracks callstack correctly", async function() {
@@ -132,7 +126,7 @@ describe("EVM Debugging", function() {
 
       // follow callstack length values in list
       // see source above
-      let expectedDepthSequence = [1,2,1];
+      let expectedDepthSequence = [1, 2, 1];
       let actualSequence = [session.view(evm.current.callstack).length];
 
       var finished; // is the trace finished?
@@ -147,7 +141,7 @@ describe("EVM Debugging", function() {
         if (currentDepth !== lastKnown) {
           actualSequence.push(currentDepth);
         }
-      } while(!finished);
+      } while (!finished);
 
       assert.deepEqual(actualSequence, expectedDepthSequence);
     });

--- a/packages/truffle-debugger/test/helpers.js
+++ b/packages/truffle-debugger/test/helpers.js
@@ -25,7 +25,7 @@ export async function prepareContracts(provider, sources = {}, migrations) {
 
   config.compilers = {
     solc: {
-      version: "0.4.25"
+      version: "0.5.0"
     }
   };
 

--- a/packages/truffle-debugger/test/helpers.js
+++ b/packages/truffle-debugger/test/helpers.js
@@ -68,17 +68,21 @@ export function getAccounts(provider) {
 
 export async function createSandbox() {
   let config = await new Promise(function(accept, reject) {
-    Box.sandbox({ unsafeCleanup: true, setGracefulCleanup: true }, function(
-      err,
-      result
-    ) {
-      if (err) return reject(err);
-      result.resolver = new Resolver(result);
-      result.artifactor = new Artifactor(result.contracts_build_directory);
-      result.networks = {};
+    Box.sandbox(
+      {
+        unsafeCleanup: true,
+        setGracefulCleanup: true,
+        name: "default#web3-one"
+      },
+      function(err, result) {
+        if (err) return reject(err);
+        result.resolver = new Resolver(result);
+        result.artifactor = new Artifactor(result.contracts_build_directory);
+        result.networks = {};
 
-      accept(result);
-    });
+        accept(result);
+      }
+    );
   });
 
   await fs.remove(path.join(config.contracts_directory, "MetaCoin.sol"));

--- a/packages/truffle-debugger/test/precompiles.js
+++ b/packages/truffle-debugger/test/precompiles.js
@@ -1,10 +1,9 @@
 import debugModule from "debug";
-const debug = debugModule("test:precompiles");
+const debug = debugModule("test:precompiles"); // eslint-disable-line no-unused-vars
 
 import { assert } from "chai";
 
 import Ganache from "ganache-cli";
-import Web3 from "web3";
 
 import { prepareContracts } from "./helpers";
 import Debugger from "lib/debugger";
@@ -14,7 +13,7 @@ import trace from "lib/trace/selectors";
 import solidity from "lib/solidity/selectors";
 
 const __PRECOMPILE = `
-pragma solidity ^0.4.18;
+pragma solidity ~0.5;
 
 contract HasPrecompile {
   event Called();
@@ -28,23 +27,26 @@ contract HasPrecompile {
 `;
 
 let sources = {
-  "HasPrecompile.sol": __PRECOMPILE,
+  "HasPrecompile.sol": __PRECOMPILE
 };
 
-const TEST_CASES = [{
-  name: "trace.step",
-  selector: trace.step
-}, {
-  name: "evm.current.context",
-  selector: evm.current.context
-}, {
-  name: "solidity.current.sourceRange",
-  selector: solidity.current.sourceRange
-}];
+const TEST_CASES = [
+  {
+    name: "trace.step",
+    selector: trace.step
+  },
+  {
+    name: "evm.current.context",
+    selector: evm.current.context
+  },
+  {
+    name: "solidity.current.sourceRange",
+    selector: solidity.current.sourceRange
+  }
+];
 
 describe("Precompiled Contracts", () => {
   let provider;
-  let web3;
 
   let abstractions;
   let artifacts;
@@ -54,8 +56,7 @@ describe("Precompiled Contracts", () => {
   let results = {};
 
   before("Create Provider", async function() {
-    provider = Ganache.provider({seed: "debugger", gasLimit: 7000000});
-    web3 = new Web3(provider);
+    provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
   });
 
   before("Prepare contracts and artifacts", async function() {
@@ -86,7 +87,7 @@ describe("Precompiled Contracts", () => {
     });
 
     let session = bugger.connect();
-    var finished;  // is the trace finished?
+    var finished; // is the trace finished?
 
     do {
       for (let { name, selector } of TEST_CASES) {
@@ -103,7 +104,7 @@ describe("Precompiled Contracts", () => {
 
       session.advance();
       finished = session.view(trace.finished);
-    } while(!finished);
+    } while (!finished);
   });
 
   before("remove final step results", () => {

--- a/packages/truffle-debugger/test/reset.js
+++ b/packages/truffle-debugger/test/reset.js
@@ -37,6 +37,7 @@ describe("Reset Button", function() {
 
   var abstractions;
   var artifacts;
+  var files;
 
   before("Create Provider", async function() {
     provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
@@ -48,6 +49,7 @@ describe("Reset Button", function() {
     let prepared = await prepareContracts(provider, sources);
     abstractions = prepared.abstractions;
     artifacts = prepared.artifacts;
+    files = prepared.files;
   });
 
   it("Correctly resets after finishing", async function() {
@@ -57,6 +59,7 @@ describe("Reset Button", function() {
 
     let bugger = await Debugger.forTx(txHash, {
       provider,
+      files,
       contracts: artifacts
     });
 

--- a/packages/truffle-debugger/test/reset.js
+++ b/packages/truffle-debugger/test/reset.js
@@ -1,5 +1,5 @@
 import debugModule from "debug";
-const debug = debugModule("test:reset"); //eslint-disable-line no-unused-vars
+const debug = debugModule("test:reset"); // eslint-disable-line no-unused-vars
 
 import { assert } from "chai";
 
@@ -12,14 +12,14 @@ import data from "lib/data/selectors";
 import solidity from "lib/solidity/selectors";
 
 const __SETSTHINGS = `
-pragma solidity ^0.4.24;
+pragma solidity ~0.5;
 
 contract SetsThings {
   int x;
   int y;
   int z;
   int w;
-  function run() {
+  function run() public {
     x = 1;
     y = 2;
     z = 3;

--- a/packages/truffle-debugger/test/solidity.js
+++ b/packages/truffle-debugger/test/solidity.js
@@ -12,7 +12,7 @@ import solidity from "lib/solidity/selectors";
 import trace from "lib/trace/selectors";
 
 const __SINGLE_CALL = `
-pragma solidity ^0.4.18;
+pragma solidity ~0.5;
 
 contract SingleCall {
   event Called();
@@ -30,7 +30,7 @@ contract SingleCall {
 }
 `;
 
-const __NESTED_CALL = `pragma solidity ^0.4.18;
+const __NESTED_CALL = `pragma solidity ~0.5;
 
 contract NestedCall {
   event First();


### PR DESCRIPTION
[Note: This branch is kind of a mess; it might not end up getting merged in as such.]

This branch upgrades all the test contracts to 0.5.0, and attempts to fix all the resulting problems.  I've already fixed one such problem, namely the lack of support for `STATICCALL`, in PR #1446.  But there's more.

One issue that's come up is that a number of my tests are quite shaky.  This isn't an 0.5.0 problem, but I in my investigations I think I've figured out what's causing it anyway -- namely, I was relying on `sourceId` to be consistent between runs, when it's not.  That's an easy fix.

But the real problems are the 0.5.0-specific problems, which are very consistent.  The failing tests (now that I've fixed the storage decoding tests, where the problem was `STATICCALL`) are:
1. The memory decoding tests
2. The variable IDs tests
3. The two mapping tests where the domain is numeric

Note that these errors exist also, in near-identical form, on the `truffle-decoder` branch; I made a separate branch for testing that, namely `decoder-0.5.0-tests`, which see.

The memory decoding tests, as best I can tell, do seem to be due to a decoding problem.  However, I'm not certain of this.

The variable ID tests seem to be due to some difference in how variable declarations are handled, except for one of them which also seems to be due to a decoding problem like above.  Again, all this is uncertain.

The two mapping tests... I'd say also a decoding problem, probably, but a different one.  However I've made no real exploration of this at all.

Basically, I don't know what's going on, but that's my current progress.  Will update.