### PR TITLE
Include creation calls in the list of addresses

### DIFF
--- a/packages/truffle-debugger/lib/session/sagas/index.js
+++ b/packages/truffle-debugger/lib/session/sagas/index.js
@@ -68,6 +68,7 @@ function* forkListeners() {
 
 function* fetchTx(txHash, provider) {
   let result = yield* web3.inspectTransaction(txHash, provider);
+  debug("result %o", result);
 
   if (result.error) {
     return result.error;

--- a/packages/truffle-debugger/lib/session/sagas/index.js
+++ b/packages/truffle-debugger/lib/session/sagas/index.js
@@ -75,9 +75,19 @@ function* fetchTx(txHash, provider) {
 
   yield* evm.begin(result);
 
+  //get addresses created/called during transaction
   let addresses = yield* trace.processTrace(result.trace);
-  if (result.address && addresses.indexOf(result.address) == -1) {
+  //add in the address of the call itself (if a call)
+  if (result.address && !addresses.includes(result.address)) {
     addresses.push(result.address);
+  }
+  //if a create, only add in address if it was successful
+  if (
+    result.binary &&
+    result.status &&
+    !addresses.includes(result.storageAddress)
+  ) {
+    addresses.push(result.storageAddress);
   }
 
   let binaries = yield* web3.obtainBinaries(addresses);

--- a/packages/truffle-debugger/lib/web3/actions/index.js
+++ b/packages/truffle-debugger/lib/web3/actions/index.js
@@ -40,13 +40,14 @@ export function receiveTrace(trace) {
 }
 
 export const RECEIVE_CALL = "RECEIVE_CALL";
-export function receiveCall({ address, binary, data, storageAddress }) {
+export function receiveCall({ address, binary, data, storageAddress, status }) {
   return {
     type: RECEIVE_CALL,
     address,
     binary,
     data,
-    storageAddress
+    storageAddress,
+    status //only used for creation calls at present!
   };
 }
 

--- a/packages/truffle-debugger/lib/web3/sagas/index.js
+++ b/packages/truffle-debugger/lib/web3/sagas/index.js
@@ -52,7 +52,8 @@ function* fetchTransactionInfo(adapter, { txHash }) {
     yield put(
       actions.receiveCall({
         binary: tx.input,
-        storageAddress: receipt.createdAddress
+        storageAddress: receipt.createdAddress,
+        status: receipt.status
       })
     );
     return;
@@ -88,12 +89,10 @@ export function* inspectTransaction(txHash, provider) {
     return { error: action.error };
   }
 
-  let { address, binary, data, storageAddress } = yield take(
-    actions.RECEIVE_CALL
-  );
+  let call = yield take(actions.RECEIVE_CALL);
   debug("received call");
 
-  return { trace, address, binary, data, storageAddress };
+  return { trace, ...call };
 }
 
 export function* obtainBinaries(addresses) {

--- a/packages/truffle-debugger/lib/web3/sagas/index.js
+++ b/packages/truffle-debugger/lib/web3/sagas/index.js
@@ -52,7 +52,7 @@ function* fetchTransactionInfo(adapter, { txHash }) {
     yield put(
       actions.receiveCall({
         binary: tx.input,
-        storageAddress: receipt.createdAddress,
+        storageAddress: receipt.contractAddress,
         status: receipt.status
       })
     );
@@ -89,10 +89,12 @@ export function* inspectTransaction(txHash, provider) {
     return { error: action.error };
   }
 
-  let call = yield take(actions.RECEIVE_CALL);
+  let { address, binary, data, storageAddress, status } = yield take(
+    actions.RECEIVE_CALL
+  );
   debug("received call");
 
-  return { trace, ...call };
+  return { trace, address, binary, data, storageAddress, status };
 }
 
 export function* obtainBinaries(addresses) {

--- a/packages/truffle-decode-utils/src/constants.ts
+++ b/packages/truffle-decode-utils/src/constants.ts
@@ -5,4 +5,5 @@ export namespace Constants {
   export const ADDRESS_SIZE = 20;
   export const SELECTOR_SIZE = 4;
   export const MAX_WORD = new BN(-1).toTwos(WORD_SIZE * 8);
+  export const ZERO_ADDRESS = "0x" + "00".repeat(ADDRESS_SIZE);
 }

--- a/packages/truffle-decode-utils/src/evm.ts
+++ b/packages/truffle-decode-utils/src/evm.ts
@@ -12,6 +12,7 @@ export namespace EVM {
   export const ADDRESS_SIZE = Constants.ADDRESS_SIZE;
   export const SELECTOR_SIZE = Constants.SELECTOR_SIZE;
   export const MAX_WORD = Constants.MAX_WORD;
+  export const ZERO_ADDRESS = Constants.ZERO_ADDRESS;
 
   //beware of using this for generic strings! (it's fine for bytestrings, or
   //strings representing numbers) if you want to use this on a generic string,


### PR DESCRIPTION
This PR adds addresses created during a transaction to the internal list of addresses (which is used for both fetching instances and for displaying addresses affected).  It also fixes a bug in #1814 where if the initial call of the transation was a creation, its storage address would not be obtained properly due to a misnamed variable.

Aside from the bug fix, the effects of this PR are mostly internal -- it does mean that creation calls now show up in "addresses affected", which is nice but minor.  The main point is really setting things up for later when I implement internal function decoding.  I'm not entirely certain whether it's needed for that, but, whatever, we can always take it out later if it's a problem.

Note that because this address list is used for fetching binaries, *failed* creations are deliberately excluded.  Note that if the initial call is a creation this has to be done by checking the status rather than just checking if the address is zero.

Getting the address is done using the same logic as in #1814, but I'm not worried about the duplicated logic here (which is hard to avoid in this case), because, while we'll eventually want to modify how storage addresses are computed to account for failed creations, we really don't want to add failed creations to this list, so this method is good enough and can stay.