### PR TITLE
Add partial support for modifier parameters

### DIFF
--- a/packages/truffle-debugger/lib/data/sagas/index.js
+++ b/packages/truffle-debugger/lib/data/sagas/index.js
@@ -86,6 +86,8 @@ function* variablesAndMappingsSaga() {
 
   switch (node.nodeType) {
     case "FunctionDefinition":
+    case "ModifierDefinition":
+      //NOTE: this will *not* catch most modifier definitions! BUG
       let parameters = node.parameters.parameters;
       //note that we do *not* include return parameters, since those are
       //handled by the VariableDeclaration case (no, I don't know why it


### PR DESCRIPTION
This PR adds partial support for modifier parameters, which previously would not appear in `data.proc.assignments`.  Unfortunately many modifiers skip right over the modifier definition node while debugging, so many modifiers will still not have their parameters appear in `data.proc.assignments` and still will not be able to have their parameters decoded.  Still, for what it's worth, this catches some of them.