### PR TITLE
Add support for the CREATE2 opcode

### DIFF
--- a/packages/truffle-debugger/lib/evm/selectors/index.js
+++ b/packages/truffle-debugger/lib/evm/selectors/index.js
@@ -6,7 +6,7 @@ import levenshtein from "fast-levenshtein";
 
 import trace from "lib/trace/selectors";
 
-import { isCallMnemonic } from "lib/helpers";
+import { isCallMnemonic, isCreateMnemonic } from "lib/helpers";
 
 function findContext({ address, binary }, instances, search, contexts) {
   let record;
@@ -64,7 +64,7 @@ function createStepSelectors(step, state = null) {
     /**
      * .isCreate
      */
-    isCreate: createLeaf(["./trace"], step => step.op == "CREATE"),
+    isCreate: createLeaf(["./trace"], step => isCreateMnemonic(step.op)),
 
     /**
      * .isHalting

--- a/packages/truffle-debugger/lib/helpers/index.js
+++ b/packages/truffle-debugger/lib/helpers/index.js
@@ -34,3 +34,12 @@ export function isCallMnemonic(op) {
   const calls = ["CALL", "DELEGATECALL", "STATICCALL", "CALLCODE"];
   return calls.includes(op);
 }
+
+/*
+ * Given a mmemonic, determine whether it's the mnemonic of a creation
+ * instruction
+ */
+export function isCreateMnemonic(op) {
+  const creates = ["CREATE", "CREATE2"];
+  return creates.includes(op);
+}


### PR DESCRIPTION
This PR adds support for the `CREATE2` opcode.  Due to the dummy address system, no special support different from that for `CREATE` is necessary; I just had to add it to the list of possible creation opcodes.

For technical reasons related to `redux-saga` versions, this branch branches off of the `united-allocator` branch, but it is unrelated to allocation.