### PR TITLE
Support Hexstrings and BNs for Gas to Support Quorum's Potential Large Block Gas Limits

### DIFF
--- a/packages/truffle-contract/lib/execute.js
+++ b/packages/truffle-contract/lib/execute.js
@@ -1,7 +1,6 @@
 const debug = require("debug")("contract:execute"); // eslint-disable-line no-unused-vars
 var Web3PromiEvent = require("web3-core-promievent");
 var EventEmitter = require("events");
-var BigNumber = require("bignumber.js");
 var utils = require("./utils");
 var StatusError = require("./statuserror");
 var Reason = require("./reason");
@@ -29,15 +28,15 @@ var execute = {
       web3.eth
         .estimateGas(params)
         .then(gas => {
-          var bestEstimate = new BigNumber(gas)
-            .multipliedBy(constructor.gasMultiplier)
-            .integerValue(BigNumber.ROUND_DOWN);
+          var bestEstimate = utils
+            .bigNumberify(gas)
+            .mul(constructor.gasMultiplier);
 
           // Don't go over blockLimit
-          const limit = new BigNumber(blockLimit);
-          bestEstimate.isGreaterThanOrEqualTo(limit)
-            ? accept("0x" + limit.minus(1).toString(16))
-            : accept("0x" + bestEstimate.toString(16));
+          const limit = utils.bigNumberify(blockLimit);
+          bestEstimate.gte(limit)
+            ? accept(limit.sub(1).toHexString())
+            : accept(bestEstimate.toHexString());
 
           // We need to let txs that revert through.
           // Often that's exactly what you are testing.

--- a/packages/truffle-contract/lib/execute.js
+++ b/packages/truffle-contract/lib/execute.js
@@ -7,16 +7,6 @@ var Reason = require("./reason");
 var handlers = require("./handlers");
 var override = require("./override");
 var reformat = require("./reformat");
-var BN = require("bn.js");
-
-function createBN(n) {
-  if (typeof n === "string" && n.startsWith("0x")) {
-    n = n.slice(2);
-    return new BN(n, "hex");
-  } else {
-    return new BN(n);
-  }
-}
 
 var execute = {
   // -----------------------------------  Helpers --------------------------------------------------
@@ -38,13 +28,15 @@ var execute = {
       web3.eth
         .estimateGas(params)
         .then(gas => {
-          var bestEstimate = createBN(gas).muln(constructor.gasMultiplier);
+          var bestEstimate = utils
+            .bigNumberify(gas)
+            .mul(constructor.gasMultiplier);
 
           // Don't go over blockLimit
-          const limit = createBN(blockLimit);
+          const limit = utils.bigNumberify(blockLimit);
           bestEstimate.gte(limit)
-            ? accept("0x" + limit.subn(1).toString(16))
-            : accept("0x" + bestEstimate.toString(16));
+            ? accept(limit.sub(1).toHexString())
+            : accept(bestEstimate.toHexString());
 
           // We need to let txs that revert through.
           // Often that's exactly what you are testing.

--- a/packages/truffle-contract/lib/execute.js
+++ b/packages/truffle-contract/lib/execute.js
@@ -28,9 +28,10 @@ var execute = {
       web3.eth
         .estimateGas(params)
         .then(gas => {
-          var bestEstimate = utils
-            .bigNumberify(gas)
-            .mul(constructor.gasMultiplier);
+          const bestEstimate = utils.multiplyBigNumberByDecimal(
+            utils.bigNumberify(gas),
+            constructor.gasMultiplier
+          );
 
           // Don't go over blockLimit
           const limit = utils.bigNumberify(blockLimit);

--- a/packages/truffle-contract/lib/statuserror.js
+++ b/packages/truffle-contract/lib/statuserror.js
@@ -1,28 +1,39 @@
 var TruffleError = require("truffle-error");
 var inherits = require("util").inherits;
+var BN = require("bn.js");
 
 inherits(StatusError, TruffleError);
 
 var defaultGas = 90000;
 
+function createBN(n) {
+  if (typeof n === "string" && n.startsWith("0x")) {
+    n = n.slice(2);
+    return new BN(n, "hex");
+  } else {
+    return new BN(n);
+  }
+}
+
 function StatusError(args, tx, receipt, reason) {
   var message;
-  var gasLimit = parseInt(args.gas) || defaultGas;
-  var reasonString = '';
+  var gasLimit = args.gas || defaultGas;
+  var reasonString = "";
 
-  if(reason) reasonString = `Reason given: ${reason}.`;
+  if (reason) reasonString = `Reason given: ${reason}.`;
 
-  if(receipt.gasUsed === gasLimit){
-
-    message = "Transaction: " + tx + " exited with an error (status 0) after consuming all gas.\n" +
+  if (createBN(receipt.gasUsed).eq(createBN(gasLimit))) {
+    message =
+      "Transaction: " +
+      tx +
+      " exited with an error (status 0) after consuming all gas.\n" +
       "     Please check that the transaction:\n" +
       "     - satisfies all conditions set by Solidity `assert` statements.\n" +
       "     - has enough gas to execute the full transaction.\n" +
       "     - does not trigger an invalid opcode by other means (ex: accessing an array out of bounds).";
-
   } else {
-
-    message = `Transaction: ${tx} exited with an error (status 0). ${reasonString}\n` +
+    message =
+      `Transaction: ${tx} exited with an error (status 0). ${reasonString}\n` +
       "     Please check that the transaction:\n" +
       "     - satisfies all conditions set by Solidity `require` statements.\n" +
       "     - does not trigger a Solidity `revert` statement.\n";

--- a/packages/truffle-contract/lib/statuserror.js
+++ b/packages/truffle-contract/lib/statuserror.js
@@ -1,6 +1,6 @@
 var TruffleError = require("truffle-error");
 var inherits = require("util").inherits;
-var BigNumber = require("bignumber.js");
+var utils = require("./utils");
 
 inherits(StatusError, TruffleError);
 
@@ -13,7 +13,7 @@ function StatusError(args, tx, receipt, reason) {
 
   if (reason) reasonString = `Reason given: ${reason}.`;
 
-  if (new BigNumber(receipt.gasUsed).isEqualTo(new BigNumber(gasLimit))) {
+  if (utils.bigNumberify(receipt.gasUsed).eq(utils.bigNumberify(gasLimit))) {
     message =
       "Transaction: " +
       tx +

--- a/packages/truffle-contract/lib/statuserror.js
+++ b/packages/truffle-contract/lib/statuserror.js
@@ -1,6 +1,6 @@
 var TruffleError = require("truffle-error");
 var inherits = require("util").inherits;
-var utils = require("./utils");
+var BigNumber = require("bignumber.js");
 
 inherits(StatusError, TruffleError);
 
@@ -13,7 +13,7 @@ function StatusError(args, tx, receipt, reason) {
 
   if (reason) reasonString = `Reason given: ${reason}.`;
 
-  if (utils.bigNumberify(receipt.gasUsed).eq(utils.bigNumberify(gasLimit))) {
+  if (new BigNumber(receipt.gasUsed).isEqualTo(new BigNumber(gasLimit))) {
     message =
       "Transaction: " +
       tx +

--- a/packages/truffle-contract/lib/statuserror.js
+++ b/packages/truffle-contract/lib/statuserror.js
@@ -1,19 +1,10 @@
 var TruffleError = require("truffle-error");
 var inherits = require("util").inherits;
-var BN = require("bn.js");
+var utils = require("./utils");
 
 inherits(StatusError, TruffleError);
 
 var defaultGas = 90000;
-
-function createBN(n) {
-  if (typeof n === "string" && n.startsWith("0x")) {
-    n = n.slice(2);
-    return new BN(n, "hex");
-  } else {
-    return new BN(n);
-  }
-}
 
 function StatusError(args, tx, receipt, reason) {
   var message;
@@ -22,7 +13,7 @@ function StatusError(args, tx, receipt, reason) {
 
   if (reason) reasonString = `Reason given: ${reason}.`;
 
-  if (createBN(receipt.gasUsed).eq(createBN(gasLimit))) {
+  if (utils.bigNumberify(receipt.gasUsed).eq(utils.bigNumberify(gasLimit))) {
     message =
       "Transaction: " +
       tx +

--- a/packages/truffle-contract/lib/utils.js
+++ b/packages/truffle-contract/lib/utils.js
@@ -215,7 +215,9 @@ var Utils = {
       }
     });
     return converted;
-  }
+  },
+
+  bigNumberify
 };
 
 module.exports = Utils;

--- a/packages/truffle-contract/lib/utils.js
+++ b/packages/truffle-contract/lib/utils.js
@@ -215,9 +215,7 @@ var Utils = {
       }
     });
     return converted;
-  },
-
-  bigNumberify
+  }
 };
 
 module.exports = Utils;

--- a/packages/truffle-contract/lib/utils.js
+++ b/packages/truffle-contract/lib/utils.js
@@ -217,7 +217,34 @@ var Utils = {
     return converted;
   },
 
-  bigNumberify
+  bigNumberify,
+
+  /**
+   * Multiplies an ethers.js BigNumber and a number with decimal places using
+   * integer math rather than using an arbitrary floating-point library like
+   * `bignumber.js`.
+   * @param  {BigNumber} bignum            an ethers.js BigNumber (use bigNumberify)
+   * @param  {Number}    decimal           a number which has 0+ decimal places
+   * @param  {Number}    [maxPrecision=5]  the max number of signficant figures
+   *                                       `decimal` can have. (default: 5)
+   * @return {BigNumber}                   floor(bignum * decimal)
+   */
+  multiplyBigNumberByDecimal: function(bignum, decimal, maxPrecision) {
+    if (typeof maxPrecision === "undefined") {
+      maxPrecision = 5;
+    }
+
+    const significantFigures = Math.min(
+      decimal.toString().length - 1, // length less one because `.`
+      maxPrecision
+    );
+
+    const denominator = bigNumberify(10).pow(significantFigures);
+    const numerator = Math.round(decimal * denominator);
+    const secondOperand = bigNumberify(numerator).div(denominator);
+
+    return bignum.mul(secondOperand);
+  }
 };
 
 module.exports = Utils;

--- a/packages/truffle-contract/package.json
+++ b/packages/truffle-contract/package.json
@@ -26,6 +26,7 @@
   "homepage": "https://github.com/trufflesuite/truffle-contract#readme",
   "dependencies": {
     "bignumber.js": "^7.2.1",
+    "bn.js": "^4.11.8",
     "ethers": "^4.0.0-beta.1",
     "truffle-blockchain-utils": "^0.0.8",
     "truffle-contract-schema": "^3.0.3",

--- a/packages/truffle-contract/package.json
+++ b/packages/truffle-contract/package.json
@@ -26,7 +26,6 @@
   "homepage": "https://github.com/trufflesuite/truffle-contract#readme",
   "dependencies": {
     "bignumber.js": "^7.2.1",
-    "bn.js": "^4.11.8",
     "ethers": "^4.0.0-beta.1",
     "truffle-blockchain-utils": "^0.0.8",
     "truffle-contract-schema": "^3.0.3",

--- a/packages/truffle-interface-adapter/lib/ethereum-overloads.js
+++ b/packages/truffle-interface-adapter/lib/ethereum-overloads.js
@@ -1,0 +1,49 @@
+const BN = require("bn.js");
+
+module.exports.getBlock = web3 => {
+  const _oldFormatter = web3.eth.getBlock.method.outputFormatter;
+  web3.eth.getBlock.method.outputFormatter = block => {
+    let result = _oldFormatter.call(web3.eth.getBlock.method, block);
+
+    // Perhaps there is a better method of doing this,
+    // but the raw hexstrings work for the time being
+    result.gasLimit = "0x" + new BN(result.gasLimit).toString(16);
+    result.gasUsed = "0x" + new BN(result.gasUsed).toString(16);
+
+    return result;
+  };
+};
+
+module.exports.getTransaction = web3 => {
+  const _oldTransactionFormatter =
+    web3.eth.getTransaction.method.outputFormatter;
+  web3.eth.getTransaction.method.outputFormatter = tx => {
+    let result = _oldTransactionFormatter.call(
+      web3.eth.getTransaction.method,
+      tx
+    );
+
+    // Perhaps there is a better method of doing this,
+    // but the raw hexstrings work for the time being
+    result.gas = "0x" + new BN(result.gas).toString(16);
+
+    return result;
+  };
+};
+
+module.exports.getTransactionReceipt = web3 => {
+  const _oldTransactionReceiptFormatter =
+    web3.eth.getTransactionReceipt.method.outputFormatter;
+  web3.eth.getTransactionReceipt.method.outputFormatter = receipt => {
+    let result = _oldTransactionReceiptFormatter.call(
+      web3.eth.getTransactionReceipt.method,
+      receipt
+    );
+
+    // Perhaps there is a better method of doing this,
+    // but the raw hexstrings work for the time being
+    result.gasUsed = "0x" + new BN(result.gasUsed).toString(16);
+
+    return result;
+  };
+};

--- a/packages/truffle-interface-adapter/lib/quorum-overloads.js
+++ b/packages/truffle-interface-adapter/lib/quorum-overloads.js
@@ -1,0 +1,76 @@
+const BN = require("bn.js");
+
+module.exports.getBlock = web3 => {
+  const _oldBlockFormatter = web3.eth.getBlock.method.outputFormatter;
+  web3.eth.getBlock.method.outputFormatter = block => {
+    const _oldTimestamp = block.timestamp;
+    const _oldGasLimit = block.gasLimit;
+    const _oldGasUsed = block.gasUsed;
+
+    // Quorum uses nanoseconds instead of seconds in timestamp
+    let timestamp = new BN(block.timestamp.slice(2), 16);
+    timestamp = timestamp.div(new BN(10).pow(new BN(9)));
+    block.timestamp = "0x" + timestamp.toString(16);
+
+    // Since we're overwriting the gasLimit/Used later,
+    // it doesn't matter what it is before the call
+    // The same applies to the timestamp, but I reduced
+    // the precision since there was an accurate representation
+    // We do this because Quorum can have large block/transaction
+    // gas limits
+    block.gasLimit = "0x0";
+    block.gasUsed = "0x0";
+
+    let result = _oldBlockFormatter.call(web3.eth.getBlock.method, block);
+
+    // Perhaps there is a better method of doing this,
+    // but the raw hexstrings work for the time being
+    result.timestamp = _oldTimestamp;
+    result.gasLimit = _oldGasLimit;
+    result.gasUsed = _oldGasUsed;
+
+    return result;
+  };
+};
+
+module.exports.getTransaction = web3 => {
+  const _oldTransactionFormatter =
+    web3.eth.getTransaction.method.outputFormatter;
+  web3.eth.getTransaction.method.outputFormatter = tx => {
+    const _oldGas = tx.gas;
+
+    tx.gas = "0x0";
+
+    let result = _oldTransactionFormatter.call(
+      web3.eth.getTransaction.method,
+      tx
+    );
+
+    // Perhaps there is a better method of doing this,
+    // but the raw hexstrings work for the time being
+    result.gas = _oldGas;
+
+    return result;
+  };
+};
+
+module.exports.getTransactionReceipt = web3 => {
+  const _oldTransactionReceiptFormatter =
+    web3.eth.getTransactionReceipt.method.outputFormatter;
+  web3.eth.getTransactionReceipt.method.outputFormatter = receipt => {
+    const _oldGasUsed = receipt.gasUsed;
+
+    receipt.gasUsed = "0x0";
+
+    let result = _oldTransactionReceiptFormatter.call(
+      web3.eth.getTransactionReceipt.method,
+      receipt
+    );
+
+    // Perhaps there is a better method of doing this,
+    // but the raw hexstrings work for the time being
+    result.gasUsed = _oldGasUsed;
+
+    return result;
+  };
+};

--- a/packages/truffle-reporters/reporters/migrations-V5/reporter.js
+++ b/packages/truffle-reporters/reporters/migrations-V5/reporter.js
@@ -25,7 +25,7 @@ class Reporter {
   constructor() {
     this.deployer = null;
     this.migration = null;
-    this.currentGasTotal = 0;
+    this.currentGasTotal = new web3Utils.BN(0);
     this.currentCostTotal = new web3Utils.BN(0);
     this.finalCostTotal = new web3Utils.BN(0);
     this.deployments = 0;
@@ -91,15 +91,15 @@ class Reporter {
    * started running. Calling this method resets the gas counters for migrations totals
    */
   getTotals() {
-    const gas = this.currentGasTotal;
+    const gas = this.currentGasTotal.clone();
     const cost = web3Utils.fromWei(this.currentCostTotal, "ether");
     this.finalCostTotal = this.finalCostTotal.add(this.currentCostTotal);
 
-    this.currentGasTotal = 0;
+    this.currentGasTotal = new web3Utils.BN(0);
     this.currentCostTotal = new web3Utils.BN(0);
 
     return {
-      gas: gas,
+      gas: gas.toString(10),
       cost: cost,
       finalCost: web3Utils.fromWei(this.finalCostTotal, "ether"),
       deployments: this.deployments.toString()
@@ -317,13 +317,13 @@ class Reporter {
       const cost = gasPrice.mul(gas).add(value);
 
       data.gasPrice = web3Utils.fromWei(gasPrice, "gwei");
-      data.gas = data.receipt.gasUsed;
+      data.gas = gas.toString(10);
       data.from = tx.from;
       data.value = web3Utils.fromWei(value, "ether");
       data.cost = web3Utils.fromWei(cost, "ether");
       data.balance = web3Utils.fromWei(balance, "ether");
 
-      this.currentGasTotal += data.gas;
+      this.currentGasTotal = this.currentGasTotal.add(gas);
       this.currentCostTotal = this.currentCostTotal.add(cost);
       this.currentAddress = this.from;
       this.deployments++;


### PR DESCRIPTION
This extends on #1806 by adding support for Quorum's ability to have 54+ bit block gas limits.

This is blocked by merging #1806 just because it's based off those commits, so the changes here are going to look like more than they actually are. **You can look at the compare here in the meantime**: https://github.com/trufflesuite/truffle/compare/adapter/init-and-quorum...adapter/large-gas