### PR TITLE
Supply blockNumber when doing the call for getting revert reason.

### DIFF
--- a/packages/truffle-contract/lib/handlers.js
+++ b/packages/truffle-contract/lib/handlers.js
@@ -112,7 +112,7 @@ var handlers = {
 
     // .method(): resolve/reject receipt in handler
     if (receipt.status !== undefined && !receipt.status) {
-      var reason = await Reason.get(context.params, receipt.blockNumber, context.contract.web3);
+      var reason = await Reason.get(context.params, context.contract.web3);
 
       var error = new StatusError(
         context.params,

--- a/packages/truffle-contract/lib/handlers.js
+++ b/packages/truffle-contract/lib/handlers.js
@@ -112,7 +112,7 @@ var handlers = {
 
     // .method(): resolve/reject receipt in handler
     if (receipt.status !== undefined && !receipt.status) {
-      var reason = await Reason.get(context.params, context.contract.web3);
+      var reason = await Reason.get(context.params, receipt.blockNumber, context.contract.web3);
 
       var error = new StatusError(
         context.params,

--- a/packages/truffle-contract/lib/reason.js
+++ b/packages/truffle-contract/lib/reason.js
@@ -37,9 +37,9 @@ const reason = {
    */
   get: function(params, web3){
     const packet = {
-      jsonrpc: "2.0",
-      method: "eth_call",
-      params: [params],
+      jsonrpc: '2.0',
+      method: 'eth_call',
+      params: [params, 'latest'],
       id: new Date().getTime(),
     };
 

--- a/packages/truffle-contract/lib/reason.js
+++ b/packages/truffle-contract/lib/reason.js
@@ -39,7 +39,7 @@ const reason = {
     const packet = {
       jsonrpc: '2.0',
       method: 'eth_call',
-      params: [params, 'latest'],
+      params: [params, 'pending'],
       id: new Date().getTime(),
     };
 

--- a/packages/truffle-contract/lib/reason.js
+++ b/packages/truffle-contract/lib/reason.js
@@ -35,11 +35,11 @@ const reason = {
    * @param  {Object} web3
    * @return {String|Undefined}
    */
-  get: function(params, blockNumber, web3){
+  get: function(params, web3){
     const packet = {
       jsonrpc: '2.0',
       method: 'eth_call',
-      params: [params, web3.utils.toHex(blockNumber)],
+      params: [params, 'latest'],
       id: new Date().getTime(),
     };
 

--- a/packages/truffle-contract/lib/reason.js
+++ b/packages/truffle-contract/lib/reason.js
@@ -35,11 +35,11 @@ const reason = {
    * @param  {Object} web3
    * @return {String|Undefined}
    */
-  get: function(params, web3){
+  get: function(params, blockNumber, web3){
     const packet = {
       jsonrpc: '2.0',
       method: 'eth_call',
-      params: [params, 'latest'],
+      params: [params, web3.utils.toHex(blockNumber)],
       id: new Date().getTime(),
     };
 


### PR DESCRIPTION
Returning the revert reason did not work for me (on Quorum), it turned out it was missing parameter 1 for `eth_call` (which is used to perform the same tx to get the revert reason).

The assumption was made that `latest` would be a proper value for a block number, since new transactions are on the latest block. A rare situation could however occur in which a new block was added between the failed transaction and getting the reason, possibly altering the behavior of the smart contract. The `blockNumber` from the transaction receipt appears as the right value to me, hence it's passed to `reason.js`.