### PR TITLE
Compiler version output

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,10 @@
     "sourceType": "module"
   },
   "rules": {
-    "no-unused-vars": ["error", {"argsIgnorePattern": "^_"}],
+    "no-unused-vars": [
+      "error",
+      { "argsIgnorePattern": "^_", "varsIgnorePattern": "debug" }
+    ],
     "quote-props": [ "error", "consistent" ],
     "semi": [ "error", "always" ],
     "no-mixed-operators": "warn",

--- a/packages/truffle-compile-vyper/index.js
+++ b/packages/truffle-compile-vyper/index.js
@@ -1,19 +1,19 @@
-const path = require('path');
-const exec = require('child_process').exec;
+const path = require("path");
+const exec = require("child_process").exec;
 
-const async = require('async');
-const colors = require('colors');
-const minimatch = require('minimatch');
+const async = require("async");
+const colors = require("colors");
+const minimatch = require("minimatch");
 
-const find_contracts = require('truffle-contract-sources');
-const Profiler = require('truffle-compile/profiler');
+const find_contracts = require("truffle-contract-sources");
+const Profiler = require("truffle-compile/profiler");
 
 const compiler = {
-  name: 'vyper',
-  version: null,
+  name: "vyper",
+  version: null
 };
 
-const VYPER_PATTERN = '**/*.{vy,v.py,vyper.py}';
+const VYPER_PATTERN = "**/*.{vy,v.py,vyper.py}";
 
 // -------- TODO: Common with truffle-compile --------
 
@@ -23,7 +23,6 @@ const compile = {};
 // quiet: Boolean. Suppress output. Defaults to false.
 // strict: Boolean. Return compiler warnings as errors. Defaults to false.
 compile.all = function(options, callback) {
-
   find_contracts(options.contracts_directory, function(err, files) {
     if (err) return callback(err);
 
@@ -39,7 +38,6 @@ compile.all = function(options, callback) {
 // quiet: Boolean. Suppress output. Defaults to false.
 // strict: Boolean. Return compiler warnings as errors. Defaults to false.
 compile.necessary = function(options, callback) {
-  var self = this;
   options.logger = options.logger || console;
 
   Profiler.updated(options, function(err, updated) {
@@ -54,17 +52,18 @@ compile.necessary = function(options, callback) {
   });
 };
 
-compile.display = function(paths, options){
+compile.display = function(paths, options) {
   if (options.quiet !== true) {
-    if (!Array.isArray(paths)){
+    if (!Array.isArray(paths)) {
       paths = Object.keys(paths);
     }
 
     paths.sort().forEach(contract => {
       if (path.isAbsolute(contract)) {
-        contract = "." + path.sep + path.relative(options.working_directory, contract);
+        contract =
+          "." + path.sep + path.relative(options.working_directory, contract);
       }
-      options.logger.log("Compiling " + contract + "...");
+      options.logger.log("    > compiling " + contract);
     });
   }
 };
@@ -73,8 +72,9 @@ compile.display = function(paths, options){
 
 // Check that vyper is available, save its version
 function checkVyper(callback) {
-  exec('vyper --version', function (err, stdout, stderr) {
-    if (err) return callback(`${colors.red('Error executing vyper:')}\n${stderr}`);
+  exec("vyper --version", function(err, stdout, stderr) {
+    if (err)
+      return callback(`${colors.red("Error executing vyper:")}\n${stderr}`);
 
     compiler.version = stdout.trim();
 
@@ -84,20 +84,22 @@ function checkVyper(callback) {
 
 // Execute vyper for single source file
 function execVyper(source_path, callback) {
-  const formats = ['abi', 'bytecode', 'bytecode_runtime'];
-  const command = `vyper -f${formats.join(',')} ${source_path}`;
+  const formats = ["abi", "bytecode", "bytecode_runtime"];
+  const command = `vyper -f${formats.join(",")} ${source_path}`;
 
-  exec(command, function (err, stdout, stderr) {
-    if (err) return callback(`${stderr}\n${colors.red(`Compilation of ${source_path} failed. See above.`)}`);
+  exec(command, function(err, stdout, stderr) {
+    if (err)
+      return callback(
+        `${stderr}\n${colors.red(
+          `Compilation of ${source_path} failed. See above.`
+        )}`
+      );
 
     var outputs = stdout.split(/\r?\n/);
 
-    const compiled_contract = outputs.reduce(
-      function (contract, output, index) {
-        return Object.assign(contract, { [formats[index]]: output });
-      },
-      {}
-    );
+    const compiled_contract = outputs.reduce(function(contract, output, index) {
+      return Object.assign(contract, { [formats[index]]: output });
+    }, {});
 
     callback(null, compiled_contract);
   });
@@ -109,54 +111,63 @@ function compileAll(options, callback) {
 
   compile.display(options.paths, options);
 
-  async.map(options.paths, function (source_path, c) {
-    execVyper(source_path, function (err, compiled_contract) {
-      if (err) return c(err);
+  async.map(
+    options.paths,
+    function(source_path, c) {
+      execVyper(source_path, function(err, compiled_contract) {
+        if (err) return c(err);
 
-      // remove first extension from filename
-      const extension = path.extname(source_path);
-      const basename = path.basename(source_path, extension);
+        // remove first extension from filename
+        const extension = path.extname(source_path);
+        const basename = path.basename(source_path, extension);
 
-      // if extension is .py, remove second extension from filename
-      const contract_name = extension !== '.py' ? basename : path.basename(basename, path.extname(basename));
+        // if extension is .py, remove second extension from filename
+        const contract_name =
+          extension !== ".py"
+            ? basename
+            : path.basename(basename, path.extname(basename));
 
-      const contract_definition = {
-        contract_name: contract_name,
-        sourcePath: source_path,
+        const contract_definition = {
+          contract_name: contract_name,
+          sourcePath: source_path,
 
-        abi: compiled_contract.abi,
-        bytecode: compiled_contract.bytecode,
-        deployedBytecode: compiled_contract.bytecode_runtime,
+          abi: compiled_contract.abi,
+          bytecode: compiled_contract.bytecode,
+          deployedBytecode: compiled_contract.bytecode_runtime,
 
-        compiler: compiler
-      };
+          compiler: compiler
+        };
 
-      c(null, contract_definition);
-    });
-  }, function (err, contracts) {
-    if (err) return callback(err);
+        c(null, contract_definition);
+      });
+    },
+    function(err, contracts) {
+      if (err) return callback(err);
 
-    const result = contracts.reduce(function(result, contract) {
-      result[contract.contract_name] = contract;
+      const result = contracts.reduce(function(result, contract) {
+        result[contract.contract_name] = contract;
 
-      return result;
-    }, {});
+        return result;
+      }, {});
 
-    callback(null, result, options.paths);
-  });
+      const compilerInfo = { name: "vyper", version: compiler.version };
+
+      callback(null, result, options.paths, compilerInfo);
+    }
+  );
 }
 
 // Check that vyper is available then forward to internal compile function
 function compileVyper(options, callback) {
   // filter out non-vyper paths
-  options.paths = options.paths.filter(function (path) {
+  options.paths = options.paths.filter(function(path) {
     return minimatch(path, VYPER_PATTERN);
   });
 
   // no vyper files found, no need to check vyper
   if (options.paths.length === 0) return callback(null, {}, []);
 
-  checkVyper(function (err) {
+  checkVyper(function(err) {
     if (err) return callback(err);
 
     return compileAll(options, callback);
@@ -166,17 +177,17 @@ function compileVyper(options, callback) {
 // append .vy pattern to contracts_directory in options and return updated options
 function updateContractsDirectory(options) {
   return options.with({
-    contracts_directory: path.join(options.contracts_directory, VYPER_PATTERN),
+    contracts_directory: path.join(options.contracts_directory, VYPER_PATTERN)
   });
 }
 
 // wrapper for compile.all. only updates contracts_directory to find .vy
-compileVyper.all = function (options, callback) {
+compileVyper.all = function(options, callback) {
   return compile.all(updateContractsDirectory(options), callback);
 };
 
 // wrapper for compile.necessary. only updates contracts_directory to find .vy
-compileVyper.necessary = function (options, callback) {
+compileVyper.necessary = function(options, callback) {
   return compile.necessary(updateContractsDirectory(options), callback);
 };
 

--- a/packages/truffle-compile/index.js
+++ b/packages/truffle-compile/index.js
@@ -1,12 +1,12 @@
-var OS = require("os");
-var path = require("path");
-var Profiler = require("./profiler");
-var CompileError = require("./compileerror");
-var CompilerSupplier = require("./compilerSupplier");
-var expect = require("truffle-expect");
-var find_contracts = require("truffle-contract-sources");
-var Config = require("truffle-config");
-var debug = require("debug")("compile"); // eslint-disable-line no-unused-vars
+const OS = require("os");
+const path = require("path");
+const Profiler = require("./profiler");
+const CompileError = require("./compileerror");
+const CompilerSupplier = require("./compilerSupplier");
+const expect = require("truffle-expect");
+const find_contracts = require("truffle-contract-sources");
+const Config = require("truffle-config");
+const debug = require("debug")("compile"); // eslint-disable-line no-unused-vars
 
 // Most basic of the compile commands. Takes a hash of sources, where
 // the keys are file or module paths and the values are the bodies of
@@ -18,7 +18,7 @@ var debug = require("debug")("compile"); // eslint-disable-line no-unused-vars
 //   quiet: false,
 //   logger: console
 // }
-var compile = function(sources, options, callback) {
+const compile = function(sources, options, callback) {
   if (typeof options === "function") {
     callback = options;
     options = {};
@@ -26,7 +26,7 @@ var compile = function(sources, options, callback) {
 
   if (options.logger === undefined) options.logger = console;
 
-  var hasTargets =
+  const hasTargets =
     options.compilationTargets && options.compilationTargets.length;
 
   expect.options(options, ["contracts_directory", "compilers"]);
@@ -50,9 +50,9 @@ var compile = function(sources, options, callback) {
 
   // Ensure sources have operating system independent paths
   // i.e., convert backslashes to forward slashes; things like C: are left intact.
-  var operatingSystemIndependentSources = {};
-  var operatingSystemIndependentTargets = {};
-  var originalPathMappings = {};
+  const operatingSystemIndependentSources = {};
+  const operatingSystemIndependentTargets = {};
+  const originalPathMappings = {};
 
   Object.keys(sources).forEach(function(source) {
     // Turn all backslashes into forward slashes
@@ -77,7 +77,7 @@ var compile = function(sources, options, callback) {
     originalPathMappings[replacement] = source;
   });
 
-  var defaultSelectors = {
+  const defaultSelectors = {
     "": ["legacyAST", "ast"],
     "*": [
       "abi",
@@ -92,15 +92,15 @@ var compile = function(sources, options, callback) {
 
   // Specify compilation targets
   // Each target uses defaultSelectors, defaulting to single target `*` if targets are unspecified
-  var outputSelection = {};
-  var targets = operatingSystemIndependentTargets;
-  var targetPaths = Object.keys(targets);
+  const outputSelection = {};
+  const targets = operatingSystemIndependentTargets;
+  const targetPaths = Object.keys(targets);
 
   targetPaths.length
     ? targetPaths.forEach(key => (outputSelection[key] = defaultSelectors))
     : (outputSelection["*"] = defaultSelectors);
 
-  var solcStandardInput = {
+  const solcStandardInput = {
     language: "Solidity",
     sources: {},
     settings: {
@@ -115,44 +115,40 @@ var compile = function(sources, options, callback) {
     return callback(null, [], []);
   }
 
-  Object.keys(operatingSystemIndependentSources).forEach(function(file_path) {
+  Object.keys(operatingSystemIndependentSources).forEach(file_path => {
     solcStandardInput.sources[file_path] = {
       content: operatingSystemIndependentSources[file_path]
     };
   });
 
   // Load solc module only when compilation is actually required.
-  var supplier = new CompilerSupplier(options.compilers.solc);
+  const supplier = new CompilerSupplier(options.compilers.solc);
 
   supplier
     .load()
     .then(solc => {
-      var result = solc.compile(JSON.stringify(solcStandardInput));
+      const result = solc.compile(JSON.stringify(solcStandardInput));
 
-      var standardOutput = JSON.parse(result);
+      if (options.quiet !== true) {
+        options.logger.log(`    > using solc ${solc.version()}`);
+      }
 
-      var errors = standardOutput.errors || [];
-      var warnings = [];
+      const standardOutput = JSON.parse(result);
+
+      let errors = standardOutput.errors || [];
+      let warnings = [];
 
       if (options.strict !== true) {
-        warnings = errors.filter(function(error) {
-          return error.severity === "warning";
-        });
+        warnings = errors.filter(error => error.severity === "warning");
 
-        errors = errors.filter(function(error) {
-          return error.severity !== "warning";
-        });
+        errors = errors.filter(error => error.severity !== "warning");
 
         if (options.quiet !== true && warnings.length > 0) {
           options.logger.log(
-            OS.EOL + "Compilation warnings encountered:" + OS.EOL
+            OS.EOL + "    > compilation warnings encountered:" + OS.EOL
           );
           options.logger.log(
-            warnings
-              .map(function(warning) {
-                return warning.formattedMessage;
-              })
-              .join()
+            warnings.map(warning => warning.formattedMessage).join()
           );
         }
       }
@@ -161,11 +157,7 @@ var compile = function(sources, options, callback) {
         options.logger.log("");
         return callback(
           new CompileError(
-            standardOutput.errors
-              .map(function(error) {
-                return error.formattedMessage;
-              })
-              .join()
+            standardOutput.errors.map(error => error.formattedMessage).join()
           )
         );
       }
@@ -173,7 +165,7 @@ var compile = function(sources, options, callback) {
       var contracts = standardOutput.contracts;
 
       var files = [];
-      Object.keys(standardOutput.sources).forEach(function(filename) {
+      Object.keys(standardOutput.sources).forEach(filename => {
         var source = standardOutput.sources[filename];
         files[source.id] = originalPathMappings[filename];
       });
@@ -181,10 +173,10 @@ var compile = function(sources, options, callback) {
       var returnVal = {};
 
       // This block has comments in it as it's being prepared for solc > 0.4.10
-      Object.keys(contracts).forEach(function(source_path) {
+      Object.keys(contracts).forEach(source_path => {
         var files_contracts = contracts[source_path];
 
-        Object.keys(files_contracts).forEach(function(contract_name) {
+        Object.keys(files_contracts).forEach(contract_name => {
           var contract = files_contracts[contract_name];
 
           // All source will have a key, but only the compiled source will have
@@ -429,13 +421,14 @@ compile.display = function(paths, options) {
 
     const blacklistRegex = /^truffle\//;
 
+    options.logger.log();
     paths.sort().forEach(contract => {
       if (path.isAbsolute(contract)) {
         contract =
           "." + path.sep + path.relative(options.working_directory, contract);
       }
       if (contract.match(blacklistRegex)) return;
-      options.logger.log("Compiling " + contract + "...");
+      options.logger.log("    > compiling " + contract + "...");
     });
   }
 };

--- a/packages/truffle-compile/index.js
+++ b/packages/truffle-compile/index.js
@@ -129,10 +129,6 @@ const compile = function(sources, options, callback) {
     .then(solc => {
       const result = solc.compile(JSON.stringify(solcStandardInput));
 
-      if (options.quiet !== true) {
-        options.logger.log(`    > using solc ${solc.version()}`);
-      }
-
       const standardOutput = JSON.parse(result);
 
       let errors = standardOutput.errors || [];
@@ -253,7 +249,9 @@ const compile = function(sources, options, callback) {
         });
       });
 
-      callback(null, returnVal, files);
+      const compilerInfo = { name: "solc", version: solc.version() };
+
+      callback(null, returnVal, files, compilerInfo);
     })
     .catch(callback);
 };
@@ -421,14 +419,13 @@ compile.display = function(paths, options) {
 
     const blacklistRegex = /^truffle\//;
 
-    options.logger.log();
     paths.sort().forEach(contract => {
       if (path.isAbsolute(contract)) {
         contract =
           "." + path.sep + path.relative(options.working_directory, contract);
       }
       if (contract.match(blacklistRegex)) return;
-      options.logger.log("    > compiling " + contract + "...");
+      options.logger.log("    > compiling " + contract);
     });
   }
 };

--- a/packages/truffle-core/test/compile.js
+++ b/packages/truffle-core/test/compile.js
@@ -14,6 +14,13 @@ describe("compile", function() {
   var output = "";
   var memStream;
 
+  beforeEach(() => {
+    memStream = new MemoryStream();
+    memStream.on("data", function(data) {
+      output += data.toString();
+    });
+  });
+
   before("Create a sandbox", function(done) {
     this.timeout(20000);
 
@@ -78,11 +85,10 @@ describe("compile", function() {
       }),
       function(err, result) {
         if (err) return done(err);
-        let { contracts } = result;
 
         assert.equal(
-          Object.keys(contracts).length,
-          0,
+          typeof result,
+          "undefined",
           "Compiled a contract even though we weren't expecting it"
         );
         done();
@@ -135,13 +141,6 @@ describe("compile", function() {
   });
 
   describe("solc listing options", function() {
-    beforeEach(() => {
-      memStream = new MemoryStream();
-      memStream.on("data", function(data) {
-        output += data.toString();
-      });
-    });
-
     it("prints a truncated list of solcjs versions", function(done) {
       this.timeout(5000);
 

--- a/packages/truffle-workflow-compile/index.js
+++ b/packages/truffle-workflow-compile/index.js
@@ -68,11 +68,18 @@ var Contracts = {
     // convert to promise to compile+write
     const compilations = await this.compileSources(config, compilers);
 
+    const numberOfCompiledContracts = compilations.reduce(
+      (number, compilation) => {
+        return number + Object.keys(compilation.contracts).length;
+      },
+      0
+    );
+    if (numberOfCompiledContracts === 0) {
+      return this.reportNothingToCompile(options);
+    }
+
     const collect = async compilations => {
-      let result = {
-        outputs: {},
-        contracts: {}
-      };
+      let result = { outputs: {}, contracts: {} };
 
       for (let compilation of await Promise.all(compilations)) {
         let { compiler, output, contracts } = compilation;
@@ -124,7 +131,7 @@ var Contracts = {
   reportCompilationStarted: options => {
     const logger = options.logger || console;
     if (!options.quiet) {
-      logger.log(OS.EOL + `Compiling your contracts`);
+      logger.log(OS.EOL + `Compiling your contracts` + OS.EOL);
     }
   },
 
@@ -144,6 +151,15 @@ var Contracts = {
         logger.log(OS.EOL + `Compilation successful`);
       }
       logger.log();
+    }
+  },
+
+  reportNothingToCompile: options => {
+    const logger = options.logger || console;
+    if (!options.quiet) {
+      logger.log(
+        `Everything is up to date, there is nothing to compile.` + OS.EOL
+      );
     }
   },
 

--- a/packages/truffle-workflow-compile/index.js
+++ b/packages/truffle-workflow-compile/index.js
@@ -1,14 +1,14 @@
-var debug = require("debug")("workflow-compile");
-var mkdirp = require("mkdirp");
-var { callbackify, promisify } = require("util");
-var Config = require("truffle-config");
-var solcCompile = require("truffle-compile");
-var vyperCompile = require("truffle-compile-vyper");
-var externalCompile = require("truffle-external-compile");
-var expect = require("truffle-expect");
-var Resolver = require("truffle-resolver");
-var Artifactor = require("truffle-artifactor");
-var OS = require("os");
+const debug = require("debug")("workflow-compile");
+const mkdirp = require("mkdirp");
+const { callbackify, promisify } = require("util");
+const Config = require("truffle-config");
+const solcCompile = require("truffle-compile");
+const vyperCompile = require("truffle-compile-vyper");
+const externalCompile = require("truffle-external-compile");
+const expect = require("truffle-expect");
+const Resolver = require("truffle-resolver");
+const Artifactor = require("truffle-artifactor");
+const OS = require("os");
 
 const SUPPORTED_COMPILERS = {
   solc: solcCompile,
@@ -26,9 +26,7 @@ function prepareConfig(options) {
 
   config.compilersInfo = {};
 
-  if (!config.resolver) {
-    config.resolver = new Resolver(config);
-  }
+  if (!config.resolver) config.resolver = new Resolver(config);
 
   if (!config.artifactor) {
     config.artifactor = new Artifactor(config.contracts_build_directory);
@@ -108,9 +106,11 @@ var Contracts = {
           compileFunc
         )(config);
 
-        config.compilersInfo[compilerUsed.name] = {
-          version: compilerUsed.version
-        };
+        if (compilerUsed) {
+          config.compilersInfo[compilerUsed.name] = {
+            version: compilerUsed.version
+          };
+        }
 
         if (contracts && Object.keys(contracts).length > 0) {
           await this.writeContracts(contracts, config);

--- a/packages/truffle-workflow-compile/index.js
+++ b/packages/truffle-workflow-compile/index.js
@@ -1,7 +1,5 @@
 var debug = require("debug")("workflow-compile");
-var async = require("async");
 var mkdirp = require("mkdirp");
-var path = require("path");
 var { callbackify, promisify } = require("util");
 var Config = require("truffle-config");
 var solcCompile = require("truffle-compile");
@@ -13,20 +11,15 @@ var Artifactor = require("truffle-artifactor");
 var OS = require("os");
 
 const SUPPORTED_COMPILERS = {
-  "solc": solcCompile,
-  "vyper": vyperCompile,
-  "external": externalCompile,
+  solc: solcCompile,
+  vyper: vyperCompile,
+  external: externalCompile
 };
 
 function prepareConfig(options) {
-  expect.options(options, [
-    "contracts_build_directory"
-  ]);
+  expect.options(options, ["contracts_build_directory"]);
 
-  expect.one(options, [
-    "contracts_directory",
-    "files"
-  ]);
+  expect.one(options, ["contracts_directory", "files"]);
 
   // Use a config object to ensure we get the default sources.
   const config = Config.default().merge(options);
@@ -42,20 +35,20 @@ function prepareConfig(options) {
   return config;
 }
 
-function multiPromisify (func) {
-  return (...args) => new Promise( (accept, reject) => {
-    const callback = (err, ...results) => {
-      if (err) reject(err);
+function multiPromisify(func) {
+  return (...args) =>
+    new Promise((accept, reject) => {
+      const callback = (err, ...results) => {
+        if (err) reject(err);
 
-      accept(results);
-    };
+        accept(results);
+      };
 
-    func(...args, callback);
-  });
+      func(...args, callback);
+    });
 }
 
 var Contracts = {
-
   // contracts_directory: String. Directory where .sol files can be found.
   // contracts_build_directory: String. Directory where .sol.js files can be found and written to.
   // all: Boolean. Compile all sources found. Defaults to true. If false, will compare sources against built files
@@ -66,18 +59,19 @@ var Contracts = {
   compile: callbackify(async function(options) {
     const config = prepareConfig(options);
 
-    const compilers = (config.compiler)
+    const compilers = config.compiler
       ? [config.compiler]
       : Object.keys(config.compilers);
 
     // convert to promise to compile+write
-    const compilations = compilers.map(async (compiler) => {
+    const compilations = compilers.map(async compiler => {
       const compile = SUPPORTED_COMPILERS[compiler];
       if (!compile) throw new Error("Unsupported compiler: " + compiler);
 
-      const compileFunc = (config.all === true || config.compileAll === true)
-        ? compile.all
-        : compile.necessary;
+      const compileFunc =
+        config.all === true || config.compileAll === true
+          ? compile.all
+          : compile.necessary;
 
       let [contracts, output] = await multiPromisify(compileFunc)(config);
 
@@ -88,7 +82,7 @@ var Contracts = {
       return { compiler, contracts, output };
     });
 
-    const collect = async (compilations) => {
+    const collect = async compilations => {
       let result = {
         outputs: {},
         contracts: {}
@@ -99,10 +93,9 @@ var Contracts = {
 
         result.outputs[compiler] = output;
 
-        for (let [ name, abstraction ] of Object.entries(contracts)) {
+        for (let [name, abstraction] of Object.entries(contracts)) {
           result.contracts[name] = abstraction;
         }
-
       }
 
       return result;
@@ -112,17 +105,19 @@ var Contracts = {
   }),
 
   writeContracts: async function(contracts, options) {
-    var logger = options.logger || console;
+    const logger = options.logger || console;
 
-    const result = await promisify(mkdirp)(options.contracts_build_directory);
+    await promisify(mkdirp)(options.contracts_build_directory);
 
-    if (options.quiet != true && options.quietWrite != true) {
-      logger.log("Writing artifacts to ." + path.sep + path.relative(options.working_directory, options.contracts_build_directory) + OS.EOL);
+    if (options.quiet !== true) {
+      logger.log(
+        `    > writing artifacts to ${options.contracts_build_directory}${
+          OS.EOL
+        }`
+      );
     }
 
-    var extra_opts = {
-      network_id: options.network_id
-    };
+    const extra_opts = { network_id: options.network_id };
 
     await options.artifactor.saveAll(contracts, extra_opts);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13882,6 +13882,11 @@ truffle-contract@^2.0.3:
     truffle-contract-schema "^0.0.5"
     web3 "^0.20.1"
 
+truffle-error@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/truffle-error/-/truffle-error-0.0.3.tgz#4bf55242e14deee1c7194932709182deff2c97ca"
+  integrity sha1-S/VSQuFN7uHHGUkycJGC3v8sl8o=
+
 truffle-init@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/truffle-init/-/truffle-init-1.0.7.tgz#c3de57fbddfa77ae93642ae025f41c1157de2ba7"


### PR DESCRIPTION
Include solc version in the output during compilation and update some syntax.

Additionally, this restructures the compilation code so that when errors occur they are not swallowed.