### PR TITLE
Fix misnamed property in config.js

### DIFF
--- a/packages/truffle-core/lib/commands/config.js
+++ b/packages/truffle-core/lib/commands/config.js
@@ -1,7 +1,7 @@
 const command = {
   command: "config",
   description: "Set user-level configuration options",
-  config: {
+  help: {
     usage: "truffle config <option>",
     options: [   
       {


### PR DESCRIPTION
Attempting `truffle help config` causes truffle to crash due to a misnamed property in config.js. PR is simply a small fix for the typo.  :)