### PR TITLE
Update projects' package.json repository fields

### DIFF
--- a/packages/truffle-artifactor/package.json
+++ b/packages/truffle-artifactor/package.json
@@ -8,10 +8,7 @@
   "scripts": {
     "test": "mocha"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/trufflesuite/truffle-artifactor.git"
-  },
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-artifactor",
   "license": "MIT",
   "devDependencies": {
     "chai": "4.2.0",

--- a/packages/truffle-blockchain-utils/package.json
+++ b/packages/truffle-blockchain-utils/package.json
@@ -4,10 +4,7 @@
   "description": "Utilities for identifying and managing blockchains",
   "main": "index.js",
   "scripts": {},
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/trufflesuite/truffle-blockchain-utils.git"
-  },
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-blockchain-utils",
   "keywords": [
     "ethereum",
     "truffle",

--- a/packages/truffle-box/package.json
+++ b/packages/truffle-box/package.json
@@ -7,6 +7,7 @@
     "lint": "eslint ./index.js ./lib || true",
     "test": "mocha"
   },
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-box",
   "keywords": [
     "ethereum",
     "truffle",

--- a/packages/truffle-code-utils/package.json
+++ b/packages/truffle-code-utils/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {},
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-code-utils",
   "author": "",
   "license": "MIT",
   "publishConfig": {

--- a/packages/truffle-compile-vyper/package.json
+++ b/packages/truffle-compile-vyper/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "test": "mocha"
   },
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-compile-vyper",
   "keywords": [
     "ethereum",
     "truffle",

--- a/packages/truffle-compile/package.json
+++ b/packages/truffle-compile/package.json
@@ -37,10 +37,7 @@
   "scripts": {
     "test": "./scripts/test.sh"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/trufflesuite/truffle-compile.git"
-  },
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-compile",
   "keywords": [
     "ethereum",
     "truffle",

--- a/packages/truffle-config/package.json
+++ b/packages/truffle-config/package.json
@@ -4,10 +4,7 @@
   "description": "Utility for interacting with truffle-config.js files",
   "main": "index.js",
   "scripts": {},
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/trufflesuite/truffle-config.git"
-  },
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-config",
   "keywords": [
     "ethereum",
     "truffle",

--- a/packages/truffle-contract-schema/package.json
+++ b/packages/truffle-contract-schema/package.json
@@ -8,10 +8,7 @@
     "build": "cd spec && json2ts -i contract-object.spec.json -o ./index.d.ts",
     "test": "mocha"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/trufflesuite/truffle-schema.git"
-  },
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-contract-schema",
   "keywords": [
     "ethereum",
     "json",

--- a/packages/truffle-contract-sources/package.json
+++ b/packages/truffle-contract-sources/package.json
@@ -4,10 +4,7 @@
   "description": "Utility for finding all contracts within a directory",
   "main": "index.js",
   "scripts": {},
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/trufflesuite/truffle-contract-sources.git"
-  },
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-contract-sources",
   "keywords": [
     "ethereum",
     "contracts",

--- a/packages/truffle-contract/package.json
+++ b/packages/truffle-contract/package.json
@@ -11,10 +11,7 @@
     "test:trace": "$(npm bin)/mocha --trace-warnings",
     "compile": "mkdir -p dist && browserify ./index.js -o ./dist/truffle-contract.js && uglifyjs ./dist/truffle-contract.js -o ./dist/truffle-contract.min.js"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/trufflesuite/truffle-contract.git"
-  },
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-contract",
   "keywords": [
     "ethereum",
     "truffle",

--- a/packages/truffle-core/package.json
+++ b/packages/truffle-core/package.json
@@ -63,10 +63,7 @@
   "scripts": {
     "test": "mocha ./test/**"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ConsenSys/truffle.git"
-  },
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-core",
   "homepage": "https://github.com/ConsenSys/truffle",
   "bugs": {
     "url": "https://github.com/ConsenSys/truffle/issues"

--- a/packages/truffle-debug-utils/package.json
+++ b/packages/truffle-debug-utils/package.json
@@ -9,10 +9,7 @@
   },
   "main": "index.js",
   "scripts": {},
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/trufflesuite/truffle-debug-utils.git"
-  },
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-debug-utils",
   "author": "Truffle Suite <inquiry@trufflesuite.com>",
   "license": "MIT",
   "bugs": {

--- a/packages/truffle-debugger/package.json
+++ b/packages/truffle-debugger/package.json
@@ -73,10 +73,7 @@
     "webpack-node-externals": "^1.6.0",
     "write-file-webpack-plugin": "^4.2.0"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/trufflesuite/truffle-debugger.git"
-  },
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-debugger",
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle-debugger/issues"
   },

--- a/packages/truffle-decode-utils/package.json
+++ b/packages/truffle-decode-utils/package.json
@@ -14,10 +14,7 @@
     "start": "node_modules/.bin/tsc --watch",
     "test": "echo \"No test specified\" && exit 0;"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/trufflesuite/truffle-decode-utils.git"
-  },
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-decode-utils",
   "author": "Truffle Suite <inquiry@trufflesuite.com>",
   "license": "MIT",
   "bugs": {

--- a/packages/truffle-decoder/package.json
+++ b/packages/truffle-decoder/package.json
@@ -12,10 +12,7 @@
     "start": "node_modules/.bin/tsc --watch",
     "test": "cd test && truffle test"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/trufflesuite/truffle.git"
-  },
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-decoder",
   "keywords": [
     "ethereum",
     "contract",

--- a/packages/truffle-deployer/package.json
+++ b/packages/truffle-deployer/package.json
@@ -6,10 +6,7 @@
   "scripts": {
     "test": "mocha --no-warnings --timeout 10000 --exit"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/trufflesuite/truffle-deployer.git"
-  },
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-deployer",
   "keywords": [
     "ethereum",
     "truffle",

--- a/packages/truffle-error/package.json
+++ b/packages/truffle-error/package.json
@@ -4,10 +4,7 @@
   "description": "Simple module that allows native Error objects to be extended",
   "main": "index.js",
   "scripts": {},
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/trufflesuite/truffle-error.git"
-  },
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-error",
   "keywords": [
     "ethereum",
     "truffle",

--- a/packages/truffle-expect/package.json
+++ b/packages/truffle-expect/package.json
@@ -4,10 +4,7 @@
   "description": "Simple module for ensuring specific options are passed to a function",
   "main": "index.js",
   "scripts": {},
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/trufflesuite/truffle-expect.git"
-  },
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-expect",
   "keywords": [
     "truffle",
     "ethereum",

--- a/packages/truffle-external-compile/package.json
+++ b/packages/truffle-external-compile/package.json
@@ -11,10 +11,7 @@
   "homepage": "https://github.com/trufflesuite/truffle#readme",
   "license": "MIT",
   "main": "index.js",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/trufflesuite/truffle.git"
-  },
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-external-compile",
   "scripts": {
     "test": "mocha"
   },

--- a/packages/truffle-hdwallet-provider/package.json
+++ b/packages/truffle-hdwallet-provider/package.json
@@ -7,10 +7,7 @@
     "test": "mocha --timeout 5000",
     "prepare": "npx webpack --config webpack/webpack.config.js"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/trufflesuite/truffle-hdwallet-provider.git"
-  },
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-hdwallet-provider",
   "keywords": [
     "etheruem",
     "hd",

--- a/packages/truffle-migrate/package.json
+++ b/packages/truffle-migrate/package.json
@@ -4,10 +4,7 @@
   "description": "On-chain migrations management",
   "main": "index.js",
   "scripts": {},
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/trufflesuite/truffle-migrate.git"
-  },
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-migrate",
   "keywords": [
     "ethereum",
     "truffle",

--- a/packages/truffle-provider/package.json
+++ b/packages/truffle-provider/package.json
@@ -6,10 +6,7 @@
   "scripts": {
     "test": "mocha"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/trufflesuite/truffle-provider.git"
-  },
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-provider",
   "keywords": [
     "ethereum",
     "truffle",

--- a/packages/truffle-provisioner/package.json
+++ b/packages/truffle-provisioner/package.json
@@ -4,10 +4,7 @@
   "description": "Provision contract objects for use from multiple sources",
   "main": "index.js",
   "scripts": {},
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/trufflesuite/truffle-provisioner.git"
-  },
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-provisioner",
   "keywords": [
     "ethereum",
     "truffle",

--- a/packages/truffle-reporters/package.json
+++ b/packages/truffle-reporters/package.json
@@ -4,6 +4,7 @@
   "description": "Reporters for Truffle modules",
   "main": "index.js",
   "scripts": {},
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-reporters",
   "author": "",
   "license": "MIT",
   "publishConfig": {

--- a/packages/truffle-require/package.json
+++ b/packages/truffle-require/package.json
@@ -6,10 +6,7 @@
   "scripts": {
     "test": "mocha"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/trufflesuite/truffle-exec.git"
-  },
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-require",
   "keywords": [
     "ethereum",
     "truffle",

--- a/packages/truffle-resolver/package.json
+++ b/packages/truffle-resolver/package.json
@@ -4,10 +4,7 @@
   "description": "Resolve contract dependencies given multiple configurable dependency sources",
   "main": "index.js",
   "scripts": {},
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/trufflesuite/truffle-resolver.git"
-  },
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-resolver",
   "keywords": [
     "ethereum",
     "truffle",

--- a/packages/truffle-sawtooth-seth-provider/package.json
+++ b/packages/truffle-sawtooth-seth-provider/package.json
@@ -5,10 +5,7 @@
   "main": "index.js",
   "author": "Ben Burns",
   "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/benjamincburns/truffle-sawtooth-seth-provider.git"
-  },
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-sawtooth-seth-provider",
   "homepage": "https://truffleframework.com",
   "bugs": {
     "url": "https://github.com/benjamincburns/truffle-sawtooth-seth-provider/issues"

--- a/packages/truffle-solidity-loader/package.json
+++ b/packages/truffle-solidity-loader/package.json
@@ -7,6 +7,7 @@
     "lintjs": "standard",
     "lintjs-fix": "standard --fix"
   },
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-solidity-loader",
   "authors": [
     "John McDowall <john@kantan.io>",
     "Angello Pozo <angellopozo@gmail.com>"

--- a/packages/truffle-solidity-utils/package.json
+++ b/packages/truffle-solidity-utils/package.json
@@ -4,10 +4,7 @@
   "description": "Utilities for Solidity contracts",
   "main": "index.js",
   "scripts": {},
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/trufflesuite/truffle-solidity-utils.git"
-  },
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-solidity-utils",
   "keywords": [
     "ethereum",
     "truffle",

--- a/packages/truffle-workflow-compile/package.json
+++ b/packages/truffle-workflow-compile/package.json
@@ -17,10 +17,7 @@
   },
   "main": "index.js",
   "scripts": {},
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/trufflesuite/truffle-debug-utils.git"
-  },
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-workflow-compile",
   "author": "Truffle Suite <inquiry@trufflesuite.com>",
   "license": "MIT",
   "bugs": {

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -51,10 +51,7 @@
     "publish:user-level-mnemonic": "node ./scripts/prereleaseVersion.js user-level-mnemonic user-level-mnemonic",
     "test:raw": "NO_BUILD=true mocha"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/trufflesuite/truffle.git"
-  },
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle",
   "homepage": "https://github.com/trufflesuite/truffle/",
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"


### PR DESCRIPTION
I noticed that many of the repository fields for sub-packages here were pointed at the now defunct original repositories (pre-monorepo). I actually had some initial confusion when I was looking into a `truffle-foo` dependency I'm using, and was directed to a now-defunct github repo with old code.

They now point at the individual packages here in a standard way.

**For example:**

```diff
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/trufflesuite/truffle-compile.git"
-  },
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-compile",
```

This field can apparently be configured in several different ways, and given this mono-repo setup, its not totally clear to me what the *best* setup is, but I just copied [what *babel* uses](https://github.com/babel/babel/blob/master/packages/babel-parser/package.json#L19) because that seems reasonable.

---

#### Notes:

In my opinion, the [`package.json` repository field](https://docs.npmjs.com/files/package.json#repository) is super useful.

- it populates the *repository* link for [npmjs.com](https://www.npmjs.com) package pages
- from the terminal you can type `npm docs truffle-core` or `npm repo truffle-core` and be directed to the right GH page in your browser
- if you're in the directory of a package here, you can just type `npm docs` or `npm repo` and it will do the same

