### PR TITLE
Fix compiler cache path

### DIFF
--- a/packages/truffle-compile/compilerSupplier/loadingStrategies/LoadingStrategy.js
+++ b/packages/truffle-compile/compilerSupplier/loadingStrategies/LoadingStrategy.js
@@ -17,7 +17,7 @@ class LoadingStrategy {
 
     const compilerCachePath = path.resolve(
       Config.getTruffleDataDirectory(),
-      "compilers"
+      "compilers/node_modules" // because babel binds to require & does weird things
     );
     if (!fs.existsSync(compilerCachePath)) fs.mkdirSync(compilerCachePath);
     this.compilerCachePath = compilerCachePath;

--- a/packages/truffle-compile/compilerSupplier/loadingStrategies/LoadingStrategy.js
+++ b/packages/truffle-compile/compilerSupplier/loadingStrategies/LoadingStrategy.js
@@ -15,15 +15,17 @@ class LoadingStrategy {
     };
     this.config = Object.assign({}, defaultConfig, options);
 
-    let compilerCachePath = path.resolve(
+    const compilersDir = path.resolve(
       Config.getTruffleDataDirectory(),
       "compilers"
     );
-    if (!fs.existsSync(compilerCachePath)) {
-      fs.mkdirSync(compilerCachePath);
-      compilerCachePath = path.resolve(compilerCachePath, "node_modules"); // because babel binds to require & does weird things
+    const compilerCachePath = path.resolve(compilersDir, "node_modules"); // because babel binds to require & does weird things
+    if (!fs.existsSync(compilersDir)) {
+      fs.mkdirSync(compilerDir);
       fs.mkdirSync(compilerCachePath);
     }
+    if (!fs.existsSync(compilerCachePath)) fs.mkdirSync(compilerCachePath); // for 5.0.8 users
+
     this.compilerCachePath = compilerCachePath;
   }
 

--- a/packages/truffle-compile/compilerSupplier/loadingStrategies/LoadingStrategy.js
+++ b/packages/truffle-compile/compilerSupplier/loadingStrategies/LoadingStrategy.js
@@ -15,11 +15,15 @@ class LoadingStrategy {
     };
     this.config = Object.assign({}, defaultConfig, options);
 
-    const compilerCachePath = path.resolve(
+    let compilerCachePath = path.resolve(
       Config.getTruffleDataDirectory(),
-      "compilers/node_modules" // because babel binds to require & does weird things
+      "compilers"
     );
-    if (!fs.existsSync(compilerCachePath)) fs.mkdirSync(compilerCachePath);
+    if (!fs.existsSync(compilerCachePath)) {
+      fs.mkdirSync(compilerCachePath);
+      compilerCachePath += "/node_modules"; // because babel binds to require & does weird things
+      fs.mkdirSync(compilerCachePath);
+    }
     this.compilerCachePath = compilerCachePath;
   }
 

--- a/packages/truffle-compile/compilerSupplier/loadingStrategies/LoadingStrategy.js
+++ b/packages/truffle-compile/compilerSupplier/loadingStrategies/LoadingStrategy.js
@@ -21,7 +21,7 @@ class LoadingStrategy {
     );
     if (!fs.existsSync(compilerCachePath)) {
       fs.mkdirSync(compilerCachePath);
-      compilerCachePath += "/node_modules"; // because babel binds to require & does weird things
+      compilerCachePath = path.resolve(compilerCachePath, "node_modules"); // because babel binds to require & does weird things
       fs.mkdirSync(compilerCachePath);
     }
     this.compilerCachePath = compilerCachePath;

--- a/packages/truffle-compile/compilerSupplier/loadingStrategies/LoadingStrategy.js
+++ b/packages/truffle-compile/compilerSupplier/loadingStrategies/LoadingStrategy.js
@@ -21,7 +21,7 @@ class LoadingStrategy {
     );
     const compilerCachePath = path.resolve(compilersDir, "node_modules"); // because babel binds to require & does weird things
     if (!fs.existsSync(compilersDir)) {
-      fs.mkdirSync(compilerDir);
+      fs.mkdirSync(compilersDir);
       fs.mkdirSync(compilerCachePath);
     }
     if (!fs.existsSync(compilerCachePath)) fs.mkdirSync(compilerCachePath); // for 5.0.8 users

--- a/packages/truffle-compile/compilerSupplier/loadingStrategies/LoadingStrategy.js
+++ b/packages/truffle-compile/compilerSupplier/loadingStrategies/LoadingStrategy.js
@@ -20,10 +20,7 @@ class LoadingStrategy {
       "compilers"
     );
     const compilerCachePath = path.resolve(compilersDir, "node_modules"); // because babel binds to require & does weird things
-    if (!fs.existsSync(compilersDir)) {
-      fs.mkdirSync(compilersDir);
-      fs.mkdirSync(compilerCachePath);
-    }
+    if (!fs.existsSync(compilersDir)) fs.mkdirSync(compilersDir);
     if (!fs.existsSync(compilerCachePath)) fs.mkdirSync(compilerCachePath); // for 5.0.8 users
 
     this.compilerCachePath = compilerCachePath;

--- a/packages/truffle-compile/test/test_supplier.js
+++ b/packages/truffle-compile/test/test_supplier.js
@@ -125,7 +125,7 @@ describe("CompilerSupplier", function() {
 
       const compilerCacheDirectory = path.resolve(
         Config.getTruffleDataDirectory(),
-        "compilers"
+        "compilers/node_modules"
       );
       const expectedCache = path.resolve(
         compilerCacheDirectory,


### PR DESCRIPTION
Change the `compilerCachePath` to cache compilers in a `node_modules` directory (`~/.config/truffle/compilers/node_modules/`).
This helps truffle users avoid the issue outlined in #1813.

Also indirectly related to #1835 .