### PR TITLE
Optimize travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,11 @@ install:
   - npm install -g yarn
   - npm run bootstrap
 
+cache:
+  directories:
+    - node_modules
+    - $(npm config get prefix)/lib/node_modules # globally installed stuff (i.e. lerna)
+
 script:
   - npm run ci
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ dist: trusty
 sudo: required
 language: node_js
 
-services:
-  - docker
-
 before_install:
   - docker pull ethereum/client-go:latest
   - docker pull ethereum/solc:0.4.22

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ before_install:
   - sudo apt-get install solc jq snapd
   - export PATH=$PATH:/snap/bin
   - sudo snap install vyper --beta --devmode
+  - npm list -g lerna --depth=0 || npm install -g lerna
+  - npm install -g yarn
 
 matrix:
   fast_finish: true
@@ -31,8 +33,6 @@ matrix:
 
 
 install:
-  - npm install -g lerna
-  - npm install -g yarn
   - npm run bootstrap
 
 cache:


### PR DESCRIPTION
Remove redundant docker start & cache node_modules.

Appears to save us ~1 min on travis jobs. 🤞 

Would have also cached yarn but couldn't figure out a quick way to have `lerna boostrap` use cached yarn instead of travis' older yucky yarn.