### PR TITLE
Stop saving this.mnemonic in truffle-hdwallet-provider

### DIFF
--- a/packages/truffle-hdwallet-provider/src/index.js
+++ b/packages/truffle-hdwallet-provider/src/index.js
@@ -41,7 +41,6 @@ function HDWalletProvider(
       }
     }
   } else {
-    this.mnemonic = mnemonic;
     this.hdwallet = hdkey.fromMasterSeed(bip39.mnemonicToSeed(mnemonic));
     this.wallet_hdpath = wallet_hdpath;
     this.wallets = {};


### PR DESCRIPTION
Apparently `this.mnemonic` is doing nothing but serving as an easy way for external code to read terrible secrets