### PR TITLE
Prevent {constructor: undefined} problem with watch expressions

### DIFF
--- a/packages/truffle-core/lib/commands/debug.js
+++ b/packages/truffle-core/lib/commands/debug.js
@@ -264,6 +264,8 @@ var command = {
           // TODO make this more robust for all cases and move to
           // truffle-debug-utils
           function formatValue(value, indent) {
+            value = DebugUtils.cleanConstructors(value); //HACK
+
             if (!indent) {
               indent = 0;
             }

--- a/packages/truffle-debug-utils/index.js
+++ b/packages/truffle-debug-utils/index.js
@@ -3,6 +3,7 @@ var dir = require("node-dir");
 var path = require("path");
 var async = require("async");
 var debug = require("debug")("lib:debug");
+var BN = require("bn.js");
 
 var commandReference = {
   "o": "step over",
@@ -265,6 +266,44 @@ var DebugUtils = {
     }
 
     return formatted.join(OS.EOL);
+  },
+
+  //HACK
+  cleanConstructors: function(object) {
+    debug("object %o", object);
+
+    if (object && typeof object.map === "function") {
+      //array case
+      return object.map(DebugUtils.cleanConstructors);
+    }
+
+    try {
+      //we do not want to alter BNs!
+      //(or other special objects, but that's just BNs right now)
+      if (BN.isBN(object)) {
+        return object;
+      }
+    } catch (e) {
+      //HACK
+      //if isBN threw an error, it's not a BN, so move on
+    }
+
+    if (object && typeof object === "object") {
+      //generic object case
+      return Object.assign(
+        {},
+        ...Object.entries(object)
+          .filter(
+            ([key, value]) => key !== "constructor" || value !== undefined
+          )
+          .map(([key, value]) => ({
+            [key]: DebugUtils.cleanConstructors(value)
+          }))
+      );
+    }
+
+    //for strings, numbers, etc
+    return object;
   }
 };
 

--- a/packages/truffle-debug-utils/index.js
+++ b/packages/truffle-debug-utils/index.js
@@ -277,6 +277,16 @@ var DebugUtils = {
       return object.map(DebugUtils.cleanConstructors);
     }
 
+    if (object && object instanceof Map) {
+      //map case
+      return new Map(
+        Array.from(object.entries()).map(([key, value]) => [
+          key,
+          DebugUtils.cleanConstructors(value)
+        ])
+      );
+    }
+
     try {
       //we do not want to alter BNs!
       //(or other special objects, but that's just BNs right now)


### PR DESCRIPTION
Watch expressions have something of a problem with complex objects, as used for representing, say, structs.  If you use a colon expression with such a thing (whether you're making it into a watch expression or not), an unexpected `constructor: undefined` will appear among its properties.  Worse, after doing so, you'll see the same thing even when you just type `v`, which normally does not have this problem!

As best I can tell, this is a problem with `safeEval`, as used by the CLI -- somehow it is altering objects to include this.  That's my inference, anyway.  I don't know how to prevent this, so this PR instead just adds a function to the CLI to strip such things out.  It's pretty hacky, but it seems to work.  Note that the call is made inside `formatValue` in order to prevent the problem with `v` mentioned above; I originally had it inside something more watch-expression-specific, but that failed to handle this case.

Note that if you're not using the CLI, there's no problem here (unless you use `safeEval` in your own code, I guess).  If you are using the CLI, this should solve it.

The need for this should be reduced once we have the new debugger output format, and eliminated once we have Solidity watch expressions (but of course the latter is quite a ways off).  Still, for now, here it is.