### PR TITLE
Track storage across intra-transaction call boundaries

### DIFF
--- a/packages/truffle-debugger/lib/data/selectors/index.js
+++ b/packages/truffle-debugger/lib/data/selectors/index.js
@@ -320,7 +320,7 @@ const data = createSelectorTree({
        * data.current.state.storage
        */
       storage: createLeaf(
-        [evm.current.state.storage],
+        [evm.current.codex.storage],
 
         mapping =>
           Object.assign(

--- a/packages/truffle-debugger/lib/evm/actions/index.js
+++ b/packages/truffle-debugger/lib/evm/actions/index.js
@@ -53,6 +53,16 @@ export function returnCall() {
   };
 }
 
+export const STORE = "STORE";
+export function store(address, slot, value) {
+  return {
+    type: STORE,
+    address,
+    slot,
+    value
+  };
+}
+
 export const RESET = "EVM_RESET";
 export function reset() {
   return { type: RESET };

--- a/packages/truffle-debugger/lib/evm/actions/index.js
+++ b/packages/truffle-debugger/lib/evm/actions/index.js
@@ -64,6 +64,9 @@ export function store(address, slot, value) {
 }
 
 export const RESET = "EVM_RESET";
-export function reset() {
-  return { type: RESET };
+export function reset(storageAddress) {
+  return {
+    type: RESET,
+    storageAddress
+  };
 }

--- a/packages/truffle-debugger/lib/evm/reducers.js
+++ b/packages/truffle-debugger/lib/evm/reducers.js
@@ -177,6 +177,7 @@ export function codex(state = DEFAULT_CODEX, action) {
         return state;
       }
       return {
+        ...state,
         byAddress: {
           ...state.byAddress,
           [action.storageAddress]: {
@@ -190,6 +191,7 @@ export function codex(state = DEFAULT_CODEX, action) {
       //add or update the needed slot
       const { address, slot, value } = action;
       return {
+        ...state,
         byAddress: {
           ...state.byAddress,
           [address]: {

--- a/packages/truffle-debugger/lib/evm/reducers.js
+++ b/packages/truffle-debugger/lib/evm/reducers.js
@@ -146,10 +146,23 @@ export function callstack(state = [], action) {
   }
 }
 
+//default codex with nothing
 const DEFAULT_CODEX = {
   byAddress: {}
   //there will be more here later!
 };
+
+//default codex with a single address
+function defaultCodex(address) {
+  return {
+    byAddress: {
+      [address]: {
+        storage: {}
+        //there will be more here later!
+      }
+    }
+  };
+}
 
 export function codex(state = DEFAULT_CODEX, action) {
   switch (action.type) {
@@ -188,6 +201,8 @@ export function codex(state = DEFAULT_CODEX, action) {
           }
         }
       };
+    case actions.RESET:
+      return defaultCodex(action.storageAddress);
     default:
       return state;
   }

--- a/packages/truffle-debugger/lib/evm/reducers.js
+++ b/packages/truffle-debugger/lib/evm/reducers.js
@@ -2,6 +2,7 @@ import { combineReducers } from "redux";
 
 import * as actions from "./actions";
 import { keccak256 } from "lib/helpers";
+import * as DecodeUtils from "truffle-decode-utils";
 
 const DEFAULT_CONTEXTS = {
   byContext: {},
@@ -145,8 +146,56 @@ export function callstack(state = [], action) {
   }
 }
 
+const DEFAULT_CODEX = {
+  byAddress: {}
+  //there will be more here later!
+};
+
+export function codex(state = DEFAULT_CODEX, action) {
+  switch (action.type) {
+    case actions.CALL:
+    case actions.CREATE:
+      //on a call or create, add new pages to the codex if necessary;
+      //don't add a zero page though (or pages that already exist)
+      if (
+        state.byAddress[action.storageAddress] !== undefined ||
+        action.storageAddress === DecodeUtils.EVM.ZERO_ADDRESS
+      ) {
+        return state;
+      }
+      return {
+        byAddress: {
+          ...state.byAddress,
+          [action.storageAddress]: {
+            storage: {}
+            //there will be more here later!
+          }
+        }
+      };
+    case actions.STORE:
+      //on a store, the relevant page should already exist, so we can just
+      //add or update the needed slot
+      const { address, slot, value } = action;
+      return {
+        byAddress: {
+          ...state.byAddress,
+          [address]: {
+            ...state.byAddress[address],
+            storage: {
+              ...state.byAddress[address].storage,
+              [slot]: value
+            }
+          }
+        }
+      };
+    default:
+      return state;
+  }
+}
+
 const proc = combineReducers({
-  callstack
+  callstack,
+  codex
 });
 
 const reducer = combineReducers({

--- a/packages/truffle-debugger/lib/evm/sagas/index.js
+++ b/packages/truffle-debugger/lib/evm/sagas/index.js
@@ -116,7 +116,8 @@ export function* callstackAndCodexSaga() {
 }
 
 export function* reset() {
-  yield put(actions.reset());
+  let initialAddress = (yield select(evm.current.callstack))[0].storageAddress;
+  yield put(actions.reset(initialAddress));
 }
 
 export function* saga() {

--- a/packages/truffle-debugger/lib/evm/selectors/index.js
+++ b/packages/truffle-debugger/lib/evm/selectors/index.js
@@ -390,7 +390,7 @@ const evm = createSelectorTree({
         ["./_", "../state/storage", "../call"],
         (codex, rawStorage, { storageAddress }) =>
           storageAddress === DecodeUtils.EVM.ZERO_ADDRESS
-            ? rawStorage
+            ? rawStorage //HACK -- if zero address ignore the codex
             : codex.byAddress[storageAddress].storage
       )
     }

--- a/packages/truffle-debugger/lib/evm/selectors/index.js
+++ b/packages/truffle-debugger/lib/evm/selectors/index.js
@@ -96,6 +96,16 @@ function createStepSelectors(step, state = null) {
     isHalting: createLeaf(
       ["./trace"],
       step => step.op == "STOP" || step.op == "RETURN"
+    ),
+
+    /**
+     * .touchesStorage
+     *
+     * whether the instruction involves storage
+     */
+    touchesStorage: createLeaf(
+      ["./trace"],
+      step => step.op == "SLOAD" || step.op == "SSTORE"
     )
   };
 
@@ -115,10 +125,12 @@ function createStepSelectors(step, state = null) {
        * address transferred to by call operation
        */
       callAddress: createLeaf(
-        ["./isCall", "./trace", state],
+        ["./isCall", state],
 
-        (matches, step, { stack }) => {
-          if (!matches) return null;
+        (matches, { stack }) => {
+          if (!matches) {
+            return null;
+          }
 
           let address = stack[stack.length - 2];
           return DecodeUtils.Conversion.toAddress(address);
@@ -131,10 +143,12 @@ function createStepSelectors(step, state = null) {
        * binary code to execute via create operation
        */
       createBinary: createLeaf(
-        ["./isCreate", "./trace", state],
+        ["./isCreate", state],
 
-        (matches, step, { stack, memory }) => {
-          if (!matches) return null;
+        (matches, { stack, memory }) => {
+          if (!matches) {
+            return null;
+          }
 
           // Get the code that's going to be created from memory.
           // Note we multiply by 2 because these offsets are in bytes.
@@ -151,9 +165,11 @@ function createStepSelectors(step, state = null) {
        * data passed to EVM call
        */
       callData: createLeaf(
-        ["./isCall", "./isShortCall", "./trace", state],
-        (matches, short, step, { stack, memory }) => {
-          if (!matches) return null;
+        ["./isCall", "./isShortCall", state],
+        (matches, short, { stack, memory }) => {
+          if (!matches) {
+            return null;
+          }
 
           //if it's 6-argument call, the data start and offset will be one spot
           //higher in the stack than they would be for a 7-argument call, so
@@ -201,6 +217,24 @@ function createStepSelectors(step, state = null) {
           let { context } = instances[address] || {};
           let { binary } = contexts[context] || {};
           return !binary;
+        }
+      ),
+
+      /**
+       * .storageAffected
+       *
+       * storage slot being stored to or loaded from
+       * we do NOT prepend "0x"
+       */
+      storageAffected: createLeaf(
+        ["./touchesStorage", state],
+
+        (matches, { stack }) => {
+          if (!matches) {
+            return null;
+          }
+
+          return stack[stack.length - 1];
         }
       )
     });
@@ -327,11 +361,37 @@ const evm = createSelectorTree({
         ["./isCreate", "/nextOfSameDepth/state/stack"],
         (matches, stack) => {
           if (!matches) {
-            return undefined;
+            return null;
           }
           let address = stack[stack.length - 1];
           return DecodeUtils.Conversion.toAddress(address);
         }
+      )
+    },
+
+    /**
+     * evm.current.codex (namespace)
+     */
+    codex: {
+      /**
+       * evm.current.codex (selector)
+       * the whole codex! not that that's very much at the moment
+       */
+      _: createLeaf(["/state"], state => state.proc.codex),
+
+      /**
+       * evm.current.codex.storage
+       * the current storage, as fetched from the codex... unless we're in a
+       * failed creation call, then we just fall back on the state (which will
+       * work, since nothing else can interfere with the storage of a failed
+       * creation call!)
+       */
+      storage: createLeaf(
+        ["./_", "../state/storage", "../call"],
+        (codex, rawStorage, { storageAddress }) =>
+          storageAddress === DecodeUtils.EVM.ZERO_ADDRESS
+            ? rawStorage
+            : codex.byAddress[storageAddress].storage
       )
     }
   },

--- a/packages/truffle-debugger/test/data/codex.js
+++ b/packages/truffle-debugger/test/data/codex.js
@@ -1,0 +1,94 @@
+import debugModule from "debug";
+const debug = debugModule("test:data:codex");
+
+import { assert } from "chai";
+
+import Ganache from "ganache-core";
+
+import { prepareContracts } from "../helpers";
+import Debugger from "lib/debugger";
+
+import * as TruffleDecodeUtils from "truffle-decode-utils";
+
+const __LIBTEST = `
+pragma solidity ^0.5.4;
+
+contract MappingPointerTest {
+  mapping(string => uint) surface;
+
+  event Done();
+
+  function run() public {
+    TouchLib.touch(surface);
+  }
+}
+
+library TouchLib {
+  function touch(mapping(string => uint) storage surface) external {
+    surface["ping"] = 1;
+  }
+}
+`;
+
+const __MIGRATION = `
+var MappingPointerTest = artifacts.require("MappingPointerTest");
+var TouchLib = artifacts.require("TouchLib");
+
+module.exports = function(deployer) {
+  deployer.deploy(TouchLib);
+  deployer.link(TouchLib, MappingPointerTest);
+  deployer.deploy(MappingPointerTest);
+};
+`;
+
+let sources = {
+  "MappingPointerTest.sol": __LIBTEST
+};
+
+let migrations = {
+  "2_deploy_contracts.js": __MIGRATION
+};
+
+describe("Codex", function() {
+  var provider;
+
+  var abstractions;
+  var artifacts;
+  var files;
+
+  before("Create Provider", async function() {
+    provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
+  });
+
+  before("Prepare contracts and artifacts", async function() {
+    this.timeout(30000);
+
+    let prepared = await prepareContracts(provider, sources, migrations);
+    abstractions = prepared.abstractions;
+    artifacts = prepared.artifacts;
+    files = prepared.files;
+  });
+
+  it("Tracks storage across call boundaries", async function() {
+    this.timeout(6000);
+    let instance = await abstractions.MappingPointerTest.deployed();
+    let receipt = await instance.run();
+    let txHash = receipt.tx;
+
+    let bugger = await Debugger.forTx(txHash, {
+      provider,
+      files,
+      contracts: artifacts
+    });
+
+    let session = bugger.connect();
+
+    await session.continueUntilBreakpoint(); //run till end
+
+    const variables = TruffleDecodeUtils.Conversion.cleanBNs(
+      await session.variables()
+    );
+
+    assert.equal(variables.surface.get("ping"), 1);
+  });
+});

--- a/packages/truffle-debugger/test/reset.js
+++ b/packages/truffle-debugger/test/reset.js
@@ -6,6 +6,7 @@ import { assert } from "chai";
 import Ganache from "ganache-core";
 
 import { prepareContracts, lineOf } from "./helpers";
+import * as TruffleDecodeUtils from "truffle-decode-utils";
 import Debugger from "lib/debugger";
 
 import solidity from "lib/solidity/selectors";
@@ -70,21 +71,35 @@ describe("Reset Button", function() {
     variables[0] = []; //collected during 1st run
     variables[1] = []; //collected during 2nd run
 
-    variables[0].push(await session.variables());
     await session.addBreakpoint({ sourceId, line: lineOf("BREAK", source) });
+
+    variables[0].push(
+      TruffleDecodeUtils.Conversion.cleanBNs(await session.variables())
+    );
     await session.continueUntilBreakpoint(); //advance to line 10
-    variables[0].push(await session.variables());
+    variables[0].push(
+      TruffleDecodeUtils.Conversion.cleanBNs(await session.variables())
+    );
     await session.continueUntilBreakpoint(); //advance to the end
-    variables[0].push(await session.variables());
+    variables[0].push(
+      TruffleDecodeUtils.Conversion.cleanBNs(await session.variables())
+    );
 
     //now, reset and do it again
     await session.reset();
 
-    variables[1].push(await session.variables());
+    variables[1].push(
+      TruffleDecodeUtils.Conversion.cleanBNs(await session.variables())
+    );
+    await session.addBreakpoint({ sourceId, line: lineOf("BREAK", source) });
     await session.continueUntilBreakpoint(); //advance to line 10
-    variables[1].push(await session.variables());
+    variables[1].push(
+      TruffleDecodeUtils.Conversion.cleanBNs(await session.variables())
+    );
     await session.continueUntilBreakpoint(); //advance to the end
-    variables[1].push(await session.variables());
+    variables[1].push(
+      TruffleDecodeUtils.Conversion.cleanBNs(await session.variables())
+    );
 
     assert.deepEqual(variables[1], variables[0]);
   });


### PR DESCRIPTION
This PR gives the debugger the ability to track storage across call boundaries.  The debugger still can't track storage across transaction boundaries; storage that hasn't been touched (i.e., read from or written to) within the current transaction will still show up as 0.  However, now, if one call within the transaction touches a storage slot, all calls within that transaction sharing that storage address will be able to see it.

This PR is the start of what I'm calling the "codex" -- an effort to have the debugger keep track of the state itself, instead of being totally helpless when the trace won't tell us things directly.  (Arguably, keeping track of calldata was also part of this.)  However, right now we only really need to do this for storage, so, I'm not introducing anything else into the codex yet.  That can wait until we need it.

So, now, the `evm` state contains `evm.proc.codex`.  While it will do more in the future, right now it keeps track of the current storage at each address.  It starts out empty; whenever there's a `CALL` or `CREATE` action, it adds a "page" to the codex for the call's storage address.  (If necessary; we don't add pages already there.  Also, there is no zero page; see below for more on this special case.)  The new addition is that the EVM saga now also looks for `SLOAD` and `SSTORE` instructions, and on finding one, issues a `STORE` action that instructs the codex to update its copy of storage.  This action has three parameters: `address`, `slot`, and `value`.  The slot, of course, is read off of the stack, and the value is read from `evm.next.state.storage` based on the slot.  (For an `SSTORE` the value could of course also be read off the stack, but I thought it was simpler to take a unified approach.)

So, some new selectors have been added.  There's now `evm.current.codex`, which returns the current codex; and there's `evm.current.codex.storage`, which does not return the full storage portion of the codex (that's the only portion at the moment), but rather the storage for the current storage address *based* on the codex.

There is a special case to be aware of -- as you know, currently, failed creation calls all get tagged with a storage address of zero (unless it was the initial call of the transaction).  So, if we didn't account for that, and there were multiple failed creation calls, the zero page of the codex would contain a lot of garbage, and attempting to read storage during a failed creation call would be a total crapshoot.  So instead, we don't maintain a zero page (responsibility for this is split between the reducer, which doesn't add a zero page on `CALL` or `CREATE`, and the saga, which doesn't issue a `STORE` action if the current storage address is zero).  While inside a failed creation call, `evm.current.codex.storage` does not look at the codex, but rather just returns `evm.current.state.storage`.

This is something of a hack, but note that we won't be missing anything this way -- after all, if we're dealing with a failed creation call, there's no other call (even in another transaction) that could have altered this storage, right?  So just using `evm.current.state.storage` is good enough.

(Note that mapping keys for distinct failed creation calls are still not tracked separately -- those will get mixed together.  I don't really consider that a big problem, though.)

Meanwhile, over in `data`, the selector `data.current.state.storage` is now based on `evm.current.codex.storage` rather than `evm.current.state.storage`.  Originally the plan for the codex was a much bigger reorganization, but I'm doing this the lazy way for now.

Finally, in the process of this I had to make a slight alteration to how the reset button works in the `evm` submodule.  You see, the default codex is empty; it relies on that initial `CALL` or `CREATE` to have its first page added.  But right now resetting doesn't work by fully resetting the debugger, so resetting the codex to default will result in that initial page being missing.  So now, the `reset` saga in EVM first reads the initial storage address off the callstack, and the reset action takes this as an argument, and sets up a default codex with that one page already there.  A little bit of a hack, but again, it's not like there's some case it's missing.

I also added a quick test of this new functionality.  There's still much to be done, but missing values in storage should be substantially less of a problem now!