### PR TITLE
Keep precompiles from affecting function depth

### DIFF
--- a/packages/truffle-debugger/lib/evm/sagas/index.js
+++ b/packages/truffle-debugger/lib/evm/sagas/index.js
@@ -59,34 +59,18 @@ export function* begin({ address, binary }) {
 }
 
 export function* callstackSaga() {
-  let contexts;
-  let instances;
-
   while (true) {
     yield take(TICK);
-
-    // contexts and instances never change, so only capture them the first time
-    //
-    // HACK these selectors are available before TICK, i.e., they're available
-    // after session.READY, but there's no existing hookup for other sagas to
-    // wait for READY.
-    if (!contexts) {
-      contexts = yield select(evm.info.contexts);
-      instances = yield select(evm.info.instances);
-    }
 
     if (yield select(evm.current.step.isCall)) {
       debug("got call");
       let address = yield select(evm.current.step.callAddress);
 
-      // HACK
       // if there is no binary (e.g. in the case of precompiled contracts),
       // then there will be no trace steps for the called code, and so we
       // shouldn't tell the debugger that we're entering another execution
       // context
-      let { context } = instances[address] || {};
-      let { binary } = contexts[context] || {};
-      if (!binary) {
+      if (yield select(evm.current.step.callsPrecompile)) {
         continue;
       }
 

--- a/packages/truffle-debugger/lib/evm/selectors/index.js
+++ b/packages/truffle-debugger/lib/evm/selectors/index.js
@@ -102,6 +102,24 @@ function createStepSelectors(step, state = null) {
 
           return "0x" + memory.join("").substring(offset, offset + length);
         }
+      ),
+
+      /**
+       * .callsPrecompile
+       *
+       * is the call address to a precompiled contract?
+       * HACK
+       */
+      callsPrecompile: createLeaf(
+        ["./callAddress", "/info/contexts", "/info/instances"],
+
+        (address, contexts, instances) => {
+          if (!address) return null;
+
+          let { context } = instances[address] || {};
+          let { binary } = contexts[context] || {};
+          return !binary;
+        }
       )
     });
   }

--- a/packages/truffle-debugger/lib/solidity/sagas/index.js
+++ b/packages/truffle-debugger/lib/solidity/sagas/index.js
@@ -29,22 +29,31 @@ function* tickSaga() {
 function* functionDepthSaga() {
   if (yield select(solidity.current.willJump)) {
     let jumpDirection = yield select(solidity.current.jumpDirection);
-
     yield put(actions.jump(jumpDirection));
   } else if (yield select(solidity.current.willCall)) {
+    //we have several cases here:
+    //1. precompile -- *don't* put any jump
+    //2. workaround case -- put a double jump (see below)
+    //3. general case -- put a single jump as expected
+
     debug("about to call");
-    //HACK WORKAROUND
-    //because of the solc problem where contract method calls essentially
-    //return twice, we compensate by putting *two* inward jumps for such a
-    //call.  Note that this won't work if the contract method was previously
-    //placed in a function variable!  Those will continue to screw things up!
-    //But if a contract call is being made directly, we can detect that.
-    if (yield select(solidity.current.isContractCall)) {
+    if (yield select(solidity.current.callsPrecompile)) {
+      //call to precompile; do nothing
+    } else if (yield select(solidity.current.isContractCall)) {
+      //HACK WORKAROUND
+      //because of the solc problem where contract method calls essentially
+      //return twice, we compensate by putting *two* inward jumps for such a
+      //call.  Note that this won't work if the contract method was previously
+      //placed in a function variable!  Those will continue to screw things up!
+      //But if a contract call is being made directly, we can detect that.
       debug("workaround invoked!");
       yield put(actions.jump("2"));
     } else {
       yield put(actions.jump("i"));
     }
+  } else if (yield select(solidity.current.willCreate)) {
+    //this case, thankfully, needs no further breakdown
+    yield put(actions.jump("i"));
   } else if (yield select(solidity.current.willReturn)) {
     yield put(actions.jump("o"));
   }

--- a/packages/truffle-debugger/lib/solidity/selectors/index.js
+++ b/packages/truffle-debugger/lib/solidity/selectors/index.js
@@ -256,12 +256,18 @@ let solidity = createSelectorTree({
 
     /**
      * solidity.current.willCall
-     * NOTE: this includes creations
      */
-    willCall: createLeaf(
-      [evm.current.step.isCall, evm.current.step.isCreate],
-      (isCall, isCreate) => isCall || isCreate
-    ),
+    willCall: createLeaf([evm.current.step.isCall], x => x),
+
+    /**
+     * solidity.current.willCreate
+     */
+    willCreate: createLeaf([evm.current.step.isCreate], x => x),
+
+    /**
+     * solidity.current.callsPrecompile
+     */
+    callsPrecompile: createLeaf([evm.current.step.callsPrecompile], x => x),
 
     /**
      * solidity.current.willReturn


### PR DESCRIPTION
This pull request makes it so that calls to precompiles once again no longer affect the function depth (as they didn't back when *no* external calls did so!).  Since we're now checking for precompiles in two places -- both the `callstackSaga` and the `functionDepthSaga` -- I factored out the logic for such and put it in a new selector.  This means that the optimization of only getting `instances` and `contexts` once in `callstackSaga` is gone, but I figure that's OK because selectors are memoized anyway.

This pull request also adds a test to verify that precompiles don't affect the function depth.