### PR TITLE
Suppress anonymous output parameters from data.current.identifiers.

### DIFF
--- a/packages/truffle-debugger/lib/data/selectors/index.js
+++ b/packages/truffle-debugger/lib/data/selectors/index.js
@@ -216,6 +216,7 @@ const data = createSelectorTree({
             variables = Object.assign(
               variables,
               ...(scopes[cur].variables || [])
+                .filter(v => v.name !== "") //exclude anonymous output params
                 .filter(v => variables[v.name] == undefined)
                 .map(v => ({ [v.name]: v.id }))
             );


### PR DESCRIPTION
This pull request prevents anonymous output parameters from displaying (with the empty string for a name) when the user hits `v`, by excluding them for `data.current.identifiers`.  The empty string for a name is confusing, and it doesn't really make sense to display such parameters in the first place as they'll basically only ever contain nonsense except at the very end of their lifetime.  (I didn't bother adding any tests in this PR.)