### PR TITLE
Prevent the reset command from being repeated with enter

### DIFF
--- a/packages/truffle-core/lib/commands/debug.js
+++ b/packages/truffle-core/lib/commands/debug.js
@@ -672,6 +672,7 @@ var command = {
               cmd != "!" &&
               cmd != ":" &&
               cmd != "+" &&
+              cmd != "r" &&
               cmd != "-"
             ) {
               lastCommand = cmd;


### PR DESCRIPTION
This one-line PR adds the reset command to the list of commands that can't be repeated by pressing enter.  Repeating a reset doesn't make sense and isn't the behavior I expect (I expect it to continue doing next or step or whatever).  So, I just added it to the list of excluded commands.