### PR TITLE
Stabilize options.solc

### DIFF
--- a/packages/truffle-compile/index.js
+++ b/packages/truffle-compile/index.js
@@ -44,10 +44,8 @@ var compile = function(sources, options, callback) {
 
   // Grandfather in old solc config
   if (options.solc) {
-    options.compilers.solc.settings.evmVersion =
-      options.solc.settings.evmVersion || options.solc.evmVersion;
-    options.compilers.solc.settings.optimizer =
-      options.solc.settings.optimizer || options.solc.optimizer;
+    options.compilers.solc.settings.evmVersion = options.solc.evmVersion;
+    options.compilers.solc.settings.optimizer = options.solc.optimizer;
   }
 
   // Ensure sources have operating system independent paths


### PR DESCRIPTION
## Bug Fix

As a grandfathered config option, `options.solc` should be stabilized and kept as it was (w/o the ability to set config options as `options.solc.settings`). If we want to allow the latter, more work would need to be done in `truffle-config` to enable it.

Thanks to @cds-amal for catching this one before release!