### PR TITLE
Fix stack allocation

### DIFF
--- a/packages/truffle-debugger/lib/data/actions/index.js
+++ b/packages/truffle-debugger/lib/data/actions/index.js
@@ -18,10 +18,9 @@ export function declare(node) {
 }
 
 export const ASSIGN = "ASSIGN";
-export function assign(context, assignments) {
+export function assign(assignments) {
   return {
     type: ASSIGN,
-    context,
     assignments
   };
 }

--- a/packages/truffle-debugger/lib/data/sagas/index.js
+++ b/packages/truffle-debugger/lib/data/sagas/index.js
@@ -63,13 +63,17 @@ function* tickSaga() {
   switch (node.nodeType) {
     case "FunctionDefinition":
       let parameters = node.parameters.parameters;
-      let returnParameters = node.returnParameters.parameters;
-      let reverseParameters = parameters.concat(returnParameters).reverse();
+      //note that we do *not* include return parameters, since those are
+      //handled by the VariableDeclaration case (no, I don't know why it
+      //works out that way)
+      let reverseParameters = parameters.slice().reverse();
+      //reverse is in-place, so we use slice() to clone first
+      debug("reverseParameters %o", parameters);
 
       let currentPosition = top;
       assignments = { byId: {} };
 
-      for (parameter of reverseParameters) {
+      for (let parameter of reverseParameters) {
         let words = DecodeUtils.Definition.stackSize(parameter);
         let pointer = {
           stack: {

--- a/packages/truffle-debugger/lib/data/selectors/index.js
+++ b/packages/truffle-debugger/lib/data/selectors/index.js
@@ -29,10 +29,8 @@ function createStateSelectors({ stack, memory, storage }) {
       words =>
         (words || []).map(word =>
           TruffleDecodeUtils.Conversion.toBytes(
-            TruffleDecodeUtils.Conversion.toBN(
-              word,
-              TruffleDecodeUtils.EVM.WORD_SIZE
-            )
+            word,
+            TruffleDecodeUtils.EVM.WORD_SIZE
           )
         )
     ),

--- a/packages/truffle-decode-utils/src/definition.ts
+++ b/packages/truffle-decode-utils/src/definition.ts
@@ -25,7 +25,8 @@ export namespace Definition {
    * should only return "internal" or "external"
    */
   export function visibility(definition: AstDefinition): string {
-    return definition.visibility || definition.typeName.visibility;
+    return definition.typeName ?
+      definition.typeName.visibility : definition.typeName.visibility;
   }
 
 

--- a/packages/truffle-decode-utils/src/definition.ts
+++ b/packages/truffle-decode-utils/src/definition.ts
@@ -94,7 +94,7 @@ export namespace Definition {
   }
 
   export function isReference(definition: AstDefinition): boolean {
-    return typeIdentifier(definition).match(/_(memory|storage)(_ptr)?$/) != null;
+    return typeIdentifier(definition).match(/_(memory|storage|calldata)(_ptr)?$/) != null;
   }
 
   export function isContractType(definition: AstDefinition): boolean {
@@ -105,5 +105,23 @@ export namespace Definition {
 
   export function referenceType(definition: AstDefinition): string {
     return typeIdentifier(definition).match(/_([^_]+)(_ptr)?$/)[1];
+  }
+
+  //stack size, in words, of a given type
+  export function stackSize(definition: AstDefinition): number {
+    if(typeClass(definition) === "function" &&
+      visibility(definition) === "external") {
+      return 2;
+    }
+    if(isReference(definition) && referenceType(definition) === "calldata") {
+      if(typeClass(definition) === "string" ||
+        typeClass(definition) === "bytes") {
+        return 2;
+      }
+      if(isDynamicArray(definition)) {
+        return 2;
+      }
+    }
+    return 1;
   }
 }

--- a/packages/truffle-decoder/lib/decode/index.ts
+++ b/packages/truffle-decoder/lib/decode/index.ts
@@ -13,6 +13,7 @@ import Web3 from "web3";
 
 export default async function decode(definition: AstDefinition, pointer: DataPointer, info: EvmInfo, web3?: Web3, contractAddress?: string): Promise<any> {
   debug("Decoding %s", definition.name);
+  debug("pointer %O", pointer);
 
   if (isLiteralPointer(pointer)) {
     return await decodeLiteral(definition, pointer, info);

--- a/packages/truffle-decoder/lib/interface/index.ts
+++ b/packages/truffle-decoder/lib/interface/index.ts
@@ -6,6 +6,7 @@ import TruffleDecoder from "./contract-decoder";
 import { ContractObject } from "truffle-contract-schema/spec";
 import { Provider } from "web3/providers";
 import { getStorageAllocations } from "../allocate/storage";
+import { readStack } from "../read/stack";
 
 export function forContract(contract: ContractObject, inheritedContracts: ContractObject[], provider: Provider): TruffleDecoder {
   return new TruffleDecoder(contract, inheritedContracts, provider);
@@ -16,3 +17,4 @@ export async function forEvmState(definition: AstDefinition, pointer: DataPointe
 }
 
 export { getStorageAllocations };
+export { readStack };

--- a/packages/truffle-decoder/lib/read/index.ts
+++ b/packages/truffle-decoder/lib/read/index.ts
@@ -1,12 +1,13 @@
 import * as storage from "./storage";
 import * as memory from "./memory";
+import * as stack from "./stack";
 import { DataPointer, isStackPointer, isStoragePointer, isMemoryPointer, isLiteralPointer } from "../types/pointer";
 import { EvmState } from "../types/evm";
 import Web3 from "web3";
 
 export default async function read(pointer: DataPointer, state: EvmState, web3?: Web3, contractAddress?: string): Promise<Uint8Array> {
-  if (isStackPointer(pointer) && state.stack && pointer.stack < state.stack.length) {
-    return state.stack[pointer.stack];
+  if (isStackPointer(pointer) && state.stack) {
+    return stack.readStack(state.stack, pointer.stack.from, pointer.stack.to);
   } else if (isStoragePointer(pointer) && state.storage) {
     return await storage.readRange(state.storage, pointer.storage, web3, contractAddress);
   } else if (isMemoryPointer(pointer) && state.memory) {

--- a/packages/truffle-decoder/lib/read/stack.ts
+++ b/packages/truffle-decoder/lib/read/stack.ts
@@ -1,0 +1,19 @@
+import * as DecodeUtils from "truffle-decode-utils";
+
+export function readStack(stack: Uint8Array[], from: number, to: number): Uint8Array {
+  if(from < 0 || to >= stack.length) {
+    return undefined;
+  }
+  //unforunately, Uint8Arrays don't support concat; if they did the rest of
+  //this would be one line.  Or similarly if they worked with lodash's flatten,
+  //but they don't support that either.  But neither of those are the case, so
+  //we'll have to concatenate a bit more manually.
+  let words = stack.slice(from, to + 1);
+  let result = new Uint8Array(words.length * DecodeUtils.EVM.WORD_SIZE);
+    //shouldn't we total up the lengths? yeah, but each one should have a
+    //length of 32, so unless somehting's gone wrong we can just multiply
+  for(let index = 0; index < words.length; index++) {
+    result.set(words[index], index * DecodeUtils.EVM.WORD_SIZE);
+  }
+  return result;
+}

--- a/packages/truffle-decoder/lib/types/pointer.ts
+++ b/packages/truffle-decoder/lib/types/pointer.ts
@@ -7,7 +7,10 @@ export interface GenericPointer {
 }
 
 export interface StackPointer extends GenericPointer {
-  stack: number;
+  stack: {
+    from: number;
+    to: number;
+  }
 }
 
 export interface MemoryPointer extends GenericPointer {


### PR DESCRIPTION
The primary purpose of this PR is to fix stack allocation for input parameters to functions.  The existing allocation algorithm assumed all stack variables take up a single word; however, some -- specifically, external functions and some calldata pointers -- take up two.  Since we process input parameters from right to left, this could cause decoding errors for any input parameter which had a two-word input parameter somewhere to the right of it, as its stack allocation would be incorrect.

To accomplish this, the `StackPointer` type has been redefined; instead of containing just a single number, it now contains `from` and `to` numbers.  A new file, `read/stack.ts`, with a function `readStack`, has been added to the decoder, and the `read` function now calls this instead of reading from the stack manually.  The `readStack` function is now also used in the debugger itself for the stack read when assigning literal pointers to nodes, in anticipation of future improvements where we will need this for calldata variables used as mapping keys.  (Other stack reads have been left as raw stack reads; I didn't see any need to change them.)

Note that all stack pointers have been adjusted to be appropriately sized now, but this only currently matters in the parameter case mentioned above.  The only two-word stack variables are, as mentioned above, external functions and certain calldata pointers, and there is still no decoding support for calldata variables or functions of any kind.  This PR covers allocation and reading only, not decoding.

Additional notes:

1. This PR does contain a change which is redundant with one of the changes in the `value-types` PR.  It's a very small change, so it's not redoing substantial work, don't worry.
2. I did various cleanup of the data sagas and actions -- for instance, I found that the `ASSIGN` action had a component which was unused, so I removed it.  I also found that the data saga was doing a lot of unnecessary operations with JSON pointers when it could simply use the AST nodes instead, so I changed it to do that.
3. It turns out that the existing stack allocation code had an interesting error -- it put output parameters below input parameters rather than above them.  It worked anyway, because in fact the stack position in the `FunctionDefinition` case is appropriate for input, not output, parameters; and because output parameters, unlike input parameters, have their declarations sourcemapped, and so ended up overwritten by the `VariableDeclaration` case, which got them right.  This PR alters the `FunctionDefinition` case to only cover input parameters, and leaves the output parameters to the `VariableDeclaration` case.
4. You may be wondering why I did `StackPointer` as `from` and `to`, instead of a start and a length.  The reason is that we typically process the stack from the top down, so `start` and `length` would have been less natural than `top` and `length`, and, well, end-and-length just seems awkward.  (And maybe we'll want to go bottom-up someday.)  So I went with from-and-to.