### PR TITLE
Fix CI Geth Build

### DIFF
--- a/packages/truffle/test/scenarios/migrations/errors.js
+++ b/packages/truffle/test/scenarios/migrations/errors.js
@@ -88,7 +88,9 @@ describe("migration errors", function() {
       assert(output.includes("Deploying 'Loops'"));
       assert(output.includes("Error"));
       assert(
-        output.includes("out of gas") || output.includes("gas required exceeds")
+        output.includes("out of gas") ||
+          output.includes("gas required exceeds") ||
+          output.includes("check your gas limit")
       );
       done();
     });


### PR DESCRIPTION
Looks like latest geth client throws the following when truffle attempts to migrate w/o enough gas:

```
Error:  *** Deployment Failed ***
"SampleContract" -- The contract code couldn't be stored, please check your gas limit..
```

Updated `migration/errors.js` scenario test to handle this case.