### PR TITLE
Fix crash resulting from contracts without state variables

### DIFF
--- a/packages/truffle-debugger/lib/data/selectors/index.js
+++ b/packages/truffle-debugger/lib/data/selectors/index.js
@@ -1,5 +1,5 @@
 import debugModule from "debug";
-const debug = debugModule("debugger:data:selectors"); // eslint-disable-line no-unused-vars
+const debug = debugModule("debugger:data:selectors");
 
 import { createSelectorTree, createLeaf } from "reselect-tree";
 import jsonpointer from "json-pointer";
@@ -213,10 +213,7 @@ const data = createSelectorTree({
           {},
           ...Object.entries(scopes).map(([id, scope]) => {
             let definition = inlined[id].definition;
-            if (
-              definition.nodeType !== "ContractDefinition" ||
-              scope.variables === undefined
-            ) {
+            if (definition.nodeType !== "ContractDefinition") {
               return { [id]: scope };
             }
             //if we've reached this point, we should be dealing with a
@@ -234,12 +231,15 @@ const data = createSelectorTree({
             newScope.variables = []
               .concat(
                 ...linearizedBaseContractsFromBase.map(
-                  contractId => scopes[contractId].variables
+                  contractId => scopes[contractId].variables || []
+                  //we need the || [] because contracts with no state variables
+                  //have variables undefined rather than empty like you'd expect
                 )
               )
               .filter(variable => {
                 //...except, HACK, let's filter out those constants we don't know
                 //how to read.  they'll just clutter things up.
+                debug("variable %O", variable);
                 let definition = inlined[variable.id].definition;
                 return (
                   !definition.constant ||


### PR DESCRIPTION
This PR address issue #1752, where, if a contract `Base` has a subclass `Derived`, and `Derived` has state variables but `Base` does not, the debugger would crash on startup.  (It also fixes a bug where, if `Base` has state variables but `Derived` does not, the state variables in `Base` would not be recorded as inherited by `Derived`.)

The problem is that, under the `SCOPE`/`DECLARE` system, `variables` state for a contract isn't created unless that contract has at least one state variable.  Unfortunately, this is hard to change; so `data.info.scopes.raw` (and its inlined counterpart) will continue to have `variables` undefined for such contracts.  However, I added something to account for this possibility in `data.info.scopes`, so this will no longer cause a crash, and in `data.info.scopes` the list of variables will always be present (but possibly empty) and will be computed correctly.  (This is true even for contract types that could not possibly have state variables, such as interfaces and libraries, but that's fine, I figure.)