### PR TITLE
Avoid raw line numbers in debugger tests with lineOf function

### DIFF
--- a/packages/truffle-debugger/test/data/ids.js
+++ b/packages/truffle-debugger/test/data/ids.js
@@ -5,7 +5,7 @@ import { assert } from "chai";
 
 import Ganache from "ganache-core";
 
-import { prepareContracts } from "../helpers";
+import { prepareContracts, lineOf } from "../helpers";
 import Debugger from "lib/debugger";
 
 import trace from "lib/trace/selectors";
@@ -26,7 +26,7 @@ contract FactorialTest {
     uint prev;
     uint prevFac;
     nbang = n;
-    prev = n - 1; //break here (12)
+    prev = n - 1; //break here #1 (12)
     if(n>0)
     {
       prevFac = factorial(n - 1);
@@ -36,7 +36,7 @@ contract FactorialTest {
     {
       nbang = 1;
     }
-    lastResult = nbang; //break here (22)
+    lastResult = nbang; //break here #2 (22)
   }
 }
 `;
@@ -97,7 +97,7 @@ contract Intervening {
     flag = 0;
     inner.run();
 
-    flag = 1; //break here (18)
+    flag = 1; //break here #1 (18)
 
   }
 
@@ -106,7 +106,7 @@ contract Intervening {
     flag = 0;
     flag = InterveningLib.run();
 
-    flag = 1; //break here (27)
+    flag = 1; //break here #2 (27)
 
   }
 }
@@ -202,8 +202,9 @@ describe("Variable IDs", function() {
     debug("sourceId %d", session.view(solidity.current.source).id);
 
     let sourceId = session.view(solidity.current.source).id;
-    session.addBreakpoint({ sourceId, line: 12 });
-    session.addBreakpoint({ sourceId, line: 22 });
+    let source = session.view(solidity.current.source).source;
+    session.addBreakpoint({ sourceId, line: lineOf("break here #1", source) });
+    session.addBreakpoint({ sourceId, line: lineOf("break here #2", source) });
 
     var values = [];
 
@@ -241,7 +242,8 @@ describe("Variable IDs", function() {
     debug("sourceId %d", session.view(solidity.current.source).id);
 
     let sourceId = session.view(solidity.current.source).id;
-    session.addBreakpoint({ sourceId, line: 32 });
+    let source = session.view(solidity.current.source).source;
+    session.addBreakpoint({ sourceId, line: lineOf("break here", source) });
     session.continueUntilBreakpoint();
     debug("node %o", session.view(solidity.current.node));
     assert.equal(
@@ -271,7 +273,8 @@ describe("Variable IDs", function() {
     debug("sourceId %d", session.view(solidity.current.source).id);
 
     let sourceId = session.view(solidity.current.source).id;
-    session.addBreakpoint({ sourceId, line: 18 });
+    let source = session.view(solidity.current.source).source;
+    session.addBreakpoint({ sourceId, line: lineOf("break here #1", source) });
     session.continueUntilBreakpoint();
     assert.property(await session.variables(), "flag");
   });
@@ -291,7 +294,8 @@ describe("Variable IDs", function() {
     debug("sourceId %d", session.view(solidity.current.source).id);
 
     let sourceId = session.view(solidity.current.source).id;
-    session.addBreakpoint({ sourceId, line: 27 });
+    let source = session.view(solidity.current.source).source;
+    session.addBreakpoint({ sourceId, line: lineOf("break here #2", source) });
     session.continueUntilBreakpoint();
     assert.property(await session.variables(), "flag");
   });

--- a/packages/truffle-debugger/test/data/more-decoding.js
+++ b/packages/truffle-debugger/test/data/more-decoding.js
@@ -5,7 +5,7 @@ import { assert } from "chai";
 
 import Ganache from "ganache-core";
 
-import { prepareContracts } from "../helpers";
+import { prepareContracts, lineOf } from "../helpers";
 import Debugger from "lib/debugger";
 
 import solidity from "lib/solidity/selectors";
@@ -234,7 +234,8 @@ describe("Further Decoding", function() {
     let session = bugger.connect();
 
     let sourceId = session.view(solidity.current.source).id;
-    session.addBreakpoint({ sourceId, line: 71 });
+    let source = session.view(solidity.current.source).source;
+    session.addBreakpoint({ sourceId, line: lineOf("break here", source) });
 
     session.continueUntilBreakpoint();
 
@@ -286,7 +287,8 @@ describe("Further Decoding", function() {
     let session = bugger.connect();
 
     let sourceId = session.view(solidity.current.source).id;
-    session.addBreakpoint({ sourceId, line: 52 });
+    let source = session.view(solidity.current.source).source;
+    session.addBreakpoint({ sourceId, line: lineOf("break here", source) });
 
     session.continueUntilBreakpoint();
 
@@ -352,7 +354,8 @@ describe("Further Decoding", function() {
     let session = bugger.connect();
 
     let sourceId = session.view(solidity.current.source).id;
-    session.addBreakpoint({ sourceId, line: 40 });
+    let source = session.view(solidity.current.source).source;
+    session.addBreakpoint({ sourceId, line: lineOf("break here", source) });
 
     session.continueUntilBreakpoint();
 

--- a/packages/truffle-debugger/test/helpers.js
+++ b/packages/truffle-debugger/test/helpers.js
@@ -178,3 +178,8 @@ export async function migrate(config) {
 export async function gatherArtifacts(config) {
   return Debug.gatherArtifacts(config);
 }
+
+export function lineOf(searchString, source) {
+  const lines = source.split("\n");
+  return lines.findIndex(line => line.includes(searchString));
+}

--- a/packages/truffle-debugger/test/reset.js
+++ b/packages/truffle-debugger/test/reset.js
@@ -5,7 +5,7 @@ import { assert } from "chai";
 
 import Ganache from "ganache-core";
 
-import { prepareContracts } from "./helpers";
+import { prepareContracts, lineOf } from "./helpers";
 import Debugger from "lib/debugger";
 
 import solidity from "lib/solidity/selectors";
@@ -20,7 +20,7 @@ contract SetsThings {
   int w;
   function run() public {
     x = 1;
-    y = 2;
+    y = 2; //BREAK
     z = 3;
     w = 4;
   }
@@ -64,13 +64,14 @@ describe("Reset Button", function() {
 
     let session = bugger.connect();
     let sourceId = session.view(solidity.current.source).id;
+    let source = session.view(solidity.current.source).source;
 
     let variables = [];
     variables[0] = []; //collected during 1st run
     variables[1] = []; //collected during 2nd run
 
     variables[0].push(await session.variables());
-    session.addBreakpoint({ sourceId, line: 10 });
+    session.addBreakpoint({ sourceId, line: lineOf("BREAK", source) });
     session.continueUntilBreakpoint(); //advance to line 10
     variables[0].push(await session.variables());
     session.continueUntilBreakpoint(); //advance to the end

--- a/packages/truffle-debugger/test/solidity.js
+++ b/packages/truffle-debugger/test/solidity.js
@@ -5,7 +5,7 @@ import { assert } from "chai";
 
 import Ganache from "ganache-core";
 
-import { prepareContracts } from "./helpers";
+import { prepareContracts, lineOf } from "./helpers";
 import Debugger from "lib/debugger";
 
 import solidity from "lib/solidity/selectors";
@@ -46,7 +46,7 @@ contract NestedCall {
   //              1
   function run() public {
     first();
-    second();
+    second(); //BREAK
   }
 
   function first() public {
@@ -104,7 +104,8 @@ describe("Solidity Debugging", function() {
 
     // at `second();`
     let source = await session.view(solidity.current.source);
-    let breakpoint = { sourceId: source.id, line: 16 };
+    let breakLine = lineOf("BREAK", source.source);
+    let breakpoint = { sourceId: source.id, line: breakLine };
 
     session.addBreakpoint(breakpoint);
 
@@ -113,7 +114,7 @@ describe("Solidity Debugging", function() {
 
       if (!session.view(trace.finished)) {
         let range = await session.view(solidity.current.sourceRange);
-        assert.equal(range.lines.start.line, 16);
+        assert.equal(range.lines.start.line, breakLine);
       }
     } while (!session.view(trace.finished));
   });


### PR DESCRIPTION
This PR is just some internal improvements to the debugger tests.  Specifically, a number of the existing debugger tests involved hardcoded breakpoints, which was hard to read and easy to accidentally get wrong by 1.  This PR adds a `lineOf` function in `test/helpers.js`, which will search for the first line on which a given string occurs.  Now you can set breakpoints with `lineOf`, perhaps searching for a "break here" comment that you have placed.  Moreover, all existing tests that used hardcoded breakpoints have been converted to use this instead.