### PR TITLE
Use solc.trufflesuite.com URL for solc-bin fetching

### DIFF
--- a/packages/truffle-compile/compilerSupplier/loadingStrategies/LoadingStrategy.js
+++ b/packages/truffle-compile/compilerSupplier/loadingStrategies/LoadingStrategy.js
@@ -4,8 +4,8 @@ const fs = require("fs");
 class LoadingStrategy {
   constructor(options) {
     const defaultConfig = {
-      versionsUrl: "https://ethereum.github.io/solc-bin/bin/list.json",
-      compilerUrlRoot: "https://ethereum.github.io/solc-bin/bin/",
+      versionsUrl: "https://solc.trufflesuite.com/bin/list.json",
+      compilerUrlRoot: "https://solc.trufflesuite.com/bin/",
       dockerTagsUrl:
         "https://registry.hub.docker.com/v2/repositories/ethereum/solc/tags/"
     };

--- a/packages/truffle-compile/compilerSupplier/loadingStrategies/LoadingStrategy.js
+++ b/packages/truffle-compile/compilerSupplier/loadingStrategies/LoadingStrategy.js
@@ -4,8 +4,8 @@ const fs = require("fs");
 class LoadingStrategy {
   constructor(options) {
     const defaultConfig = {
-      versionsUrl: "https://solc-bin.ethereum.org/bin/list.json",
-      compilerUrlRoot: "https://solc-bin.ethereum.org/bin/",
+      versionsUrl: "https://ethereum.github.io/solc-bin/bin/list.json",
+      compilerUrlRoot: "https://ethereum.github.io/solc-bin/bin/",
       dockerTagsUrl:
         "https://registry.hub.docker.com/v2/repositories/ethereum/solc/tags/"
     };

--- a/packages/truffle-compile/compilerSupplier/loadingStrategies/LoadingStrategy.js
+++ b/packages/truffle-compile/compilerSupplier/loadingStrategies/LoadingStrategy.js
@@ -4,8 +4,8 @@ const fs = require("fs");
 class LoadingStrategy {
   constructor(options) {
     const defaultConfig = {
-      versionsUrl: "https://solc.trufflesuite.com/bin/list.json",
-      compilerUrlRoot: "https://solc.trufflesuite.com/bin/",
+      versionsUrl: "https://relay.trufflesuite.com/solc/bin/list.json",
+      compilerUrlRoot: "https://relay.trufflesuite.com/solc/bin/",
       dockerTagsUrl:
         "https://registry.hub.docker.com/v2/repositories/ethereum/solc/tags/"
     };

--- a/packages/truffle-compile/test/compilerSupplier/loadingStrategies/LoadingStrategy.js
+++ b/packages/truffle-compile/test/compilerSupplier/loadingStrategies/LoadingStrategy.js
@@ -8,8 +8,8 @@ describe("LoadingStrategy base class", () => {
   beforeEach(() => {
     instance = new LoadingStrategy();
     expectedDefaultConfig = {
-      versionsUrl: "https://solc-bin.ethereum.org/bin/list.json",
-      compilerUrlRoot: "https://solc-bin.ethereum.org/bin/",
+      versionsUrl: "https://ethereum.github.io/solc-bin/bin/list.json",
+      compilerUrlRoot: "https://ethereum.github.io/solc-bin/bin/",
       dockerTagsUrl:
         "https://registry.hub.docker.com/v2/repositories/ethereum/solc/tags/"
     };

--- a/packages/truffle-compile/test/compilerSupplier/loadingStrategies/LoadingStrategy.js
+++ b/packages/truffle-compile/test/compilerSupplier/loadingStrategies/LoadingStrategy.js
@@ -8,8 +8,8 @@ describe("LoadingStrategy base class", () => {
   beforeEach(() => {
     instance = new LoadingStrategy();
     expectedDefaultConfig = {
-      versionsUrl: "https://solc.trufflesuite.com/bin/list.json",
-      compilerUrlRoot: "https://solc.trufflesuite.com/bin/",
+      versionsUrl: "https://relay.trufflesuite.com/solc/bin/list.json",
+      compilerUrlRoot: "https://relay.trufflesuite.com/solc/bin/",
       dockerTagsUrl:
         "https://registry.hub.docker.com/v2/repositories/ethereum/solc/tags/"
     };

--- a/packages/truffle-compile/test/compilerSupplier/loadingStrategies/LoadingStrategy.js
+++ b/packages/truffle-compile/test/compilerSupplier/loadingStrategies/LoadingStrategy.js
@@ -8,8 +8,8 @@ describe("LoadingStrategy base class", () => {
   beforeEach(() => {
     instance = new LoadingStrategy();
     expectedDefaultConfig = {
-      versionsUrl: "https://ethereum.github.io/solc-bin/bin/list.json",
-      compilerUrlRoot: "https://ethereum.github.io/solc-bin/bin/",
+      versionsUrl: "https://solc.trufflesuite.com/bin/list.json",
+      compilerUrlRoot: "https://solc.trufflesuite.com/bin/",
       dockerTagsUrl:
         "https://registry.hub.docker.com/v2/repositories/ethereum/solc/tags/"
     };


### PR DESCRIPTION
solc-bin.ethereum.org has been causing problems.

We have configured solc.trufflesuite.com to serve 302 redirects to the underlying ethereum.github.io/solc-bin resource, to make it easier to handle service availability in the future, without requiring subsequent upgrades of Truffle.