### PR TITLE
skip already linked contracts instead of all contracts

### DIFF
--- a/packages/truffle-deployer/src/linker.js
+++ b/packages/truffle-deployer/src/linker.js
@@ -39,7 +39,7 @@ module.exports = {
       const alreadyLinked = (destination.links[library.contract_name] == library.address);
       const noLinkage =     (destination.unlinked_binary.indexOf(library.contract_name) < 0);
 
-      if (alreadyLinked || noLinkage) return;
+      if (alreadyLinked || noLinkage) continue;
 
       eventArgs = {
         libraryName: library.contractName,


### PR DESCRIPTION
The truffle docs (https://truffleframework.com/docs/truffle/getting-started/running-migrations#deployer-link-library-destinations-) state that:

> If any contract within the destination doesn't rely on the library being linked, the contract will be ignored.

However, if a destination doesn't rely on the library being link, the `link` function returns early, failing to link the other destinations.

This bug seems to have been introduced in https://github.com/trufflesuite/truffle/pull/1028 when a `forEach` was changed to a loop without changing a `return` statement into a `continue`. cc @cgewecke 