### PR TITLE
Remove v4 CI node 6 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,15 +24,11 @@ matrix:
       env: PACKAGES=true
     - node_js: 8
       env: INTEGRATION=true
-    - node_js: 6
-      env: INTEGRATION=true
     - node_js: 8
       env: COVERAGE=true
   allow_failures:
     - node_js: 8
       env: GETH=true
-    - node_js: 6
-      env: INTEGRATION=true
     - node_js: 8
       env: COVERAGE=true
 


### PR DESCRIPTION
CI node 6 build no longer needed since we currently maintain & support v5 & up moving forward.

🍬 