### PR TITLE
Fix truffle-contacts dependencies

### DIFF
--- a/packages/truffle-contract/lib/contract/properties.js
+++ b/packages/truffle-contract/lib/contract/properties.js
@@ -1,5 +1,5 @@
 const utils = require("../utils");
-const Web3 = require("web3");
+const web3Utils = require("web3-utils");
 
 module.exports = {
   contract_name: {
@@ -200,9 +200,6 @@ module.exports = {
     return this.network.links || {};
   },
   events: function() {
-    // helper web3; not used for provider
-    var web3 = new Web3();
-
     var events;
 
     if (this._json.networks[this.network_id] == null) {
@@ -232,7 +229,7 @@ module.exports = {
 
         signature += ")";
 
-        var topic = web3.utils.keccak256(signature);
+        var topic = web3Utils.keccak256(signature);
 
         events[topic] = item;
       }

--- a/packages/truffle-contract/lib/utils.js
+++ b/packages/truffle-contract/lib/utils.js
@@ -1,10 +1,8 @@
 const debug = require("debug")("contract:utils"); // eslint-disable-line no-unused-vars
-var Web3 = require("web3");
-var ethers = require("ethers");
+var web3Utils = require("web3-utils");
+var bigNumberify = require("ethers/utils/bignumber").bigNumberify;
 var abi = require("web3-eth-abi");
 var reformat = require("./reformat");
-
-var web3 = new Web3();
 
 var Utils = {
   is_object: function(val) {
@@ -14,7 +12,7 @@ var Utils = {
   is_big_number: function(val) {
     if (typeof val !== "object") return false;
 
-    return web3.utils.isBN(val) || web3.utils.isBigNumber(val);
+    return web3Utils.isBN(val) || web3Utils.isBigNumber(val);
   },
 
   is_tx_params: function(val) {
@@ -210,7 +208,7 @@ var Utils = {
 
         // Convert Web3 BN / BigNumber
       } else if (Utils.is_big_number(item)) {
-        const ethersBN = ethers.utils.bigNumberify(item.toString());
+        const ethersBN = bigNumberify(item.toString());
         converted.push(ethersBN);
       } else {
         converted.push(item);

--- a/packages/truffle-contract/package.json
+++ b/packages/truffle-contract/package.json
@@ -9,7 +9,7 @@
     "test": "./scripts/test.sh",
     "test:debug": "$(npm bin)/mocha --inspect-brk",
     "test:trace": "$(npm bin)/mocha --trace-warnings",
-    "compile": "mkdir -p dist && browserify ./index.js -i xmlhttprequest -o ./dist/truffle-contract.js && uglifyjs ./dist/truffle-contract.js -o ./dist/truffle-contract.min.js"
+    "compile": "mkdir -p dist && browserify ./index.js -o ./dist/truffle-contract.js && uglifyjs ./dist/truffle-contract.js -o ./dist/truffle-contract.min.js"
   },
   "repository": {
     "type": "git",
@@ -29,12 +29,10 @@
   "homepage": "https://github.com/trufflesuite/truffle-contract#readme",
   "dependencies": {
     "bignumber.js": "^7.2.1",
-    "ethereumjs-util": "^5.2.0",
-    "ethjs-abi": "0.1.8",
+    "ethers": "^4.0.0-beta.1",
     "truffle-blockchain-utils": "^0.0.7",
     "truffle-contract-schema": "^3.0.1",
     "truffle-error": "^0.0.3",
-    "uglify-es": "^3.3.9",
     "web3": "^1.0.0-beta.37",
     "web3-core-promievent": "^1.0.0-beta.37",
     "web3-eth-abi": "^1.0.0-beta.37",
@@ -49,11 +47,11 @@
     "chai": "4.2.0",
     "debug": "^4.1.0",
     "ganache-core": "2.3.3",
-    "lodash": "4.17.10",
     "mocha": "5.2.0",
-    "require-nocache": "^1.0.0",
     "solc": "0.5.0",
-    "temp": "^0.8.3"
+    "temp": "^0.8.3",
+    "truffle-compile": "^4.0.2",
+    "uglify-es": "^3.3.9"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
- Add missed `ethers` and `truffle-compile` dependencies
- Remove unused `ethereumjs-util`, `ethjs-abi`, `lodash ` and `require-nocache` dependencies
- Move `uglify-es` to `devDependencies`
- Replace `web3.utils` with `web3-utils`
- Replace `ethers.utils.bigNumberify` with `require('ethers/utils/bignumber').bigNumberify`

Production bundle size has been reduced by more than **264 KB (≈12%)**.