### PR TITLE
Fix truffle develop MetaMask compatibility

### DIFF
--- a/packages/truffle-core/lib/commands/develop.js
+++ b/packages/truffle-core/lib/commands/develop.js
@@ -84,7 +84,7 @@ var command = {
     var ganacheOptions = {
       host: "127.0.0.1",
       port: 9545,
-      network_id: 4447,
+      network_id: 5777,
       total_accounts: numAddresses,
       default_balance_ether: defaultEtherBalance,
       blockTime: bTime,


### PR DESCRIPTION
This PR aims to fix the broken `truffle develop` MetaMask compatibility for the latest ver of MetaMask (6.1.0).

Issue has been raised here by @jgege (#1761) as well as here [MetaMask/metamask-extension#6211](https://github.com/MetaMask/metamask-extension/issues/6211).