### PR TITLE
Clean BNs before comparison to speed up Travis

### DIFF
--- a/packages/truffle-debugger/test/data/calldata.js
+++ b/packages/truffle-debugger/test/data/calldata.js
@@ -8,9 +8,9 @@ import Ganache from "ganache-core";
 import { prepareContracts, lineOf } from "../helpers";
 import Debugger from "lib/debugger";
 
-import solidity from "lib/solidity/selectors";
+import * as TruffleDecodeUtils from "truffle-decode-utils";
 
-import BN from "bn.js";
+import solidity from "lib/solidity/selectors";
 
 const __CALLDATA = `
 pragma solidity ^0.5.4;
@@ -139,14 +139,16 @@ describe("Calldata Decoding", function() {
 
     await session.continueUntilBreakpoint();
 
-    const variables = await session.variables();
+    const variables = TruffleDecodeUtils.Conversion.cleanBNs(
+      await session.variables()
+    );
 
     const expectedResult = {
       hello: "hello",
       deadbeef: "0xdeadbeef",
-      twoInts: [new BN(107), new BN(683)],
-      someInts: [new BN(41), new BN(42)],
-      pair: { x: new BN(321), y: new BN(2049) }
+      twoInts: [107, 683],
+      someInts: [41, 42],
+      pair: { x: 321, y: 2049 }
     };
 
     assert.deepEqual(variables, expectedResult);

--- a/packages/truffle-debugger/test/data/ids.js
+++ b/packages/truffle-debugger/test/data/ids.js
@@ -11,9 +11,6 @@ import Debugger from "lib/debugger";
 import trace from "lib/trace/selectors";
 import solidity from "lib/solidity/selectors";
 
-import * as TruffleDecodeUtils from "truffle-decode-utils";
-import BN from "bn.js";
-
 const __FACTORIAL = `
 pragma solidity ^0.5.0;
 
@@ -188,6 +185,7 @@ describe("Variable IDs", function() {
   });
 
   it("Distinguishes between stackframes", async function() {
+    this.timeout(8000);
     let instance = await abstractions.FactorialTest.deployed();
     let receipt = await instance.factorial(3);
     let txHash = receipt.tx;
@@ -216,55 +214,11 @@ describe("Variable IDs", function() {
 
     await session.continueUntilBreakpoint();
     while (!session.view(trace.finished)) {
-      values.push(await session.variable("nbang"));
+      values.push((await session.variable("nbang")).toNumber());
       await session.continueUntilBreakpoint();
     }
 
-    assert.deepEqual(values, [
-      new BN(3),
-      new BN(2),
-      new BN(1),
-      new BN(0),
-      new BN(1),
-      new BN(1),
-      new BN(2),
-      new BN(6)
-    ]);
-  }).timeout(8000);
-
-  it("Learns contract addresses and distinguishes the results", async function() {
-    this.timeout(4000);
-    let instance = await abstractions.AddressTest.deployed();
-    let receipt = await instance.run();
-    let txHash = receipt.tx;
-
-    let bugger = await Debugger.forTx(txHash, {
-      provider,
-      files,
-      contracts: artifacts
-    });
-
-    let session = bugger.connect();
-    debug("sourceId %d", session.view(solidity.current.source).id);
-
-    let sourceId = session.view(solidity.current.source).id;
-    let source = session.view(solidity.current.source).source;
-    await session.addBreakpoint({
-      sourceId,
-      line: lineOf("break here", source)
-    });
-    await session.continueUntilBreakpoint();
-    debug("node %o", session.view(solidity.current.node));
-    assert.equal(
-      TruffleDecodeUtils.Conversion.cleanBNs(await session.variable("secret")),
-      "107"
-    );
-    await session.continueUntilBreakpoint();
-    debug("node %o", session.view(solidity.current.node));
-    assert.equal(
-      TruffleDecodeUtils.Conversion.cleanBNs(await session.variable("secret")),
-      "46"
-    );
+    assert.deepEqual(values, [3, 2, 1, 0, 1, 1, 2, 6]);
   });
 
   it("Stays at correct stackframe after contract call", async function() {

--- a/packages/truffle-debugger/test/data/more-decoding.js
+++ b/packages/truffle-debugger/test/data/more-decoding.js
@@ -13,8 +13,6 @@ import data from "lib/data/selectors";
 
 import * as TruffleDecodeUtils from "truffle-decode-utils";
 
-import BN from "bn.js";
-
 const __CONTAINERS = `
 pragma solidity ^0.5.0;
 
@@ -244,18 +242,20 @@ describe("Further Decoding", function() {
 
     await session.continueUntilBreakpoint();
 
-    const variables = await session.variables();
+    const variables = TruffleDecodeUtils.Conversion.cleanBNs(
+      await session.variables()
+    );
 
     const expectedResult = {
-      memoryStaticArray: [new BN(107)],
-      memoryStructWithMap: { x: new BN(107), y: new BN(214) },
-      localStorage: [new BN(107), new BN(214)],
-      storageStructArray: [{ x: new BN(107) }],
-      storageArrayArray: [[new BN(2), new BN(3)]],
-      structMapping: new Map([["hello", { x: new BN(107) }]]),
-      arrayMapping: new Map([["hello", [new BN(2), new BN(3)]]]),
-      signedMapping: new Map([["hello", new BN(-1)]]),
-      pointedAt: [new BN(107), new BN(214)]
+      memoryStaticArray: [107],
+      memoryStructWithMap: { x: 107, y: 214 },
+      localStorage: [107, 214],
+      storageStructArray: [{ x: 107 }],
+      storageArrayArray: [[2, 3]],
+      structMapping: new Map([["hello", { x: 107 }]]),
+      arrayMapping: new Map([["hello", [2, 3]]]),
+      signedMapping: new Map([["hello", -1]]),
+      pointedAt: [107, 214]
     };
 
     assert.hasAllKeys(variables, expectedResult);
@@ -357,13 +357,15 @@ describe("Further Decoding", function() {
 
     await session.continueUntilBreakpoint();
 
-    const variables = await session.variables();
+    const variables = TruffleDecodeUtils.Conversion.cleanBNs(
+      await session.variables()
+    );
 
     const expectedResult = {
       map: new Map([["key1", "value1"], ["key2", "value2"]]),
       pointedAt: "key2",
-      arrayArray: [[new BN(82)]],
-      arrayStruct: { x: [new BN(82)] },
+      arrayArray: [[82]],
+      arrayStruct: { x: [82] },
       key1: "key1",
       key2: "key2",
       pointedAt: "key2"

--- a/packages/truffle-debugger/test/data/utils.js
+++ b/packages/truffle-debugger/test/data/utils.js
@@ -35,7 +35,7 @@ describe("Utils", function() {
     it("returns correct negative value", function() {
       let bytes = [0xf5, 0xe2, 0xc5, 0x17]; // starts with 0b1
       let raw = new BN("f5e2c517", 16);
-      let bitfipped = new BN(
+      let bitflipped = new BN(
         raw
           .toString(2)
           .replace(/0/g, "x")
@@ -44,7 +44,7 @@ describe("Utils", function() {
         2
       );
 
-      let expectedValue = bitfipped.addn(1).neg();
+      let expectedValue = bitflipped.addn(1).neg();
 
       let result = TruffleDecodeUtils.Conversion.toSignedBN(bytes);
 

--- a/packages/truffle-debugger/test/endstate.js
+++ b/packages/truffle-debugger/test/endstate.js
@@ -11,7 +11,7 @@ import Debugger from "lib/debugger";
 import sessionSelector from "lib/session/selectors";
 import data from "lib/data/selectors";
 
-import BN from "bn.js";
+import * as TruffleDecodeUtils from "truffle-decode-utils";
 
 const __FAILURE = `
 pragma solidity ~0.5;
@@ -102,7 +102,9 @@ describe("End State", function() {
     debug("proc.assignments %O", session.view(data.proc.assignments));
 
     assert.ok(session.view(sessionSelector.transaction.receipt).status);
-    const variables = await session.variables();
-    assert.deepEqual(variables, { x: new BN(107) });
+    const variables = TruffleDecodeUtils.Conversion.cleanBNs(
+      await session.variables()
+    );
+    assert.deepEqual(variables, { x: 107 });
   });
 });


### PR DESCRIPTION
Earlier, out of laziness, I wrote a number of tests that just used deep equality to compare structures filled with BNs.  In fact it's probably faster to clean those BNs to numbers before comparison.  So in this PR I do that.  (I also delete that dummy address test, although of course this change is also made in my PR that removes the dummy address system.)