### PR TITLE
Add total steps and gas displays to 'p' and ';' commands

### DIFF
--- a/packages/truffle-core/lib/commands/debug.js
+++ b/packages/truffle-core/lib/commands/debug.js
@@ -42,6 +42,7 @@ var command = {
     var trace = selectors.trace;
     var solidity = selectors.solidity;
     var controller = selectors.controller;
+    var evm = selectors.evm;
 
     var config = Config.detect(options);
 
@@ -172,12 +173,20 @@ var command = {
             var instruction = session.view(solidity.current.instruction);
             var step = session.view(trace.step);
             var traceIndex = session.view(trace.index);
+            var totalSteps = session.view(trace.steps).length;
+            var gas = session.view(evm.current.state.gas);
 
             config.logger.log("");
             config.logger.log(
-              DebugUtils.formatInstruction(traceIndex, instruction)
+              DebugUtils.formatInstruction(
+                traceIndex + 1,
+                totalSteps,
+                instruction
+              )
             );
             config.logger.log(DebugUtils.formatStack(step.stack));
+            config.logger.log("");
+            config.logger.log(gas + " gas remaining");
           }
 
           function select(expr) {

--- a/packages/truffle-debug-utils/index.js
+++ b/packages/truffle-debug-utils/index.js
@@ -236,10 +236,12 @@ var DebugUtils = {
     return allLines.join(OS.EOL);
   },
 
-  formatInstruction: function(traceIndex, instruction) {
+  formatInstruction: function(traceIndex, traceLength, instruction) {
     return (
       "(" +
       traceIndex +
+      "/" +
+      traceLength +
       ") " +
       instruction.name +
       " " +


### PR DESCRIPTION
This pull request was inspired by the earlier PR #1346 which seems to have been left to languish.  As was pointed out there, there already is a step counter display, which is visible when using the `p` or `;` commands, so we don't need to add one, really, but I thought I'd make it a bit more obvious that that's what it was by including along with it a display of the total step count.  I also changed the step counter display to be 1-indexed rather than 0-indexed, because it looks pretty odd when it finally stops at `(236/237)`.

In addition, I added a gas remaining display to the `p` and `;` commands as well, because I expect someone will want it; and what with the removal of `msg.gas` in Solidity 0.5.0, this won't be part of the globally-available variables effort that's coming later, so I thought I'd just make it a separate display.