### PR TITLE
Add solc metadata output

### DIFF
--- a/packages/truffle-compile/index.js
+++ b/packages/truffle-compile/index.js
@@ -81,6 +81,7 @@ const compile = function(sources, options, callback) {
     "": ["legacyAST", "ast"],
     "*": [
       "abi",
+      "metadata",
       "evm.bytecode.object",
       "evm.bytecode.sourceMap",
       "evm.deployedBytecode.object",
@@ -188,6 +189,7 @@ const compile = function(sources, options, callback) {
             legacyAST: standardOutput.sources[source_path].legacyAST,
             ast: standardOutput.sources[source_path].ast,
             abi: contract.abi,
+            metadata: contract.metadata,
             bytecode: "0x" + contract.evm.bytecode.object,
             deployedBytecode: "0x" + contract.evm.deployedBytecode.object,
             unlinked_binary: "0x" + contract.evm.bytecode.object, // deprecated

--- a/packages/truffle-contract-schema/index.js
+++ b/packages/truffle-contract-schema/index.js
@@ -45,6 +45,9 @@ var properties = {
       return value;
     }
   },
+  metadata: {
+    sources: ["metadata"]
+  },
   bytecode: {
     sources: ["bytecode", "binary", "unlinked_binary", "evm.bytecode.object"],
     transform: function(value) {

--- a/packages/truffle-contract-schema/spec/contract-object.spec.json
+++ b/packages/truffle-contract-schema/spec/contract-object.spec.json
@@ -15,6 +15,7 @@
       "allOf": [{ "$ref": "abi.spec.json#" }],
       "description": "Interface description returned by compiler for source"
     },
+    "metadata": { "$ref": "#/definitions/Metadata" },
     "bytecode": {
       "allOf": [{ "$ref": "#/definitions/Bytecode" }],
       "description": "Bytecode sent as contract-creation transaction data, with unresolved link references"
@@ -78,6 +79,10 @@
 
     "NatSpec": {
       "type": "object"
+    },
+
+    "Metadata": {
+      "type": "string"
     },
 
     "Bytecode": {

--- a/packages/truffle-contract-schema/test/solc.js
+++ b/packages/truffle-contract-schema/test/solc.js
@@ -34,6 +34,7 @@ contract B {
           "*": {
             "*": [
               "abi",
+              "metadata",
               "evm.bytecode.object",
               "evm.bytecode.sourceMap",
               "evm.deployedBytecode.object",
@@ -54,10 +55,13 @@ contract B {
 
     var expected = {
       abi: rawA.abi,
+      metadata: rawA.metadata,
       bytecode: "0x" + rawA.evm.bytecode.object,
       deployedBytecode: "0x" + rawA.evm.deployedBytecode.object,
       sourceMap: rawA.evm.bytecode.sourceMap,
-      deployedSourceMap: rawA.evm.deployedBytecode.sourceMap
+      deployedSourceMap: rawA.evm.deployedBytecode.sourceMap,
+      devdoc: rawA.devdoc,
+      userdoc: rawA.userdoc
     };
 
     Object.keys(expected).forEach(function(key) {

--- a/packages/truffle-contract/lib/contract/properties.js
+++ b/packages/truffle-contract/lib/contract/properties.js
@@ -76,6 +76,9 @@ module.exports = {
       this._json.abi = val;
     }
   },
+  metadata: function() {
+    return this._json.metadata;
+  },
   network: function() {
     var network_id = this.network_id;
 


### PR DESCRIPTION
This PR stores solc's metadata output in the artifact json on successful compilation.