### PR TITLE
Fix calldata mapping keys for Solidity 0.5.6

### DIFF
--- a/packages/truffle-debugger/lib/data/selectors/index.js
+++ b/packages/truffle-debugger/lib/data/selectors/index.js
@@ -736,8 +736,33 @@ const data = createSelectorTree({
         return modifierForInvocation(invocation, scopes);
       }
     )
-
     //END HACK WARNING
+  },
+
+  /**
+   * data.nextMapped
+   */
+  nextMapped: {
+    /**
+     * data.nextMapped.state
+     * Yes, I'm just repeating the code for data.current.state.stack here;
+     * not worth the trouble to factor out
+     * HACK: this assumes we're not about to change context! don't use this if we
+     * are!
+     */
+    state: {
+      /**
+       * data.nextMapped.state.stack
+       */
+      stack: createLeaf(
+        [solidity.current.nextMapped],
+
+        step =>
+          ((step || {}).stack || []).map(word =>
+            DecodeUtils.Conversion.toBytes(word)
+          )
+      )
+    }
   }
 });
 

--- a/packages/truffle-debugger/lib/solidity/selectors/index.js
+++ b/packages/truffle-debugger/lib/solidity/selectors/index.js
@@ -10,6 +10,7 @@ import { findRange } from "lib/ast/map";
 import jsonpointer from "json-pointer";
 
 import evm from "lib/evm/selectors";
+import trace from "lib/trace/selectors";
 
 const semver = require("semver");
 
@@ -342,6 +343,19 @@ let solidity = createSelectorTree({
         context.compiler !== undefined && //would be undefined for e.g. a precompile
         context.compiler.name === "solc" &&
         semver.satisfies(context.compiler.version, "<0.5.1")
+    ),
+
+    /*
+     * solidity.current.nextMapped
+     * returns the next trace step after this one which is sourcemapped
+     * HACK: this assumes we're not about to change context! don't use this if
+     * we are!
+     * ALSO, this may return undefined, so be prepared for that
+     */
+    nextMapped: createLeaf(
+      ["./instructionAtProgramCounter", trace.steps, trace.index],
+      (map, steps, index) =>
+        steps.slice(index + 1).find(({ pc }) => map[pc] && map[pc].file !== -1)
     )
   },
 


### PR DESCRIPTION
This PR is a companion to #1839.  It should get us back to where we were before Solidity 0.5.6 came out; namely, it should once again be the case that all mapping keys work except for some constant state variables.  (Well, and `msg.data` -- a case that was in fact already a problem before 0.5.6, but which I failed to notice -- but that's what #1839 is for.)

You see, calldata mapping keys work fine when they're a top-level variable.  And unsurprisingly they work fine when they're value types.  But, if they're of type `bytes` or `string`, and are not top-level but rather are an element of a calldata array or struct, they don't work.  Now, before Solidity 0.5.6, this wasn't a problem, because before Solidity 0.5.6, it wasn't legal to put a `string` or `bytes` inside a calldata array or struct!  But now it is.

So what's the problem, then?  Are the pointers not formatted as we expect, or something?  No, the pointers are formatted as we expect and go onto the stack just as usual.  The problem is *when* they go on to the stack.

You see, the `data` saga normally relies on `solidity.current.isSourceRangeFinal` and `data.next.state.stack` to determine what stack literal to assign to each node; `isSourceRangeFinal` makes sure we're at the last instruction for that node, so that `data.next.state.stack` gets the result after that node is finished.  But what if you had a case where `solidity.current.isSourceRangeFinal` holds, but it's not *really* the last instruction for that node?

This is exactly what happens when you have an index access into a calldata array, or a member access of a calldata struct.  You see, after the last instruction that's actually mapped to that node, Solidity goes into a bunch of unmapped instructions while computing the pointer to put on the stack.  The stack won't actually be ready until these unmapped instructions are done, so just using `data.next.state.stack` at the last *mapped* instruction won't be good enough.

There are a number of solutions to this problem, but here's the one I went with.  I added a selector, `solidity.current.nextMapped`; this returns the next trace step, after the current one, that is sourcemapped.  It's a bit of a hack; it may return undefined, and it won't work properly if we're about to change contexts.  But in the cases where we need it, it should work.  Then, I added a selector `data.nextMapped.state.stack`; this gets the stack (formatted for `data` purposes, i.e., using `Uint8Array`s) at that next mapped step.

Then, in the data saga, I added a variable, `alternateStack`, which is pulled from `data.nextMapped.state.stack`.  In most cases, we continue to use `stack`, i.e., `data.next.state.stack`.  However, if we're in the index access or member access case, we use `alternateStack` instead.  This gets the case of calldata index and member accesses to work correctly, and shouldn't interfere with existing cases (this PR passes all debugger tests, nor have I found any problems in manual testing).  If we're really worried about potential regressions we could further restrict the use of `alternateStack` to when the structure being accessed lives in calldata, but like I said, neither I nor `yarn test` found any problems, so I don't think we need to worry about this.  (Indeed we could really probably use `alternateStack` in every case, but I decided to leave the other cases as they are for simplicity.)

Whew.  OK, hopefully that's the last adjustment I need to make to mapping keys for a long time...