### PR TITLE
Split off watch variables from watch expressions and make the latter work better

### DIFF
--- a/packages/truffle-core/lib/commands/debug.js
+++ b/packages/truffle-core/lib/commands/debug.js
@@ -283,7 +283,9 @@ var command = {
               .join(OS.EOL);
           }
 
-          function printVariables(variables) {
+          async function printVariables() {
+            let variables = await session.variables();
+
             debug("variables %o", variables);
 
             // Get the length of the longest name.
@@ -344,7 +346,8 @@ var command = {
 
             let variable = raw.trim();
             if (variable in variables) {
-              printVariables({ [variable]: variables[variable] });
+              let formatted = formatValue(variables[variable], indent);
+              config.logger.log(formatted);
               return;
             }
 
@@ -710,7 +713,7 @@ var command = {
                 printWatchExpressions();
                 break;
               case "v":
-                printVariables(await session.variables());
+                await printVariables();
                 break;
               case ":":
                 evalAndPrintExpression(cmdArgs);

--- a/packages/truffle-core/lib/commands/debug.js
+++ b/packages/truffle-core/lib/commands/debug.js
@@ -262,8 +262,6 @@ var command = {
           // TODO make this more robust for all cases and move to
           // truffle-debug-utils
           function formatValue(value, indent) {
-            value = DebugUtils.cleanConstructors(value); //HACK
-
             if (!indent) {
               indent = 0;
             }
@@ -348,6 +346,7 @@ var command = {
             if (variable in variables) {
               let formatted = formatValue(variables[variable], indent);
               config.logger.log(formatted);
+              config.logger.log();
               return;
             }
 
@@ -397,6 +396,7 @@ var command = {
 
             try {
               var result = safeEval(expr, context);
+              result = DebugUtils.cleanConstructors(result); //HACK
               var formatted = formatValue(result, indent);
               config.logger.log(formatted);
               config.logger.log();

--- a/packages/truffle-core/lib/commands/debug.js
+++ b/packages/truffle-core/lib/commands/debug.js
@@ -423,7 +423,7 @@ var command = {
             }
           }
 
-          async function watchExpressionAnalytics(raw) {
+          function watchExpressionAnalytics(raw) {
             let type = raw[0];
             let exprArgs = raw.substring(1);
 
@@ -432,12 +432,11 @@ var command = {
               return;
             }
 
-            let variables = await session.variables();
-
             let expression = exprArgs.trim();
+            let isVariable = expression.match(/[a-zA-Z_$][a-zA-Z_$0-9]*/);
             analytics.send({
               command: "watch expression",
-              args: { isVariable: expression in variables }
+              args: { isVariable }
             });
           }
 
@@ -719,7 +718,7 @@ var command = {
             // (we want to see if execution stopped before printing state).
             switch (cmd) {
               case "+":
-                await watchExpressionAnalytics(cmdArgs);
+                watchExpressionAnalytics(cmdArgs);
                 enabledExpressions.add(cmdArgs);
                 await printWatchExpressionResult(cmdArgs);
                 break;
@@ -736,7 +735,7 @@ var command = {
                 await printVariables();
                 break;
               case ":":
-                await watchExpressionAnalytics(cmdArgs);
+                watchExpressionAnalytics(cmdArgs);
                 evalAndPrintExpression(cmdArgs);
                 break;
               case "b":

--- a/packages/truffle-core/lib/commands/debug.js
+++ b/packages/truffle-core/lib/commands/debug.js
@@ -424,16 +424,14 @@ var command = {
           }
 
           function watchExpressionAnalytics(raw) {
-            let type = raw[0];
-            let exprArgs = raw.substring(1);
-
-            if (type === "!") {
-              //not doing analytics on selector watches...
+            if (raw.includes("!<")) {
+              //don't send analytics for watch expressions involving selectors
               return;
             }
-
-            let expression = exprArgs.trim();
-            let isVariable = expression.match(/[a-zA-Z_$][a-zA-Z_$0-9]*/);
+            let expression = raw.trim();
+            //legal Solidity identifiers (= legal JS identifiers)
+            let identifierRegex = /^[a-zA-Z_$][a-zA-Z_$0-9]*$/;
+            let isVariable = expression.match(identifierRegex) !== null;
             analytics.send({
               command: "watch expression",
               args: { isVariable }
@@ -718,7 +716,9 @@ var command = {
             // (we want to see if execution stopped before printing state).
             switch (cmd) {
               case "+":
-                watchExpressionAnalytics(cmdArgs);
+                if (cmdArgs[0] === ":") {
+                  watchExpressionAnalytics(cmdArgs.substring(1));
+                }
                 enabledExpressions.add(cmdArgs);
                 await printWatchExpressionResult(cmdArgs);
                 break;

--- a/packages/truffle-core/lib/commands/debug.js
+++ b/packages/truffle-core/lib/commands/debug.js
@@ -433,7 +433,7 @@ var command = {
             let identifierRegex = /^[a-zA-Z_$][a-zA-Z_$0-9]*$/;
             let isVariable = expression.match(identifierRegex) !== null;
             analytics.send({
-              command: "watch expression",
+              command: "debug: watch expression",
               args: { isVariable }
             });
           }

--- a/packages/truffle-debug-utils/index.js
+++ b/packages/truffle-debug-utils/index.js
@@ -287,6 +287,8 @@ var DebugUtils = {
       );
     }
 
+    //HACK -- due to safeEval altering things, it's possible for isBN() to
+    //throw an error here
     try {
       //we do not want to alter BNs!
       //(or other special objects, but that's just BNs right now)
@@ -294,7 +296,6 @@ var DebugUtils = {
         return object;
       }
     } catch (e) {
-      //HACK
       //if isBN threw an error, it's not a BN, so move on
     }
 
@@ -325,6 +326,54 @@ var DebugUtils = {
           variable === "this" ? { [replacement]: value } : { [variable]: value }
       )
     );
+  },
+
+  //HACK
+  //replace maps with objects (POJSOs?) and BNs with numbers
+  //May cause errors if BNs are too big!  But I think this is the right
+  //tradeoff for now; note this is only used when dealing with *expressions*,
+  //not individual variables (it's used so you can add and index and etc like
+  //you would in Solidity)
+  nativize: function(object) {
+    if (object && typeof object.map === "function") {
+      //array case
+      return object.map(DebugUtils.nativize);
+    }
+
+    if (object && object instanceof Map) {
+      //map case
+      //HACK -- we apply toString() to all the keys; due to JS's use of weak
+      //comparison for indexing, this should still work
+      return Object.assign(
+        {},
+        ...Array.from(object.entries()).map(([key, value]) => ({
+          [key.toString()]: DebugUtils.nativize(value)
+        }))
+      );
+    }
+
+    //HACK -- due to safeEval altering things, it's possible for isBN() to
+    //throw an error here
+    try {
+      if (BN.isBN(object)) {
+        return object.toNumber();
+      }
+    } catch (e) {
+      //if isBN threw an error, it's not a BN, so move on
+    }
+
+    if (object && typeof object === "object") {
+      //generic object case
+      return Object.assign(
+        {},
+        ...Object.entries(object).map(([key, value]) => ({
+          [key]: DebugUtils.nativize(value)
+        }))
+      );
+    }
+
+    //default case for strings, numbers, etc
+    return object;
   }
 };
 


### PR DESCRIPTION
(Edit: The original verison of this PR had some mistakes, I've edited the text below to match the current version.)

This PR makes it so that watch expressions are treated differently based on whether or not they consist of just a single variable.  Now, when a watch expression does not just consist of a single variable, the `variables` object is first run through an additional `nativize` step before the watch expression is evaluated.  This step converts `Map`s to plain old objects and `BN`s to numbers (although this may cause an error).  The point of this is to allow arithmetic operations and indexing to work normally, just as it would in Solidity, without the user having to use `BN` operations or `get()`.

This does mean that the same object can print out differently depending on whether the expression you enter consists of just a single variable or not, and it does mean that we have the problems with numbers above (and also mappings with boolean keys?), but I think this is the right tradeoff to make for the moment.

Also, yes, converting things from objects to `Map`s and then later converting them back is a bit silly, but it seems like the best way with the current structure.  Things will get a bit less silly once we have the new decoder output format.