### PR TITLE
Use only contract name for resolver intercept cache

### DIFF
--- a/packages/truffle-migrate/resolverintercept.js
+++ b/packages/truffle-migrate/resolverintercept.js
@@ -1,12 +1,15 @@
+const path = require("path");
+
 function ResolverIntercept(resolver) {
   this.resolver = resolver;
   this.cache = {};
 };
 
 ResolverIntercept.prototype.require = function(import_path) {
-  // Modify import_path so the cache key is consistently the same irrespective
-  // of whether a user explicated .sol extension
-  import_path = import_path.replace(/\.sol$/i, '');
+  // Modify import_path so the cache key is consistently based only on the contract name.
+  // This works because Truffle already prevents more than one contract with the same name.
+  // Ref: https://github.com/trufflesuite/truffle/issues/1087
+  import_path = path.basename(import_path).replace(/\.sol$/i, '');
 
   // TODO: Using the import path for relative files may result in multiple
   // paths for the same file. This could return different objects since it won't be a cache hit.


### PR DESCRIPTION
Ref: #1738 

Strip off all leading path information, so that, e.g., `"./Migrations.sol"` resolves to the `"Migrations"`.

This relies on the existing limitation that contracts may not share the same name. See #1087 for related issue about this limitation.