### PR TITLE
Default Testing network_id to match GanacheUI

### DIFF
--- a/packages/truffle-core/lib/commands/test.js
+++ b/packages/truffle-core/lib/commands/test.js
@@ -150,7 +150,7 @@ var command = {
           var ganacheOptions = {
             host: "127.0.0.1",
             port: 7545,
-            network_id: 4447,
+            network_id: 5777,
             mnemonic:
               "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat",
             gasLimit: config.gas,


### PR DESCRIPTION
Per DavidBurela's feedback: https://twitter.com/DavidBurela/status/1075961475145949185

Defaults `truffle test` to use GanacheUI's default network_id when no network configuration is defined. The network will currently be defined as `test`.

If it's a must for UX/UI reasons to have the network logged as `ganache`, then probably something along the lines of setting a boolean in options during the workflow and passing that val around will need to be done.