### PR TITLE
Update Node version pre-flight check

### DIFF
--- a/packages/truffle-core/cli.js
+++ b/packages/truffle-core/cli.js
@@ -1,23 +1,29 @@
 #!/usr/bin/env node
 require("source-map-support/register");
 
-const TaskError = require("./lib/errors/taskerror");
+const semver = require("semver"); // to validate Node version
+
 const TruffleError = require("truffle-error");
-
+const TaskError = require("./lib/errors/taskerror");
 const analytics = require("./lib/services/analytics");
-const version = require("./lib/version");
-const versionInfo = version.info();
+const versionInfo = require("./lib/version").info();
 
-const nodeMajorVersion = parseInt(process.version.slice(1));
-if (nodeMajorVersion < 8) {
+// pre-flight check: Node version compatibility
+const minimumNodeVersion = "8.9.4";
+if (!semver.satisfies(process.version, ">=" + minimumNodeVersion)) {
   console.log(
-    `You are currently using version ${process.version.slice(1)} of Node.`
+    "Error: Node version not supported. You are currently using version " +
+      process.version.slice(1) +
+      " of Node. Truffle requires Node v" +
+      minimumNodeVersion +
+      " or higher."
   );
-  console.log("You must use version 8 or newer.");
+
   analytics.send({
     exception: "wrong node version",
     version: versionInfo.bundle || "(unbundled) " + versionInfo.core
   });
+
   process.exit(1);
 }
 


### PR DESCRIPTION
- Fix to match actual minimum requirement of v8.9.4
- Use semver to check compatibility
- Reörder imports nitpickingly
- Switch to "string"+"math" in case Node version doesn't support backtick syntax
- Reword error, remove line-break.