### PR TITLE
Enable out-of-box `truffle test` support for vyper projects

### DIFF
--- a/packages/truffle-compile/profiler.js
+++ b/packages/truffle-compile/profiler.js
@@ -222,9 +222,9 @@ module.exports = {
           );
           // Generate hash of all sources including external packages - passed to solc inputs.
           var resolvedPaths = Object.keys(resolved);
-          resolvedPaths.forEach(
-            file => (allSources[file] = resolved[file].body)
-          );
+          resolvedPaths.forEach(file => {
+            allSources[file] = resolved[file].body;
+          });
 
           // Exit w/out minimizing if we've been asked to compile everything, or nothing.
           if (self.listsEqual(options.paths, allPaths)) {
@@ -374,6 +374,9 @@ module.exports = {
 
   getImports: function(file, resolved, solc) {
     var self = this;
+
+    // No imports in vyper!
+    if (path.extname(file) === ".vy") return [];
 
     var imports = Parser.parseImports(resolved.body, solc);
 

--- a/packages/truffle-compile/profiler.js
+++ b/packages/truffle-compile/profiler.js
@@ -223,7 +223,9 @@ module.exports = {
           // Generate hash of all sources including external packages - passed to solc inputs.
           var resolvedPaths = Object.keys(resolved);
           resolvedPaths.forEach(file => {
-            allSources[file] = resolved[file].body;
+            // Don't throw vyper files into solc!
+            if (path.extname(file) !== ".vy")
+              allSources[file] = resolved[file].body;
           });
 
           // Exit w/out minimizing if we've been asked to compile everything, or nothing.

--- a/packages/truffle-contract-sources/index.js
+++ b/packages/truffle-contract-sources/index.js
@@ -3,7 +3,7 @@ const debug = require("debug")("contract-sources");
 const path = require("path");
 const glob = require("glob");
 
-const DEFAULT_PATTERN = "**/*.sol";
+const DEFAULT_PATTERN = "**/*.{sol,vy}";
 
 module.exports = function(pattern, callback) {
   // pattern is either a directory (contracts directory), or an absolute path
@@ -13,7 +13,7 @@ module.exports = function(pattern, callback) {
   }
 
   const globOptions = {
-    follow: true  // follow symlinks
+    follow: true // follow symlinks
   };
 
   glob(pattern, globOptions, callback);

--- a/packages/truffle-contract-sources/index.js
+++ b/packages/truffle-contract-sources/index.js
@@ -5,7 +5,7 @@ const glob = require("glob");
 
 const DEFAULT_PATTERN = "**/*.{sol,vy}";
 
-module.exports = function(pattern, callback) {
+module.exports = (pattern, callback) => {
   // pattern is either a directory (contracts directory), or an absolute path
   // with a glob expression
   if (!glob.hasMagic(pattern)) {


### PR DESCRIPTION
This PR allows users to run `truffle test` in a truffle vyper project w/o needing to first run `truffle compile`.

This is accomplished by:

- adding the `.vy` file pattern to `truffle-contract-sources/index.js`
- skipping attempts to parse `.vy` files for imports (imports unsupported in vyper)
- skipping attempts to add `.vy` files to solc dependency compilation attempts