### PR TITLE
Add multiple-advance command

### DIFF
--- a/packages/truffle-core/lib/commands/debug.js
+++ b/packages/truffle-core/lib/commands/debug.js
@@ -603,7 +603,7 @@ var command = {
                       config.logger.log("Number of steps must be an integer.");
                       break;
                     }
-                    await session.multiadvance(count);
+                    await session.advance(count);
                   } else {
                     await session.advance();
                   }

--- a/packages/truffle-core/lib/commands/debug.js
+++ b/packages/truffle-core/lib/commands/debug.js
@@ -567,6 +567,8 @@ var command = {
 
             if (cmd === "") {
               cmd = lastCommand;
+              cmdArgs = "";
+              splitArgs = [];
             }
 
             //quit if that's what we were given
@@ -593,7 +595,18 @@ var command = {
                   await session.stepNext();
                   break;
                 case ";":
-                  await session.advance();
+                  //two cases -- parameterized and unparameterized
+                  if (cmdArgs !== "") {
+                    let count = parseInt(cmdArgs, 10);
+                    debug("cmdArgs=%s", cmdArgs);
+                    if (isNaN(count)) {
+                      config.logger.log("Number of steps must be an integer.");
+                      break;
+                    }
+                    await session.multiadvance(count);
+                  } else {
+                    await session.advance();
+                  }
                   break;
                 case "c":
                   await session.continueUntilBreakpoint();

--- a/packages/truffle-debug-utils/index.js
+++ b/packages/truffle-debug-utils/index.js
@@ -9,7 +9,7 @@ var commandReference = {
   "i": "step into",
   "u": "step out",
   "n": "step next",
-  ";": "step instruction",
+  ";": "step instruction (include number to step multiple)",
   "p": "print instruction",
   "h": "print this help",
   "v": "print variables and values",
@@ -125,8 +125,9 @@ var DebugUtils = {
     ];
 
     var commandSections = [
-      ["o", "i", "u", "n", ";"],
-      ["p", "h", "q", "r"],
+      ["o", "i", "u", "n"],
+      [";", "p"],
+      ["h", "q", "r"],
       ["b", "B", "c"],
       ["+", "-"],
       ["?"],

--- a/packages/truffle-debugger/lib/controller/actions/index.js
+++ b/packages/truffle-debugger/lib/controller/actions/index.js
@@ -1,11 +1,6 @@
 export const ADVANCE = "ADVANCE";
-export function advance() {
-  return { type: ADVANCE };
-}
-
-export const MULTIADVANCE = "MULTIADVANCE";
-export function multiadvance(count) {
-  return { type: MULTIADVANCE, count };
+export function advance(count = 1) {
+  return { type: ADVANCE, count };
 }
 
 export const STEP_NEXT = "STEP_NEXT";

--- a/packages/truffle-debugger/lib/controller/actions/index.js
+++ b/packages/truffle-debugger/lib/controller/actions/index.js
@@ -3,6 +3,11 @@ export function advance() {
   return { type: ADVANCE };
 }
 
+export const MULTIADVANCE = "MULTIADVANCE";
+export function multiadvance(count) {
+  return { type: MULTIADVANCE, count };
+}
+
 export const STEP_NEXT = "STEP_NEXT";
 export function stepNext() {
   return { type: STEP_NEXT };

--- a/packages/truffle-debugger/lib/controller/reducers.js
+++ b/packages/truffle-debugger/lib/controller/reducers.js
@@ -44,7 +44,6 @@ function breakpoints(state = [], action) {
 
 const CONTROL_ACTIONS = [
   actions.ADVANCE,
-  actions.MULTIADVANCE,
   actions.STEP_NEXT,
   actions.STEP_OVER,
   actions.STEP_INTO,

--- a/packages/truffle-debugger/lib/controller/reducers.js
+++ b/packages/truffle-debugger/lib/controller/reducers.js
@@ -44,6 +44,7 @@ function breakpoints(state = [], action) {
 
 const CONTROL_ACTIONS = [
   actions.ADVANCE,
+  actions.MULTIADVANCE,
   actions.STEP_NEXT,
   actions.STEP_OVER,
   actions.STEP_INTO,

--- a/packages/truffle-debugger/lib/controller/sagas/index.js
+++ b/packages/truffle-debugger/lib/controller/sagas/index.js
@@ -18,7 +18,6 @@ import controller from "../selectors";
 //reducers.js as well!
 const CONTROL_SAGAS = {
   [actions.ADVANCE]: advance,
-  [actions.MULTIADVANCE]: multiadvance,
   [actions.STEP_NEXT]: stepNext,
   [actions.STEP_OVER]: stepOver,
   [actions.STEP_INTO]: stepInto,
@@ -47,22 +46,13 @@ export function* saga() {
 
 export default prefixName("controller", saga);
 
-/**
- * Advance the state by one instruction
- */
-function* advance() {
-  // send action to advance trace
-  yield* trace.advance();
-}
-
 /*
- * Advance the state by the given number of instructions
+ * Advance the state by the given number of instructions (but not past the end)
  */
-function* multiadvance(action) {
+function* advance(action = actions.advance()) {
   let { count } = action;
   for (let i = 0; i < count && !(yield select(controller.finished)); i++) {
-    debug("about to advance #%d", i);
-    yield* advance();
+    yield* trace.advance();
   }
 }
 

--- a/packages/truffle-debugger/lib/session/index.js
+++ b/packages/truffle-debugger/lib/session/index.js
@@ -152,12 +152,8 @@ export default class Session {
     });
   }
 
-  async advance() {
-    return await this.doneStepping(controller.advance());
-  }
-
-  async multiadvance(count) {
-    return await this.doneStepping(controller.multiadvance(count));
+  async advance(count = 1) {
+    return await this.doneStepping(controller.advance(count));
   }
 
   async stepNext() {

--- a/packages/truffle-debugger/lib/session/index.js
+++ b/packages/truffle-debugger/lib/session/index.js
@@ -156,6 +156,10 @@ export default class Session {
     return await this.doneStepping(controller.advance());
   }
 
+  async multiadvance(count) {
+    return await this.doneStepping(controller.multiadvance(count));
+  }
+
   async stepNext() {
     return await this.doneStepping(controller.stepNext());
   }


### PR DESCRIPTION
This PR allows one to advance the state a specified number of steps by specifying the number after the `;` command.  I've also updated the help text to mention this.  This PR was inspired by the discussion in PR #1346, and I'm hoping it successfully addresses the problems raised there.

Note that this is our first (intentional) example of a command with an argument being repeatable.  The way I set it up is so that if you repeat it, the argument is lost on repeats; so that `; 3`, followed by a repeat, yields 4 steps, not 6.  Not sure if this is the best way, just what I figured made sense.