### PR TITLE
Add address parameter to contract decoder

### DIFF
--- a/packages/truffle-decoder/lib/interface/contract-decoder.ts
+++ b/packages/truffle-decoder/lib/interface/contract-decoder.ts
@@ -113,7 +113,7 @@ export default class TruffleContractDecoder extends AsyncEventEmitter {
 
   private mappingKeys: Slot[] = [];
 
-  constructor(contract: ContractObject, relevantContracts: ContractObject[], provider: Provider) {
+  constructor(contract: ContractObject, relevantContracts: ContractObject[], provider: Provider, address: string) {
     super();
 
     this.web3 = new Web3(provider);
@@ -122,7 +122,9 @@ export default class TruffleContractDecoder extends AsyncEventEmitter {
     this.relevantContracts = relevantContracts;
 
     this.contractNetwork = Object.keys(this.contract.networks)[0];
-    this.contractAddress = this.contract.networks[this.contractNetwork].address;
+    this.contractAddress = address !== undefined
+      ? address
+      : this.contract.networks[this.contractNetwork].address;
 
     this.contractNode = getContractNode(this.contract);
 
@@ -178,7 +180,6 @@ export default class TruffleContractDecoder extends AsyncEventEmitter {
         mappingKeys: this.mappingKeys,
         referenceDeclarations: this.referenceDeclarations,
         storageAllocations: this.storageAllocations,
-        variables: this.stateVariableReferences
       };
 
       debug("about to decode %s", variable.definition.name);
@@ -209,7 +210,6 @@ export default class TruffleContractDecoder extends AsyncEventEmitter {
       mappingKeys: this.mappingKeys,
       referenceDeclarations: this.referenceDeclarations,
       storageAllocations: this.storageAllocations,
-      variables: this.stateVariableReferences
     };
 
     let variable: StorageMemberAllocation;

--- a/packages/truffle-decoder/lib/interface/index.ts
+++ b/packages/truffle-decoder/lib/interface/index.ts
@@ -12,8 +12,8 @@ export { getMemoryAllocations } from "../allocate/memory";
 export { readStack } from "../read/stack";
 export { slotAddress } from "../read/storage";
 
-export function forContract(contract: ContractObject, relevantContracts: ContractObject[], provider: Provider): TruffleDecoder {
-  return new TruffleDecoder(contract, relevantContracts, provider);
+export function forContract(contract: ContractObject, relevantContracts: ContractObject[], provider: Provider, address?: string): TruffleDecoder {
+  return new TruffleDecoder(contract, relevantContracts, provider, address);
 }
 
 export async function forEvmState(definition: AstDefinition, pointer: DataPointer, info: EvmInfo): Promise<any> {

--- a/packages/truffle-decoder/lib/types/evm.ts
+++ b/packages/truffle-decoder/lib/types/evm.ts
@@ -20,5 +20,4 @@ export interface EvmInfo {
   storageAllocations?: StorageAllocations;
   calldataAllocations?: CalldataAllocations;
   memoryAllocations?: MemoryAllocations;
-  variables?: StorageMemberAllocations;
 }


### PR DESCRIPTION
This PR addresses issue #1597, allowing an address to be provided manually (as a string) in the contract decoder.  (The particular format of the address is, anything that's good enough for Web3; we don't process this address at all.)  Note that we do not create a whole `networks` member of the contract object, we just manually set the address -- that should be good enough for our purposes.

In addition, while doing this I took a moment to eliminate the now-unused `variables` field from the `EvmInfo` type.  This should not be a functional change.