### PR TITLE
docs: update site url references to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,15 @@ $ truffle init
 
 From there, you can run `truffle compile`, `truffle migrate` and `truffle test` to compile your contracts, deploy those contracts to the network, and run their associated unit tests.
 
-Truffle comes bundled with a local development blockchain server that launches automatically when you invoke the commands  above. If you'd like to [configure a more advanced development environment](http://truffleframework.com/docs/advanced/configuration) we recommend you install the blockchain server separately by running `npm install -g ganache-cli` at the command line.
+Truffle comes bundled with a local development blockchain server that launches automatically when you invoke the commands  above. If you'd like to [configure a more advanced development environment](https://truffleframework.com/docs/advanced/configuration) we recommend you install the blockchain server separately by running `npm install -g ganache-cli` at the command line.
 
 +  [ganache-cli](https://github.com/trufflesuite/ganache-cli): a command-line version of Truffle's blockchain server.
-+  [ganache](http://truffleframework.com/ganache/): A GUI for the server that displays your transaction history and chain state.
++  [ganache](https://truffleframework.com/ganache/): A GUI for the server that displays your transaction history and chain state.
 
 
 ### Documentation
 
-Please see the [Official Truffle Documentation](http://truffleframework.com/docs/) for guides, tips, and examples.
+Please see the [Official Truffle Documentation](https://truffleframework.com/docs/) for guides, tips, and examples.
 
 ### Development
 


### PR DESCRIPTION
Site links weren't working for me initially. I kept getting 5xx errors. Now they seem to be redirecting properly though, but might as well fix these links anyway.