### PR TITLE
Alter no-source-map fallback to treat as unmapped

### DIFF
--- a/packages/truffle-debugger/lib/solidity/selectors/index.js
+++ b/packages/truffle-debugger/lib/solidity/selectors/index.js
@@ -139,17 +139,11 @@ let solidity = createSelectorTree({
         let instructions = CodeUtils.parseCode(binary);
 
         if (!sourceMap) {
+          // HACK
           // Let's create a source map to use since none exists. This source map
-          // maps just as many ranges as there are instructions, and ensures every
-          // instruction is marked as "jumping out". This will ensure all
-          // available debugger commands step one instruction at a time.
-          //
-          // This is kindof a hack; perhaps this should be broken out into separate
-          // context types. TODO
-          sourceMap = "";
-          for (var i = 0; i < instructions.length; i++) {
-            sourceMap += i + ":" + i + ":1:-1;";
-          }
+          // maps just as many ranges as there are instructions, and marks them
+          // all as being Solidity-internal and not jumps.
+          sourceMap = "0:0:-1:-".concat(";".repeat(instructions.length - 1));
         }
 
         var lineAndColumnMappings = Object.assign(


### PR DESCRIPTION
This PR changes the default sourcemap used when we can't locate a sourcemap.  The existing fallback mapped the source as progressing character-by-character through source file number 1 (whichever one that is), and always jumping outward.  The effect of this was that when no sourcemap was found, `stepNext` would progress instruction by instruction.  The other effect of this, however, is that it would screw up your Solidity stackframe so you wouldn't see the right variables.

The new fallback instead maps the source as being Solidity-internal and not containing any jumps inward or outward.  Note that this *is* a change in behavior; `stepNext` will now skip over such code instead of going through it one instruction at a time.  If you want to go through it one instruction at a time, though, there's always `advance`.

Of course the main reason I'm doing this is to get rid of the jump outwards markings so that it doesn't screw up your variables.  Thanks to the function depth stack introduced in #1855, the *lack* of jumps shouldn't screw up your variables either!

(...I guess, come to think of it, that the function depth stack also makes this change largely unnecessary; the jump outwards markings should be fine now that we have that.  Oh well.  I only just realized that.  I still think this is a good change to make, even if it's less necessary than I thought.)

Btw, there's also one more effect of this: Now if you're in code where we don't have a source map, the CLI will tell you no source code found, rather than claiming you're advancing through file number 1 character-by-character, which, well, just seems less confusing and misleading...