### PR TITLE
Strip down some decoding tests to run faster

### DIFF
--- a/packages/truffle-debugger/test/data/more-decoding.js
+++ b/packages/truffle-debugger/test/data/more-decoding.js
@@ -23,9 +23,8 @@ contract ContainersTest {
   event Done();
 
   //declare needed structs
-  struct Pair {
+  struct Wrapper {
     uint x;
-    uint y;
   }
 
   struct HasMap {
@@ -35,11 +34,11 @@ contract ContainersTest {
   }
 
   //declare storage variables to be tested
-  Pair[] storageStructArray;
-  uint128[4][] storageArrayArray;
+  Wrapper[] storageStructArray;
+  uint128[2][] storageArrayArray;
 
-  mapping(string => Pair) structMapping;
-  mapping(string => uint128[4]) arrayMapping;
+  mapping(string => Wrapper) structMapping;
+  mapping(string => uint128[2]) arrayMapping;
 
   mapping(string => int128) signedMapping;
 
@@ -49,33 +48,26 @@ contract ContainersTest {
   function run() public {
 
     //declare local variables to be tested
-    uint[2] memory memoryStaticArray;
+    uint[1] memory memoryStaticArray;
     HasMap memory memoryStructWithMap;
     uint[2] storage localStorage = pointedAt;
 
     //set up variables with values
     storageStructArray.length = 1;
     storageStructArray[0].x = 107;
-    storageStructArray[0].y = 214;
 
     storageArrayArray.length = 1;
     storageArrayArray[0][0] = 2;
     storageArrayArray[0][1] = 3;
-    storageArrayArray[0][2] = 7;
-    storageArrayArray[0][3] = 57;
 
     structMapping["hello"].x = 107;
-    structMapping["hello"].y = 214;
 
     arrayMapping["hello"][0] = 2;
     arrayMapping["hello"][1] = 3;
-    arrayMapping["hello"][2] = 7;
-    arrayMapping["hello"][3] = 57;
 
     signedMapping["hello"] = -1;
 
     memoryStaticArray[0] = 107;
-    memoryStaticArray[1] = 214;
 
     memoryStructWithMap.x = 107;
     memoryStructWithMap.y = 214;
@@ -85,7 +77,7 @@ contract ContainersTest {
     pointedAt[1] = 214;
 
     //everything's set up, time to decode!
-    emit Done(); //break here (71)
+    emit Done(); //break here
   }
 }
 `;
@@ -105,7 +97,6 @@ contract ElementaryTest {
   mapping(int => int) intMap;
   mapping(string => string) stringMap;
   mapping(address => address) addressMap;
-  mapping(uint8 => uint8) uint8Map;
 
   function run() public {
     //local variables to be tested
@@ -120,29 +111,19 @@ contract ElementaryTest {
     boolMap[true] = true;
 
     byteMap[0x01] = 0x01;
-    byteMap[0xff] = 0xff;
-    byteMap[byte(0x02)] = byte(0x02);
 
     bytesMap[hex"01"] = hex"01";
-    bytesMap[hex"ff"] = hex"ff";
 
     uintMap[1] = 1;
 
-    intMap[1] = 1;
     intMap[-1] = -1;
 
-    uint8Map[uint8(byte(0x01))] = uint8(byte(0x01));
-    uint8Map[uint8(int8(2))] = uint8(int8(2));
-
-    addressMap[0x0000000000000000000000000000000000000001] =
-      0x0000000000000000000000000000000000000001;
     addressMap[address(this)] = address(this);
 
-    stringMap["innocuous string"] = "innocuous string";
     stringMap["0xdeadbeef"] = "0xdeadbeef";
     stringMap["12345"] = "12345";
 
-    emit Done(); //break here (52)
+    emit Done(); //break here
   }
 }
 `;
@@ -160,26 +141,19 @@ contract SpliceTest {
 
   mapping(string => string) map;
 
-  struct ArrayPair {
-    uint[2] x;
-    uint[2] y;
+  struct ArrayStruct {
+    uint[1] x;
   }
 
   string pointedAt = "key2";
 
   function run() public {
-    uint[2][2] memory arrayArray;
-    ArrayPair memory arrayStruct;
+    uint[1][1] memory arrayArray;
+    ArrayStruct memory arrayStruct;
 
-    arrayArray[0][0] = 1;
-    arrayArray[0][1] = 2;
-    arrayArray[1][0] = 3;
-    arrayArray[1][1] = 4;
+    arrayArray[0][0] = 82;
 
-    arrayStruct.x[0] = 1;
-    arrayStruct.x[1] = 2;
-    arrayStruct.y[0] = 3;
-    arrayStruct.y[1] = 4;
+    arrayStruct.x[0] = 82;
 
     string memory key1 = "key1";
     string storage key2 = pointedAt;
@@ -187,13 +161,13 @@ contract SpliceTest {
     map[key1] = "value1";
     map[key2] = "value2";
 
-    emit Done(); //break here (40)
+    emit Done(); //break here
   }
 }
 `;
 
 let sources = {
-  "ContainerTest.sol": __CONTAINERS,
+  "ContainersTest.sol": __CONTAINERS,
   "ElementaryTest.sol": __KEYSANDBYTES,
   "SpliceTest.sol": __SPLICING
 };
@@ -242,15 +216,13 @@ describe("Further Decoding", function() {
     const variables = await session.variables();
 
     const expectedResult = {
-      memoryStaticArray: [new BN(107), new BN(214)],
+      memoryStaticArray: [new BN(107)],
       memoryStructWithMap: { x: new BN(107), y: new BN(214) },
       localStorage: [new BN(107), new BN(214)],
-      storageStructArray: [{ x: new BN(107), y: new BN(214) }],
-      storageArrayArray: [[new BN(2), new BN(3), new BN(7), new BN(57)]],
-      structMapping: new Map([["hello", { x: new BN(107), y: new BN(214) }]]),
-      arrayMapping: new Map([
-        ["hello", [new BN(2), new BN(3), new BN(7), new BN(57)]]
-      ]),
+      storageStructArray: [{ x: new BN(107) }],
+      storageArrayArray: [[new BN(2), new BN(3)]],
+      structMapping: new Map([["hello", { x: new BN(107) }]]),
+      arrayMapping: new Map([["hello", [new BN(2), new BN(3)]]]),
       signedMapping: new Map([["hello", new BN(-1)]]),
       pointedAt: [new BN(107), new BN(214)]
     };
@@ -299,23 +271,12 @@ describe("Further Decoding", function() {
 
     const expectedResult = {
       boolMap: new Map([[true, true]]),
-      byteMap: new Map([["0x01", "0x01"], ["0x02", "0x02"], ["0xff", "0xff"]]),
-      bytesMap: new Map([["0x01", "0x01"], ["0xff", "0xff"]]),
+      byteMap: new Map([["0x01", "0x01"]]),
+      bytesMap: new Map([["0x01", "0x01"]]),
       uintMap: new Map([[1, 1]]),
-      intMap: new Map([[1, 1], [-1, -1]]),
-      stringMap: new Map([
-        ["innocuous string", "innocuous string"],
-        ["0xdeadbeef", "0xdeadbeef"],
-        ["12345", "12345"]
-      ]),
-      addressMap: new Map([
-        [
-          "0x0000000000000000000000000000000000000001",
-          "0x0000000000000000000000000000000000000001"
-        ],
-        [address, address]
-      ]),
-      uint8Map: new Map([[1, 1], [2, 2]]),
+      intMap: new Map([[-1, -1]]),
+      stringMap: new Map([["0xdeadbeef", "0xdeadbeef"], ["12345", "12345"]]),
+      addressMap: new Map([[address, address]]),
       oneByte: "0xff",
       severalBytes: ["0xff"]
     };
@@ -364,8 +325,8 @@ describe("Further Decoding", function() {
     const expectedResult = {
       map: new Map([["key1", "value1"], ["key2", "value2"]]),
       pointedAt: "key2",
-      arrayArray: [[new BN(1), new BN(2)], [new BN(3), new BN(4)]],
-      arrayStruct: { x: [new BN(1), new BN(2)], y: [new BN(3), new BN(4)] },
+      arrayArray: [[new BN(82)]],
+      arrayStruct: { x: [new BN(82)] },
       key1: "key1",
       key2: "key2",
       pointedAt: "key2"


### PR DESCRIPTION
Some of the tests in `more-decoding.js` were quite slow so I stripped them down a bit so they'd be faster.