### PR TITLE
Restore ability to use external list of breakpoints

### DIFF
--- a/packages/truffle-debugger/lib/controller/actions/index.js
+++ b/packages/truffle-debugger/lib/controller/actions/index.js
@@ -1,5 +1,5 @@
 export const ADVANCE = "ADVANCE";
-export function advance(count = 1) {
+export function advance(count) {
   return { type: ADVANCE, count };
 }
 
@@ -34,7 +34,7 @@ export function interrupt() {
 }
 
 export const CONTINUE = "CONTINUE";
-export function continueUntilBreakpoint(breakpoints = undefined) {
+export function continueUntilBreakpoint(breakpoints) {
   //"continue" is not a legal name
   return {
     type: CONTINUE,

--- a/packages/truffle-debugger/lib/controller/actions/index.js
+++ b/packages/truffle-debugger/lib/controller/actions/index.js
@@ -34,9 +34,12 @@ export function interrupt() {
 }
 
 export const CONTINUE = "CONTINUE";
-export function continueUntilBreakpoint() {
+export function continueUntilBreakpoint(breakpoints = undefined) {
   //"continue" is not a legal name
-  return { type: CONTINUE };
+  return {
+    type: CONTINUE,
+    breakpoints
+  };
 }
 
 export const ADD_BREAKPOINT = "ADD_BREAKPOINT";

--- a/packages/truffle-debugger/lib/controller/sagas/index.js
+++ b/packages/truffle-debugger/lib/controller/sagas/index.js
@@ -190,12 +190,18 @@ function* stepOver() {
 /**
  * continueUntilBreakpoint - step through execution until a breakpoint
  */
-function* continueUntilBreakpoint() {
+function* continueUntilBreakpoint(action = actions.continueUntilBreakpoint()) {
   var currentLocation, currentNode, currentLine, currentSourceId;
   var finished;
   var previousLine, previousSourceId;
 
-  let breakpoints = yield select(controller.breakpoints);
+  //if breakpoints was not specified, use the stored list from the state.
+  //if it was, override that with the specified list.
+  //note that explicitly specifying an empty list will advance to the end.
+  let breakpoints =
+    action.breakpoints !== undefined
+      ? action.breakpoints
+      : yield select(controller.breakpoints);
 
   let breakpointHit = false;
 

--- a/packages/truffle-debugger/lib/controller/sagas/index.js
+++ b/packages/truffle-debugger/lib/controller/sagas/index.js
@@ -48,9 +48,11 @@ export default prefixName("controller", saga);
 
 /*
  * Advance the state by the given number of instructions (but not past the end)
+ * (if no count given, advance 1)
  */
-function* advance(action = actions.advance()) {
-  let { count } = action;
+function* advance(action) {
+  let count =
+    action !== undefined && action.count !== undefined ? action.count : 1; //default is, as mentioned, to advance 1
   for (let i = 0; i < count && !(yield select(controller.finished)); i++) {
     yield* trace.advance();
   }
@@ -190,7 +192,7 @@ function* stepOver() {
 /**
  * continueUntilBreakpoint - step through execution until a breakpoint
  */
-function* continueUntilBreakpoint(action = actions.continueUntilBreakpoint()) {
+function* continueUntilBreakpoint(action) {
   var currentLocation, currentNode, currentLine, currentSourceId;
   var finished;
   var previousLine, previousSourceId;
@@ -199,7 +201,7 @@ function* continueUntilBreakpoint(action = actions.continueUntilBreakpoint()) {
   //if it was, override that with the specified list.
   //note that explicitly specifying an empty list will advance to the end.
   let breakpoints =
-    action.breakpoints !== undefined
+    action !== undefined && action.breakpoints !== undefined
       ? action.breakpoints
       : yield select(controller.breakpoints);
 

--- a/packages/truffle-debugger/lib/session/index.js
+++ b/packages/truffle-debugger/lib/session/index.js
@@ -152,7 +152,8 @@ export default class Session {
     });
   }
 
-  async advance(count = 1) {
+  //Note: count is an optional argument; default behavior is to advance 1
+  async advance(count) {
     return await this.doneStepping(controller.advance(count));
   }
 
@@ -176,9 +177,10 @@ export default class Session {
     return await this.doneStepping(controller.reset());
   }
 
-  async continueUntilBreakpoint(
-    breakpoints = this.view(controllerSelector.breakpoints)
-  ) {
+  //NOTE: breakpoints is an OPTIONAL argument for if you want to supply your
+  //own list of breakpoints; leave it out to use the internal one (as
+  //controlled by the functions below)
+  async continueUntilBreakpoint(breakpoints) {
     return await this.doneStepping(
       controller.continueUntilBreakpoint(breakpoints)
     );

--- a/packages/truffle-debugger/lib/session/index.js
+++ b/packages/truffle-debugger/lib/session/index.js
@@ -176,8 +176,12 @@ export default class Session {
     return await this.doneStepping(controller.reset());
   }
 
-  async continueUntilBreakpoint() {
-    return await this.doneStepping(controller.continueUntilBreakpoint());
+  async continueUntilBreakpoint(
+    breakpoints = this.view(controllerSelector.breakpoints)
+  ) {
+    return await this.doneStepping(
+      controller.continueUntilBreakpoint(breakpoints)
+    );
   }
 
   async addBreakpoint(breakpoint) {


### PR DESCRIPTION
Background: Originally breakpoints were stored in the CLI, not the debugger state; the debugger exposed a function to stop at a specified breakpoint, but you had to supply the list of breakpoints yourself.  Later I moved them into the debugger state, exposing functions to add and remove breakpoints instead of having the list of breakpoints be an input to the `continueUntilBreakpoint` function.

However, I recently realized that if you're using the debugger as a library, this isn't necessarily a convenient interface.  So, I decided to add the old way back in as another way of doing things.  The `continueUntilBreakpoint` function now takes as an optional argument a list of breakpoints.  If supplied, it will continue to one of these breakpoints, rather than using the list stored in the state.  So, if you're using the debugger as a library, you may want to use this instead.

I also added a test.

Note: Yes, I used some redundant defaults here.