### PR TITLE
Strip down calldata test to reduce timeouts

### DIFF
--- a/packages/truffle-debugger/test/data/calldata.js
+++ b/packages/truffle-debugger/test/data/calldata.js
@@ -43,8 +43,6 @@ contract CalldataTest {
 
   function multiTest(
     string calldata hello,
-    bytes calldata deadbeef,
-    uint[2] calldata twoInts,
     uint[] calldata someInts,
     Pair calldata pair)
   external {
@@ -53,8 +51,6 @@ contract CalldataTest {
 
   function multiTester() public {
     uint[2] memory twoInts;
-    twoInts[0] = 107;
-    twoInts[1] = 683;
     uint[] memory someInts;
     someInts = new uint[](2);
     someInts[0] = 41;
@@ -62,7 +58,7 @@ contract CalldataTest {
     Pair memory pair;
     pair.x = 321;
     pair.y = 2049;
-    this.multiTest("hello", hex"deadbeef", twoInts, someInts, pair);
+    this.multiTest("hello", someInts, pair);
   }
 
 }
@@ -145,8 +141,6 @@ describe("Calldata Decoding", function() {
 
     const expectedResult = {
       hello: "hello",
-      deadbeef: "0xdeadbeef",
-      twoInts: [107, 683],
       someInts: [41, 42],
       pair: { x: 321, y: 2049 }
     };


### PR DESCRIPTION
This test was timing out too often, so I stripped it down a bit.  It used to test decoding for a `string`, a `bytes`, a statically-sized array, a dynamically-sized array, and a struct.  I removed the `bytes` (basically redundant with string) and the statically-sized array.