### PR TITLE
Use truffle web3 fork

### DIFF
--- a/packages/truffle-artifactor/package.json
+++ b/packages/truffle-artifactor/package.json
@@ -21,7 +21,7 @@
     "solc": "^0.5.0",
     "temp": "^0.8.3",
     "truffle-blockchain-utils": "^0.0.6-beta.1",
-    "web3": "1.0.0-beta.36"
+    "web3": "github:trufflesuite/web3.js#master"
   },
   "dependencies": {
     "async": "2.6.1",

--- a/packages/truffle-artifactor/package.json
+++ b/packages/truffle-artifactor/package.json
@@ -21,7 +21,7 @@
     "solc": "^0.5.0",
     "temp": "^0.8.3",
     "truffle-blockchain-utils": "^0.0.6-beta.1",
-    "web3": "github:trufflesuite/web3.js#master"
+    "web3": "github:trufflesuite/web3.js#1.0"
   },
   "dependencies": {
     "async": "2.6.1",

--- a/packages/truffle-contract/package.json
+++ b/packages/truffle-contract/package.json
@@ -35,7 +35,7 @@
     "truffle-contract-schema": "^3.0.0-beta.2",
     "truffle-error": "^0.0.3",
     "uglify-es": "^3.3.9",
-    "web3": "1.0.0-beta.36",
+    "web3": "github:trufflesuite/web3.js#master",
     "web3-core-promievent": "1.0.0-beta.36",
     "web3-eth-abi": "1.0.0-beta.36",
     "web3-utils": "1.0.0-beta.36"

--- a/packages/truffle-contract/package.json
+++ b/packages/truffle-contract/package.json
@@ -35,7 +35,7 @@
     "truffle-contract-schema": "^3.0.0-beta.2",
     "truffle-error": "^0.0.3",
     "uglify-es": "^3.3.9",
-    "web3": "github:trufflesuite/web3.js#master",
+    "web3": "github:trufflesuite/web3.js#1.0",
     "web3-core-promievent": "1.0.0-beta.36",
     "web3-eth-abi": "1.0.0-beta.36",
     "web3-utils": "1.0.0-beta.36"

--- a/packages/truffle-contract/test/util.js
+++ b/packages/truffle-contract/test/util.js
@@ -73,7 +73,9 @@ var util = {
     var web3 = new Web3();
 
     process.env.GETH
-      ? (provider = new Web3.providers.HttpProvider("http://localhost:8545"))
+      ? (provider = new Web3.providers.HttpProvider("http://localhost:8545", {
+          keepAlive: false
+        }))
       : (provider = ganache.provider(options));
 
     web3.setProvider(provider);

--- a/packages/truffle-core/lib/environment.js
+++ b/packages/truffle-core/lib/environment.js
@@ -136,7 +136,7 @@ var Environment = {
     config.networks[network] = {
       network_id: testrpcOptions.network_id,
       provider: function() {
-        return new Web3.providers.HttpProvider(url);
+        return new Web3.providers.HttpProvider(url, { keepAlive: false });
       }
     };
 

--- a/packages/truffle-core/lib/package.js
+++ b/packages/truffle-core/lib/package.js
@@ -6,34 +6,32 @@ var EthPMRegistry = require("ethpm-registry");
 var Web3 = require("web3");
 var async = require("async");
 var path = require("path");
-var fs = require('fs');
+var fs = require("fs");
 var OS = require("os");
 
 var Package = {
   install: async function(options, callback) {
-    expect.options(options, [
-      "working_directory",
-      "ethpm"
-    ]);
+    expect.options(options, ["working_directory", "ethpm"]);
 
-    expect.options(options.ethpm, [
-      "registry",
-      "ipfs_host"
-    ]);
+    expect.options(options.ethpm, ["registry", "ipfs_host"]);
 
-    expect.one(options.ethpm, [
-      "provider",
-      "install_provider_uri"
-    ]);
+    expect.one(options.ethpm, ["provider", "install_provider_uri"]);
 
     // ipfs_port and ipfs_protocol are optinal.
 
-    var provider = options.ethpm.provider || new Web3.providers.HttpProvider(options.ethpm.install_provider_uri);
-    var web3 = new Web3(provider);
+    var provider =
+      options.ethpm.provider ||
+      new Web3.providers.HttpProvider(options.ethpm.install_provider_uri, {
+        keepAlive: false
+      });
     var host = options.ethpm.ipfs_host;
 
-    if ((host instanceof EthPM.hosts.IPFS) == false) {
-      host = new EthPM.hosts.IPFSWithLocalReader(options.ethpm.ipfs_host, options.ethpm.ipfs_port, options.ethpm.ipfs_protocol);
+    if (host instanceof EthPM.hosts.IPFS == false) {
+      host = new EthPM.hosts.IPFSWithLocalReader(
+        options.ethpm.ipfs_host,
+        options.ethpm.ipfs_port,
+        options.ethpm.ipfs_protocol
+      );
     }
 
     // When installing, we use infura to make a bunch of eth_call's.
@@ -44,7 +42,11 @@ var Package = {
     var registry = options.ethpm.registry;
 
     if (typeof registry == "string") {
-      registry = await EthPMRegistry.use(options.ethpm.registry, fakeAddress, provider);
+      registry = await EthPMRegistry.use(
+        options.ethpm.registry,
+        fakeAddress,
+        provider
+      );
     }
 
     var pkg = new EthPM(options.working_directory, host, registry);
@@ -63,22 +65,31 @@ var Package = {
         return pkg.installDependency(package_name, version);
       });
 
-      Promise.all(promises).then(function() {
-        callback();
-      }).catch(callback);
-    } else {
-      fs.access(path.join(options.working_directory, "ethpm.json"), fs.constants.R_OK, function(err) {
-        var manifest;
-
-        // If the ethpm.json file doesn't exist, use the config as the manifest.
-        if (err) {
-          manifest = options;
-        }
-
-        pkg.install(manifest).then(function() {
+      Promise.all(promises)
+        .then(function() {
           callback();
-        }).catch(callback);
-      });
+        })
+        .catch(callback);
+    } else {
+      fs.access(
+        path.join(options.working_directory, "ethpm.json"),
+        fs.constants.R_OK,
+        function(err) {
+          var manifest;
+
+          // If the ethpm.json file doesn't exist, use the config as the manifest.
+          if (err) {
+            manifest = options;
+          }
+
+          pkg
+            .install(manifest)
+            .then(function() {
+              callback();
+            })
+            .catch(callback);
+        }
+      );
     }
   },
 
@@ -92,10 +103,7 @@ var Package = {
       "networks"
     ]);
 
-    expect.options(options.ethpm, [
-      "registry",
-      "ipfs_host"
-    ]);
+    expect.options(options.ethpm, ["registry", "ipfs_host"]);
 
     // ipfs_port and ipfs_protocol are optinal.
 
@@ -103,7 +111,15 @@ var Package = {
     var ropsten = options.networks.ropsten;
 
     if (!ropsten) {
-      return callback(new TruffleError("You need to have a `ropsten` network configured in order to publish to the Ethereum Package Registry. See the following link for an example configuration:" + OS.EOL + OS.EOL + "    http://truffleframework.com/tutorials/using-infura-custom-provider" + OS.EOL));
+      return callback(
+        new TruffleError(
+          "You need to have a `ropsten` network configured in order to publish to the Ethereum Package Registry. See the following link for an example configuration:" +
+            OS.EOL +
+            OS.EOL +
+            "    http://truffleframework.com/tutorials/using-infura-custom-provider" +
+            OS.EOL
+        )
+      );
     }
 
     options.network = "ropsten";
@@ -112,8 +128,12 @@ var Package = {
     var web3 = new Web3(provider);
     var host = options.ethpm.ipfs_host;
 
-    if ((host instanceof EthPM.hosts.IPFS) == false) {
-      host = new EthPM.hosts.IPFS(options.ethpm.ipfs_host, options.ethpm.ipfs_port, options.ethpm.ipfs_protocol);
+    if (host instanceof EthPM.hosts.IPFS == false) {
+      host = new EthPM.hosts.IPFS(
+        options.ethpm.ipfs_host,
+        options.ethpm.ipfs_port,
+        options.ethpm.ipfs_protocol
+      );
     }
 
     options.logger.log("Finding publishable artifacts...");
@@ -121,28 +141,50 @@ var Package = {
     self.publishable_artifacts(options, function(err, artifacts) {
       if (err) return callback(err);
 
-      web3.eth.getAccounts().then(async (accs) => {
-        var registry = await EthPMRegistry.use(options.ethpm.registry, accs[0], provider);
-        var pkg = new EthPM(options.working_directory, host, registry);
+      web3.eth
+        .getAccounts()
+        .then(async accs => {
+          var registry = await EthPMRegistry.use(
+            options.ethpm.registry,
+            accs[0],
+            provider
+          );
+          var pkg = new EthPM(options.working_directory, host, registry);
 
-        fs.access(path.join(options.working_directory, "ethpm.json"), fs.constants.R_OK, function(err) {
-          var manifest;
+          fs.access(
+            path.join(options.working_directory, "ethpm.json"),
+            fs.constants.R_OK,
+            function(err) {
+              var manifest;
 
-          // If the ethpm.json file doesn't exist, use the config as the manifest.
-          if (err) {
-            manifest = options;
-          }
+              // If the ethpm.json file doesn't exist, use the config as the manifest.
+              if (err) {
+                manifest = options;
+              }
 
-          options.logger.log("Uploading sources and publishing to registry...");
+              options.logger.log(
+                "Uploading sources and publishing to registry..."
+              );
 
-          // TODO: Gather contract_types and deployments
-          pkg.publish(artifacts.contract_types, artifacts.deployments, manifest).then(function(lockfile) {
-            // If we get here, publishing was a success.
-            options.logger.log("+ " + lockfile.package_name + "@" + lockfile.version);
-            callback();
-          }).catch(callback);
-        });
-      }).catch(callback);
+              // TODO: Gather contract_types and deployments
+              pkg
+                .publish(
+                  artifacts.contract_types,
+                  artifacts.deployments,
+                  manifest
+                )
+                .then(function(lockfile) {
+                  // If we get here, publishing was a success.
+                  options.logger.log(
+                    "+ " + lockfile.package_name + "@" + lockfile.version
+                  );
+                  callback();
+                })
+                .catch(callback);
+            }
+          );
+        })
+        .catch(callback);
     });
   },
 
@@ -165,7 +207,9 @@ var Package = {
   // Return a list of publishable artifacts
   publishable_artifacts: function(options, callback) {
     // Filter out "test" and "development" networks.
-    var deployed_networks = Object.keys(options.networks).filter(function(network_name) {
+    var deployed_networks = Object.keys(options.networks).filter(function(
+      network_name
+    ) {
       return network_name != "test" && network_name != "development";
     });
 
@@ -176,98 +220,121 @@ var Package = {
       var uris = result.uris;
 
       if (result.failed.length > 0) {
-        return callback(new Error("Could not connect to the following networks: " + result.failed.join(", ") + ". These networks have deployed artifacts that can't be published as a package without an active and accessible connection. Please ensure clients for each network are up and running prior to publishing, or use the -n option to specify specific networks you'd like published."));
+        return callback(
+          new Error(
+            "Could not connect to the following networks: " +
+              result.failed.join(", ") +
+              ". These networks have deployed artifacts that can't be published as a package without an active and accessible connection. Please ensure clients for each network are up and running prior to publishing, or use the -n option to specify specific networks you'd like published."
+          )
+        );
       }
 
       var files = fs.readdirSync(options.contracts_build_directory);
-      files = files.filter(file => file.includes('.json'));
+      files = files.filter(file => file.includes(".json"));
 
-      if(!files.length){
-        var msg = "Could not locate any publishable artifacts in " +
-                  options.contracts_build_directory + ". " +
-                  "Run `truffle compile` before publishing.";
+      if (!files.length) {
+        var msg =
+          "Could not locate any publishable artifacts in " +
+          options.contracts_build_directory +
+          ". " +
+          "Run `truffle compile` before publishing.";
 
         return callback(new Error(msg));
       }
 
       var promises = files.map(function(file) {
         return new Promise(function(accept, reject) {
-          fs.readFile(path.join(options.contracts_build_directory, file), "utf8", function(err, body) {
-            if (err) return reject(err);
+          fs.readFile(
+            path.join(options.contracts_build_directory, file),
+            "utf8",
+            function(err, body) {
+              if (err) return reject(err);
 
-            try {
-              body = JSON.parse(body);
-            } catch (e) {
-              return reject(e);
+              try {
+                body = JSON.parse(body);
+              } catch (e) {
+                return reject(e);
+              }
+
+              accept(body);
             }
-
-            accept(body);
-          });
+          );
         });
       });
 
       var contract_types = {};
       var deployments = {};
 
-      Promise.all(promises).then(function(contracts) {
-        // contract_types first.
-        contracts.forEach(function(data) {
-          contract_types[data.contractName] = {
-            contract_name: data.contractName,
-            bytecode: data.bytecode,
-            abi: data.abi
-          };
-        });
-
-        //var network_cache = {};
-        var matching_promises = [];
-
-        contracts.forEach(function(data) {
-          Object.keys(data.networks).forEach(function(network_id) {
-
-            matching_promises.push(new Promise(function(accept, reject) {
-              // Go through each deployed network and see if this network matches.
-              // Bail early if we foun done.
-              async.each(deployed_networks, function(deployed_network, finished) {
-                Networks.matchesNetwork(network_id, options.networks[deployed_network], function(err, matches) {
-                  if (err) return finished(err);
-                  if (matches) {
-                    var uri = uris[deployed_network];
-
-                    if (!deployments[uri]) {
-                      deployments[uri] = {};
-                    }
-
-                    deployments[uri][data.contractName] = {
-                      contract_type: data.contractName, // TODO: Handle conflict resolution
-                      address: data.networks[network_id].address
-                    };
-
-                    return finished("bail early");
-                  }
-                  finished();
-                });
-              }, function(err) {
-                if (err && err != "bail early") {
-                  return reject(err);
-                }
-
-                accept();
-              });
-
-            }));
+      Promise.all(promises)
+        .then(function(contracts) {
+          // contract_types first.
+          contracts.forEach(function(data) {
+            contract_types[data.contractName] = {
+              contract_name: data.contractName,
+              bytecode: data.bytecode,
+              abi: data.abi
+            };
           });
-        });
 
-        return Promise.all(matching_promises);
-      }).then(function() {
-        var to_return = {
-          contract_types: contract_types,
-          deployments: deployments
-        };
+          //var network_cache = {};
+          var matching_promises = [];
 
-        callback(null, to_return);
-      }).catch(callback);
+          contracts.forEach(function(data) {
+            Object.keys(data.networks).forEach(function(network_id) {
+              matching_promises.push(
+                new Promise(function(accept, reject) {
+                  // Go through each deployed network and see if this network matches.
+                  // Bail early if we foun done.
+                  async.each(
+                    deployed_networks,
+                    function(deployed_network, finished) {
+                      Networks.matchesNetwork(
+                        network_id,
+                        options.networks[deployed_network],
+                        function(err, matches) {
+                          if (err) return finished(err);
+                          if (matches) {
+                            var uri = uris[deployed_network];
+
+                            if (!deployments[uri]) {
+                              deployments[uri] = {};
+                            }
+
+                            deployments[uri][data.contractName] = {
+                              contract_type: data.contractName, // TODO: Handle conflict resolution
+                              address: data.networks[network_id].address
+                            };
+
+                            return finished("bail early");
+                          }
+                          finished();
+                        }
+                      );
+                    },
+                    function(err) {
+                      if (err && err != "bail early") {
+                        return reject(err);
+                      }
+
+                      accept();
+                    }
+                  );
+                })
+              );
+            });
+          });
+
+          return Promise.all(matching_promises);
+        })
+        .then(function() {
+          var to_return = {
+            contract_types: contract_types,
+            deployments: deployments
+          };
+
+          callback(null, to_return);
+        })
+        .catch(callback);
     });
   }
 };

--- a/packages/truffle-core/package.json
+++ b/packages/truffle-core/package.json
@@ -52,7 +52,7 @@
     "truffle-solidity-utils": "^1.2.0-beta.0",
     "truffle-workflow-compile": "^2.0.0-beta.2",
     "universal-analytics": "^0.4.17",
-    "web3": "github:trufflesuite/web3.js#master",
+    "web3": "github:trufflesuite/web3.js#1.0",
     "yargs": "^8.0.2"
   },
   "bin": {

--- a/packages/truffle-core/package.json
+++ b/packages/truffle-core/package.json
@@ -52,7 +52,7 @@
     "truffle-solidity-utils": "^1.2.0-beta.0",
     "truffle-workflow-compile": "^2.0.0-beta.2",
     "universal-analytics": "^0.4.17",
-    "web3": "1.0.0-beta.36",
+    "web3": "github:trufflesuite/web3.js#master",
     "yargs": "^8.0.2"
   },
   "bin": {

--- a/packages/truffle-debugger/package.json
+++ b/packages/truffle-debugger/package.json
@@ -33,7 +33,7 @@
     "truffle-code-utils": "^1.1.2-beta.1",
     "truffle-expect": "^0.0.5-beta.0",
     "truffle-solidity-utils": "^1.2.0-beta.0",
-    "web3": "1.0.0-beta.36",
+    "web3": "github:trufflesuite/web3.js#master",
     "web3-eth-abi": "1.0.0-beta.36"
   },
   "devDependencies": {

--- a/packages/truffle-debugger/package.json
+++ b/packages/truffle-debugger/package.json
@@ -33,7 +33,7 @@
     "truffle-code-utils": "^1.1.2-beta.1",
     "truffle-expect": "^0.0.5-beta.0",
     "truffle-solidity-utils": "^1.2.0-beta.0",
-    "web3": "github:trufflesuite/web3.js#master",
+    "web3": "github:trufflesuite/web3.js#1.0",
     "web3-eth-abi": "1.0.0-beta.36"
   },
   "devDependencies": {

--- a/packages/truffle-deployer/package.json
+++ b/packages/truffle-deployer/package.json
@@ -33,7 +33,7 @@
     "mocha": "5.2.0",
     "truffle-reporters": "^1.0.0-beta.2",
     "truffle-workflow-compile": "^2.0.0-beta.2",
-    "web3": "1.0.0-beta.36"
+    "web3": "github:trufflesuite/web3.js#master"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/truffle-deployer/package.json
+++ b/packages/truffle-deployer/package.json
@@ -33,7 +33,7 @@
     "mocha": "5.2.0",
     "truffle-reporters": "^1.0.0-beta.2",
     "truffle-workflow-compile": "^2.0.0-beta.2",
-    "web3": "github:trufflesuite/web3.js#master"
+    "web3": "github:trufflesuite/web3.js#1.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/truffle-hdwallet-provider/package.json
+++ b/packages/truffle-hdwallet-provider/package.json
@@ -33,7 +33,7 @@
     "ganache-core": "^2.2.1",
     "js-scrypt": "^0.2.0",
     "mocha": "^5.1.1",
-    "web3": "github:trufflesuite/web3.js#master",
+    "web3": "github:trufflesuite/web3.js#1.0",
     "web3-provider-engine": "git+https://github.com/cgewecke/provider-engine.git#web3-one",
     "webpack": "^4.24.0",
     "webpack-cli": "^3.1.2"

--- a/packages/truffle-hdwallet-provider/package.json
+++ b/packages/truffle-hdwallet-provider/package.json
@@ -33,7 +33,7 @@
     "ganache-core": "^2.2.1",
     "js-scrypt": "^0.2.0",
     "mocha": "^5.1.1",
-    "web3": "1.0.0-beta.36",
+    "web3": "github:trufflesuite/web3.js#master",
     "web3-provider-engine": "git+https://github.com/cgewecke/provider-engine.git#web3-one",
     "webpack": "^4.24.0",
     "webpack-cli": "^3.1.2"

--- a/packages/truffle-hdwallet-provider/src/index.js
+++ b/packages/truffle-hdwallet-provider/src/index.js
@@ -115,7 +115,9 @@ function HDWalletProvider(
   this.engine.addProvider(new FiltersSubprovider());
   if (typeof provider === "string") {
     this.engine.addProvider(
-      new ProviderSubprovider(new Web3.providers.HttpProvider(provider))
+      new ProviderSubprovider(
+        new Web3.providers.HttpProvider(provider, { keepAlive: false })
+      )
     );
   } else {
     this.engine.addProvider(new ProviderSubprovider(provider));

--- a/packages/truffle-migrate/package.json
+++ b/packages/truffle-migrate/package.json
@@ -28,7 +28,7 @@
     "truffle-expect": "^0.0.5-beta.0",
     "truffle-reporters": "^1.0.0-beta.2",
     "truffle-require": "^2.0.0-beta.2",
-    "web3": "github:trufflesuite/web3.js#master"
+    "web3": "github:trufflesuite/web3.js#1.0"
   },
   "devDependencies": {
     "mocha": "5.2.0"

--- a/packages/truffle-migrate/package.json
+++ b/packages/truffle-migrate/package.json
@@ -28,7 +28,7 @@
     "truffle-expect": "^0.0.5-beta.0",
     "truffle-reporters": "^1.0.0-beta.2",
     "truffle-require": "^2.0.0-beta.2",
-    "web3": "1.0.0-beta.36"
+    "web3": "github:trufflesuite/web3.js#master"
   },
   "devDependencies": {
     "mocha": "5.2.0"

--- a/packages/truffle-provider/index.js
+++ b/packages/truffle-provider/index.js
@@ -21,7 +21,8 @@ module.exports = {
       );
     } else {
       provider = new Web3.providers.HttpProvider(
-        "http://" + options.host + ":" + options.port
+        "http://" + options.host + ":" + options.port,
+        { keepAlive: false }
       );
     }
 

--- a/packages/truffle-provider/package.json
+++ b/packages/truffle-provider/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/trufflesuite/truffle-provider#readme",
   "dependencies": {
     "truffle-error": "^0.0.3",
-    "web3": "1.0.0-beta.36"
+    "web3": "github:trufflesuite/web3.js#master"
   },
   "devDependencies": {
     "ganache-cli": "6.1.8",

--- a/packages/truffle-provider/package.json
+++ b/packages/truffle-provider/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/trufflesuite/truffle-provider#readme",
   "dependencies": {
     "truffle-error": "^0.0.3",
-    "web3": "github:trufflesuite/web3.js#master"
+    "web3": "github:trufflesuite/web3.js#1.0"
   },
   "devDependencies": {
     "ganache-cli": "6.1.8",

--- a/packages/truffle-require/package.json
+++ b/packages/truffle-require/package.json
@@ -29,7 +29,7 @@
     "original-require": "1.0.1",
     "truffle-config": "^1.1.0-beta.2",
     "truffle-expect": "^0.0.5-beta.0",
-    "web3": "github:trufflesuite/web3.js#master"
+    "web3": "github:trufflesuite/web3.js#1.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/truffle-require/package.json
+++ b/packages/truffle-require/package.json
@@ -29,7 +29,7 @@
     "original-require": "1.0.1",
     "truffle-config": "^1.1.0-beta.2",
     "truffle-expect": "^0.0.5-beta.0",
-    "web3": "1.0.0-beta.36"
+    "web3": "github:trufflesuite/web3.js#master"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -30,7 +30,7 @@
     "tmp": "0.0.33",
     "truffle-box": "^1.0.8-beta.2",
     "truffle-contract": "^4.0.0-beta.2",
-    "web3": "1.0.0-beta.36",
+    "web3": "github:trufflesuite/web3.js#master",
     "webpack": "^2.5.1",
     "yargs": "^8.0.2"
   },

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -30,7 +30,7 @@
     "tmp": "0.0.33",
     "truffle-box": "^1.0.8-beta.2",
     "truffle-contract": "^4.0.0-beta.2",
-    "web3": "github:trufflesuite/web3.js#master",
+    "web3": "github:trufflesuite/web3.js#1.0",
     "webpack": "^2.5.1",
     "yargs": "^8.0.2"
   },

--- a/packages/truffle/test/scenarios/migrations/dryrun.js
+++ b/packages/truffle/test/scenarios/migrations/dryrun.js
@@ -5,12 +5,12 @@ const assert = require("assert");
 const Server = require("../server");
 const Reporter = require("../reporter");
 const sandbox = require("../sandbox");
-const Web3 = require('web3');
+const Web3 = require("web3");
 
 const log = console.log;
 
-function processErr(err, output){
-  if (err){
+function processErr(err, output) {
+  if (err) {
     log(output);
     throw new Error(err);
   }
@@ -19,7 +19,7 @@ function processErr(err, output){
 describe("migrate (dry-run)", function() {
   let config;
   let web3;
-  const project = path.join(__dirname, '../../sources/migrations/success');
+  const project = path.join(__dirname, "../../sources/migrations/success");
   const logger = new MemoryLogger();
 
   before(done => Server.start(done));
@@ -34,34 +34,33 @@ describe("migrate (dry-run)", function() {
       reporter: new Reporter(logger)
     };
 
-    const provider = new Web3.providers.HttpProvider('http://localhost:8545');
+    const provider = new Web3.providers.HttpProvider("http://localhost:8545", {
+      keepAlive: false
+    });
     web3 = new Web3(provider);
     networkId = await web3.eth.net.getId();
   });
 
-  it('uses the dry-run option', function(done){
+  it("uses the dry-run option", function(done) {
     this.timeout(70000);
 
     CommandRunner.run("migrate --dry-run", config, err => {
       const output = logger.contents();
       processErr(err, output);
       console.log(output);
-      assert(output.includes('dry-run'));
+      assert(output.includes("dry-run"));
 
-      assert(!output.includes('transaction hash'));
+      assert(!output.includes("transaction hash"));
 
-      assert(output.includes('Migrations'));
-      assert(output.includes('development-fork'));
-      assert(output.includes('2_migrations_sync.js'));
+      assert(output.includes("Migrations"));
+      assert(output.includes("development-fork"));
+      assert(output.includes("2_migrations_sync.js"));
       assert(output.includes("Deploying 'UsesExample'"));
-      assert(output.includes('3_migrations_async.js'));
+      assert(output.includes("3_migrations_async.js"));
       assert(output.includes("Replacing 'UsesExample'"));
-      assert(output.includes('Total deployments'));
-
-      const location = path.join(config.contracts_build_directory, "UsesExample.json");
+      assert(output.includes("Total deployments"));
 
       done();
     });
   });
 });
-

--- a/packages/truffle/test/scenarios/migrations/errors.js
+++ b/packages/truffle/test/scenarios/migrations/errors.js
@@ -5,13 +5,13 @@ const assert = require("assert");
 const Server = require("../server");
 const Reporter = require("../reporter");
 const sandbox = require("../sandbox");
-const Web3 = require('web3');
+const Web3 = require("web3");
 
 describe("migration errors", function() {
   let config;
   let web3;
   let networkId;
-  const project = path.join(__dirname, '../../sources/migrations/error');
+  const project = path.join(__dirname, "../../sources/migrations/error");
   const logger = new MemoryLogger();
 
   before(done => Server.start(done));
@@ -26,7 +26,9 @@ describe("migration errors", function() {
       reporter: new Reporter(logger)
     };
 
-    const provider = new Web3.providers.HttpProvider('http://localhost:8545');
+    const provider = new Web3.providers.HttpProvider("http://localhost:8545", {
+      keepAlive: false
+    });
     web3 = new Web3(provider);
     networkId = await web3.eth.net.getId();
   });
@@ -39,15 +41,21 @@ describe("migration errors", function() {
       console.log(output);
       assert(err);
 
-      assert(output.includes('2_migrations_revert.js'));
+      assert(output.includes("2_migrations_revert.js"));
       assert(output.includes("Deploying 'Example'"));
       assert(output.includes("Deploying 'ExampleRevert'"));
       assert(output.includes("Error"));
-      assert(output.includes('require or revert') || output.includes('gas required exceeds'));
+      assert(
+        output.includes("require or revert") ||
+          output.includes("gas required exceeds")
+      );
       assert(!output.includes("Deploying 'UsesExample'"));
-      assert(!output.includes('3_migrations_ok.js'));
+      assert(!output.includes("3_migrations_ok.js"));
 
-      const location = path.join(config.contracts_build_directory, "UsesExample.json");
+      const location = path.join(
+        config.contracts_build_directory,
+        "UsesExample.json"
+      );
       const artifact = require(location);
       const network = artifact.networks[networkId];
       assert(network === undefined);
@@ -63,95 +71,96 @@ describe("migration errors", function() {
       console.log(output);
       assert(err);
 
-      assert(!output.includes('1_initial_migration.js'));
-      assert(output.includes('2_migrations_revert.js'));
+      assert(!output.includes("1_initial_migration.js"));
+      assert(output.includes("2_migrations_revert.js"));
       done();
     });
   });
 
-  it("should run out of gas correctly", function(done){
+  it("should run out of gas correctly", function(done) {
     this.timeout(70000);
 
     CommandRunner.run("migrate -f 4", config, err => {
       const output = logger.contents();
       assert(err);
       console.log(output);
-      assert(output.includes('4_migrations_oog.js'));
+      assert(output.includes("4_migrations_oog.js"));
       assert(output.includes("Deploying 'Loops'"));
-      assert(output.includes('Error'));
-      assert(output.includes('out of gas') || output.includes('gas required exceeds'));
+      assert(output.includes("Error"));
+      assert(
+        output.includes("out of gas") || output.includes("gas required exceeds")
+      );
       done();
     });
   });
 
-  it("should expose the reason string if available [ @ganache ]", function(done){
+  it("should expose the reason string if available [ @ganache ]", function(done) {
     this.timeout(70000);
 
     CommandRunner.run("migrate -f 5", config, err => {
       const output = logger.contents();
       assert(err);
       console.log(output);
-      assert(output.includes('5_migrations_reason.js'));
+      assert(output.includes("5_migrations_reason.js"));
       assert(output.includes("Deploying 'RevertWithReason'"));
-      assert(output.includes('reasonstring'));
+      assert(output.includes("reasonstring"));
       done();
     });
   });
 
-  it("should error on insufficient funds correctly", function(done){
+  it("should error on insufficient funds correctly", function(done) {
     this.timeout(70000);
 
     CommandRunner.run("migrate -f 6", config, err => {
       const output = logger.contents();
       assert(err);
       console.log(output);
-      assert(output.includes('6_migrations_funds.js'));
+      assert(output.includes("6_migrations_funds.js"));
       assert(output.includes("Deploying 'Example'"));
-      assert(output.includes('insufficient funds'));
-      assert(output.includes('Account'));
-      assert(output.includes('Balance'));
+      assert(output.includes("insufficient funds"));
+      assert(output.includes("Account"));
+      assert(output.includes("Balance"));
       done();
     });
   });
 
-  it("should error if user tries to use batch syntax", function(done){
+  it("should error if user tries to use batch syntax", function(done) {
     this.timeout(70000);
 
     CommandRunner.run("migrate -f 7", config, err => {
       const output = logger.contents();
       assert(err);
       console.log(output);
-      assert(output.includes('7_batch_deployments.js'));
+      assert(output.includes("7_batch_deployments.js"));
       assert(output.includes("batch deployments"));
       assert(output.includes("deprecated"));
       done();
     });
   });
 
-  it("should error if there are js errors in the migrations script (sync)", function(done){
+  it("should error if there are js errors in the migrations script (sync)", function(done) {
     this.timeout(70000);
 
     CommandRunner.run("migrate -f 8", config, err => {
       const output = logger.contents();
       assert(err);
       console.log(output);
-      assert(output.includes('8_js_error_sync.js'));
+      assert(output.includes("8_js_error_sync.js"));
       assert(output.includes("ReferenceError"));
       done();
     });
   });
 
-  it("should error if there are js errors in the migrations script (async)", function(done){
+  it("should error if there are js errors in the migrations script (async)", function(done) {
     this.timeout(70000);
 
     CommandRunner.run("migrate -f 9", config, err => {
       const output = logger.contents();
       assert(err);
       console.log(output);
-      assert(output.includes('9_js_error_async.js'));
+      assert(output.includes("9_js_error_async.js"));
       assert(output.includes("ReferenceError"));
       done();
     });
   });
 });
-

--- a/packages/truffle/test/scenarios/migrations/init.js
+++ b/packages/truffle/test/scenarios/migrations/init.js
@@ -5,12 +5,12 @@ const assert = require("assert");
 const Server = require("../server");
 const Reporter = require("../reporter");
 const sandbox = require("../sandbox");
-const Web3 = require('web3');
+const Web3 = require("web3");
 
 const log = console.log;
 
-function processErr(err, output){
-  if (err){
+function processErr(err, output) {
+  if (err) {
     log(output);
     throw new Error(err);
   }
@@ -20,7 +20,7 @@ describe("solo migration", function() {
   let config;
   let web3;
   let networkId;
-  const project = path.join(__dirname, '../../sources/migrations/init');
+  const project = path.join(__dirname, "../../sources/migrations/init");
   const logger = new MemoryLogger();
 
   before(done => Server.start(done));
@@ -35,7 +35,9 @@ describe("solo migration", function() {
       reporter: new Reporter(logger)
     };
 
-    const provider = new Web3.providers.HttpProvider('http://localhost:8545');
+    const provider = new Web3.providers.HttpProvider("http://localhost:8545", {
+      keepAlive: false
+    });
     web3 = new Web3(provider);
     networkId = await web3.eth.net.getId();
   });
@@ -47,7 +49,10 @@ describe("solo migration", function() {
       const output = logger.contents();
       processErr(err, output);
 
-      const location = path.join(config.contracts_build_directory, "Migrations.json");
+      const location = path.join(
+        config.contracts_build_directory,
+        "Migrations.json"
+      );
       const artifact = require(location);
       const network = artifact.networks[networkId];
 
@@ -60,7 +65,7 @@ describe("solo migration", function() {
       CommandRunner.run("migrate", config, err => {
         const output = logger.contents();
         processErr(err, output);
-        assert(output.includes('Network up to date.'));
+        assert(output.includes("Network up to date."));
         done();
       });
     });

--- a/packages/truffle/test/scenarios/migrations/migrate.js
+++ b/packages/truffle/test/scenarios/migrations/migrate.js
@@ -5,12 +5,12 @@ const assert = require("assert");
 const Server = require("../server");
 const Reporter = require("../reporter");
 const sandbox = require("../sandbox");
-const Web3 = require('web3');
+const Web3 = require("web3");
 
 const log = console.log;
 
-function processErr(err, output){
-  if (err){
+function processErr(err, output) {
+  if (err) {
     log(output);
     throw new Error(err);
   }
@@ -20,7 +20,7 @@ describe("migrate (success)", function() {
   let config;
   let web3;
   let networkId;
-  const project = path.join(__dirname, '../../sources/migrations/success');
+  const project = path.join(__dirname, "../../sources/migrations/success");
   const logger = new MemoryLogger();
 
   before(done => Server.start(done));
@@ -35,7 +35,9 @@ describe("migrate (success)", function() {
       reporter: new Reporter(logger)
     };
 
-    const provider = new Web3.providers.HttpProvider('http://localhost:8545');
+    const provider = new Web3.providers.HttpProvider("http://localhost:8545", {
+      keepAlive: false
+    });
     web3 = new Web3(provider);
     networkId = await web3.eth.net.getId();
   });
@@ -47,9 +49,9 @@ describe("migrate (success)", function() {
       const output = logger.contents();
       processErr(err, output);
 
-      assert(output.includes('2_migrations_sync.js'));
+      assert(output.includes("2_migrations_sync.js"));
       assert(output.includes("Deploying 'UsesExample'"));
-      assert(output.includes('3_migrations_async.js'));
+      assert(output.includes("3_migrations_async.js"));
       assert(output.includes("Re-using deployed 'Example'"));
       assert(output.includes("Replacing 'UsesExample'"));
       assert(output.includes("PayableExample"));
@@ -57,7 +59,10 @@ describe("migrate (success)", function() {
       assert(output.includes("Saving migration"));
       assert(output.includes("Saving artifacts"));
 
-      const location = path.join(config.contracts_build_directory, "UsesExample.json");
+      const location = path.join(
+        config.contracts_build_directory,
+        "UsesExample.json"
+      );
       const artifact = require(location);
       const network = artifact.networks[networkId];
 
@@ -69,14 +74,14 @@ describe("migrate (success)", function() {
     });
   });
 
-  it('forces a migration with the -f option', function(done){
+  it("forces a migration with the -f option", function(done) {
     this.timeout(70000);
 
     CommandRunner.run("migrate -f 3", config, err => {
       const output = logger.contents();
       processErr(err, output);
-      assert(!output.includes('2_migrations_sync.js'));
-      assert(output.includes('3_migrations_async.js'));
+      assert(!output.includes("2_migrations_sync.js"));
+      assert(output.includes("3_migrations_async.js"));
       assert(output.includes("Replacing 'IsLibrary'"));
       assert(output.includes("Replacing 'UsesLibrary'"));
       console.log(output);
@@ -84,4 +89,3 @@ describe("migrate (success)", function() {
     });
   });
 });
-

--- a/packages/truffle/test/scenarios/migrations/production.js
+++ b/packages/truffle/test/scenarios/migrations/production.js
@@ -4,26 +4,25 @@ const path = require("path");
 const assert = require("assert");
 const Reporter = require("../reporter");
 const sandbox = require("../sandbox");
-const Web3 = require('web3');
+const Web3 = require("web3");
 
 const log = console.log;
 
-function processErr(err, output){
-  if (err){
+function processErr(err, output) {
+  if (err) {
     log(output);
     throw new Error(err);
   }
 }
 
-describe('production', function() {
-
+describe("production", function() {
   describe("{production: true, confirmations: 2 } [ @geth ]", function() {
     if (!process.env.GETH) return;
 
     let config;
     let web3;
     let networkId;
-    const project = path.join(__dirname, '../../sources/migrations/production');
+    const project = path.join(__dirname, "../../sources/migrations/production");
     const logger = new MemoryLogger();
 
     before(async function() {
@@ -35,7 +34,10 @@ describe('production', function() {
         reporter: new Reporter(logger)
       };
 
-      const provider = new Web3.providers.HttpProvider('http://localhost:8545');
+      const provider = new Web3.providers.HttpProvider(
+        "http://localhost:8545",
+        { keepAlive: false }
+      );
       web3 = new Web3(provider);
       networkId = await web3.eth.net.getId();
     });
@@ -47,12 +49,15 @@ describe('production', function() {
         const output = logger.contents();
         processErr(err, output);
 
-        assert(output.includes('dry-run'));
+        assert(output.includes("dry-run"));
 
-        assert(output.includes('2_migrations_conf.js'));
+        assert(output.includes("2_migrations_conf.js"));
         assert(output.includes("Deploying 'Example'"));
 
-        const location = path.join(config.contracts_build_directory, "Example.json");
+        const location = path.join(
+          config.contracts_build_directory,
+          "Example.json"
+        );
         const artifact = require(location);
         const network = artifact.networks[networkId];
 
@@ -61,10 +66,10 @@ describe('production', function() {
 
         // Geth automines too quickly for the 4 sec resolution we set
         // to trigger the output.
-        if (!process.env.GETH){
-          assert(output.includes('2 confirmations'));
-          assert(output.includes('confirmation number: 1'));
-          assert(output.includes('confirmation number: 2'));
+        if (!process.env.GETH) {
+          assert(output.includes("2 confirmations"));
+          assert(output.includes("confirmation number: 1"));
+          assert(output.includes("confirmation number: 2"));
         }
 
         console.log(output);
@@ -79,7 +84,7 @@ describe('production', function() {
     let config;
     let web3;
     let networkId;
-    const project = path.join(__dirname, '../../sources/migrations/production');
+    const project = path.join(__dirname, "../../sources/migrations/production");
     const logger = new MemoryLogger();
 
     before(async function() {
@@ -91,7 +96,10 @@ describe('production', function() {
         reporter: new Reporter(logger)
       };
 
-      const provider = new Web3.providers.HttpProvider('http://localhost:8545');
+      const provider = new Web3.providers.HttpProvider(
+        "http://localhost:8545",
+        { keepAlive: false }
+      );
       web3 = new Web3(provider);
       networkId = await web3.eth.net.getId();
     });
@@ -100,16 +108,18 @@ describe('production', function() {
       this.timeout(70000);
 
       CommandRunner.run("migrate --network fakeRopsten", config, err => {
-
         const output = logger.contents();
         processErr(err, output);
 
-        assert(!output.includes('dry-run'));
+        assert(!output.includes("dry-run"));
 
-        assert(output.includes('2_migrations_conf.js'));
+        assert(output.includes("2_migrations_conf.js"));
         assert(output.includes("Deploying 'Example'"));
 
-        const location = path.join(config.contracts_build_directory, "Example.json");
+        const location = path.join(
+          config.contracts_build_directory,
+          "Example.json"
+        );
         const artifact = require(location);
         const network = artifact.networks[networkId];
 


### PR DESCRIPTION
This causes truffle to use the trufflesuite fork of web3 in order to try and resolve an issue presumably coming from an option set while creating an HttpProvider.  A keepAlive option is now passed while instantiating an HttpProvider.