### PR TITLE
Document `truffle migrate` --to flag

### DIFF
--- a/packages/truffle-core/lib/commands/migrate.js
+++ b/packages/truffle-core/lib/commands/migrate.js
@@ -20,6 +20,10 @@ var command = {
       describe: "Specify a migration number to run from",
       type: "number"
     },
+    "to": {
+      describe: "Specify a migration number to run to",
+      type: "number"
+    },
     "interactive": {
       describe: "Manually authorize deployments after seeing a preview",
       type: "boolean",
@@ -28,7 +32,7 @@ var command = {
   },
   help: {
     usage:
-      "truffle migrate [--reset] [-f <number>] [--network <name>] [--compile-all] [--verbose-rpc] [--interactive]",
+      "truffle migrate [--reset] [--f <number>] [--to <number>] [--network <name>] [--compile-all] [--verbose-rpc] [--interactive]",
     options: [
       {
         option: "--reset",
@@ -37,10 +41,15 @@ var command = {
           "completed migration."
       },
       {
-        option: "-f <number>",
+        option: "--f <number>",
         description:
           "Run contracts from a specific migration. The number refers to the prefix of " +
           "the migration file."
+      },
+      {
+        option: "--to <number>",
+        description:
+          "Run contracts to a specific migration. The number refers to the prefix of the migration file."
       },
       {
         option: "--network <name>",


### PR DESCRIPTION
Documents the `--to` flag for running migration files up to a specific number.

📝 