### PR TITLE
Add & document --from flag to `truffle migrate`

### DIFF
--- a/packages/truffle-core/lib/commands/migrate.js
+++ b/packages/truffle-core/lib/commands/migrate.js
@@ -20,6 +20,10 @@ var command = {
       describe: "Specify a migration number to run from",
       type: "number"
     },
+    "from": {
+      describe: "Specify a migration number to run from",
+      type: "number"
+    },
     "to": {
       describe: "Specify a migration number to run to",
       type: "number"
@@ -32,7 +36,7 @@ var command = {
   },
   help: {
     usage:
-      "truffle migrate [--reset] [--f <number>] [--to <number>] [--network <name>] [--compile-all] [--verbose-rpc] [--interactive]",
+      "truffle migrate [--reset] [--f <number> | --from <number>] [--to <number>] [--network <name>] [--compile-all] [--verbose-rpc] [--interactive]",
     options: [
       {
         option: "--reset",
@@ -41,7 +45,7 @@ var command = {
           "completed migration."
       },
       {
-        option: "--f <number>",
+        option: "--f <number> | --from <number>",
         description:
           "Run contracts from a specific migration. The number refers to the prefix of " +
           "the migration file."

--- a/packages/truffle-core/lib/commands/migrate.js
+++ b/packages/truffle-core/lib/commands/migrate.js
@@ -145,8 +145,11 @@ var command = {
     function runMigrations(config, callback) {
       Migrate.launchReporter();
 
-      if (options.f) {
-        Migrate.runFrom(options.f, config, done);
+      // check --f && --from flag usage
+      const from = options.f || options.from;
+
+      if (from) {
+        Migrate.runFrom(from, config, done);
       } else {
         Migrate.needsMigrating(config, function(err, needsMigrating) {
           if (err) return callback(err);


### PR DESCRIPTION
Adds & documents a `--from` flag for running migration files from a specific number.

🎏 