### PR TITLE
Handle non-integer `truffle develop` network_id values

### DIFF
--- a/packages/truffle-core/lib/commands/develop.js
+++ b/packages/truffle-core/lib/commands/develop.js
@@ -84,8 +84,7 @@ const command = {
       ganacheOptions["hardfork"] = customConfig.hardfork;
     }
 
-    function sanitizeNetworkID() {
-      let network_id = ganacheOptions.network_id;
+    function sanitizeNetworkID(network_id) {
       if (network_id !== "*") {
         if (!parseInt(network_id, 10)) {
           const error =
@@ -93,13 +92,14 @@ const command = {
             `(${network_id}) is not valid. Please properly configure the network id as an integer value.`;
           throw new Error(error);
         }
+        return network_id;
       } else {
-        // We have a "*" network. Replace it w/ the default.
-        ganacheOptions.network_id = 5777;
+        // We have a "*" network. Return the default.
+        return 5777;
       }
     }
 
-    sanitizeNetworkID();
+    ganacheOptions.network_id = sanitizeNetworkID(ganacheOptions.network_id);
 
     Develop.connectOrStart(ipcOptions, ganacheOptions, started => {
       const url = `http://${ganacheOptions.host}:${ganacheOptions.port}/`;

--- a/packages/truffle-core/lib/commands/develop.js
+++ b/packages/truffle-core/lib/commands/develop.js
@@ -84,6 +84,23 @@ const command = {
       ganacheOptions["hardfork"] = customConfig.hardfork;
     }
 
+    function sanitizeNetworkID() {
+      let network_id = ganacheOptions.network_id;
+      if (network_id !== "*") {
+        if (!parseInt(network_id, 10)) {
+          const error =
+            `The network id specified in the truffle config ` +
+            `(${network_id}) is not valid. Please properly configure the network id as an integer value.`;
+          throw new Error(error);
+        }
+      } else {
+        // We have a "*" network. Replace it w/ the default.
+        ganacheOptions.network_id = 5777;
+      }
+    }
+
+    sanitizeNetworkID();
+
     Develop.connectOrStart(ipcOptions, ganacheOptions, started => {
       const url = `http://${ganacheOptions.host}:${ganacheOptions.port}/`;
 


### PR DESCRIPTION
This PR is a fix for #1824 .

Since `truffle develop` is now configurable, we need to sanitize & handle invalid `network_id` values.

☕️ 