### PR TITLE
Default Develop port to match metamask & ganache-cli default port

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - docker pull ethereum/solc:0.4.22
   - sudo add-apt-repository --yes ppa:ethereum/ethereum
   - sudo apt-get update
-  - sudo apt-get install solc jq snapd
+  - sudo apt-get install -y dpkg && sudo apt-get install solc jq snapd
   - export PATH=$PATH:/snap/bin
   - sudo snap install vyper --edge --devmode
 

--- a/packages/truffle-core/lib/commands/develop.js
+++ b/packages/truffle-core/lib/commands/develop.js
@@ -68,7 +68,7 @@ var command = {
       numAddresses
     );
 
-    var onMissing = function(name) {
+    var onMissing = function() {
       return "**";
     };
 
@@ -83,7 +83,7 @@ var command = {
 
     var ganacheOptions = {
       host: "127.0.0.1",
-      port: 9545,
+      port: 8545,
       network_id: 4447,
       total_accounts: numAddresses,
       default_balance_ether: defaultEtherBalance,


### PR DESCRIPTION
Per @adrianmcli's feedback

Defaults `truffle develop` to use Metamask & ganache-cli's default port (8545) when no network configuration is defined.

Should allow a user to unbox a `drizzle` box, call `truffle develop`, and connect using MM out of the box.

(Should pass tests and build successfully once v4 test leftovers are updated)