### PR TITLE
Add support for globally-available variables

### DIFF
--- a/packages/truffle-debug-utils/index.js
+++ b/packages/truffle-debug-utils/index.js
@@ -314,6 +314,17 @@ var DebugUtils = {
 
     //for strings, numbers, etc
     return object;
+  },
+
+  //HACK
+  cleanThis: function(variables, replacement) {
+    return Object.assign(
+      {},
+      ...Object.entries(variables).map(
+        ([variable, value]) =>
+          variable === "this" ? { [replacement]: value } : { [variable]: value }
+      )
+    );
   }
 };
 

--- a/packages/truffle-debugger/lib/data/sagas/index.js
+++ b/packages/truffle-debugger/lib/data/sagas/index.js
@@ -3,7 +3,7 @@ const debug = debugModule("debugger:data:sagas");
 
 import { put, takeEvery, select, call } from "redux-saga/effects";
 
-import { prefixName, stableKeccak256 } from "lib/helpers";
+import { prefixName, stableKeccak256, makeAssignment } from "lib/helpers";
 
 import { TICK } from "lib/trace/actions";
 import * as actions from "../actions";
@@ -520,11 +520,6 @@ export function* recordAllocations() {
   yield put(
     actions.allocate(storageAllocations, memoryAllocations, calldataAllocations)
   );
-}
-
-function makeAssignment(idObj, ref) {
-  let id = stableKeccak256(idObj);
-  return { ...idObj, id, ref };
 }
 
 function literalAssignments(node, stack, currentDepth) {

--- a/packages/truffle-debugger/lib/data/selectors/index.js
+++ b/packages/truffle-debugger/lib/data/selectors/index.js
@@ -575,20 +575,22 @@ const data = createSelectorTree({
         ["/views/scopes/inlined", "/current/node"],
 
         (scopes, scope) => {
-          let cur = scope.id;
           let variables = {};
+          if (scope !== undefined) {
+            let cur = scope.id;
 
-          do {
-            variables = Object.assign(
-              variables,
-              ...(scopes[cur].variables || [])
-                .filter(v => v.name !== "") //exclude anonymous output params
-                .filter(v => variables[v.name] == undefined)
-                .map(v => ({ [v.name]: { astId: v.id } }))
-            );
+            do {
+              variables = Object.assign(
+                variables,
+                ...(scopes[cur].variables || [])
+                  .filter(v => v.name !== "") //exclude anonymous output params
+                  .filter(v => variables[v.name] == undefined)
+                  .map(v => ({ [v.name]: { astId: v.id } }))
+              );
 
-            cur = scopes[cur].parentId;
-          } while (cur != null);
+              cur = scopes[cur].parentId;
+            } while (cur != null);
+          }
 
           let builtins = {
             msg: { builtin: "msg" },

--- a/packages/truffle-debugger/lib/data/selectors/index.js
+++ b/packages/truffle-debugger/lib/data/selectors/index.js
@@ -367,7 +367,7 @@ const data = createSelectorTree({
       ),
 
       /*
-       * data.current.specials
+       * data.current.state.specials
        * I've named these after the solidity variables they correspond to,
        * which are *mostly* the same as the corresponding EVM opcodes
        * (FWIW: this = ADDRESS, sender = CALLER, value = CALLVALUE)

--- a/packages/truffle-debugger/lib/evm/actions/index.js
+++ b/packages/truffle-debugger/lib/evm/actions/index.js
@@ -1,10 +1,11 @@
 export const ADD_CONTEXT = "EVM_ADD_CONTEXT";
-export function addContext(contractName, raw, compiler) {
+export function addContext(contractName, raw, compiler, contractId) {
   return {
     type: ADD_CONTEXT,
     contractName,
     raw,
-    compiler
+    compiler,
+    contractId
   };
 }
 
@@ -27,22 +28,36 @@ export function addInstance(address, context, binary) {
   };
 }
 
+export const SAVE_GLOBALS = "SAVE_GLOBALS";
+export function saveGlobals(origin, gasprice, block) {
+  return {
+    type: SAVE_GLOBALS,
+    origin,
+    gasprice,
+    block
+  };
+}
+
 export const CALL = "CALL";
-export function call(address, data, storageAddress) {
+export function call(address, data, storageAddress, sender, value) {
   return {
     type: CALL,
     address,
     data,
-    storageAddress
+    storageAddress,
+    sender,
+    value
   };
 }
 
 export const CREATE = "CREATE";
-export function create(binary, storageAddress) {
+export function create(binary, storageAddress, sender, value) {
   return {
     type: CREATE,
     binary,
-    storageAddress
+    storageAddress,
+    sender,
+    value
   };
 }
 

--- a/packages/truffle-debugger/lib/evm/reducers.js
+++ b/packages/truffle-debugger/lib/evm/reducers.js
@@ -1,8 +1,13 @@
+import debugModule from "debug";
+const debug = debugModule("debugger:evm:reducers");
+
 import { combineReducers } from "redux";
 
 import * as actions from "./actions";
 import { keccak256 } from "lib/helpers";
 import * as DecodeUtils from "truffle-decode-utils";
+
+import BN from "bn.js";
 
 const DEFAULT_CONTEXTS = {
   byContext: {},
@@ -15,7 +20,7 @@ function contexts(state = DEFAULT_CONTEXTS, action) {
      * Adding a new context
      */
     case actions.ADD_CONTEXT: {
-      const { contractName, raw, compiler } = action;
+      const { contractName, raw, compiler, contractId } = action;
       const context = keccak256(raw);
 
       return {
@@ -29,7 +34,8 @@ function contexts(state = DEFAULT_CONTEXTS, action) {
 
             contractName,
             context,
-            compiler
+            compiler,
+            contractId
           }
         }
       };
@@ -114,23 +120,61 @@ function instances(state = DEFAULT_INSTANCES, action) {
   }
 }
 
-const info = combineReducers({
-  contexts,
-  instances
+const DEFAULT_TX = {
+  gasprice: new BN(0),
+  origin: DecodeUtils.EVM.ZERO_ADDRESS
+};
+
+function tx(state = DEFAULT_TX, action) {
+  if (action.type === actions.SAVE_GLOBALS) {
+    let { gasprice, origin } = action;
+    return { gasprice, origin };
+  } else {
+    return state;
+  }
+}
+
+const DEFAULT_BLOCK = {
+  coinbase: DecodeUtils.EVM.ZERO_ADDRESS,
+  difficulty: new BN(0),
+  gaslimit: new BN(0),
+  number: new BN(0),
+  timestamp: new BN(0)
+};
+
+function block(state = DEFAULT_BLOCK, action) {
+  if (action.type === actions.SAVE_GLOBALS) {
+    debug("action %O", action);
+    return action.block;
+  } else {
+    return state;
+  }
+}
+
+const globals = combineReducers({
+  tx,
+  block
 });
 
-export function callstack(state = [], action) {
+const info = combineReducers({
+  contexts,
+  instances,
+  globals
+});
+
+function callstack(state = [], action) {
   switch (action.type) {
     case actions.CALL: {
-      const { address, data, storageAddress } = action;
-      return state.concat([{ address, data, storageAddress }]);
+      const { address, data, storageAddress, sender, value } = action;
+      return state.concat([{ address, data, storageAddress, sender, value }]);
     }
 
     case actions.CREATE: {
-      const { binary, storageAddress } = action;
-      return state.concat([{ binary, data: "0x", storageAddress }]);
-      //note: the empty data for creation calls doesn't matter right now, but
-      //it will once I implement globally available variables
+      const { binary, storageAddress, sender, value } = action;
+      return state.concat(
+        [{ binary, data: "0x", storageAddress, sender, value }]
+        //the empty data field is to make msg.data and msg.sig come out right
+      );
     }
 
     case actions.RETURN:
@@ -164,7 +208,7 @@ function defaultCodex(address) {
   };
 }
 
-export function codex(state = DEFAULT_CODEX, action) {
+function codex(state = DEFAULT_CODEX, action) {
   switch (action.type) {
     case actions.CALL:
     case actions.CREATE:

--- a/packages/truffle-debugger/lib/evm/sagas/index.js
+++ b/packages/truffle-debugger/lib/evm/sagas/index.js
@@ -110,9 +110,7 @@ export function* callstackAndCodexSaga() {
       let storageAddress = (yield select(evm.current.step.isDelegateCallBroad))
         ? currentCall.storageAddress //for CALLCODE
         : address;
-      let sender = currentCall.address || currentCall.storageAddress;
-      //if calling from a creation call, sender will be the address the
-      //contract will be created at, which can be found in storageAddress
+      let sender = currentCall.storageAddress; //not the code address!
       let value = yield select(evm.current.step.callValue); //0 if static
       yield put(actions.call(address, data, storageAddress, sender, value));
     }
@@ -121,11 +119,10 @@ export function* callstackAndCodexSaga() {
     let binary = yield select(evm.current.step.createBinary);
     let createdAddress = yield select(evm.current.step.createdAddress);
     let value = yield select(evm.current.step.createValue);
-    let { address, storageAddress } = yield select(evm.current.call);
+    let sender = (yield select(evm.current.call)).storageAddress;
+    //not the code address!
 
-    yield put(
-      actions.create(binary, createdAddress, address || storageAddress, value)
-    );
+    yield put(actions.create(binary, createdAddress, sender, value));
     //as above, storageAddress handles when calling from a creation call
   } else if (yield select(evm.current.step.isHalting)) {
     debug("got return");

--- a/packages/truffle-debugger/lib/evm/sagas/index.js
+++ b/packages/truffle-debugger/lib/evm/sagas/index.js
@@ -18,11 +18,16 @@ import * as trace from "lib/trace/sagas";
  *
  * @return {string} ID (0x-prefixed keccak of binary)
  */
-export function* addContext(contractName, { address, binary }, compiler) {
+export function* addContext(
+  contractName,
+  { address, binary },
+  compiler,
+  contractId
+) {
   const raw = binary || address;
   const context = keccak256(raw);
 
-  yield put(actions.addContext(contractName, raw, compiler));
+  yield put(actions.addContext(contractName, raw, compiler, contractId));
 
   if (binary) {
     yield put(actions.addBinary(context, binary));
@@ -51,11 +56,21 @@ export function* addInstance(address, binary) {
   return context;
 }
 
-export function* begin({ address, binary, data, storageAddress }) {
+export function* begin({
+  address,
+  binary,
+  data,
+  storageAddress,
+  sender,
+  value,
+  gasprice,
+  block
+}) {
+  yield put(actions.saveGlobals(sender, gasprice, block));
   if (address) {
-    yield put(actions.call(address, data, storageAddress));
+    yield put(actions.call(address, data, storageAddress, sender, value));
   } else {
-    yield put(actions.create(binary, storageAddress));
+    yield put(actions.create(binary, storageAddress, sender, value));
   }
 }
 
@@ -74,27 +89,44 @@ export function* callstackAndCodexSaga() {
 
     debug("calling address %s", address);
 
+    debug("step", yield select(evm.current.step.trace));
+
     // if there is no binary (e.g. in the case of precompiled contracts),
     // then there will be no trace steps for the called code, and so we
     // shouldn't tell the debugger that we're entering another execution
     // context
+    // (This also catches calls to externally-owned accounts rather than
+    // contract accounts)
     if (yield select(evm.current.step.callsPrecompile)) {
       return;
     }
-    if (yield select(evm.current.step.isDelegateCallBroad)) {
-      //if delegating, keep same storage address we already have
-      let storageAddress = (yield select(evm.current.call)).storageAddress;
-      yield put(actions.call(address, data, storageAddress));
+    if (yield select(evm.current.step.isDelegateCallStrict)) {
+      //if delegating, leave storageAddress, sender, and value the same
+      let { storageAddress, sender, value } = yield select(evm.current.call);
+      yield put(actions.call(address, data, storageAddress, sender, value));
     } else {
-      //if we're not delegating storage, storageAddress == address
-      yield put(actions.call(address, data, address));
+      //this branch covers CALL, CALLCODE, and STATICCALL
+      let currentCall = yield select(evm.current.call);
+      let storageAddress = (yield select(evm.current.step.isDelegateCallBroad))
+        ? currentCall.storageAddress //for CALLCODE
+        : address;
+      let sender = currentCall.address || currentCall.storageAddress;
+      //if calling from a creation call, sender will be the address the
+      //contract will be created at, which can be found in storageAddress
+      let value = yield select(evm.current.step.callValue); //0 if static
+      yield put(actions.call(address, data, storageAddress, sender, value));
     }
   } else if (yield select(evm.current.step.isCreate)) {
     debug("got create");
     let binary = yield select(evm.current.step.createBinary);
     let createdAddress = yield select(evm.current.step.createdAddress);
+    let value = yield select(evm.current.step.createValue);
+    let { address, storageAddress } = yield select(evm.current.call);
 
-    yield put(actions.create(binary, createdAddress));
+    yield put(
+      actions.create(binary, createdAddress, address || storageAddress, value)
+    );
+    //as above, storageAddress handles when calling from a creation call
   } else if (yield select(evm.current.step.isHalting)) {
     debug("got return");
 

--- a/packages/truffle-debugger/lib/evm/selectors/index.js
+++ b/packages/truffle-debugger/lib/evm/selectors/index.js
@@ -3,6 +3,7 @@ const debug = debugModule("debugger:evm:selectors"); // eslint-disable-line no-u
 
 import { createSelectorTree, createLeaf } from "reselect-tree";
 import levenshtein from "fast-levenshtein";
+import BN from "bn.js";
 
 import trace from "lib/trace/selectors";
 
@@ -11,7 +12,9 @@ import {
   isCallMnemonic,
   isCreateMnemonic,
   isShortCallMnemonic,
-  isDelegateCallMnemonicBroad
+  isDelegateCallMnemonicBroad,
+  isDelegateCallMnemonicStrict,
+  isStaticCallMnemonic
 } from "lib/helpers";
 
 function findContext({ address, binary }, instances, search, contexts) {
@@ -77,10 +80,26 @@ function createStepSelectors(step, state = null) {
     /**
      * .isDelegateCallBroad
      *
-     * for calls delegate storage
+     * for calls that delegate storage
      */
     isDelegateCallBroad: createLeaf(["./trace"], step =>
       isDelegateCallMnemonicBroad(step.op)
+    ),
+
+    /**
+     * .isDelegateCallStrict
+     *
+     * for calls that additionally delegate sender and value
+     */
+    isDelegateCallStrict: createLeaf(["./trace"], step =>
+      isDelegateCallMnemonicStrict(step.op)
+    ),
+
+    /**
+     * .isStaticCall
+     */
+    isStaticCall: createLeaf(["./trace"], step =>
+      isStaticCallMnemonic(step.op)
     ),
 
     /**
@@ -195,6 +214,43 @@ function createStepSelectors(step, state = null) {
       ),
 
       /**
+       * .callValue
+       *
+       * value for the call (not create); returns null for DELEGATECALL
+       */
+      callValue: createLeaf(
+        ["./isCall", "./isDelegateCallStrict", "./isStaticCall", state],
+        (calls, delegates, isStatic, { stack }) => {
+          if (!calls || delegates) {
+            return null;
+          }
+
+          if (isStatic) {
+            return new BN(0);
+          }
+
+          //otherwise, for CALL and CALLCODE, it's the 3rd argument
+          let value = stack[stack.length - 3];
+          return DecodeUtils.Conversion.toBN(value);
+        }
+      ),
+
+      /**
+       * .createValue
+       *
+       * value for the create
+       */
+      createValue: createLeaf(["./isCreate", state], (matches, { stack }) => {
+        if (!matches) {
+          return null;
+        }
+
+        //creates have the value as the first argument
+        let value = stack[stack.length - 1];
+        return DecodeUtils.Conversion.toBN(value);
+      }),
+
+      /**
        * .callContext
        *
        * context for what we're about to call into (or create)
@@ -215,6 +271,7 @@ function createStepSelectors(step, state = null) {
        * .callsPrecompile
        *
        * is the call address to a precompiled contract?
+       * NOTE: this also handles calls to externally-owned accounts
        * HACK
        */
       callsPrecompile: createLeaf(
@@ -313,6 +370,20 @@ const evm = createSelectorTree({
 
         return {};
       })
+    },
+
+    /*
+     * evm.info.globals
+     */
+    globals: {
+      /*
+       * evm.info.globals.tx
+       */
+      tx: createLeaf(["/state"], state => state.info.globals.tx),
+      /*
+       * evm.info.globals.block
+       */
+      block: createLeaf(["/state"], state => state.info.globals.block)
     }
   },
 

--- a/packages/truffle-debugger/lib/helpers/index.js
+++ b/packages/truffle-debugger/lib/helpers/index.js
@@ -27,6 +27,15 @@ export function stableKeccak256(obj) {
 }
 
 /*
+ * used by data; takes an id object and a ref (pointer) and returns a full
+ * corresponding assignment object
+ */
+export function makeAssignment(idObj, ref) {
+  let id = stableKeccak256(idObj);
+  return { ...idObj, id, ref };
+}
+
+/*
  * Given a mmemonic, determine whether it's the mnemonic of a calling
  * instruction (does NOT include creation instructions)
  */
@@ -44,11 +53,27 @@ export function isShortCallMnemonic(op) {
 }
 
 /*
- * returns true for mnemonics call and delegate storage
+ * returns true for mnemonics for calls that delegate storage
  */
 export function isDelegateCallMnemonicBroad(op) {
-  const shortCalls = ["DELEGATECALL", "CALLCODE"];
-  return shortCalls.includes(op);
+  const delegateCalls = ["DELEGATECALL", "CALLCODE"];
+  return delegateCalls.includes(op);
+}
+
+/*
+ * returns true for mnemonics for calls that delegate everything
+ */
+export function isDelegateCallMnemonicStrict(op) {
+  const delegateCalls = ["DELEGATECALL"];
+  return delegateCalls.includes(op);
+}
+
+/*
+ * returns true for mnemonics for static calls
+ */
+export function isStaticCallMnemonic(op) {
+  const delegateCalls = ["STATICCALL"];
+  return delegateCalls.includes(op);
 }
 
 /*

--- a/packages/truffle-debugger/lib/session/actions/index.js
+++ b/packages/truffle-debugger/lib/session/actions/index.js
@@ -3,14 +3,14 @@ export function start(txHash, provider) {
   return {
     type: START,
     txHash,
-provider
+    provider
   };
 }
 
 export const READY = "SESSION_READY";
 export function ready() {
   return {
-    type: READY,
+    type: READY
   };
 }
 
@@ -27,7 +27,7 @@ export function recordContracts(contexts, sources) {
   return {
     type: RECORD_CONTRACTS,
     contexts,
-sources
+    sources
   };
 }
 
@@ -44,5 +44,13 @@ export function saveReceipt(receipt) {
   return {
     type: SAVE_RECEIPT,
     receipt
+  };
+}
+
+export const SAVE_BLOCK = "SAVE_BLOCK";
+export function saveBlock(block) {
+  return {
+    type: SAVE_BLOCK,
+    block
   };
 }

--- a/packages/truffle-debugger/lib/session/index.js
+++ b/packages/truffle-debugger/lib/session/index.js
@@ -81,13 +81,21 @@ export default class Session {
       debug("sourceMap %o", sourceMap);
       debug("compiler %o", compiler);
 
+      let contractId = ast.nodes.find(
+        node =>
+          node.nodeType === "ContractDefinition" && node.name === contractName
+      ).id; //could also record contractKind, but we don't need to
+
+      debug("contractId %d", contractId);
+
       sourcesByPath[sourcePath] = { sourcePath, source, ast };
 
       if (binary && binary != "0x") {
         contexts.push({
           contractName,
           binary,
-          sourceMap
+          sourceMap,
+          contractId
         });
       }
 
@@ -96,7 +104,8 @@ export default class Session {
           contractName,
           binary: deployedBinary,
           sourceMap: deployedSourceMap,
-          compiler
+          compiler,
+          contractId
         });
       }
     }

--- a/packages/truffle-debugger/lib/session/reducers.js
+++ b/packages/truffle-debugger/lib/session/reducers.js
@@ -12,7 +12,7 @@ export const WAITING = "WAITING";
 export const ACTIVE = "ACTIVE";
 export const ERROR = "ERROR";
 
-export function status(state = WAITING, action) {
+function status(state = WAITING, action) {
   switch (action.type) {
     case actions.READY:
       return ACTIVE;
@@ -25,8 +25,8 @@ export function status(state = WAITING, action) {
   }
 }
 
-export function transaction(state = {}, action) {
-  switch(action.type) {
+function transaction(state = {}, action) {
+  switch (action.type) {
     case actions.SAVE_TRANSACTION:
       return action.transaction;
     default:
@@ -34,10 +34,19 @@ export function transaction(state = {}, action) {
   }
 }
 
-export function receipt(state = {}, action) {
-  switch(action.type) {
+function receipt(state = {}, action) {
+  switch (action.type) {
     case actions.SAVE_RECEIPT:
       return action.receipt;
+    default:
+      return state;
+  }
+}
+
+function block(state = {}, action) {
+  switch (action.type) {
+    case actions.SAVE_BLOCK:
+      return action.block;
     default:
       return state;
   }
@@ -46,7 +55,8 @@ export function receipt(state = {}, action) {
 const session = combineReducers({
   status,
   transaction,
-  receipt
+  receipt,
+  block
 });
 
 const reduceState = combineReducers({

--- a/packages/truffle-debugger/lib/session/sagas/index.js
+++ b/packages/truffle-debugger/lib/session/sagas/index.js
@@ -99,8 +99,14 @@ function* fetchTx(txHash, provider) {
 }
 
 function* recordContexts(...contexts) {
-  for (let { contractName, binary, sourceMap, compiler } of contexts) {
-    yield* evm.addContext(contractName, { binary }, compiler);
+  for (let {
+    contractName,
+    binary,
+    sourceMap,
+    compiler,
+    contractId
+  } of contexts) {
+    yield* evm.addContext(contractName, { binary }, compiler, contractId);
 
     if (sourceMap) {
       yield* solidity.addSourceMap(binary, sourceMap);

--- a/packages/truffle-debugger/lib/session/sagas/index.js
+++ b/packages/truffle-debugger/lib/session/sagas/index.js
@@ -115,8 +115,7 @@ function* recordContexts(...contexts) {
 }
 
 function* recordSources(...sources) {
-  for (let i = 0; i < sources.length; i++) {
-    const sourceData = sources[i];
+  for (let sourceData of sources) {
     if (sourceData !== undefined && sourceData !== null) {
       yield* solidity.addSource(
         sourceData.source,

--- a/packages/truffle-debugger/lib/session/selectors/index.js
+++ b/packages/truffle-debugger/lib/session/selectors/index.js
@@ -11,58 +11,65 @@ const session = createSelectorTree({
    * session.info
    */
   info: {
-
     /**
      * session.info.affectedInstances
      */
     affectedInstances: createLeaf(
-      [evm.info.instances, evm.info.contexts, solidity.info.sources, solidity.info.sourceMaps],
+      [
+        evm.info.instances,
+        evm.info.contexts,
+        solidity.info.sources,
+        solidity.info.sourceMaps
+      ],
 
-      (instances, contexts, sources, sourceMaps) => Object.assign({},
-        ...Object.entries(instances).map(
-          ([address, {context}]) => {
+      (instances, contexts, sources, sourceMaps) =>
+        Object.assign(
+          {},
+          ...Object.entries(instances).map(([address, { context }]) => {
             debug("instances %O", instances);
             debug("contexts %O", contexts);
             let { contractName, binary } = contexts[context];
             let { sourceMap } = sourceMaps[context] || {};
 
-            let { source } = sourceMap ?
-              // look for source ID between second and third colons (HACK)
-              sources[sourceMap.match(/^[^:]+:[^:]+:([^:]+):/)[1]] :
-              {};
+            let { source } = sourceMap
+              ? // look for source ID between second and third colons (HACK)
+                sources[sourceMap.match(/^[^:]+:[^:]+:([^:]+):/)[1]]
+              : {};
 
             return {
               [address]: {
-                contractName, source, binary
+                contractName,
+                source,
+                binary
               }
             };
-          }
+          })
         )
-      )
     )
-
   },
-
 
   /**
    * session.transaction (namespace)
    */
   transaction: {
-
     /**
      * session.transaction (selector)
      * contains the web3 transaction object
      */
-    _: (state) => state.session.transaction,
+    _: state => state.session.transaction,
 
     /**
      * session.transaction.receipt
      * contains the web3 receipt object
      */
-    receipt: (state) => state.session.receipt,
+    receipt: state => state.session.receipt,
 
+    /**
+     * session.transaction.block
+     * contains the web3 block object
+     */
+    block: state => state.session.block
   }
-  
 });
 
 export default session;

--- a/packages/truffle-debugger/lib/solidity/reducers.js
+++ b/packages/truffle-debugger/lib/solidity/reducers.js
@@ -77,7 +77,7 @@ const info = combineReducers({
   sourceMaps
 });
 
-export function functionDepth(state = 0, action) {
+function functionDepth(state = 0, action) {
   switch (action.type) {
     case actions.JUMP:
       const delta = spelunk(action.jumpDirection);

--- a/packages/truffle-debugger/lib/trace/reducers.js
+++ b/packages/truffle-debugger/lib/trace/reducers.js
@@ -2,7 +2,7 @@ import { combineReducers } from "redux";
 
 import * as actions from "./actions";
 
-export function index(state = 0, action) {
+function index(state = 0, action) {
   switch (action.type) {
     case actions.TOCK:
       return state + 1;
@@ -15,7 +15,7 @@ export function index(state = 0, action) {
   }
 }
 
-export function finished(state = false, action) {
+function finished(state = false, action) {
   switch (action.type) {
     case actions.END_OF_TRACE:
       return true;
@@ -28,7 +28,7 @@ export function finished(state = false, action) {
   }
 }
 
-export function steps(state = null, action) {
+function steps(state = null, action) {
   if (action.type === actions.SAVE_STEPS) {
     return action.steps;
   } else {

--- a/packages/truffle-debugger/lib/web3/actions/index.js
+++ b/packages/truffle-debugger/lib/web3/actions/index.js
@@ -40,14 +40,28 @@ export function receiveTrace(trace) {
 }
 
 export const RECEIVE_CALL = "RECEIVE_CALL";
-export function receiveCall({ address, binary, data, storageAddress, status }) {
+export function receiveCall({
+  address,
+  binary,
+  data,
+  storageAddress,
+  status,
+  sender,
+  value,
+  gasprice,
+  block
+}) {
   return {
     type: RECEIVE_CALL,
     address,
     binary,
     data,
     storageAddress,
-    status //only used for creation calls at present!
+    status, //only used for creation calls at present!
+    sender,
+    value,
+    gasprice,
+    block
   };
 }
 

--- a/packages/truffle-debugger/lib/web3/adapter.js
+++ b/packages/truffle-debugger/lib/web3/adapter.js
@@ -1,8 +1,7 @@
 import debugModule from "debug";
+const debug = debugModule("debugger:web3:adapter");
 
 import Web3 from "web3";
-
-const debug = debugModule("debugger:web3:adapter");
 
 export default class Web3Adapter {
   constructor(provider) {
@@ -10,40 +9,35 @@ export default class Web3Adapter {
   }
 
   async getTrace(txHash) {
-    return new Promise( (accept, reject) => {
-      this.web3.currentProvider.send({
-        jsonrpc: "2.0",
-        method: "debug_traceTransaction",
-        params: [txHash, {}],
-        id: new Date().getTime()
-      }, (err, result) => {
-        if (err) return reject(err);
-        if (result.error) return reject(new Error(result.error.message));
-        debug("result: %o", result);
-        accept(result.result.structLogs);
-      });
+    return new Promise((accept, reject) => {
+      this.web3.currentProvider.send(
+        {
+          jsonrpc: "2.0",
+          method: "debug_traceTransaction",
+          params: [txHash, {}],
+          id: new Date().getTime()
+        },
+        (err, result) => {
+          if (err) return reject(err);
+          if (result.error) return reject(new Error(result.error.message));
+          debug("result: %o", result);
+          accept(result.result.structLogs);
+        }
+      );
     });
-  };
+  }
 
   async getTransaction(txHash) {
-    return new Promise( (accept, reject) => {
-      this.web3.eth.getTransaction(txHash, (err, tx) => {
-        if (err) return reject(err);
-
-        return accept(tx);
-      });
-    });
-  };
+    return await this.web3.eth.getTransaction(txHash);
+  }
 
   async getReceipt(txHash) {
-    return new Promise( (accept, reject) => {
-      this.web3.eth.getTransactionReceipt(txHash, (err, receipt) => {
-        if (err) return reject(err);
+    return await this.web3.eth.getTransactionReceipt(txHash);
+  }
 
-        return accept(receipt);
-      });
-    });
-  };
+  async getBlock(blockNumberOrHash) {
+    return await this.web3.eth.getBlock(blockNumberOrHash);
+  }
 
   /**
    * getDeployedCode - get the deployed code for an address from the client
@@ -52,13 +46,6 @@ export default class Web3Adapter {
    */
   async getDeployedCode(address) {
     debug("getting deployed code for %s", address);
-    return new Promise((accept, reject) => {
-      this.web3.eth.getCode(address, (err, deployedBinary) => {
-        if (err) debug("error: %o", err);
-        if (err) return reject(err);
-        debug("got deployed code for %s", address);
-        accept(deployedBinary);
-      });
-    });
-  };
+    return await this.web3.eth.getCode(address);
+  }
 }

--- a/packages/truffle-debugger/lib/web3/sagas/index.js
+++ b/packages/truffle-debugger/lib/web3/sagas/index.js
@@ -16,6 +16,8 @@ import * as actions from "../actions";
 import * as session from "lib/session/actions";
 
 import BN from "bn.js";
+import Web3 from "web3"; //just for utils!
+import * as DecodeUtils from "truffle-decode-utils";
 
 import Web3Adapter from "../adapter";
 
@@ -65,14 +67,14 @@ function* fetchTransactionInfo(adapter, { txHash }) {
         block: solidityBlock
       })
     );
-    return;
-  }
-
-  if (receipt.contractAddress) {
+  } else {
+    let storageAddress = Web3.utils.isAddress(receipt.contractAddress)
+      ? receipt.contractAddress
+      : DecodeUtils.EVM.ZERO_ADDRESS;
     yield put(
       actions.receiveCall({
         binary: tx.input,
-        storageAddress: receipt.contractAddress,
+        storageAddress,
         status: receipt.status,
         sender: tx.from,
         value: new BN(tx.value),
@@ -80,14 +82,7 @@ function* fetchTransactionInfo(adapter, { txHash }) {
         block: solidityBlock
       })
     );
-    return;
   }
-
-  throw new Error(
-    "Could not find contract associated with transaction. " +
-      "Please make sure you're debugging a transaction that executes a " +
-      "contract function or creates a new contract."
-  );
 }
 
 function* fetchBinary(adapter, { address }) {

--- a/packages/truffle-debugger/test/data/calldata.js
+++ b/packages/truffle-debugger/test/data/calldata.js
@@ -151,7 +151,7 @@ describe("Calldata Decoding", function() {
       pair: { x: 321, y: 2049 }
     };
 
-    assert.deepEqual(variables, expectedResult);
+    assert.deepInclude(variables, expectedResult);
   });
 
   it("Decodes correctly in the initial call", async function() {
@@ -183,7 +183,7 @@ describe("Calldata Decoding", function() {
       hello: "hello world"
     };
 
-    assert.deepEqual(variables, expectedResult);
+    assert.include(variables, expectedResult);
   });
 
   it("Decodes correctly in a pure call", async function() {
@@ -215,7 +215,7 @@ describe("Calldata Decoding", function() {
       hello: "hello world"
     };
 
-    assert.deepEqual(variables, expectedResult);
+    assert.include(variables, expectedResult);
   });
 
   it("Decodes correctly in a library call", async function() {
@@ -247,6 +247,6 @@ describe("Calldata Decoding", function() {
       hello: "hello world"
     };
 
-    assert.deepEqual(variables, expectedResult);
+    assert.include(variables, expectedResult);
   });
 });

--- a/packages/truffle-debugger/test/data/codex.js
+++ b/packages/truffle-debugger/test/data/codex.js
@@ -8,8 +8,6 @@ import Ganache from "ganache-core";
 import { prepareContracts } from "../helpers";
 import Debugger from "lib/debugger";
 
-import * as TruffleDecodeUtils from "truffle-decode-utils";
-
 const __LIBTEST = `
 pragma solidity ^0.5.4;
 
@@ -85,10 +83,8 @@ describe("Codex", function() {
 
     await session.continueUntilBreakpoint(); //run till end
 
-    const variables = TruffleDecodeUtils.Conversion.cleanBNs(
-      await session.variables()
-    );
+    const variables = await session.variables();
 
-    assert.equal(variables.surface.get("ping"), 1);
+    assert.equal(variables.surface.get("ping").toNumber(), 1);
   });
 });

--- a/packages/truffle-debugger/test/data/global.js
+++ b/packages/truffle-debugger/test/data/global.js
@@ -1,0 +1,365 @@
+import debugModule from "debug";
+const debug = debugModule("test:data:global");
+
+import { assert } from "chai";
+
+import Ganache from "ganache-core";
+
+import { prepareContracts, lineOf } from "../helpers";
+import Debugger from "lib/debugger";
+
+import * as TruffleDecodeUtils from "truffle-decode-utils";
+
+import solidity from "lib/solidity/selectors";
+
+const __GLOBAL = `
+pragma solidity ^0.5.4;
+
+contract GlobalTest {
+
+  event Done(uint x);
+
+  struct Msg {
+    bytes data;
+    address payable sender;
+    bytes4 sig;
+    uint value;
+  }
+
+  struct Tx {
+    address payable origin;
+    uint gasprice;
+  }
+
+  struct Block {
+    address payable coinbase;
+    uint difficulty;
+    uint gaslimit;
+    uint number;
+    uint timestamp;
+  }
+
+  Msg _msg;
+  Tx _tx;
+  Block _block;
+  GlobalTest _this;
+  uint _now;
+
+  function run(uint x) public payable {
+    _this = this;
+    _now = now;
+    _msg = Msg(msg.data, msg.sender, msg.sig, msg.value);
+    _tx = Tx(tx.origin, tx.gasprice);
+    _block = Block(block.coinbase, block.difficulty,
+      block.gaslimit, block.number, block.timestamp);
+    emit Done(x); //BREAK SIMPLE
+  }
+
+  function runRun(uint x) public payable {
+    this.run.value(msg.value / 2)(x);
+  }
+
+  function staticTest(uint x) public view returns (uint) {
+    Msg memory __msg;
+    Tx memory __tx;
+    Block memory __block;
+    GlobalTest __this;
+    uint __now;
+    __this = this;
+    __now = now;
+    __msg = Msg(msg.data, msg.sender, msg.sig, 0);
+    __tx = Tx(tx.origin, tx.gasprice);
+    __block = Block(block.coinbase, block.difficulty,
+      block.gaslimit, block.number, block.timestamp);
+    return x + uint(address(__this)) + __now         //BREAK STATIC
+      + __msg.value + __tx.gasprice + __block.number;
+  }
+
+  function runStatic(uint x) public {
+    emit Done(this.staticTest(x));
+  }
+
+  function runLib(uint x) public payable {
+    GlobalTestLib.run(x);
+  }
+
+  function runCreate(uint x) public payable {
+    (new CreationTest).value(msg.value / 2)(x);
+  }
+}
+
+contract CreationTest {
+  GlobalTest.Msg _msg;
+  GlobalTest.Tx _tx;
+  GlobalTest.Block _block;
+  CreationTest _this;
+  uint _now;
+
+  event Done(uint x);
+
+  constructor(uint x) public payable {
+    _this = this;
+    _now = now;
+    _msg = GlobalTest.Msg(msg.data, msg.sender, msg.sig, msg.value);
+    _tx = GlobalTest.Tx(tx.origin, tx.gasprice);
+    _block = GlobalTest.Block(block.coinbase, block.difficulty,
+      block.gaslimit, block.number, block.timestamp);
+    emit Done(x); //BREAK CREATE
+  }
+}
+
+library GlobalTestLib {
+
+  event Done(uint x);
+
+  function run(uint x) external {
+    GlobalTest.Msg memory __msg;
+    GlobalTest.Tx memory __tx;
+    GlobalTest.Block memory __block;
+    GlobalTestLib __this;
+    uint __now;
+    __this = this;
+    __now = now;
+    __msg = GlobalTest.Msg(msg.data, msg.sender, msg.sig, msg.value);
+    __tx = GlobalTest.Tx(tx.origin, tx.gasprice);
+    __block = GlobalTest.Block(block.coinbase, block.difficulty,
+      block.gaslimit, block.number, block.timestamp);
+    emit Done(x + uint(address(__this)) + __now       //BREAK LIBRARY
+      + __msg.value + __tx.gasprice + __block.number);
+  }
+}
+`;
+
+const __MIGRATION = `
+var GlobalTest = artifacts.require("GlobalTest");
+var CreationTest = artifacts.require("CreationTest");
+var GlobalTestLib = artifacts.require("GlobalTestLib");
+
+module.exports = function(deployer) {
+  deployer.deploy(GlobalTestLib);
+  deployer.link(GlobalTestLib, GlobalTest);
+  deployer.deploy(GlobalTest);
+};
+`;
+
+let sources = {
+  "GlobalTest.sol": __GLOBAL
+};
+
+let migrations = {
+  "2_deploy_contracts.js": __MIGRATION
+};
+
+describe("Globally-available variables", function() {
+  var provider;
+
+  var abstractions;
+  var artifacts;
+  var files;
+
+  before("Create Provider", async function() {
+    this.skip();
+    provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
+  });
+
+  before("Prepare contracts and artifacts", async function() {
+    this.skip();
+    this.timeout(30000);
+
+    let prepared = await prepareContracts(provider, sources, migrations);
+    abstractions = prepared.abstractions;
+    artifacts = prepared.artifacts;
+    files = prepared.files;
+  });
+
+  it("Gets globals correctly in simple call", async function() {
+    this.skip();
+    this.timeout(8000);
+    let instance = await abstractions.GlobalTest.deployed();
+    let receipt = await instance.run(9, { value: 100 });
+    let txHash = receipt.tx;
+
+    let bugger = await Debugger.forTx(txHash, {
+      provider,
+      files,
+      contracts: artifacts
+    });
+
+    let session = bugger.connect();
+
+    await session.continueUntilBreakpoint(); //run till end
+
+    const variables = TruffleDecodeUtils.Conversion.cleanBNs(
+      await session.variables()
+    );
+
+    assert.equal(variables.this, variables._this);
+    assert.deepEqual(variables.msg, variables._msg);
+    assert.deepEqual(variables.tx, variables._tx);
+    assert.deepEqual(variables.block, variables._block);
+    assert.equal(variables.now, variables._now);
+  });
+
+  it("Gets globals correctly in nested call", async function() {
+    this.skip();
+    this.timeout(8000);
+    let instance = await abstractions.GlobalTest.deployed();
+    let receipt = await instance.runRun(9, { value: 100 });
+    let txHash = receipt.tx;
+
+    let bugger = await Debugger.forTx(txHash, {
+      provider,
+      files,
+      contracts: artifacts
+    });
+
+    let session = bugger.connect();
+
+    let sourceId = session.view(solidity.current.source).id;
+    let source = session.view(solidity.current.source).source;
+    await session.addBreakpoint({
+      sourceId,
+      line: lineOf("BREAK SIMPLE", source)
+    });
+    await session.continueUntilBreakpoint();
+
+    const variables = TruffleDecodeUtils.Conversion.cleanBNs(
+      await session.variables()
+    );
+
+    assert.equal(variables.this, variables._this);
+    assert.deepEqual(variables.msg, variables._msg);
+    assert.deepEqual(variables.tx, variables._tx);
+    assert.deepEqual(variables.block, variables._block);
+    assert.equal(variables.now, variables._now);
+  });
+
+  it("Gets globals correctly in static call", async function() {
+    this.skip();
+    this.timeout(8000);
+    let instance = await abstractions.GlobalTest.deployed();
+    let receipt = await instance.runStatic(9);
+    let txHash = receipt.tx;
+
+    let bugger = await Debugger.forTx(txHash, {
+      provider,
+      files,
+      contracts: artifacts
+    });
+
+    let session = bugger.connect();
+
+    let sourceId = session.view(solidity.current.source).id;
+    let source = session.view(solidity.current.source).source;
+    await session.addBreakpoint({
+      sourceId,
+      line: lineOf("BREAK STATIC", source)
+    });
+    await session.continueUntilBreakpoint();
+
+    const variables = TruffleDecodeUtils.Conversion.cleanBNs(
+      await session.variables()
+    );
+
+    assert.equal(variables.this, variables.__this);
+    assert.deepEqual(variables.msg, variables.__msg);
+    assert.deepEqual(variables.tx, variables.__tx);
+    assert.deepEqual(variables.block, variables.__block);
+    assert.equal(variables.now, variables.__now);
+  });
+
+  it("Gets globals correctly in library call", async function() {
+    this.skip();
+    this.timeout(8000);
+    let instance = await abstractions.GlobalTest.deployed();
+    let receipt = await instance.runLib(9, { value: 100 });
+    let txHash = receipt.tx;
+
+    let bugger = await Debugger.forTx(txHash, {
+      provider,
+      files,
+      contracts: artifacts
+    });
+
+    let session = bugger.connect();
+
+    let sourceId = session.view(solidity.current.source).id;
+    let source = session.view(solidity.current.source).source;
+    await session.addBreakpoint({
+      sourceId,
+      line: lineOf("BREAK LIBRARY", source)
+    });
+    await session.continueUntilBreakpoint();
+
+    const variables = TruffleDecodeUtils.Conversion.cleanBNs(
+      await session.variables()
+    );
+
+    assert.equal(variables.this, variables.__this);
+    assert.deepEqual(variables.msg, variables.__msg);
+    assert.deepEqual(variables.tx, variables.__tx);
+    assert.deepEqual(variables.block, variables.__block);
+    assert.equal(variables.now, variables.__now);
+  });
+
+  it("Gets globals correctly in simple creation", async function() {
+    this.skip();
+    this.timeout(8000);
+    let contract = await abstractions.CreationTest.new(9, { value: 100 });
+    let txHash = contract.transactionHash;
+
+    let bugger = await Debugger.forTx(txHash, {
+      provider,
+      files,
+      contracts: artifacts
+    });
+
+    let session = bugger.connect();
+
+    await session.continueUntilBreakpoint(); //run till end
+
+    const variables = TruffleDecodeUtils.Conversion.cleanBNs(
+      await session.variables()
+    );
+
+    assert.equal(variables.this, variables._this);
+    assert.deepEqual(variables.msg, variables._msg);
+    assert.deepEqual(variables.tx, variables._tx);
+    assert.deepEqual(variables.block, variables._block);
+    assert.equal(variables.now, variables._now);
+  });
+
+  it("Gets globals correctly in nested creation", async function() {
+    this.skip();
+    this.timeout(8000);
+    let instance = await abstractions.GlobalTest.deployed();
+    let receipt = await instance.runCreate(9, { value: 100 });
+    let txHash = receipt.tx;
+
+    let bugger = await Debugger.forTx(txHash, {
+      provider,
+      files,
+      contracts: artifacts
+    });
+
+    let session = bugger.connect();
+
+    let sourceId = session.view(solidity.current.source).id;
+    let source = session.view(solidity.current.source).source;
+    await session.addBreakpoint({
+      sourceId,
+      line: lineOf("BREAK CREATE", source)
+    });
+    await session.continueUntilBreakpoint();
+
+    const variables = TruffleDecodeUtils.Conversion.cleanBNs(
+      await session.variables()
+    );
+
+    assert.equal(variables.this, variables._this);
+    assert.deepEqual(variables.msg, variables._msg);
+    assert.deepEqual(variables.tx, variables._tx);
+    assert.deepEqual(variables.block, variables._block);
+    assert.equal(variables.now, variables._now);
+  });
+});

--- a/packages/truffle-debugger/test/data/more-decoding.js
+++ b/packages/truffle-debugger/test/data/more-decoding.js
@@ -258,7 +258,7 @@ describe("Further Decoding", function() {
       pointedAt: [107, 214]
     };
 
-    assert.hasAllKeys(variables, expectedResult);
+    assert.containsAllKeys(variables, expectedResult);
 
     for (let name in expectedResult) {
       if (expectedResult[name] instanceof Map) {
@@ -315,7 +315,7 @@ describe("Further Decoding", function() {
       severalBytes: ["0xff"]
     };
 
-    assert.hasAllKeys(variables, expectedResult);
+    assert.containsAllKeys(variables, expectedResult);
 
     for (let name in expectedResult) {
       if (expectedResult[name] instanceof Map) {
@@ -371,7 +371,7 @@ describe("Further Decoding", function() {
       pointedAt: "key2"
     };
 
-    assert.hasAllKeys(variables, expectedResult);
+    assert.containsAllKeys(variables, expectedResult);
 
     for (let name in expectedResult) {
       if (expectedResult[name] instanceof Map) {
@@ -423,7 +423,7 @@ describe("Further Decoding", function() {
     debug("variables %O", variables);
     debug("expectedResult %O", expectedResult);
 
-    assert.hasAllKeys(variables, expectedResult);
+    assert.containsAllKeys(variables, expectedResult);
 
     const simpleCases = ["mapArrayStatic", "mapStruct0", "mapStruct1"];
 
@@ -447,7 +447,7 @@ describe("Further Decoding", function() {
     }
 
     //second group: mappings in mappings (just mapMap)
-    assert.hasAllKeys(
+    assert.containsAllKeys(
       variables.mapMap,
       Array.from(expectedResult.mapMap.keys())
     );

--- a/packages/truffle-debugger/test/endstate.js
+++ b/packages/truffle-debugger/test/endstate.js
@@ -105,6 +105,6 @@ describe("End State", function() {
     const variables = TruffleDecodeUtils.Conversion.cleanBNs(
       await session.variables()
     );
-    assert.deepEqual(variables, { x: 107 });
+    assert.include(variables, { x: 107 });
   });
 });

--- a/packages/truffle-decode-utils/src/ast.ts
+++ b/packages/truffle-decode-utils/src/ast.ts
@@ -12,7 +12,7 @@ export interface AstDefinition {
   nodes?: any[]; //sorry
   nodeType: string;
   scope?: number;
-  src: string;
+  src?: string;
   stateVariable?: boolean;
   storageLocation?: string;
   typeDescriptions: AstTypeDescriptions;

--- a/packages/truffle-decode-utils/src/definition.ts
+++ b/packages/truffle-decode-utils/src/definition.ts
@@ -281,4 +281,91 @@ export namespace Definition {
         debug("unrecognized index access!");
     }
   }
+
+  //spoofed definitions we'll need
+  //we'll give them id -1 to indicate that they're spoofed
+
+  //id, name, nodeType, typeDescriptions.typeIdentifier
+  export function spoofUintDefinition(name: string): AstDefinition {
+    return {
+      id: -1,
+      name,
+      nodeType: "VariableDeclaration",
+      typeDescriptions: {
+        typeIdentifier: "t_uint256"
+      }
+    };
+  }
+
+  export function spoofAddressPayableDefinition(name: string): AstDefinition {
+    return {
+      id: -1,
+      name,
+      nodeType: "VariableDeclaration",
+      typeDescriptions: {
+        typeIdentifier: "t_address_payable"
+      }
+    };
+  }
+
+  export const MSG_SIG_DEFINITION: AstDefinition = {
+    id: -1,
+    name: "sig",
+    nodeType: "VariableDeclaration",
+    typeDescriptions: {
+      typeIdentifier: "t_bytes" + EVMUtils.SELECTOR_SIZE
+    }
+  };
+
+  export const MSG_DATA_DEFINITION: AstDefinition = {
+    id: -1,
+    name: "data",
+    nodeType: "VariableDeclaration",
+    typeDescriptions: {
+      typeIdentifier: "t_bytes_calldata_ptr"
+    }
+  };
+
+  export const MSG_DEFINITION: AstDefinition = {
+    id: -1,
+    name: "msg",
+    nodeType: "VariableDeclaration",
+    typeDescriptions: {
+      typeIdentifier: "t_magic_message"
+    }
+  };
+
+  export const TX_DEFINITION: AstDefinition = {
+    id: -1,
+    name: "tx",
+    nodeType: "VariableDeclaration",
+    typeDescriptions: {
+      typeIdentifier: "t_magic_transaction"
+    }
+  };
+
+  export const BLOCK_DEFINITION: AstDefinition = {
+    id: -1,
+    name: "block",
+    nodeType: "VariableDeclaration",
+    typeDescriptions: {
+      typeIdentifier: "t_magic_block"
+    }
+  };
+
+  export function spoofThisDefinition(contractName: string, contractId: number): AstDefinition {
+    let formattedName = contractName.replace(/\$/g, "$$".repeat(3));
+    //note that string.replace treats $'s specially in the replacement string;
+    //we want 3 $'s for each $ in the input, so we need to put *6* $'s in the
+    //replacement string
+    return {
+      id: -1,
+      name: "this",
+      nodeType: "VariableDeclaration",
+      typeDescriptions: {
+        typeIdentifier: "t_contract$_" + formattedName + "_$" + contractId
+      }
+    }
+  }
+
 }

--- a/packages/truffle-decoder/lib/decode/index.ts
+++ b/packages/truffle-decoder/lib/decode/index.ts
@@ -7,6 +7,7 @@ import decodeStorage from "./storage";
 import { decodeStack, decodeLiteral } from "./stack";
 import decodeCalldata from "./calldata";
 import decodeConstant from "./constant";
+import decodeSpecial from "./special";
 import { AstDefinition } from "truffle-decode-utils";
 import * as Pointer from "../types/pointer";
 import { EvmInfo } from "../types/evm";
@@ -36,6 +37,10 @@ export default async function decode(definition: AstDefinition, pointer: Pointer
     //cases to deal with
   }
 
+  if(Pointer.isSpecialPointer(pointer)) {
+    return await decodeSpecial(definition, pointer, info);
+  }
+
   //NOTE: the following two cases shouldn't come up but they've been left in as
   //fallback cases
 
@@ -48,7 +53,4 @@ export default async function decode(definition: AstDefinition, pointer: Pointer
     return await decodeCalldata(definition, pointer, info);
     //calldata does not need web3 & contractAddress
   }
-
-
-  //the type system means we can't hit this point!
 }

--- a/packages/truffle-decoder/lib/decode/special.ts
+++ b/packages/truffle-decoder/lib/decode/special.ts
@@ -1,0 +1,90 @@
+import debugModule from "debug";
+const debug = debugModule("decoder:decode:special");
+
+import * as DecodeUtils from "truffle-decode-utils";
+import decodeValue from "./value";
+import { EvmInfo } from "../types/evm";
+import { SpecialPointer } from "../types/pointer";
+
+export default async function decodeSpecial(definition: DecodeUtils.AstDefinition, pointer: SpecialPointer, info: EvmInfo): Promise <any> {
+  if(DecodeUtils.Definition.typeClass(definition) === "magic") { //that's right, magic!
+    return await decodeMagic(definition, pointer, info);
+  }
+  else {
+    return await decodeValue(definition, pointer, info);
+  }
+}
+
+export async function decodeMagic(definition: DecodeUtils.AstDefinition, pointer: SpecialPointer, info: EvmInfo): Promise <any> {
+
+  let {state} = info;
+
+  switch(pointer.special) {
+    case "msg":
+      return {
+        data: await decodeValue(
+          DecodeUtils.Definition.MSG_DATA_DEFINITION,
+          {calldata: {
+            start: 0,
+            length: state.calldata.length
+          }},
+          info
+        ),
+        sig: await decodeValue(
+          DecodeUtils.Definition.MSG_SIG_DEFINITION,
+          {calldata: {
+            start: 0,
+            length: DecodeUtils.EVM.SELECTOR_SIZE,
+          }},
+          info
+        ),
+        sender: await decodeValue(
+          DecodeUtils.Definition.spoofAddressPayableDefinition("sender"),
+          {special: "sender"},
+          info
+        ),
+        value: await decodeValue(
+          DecodeUtils.Definition.spoofUintDefinition("value"),
+          {special: "value"},
+          info
+        )
+      };
+    case "tx":
+      return {
+        origin: await decodeValue(
+          DecodeUtils.Definition.spoofAddressPayableDefinition("origin"),
+          {special: "origin"},
+          info
+        ),
+        gasprice: await decodeValue(
+          DecodeUtils.Definition.spoofUintDefinition("gasprice"),
+          {special: "gasprice"},
+          info
+        )
+      };
+    case "block":
+      return {
+        coinbase: await decodeValue(
+          DecodeUtils.Definition.spoofAddressPayableDefinition("coinbase"),
+          {special: "coinbase"},
+          info
+        ),
+        //the other ones are all uint's, so let's handle them all at once
+        ...Object.assign({},
+          ...await Promise.all(
+            ["difficulty", "gaslimit", "number", "timestamp"].map(
+              async (variable) => ({
+                [variable]: await decodeValue(
+                  DecodeUtils.Definition.spoofUintDefinition(variable),
+                  {special: variable},
+                  info
+                )
+              })
+            )
+          )
+        )
+      };
+    default:
+      debug("Unrecognized magic variable!");
+  }
+}

--- a/packages/truffle-decoder/lib/interface/contract-decoder.ts
+++ b/packages/truffle-decoder/lib/interface/contract-decoder.ts
@@ -174,8 +174,7 @@ export default class TruffleContractDecoder extends AsyncEventEmitter {
         state: {
           stack: [],
           storage: {},
-          memory: new Uint8Array(0),
-          calldata: new Uint8Array(0)
+          memory: new Uint8Array(0)
         },
         mappingKeys: this.mappingKeys,
         referenceDeclarations: this.referenceDeclarations,
@@ -204,8 +203,7 @@ export default class TruffleContractDecoder extends AsyncEventEmitter {
       state: {
         stack: [],
         storage: {},
-        memory: new Uint8Array(0),
-        calldata: new Uint8Array(0)
+        memory: new Uint8Array(0)
       },
       mappingKeys: this.mappingKeys,
       referenceDeclarations: this.referenceDeclarations,

--- a/packages/truffle-decoder/lib/read/constant.ts
+++ b/packages/truffle-decoder/lib/read/constant.ts
@@ -2,22 +2,22 @@ import debugModule from "debug";
 const debug = debugModule("decoder:read:constant");
 
 import * as DecodeUtils from "truffle-decode-utils";
-import { ConstantDefinitionPointer } from "../types/pointer";
 import BN from "bn.js";
 
-export function readDefinition(pointer: ConstantDefinitionPointer): Uint8Array {
+export function readDefinition(definition: DecodeUtils.AstDefinition): Uint8Array {
 
-  debug("pointer %o", pointer);
+  debug("definition %o", definition);
 
-  switch(DecodeUtils.Definition.typeClass(pointer.definition))
+  switch(DecodeUtils.Definition.typeClass(definition))
   {
     case "rational":
-      let numericalValue: BN = DecodeUtils.Definition.rationalValue(pointer.definition);
+      let numericalValue: BN = DecodeUtils.Definition.rationalValue(definition);
       return DecodeUtils.Conversion.toBytes(numericalValue, DecodeUtils.EVM.WORD_SIZE);
-      //you may be wondering, why do we not just use pointer.definition.value here, like
-      //we do below? answer: because if this isn't a literal, that may not exist
+      //you may be wondering, why do we not just use definition.value here,
+      //like we do below? answer: because if this isn't a literal, that may not
+      //exist
     case "stringliteral":
-      return DecodeUtils.Conversion.toBytes(pointer.definition.hexValue);
+      return DecodeUtils.Conversion.toBytes(definition.hexValue);
     default:
       //unfortunately, other types of constants are just too complicated to
       //handle right now.  sorry.

--- a/packages/truffle-decoder/lib/read/index.ts
+++ b/packages/truffle-decoder/lib/read/index.ts
@@ -20,6 +20,8 @@ export default async function read(pointer: Pointer.DataPointer, state: EvmState
   } else if (Pointer.isStackLiteralPointer(pointer)) {
     return pointer.literal;
   } else if (Pointer.isConstantDefinitionPointer(pointer)) {
-    return constant.readDefinition(pointer);
+    return constant.readDefinition(pointer.definition);
+  } else if (Pointer.isSpecialPointer(pointer)) {
+    return state.specials[pointer.special];
   }
 }

--- a/packages/truffle-decoder/lib/read/stack.ts
+++ b/packages/truffle-decoder/lib/read/stack.ts
@@ -1,3 +1,6 @@
+import debugModule from "debug";
+const debug = debugModule("decoder:read:stack");
+
 import * as DecodeUtils from "truffle-decode-utils";
 
 export function readStack(stack: Uint8Array[], from: number, to: number): Uint8Array {

--- a/packages/truffle-decoder/lib/types/evm.ts
+++ b/packages/truffle-decoder/lib/types/evm.ts
@@ -6,7 +6,10 @@ export interface EvmState {
   stack: Uint8Array[];
   storage: WordMapping;
   memory: Uint8Array;
-  calldata: Uint8Array;
+  calldata?: Uint8Array;
+  specials?: {
+    [builtin: string]: Uint8Array //sorry
+  }
 }
 
 export interface WordMapping {

--- a/packages/truffle-decoder/lib/types/pointer.ts
+++ b/packages/truffle-decoder/lib/types/pointer.ts
@@ -2,7 +2,8 @@ import { AstDefinition } from "truffle-decode-utils";
 import { Range } from "./storage";
 
 export type DataPointer = StackPointer | MemoryPointer | StoragePointer
-  | CalldataPointer | StackLiteralPointer | ConstantDefinitionPointer;
+  | CalldataPointer | StackLiteralPointer | ConstantDefinitionPointer
+  | SpecialPointer;
 
 export interface GenericPointer {
   typeClass?: string;
@@ -41,6 +42,10 @@ export interface ConstantDefinitionPointer extends GenericPointer {
   definition: AstDefinition;
 }
 
+export interface SpecialPointer extends GenericPointer {
+  special: string; //sorry
+}
+
 export function isStackPointer(pointer: DataPointer): pointer is StackPointer {
   return typeof pointer !== "undefined" && "stack" in pointer;
 }
@@ -63,4 +68,8 @@ export function isStackLiteralPointer(pointer: DataPointer): pointer is StackLit
 
 export function isConstantDefinitionPointer(pointer: DataPointer): pointer is ConstantDefinitionPointer {
   return typeof pointer !== "undefined" && "definition" in pointer;
+}
+
+export function isSpecialPointer(pointer: DataPointer): pointer is SpecialPointer {
+  return typeof pointer !== "undefined" && "special" in pointer;
 }


### PR DESCRIPTION
This PR adds support for globally-available variables to the debugger.  They will appear when `v` is entered, and they can be used in watch expressions (with one exception, see below).  Note that rather than having each member of `msg`, `tx`, and `block` as a separate variable, we decode the magic variables `msg`, `tx`, and `block` to objects containing their respective variables; thus one can use `msg.value` in a watch expression, say, and this will just work.

Before I continue, there are two issues worth noting that this PR has:

1. Firstly, `this` and `msg.sender` may not be reliable when failed contract creations are involved.  @gnidan and I discussed doing more to mitigate this, but ultimately decided it wasn't worth it (note that it is not feasible to fully fix the problem at this time).  I'll discuss this in more detail later.
2. Secondly, this isn't actually an issue with this PR per se, but when used with Ganache, the values of `block.timestamp` and `now` may not be reliable, due to [this ganache-core issue](https://github.com/trufflesuite/ganache-core/issues/111).  Since I expect that Truffle Debugger is largely used with Ganache, I'm not sure what to do about this.  I've let @davidmurdoch and the Ganache team know, and hopefully this is fixed soon.

(There was a third here, but I've since pushed a fix for it; see comment below.)

So, how does it work?  This PR can basically be broken down into three parts:

1. Keeping track of the necessary information on the debugger side;
2. Decoding that information on the decoder side;
3. Back on the debugger side, including the globally-available variables in the set of current variables.

So, let's go over these one by one.

Each stackframe in `evm.current.callstack` now contains two additional fields: `sender` and `value`.  These are what they sound like.  In addition, there's now also `evm.info.globals`, which contains `evm.info.globals.tx` and `evm.info.globals.block`.  (Yes, I put the origin in the state for convenience, even though it can also be read off of the `sender` value of the bottom stackframe.  I don't think this is a problem.)

The values for `tx.origin` and `tx.gasprice` are, of course, read from the transaction object when the debugger begins (this can be found in the `web3` saga); the `block` variables similarly are read from the block object.  However, prior to this PR we didn't fetch the block object, so I had to add a function `getBlock` to `adapter.js`.  While doing so, I took the time to rewrite `adapter.js` using `await` (and in one case, `util.promisify`) for readability.  Also, since we store the transaction and receipt objects in the session state, I thought I'd store the block object there too, for good measure?

Where do the new `msg` properties come from?  Well, in the initial call of the transaction, they are of course read from the transaction object.  In subsequent calls, `value` is read from the call's arguments on the stack (or automatically 0 in the case of `STATICCALL`, or copied from the current stackframe's `value` for a `DELEGATECALL`).  Meanwhile `sender` is of course just taken from the current stackframe's storage address (not code address!), unless of course it's a `DELEGATECALL` in which case it copies the existing stackframe's `sender`.

These then all go into a new selector under `data.current.state`, which I'm calling `data.current.state.specials`.  Note that while in `evm` these values are stored as `BN`s or address strings, in `data` they get converted, like everything else, to `Uint8Array`s.  This may seem a little silly, seeing as the decoder is going to later convert them back to their original form, but it's just easiest to keep everything consistent.  In any case, the `state` that gets passed to the debugger now has five members: `stack`, `memory`, `storage`, `calldata`, and `specials`.  (Note: Over on the TypeScript side, I've made `calldata` optional again; `specials` is optional too.  Making that required was a mistake.)

Note that the members of `specials` are all just mixed together, not grouped into `tx`, `block`, etc. -- there's just `value`, `origin`, `timestamp`, etc.  Also there's no `now` since that's redundant with timestamp.  Worth noting, each member of `specials` corresponds to an EVM opcode that takes no arguments and just pushes a particular environmental value onto the stack; I thought about naming the members after these opcodes, but ultimately I found this to be too confusing and stuck to the Solidity names instead.  (So, we have `this`, not `address`; `sender`, not `caller`; and `value`, not `callvalue`.)

So what about the decoder side?  Well, there's now a new type of pointer for reading `state.specials`, called a `SpecialPointer`.  (This should be the last type of pointer!  Barring new EVM opcodes that would make such a thing more convenient, I don't anticipate Solidity adding `returndata` or `code` as new locations.)  There's now `decode/special.ts` and a corresponding `decodeSpecial` function.  It checks the typeclass of the definition passed in; if it's not `magic` (for the magic variables `msg`, `tx`, and `block`), it just hands it off to `decodeValue`.  If it is `magic`, it passes it to `decodeMagic`, which constructs appropriate pointers for the members (as well as spoofed definitions for them; I've added some rudimentary functionality to `truffle-decode-utils` for this) and passes *those* to `decodeValue`.  (These member pointers are usually `SpecialPointer`s, obviously, but note that `msg.data` and `msg.sig` are given by `CalldataPointer`s instead.)

(Regarding these spoofed definitions: I gave them each an ID of -1.  Also, I couldn't figure out what to give them for `src`, so I just changed the type definition so that was no longer required. :P )

Meanwhile over in `read`, there actually is no `read/special.ts`, for the same reason that there didn't used to be a `read/stack.ts` -- the read operation just consists of `return state.specials[pointer.special]`, so no real need to make a new function there.  Hooray!  (But while I was at it, I cleaned up `read/constant.ts` to make it a little more consistent with how we do things elsewhere.)

So that's the decoder side -- not much new there!  Finally that leaves us with how the debugger actually includes these new variables in the `data.current.identifiers` set of selectors.

First, let me make a note about the overall approach.  Ideally, we'd have a separate `msg` variable for each EVM stackframe and similarly with `this`, because that could come in handy when later people want to write plugins and interfaces for the debugger.  However, we don't actually need that yet, so for the sake of simplcity, I just had one global `msg` variable, and one global `this` variable.  I.e., their values change with each stackframe, rather than referring to different variables for each stackframe.  Like I said, this is not ideal, but I don't think the extra effort to do it the better way is worth it at the present time.

Also note that these variables, as I've done them right now, truly are *globally* available -- they're available even when we're in unmapped code!  (Actually, turns out there was a bug where pressing `v` during unmapped code would cause an error; I had to fix that.)  Even `msg.value` is always available, even though in reality Solidity disallows using it in contexts where it is necessarily 0.  (I.e., non-library functions that aren't `payable`.)

So, anyway, on to the particular selectors (or the state they draw from).  Well, first off -- `data.current.identifiers` itself no longer just gives the AST ID for each variable, but rather gives the AST ID wrapped in an object (i.e., `{astId: n}`).  Why?  Because it now also includes the five top-level builtins, and those instead get `{builtin: name}`.

Then there's `data.current.identifiers.definitions`.  This again now includes the five top-level builtins, together with spoofed definitions for them.  I did do a bit of extra work here to correctly spoof the `typeIdentifier` in the definition of `this`, even though it's not strictly necessary (just using `t_contract` would work fine, even though that's not actually a legal Solidity type identifier).  Anyway, long story short, `evm.current.context` now stores the contract ID along with the other information (this involved making a change to `Session.normalize`).  (And of course before long it'll store even more information...)

Then there's `data.proc.assignments`.  Again, because I'm taking the approach where these variables are truly global, I just added assignments for them to the starting state here.  I also added, alongside `byId` and `byAstId`, a third part of the state, `byBuiltin`, which works like `byAstId`.  Note that yes this gives an *array* of IDs for each builtin, like `byAstId` does, even though right now that array will have only one element; this is in anticipation of a future time where I go back and do `msg` and `this` the proper way, as I've discussed above.

Finally we have `data.current.identifiers.refs`.  Not much to say about this one; it accounts for builtins now.  Hooray!

There are three more notes I want to make here.

Firstly, I added tests of this feature; but due to the timestamp problem, I've added them all as skipped.  Hopefully we can enable them before too long.  I can at least say that in my manual testing, everythign works except timestamps.  Also, I had to adjust various other existing tests so that they no longer failed if there are *additional* variables present (because now there are the globally-available variables in addition to whatever was being tested).

Secondly, I want to discuss the issue with failed contract creations in more detail.  As stated above, we rely on the `storageAddress` field in `evm.current.callstack` for `this` and `msg.sender`.  However, at the moment, for a failed contract creation, we get a `storageAddress` of zero, not the actual correct address.  Fixing this would require computing the address ourselves, and we can't do that for a `CREATE` because we have no way to get the nonce (not until we make some major changes to the debugger, anyway).  We *could* do it for a `CREATE2`, but as mentioned above, @gnidan and I decided this just wasn't worth it for the time being.

So, if you have a failed contract creation, or a library call delegated from such, then `this` will show up as the zero address instead of the correct address.  Similarly, if you have a call made from a failed contract creation, or a library call delegated from such a call, then `msg.sender` will show up as the zero address instead of the correct address.  I think this is fine for now.  We can fix this later once we have "reconstruct mode" (although that's a long way off).

One final note -- the above problem with failed contract creations *doesn't* necessarily apply if that failed contract creation was the initial call of the transaction.  Because for that one we get the address from the receipt, not off the stack... and at least with Ganache, it will give you the address even if the creation failed.  Unfortunately there doesn't seem to be any spec regarding what the receipt should return in this case.  Ganache returns what the address woud have been, but for all I know, other clients could return the zero address, or not an address at all.  (Just to prevent problems in the latter case, I've added code so that we'll use the zero address if we did not in fact get a valid address.  I also removed some now-unreachable error code that used to be there.)  So, if the failed contract creation was the initial call, the corresponding variables *may* work, or they may be zero; I make no guarantees there.

Anyway, that's globally-available variables!  Hooray!