### PR TITLE
Properly handle failed calls

### DIFF
--- a/packages/truffle-debugger/lib/evm/actions/index.js
+++ b/packages/truffle-debugger/lib/evm/actions/index.js
@@ -53,6 +53,13 @@ export function returnCall() {
   };
 }
 
+export const FAIL = "FAIL";
+export function fail() {
+  return {
+    type: FAIL
+  };
+}
+
 export const STORE = "STORE";
 export function store(address, slot, value) {
   return {

--- a/packages/truffle-debugger/lib/evm/actions/index.js
+++ b/packages/truffle-debugger/lib/evm/actions/index.js
@@ -70,6 +70,16 @@ export function store(address, slot, value) {
   };
 }
 
+export const LOAD = "LOAD";
+export function load(address, slot, value) {
+  return {
+    type: LOAD,
+    address,
+    slot,
+    value
+  };
+}
+
 export const RESET = "EVM_RESET";
 export function reset(storageAddress) {
   return {

--- a/packages/truffle-debugger/lib/evm/reducers.js
+++ b/packages/truffle-debugger/lib/evm/reducers.js
@@ -172,6 +172,10 @@ export function codex(state = [], action) {
   let newState, topCodex;
 
   const updateFrameStorage = (frame, address, slot, value) => {
+    if (address === DecodeUtils.EVM.ZERO_ADDRESS) {
+      //we do not maintain a zero page! we leave that alone!
+      return frame;
+    }
     let existingPage = frame.accounts[address] || { storage: {} };
     return {
       ...frame,

--- a/packages/truffle-debugger/lib/evm/reducers.js
+++ b/packages/truffle-debugger/lib/evm/reducers.js
@@ -172,10 +172,6 @@ export function codex(state = [], action) {
   let newState, topCodex;
 
   const updateFrameStorage = (frame, address, slot, value) => {
-    if (address === DecodeUtils.EVM.ZERO_ADDRESS) {
-      //we do not maintain a zero page! we leave that alone!
-      return frame;
-    }
     let existingPage = frame.accounts[address] || { storage: {} };
     return {
       ...frame,
@@ -231,6 +227,10 @@ export function codex(state = [], action) {
       //on a store, the relevant page should already exist, so we can just
       //add or update the needed slot
       const { address, slot, value } = action;
+      if (address === DecodeUtils.EVM.ZERO_ADDRESS) {
+        //as always, we do not maintain a zero page
+        return state;
+      }
       newState = state.slice(); //clone the state
       topCodex = newState[newState.length - 1];
       newState[newState.length - 1] = updateFrameStorage(
@@ -247,6 +247,10 @@ export function codex(state = [], action) {
       //it's an external load (there was nothing already there), then we want
       //to update *every* stackframe
       const { address, slot, value } = action;
+      if (address === DecodeUtils.EVM.ZERO_ADDRESS) {
+        //as always, we do not maintain a zero page
+        return state;
+      }
       topCodex = state[state.length - 1];
       if (topCodex.accounts[address].storage[slot] !== undefined) {
         return state;

--- a/packages/truffle-debugger/lib/evm/sagas/index.js
+++ b/packages/truffle-debugger/lib/evm/sagas/index.js
@@ -9,8 +9,6 @@ import * as actions from "../actions";
 
 import evm from "../selectors";
 
-import * as DecodeUtils from "truffle-decode-utils";
-
 import * as trace from "lib/trace/sagas";
 
 /**
@@ -108,21 +106,16 @@ export function* callstackAndCodexSaga() {
     yield put(actions.returnCall());
   } else if (yield select(evm.current.step.touchesStorage)) {
     let storageAddress = (yield select(evm.current.call)).storageAddress;
-    //skip doing a touch operation if it's the zero address, since we can't
-    //track things reliably in that case; we'll fall back on the old state
-    //mechanism in that case
-    if (storageAddress !== DecodeUtils.EVM.ZERO_ADDRESS) {
-      let slot = yield select(evm.current.step.storageAffected);
-      //note we get next storage, since we're updating to that
-      let storage = yield select(evm.next.state.storage);
-      //normally we'd need a 0 fallback for this next line, but in this case we
-      //can be sure the value will be there, since we're touching that storage
-      if (yield select(evm.current.step.isStore)) {
-        yield put(actions.store(storageAddress, slot, storage[slot]));
-      } else {
-        //otherwise, it's a load
-        yield put(actions.load(storageAddress, slot, storage[slot]));
-      }
+    let slot = yield select(evm.current.step.storageAffected);
+    //note we get next storage, since we're updating to that
+    let storage = yield select(evm.next.state.storage);
+    //normally we'd need a 0 fallback for this next line, but in this case we
+    //can be sure the value will be there, since we're touching that storage
+    if (yield select(evm.current.step.isStore)) {
+      yield put(actions.store(storageAddress, slot, storage[slot]));
+    } else {
+      //otherwise, it's a load
+      yield put(actions.load(storageAddress, slot, storage[slot]));
     }
   }
 }

--- a/packages/truffle-debugger/lib/evm/sagas/index.js
+++ b/packages/truffle-debugger/lib/evm/sagas/index.js
@@ -117,7 +117,12 @@ export function* callstackAndCodexSaga() {
       let storage = yield select(evm.next.state.storage);
       //normally we'd need a 0 fallback for this next line, but in this case we
       //can be sure the value will be there, since we're touching that storage
-      yield put(actions.store(storageAddress, slot, storage[slot]));
+      if (yield select(evm.current.step.isStore)) {
+        yield put(actions.store(storageAddress, slot, storage[slot]));
+      } else {
+        //otherwise, it's a load
+        yield put(actions.load(storageAddress, slot, storage[slot]));
+      }
     }
   }
 }

--- a/packages/truffle-debugger/lib/evm/selectors/index.js
+++ b/packages/truffle-debugger/lib/evm/selectors/index.js
@@ -100,13 +100,23 @@ function createStepSelectors(step, state = null) {
     ),
 
     /*
+     * .isStore
+     */
+    isStore: createLeaf(["./trace"], step => step.op == "SSTORE"),
+
+    /*
+     * .isLoad
+     */
+    isLoad: createLeaf(["./trace"], step => step.op == "SLOAD"),
+
+    /*
      * .touchesStorage
      *
      * whether the instruction involves storage
      */
     touchesStorage: createLeaf(
-      ["./trace"],
-      step => step.op == "SLOAD" || step.op == "SSTORE"
+      ["./isStore", "isLoad"],
+      (stores, loads) => stores || loads
     )
   };
 

--- a/packages/truffle-debugger/lib/evm/selectors/index.js
+++ b/packages/truffle-debugger/lib/evm/selectors/index.js
@@ -187,23 +187,6 @@ function createStepSelectors(step, state = null) {
       ),
 
       /**
-       * .callContext
-       *
-       * context for what we're about to call into (or create)
-       */
-      callContext: createLeaf(
-        [
-          "./callAddress",
-          "./createBinary",
-          "/info/instances",
-          "/info/binaries/search",
-          "/info/contexts"
-        ],
-        (address, binary, instances, search, contexts) =>
-          findContext({ address, binary }, instances, search, contexts)
-      ),
-
-      /**
        * .storageAffected
        *
        * storage slot being stored to or loaded from

--- a/packages/truffle-debugger/lib/solidity/actions/index.js
+++ b/packages/truffle-debugger/lib/solidity/actions/index.js
@@ -25,6 +25,16 @@ export function jump(jumpDirection) {
   };
 }
 
+export const EXTERNAL_CALL = "EXTERNAL_CALL";
+export function externalCall() {
+  return { type: EXTERNAL_CALL };
+}
+
+export const EXTERNAL_RETURN = "EXTERNAL_RETURN";
+export function externalReturn() {
+  return { type: EXTERNAL_RETURN };
+}
+
 export const RESET = "SOLIDITY_RESET";
 export function reset() {
   return { type: RESET };

--- a/packages/truffle-debugger/lib/solidity/reducers.js
+++ b/packages/truffle-debugger/lib/solidity/reducers.js
@@ -77,14 +77,24 @@ const info = combineReducers({
   sourceMaps
 });
 
-export function functionDepth(state = 0, action) {
+export function functionDepthStack(state = [0], action) {
   switch (action.type) {
     case actions.JUMP:
+      let newState = state.slice(); //clone the state
       const delta = spelunk(action.jumpDirection);
-      return state + delta;
+      let top = newState[newState.length - 1];
+      newState[newState.length - 1] = top + delta;
+      return newState;
 
     case actions.RESET:
-      return 0;
+      return [0];
+
+    case actions.EXTERNAL_CALL:
+      return [...state, state[state.length - 1] + 1];
+
+    case actions.EXTERNAL_RETURN:
+      //just pop the stack! unless, HACK, that would leave it empty
+      return state.length > 1 ? state.slice(0, -1) : state;
 
     default:
       return state;
@@ -96,15 +106,13 @@ function spelunk(jump) {
     return 1;
   } else if (jump === "o") {
     return -1;
-  } else if (jump === "2") {
-    return 2; //HACK WORKAROUND
   } else {
     return 0;
   }
 }
 
 const proc = combineReducers({
-  functionDepth
+  functionDepthStack
 });
 
 const reducer = combineReducers({

--- a/packages/truffle-debugger/lib/solidity/sagas/index.js
+++ b/packages/truffle-debugger/lib/solidity/sagas/index.js
@@ -26,44 +26,24 @@ function* tickSaga() {
 }
 
 function* functionDepthSaga() {
-  if (yield select(solidity.current.willJump)) {
+  if (yield select(solidity.current.willFail)) {
+    //we do this case first so we can be sure we're not failing in any of the
+    //other cases below!
+    yield put(actions.externalReturn());
+  } else if (yield select(solidity.current.willJump)) {
     let jumpDirection = yield select(solidity.current.jumpDirection);
     yield put(actions.jump(jumpDirection));
   } else if (yield select(solidity.current.willCall)) {
-    //we have several cases here:
-    //1. precompile -- *don't* put any jump
-    //2. workaround case -- put a double jump (see below)
-    //3. general case -- put a single jump as expected
-
     debug("about to call");
-    if (yield select(solidity.current.callsPrecompile)) {
-      //call to precompile; do nothing
-    } else if (
-      (yield select(solidity.current.needsFunctionDepthWorkaround)) &&
-      (yield select(solidity.current.isContractCall))
-    ) {
-      //all these parentheses are necessary
-      //HACK WORKAROUND
-      //because of the problem in solc <0.5.1 where contract method calls
-      //essentially return twice, we compensate by putting *two* inward jumps
-      //for such a call.
-      //Note that this won't work if the contract method was previously placed
-      //in a function variable!  Those will continue to screw things up!  But
-      //if a contract call is being made directly, we can detect that.
-      //Of course, all of this should work fine as of solidity 0.5.1, with no
-      //workaround necessary; this branch should only get take on old
-      //contracts.
-      debug("workaround invoked!");
-      yield put(actions.jump("2"));
+    if (yield select(solidity.current.callsPrecompileOrExternal)) {
+      //call to precompile or externally-owned account; do nothing
     } else {
-      //an ordinary call, not to a precompile & with no workaround needed
-      yield put(actions.jump("i"));
+      yield put(actions.externalCall());
     }
   } else if (yield select(solidity.current.willCreate)) {
-    //this case, thankfully, needs no further breakdown
-    yield put(actions.jump("i"));
+    yield put(actions.externalCall());
   } else if (yield select(solidity.current.willReturn)) {
-    yield put(actions.jump("o"));
+    yield put(actions.externalReturn());
   }
 }
 

--- a/packages/truffle-debugger/lib/trace/selectors/index.js
+++ b/packages/truffle-debugger/lib/trace/selectors/index.js
@@ -1,5 +1,18 @@
 import { createSelectorTree, createLeaf } from "reselect-tree";
 
+const PAST_END_OF_TRACE = {
+  depth: -1, //this is the part that matters!
+  //the rest of this is just to look like a trace step
+  error: "",
+  gas: 0,
+  memory: [],
+  stack: [],
+  storage: {},
+  gasCost: 0,
+  op: "STOP",
+  pc: -1 //this is not at all valid but that's fine
+};
+
 let trace = createSelectorTree({
   /**
    * trace.index
@@ -44,12 +57,12 @@ let trace = createSelectorTree({
    *
    * next trace step
    * HACK: if at the end,
-   * we will return the *same* trace step
+   * we will return a spoofed "past end" step
    */
   next: createLeaf(
     ["./steps", "./index"],
     (steps, index) =>
-      index < steps.length - 1 ? steps[index + 1] : steps[index]
+      index < steps.length - 1 ? steps[index + 1] : PAST_END_OF_TRACE
   ),
 
   /*

--- a/packages/truffle-debugger/test/data/codex.js
+++ b/packages/truffle-debugger/test/data/codex.js
@@ -8,15 +8,11 @@ import Ganache from "ganache-core";
 import { prepareContracts } from "../helpers";
 import Debugger from "lib/debugger";
 
-import * as TruffleDecodeUtils from "truffle-decode-utils";
-
 const __LIBTEST = `
 pragma solidity ^0.5.4;
 
 contract MappingPointerTest {
   mapping(string => uint) surface;
-
-  event Done();
 
   function run() public {
     TouchLib.touch(surface);
@@ -30,19 +26,58 @@ library TouchLib {
 }
 `;
 
+const __REVERT_TEST = `
+pragma solidity ^0.5.4;
+
+contract RevertTest {
+
+  uint x;
+
+  function() external {
+    x = 2;
+    revert();
+  }
+
+  function run() public {
+    x = 1;
+    address(this).call(hex"");
+  }
+}
+
+contract RevertTest2 {
+
+  uint x;
+
+  function() external {
+    x = 2;
+    assert(false);
+  }
+
+  function run() public {
+    x = 1;
+    address(this).call.gas(gasleft()/2)(hex"");
+  }
+}
+`;
+
 const __MIGRATION = `
 var MappingPointerTest = artifacts.require("MappingPointerTest");
 var TouchLib = artifacts.require("TouchLib");
+var RevertTest = artifacts.require("RevertTest");
+var RevertTest2 = artifacts.require("RevertTest2");
 
 module.exports = function(deployer) {
   deployer.deploy(TouchLib);
   deployer.link(TouchLib, MappingPointerTest);
   deployer.deploy(MappingPointerTest);
+  deployer.deploy(RevertTest);
+  deployer.deploy(RevertTest2);
 };
 `;
 
 let sources = {
-  "MappingPointerTest.sol": __LIBTEST
+  "MappingPointerTest.sol": __LIBTEST,
+  "RevertTest.sol": __REVERT_TEST
 };
 
 let migrations = {
@@ -85,10 +120,50 @@ describe("Codex", function() {
 
     await session.continueUntilBreakpoint(); //run till end
 
-    const variables = TruffleDecodeUtils.Conversion.cleanBNs(
-      await session.variables()
-    );
+    const variables = await session.variables();
 
-    assert.equal(variables.surface.get("ping"), 1);
+    assert.equal(variables.surface.get("ping").toNumber(), 1);
+  });
+
+  it("Reverts storage when a call reverts", async function() {
+    this.timeout(6000);
+    let instance = await abstractions.RevertTest.deployed();
+    let receipt = await instance.run();
+    let txHash = receipt.tx;
+
+    let bugger = await Debugger.forTx(txHash, {
+      provider,
+      files,
+      contracts: artifacts
+    });
+
+    let session = bugger.connect();
+
+    await session.continueUntilBreakpoint(); //run till end
+
+    const variables = await session.variables();
+
+    assert.equal(variables.x.toNumber(), 1);
+  });
+
+  it("Reverts storage when a call otherwise fails", async function() {
+    this.timeout(6000);
+    let instance = await abstractions.RevertTest2.deployed();
+    let receipt = await instance.run();
+    let txHash = receipt.tx;
+
+    let bugger = await Debugger.forTx(txHash, {
+      provider,
+      files,
+      contracts: artifacts
+    });
+
+    let session = bugger.connect();
+
+    await session.continueUntilBreakpoint(); //run till end
+
+    const variables = await session.variables();
+
+    assert.equal(variables.x.toNumber(), 1);
   });
 });

--- a/packages/truffle-debugger/test/solidity.js
+++ b/packages/truffle-debugger/test/solidity.js
@@ -30,7 +30,8 @@ contract SingleCall {
 }
 `;
 
-const __NESTED_CALL = `pragma solidity ~0.5;
+const __NESTED_CALL = `
+pragma solidity ~0.5;
 
 contract NestedCall {
   event First();
@@ -63,9 +64,38 @@ contract NestedCall {
 }
 `;
 
+const __FAILED_CALL = `
+pragma solidity ^0.5.0;
+
+contract RevertTest {
+
+  event Begin();
+  event Done();
+
+  function() external {
+    doStuff();
+  }
+
+  function doStuff() public {
+    fail();
+  }
+
+  function fail() public {
+    revert();
+  }
+
+  function run() public {
+    emit Begin(); //BREAK #1
+    address(this).call(hex"");
+    emit Done(); //BREAK #2
+  }
+}
+`;
+
 let sources = {
   "SingleCall.sol": __SINGLE_CALL,
-  "NestedCall.sol": __NESTED_CALL
+  "NestedCall.sol": __NESTED_CALL,
+  "FailedCall.sol": __FAILED_CALL
 };
 
 describe("Solidity Debugging", function() {
@@ -243,6 +273,36 @@ describe("Solidity Debugging", function() {
       } while (!finished);
 
       assert.deepEqual(actualSequence, expectedDepthSequence);
+    });
+
+    it("unwinds correctly on call failure", async function() {
+      // prepare
+      let instance = await abstractions.RevertTest.deployed();
+      let receipt = await instance.run();
+      let txHash = receipt.tx;
+
+      let bugger = await Debugger.forTx(txHash, {
+        provider,
+        files,
+        contracts: artifacts
+      });
+
+      let session = bugger.connect();
+
+      let source = session.view(solidity.current.source);
+      let breakLine1 = lineOf("BREAK #1", source.source);
+      let breakpoint1 = { sourceId: source.id, line: breakLine1 };
+      await session.addBreakpoint(breakpoint1);
+      let breakLine2 = lineOf("BREAK #2", source.source);
+      let breakpoint2 = { sourceId: source.id, line: breakLine2 };
+      await session.addBreakpoint(breakpoint2);
+
+      await session.continueUntilBreakpoint();
+      let depthBefore = session.view(solidity.current.functionDepth);
+      await session.continueUntilBreakpoint();
+      let depthAfter = session.view(solidity.current.functionDepth);
+
+      assert.equal(depthAfter, depthBefore);
     });
   });
 });

--- a/packages/truffle-debugger/test/solidity.js
+++ b/packages/truffle-debugger/test/solidity.js
@@ -224,7 +224,7 @@ describe("Solidity Debugging", function() {
 
       // follow functionDepth values in list
       // see source above
-      let expectedDepthSequence = [0, 1, 2, 3, 2, 1, 2, 1, -1];
+      let expectedDepthSequence = [0, 1, 2, 3, 2, 1, 2, 1, 0];
       //end at -1 due to losing 2 from contract method return
       let actualSequence = [session.view(solidity.current.functionDepth)];
 

--- a/packages/truffle-decode-utils/src/definition.ts
+++ b/packages/truffle-decode-utils/src/definition.ts
@@ -107,18 +107,8 @@ export namespace Definition {
     return typeIdentifier(definition).match(/^t_enum/) != null;
   }
 
-  export function isContract(definition: AstDefinition): boolean {
-    return typeIdentifier(definition).match(/^t_contract/) != null;
-  }
-
   export function isReference(definition: AstDefinition): boolean {
     return typeIdentifier(definition).match(/_(memory|storage|calldata)(_ptr)?$/) != null;
-  }
-
-  export function isContractType(definition: AstDefinition): boolean {
-    // checks whether the given node is a contract *type*, rather than whether
-    // it's a contract
-    return typeIdentifier(definition).match(/^t_type\$_t_contract/) != null;
   }
 
   //note: only use this on things already verified to be references


### PR DESCRIPTION
Previously, the Truffle Debugger did nothing to handle exceptional halting.  Now, in Solidity, this usually isn't much of a problem, because if one call in the transaction reverts, the entire transaction reverts in short order.  However, this isn't necessarily the case; by using `<address>.call()` (and related functions), one may catch an exceptional halt and resume execution.  As such, we need to be able to handle this case.  This requires additional state to be tracked in both the `evm` and `solidity` submodules.

Before we get to this additional state, though, let's discuss how we detect exceptional halting in the first place.  We can't just look for the `REVERT` or `INVALID` opcodes, as there's any number of ways an exceptional halt might occur.  Thus, we detect an exceptional halt as any time the depth is about to decrease but the current opcode is *not* `STOP` or `RETURN`.

Speaking of which, I've changed to an easier method of detecting calls to precompiles (or externally-owned accounts); rather than seeing whether we're able to get the binary of the address we're calling, we just check whether the depth increases or not.  If the depth stays the same, we're calling a precompile or externally-owned account, and don't need to add to the callstack.

Also, to make such comparisons simpler, I've altered `trace.next` so that, if you're at the end of the trace, `trace.next` does not return the same thing as `trace.step`, but rather returns a spoofed trace step of depth -1.  This prevents us from having to deal with special cases at the end of the trace.

So, anyway, what's the actually-new functionality here?  Well, in `evm`, we now have a new action called `FAIL`, that's triggered on exceptional halting.  The `callstack` reducer now recognizes `FAIL` and will pop a stackframe on `FAIL` as well as on `RETURN`.  (There's also another new action: `LOAD` has been separated from `STORE`, where previously they were treated in a unified manner.  But I'll get back to that.)

However the bigger change is in the `codex` reducer.  I've had to reorganize the codex, you see.  The original plan was that it would have two members, `byAddress` for things that are stored by address (like storage) and `byStackframe` for things that are stored by stackframe (like memory -- not that that's in the codex yet).  However, given that we have to account for the possibility of reversion, *everything* needs to be by stackframe!  It's just that some things need to be by address *and* stackframe.

So, the codex is now a stack, an array of stackframe objects.  Again, currently it only tracks storage, so each stackframe object currently only holds a single member, `accounts`, which is then indexed by address, and the object for each address currently only holds a single member, `storage`.  But yeah, it's the codex.

So now, on `CALL` or `CREATE`, rather than just adding a new page to the codex if necessary, we push a new stackframe onto the codex (a clone of the old top stackframe), and then add a new page to *that* if necessary.  On `STORE`, we alter only the top stackframe of the codex.  On `FAIL`, we pop the codex -- the top stackframe has reverted, so its contents are lost!  Finally, on `RETURN`, we pop the codex, but then make the new top stackframe a clone of the old; i.e., we save the results of the stackframe that just completed, rather than discarding them.  (Of course, in the actual code, I implemented this by just dropping the stackframe second from the top.)

Now I mentioned that on `STORE` we alter only the top stackframe of the codex.  What about on `LOAD`?  Well, that depends.  If the slot we're loading is already in the codex, we no longer bother altering anything.  But if it wasn't already in the codex, that means we're loading something preexisting -- something from before this transaction.  That's not a value that will get reverted when the call fails, because it's a value that wasn't actually set in this transaction at all!  So on such a load, we update *every* stackframe.

(Btw, it's now entirely the reducer's responsibility for checking for the zero address and refusing to maintain a page for this address; the saga no longer does this.)

So now we correctly track storage when a call reverts!  Previously, we didn't distinguish stackframes like this, so a change to storage made in a failing call would not be reverted at the end of that call.

But there's another problem -- when an EVM call exceptionally halts, it could do so from inside any number of internal Solidity function calls.  So we need to be able to restore the function depth, too.

So, now, in the `solidity` state, instead of `functionDepth`, there's `functionDepthStack`.  EVM calls and returns are no longer handled with the `JUMP` action, but have new actions, `EXTERNAL_CALL` and `EXTERNAL_RETURN`.  A `JUMP` now just alters the top element of the stack.  An `EXTERNAL_CALL` grows the stack by 1, pushing a duplicate of the top element onto the stack and then incrementing *that* by 1.  And an `EXTERNAL_RETURN` (which covers both ordinary and exceptional halting) pops the stack by 1.

As a nice side benefit, this allows us to get rid of that awful function depth workaround I wrote for Solidity versions prior to 0.5.1!  This method works regardless of Solidity compiler version, and, unlike that workaround, will work just fine with function variables.  I've torn out a whole bunch of code that existed solely to support it.  I did, however, leave `compiler` in the `contexts` state, because we might need it in the future.

By the way, notice that this PR doesn't touch the `data` submodule at all.  So, any mapping keys that we start tracking during a failed call will stay tracked when the call reverts.  I don't think that's a problem.

I also added a few tests of this feature.