### PR TITLE
Updated package.json of truffle-contract

### DIFF
--- a/packages/truffle-contract/package.json
+++ b/packages/truffle-contract/package.json
@@ -33,10 +33,10 @@
     "truffle-blockchain-utils": "^0.0.7",
     "truffle-contract-schema": "^3.0.1",
     "truffle-error": "^0.0.3",
-    "web3": "^1.0.0-beta.37",
-    "web3-core-promievent": "^1.0.0-beta.37",
-    "web3-eth-abi": "^1.0.0-beta.37",
-    "web3-utils": "1.0.0-beta.37"
+    "web3": "^1.0.0-beta.33",
+    "web3-core-promievent": "^1.0.0-beta.33",
+    "web3-eth-abi": "^1.0.0-beta.33",
+    "web3-utils": "1.0.0-beta.33"
   },
   "devDependencies": {
     "async": "2.6.1",


### PR DESCRIPTION
Downgraded **web3, web3-eth-abi, web3-core-promievent, web3-utils** to version **^1.0.0-beta.33** from ^1.0.0-beta.37.
Due to issues like #1667 with current truffle-contract which works on ^1.0.0-beta.37.