### PR TITLE
[POC] Using native solc for parsing

### DIFF
--- a/packages/truffle-box/package.json
+++ b/packages/truffle-box/package.json
@@ -5,7 +5,7 @@
   "main": "box.js",
   "scripts": {
     "lint": "eslint ./index.js ./lib || true",
-    "test": "mocha"
+    "test": "mocha --timeout 10000"
   },
   "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-box",
   "keywords": [

--- a/packages/truffle-compile/compilerSupplier/loadingStrategies/Native.js
+++ b/packages/truffle-compile/compilerSupplier/loadingStrategies/Native.js
@@ -5,7 +5,7 @@ const VersionRange = require("./VersionRange");
 class Native extends LoadingStrategy {
   load() {
     const versionString = this.validateAndGetSolcVersion();
-    const command = "solc --standard-json";
+    const command = "solc --standard-json --allow-paths '.'";
 
     const versionRange = new VersionRange();
     const commit = versionRange.getCommitFromVersion(versionString);

--- a/packages/truffle-compile/parser.js
+++ b/packages/truffle-compile/parser.js
@@ -18,10 +18,10 @@ module.exports = {
     // the imports speedily without doing extra work.
 
     // If we're using docker/native, we'll still want to use solcjs to do this part.
-    if (solc.importsParser) solc = solc.importsParser;
-
+    // if (solc.importsParser) solc = solc.importsParser;
     // Helper to detect import errors with an easy regex.
-    var importErrorKey = "TRUFFLE_IMPORT";
+    var importErrorKeySolcJS = "TRUFFLE_IMPORT";
+    var importErrorKeyNative = "File not found.";
 
     // Inject failing import.
     var failingImportFileName = "__Truffle__NotFound.sol";
@@ -48,7 +48,7 @@ module.exports = {
       // The existence of this function ensures we get a parsable error message.
       // Without this, we'll get an error message we *can* detect, but the key will make it easier.
       // Note: This is not a normal callback. See docs here: https://github.com/ethereum/solc-js#from-version-021
-      return { error: importErrorKey };
+      return { error: importErrorKeySolcJS || importErrorKeyNative };
     });
 
     output = JSON.parse(output);
@@ -63,7 +63,10 @@ module.exports = {
       // This means we have a *different* parsing error which we should show to the user.
       // Note: solc can return multiple parsing errors at once.
       // We ignore the "pre-release compiler" warning message.
-      return solidity_error.formattedMessage.indexOf(importErrorKey) < 0;
+      return (
+        solidity_error.formattedMessage.indexOf(importErrorKeySolcJS) < 0 &&
+        solidity_error.formattedMessage.indexOf(importErrorKeyNative) < 0
+      );
     });
 
     // Should we try to throw more than one? (aside; we didn't before)

--- a/packages/truffle-compile/parser.js
+++ b/packages/truffle-compile/parser.js
@@ -20,8 +20,7 @@ module.exports = {
     // If we're using docker/native, we'll still want to use solcjs to do this part.
     // if (solc.importsParser) solc = solc.importsParser;
     // Helper to detect import errors with an easy regex.
-    var importErrorKeySolcJS = "TRUFFLE_IMPORT";
-    var importErrorKeyNative = "File not found.";
+    var importErrorKey = "not found: File";
 
     // Inject failing import.
     var failingImportFileName = "__Truffle__NotFound.sol";
@@ -44,12 +43,7 @@ module.exports = {
       }
     };
 
-    var output = solc.compile(JSON.stringify(solcStandardInput), function() {
-      // The existence of this function ensures we get a parsable error message.
-      // Without this, we'll get an error message we *can* detect, but the key will make it easier.
-      // Note: This is not a normal callback. See docs here: https://github.com/ethereum/solc-js#from-version-021
-      return { error: importErrorKeySolcJS || importErrorKeyNative };
-    });
+    var output = solc.compile(JSON.stringify(solcStandardInput));
 
     output = JSON.parse(output);
 
@@ -63,10 +57,7 @@ module.exports = {
       // This means we have a *different* parsing error which we should show to the user.
       // Note: solc can return multiple parsing errors at once.
       // We ignore the "pre-release compiler" warning message.
-      return (
-        solidity_error.formattedMessage.indexOf(importErrorKeySolcJS) < 0 &&
-        solidity_error.formattedMessage.indexOf(importErrorKeyNative) < 0
-      );
+      return solidity_error.formattedMessage.indexOf(importErrorKey) < 0;
     });
 
     // Should we try to throw more than one? (aside; we didn't before)

--- a/packages/truffle-compile/test/sources/badSources/MyContract.sol
+++ b/packages/truffle-compile/test/sources/badSources/MyContract.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.15;
+pragma solidity >0.4.15;
 
 import "./Dependency.sol";
 import "./path/to/AnotherDep.sol";

--- a/packages/truffle-compile/test/sources/badSources/ShouldError.sol
+++ b/packages/truffle-compile/test/sources/badSources/ShouldError.sol
@@ -1,5 +1,5 @@
-paragma solidity ^0.4.0;
+paragma solidity >0.4.0;
 
 contract Error {
-  
+
 }

--- a/packages/truffle-compile/test/test_parser.js
+++ b/packages/truffle-compile/test/test_parser.js
@@ -18,12 +18,11 @@ describe("Parser", function() {
       path.join(__dirname, "./sources/badSources/ShouldError.sol"),
       "utf-8"
     );
-
     const supplier = new CompilerSupplier();
     solc = await supplier.load();
   });
 
-  it("should return correct imports", function() {
+  it("should return correct imports with solcjs", function() {
     var imports = Parser.parseImports(source, solc);
 
     // Note that this test is important because certain parts of the solidity
@@ -37,6 +36,26 @@ describe("Parser", function() {
     ];
 
     assert.deepEqual(imports, expected);
+  });
+
+  it("should return correct imports with nat solc", function() {
+    const config = { version: "native" };
+    const nativeSupplier = new CompilerSupplier(config);
+    nativeSupplier.load().then(nativeSolc => {
+      var imports = Parser.parseImports(source, nativeSolc);
+
+      // Note that this test is important because certain parts of the solidity
+      // output cuts off path prefixes like "./" and "../../../". If we get the
+      // imports list incorrectly, we'll have collisions.
+      var expected = [
+        "./Dependency.sol",
+        "./path/to/AnotherDep.sol",
+        "../../../path/to/AnotherDep.sol",
+        "ethpmpackage/Contract.sol"
+      ];
+
+      assert.deepEqual(imports, expected);
+    });
   });
 
   it("should throw an error when parsing imports if there's an actual parse error", function() {


### PR DESCRIPTION
Currently, truffle requires solcjs for parsing. This is a poc to show that it can do it with native solc as well. 
Relevant issue #1567 

PS. This is just a POC. I don't really know why it was decided to use solcjs for parsing nor do I know if my changes are in the right place.
