### PR TITLE
Refer to the default config file name in error messages and hints

### DIFF
--- a/packages/truffle-provider/error.js
+++ b/packages/truffle-provider/error.js
@@ -12,7 +12,7 @@ function ProviderError(message, error) {
       "    - is running\n" +
       "    - is accepting RPC connections (i.e., \"--rpc\" option is used in geth)\n" +
       "    - is accessible over the network\n" +
-      "    - is properly configured in your Truffle configuration file (truffle.js)\n";
+      "    - is properly configured in your Truffle configuration file (truffle-config.js)\n";
   }
   ProviderError.super_.call(this, message);
   this.message = message;

--- a/packages/truffle-reporters/reporters/migrations-V5/messages.js
+++ b/packages/truffle-reporters/reporters/migrations-V5/messages.js
@@ -88,7 +88,7 @@ class MigrationsMessages {
         `   * Gas sent:     ${data.estimate}\n` +
         `   * Try:\n` +
         `      + Setting a higher gas estimate multiplier for this contract\n` +
-        `      + Using the solc optimizer settings in 'truffle.js'\n` +
+        `      + Using the solc optimizer settings in 'truffle-config.js'\n` +
         `      + Making your contract smaller\n` +
         `      + Making your contract constructor more efficient\n` +
         `      + Setting a higher network block limit if you are on a\n` +
@@ -101,7 +101,7 @@ class MigrationsMessages {
         `(ex: infinite loop) caused gas estimation to fail. Try:\n` +
         `   * Making your contract constructor more efficient\n` +
         `   * Setting the gas manually in your config or as a deployment parameter\n` +
-        `   * Using the solc optimizer settings in 'truffle.js'\n` +
+        `   * Using the solc optimizer settings in 'truffle-config.js'\n` +
         `   * Setting a higher network block limit if you are on a\n` +
         `     private network or test client (like ganache).\n`,
 
@@ -154,7 +154,7 @@ class MigrationsMessages {
         `(using Truffle's estimate).\n` +
         `   * Block limit: ${data.blockLimit}\n` +
         `   * Report this error in the Truffle issues on Github. It should not happen.\n` +
-        `   * Try: setting gas manually in 'truffle.js' or as parameter to 'deployer.deploy'\n`,
+        `   * Try: setting gas manually in 'truffle-config.js' or as parameter to 'deployer.deploy'\n`,
 
       nonce: () =>
         `${prefix}"${data.contract.contractName}" received: ${


### PR DESCRIPTION
The default filename for the truffle config is `truffle-config.js`, this changes the name in the hints and errors to reflect that and reduce confusion.