### PR TITLE
Fix missing artifacts for Windows in v5.x

### DIFF
--- a/packages/truffle-compile/index.js
+++ b/packages/truffle-compile/index.js
@@ -18,7 +18,7 @@ var debug = require("debug")("compile"); // eslint-disable-line no-unused-vars
 //   quiet: false,
 //   logger: console
 // }
-var compile = function(sources, options, callback) {
+var compile = function (sources, options, callback) {
   if (typeof options === "function") {
     callback = options;
     options = {};
@@ -54,7 +54,7 @@ var compile = function(sources, options, callback) {
   var operatingSystemIndependentTargets = {};
   var originalPathMappings = {};
 
-  Object.keys(sources).forEach(function(source) {
+  Object.keys(sources).forEach(function (source) {
     // Turn all backslashes into forward slashes
     var replacement = source.replace(/\\/g, "/");
 
@@ -115,7 +115,7 @@ var compile = function(sources, options, callback) {
     return callback(null, [], []);
   }
 
-  Object.keys(operatingSystemIndependentSources).forEach(function(file_path) {
+  Object.keys(operatingSystemIndependentSources).forEach(function (file_path) {
     solcStandardInput.sources[file_path] = {
       content: operatingSystemIndependentSources[file_path]
     };
@@ -135,11 +135,11 @@ var compile = function(sources, options, callback) {
       var warnings = [];
 
       if (options.strict !== true) {
-        warnings = errors.filter(function(error) {
+        warnings = errors.filter(function (error) {
           return error.severity === "warning";
         });
 
-        errors = errors.filter(function(error) {
+        errors = errors.filter(function (error) {
           return error.severity !== "warning";
         });
 
@@ -149,7 +149,7 @@ var compile = function(sources, options, callback) {
           );
           options.logger.log(
             warnings
-              .map(function(warning) {
+              .map(function (warning) {
                 return warning.formattedMessage;
               })
               .join()
@@ -162,7 +162,7 @@ var compile = function(sources, options, callback) {
         return callback(
           new CompileError(
             standardOutput.errors
-              .map(function(error) {
+              .map(function (error) {
                 return error.formattedMessage;
               })
               .join()
@@ -173,18 +173,18 @@ var compile = function(sources, options, callback) {
       var contracts = standardOutput.contracts;
 
       var files = [];
-      Object.keys(standardOutput.sources).forEach(function(filename) {
+      Object.keys(standardOutput.sources).forEach(function (filename) {
         var source = standardOutput.sources[filename];
-        files[source.id] = filename;
+        files[source.id] = originalPathMappings[filename];
       });
 
       var returnVal = {};
 
       // This block has comments in it as it's being prepared for solc > 0.4.10
-      Object.keys(contracts).forEach(function(source_path) {
+      Object.keys(contracts).forEach(function (source_path) {
         var files_contracts = contracts[source_path];
 
-        Object.keys(files_contracts).forEach(function(contract_name) {
+        Object.keys(files_contracts).forEach(function (contract_name) {
           var contract = files_contracts[contract_name];
 
           // All source will have a key, but only the compiled source will have
@@ -218,12 +218,12 @@ var compile = function(sources, options, callback) {
           // Go through the link references and replace them with older-style
           // identifiers. We'll do this until we're ready to making a breaking
           // change to this code.
-          Object.keys(contract.evm.bytecode.linkReferences).forEach(function(
+          Object.keys(contract.evm.bytecode.linkReferences).forEach(function (
             file_name
           ) {
             var fileLinks = contract.evm.bytecode.linkReferences[file_name];
 
-            Object.keys(fileLinks).forEach(function(library_name) {
+            Object.keys(fileLinks).forEach(function (library_name) {
               var linkReferences = fileLinks[library_name] || [];
 
               contract_definition.bytecode = replaceLinkReferences(
@@ -241,11 +241,11 @@ var compile = function(sources, options, callback) {
 
           // Now for the deployed bytecode
           Object.keys(contract.evm.deployedBytecode.linkReferences).forEach(
-            function(file_name) {
+            function (file_name) {
               var fileLinks =
                 contract.evm.deployedBytecode.linkReferences[file_name];
 
-              Object.keys(fileLinks).forEach(function(library_name) {
+              Object.keys(fileLinks).forEach(function (library_name) {
                 var linkReferences = fileLinks[library_name] || [];
 
                 contract_definition.deployedBytecode = replaceLinkReferences(
@@ -273,7 +273,7 @@ function replaceLinkReferences(bytecode, linkReferences, libraryName) {
     linkId += "_";
   }
 
-  linkReferences.forEach(function(ref) {
+  linkReferences.forEach(function (ref) {
     // ref.start is a byte offset. Convert it to character offset.
     var start = ref.start * 2 + 2;
 
@@ -307,14 +307,14 @@ function orderABI(contract) {
   if (!contract_definition) return contract.abi;
   if (!contract_definition.children) return contract.abi;
 
-  contract_definition.children.forEach(function(child) {
+  contract_definition.children.forEach(function (child) {
     if (child.name === "FunctionDefinition") {
       ordered_function_names.push(child.attributes.name);
     }
   });
 
   // Put function names in a hash with their order, lowest first, for speed.
-  var functions_to_remove = ordered_function_names.reduce(function(
+  var functions_to_remove = ordered_function_names.reduce(function (
     obj,
     value,
     index
@@ -322,15 +322,15 @@ function orderABI(contract) {
     obj[value] = index;
     return obj;
   },
-  {});
+    {});
 
   // Filter out functions from the abi
-  var function_definitions = contract.abi.filter(function(item) {
+  var function_definitions = contract.abi.filter(function (item) {
     return functions_to_remove[item.name] !== undefined;
   });
 
   // Sort removed function defintions
-  function_definitions = function_definitions.sort(function(item_a, item_b) {
+  function_definitions = function_definitions.sort(function (item_a, item_b) {
     var a = functions_to_remove[item_a.name];
     var b = functions_to_remove[item_b.name];
 
@@ -341,7 +341,7 @@ function orderABI(contract) {
 
   // Create a new ABI, placing ordered functions at the end.
   var newABI = [];
-  contract.abi.forEach(function(item) {
+  contract.abi.forEach(function (item) {
     if (functions_to_remove[item.name] !== undefined) return;
     newABI.push(item);
   });
@@ -355,8 +355,8 @@ function orderABI(contract) {
 // contracts_directory: String. Directory where .sol files can be found.
 // quiet: Boolean. Suppress output. Defaults to false.
 // strict: Boolean. Return compiler warnings as errors. Defaults to false.
-compile.all = function(options, callback) {
-  find_contracts(options.contracts_directory, function(err, files) {
+compile.all = function (options, callback) {
+  find_contracts(options.contracts_directory, function (err, files) {
     if (err) return callback(err);
 
     options.paths = files;
@@ -370,10 +370,10 @@ compile.all = function(options, callback) {
 //      in the build directory to see what needs to be compiled.
 // quiet: Boolean. Suppress output. Defaults to false.
 // strict: Boolean. Return compiler warnings as errors. Defaults to false.
-compile.necessary = function(options, callback) {
+compile.necessary = function (options, callback) {
   options.logger = options.logger || console;
 
-  Profiler.updated(options, function(err, updated) {
+  Profiler.updated(options, function (err, updated) {
     if (err) return callback(err);
 
     if (updated.length === 0 && options.quiet !== true) {
@@ -385,7 +385,7 @@ compile.necessary = function(options, callback) {
   });
 };
 
-compile.with_dependencies = function(options, callback) {
+compile.with_dependencies = function (options, callback) {
   var self = this;
 
   options.logger = options.logger || console;
@@ -421,7 +421,7 @@ compile.with_dependencies = function(options, callback) {
   );
 };
 
-compile.display = function(paths, options) {
+compile.display = function (paths, options) {
   if (options.quiet !== true) {
     if (!Array.isArray(paths)) {
       paths = Object.keys(paths);

--- a/packages/truffle-core/lib/testing/soliditytest.js
+++ b/packages/truffle-core/lib/testing/soliditytest.js
@@ -18,7 +18,7 @@ const SolidityTest = {
     suite.timeout(runner.BEFORE_TIMEOUT);
 
     // Set up our runner's needs first.
-    suite.beforeAll("prepare suite", function(done) {
+    suite.beforeAll("prepare suite", function (done) {
       series(
         [
           runner.initialize.bind(runner),
@@ -34,7 +34,7 @@ const SolidityTest = {
       );
     });
 
-    suite.beforeEach("before test", function(done) {
+    suite.beforeEach("before test", function (done) {
       runner.startTest(this, done);
     });
 
@@ -103,7 +103,7 @@ const SolidityTest = {
       }
     });
 
-    suite.afterEach("after test", function(done) {
+    suite.afterEach("after test", function (done) {
       runner.endTest(this, done);
     });
 
@@ -165,11 +165,11 @@ const SolidityTest = {
   deployTestDependencies(abstraction, dependency_paths, runner, callback) {
     const deployer = new Deployer(
       runner.config.with({
-        logger: { log() {} }
+        logger: { log() { } }
       })
     );
 
-    const assertLibraries = [
+    const testLibraries = [
       "Assert",
       "AssertAddress",
       "AssertAddressArray",
@@ -183,27 +183,25 @@ const SolidityTest = {
       "AssertIntArray",
       "AssertString",
       "AssertUint",
-      "AssertUintArray"
+      "AssertUintArray",
+      "DeployedAddresses",
     ];
 
-    const assertAbstractions = assertLibraries.map(name =>
+    const testAbstractions = testLibraries.map(name =>
       runner.config.resolver.require(`truffle/${name}.sol`)
     );
 
-    const DeployedAddresses = runner.config.resolver.require(
-      "truffle/DeployedAddresses.sol"
-    );
     SafeSend = runner.config.resolver.require(SafeSend);
 
-    for (const abstraction of assertAbstractions) {
-      deployer.deploy(abstraction);
+    for (const testLib of testAbstractions) {
+      deployer.deploy(testLib);
+      deployer.link(testLib, abstraction);
     }
-    deployer.deploy(DeployedAddresses).then(() => {
-      return dependency_paths.forEach(dependency_path => {
-        const dependency = runner.config.resolver.require(dependency_path);
 
-        if (dependency.isDeployed()) deployer.link(dependency, abstraction);
-      });
+    dependency_paths.forEach(dependency_path => {
+      const dependency = runner.config.resolver.require(dependency_path);
+
+      if (dependency.isDeployed()) deployer.link(dependency, abstraction);
     });
 
     let deployed;


### PR DESCRIPTION
- deploy and link test deps at same time, separately from other dependencies
- revert to code in commit 6617b6386414bd812c3dddcdfcf3ab00472f4cef to keep originalMappings for windows file paths
- combine assert and deployedaddresses loading

This is my first time PRing to this project, let me know if everything looks alright. There is a chance I'm not safely handling the linking of the testLibs (assert et. al) but this fix does the job for now.