### PR TITLE
Enhance truffle develop configurability

### DIFF
--- a/packages/truffle-core/lib/commands/develop.js
+++ b/packages/truffle-core/lib/commands/develop.js
@@ -51,7 +51,7 @@ const command = {
       customConfig.accounts || 10
     );
 
-    const onMissing = name => "**";
+    const onMissing = () => "**";
 
     const warning =
       ":warning:  Important :warning:  : " +

--- a/packages/truffle-core/lib/commands/develop.js
+++ b/packages/truffle-core/lib/commands/develop.js
@@ -15,7 +15,7 @@ const command = {
     usage: "truffle develop",
     options: []
   },
-  runConsole: async (config, ganacheOptions, done) => {
+  runConsole: (config, ganacheOptions, done) => {
     const Console = require("../console");
     const Environment = require("../environment");
 
@@ -36,11 +36,11 @@ const command = {
 
     const c = new Console(console_commands, config.with({ noAliases: true }));
     c.start(done);
-    c.on("exit", async () => {
+    c.on("exit", () => {
       process.exit();
     });
   },
-  run: async (options, done) => {
+  run: (options, done) => {
     const Config = require("truffle-config");
     const Develop = require("../develop");
 

--- a/packages/truffle-core/lib/commands/develop.js
+++ b/packages/truffle-core/lib/commands/develop.js
@@ -83,17 +83,11 @@ const command = {
         config.logger.log();
 
         config.logger.log(`Accounts:`);
-        for (var i = 0; i < accounts.length; i++) {
-          const account = accounts[i];
-          config.logger.log(`(${i}) ${account}`);
-        }
+        accounts.forEach((acct, idx) => config.logger.log(`(${idx}) ${acct}`));
         config.logger.log();
 
         config.logger.log(`Private Keys:`);
-        for (var i = 0; i < privateKeys.length; i++) {
-          const privateKey = privateKeys[i];
-          config.logger.log(`(${i}) ${privateKey}`);
-        }
+        privateKeys.forEach((key, idx) => config.logger.log(`(${idx}) ${key}`));
         config.logger.log();
 
         config.logger.log(`Mnemonic: ${mnemonic}`);

--- a/packages/truffle-core/lib/commands/develop.js
+++ b/packages/truffle-core/lib/commands/develop.js
@@ -75,6 +75,10 @@ const command = {
       noVMErrorsOnRPCResponse: true
     };
 
+    if (customConfig.hardfork !== null && customConfig.hardfork !== undefined) {
+      ganacheOptions["hardfork"] = customConfig.hardfork;
+    }
+
     Develop.connectOrStart(ipcOptions, ganacheOptions, started => {
       const url = `http://${ganacheOptions.host}:${ganacheOptions.port}/`;
 

--- a/packages/truffle-core/lib/commands/develop.js
+++ b/packages/truffle-core/lib/commands/develop.js
@@ -15,7 +15,7 @@ const command = {
     usage: "truffle develop",
     options: []
   },
-  async runConsole(config, ganacheOptions, done) {
+  runConsole: async (config, ganacheOptions, done) => {
     const Console = require("../console");
     const Environment = require("../environment");
 
@@ -40,7 +40,7 @@ const command = {
       process.exit();
     });
   },
-  async run(options, done) {
+  run: async (options, done) => {
     const Config = require("truffle-config");
     const Develop = require("../develop");
 

--- a/packages/truffle-core/lib/commands/develop.js
+++ b/packages/truffle-core/lib/commands/develop.js
@@ -26,10 +26,10 @@ const command = {
       name => !excluded.includes(name)
     );
 
-    const console_commands = {};
-    available_commands.forEach(name => {
-      console_commands[name] = commands[name];
-    });
+    const console_commands = available_commands.reduce(
+      (acc, name) => Object.assign({}, acc, { [name]: commands[name] }),
+      {}
+    );
 
     const environmentDevelop = util.promisify(Environment.develop);
     environmentDevelop(config, ganacheOptions).catch(err => done(err));

--- a/packages/truffle-debugger/test/data/ids.js
+++ b/packages/truffle-debugger/test/data/ids.js
@@ -230,7 +230,7 @@ describe("Variable IDs", function() {
       new BN(2),
       new BN(6)
     ]);
-  });
+  }).timeout(8000);
 
   it("Learns contract addresses and distinguishes the results", async function() {
     this.timeout(4000);


### PR DESCRIPTION
This PR modernizes, streamlines, & enhances the configurability of `truffle develop`.

It enables the following `ganache-core` options to be pre-configured:

- `host`
- `port`
- `network_id`
- `gasLimit` (gas)
- `gasPrice`
- `hardfork`

Example `truffle-config.js`:

```
module.exports = {
  networks: {
    develop: {
      host: "127.0.0.1",
      port: 7545,
      network_id: 666,
      gas: 1000,
      gasPrice: 1,
      hardfork: "constantinople"
    }
  }
};
```