### PR TITLE
Print watch expressions with their values rather than jumbled

### DIFF
--- a/packages/truffle-core/lib/commands/debug.js
+++ b/packages/truffle-core/lib/commands/debug.js
@@ -235,19 +235,17 @@ var command = {
 
           async function printWatchExpressionsResults() {
             debug("enabledExpressions %o", enabledExpressions);
-            await Promise.all(
-              [...enabledExpressions].map(async expression => {
-                config.logger.log(expression);
-                // Add some padding. Note: This won't work with all loggers,
-                // meaning it's not portable. But doing this now so we can get something
-                // pretty until we can build more architecture around this.
-                // Note: Selector results already have padding, so this isn't needed.
-                if (expression[0] === ":") {
-                  process.stdout.write("  ");
-                }
-                await printWatchExpressionResult(expression);
-              })
-            );
+            for (let expression of enabledExpressions) {
+              config.logger.log(expression);
+              // Add some padding. Note: This won't work with all loggers,
+              // meaning it's not portable. But doing this now so we can get something
+              // pretty until we can build more architecture around this.
+              // Note: Selector results already have padding, so this isn't needed.
+              if (expression[0] === ":") {
+                process.stdout.write("  ");
+              }
+              await printWatchExpressionResult(expression);
+            }
           }
 
           async function printWatchExpressionResult(expression) {


### PR DESCRIPTION
Right now, if you have multiple watch expressions, the order of printing is jumbled so that watch expressions don't necessary appear with their corresponding values.  This is because the printing is done with the parallel `Promise.all`.  This PR replaces this with a simple `for` loop so that things print out in order and you can tell which values go with which watch expressions.