### PR TITLE
Fix reset button's interaction with EVM calls

### DIFF
--- a/packages/truffle-debugger/lib/evm/reducers.js
+++ b/packages/truffle-debugger/lib/evm/reducers.js
@@ -137,7 +137,7 @@ export function callstack(state = [], action) {
       //happen at the end when we want to keep the last one around)
       return state.length > 1 ? state.slice(0, -1) : state;
 
-    case action.RESET:
+    case actions.RESET:
       return [state[0]]; //leave the initial call still on the stack
 
     default:


### PR DESCRIPTION
A one-character error caused the reset button to not correctly reset the EVM state and thus not work properly from inside an EVM call.  This is now fixed.