### PR TITLE
Fix intermittent failures of variable ID tests by removing fixed source IDs

### DIFF
--- a/packages/truffle-debugger/test/data/ids.js
+++ b/packages/truffle-debugger/test/data/ids.js
@@ -198,8 +198,9 @@ describe("Variable IDs", function() {
     let session = bugger.connect();
     debug("sourceId %d", session.view(solidity.current.source).id);
 
-    session.addBreakpoint({ sourceId: 1, line: 12 });
-    session.addBreakpoint({ sourceId: 1, line: 22 });
+    let sourceId = session.view(solidity.current.source).id;
+    session.addBreakpoint({ sourceId, line: 12 });
+    session.addBreakpoint({ sourceId, line: 22 });
 
     var values = [];
 
@@ -226,7 +227,8 @@ describe("Variable IDs", function() {
     let session = bugger.connect();
     debug("sourceId %d", session.view(solidity.current.source).id);
 
-    session.addBreakpoint({ sourceId: 0, line: 32 });
+    let sourceId = session.view(solidity.current.source).id;
+    session.addBreakpoint({ sourceId, line: 32 });
     session.continueUntilBreakpoint();
     debug("node %o", session.view(solidity.current.node));
     assert.equal(session.view(data.current.identifiers.native)["secret"], 107);
@@ -248,7 +250,8 @@ describe("Variable IDs", function() {
     let session = bugger.connect();
     debug("sourceId %d", session.view(solidity.current.source).id);
 
-    session.addBreakpoint({ sourceId: 2, line: 18 });
+    let sourceId = session.view(solidity.current.source).id;
+    session.addBreakpoint({ sourceId, line: 18 });
     session.continueUntilBreakpoint();
     assert.property(session.view(data.current.identifiers.native), "flag");
   });
@@ -267,7 +270,8 @@ describe("Variable IDs", function() {
     let session = bugger.connect();
     debug("sourceId %d", session.view(solidity.current.source).id);
 
-    session.addBreakpoint({ sourceId: 2, line: 27 });
+    let sourceId = session.view(solidity.current.source).id;
+    session.addBreakpoint({ sourceId, line: 27 });
     session.continueUntilBreakpoint();
     assert.property(session.view(data.current.identifiers.native), "flag");
   });

--- a/packages/truffle-debugger/test/reset.js
+++ b/packages/truffle-debugger/test/reset.js
@@ -1,16 +1,15 @@
 import debugModule from "debug";
-const debug = debugModule("test:reset");
+const debug = debugModule("test:reset"); //eslint-disable-line no-unused-vars
 
 import { assert } from "chai";
 
 import Ganache from "ganache-cli";
-import Web3 from "web3";
 
 import { prepareContracts } from "./helpers";
 import Debugger from "lib/debugger";
 
-import sessionSelector from "lib/session/selectors";
 import data from "lib/data/selectors";
+import solidity from "lib/solidity/selectors";
 
 const __SETSTHINGS = `
 pragma solidity ^0.4.24;
@@ -35,14 +34,12 @@ let sources = {
 
 describe("Reset Button", function() {
   var provider;
-  var web3;
 
   var abstractions;
   var artifacts;
 
   before("Create Provider", async function() {
     provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
-    web3 = new Web3(provider);
   });
 
   before("Prepare contracts and artifacts", async function() {
@@ -64,13 +61,14 @@ describe("Reset Button", function() {
     });
 
     let session = bugger.connect();
+    let sourceId = session.view(solidity.current.source).id;
 
     let variables = [];
     variables[0] = []; //collected during 1st run
     variables[1] = []; //collected during 2nd run
 
     variables[0].push(session.view(data.current.identifiers.native));
-    session.addBreakpoint({ sourceId: 0, line: 10 });
+    session.addBreakpoint({ sourceId, line: 10 });
     session.continueUntilBreakpoint(); //advance to line 10
     variables[0].push(session.view(data.current.identifiers.native));
     session.continueUntilBreakpoint(); //advance to the end
@@ -80,7 +78,6 @@ describe("Reset Button", function() {
     session.reset();
 
     variables[1].push(session.view(data.current.identifiers.native));
-    session.addBreakpoint({ sourceId: 0, line: 10 });
     session.continueUntilBreakpoint(); //advance to line 10
     variables[1].push(session.view(data.current.identifiers.native));
     session.continueUntilBreakpoint(); //advance to the end


### PR DESCRIPTION
The variable ID tests set breakpoints with fixed source IDs instead of just calling the appropriate selector to get the current source ID.  Since in fact source IDs are not assigned deterministically, this resulted in intermittent failures (I'm pretty sure this is the cause).  This pull request fixes that.  It does not address the intermittent failure of the end state variables test.