### PR TITLE
Remove references to web3-one branch in tests

### DIFF
--- a/packages/truffle-core/test/compile.js
+++ b/packages/truffle-core/test/compile.js
@@ -17,7 +17,7 @@ describe("compile", function() {
   before("Create a sandbox", function(done) {
     this.timeout(20000);
 
-    Box.sandbox("default#web3-one", function(err, result) {
+    Box.sandbox("default", function(err, result) {
       if (err) return done(err);
       config = result;
       config.resolver = new Resolver(config);

--- a/packages/truffle-core/test/config.js
+++ b/packages/truffle-core/test/config.js
@@ -18,7 +18,7 @@ describe("config", function() {
 
   before("Create a sandbox with extra config values", function(done) {
     this.timeout(10000);
-    Box.sandbox("default#web3-one", function(err, result) {
+    Box.sandbox("default", function(err, result) {
       if (err) return done(err);
       config = result;
       config.resolver = new Resolver(config);

--- a/packages/truffle-core/test/migrate.js
+++ b/packages/truffle-core/test/migrate.js
@@ -16,7 +16,7 @@ describe("migrate", function() {
 
   before("Create a sandbox", function(done) {
     this.timeout(30000);
-    Box.sandbox("default#web3-one", function(err, result) {
+    Box.sandbox("default", function(err, result) {
       if (err) return done(err);
       config = result;
       config.resolver = new Resolver(config);

--- a/packages/truffle-core/test/npm.js
+++ b/packages/truffle-core/test/npm.js
@@ -20,7 +20,7 @@ describe("NPM integration", function() {
 
   before("Create a sandbox", function(done) {
     this.timeout(15000);
-    Box.sandbox("default#web3-one", function(err, result) {
+    Box.sandbox("default", function(err, result) {
       if (err) return done(err);
       config = result;
       config.resolver = new Resolver(config);

--- a/packages/truffle-core/test/unbox.js
+++ b/packages/truffle-core/test/unbox.js
@@ -9,11 +9,11 @@ describe("commands/unbox.js", () => {
   const invalidBoxFormats = [
     "//",
     "/truffle-box/bare-box",
-    "//truffle-box/bare-box#web3-one",
-    "//truffle-box/bare-box#web3-one:path/SubDir",
+    "//truffle-box/bare-box#truffle-test-branch",
+    "//truffle-box/bare-box#truffle-test-branch:path/SubDir",
     "/bare/",
-    "//bare#web3-one",
-    "//bare#web3-one:path/SubDir"
+    "//bare#truffle-test-branch",
+    "//bare#truffle-test-branch:path/SubDir"
   ];
   const absolutePaths = [
     "https://github.com/truffle-box/bare-box:/path/SubDir",

--- a/packages/truffle-core/test/unbox.js
+++ b/packages/truffle-core/test/unbox.js
@@ -17,33 +17,21 @@ describe("commands/unbox.js", () => {
   ];
   const absolutePaths = [
     "https://github.com/truffle-box/bare-box:/path/SubDir",
-    "https://github.com/truffle-box/bare-box#web3-one:/path/subDir",
     "truffle-box/bare-box:/path/subDir",
-    "truffle-box/bare-box#web3-one:/path/subDir",
     "bare:/path/subDir",
-    "bare#web3-one:/path/subDir",
-    "git@github.com:truffle-box/bare-box:/path/subDir",
-    "git@github.com:truffle-box/bare-box#web3-one:/path/subDir"
+    "git@github.com:truffle-box/bare-box:/path/subDir"
   ];
   const validBoxInput = [
     "https://github.com/truffle-box/bare-box",
-    "https://github.com/truffle-box/bare-box#web3-one",
     "truffle-box/bare-box",
-    "truffle-box/bare-box#web3-one",
     "bare",
-    "bare#web3-one",
-    "git@github.com:truffle-box/bare-box",
-    "git@github.com:truffle-box/bare-box#web3-one"
+    "git@github.com:truffle-box/bare-box"
   ];
   const relativePaths = [
     "https://github.com/truffle-box/bare-box:path/SubDir",
-    "https://github.com/truffle-box/bare-box#web3-one:path/subDir",
     "truffle-box/bare-box:path/subDir",
-    "truffle-box/bare-box#web3-one:path/subDir",
     "bare:path/subDir",
-    "bare#web3-one:path/subDir",
-    "git@github.com:truffle-box/bare-box:path/subDir",
-    "git@github.com:truffle-box/bare-box#web3-one:path/subDir"
+    "git@github.com:truffle-box/bare-box:path/subDir"
   ];
 
   describe("run", () => {

--- a/packages/truffle-debugger/test/helpers.js
+++ b/packages/truffle-debugger/test/helpers.js
@@ -76,7 +76,7 @@ export async function createSandbox() {
       {
         unsafeCleanup: true,
         setGracefulCleanup: true,
-        name: "default#web3-one"
+        name: "default"
       },
       function(err, result) {
         if (err) return reject(err);

--- a/packages/truffle-decoder/test/truffle-config.js
+++ b/packages/truffle-decoder/test/truffle-config.js
@@ -12,10 +12,6 @@
  * to sign your transactions before they're sent to a remote public node. Infura API
  * keys are available for free at: infura.io/register
  *
- *   > > Using Truffle V5 or later? Make sure you install the `web3-one` version.
- *
- *   > > $ npm install truffle-hdwallet-provider@web3-one
- *
  * You'll also need a mnemonic - the twelve word phrase the wallet uses to generate
  * public/private key pairs. If you're publishing your code to GitHub make sure you load this
  * phrase from a file you've .gitignored so it doesn't accidentally become public.

--- a/packages/truffle/test/scenarios/commands/unbox.js
+++ b/packages/truffle/test/scenarios/commands/unbox.js
@@ -64,7 +64,7 @@ describe("truffle unbox", () => {
       describe("full url + branch", () => {
         it("unboxes successfully", done => {
           CommandRunner.run(
-            "unbox https://github.com/truffle-box/bare-box#web3-one",
+            "unbox https://github.com/truffle-box/bare-box#truffle-test-branch",
             config,
             () => {
               const output = logger.contents();
@@ -78,7 +78,7 @@ describe("truffle unbox", () => {
       describe("full url + branch + relativePath", () => {
         it("unboxes successfully", done => {
           CommandRunner.run(
-            "unbox https://github.com/truffle-box/bare-box#web3-one:path/to/subDir",
+            "unbox https://github.com/truffle-box/bare-box#truffle-test-branch:path/to/subDir",
             config,
             () => {
               const output = logger.contents();
@@ -102,7 +102,7 @@ describe("truffle unbox", () => {
       describe("origin/master#branch", () => {
         it("unboxes successfully", done => {
           CommandRunner.run(
-            "unbox truffle-box/bare-box#web3-one",
+            "unbox truffle-box/bare-box#truffle-test-branch",
             config,
             () => {
               const output = logger.contents();
@@ -116,7 +116,7 @@ describe("truffle unbox", () => {
       describe("origin/master#branch:relativePath", () => {
         it("unboxes successfully", done => {
           CommandRunner.run(
-            "unbox truffle-box/bare-box#web3-one:path/to/subDir",
+            "unbox truffle-box/bare-box#truffle-test-branch:path/to/subDir",
             config,
             () => {
               const output = logger.contents();
@@ -139,7 +139,7 @@ describe("truffle unbox", () => {
 
       describe("official truffle box + branch", () => {
         it("unboxes successfully", done => {
-          CommandRunner.run("unbox bare#web3-one", config, () => {
+          CommandRunner.run("unbox bare#truffle-test-branch", config, () => {
             const output = logger.contents();
             assert(output.includes("Unbox successful."));
             done();
@@ -150,7 +150,7 @@ describe("truffle unbox", () => {
       describe("official truffle box + branch + relativePath", () => {
         it("unboxes successfully", done => {
           CommandRunner.run(
-            "unbox bare#web3-one:path/to/subDir",
+            "unbox bare#truffle-test-branch:path/to/subDir",
             config,
             () => {
               const output = logger.contents();
@@ -192,7 +192,7 @@ describe("truffle unbox", () => {
       describe("git@ ssh + branch", () => {
         it("unboxes successfully", done => {
           CommandRunner.run(
-            "unbox git@github.com:truffle-box/bare-box#web3-one",
+            "unbox git@github.com:truffle-box/bare-box#truffle-test-branch",
             config,
             () => {
               const output = logger.contents();
@@ -206,7 +206,7 @@ describe("truffle unbox", () => {
       describe("git@ ssh + branch + relativePath", () => {
         it("unboxes successfully", done => {
           CommandRunner.run(
-            "unbox git@github.com:truffle-box/bare-box#web3-one:path/to/subDir",
+            "unbox git@github.com:truffle-box/bare-box#truffle-test-branch:path/to/subDir",
             config,
             () => {
               const output = logger.contents();

--- a/packages/truffle/test/scenarios/cyclic_dependencies/compiles.js
+++ b/packages/truffle/test/scenarios/cyclic_dependencies/compiles.js
@@ -13,7 +13,7 @@ describe("Cyclic Dependencies", function() {
 
   before("set up sandbox", function(done) {
     this.timeout(10000);
-    Box.sandbox("default#web3-one", function(err, conf) {
+    Box.sandbox("default", function(err, conf) {
       if (err) return done(err);
       config = conf;
       config.logger = logger;

--- a/packages/truffle/test/scenarios/happy_path/happypath.js
+++ b/packages/truffle/test/scenarios/happy_path/happypath.js
@@ -22,7 +22,7 @@ describe("Happy path (truffle unbox)", function() {
 
   before("set up sandbox", function(done) {
     this.timeout(10000);
-    Box.sandbox("default#web3-one", function(err, conf) {
+    Box.sandbox("default", function(err, conf) {
       if (err) return done(err);
       config = conf;
       config.network = "development";
@@ -44,9 +44,21 @@ describe("Happy path (truffle unbox)", function() {
         return done(err);
       }
 
-      assert(fs.existsSync(path.join(config.contracts_build_directory, "MetaCoin.json")));
-      assert(fs.existsSync(path.join(config.contracts_build_directory, "ConvertLib.json")));
-      assert(fs.existsSync(path.join(config.contracts_build_directory, "Migrations.json")));
+      assert(
+        fs.existsSync(
+          path.join(config.contracts_build_directory, "MetaCoin.json")
+        )
+      );
+      assert(
+        fs.existsSync(
+          path.join(config.contracts_build_directory, "ConvertLib.json")
+        )
+      );
+      assert(
+        fs.existsSync(
+          path.join(config.contracts_build_directory, "Migrations.json")
+        )
+      );
 
       done();
     });
@@ -62,23 +74,37 @@ describe("Happy path (truffle unbox)", function() {
         return done(err);
       }
 
-      var MetaCoin = contract(require(path.join(config.contracts_build_directory, "MetaCoin.json")));
-      var ConvertLib = contract(require(path.join(config.contracts_build_directory, "ConvertLib.json")));
-      var Migrations = contract(require(path.join(config.contracts_build_directory, "Migrations.json")));
+      var MetaCoin = contract(
+        require(path.join(config.contracts_build_directory, "MetaCoin.json"))
+      );
+      var ConvertLib = contract(
+        require(path.join(config.contracts_build_directory, "ConvertLib.json"))
+      );
+      var Migrations = contract(
+        require(path.join(config.contracts_build_directory, "Migrations.json"))
+      );
 
       var promises = [];
 
       [MetaCoin, ConvertLib, Migrations].forEach(function(abstraction) {
         abstraction.setProvider(config.provider);
 
-        promises.push(abstraction.deployed().then(function(instance) {
-          assert.notEqual(instance.address, null, instance.contract_name + " didn't have an address!");
-        }));
+        promises.push(
+          abstraction.deployed().then(function(instance) {
+            assert.notEqual(
+              instance.address,
+              null,
+              instance.contract_name + " didn't have an address!"
+            );
+          })
+        );
       });
 
-      Promise.all(promises).then(function() {
-        done();
-      }).catch(done);
+      Promise.all(promises)
+        .then(function() {
+          done();
+        })
+        .catch(done);
     });
   });
 
@@ -95,5 +121,4 @@ describe("Happy path (truffle unbox)", function() {
       done();
     });
   });
-
 });


### PR DESCRIPTION
In preparation for deleting the `web3-one` branch in the truffle-init-default and bare-box repositories, remove references to them in a handful of tests. Replace that branch with a branch that was created name `truffle-test-branch`.