### PR TITLE
Update reselect-tree version

### DIFF
--- a/packages/truffle-debugger/package.json
+++ b/packages/truffle-debugger/package.json
@@ -29,7 +29,7 @@
     "redux-cli-logger": "^2.0.1",
     "redux-saga": "1.0.0",
     "remote-redux-devtools": "^0.5.12",
-    "reselect-tree": "^1.2.0",
+    "reselect-tree": "^1.3.0",
     "truffle-code-utils": "^1.1.4",
     "truffle-decode-utils": "^1.0.3",
     "truffle-decoder": "^1.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10394,19 +10394,19 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
-reselect-tree@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/reselect-tree/-/reselect-tree-1.2.0.tgz#0851198f27bdfea08db98027bb1b65f41447e95a"
+reselect-tree@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/reselect-tree/-/reselect-tree-1.3.0.tgz#baba80a04b855dcdec672a8c602ae13c337c2858"
   dependencies:
     debug "^3.1.0"
     esdoc "^1.0.4"
     json-pointer "^0.6.0"
-    reselect "^3.0.1"
+    reselect "^4.0.0"
     source-map-support "^0.5.3"
 
-reselect@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
+reselect@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
 
 resolve-cwd@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This PR updates the version of `reselect-tree` used in the debugger (the one change in `reselect-tree` being updating what version of `reselect` is used).