### PR TITLE
Fix truffle-contract's browser dependencies

### DIFF
--- a/packages/truffle-contract/README.md
+++ b/packages/truffle-contract/README.md
@@ -59,11 +59,9 @@ or equivalently in ES6 <sup>(node.js 8 or newer)</sup>:
 
 ### Browser Usage
 
-In your `head` element, include Web3 and Ethers.js and then include truffle-contract:
+In your `head` element, include truffle-contract:
 
 ```
-<script type="text/javascript" src="./path/to/web3.min.js"></script>
-<script type="text/javascript" src="./path/to/ethers.min.js"></script>
 <script type="text/javascript" src="./dist/truffle-contract.min.js"></script>
 ```
 
@@ -74,6 +72,9 @@ With this usage, `truffle-contract` will be available via the `TruffleContract` 
 ```
 var MyContract = TruffleContract(...);
 ```
+
+**Note**: Web3 and its dependencies are now bundled into truffle-contract
+v4.0.2 or higher.
 
 ### Full Example
 

--- a/packages/truffle-contract/package.json
+++ b/packages/truffle-contract/package.json
@@ -9,7 +9,7 @@
     "test": "./scripts/test.sh",
     "test:debug": "$(npm bin)/mocha --inspect-brk",
     "test:trace": "$(npm bin)/mocha --trace-warnings",
-    "compile": "mkdir -p dist && browserify ./index.js -i ethers -i web3 -o ./dist/truffle-contract.js && uglifyjs ./dist/truffle-contract.js -o ./dist/truffle-contract.min.js"
+    "compile": "mkdir -p dist && browserify ./index.js -i xmlhttprequest -o ./dist/truffle-contract.js && uglifyjs ./dist/truffle-contract.js -o ./dist/truffle-contract.min.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Should clean up the lack of clarity identified by #1619.

Update truffle-contract's bundling so that it includes `web3` and `ethers` in the bundle and excludes `xmlhttprequest`.

Tested this locally with pet-shop and there are no console errors in the browser or in tests.