### PR TITLE
Upgrade dependency: ganache-core@2.5.1

### DIFF
--- a/packages/truffle-artifactor/package.json
+++ b/packages/truffle-artifactor/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "devDependencies": {
     "chai": "4.2.0",
-    "ganache-core": "2.3.3",
+    "ganache-core": "2.5.1",
     "mocha": "5.2.0",
     "require-nocache": "^1.0.0",
     "solc": "0.5.0",

--- a/packages/truffle-contract/package.json
+++ b/packages/truffle-contract/package.json
@@ -43,7 +43,7 @@
     "browserify": "^14.0.0",
     "chai": "4.2.0",
     "debug": "^4.1.0",
-    "ganache-core": "2.3.3",
+    "ganache-core": "2.5.1",
     "mocha": "5.2.0",
     "solc": "0.5.0",
     "temp": "^0.8.3",

--- a/packages/truffle-core/package.json
+++ b/packages/truffle-core/package.json
@@ -19,7 +19,7 @@
     "ethpm": "0.0.16",
     "ethpm-registry": "0.1.0-next.2",
     "fs-extra": "6.0.1",
-    "ganache-core": "2.3.3",
+    "ganache-core": "2.5.1",
     "hdkey": "^1.1.0",
     "lodash": "4.17.11",
     "mkdirp": "^0.5.1",

--- a/packages/truffle-debugger/package.json
+++ b/packages/truffle-debugger/package.json
@@ -54,7 +54,7 @@
     "express": "^4.16.2",
     "faker": "^4.1.0",
     "fs-extra": "6.0.1",
-    "ganache-core": "2.3.3",
+    "ganache-core": "2.5.1",
     "istanbul-instrumenter-loader": "^3.0.1",
     "mocha": "5.2.0",
     "mocha-webpack": "^1.1.0",

--- a/packages/truffle-deployer/package.json
+++ b/packages/truffle-deployer/package.json
@@ -26,7 +26,7 @@
     "truffle-expect": "^0.0.7"
   },
   "devDependencies": {
-    "ganache-core": "2.3.3",
+    "ganache-core": "2.5.1",
     "mocha": "5.2.0",
     "truffle-reporters": "^1.0.3",
     "truffle-workflow-compile": "^2.0.5",

--- a/packages/truffle-hdwallet-provider/package.json
+++ b/packages/truffle-hdwallet-provider/package.json
@@ -26,7 +26,7 @@
     "ethereumjs-tx": "^1.3.7",
     "ethereumjs-util": "^5.2.0",
     "ethereumjs-wallet": "^0.6.2",
-    "ganache-core": "2.3.3",
+    "ganache-core": "2.5.1",
     "js-scrypt": "^0.2.0",
     "mocha": "^5.1.1",
     "web3": "1.0.0-beta.37",

--- a/packages/truffle-provider/package.json
+++ b/packages/truffle-provider/package.json
@@ -24,7 +24,7 @@
     "web3": "1.0.0-beta.37"
   },
   "devDependencies": {
-    "ganache-core": "2.3.3",
+    "ganache-core": "2.5.1",
     "mocha": "5.2.0"
   },
   "publishConfig": {

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -14,7 +14,7 @@
     "copy-webpack-plugin": "^4.0.1",
     "eslint": "^5.7.0",
     "fs-extra": "6.0.1",
-    "ganache-core": "2.3.3",
+    "ganache-core": "2.5.1",
     "glob": "^7.1.2",
     "go-ipfs-dep": "^0.4.17",
     "husky": "^1.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4596,13 +4596,25 @@ ethereumjs-block@^1.2.2, ethereumjs-block@^1.4.1, ethereumjs-block@^1.6.0, ether
     ethereumjs-util "^5.0.0"
     merkle-patricia-tree "^2.1.2"
 
+ethereumjs-block@~2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/ethereumjs-block/-/ethereumjs-block-2.2.0.tgz#8c6c3ab4a5eff0a16d9785fbeedbe643f4dbcbef"
+  integrity sha512-Ye+uG/L2wrp364Zihdlr/GfC3ft+zG8PdHcRtsBFNNH1CkOhxOwdB8friBU85n89uRZ9eIMAywCq0F4CwT1wAw==
+  dependencies:
+    async "^2.0.1"
+    ethereumjs-common "^1.1.0"
+    ethereumjs-tx "^1.2.2"
+    ethereumjs-util "^5.0.0"
+    merkle-patricia-tree "^2.1.2"
+
 ethereumjs-common@^0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/ethereumjs-common/-/ethereumjs-common-0.6.1.tgz#ec98edf315a7f107afb6acc48e937a8266979fae"
 
-ethereumjs-common@~0.4.0:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/ethereumjs-common/-/ethereumjs-common-0.4.1.tgz#27690a24a817b058cc3a2aedef9392e8d7d63984"
+ethereumjs-common@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ethereumjs-common/-/ethereumjs-common-1.1.0.tgz#5ec9086c314d619d8f05e79a0525829fcb0e93cb"
+  integrity sha512-LUmYkKV/HcZbWRyu3OU9YOevsH3VJDXtI6kEd8VZweQec+JjDGKCmAVKUyzhYUHqxRJu7JNALZ3A/b3NXOP6tA==
 
 ethereumjs-tx@1.3.7, ethereumjs-tx@^1.1.1, ethereumjs-tx@^1.2.0, ethereumjs-tx@^1.2.2, ethereumjs-tx@^1.3.3, ethereumjs-tx@^1.3.7:
   version "1.3.7"
@@ -4661,22 +4673,6 @@ ethereumjs-vm@2.3.4:
     rustbn.js "~0.1.1"
     safe-buffer "^5.1.1"
 
-ethereumjs-vm@2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/ethereumjs-vm/-/ethereumjs-vm-2.4.0.tgz#244f1e35f2755e537a13546111d1a4c159d34b13"
-  dependencies:
-    async "^2.1.2"
-    async-eventemitter "^0.2.2"
-    ethereumjs-account "^2.0.3"
-    ethereumjs-block "~1.7.0"
-    ethereumjs-common "~0.4.0"
-    ethereumjs-util "^5.2.0"
-    fake-merkle-patricia-tree "^1.0.1"
-    functional-red-black-tree "^1.0.1"
-    merkle-patricia-tree "^2.1.2"
-    rustbn.js "~0.2.0"
-    safe-buffer "^5.1.1"
-
 ethereumjs-vm@^2.0.2, ethereumjs-vm@^2.1.0, ethereumjs-vm@^2.3.4:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/ethereumjs-vm/-/ethereumjs-vm-2.5.1.tgz#d9ea7266ad49ff4756bddbb3924cc31b004c3642"
@@ -4686,6 +4682,23 @@ ethereumjs-vm@^2.0.2, ethereumjs-vm@^2.1.0, ethereumjs-vm@^2.3.4:
     ethereumjs-account "^2.0.3"
     ethereumjs-block "~2.1.0"
     ethereumjs-common "^0.6.0"
+    ethereumjs-util "^6.0.0"
+    fake-merkle-patricia-tree "^1.0.1"
+    functional-red-black-tree "^1.0.1"
+    merkle-patricia-tree "^2.3.2"
+    rustbn.js "~0.2.0"
+    safe-buffer "^5.1.1"
+
+ethereumjs-vm@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/ethereumjs-vm/-/ethereumjs-vm-2.6.0.tgz#76243ed8de031b408793ac33907fb3407fe400c6"
+  integrity sha512-r/XIUik/ynGbxS3y+mvGnbOKnuLo40V5Mj1J25+HEO63aWYREIqvWeRO/hnROlMBE5WoniQmPmhiaN0ctiHaXw==
+  dependencies:
+    async "^2.1.2"
+    async-eventemitter "^0.2.2"
+    ethereumjs-account "^2.0.3"
+    ethereumjs-block "~2.2.0"
+    ethereumjs-common "^1.1.0"
     ethereumjs-util "^6.0.0"
     fake-merkle-patricia-tree "^1.0.1"
     functional-red-black-tree "^1.0.1"
@@ -5482,9 +5495,10 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
 
-ganache-core@2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/ganache-core/-/ganache-core-2.3.3.tgz#e35c76d405f0ffba5c48621596fdcc38b0a03136"
+ganache-core@2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/ganache-core/-/ganache-core-2.5.1.tgz#731e88db70c12ac8a7c2b56a055483338523b739"
+  integrity sha512-sqTpmUtoExsUZqCqMdIZ+kPmXXu/fab755LpCaaty2u9EHb9gfIM9f/8gTpg0biaJ7LesbdyTfAbw66wHi4ujw==
   dependencies:
     abstract-leveldown "3.0.0"
     async "2.6.1"
@@ -5500,11 +5514,11 @@ ganache-core@2.3.3:
     ethereumjs-block "2.1.0"
     ethereumjs-tx "1.3.7"
     ethereumjs-util "5.2.0"
-    ethereumjs-vm "2.4.0"
+    ethereumjs-vm "^2.6.0"
     heap "0.2.6"
     level-sublevel "6.6.4"
     levelup "3.1.1"
-    lodash "4.17.10"
+    lodash "4.17.11"
     merkle-patricia-tree "2.3.1"
     rlp "2.1.0"
     seedrandom "2.4.4"
@@ -7812,10 +7826,6 @@ lodash.toarray@^4.4.0:
 lodash.uniqby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
-
-lodash@4.17.10:
-  version "4.17.10"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
 lodash@4.17.11, lodash@^4.1.0, lodash@^4.11.2, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.8.0:
   version "4.17.11"


### PR DESCRIPTION
* truffle: 2.3.3 →  2.5.1
* truffle-artifactor: 2.3.3→  2.5.1
* truffle-contract: 2.3.3→  2.5.1
* truffle-core: 2.3.3 →  2.5.1
* truffle-debugger: 2.3.3 →  2.5.1
* truffle-deployer: 2.3.3→  2.5.1
* truffle-hdwallet-provider: 2.3.3→  2.5.1
* truffle-provider: 2.3.3→  2.5.1