### PR TITLE
Increased unbox test timeout

### DIFF
--- a/packages/truffle-box/package.json
+++ b/packages/truffle-box/package.json
@@ -5,7 +5,7 @@
   "main": "box.js",
   "scripts": {
     "lint": "eslint ./index.js ./lib || true",
-    "test": "mocha"
+    "test": "mocha --timeout 10000"
   },
   "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-box",
   "keywords": [


### PR DESCRIPTION
It takes about 3 seconds (default timeout is 2 seconds) on my network to fetch the default package from GitHub. I have a 100mbit line but the peering between GitHub and my ISP just sucks. I suppose there must be others with not so great internet connections that will benefit from the increased timeout.