### PR TITLE
Fix bug with storage locals

### DIFF
--- a/packages/truffle-decoder/lib/decode/storage.ts
+++ b/packages/truffle-decoder/lib/decode/storage.ts
@@ -33,7 +33,7 @@ export async function decodeStorageReferenceByAddress(definition: DecodeUtils.As
   //we *know* the type being decoded must be sized in words, because it's a
   //reference type, but TypeScript doesn't, so we'll have to use a type
   //coercion
-  const size = (<{words: number}>storageSize(definition)).words;
+  const size = (<{words: number}>storageSize(definition, info.referenceDeclarations, info.storageAllocations)).words;
   //now, construct the storage pointer
   const newPointer = { storage: {
     from: {


### PR DESCRIPTION
This PR fixes a bug raised in issue #1787.  The code for decoding a storage local variable mistakenly does not pass along necessary information to the `storageSize` function.  (Maybe it was a mistake leaving those arguments optional!)  Now it does.