### PR TITLE
Update `truffle obtain`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build:truffle-contract-schema": "cd packages/truffle-contract-schema && npm run build",
     "lerna:bootstrap": "lerna bootstrap",
     "bootstrap": "./scripts/bootstrap.sh",
-    "postinstall": "truffle obtain 0.5.4",
+    "postinstall": "truffle obtain --solc=0.5.4",
     "test": "lerna run test --stream --concurrency=1 -- --colors",
     "ci": "./scripts/ci.sh",
     "geth": "./scripts/geth.sh",

--- a/packages/truffle-core/lib/commands/obtain.js
+++ b/packages/truffle-core/lib/commands/obtain.js
@@ -2,8 +2,16 @@ module.exports = {
   command: "obtain",
   description: "Fetch and cache a specified compiler",
   help: {
-    usage: "truffle obtain <--compiler_name version>",
-    options: []
+    usage: "truffle obtain <--<compiler_name> <version>>",
+    options: [
+      {
+        option: "<--<compiler_name> <version>>",
+        description:
+          `Download and cache a version of the specified compiler.\n` +
+          `                    compiler_name must be one of the following: ` +
+          `'solc'.(required)`
+      }
+    ]
   },
   run: function(options, done) {
     const CompilerSupplier = require("truffle-compile").CompilerSupplier;
@@ -15,13 +23,14 @@ module.exports = {
         .then(done)
         .catch(done);
     }
+
     const message =
       `You have specified a compiler that is unsupported by ` +
       `Truffle.\nYou must specify one of the following ` +
       `compilers as well as a version as arguments: ` +
       `${SUPPORTED_COMPILERS.join(", ")}\nSee 'truffle help ` +
       `obtain' for more information and usage.`;
-    done(new Error(message));
+    return done(new Error(message));
   },
   downloadAndCacheSolc: async ({ options, supplier }) => {
     const logger = options.logger || console;

--- a/packages/truffle-core/lib/commands/obtain.js
+++ b/packages/truffle-core/lib/commands/obtain.js
@@ -1,21 +1,31 @@
 module.exports = {
   command: "obtain",
-  description: "Fetch and cache a specified solc version",
+  description: "Fetch and cache a specified compiler",
   help: {
-    usage: "truffle obtain <version>",
+    usage: "truffle obtain <--compiler_name version>",
     options: []
   },
   run: function(options, done) {
     const CompilerSupplier = require("truffle-compile").CompilerSupplier;
     const supplier = new CompilerSupplier();
+    const SUPPORTED_COMPILERS = ["--solc"];
 
-    return this.downloadAndCacheSolc({ options, supplier })
-      .then(done)
-      .catch(done);
+    if (options.solc) {
+      return this.downloadAndCacheSolc({ options, supplier })
+        .then(done)
+        .catch(done);
+    }
+    const message =
+      `You have specified a compiler that is unsupported by ` +
+      `Truffle.\nYou must specify one of the following ` +
+      `compilers as well as a version as arguments: ` +
+      `${SUPPORTED_COMPILERS.join(", ")}\nSee 'truffle help ` +
+      `obtain' for more information and usage.`;
+    done(new Error(message));
   },
   downloadAndCacheSolc: async ({ options, supplier }) => {
     const logger = options.logger || console;
-    const version = options._[0];
+    const version = options.solc;
     const solc = await supplier.downloadAndCacheSolc(version);
     return logger.log(
       `    > successfully downloaded and cached ${solc.version()}`

--- a/packages/truffle-core/test/lib/commands/obtain.js
+++ b/packages/truffle-core/test/lib/commands/obtain.js
@@ -1,0 +1,40 @@
+const assert = require("chai").assert;
+const command = require("../../../lib/commands/obtain");
+const sinon = require("sinon");
+const CompilerSupplier = require("truffle-compile").CompilerSupplier;
+let options, done, solc;
+
+describe("obtain", () => {
+  describe(".run(options, done)", () => {
+    beforeEach(() => {
+      options = { solc: "0.5.3" };
+      done = () => {};
+      solc = { version: () => "0.5.3" };
+      sinon
+        .stub(CompilerSupplier.prototype, "downloadAndCacheSolc")
+        .returns(solc);
+    });
+    afterEach(() => {
+      CompilerSupplier.prototype.downloadAndCacheSolc.restore();
+    });
+
+    it("calls downloadAndCacheSolc on the supplier with the version", async () => {
+      await command.run(options, done);
+      assert(
+        CompilerSupplier.prototype.downloadAndCacheSolc.calledWith("0.5.3")
+      );
+    });
+
+    describe("when options.solc is present", () => {
+      beforeEach(() => {
+        options.solc = undefined;
+        done = input => input;
+      });
+
+      it("calls done with an error", async () => {
+        let returnValue = await command.run(options, done);
+        assert.instanceOf(returnValue, Error);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Update `truffle obtain` to use '--compiler=version' syntax. Also update the postinstall script to use this syntax to be more clear to the user when installing Truffle.