### PR TITLE
to avoid duplicated bn.js in bundled files.

### DIFF
--- a/packages/truffle/cli.webpack.config.js
+++ b/packages/truffle/cli.webpack.config.js
@@ -286,6 +286,13 @@ module.exports = {
   resolve: {
     alias: {
       "ws": path.join(__dirname, "./nil.js"),
+      "bn.js": path.join(
+        __dirname,
+        "../..",
+        "node_modules",
+        "bn.js",
+        "lib",
+        "bn.js"),
       "original-fs": path.join(__dirname, "./nil.js"),
       "scrypt": "js-scrypt"
     }


### PR DESCRIPTION
I saw a lots of duplicated bn.js codes in bundled file really big,  and that annoy me to hack the big number issue.