### PR TITLE
Fix missing callback linkage

### DIFF
--- a/packages/truffle-core/lib/commands/develop.js
+++ b/packages/truffle-core/lib/commands/develop.js
@@ -32,13 +32,18 @@ const command = {
     );
 
     const environmentDevelop = util.promisify(Environment.develop);
-    environmentDevelop(config, ganacheOptions).catch(err => done(err));
-
-    const c = new Console(console_commands, config.with({ noAliases: true }));
-    c.start(done);
-    c.on("exit", () => {
-      process.exit();
-    });
+    environmentDevelop(config, ganacheOptions)
+      .catch(err => done(err))
+      .then(() => {
+        const c = new Console(
+          console_commands,
+          config.with({ noAliases: true })
+        );
+        c.start(done);
+        c.on("exit", () => {
+          process.exit();
+        });
+      });
   },
   run: (options, done) => {
     const Config = require("truffle-config");


### PR DESCRIPTION
Fix problem where the console was not being started as part of the callback from environment detection. This resulted in `from` not being available as a default for contract transactions inside `truffle develop`.