### PR TITLE
Update stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,11 +1,11 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 60
+daysUntilStale: 120
 
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
-daysUntilClose: 7
+daysUntilClose: 14
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels:

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -17,6 +17,9 @@ exemptLabels:
   - optimization
   - "needs roadmapped"
 
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: true  
+
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: false
 


### PR DESCRIPTION
Increases daysUntilStale to 120 and daysUntilClose to 14. Will not mark issues with an assignee as stale.