### PR TITLE
Fix decoding of empty bytes type in storage

### DIFF
--- a/packages/truffle-decoder/lib/decode/storage.ts
+++ b/packages/truffle-decoder/lib/decode/storage.ts
@@ -189,9 +189,6 @@ export async function decodeStorageReference(definition: DecodeUtils.AstDefiniti
         // string lives in word, length is last byte / 2
         length = lengthByte / 2;
         debug("in-word; length %o", length);
-        if (length == 0) {
-          return "";
-        }
 
         return decodeValue(definition, { storage: {
           from: { slot: pointer.storage.from.slot, index: 0 },


### PR DESCRIPTION
The decoding logic for `string` and `bytes` in storage includes a special case for when the length is 0, returning the empty string.  However for `bytes` we don't want the empty string, we want `"0x"`.  There's really no need for a special case here, so I just deleted it and now it works fine.