### PR TITLE
Pass in provider to truffle-decoder rather than a string

### DIFF
--- a/packages/truffle-decoder/lib/interface/contract-decoder.ts
+++ b/packages/truffle-decoder/lib/interface/contract-decoder.ts
@@ -9,6 +9,7 @@ import decode from "../decode";
 import { Definition as DefinitionUtils, EVM, Allocation, AstDefinition } from "truffle-decode-utils";
 import { BlockType, Transaction } from "web3/eth/types";
 import { EventLog, Log } from "web3/types";
+import { Provider } from "web3/providers";
 import abiDecoder from "abi-decoder";
 
 export interface ContractStateVariable {
@@ -118,15 +119,10 @@ export default class TruffleContractDecoder extends AsyncEventEmitter {
 
   private stateVariableReferences: EvmVariableReferenceMapping;
 
-  constructor(contract: ContractObject, inheritedContracts: ContractObject[], provider: string) {
+  constructor(contract: ContractObject, inheritedContracts: ContractObject[], provider: Provider) {
     super();
 
-    if (provider.startsWith("http:\/\/") || provider.startsWith("https:\/\/")) {
-      this.web3 = new Web3(new Web3.providers.HttpProvider(provider));
-    }
-    else if (provider.startsWith("ws:\/\/")) {
-      this.web3 = new Web3(new Web3.providers.WebsocketProvider(provider));
-    }
+    this.web3 = new Web3(provider);
 
     this.contract = contract; //cloneDeep(contract);
     this.inheritedContracts = inheritedContracts; //cloneDeep(inheritedContracts);

--- a/packages/truffle-decoder/lib/interface/index.ts
+++ b/packages/truffle-decoder/lib/interface/index.ts
@@ -4,9 +4,10 @@ import { EvmInfo } from "../types/evm";
 import decode from "../decode";
 import TruffleDecoder from "./contract-decoder";
 import { ContractObject } from "truffle-contract-schema/spec";
+import { Provider } from "web3/providers";
 
-export function forContract(contract: ContractObject, inheritedContracts: ContractObject[], providerUrl: string): TruffleDecoder {
-  return new TruffleDecoder(contract, inheritedContracts, providerUrl);
+export function forContract(contract: ContractObject, inheritedContracts: ContractObject[], provider: Provider): TruffleDecoder {
+  return new TruffleDecoder(contract, inheritedContracts, provider);
 }
 
 export async function forEvmState(definition: AstDefinition, pointer: DataPointer, info: EvmInfo, providerUrl?: string): Promise<any> {

--- a/packages/truffle-decoder/test/test/test.js
+++ b/packages/truffle-decoder/test/test/test.js
@@ -12,7 +12,7 @@ contract("DecodingSample", accounts => {
     const decoder = TruffleDecoder.forContract(
       DecodingSample,
       [],
-      web3.currentProvider.host
+      web3.currentProvider
     );
     decoder.init();
 


### PR DESCRIPTION
Fixes #1596 

## What is the change?

Inversion of control; allowing the user of the package to pass in a provider rather than a string of a URL and then having to deal with string manipulation internally.

## What is the motivation?

My motivation for doing this started as I was trying to write a frontend library making use of the decoder (great work @seesemichaelj et al.).

While writing the tests (and spawning a Ganache instance in-memory like [this](https://gist.github.com/adrianmcli/2c9dff19b81a36c52b9284c71fe3a4c0)), I found that I didn't have a string to pass in as a provider URL, all I had was the Provider object given to me by Ganache.

## What caveats are there?

This is a Request For Comments, as I understand that the debugger will have to change to accommodate this as well.
