### PR TITLE
Strip mapping metadata from decoder output in debugger

### DIFF
--- a/packages/truffle-debugger/lib/data/selectors/index.js
+++ b/packages/truffle-debugger/lib/data/selectors/index.js
@@ -346,7 +346,9 @@ const data = createSelectorTree({
             })
           );
           const keyedResults = await Promise.all(keyedPromises);
-          return Object.assign({}, ...keyedResults);
+          return TruffleDecodeUtils.Conversion.cleanMappings(
+            Object.assign({}, ...keyedResults)
+          );
         }
       ),
 

--- a/packages/truffle-decode-utils/package.json
+++ b/packages/truffle-decode-utils/package.json
@@ -11,6 +11,7 @@
   "types": "src/index.ts",
   "scripts": {
     "build": "node_modules/.bin/tsc",
+    "start": "node_modules/.bin/tsc --watch",
     "test": "echo \"No test specified\" && exit 0;"
   },
   "repository": {

--- a/packages/truffle-decode-utils/src/conversion.ts
+++ b/packages/truffle-decode-utils/src/conversion.ts
@@ -150,9 +150,12 @@ export namespace Conversion {
   /**
    * Convert a mapping representation into a JS Map
    *
-   * Only converts integer types to BN right now, leaving everything else alone
+   * Only converts integer types to BN right now, leaving other keys else alone
    */
-  export function toMap({ keyType, members }: any): Map<any, any> {
+  export function toMap(
+    { keyType, members }: any,
+    convertValue?: (value: any) => any
+  ): Map<any, any> {
     // convert integer types to BN, unless string representation is hex
     const convertKey = (key: string) => {
       if (keyType.match(/int/) && key.slice(0,2) != "0x") {
@@ -162,10 +165,12 @@ export namespace Conversion {
       }
     }
 
-    // populate Map with members, using converted keys
+    convertValue = convertValue || (x => x);
+
+    // populate Map with members, using converted keys/values
     return new Map([
       ...Object.entries(members)
-        .map( ([key, value]: any) => ([convertKey(key), value]) )
+        .map( ([key, value]: any) => ([convertKey(key), convertValue(value)]) )
     ] as any);
   }
 
@@ -192,7 +197,7 @@ export namespace Conversion {
 
     // detect mapping
     else if (value && typeof value === "object" && isMapping(value)) {
-      return toMap(value);
+      return toMap(value, cleanMappings);
     }
 
     // detect arrays or anything with `.map()`, and recurse


### PR DESCRIPTION
- Recursively search through all decoder output and detect decoder's encoding for mappings.
- Strip out the wrapper info and convert the mapping to a JS `Map` object
- Use BN as `Map` key type when Solidity's mapping key type is some kind of `uint` or `int`

Previously:
<img width="550" alt="screen shot 2018-12-04 at 9 20 03 pm" src="https://user-images.githubusercontent.com/151065/49551080-d4f1f680-f8bb-11e8-9759-9f5bc37de20c.png">

Now:

<img width="582" alt="screen shot 2018-12-04 at 10 11 51 pm" src="https://user-images.githubusercontent.com/151065/49551097-e1764f00-f8bb-11e8-9c3e-fd088cf68282.png">
