### PR TITLE
Enable backwards-compatible 0.4.xx solc unit testing

### DIFF
--- a/packages/truffle-core/lib/testing/deployed.js
+++ b/packages/truffle-core/lib/testing/deployed.js
@@ -1,10 +1,11 @@
 // Using web3 for its sha function...
 var Web3 = require("web3");
+const semver = require("semver");
 
 var Deployed = {
   makeSolidityDeployedAddressesLibrary: function(
     mapping,
-    removeAddressPayable
+    { solc: { version } }
   ) {
     var self = this;
 
@@ -35,8 +36,10 @@ var Deployed = {
 
     source += "}";
 
-    // if true, strip out payable!
-    if (removeAddressPayable) source = source.replace(/ payable/gm, "");
+    if (version) {
+      if (semver.lt(semver.coerce(version), "0.5.0"))
+        source = source.replace(/ payable/gm, "");
+    }
 
     return source;
   },

--- a/packages/truffle-core/lib/testing/deployed.js
+++ b/packages/truffle-core/lib/testing/deployed.js
@@ -2,7 +2,10 @@
 var Web3 = require("web3");
 
 var Deployed = {
-  makeSolidityDeployedAddressesLibrary: function(mapping) {
+  makeSolidityDeployedAddressesLibrary: function(
+    mapping,
+    removeAddressPayable
+  ) {
     var self = this;
 
     var source = "";
@@ -31,6 +34,9 @@ var Deployed = {
     });
 
     source += "}";
+
+    // if true, strip out payable!
+    if (removeAddressPayable) source = source.replace(/ payable/gm, "");
 
     return source;
   },

--- a/packages/truffle-core/lib/testing/deployed.js
+++ b/packages/truffle-core/lib/testing/deployed.js
@@ -10,9 +10,7 @@ var Deployed = {
     var self = this;
 
     var source = "";
-    source +=
-      "pragma solidity >=0.4.15 <0.6.0; \n\n library DeployedAddresses {" +
-      "\n";
+    source += "pragma solidity ^0.5.0; \n\n library DeployedAddresses {" + "\n";
 
     Object.keys(mapping).forEach(function(name) {
       var address = mapping[name];
@@ -37,8 +35,9 @@ var Deployed = {
     source += "}";
 
     if (version) {
-      if (semver.lt(semver.coerce(version), "0.5.0"))
-        source = source.replace(/ payable/gm, "");
+      const v = semver.coerce(version);
+      if (semver.lt(v, "0.5.0")) source = source.replace(/ payable/gm, "");
+      source = source.replace(/0.5.0/gm, v);
     }
 
     return source;

--- a/packages/truffle-core/lib/testing/testsource.js
+++ b/packages/truffle-core/lib/testing/testsource.js
@@ -3,7 +3,6 @@ var path = require("path");
 var fs = require("fs");
 var contract = require("truffle-contract");
 var find_contracts = require("truffle-contract-sources");
-const semver = require("semver");
 
 function TestSource(config) {
   this.config = config;
@@ -85,17 +84,9 @@ TestSource.prototype.resolve = function(import_path, callback) {
               mapping[name] = address;
             });
 
-            let removeAddressPayable = false; // must be true for 0.4.xx solidity unit testing
-
-            if (self.config.compilers.solc.version) {
-              const solcVersion = self.config.compilers.solc.version;
-              if (semver.lt(semver.coerce(solcVersion), "0.5.0"))
-                removeAddressPayable = true;
-            }
-
             return Deployed.makeSolidityDeployedAddressesLibrary(
               mapping,
-              removeAddressPayable
+              self.config.compilers
             );
           })
           .then(function(addressSource) {

--- a/packages/truffle-core/lib/testing/testsource.js
+++ b/packages/truffle-core/lib/testing/testsource.js
@@ -3,6 +3,7 @@ var path = require("path");
 var fs = require("fs");
 var contract = require("truffle-contract");
 var find_contracts = require("truffle-contract-sources");
+const semver = require("semver");
 
 function TestSource(config) {
   this.config = config;
@@ -84,7 +85,18 @@ TestSource.prototype.resolve = function(import_path, callback) {
               mapping[name] = address;
             });
 
-            return Deployed.makeSolidityDeployedAddressesLibrary(mapping);
+            let removeAddressPayable = false; // must be true for 0.4.xx solidity unit testing
+
+            if (self.config.compilers.solc.version) {
+              const solcVersion = self.config.compilers.solc.version;
+              if (semver.lt(semver.coerce(solcVersion), "0.5.0"))
+                removeAddressPayable = true;
+            }
+
+            return Deployed.makeSolidityDeployedAddressesLibrary(
+              mapping,
+              removeAddressPayable
+            );
           })
           .then(function(addressSource) {
             callback(null, addressSource, import_path);


### PR DESCRIPTION
Truffle v5's release & default support for solidity 0.5.0 introduced a number of breaking changes & necessary quick-response stop gap measures.

This PR addresses one of those stop gaps (#1817), allowing backwards-compatible solidity unit testing for users still developing with `0.4.xx`.

🍻 