### PR TITLE
Memoize config.provider

### DIFF
--- a/packages/truffle-config/index.js
+++ b/packages/truffle-config/index.js
@@ -211,18 +211,24 @@ function Config(truffle_directory, working_directory, network) {
           return null;
         }
 
-        // use memoized provider (NOTE this requires reset if network changes)
-        if (providerMemo) {
-          return providerMemo;
-        }
-
+        // collect provider options from network config + global flags
         var options = self.network_config;
         options.verboseRpc = self.verboseRpc;
 
+        // check explicit `memoize` config value otherwise default enable
+        const shouldMemoize = "memoize" in options ? options.memoize : true;
+
+        // use memoized provider (NOTE this requires reset if network changes)
+        if (shouldMemoize && providerMemo) {
+          return providerMemo;
+        }
+
         const provider = Provider.create(options);
 
-        // set memo
-        providerMemo = provider;
+        if (shouldMemoize) {
+          // set memo
+          providerMemo = provider;
+        }
 
         return provider;
       },

--- a/packages/truffle-config/index.js
+++ b/packages/truffle-config/index.js
@@ -9,7 +9,6 @@ const Configstore = require("configstore");
 
 const DEFAULT_CONFIG_FILENAME = "truffle.js";
 const BACKUP_CONFIG_FILENAME = "truffle-config.js"; // For Windows + Command Prompt
-const DEFAULT_USER_CONFIG = "truffle";
 
 function Config(truffle_directory, working_directory, network) {
   var self = this;
@@ -20,11 +19,10 @@ function Config(truffle_directory, working_directory, network) {
     from: null
   };
 
-  const defaultUserConfig = new Configstore(
-    DEFAULT_USER_CONFIG,
-    {},
-    { globalConfigPath: true }
-  );
+  // declare memoization mechanism for provider
+  // config.provider's getter uses this memoized value if it is set
+  // config.network's setter resets the memo
+  let providerMemo = null;
 
   // This is a list of multi-level keys with defaults
   // we need to _.merge. Using this list for safety
@@ -77,7 +75,17 @@ function Config(truffle_directory, working_directory, network) {
     // These are already set.
     truffle_directory: function() {},
     working_directory: function() {},
-    network: function() {},
+    network: {
+      get: function() {
+        return this._values.network;
+      },
+      set: function(val) {
+        // reset provider memo (we changed the network, old provider invalid)
+        providerMemo = null;
+
+        this._values.network = val;
+      }
+    },
     networks: function() {},
     verboseRpc: function() {},
     build: function() {},
@@ -125,7 +133,7 @@ function Config(truffle_directory, working_directory, network) {
           return null;
         }
       },
-      set: function(val) {
+      set: function() {
         throw new Error(
           "Do not set config.network_id. Instead, set config.networks and then config.networks[<network name>].network_id"
         );
@@ -149,7 +157,7 @@ function Config(truffle_directory, working_directory, network) {
 
         return conf;
       },
-      set: function(val) {
+      set: function() {
         throw new Error(
           "Don't set config.network_config. Instead, set config.networks with the desired values."
         );
@@ -163,7 +171,7 @@ function Config(truffle_directory, working_directory, network) {
           return default_tx_values.from;
         }
       },
-      set: function(val) {
+      set: function() {
         throw new Error(
           "Don't set config.from directly. Instead, set config.networks and then config.networks[<network name>].from"
         );
@@ -177,7 +185,7 @@ function Config(truffle_directory, working_directory, network) {
           return default_tx_values.gas;
         }
       },
-      set: function(val) {
+      set: function() {
         throw new Error(
           "Don't set config.gas directly. Instead, set config.networks and then config.networks[<network name>].gas"
         );
@@ -191,7 +199,7 @@ function Config(truffle_directory, working_directory, network) {
           return default_tx_values.gasPrice;
         }
       },
-      set: function(val) {
+      set: function() {
         throw new Error(
           "Don't set config.gasPrice directly. Instead, set config.networks and then config.networks[<network name>].gasPrice"
         );
@@ -203,11 +211,22 @@ function Config(truffle_directory, working_directory, network) {
           return null;
         }
 
+        // use memoized provider (NOTE this requires reset if network changes)
+        if (providerMemo) {
+          return providerMemo;
+        }
+
         var options = self.network_config;
         options.verboseRpc = self.verboseRpc;
-        return Provider.create(options);
+
+        const provider = Provider.create(options);
+
+        // set memo
+        providerMemo = provider;
+
+        return provider;
       },
-      set: function(val) {
+      set: function() {
         throw new Error(
           "Don't set config.provider directly. Instead, set config.networks and then set config.networks[<network name>].provider"
         );
@@ -221,7 +240,7 @@ function Config(truffle_directory, working_directory, network) {
           return 0;
         }
       },
-      set: function(val) {
+      set: function() {
         throw new Error(
           "Don't set config.confirmations directly. Instead, set config.networks and then config.networks[<network name>].confirmations"
         );
@@ -235,7 +254,7 @@ function Config(truffle_directory, working_directory, network) {
           return false;
         }
       },
-      set: function(val) {
+      set: function() {
         throw new Error(
           "Don't set config.production directly. Instead, set config.networks and then config.networks[<network name>].production"
         );
@@ -249,7 +268,7 @@ function Config(truffle_directory, working_directory, network) {
           return 0;
         }
       },
-      set: function(val) {
+      set: function() {
         throw new Error(
           "Don't set config.timeoutBlocks directly. Instead, set config.networks and then config.networks[<network name>].timeoutBlocks"
         );
@@ -263,7 +282,7 @@ function Config(truffle_directory, working_directory, network) {
           return false;
         }
       },
-      set: function(val) {
+      set: function() {
         throw new Error(
           "Don't set config.skipDryRun directly. Instead, set config.networks and then config.networks[<network name>].skipDryRun"
         );


### PR DESCRIPTION
To (hopefully) address #1461, but at the very least this should improve performance.

Memoization works via:
- Memo is stored upon `config.provider`'s get
- Memo is reset upon `config.network`'s set

Risks/downsides:
- It might be dangerous to use a memoization mechanism that spans three different parts of the code (i.e., initialization, provider get, network set)

- It's dangerous if the `config.provider` memo is theoretically invalidated but never reset. It might not be sufficient to reset the memo when `config.network = ...` happens.

  For instance, `config.network["..."].port = "..."` would result in an invalid memoized `config.provider`.

  This may not matter.

- We might want to make a `config.networks["..."].memoize` option, to allow this to be turned off.

For now though... see what Travis does.