### PR TITLE
Sign personal messages trough signPersonalMessage

### DIFF
--- a/packages/truffle-hdwallet-provider/src/index.js
+++ b/packages/truffle-hdwallet-provider/src/index.js
@@ -103,6 +103,9 @@ function HDWalletProvider(
         const sig = ethUtil.ecsign(msgHashBuff, pkey);
         const rpcSig = ethUtil.toRpcSig(sig.v, sig.r, sig.s);
         cb(null, rpcSig);
+      },
+      signPersonalMessage() {
+        this.signMessage(...arguments);
       }
     })
   );


### PR DESCRIPTION
I was having problems using HDWalletProvider when I execute `web3.eth.personal.sign('text', '0x0...')` because seems that the provider needs to implement the method `signPersonalMessage`. Both need the same parameters and both use the same signature algorithm.