### PR TITLE
Add some comments and tweak some tests

### DIFF
--- a/packages/truffle-debugger/lib/evm/reducers.js
+++ b/packages/truffle-debugger/lib/evm/reducers.js
@@ -297,8 +297,16 @@ function codex(state = [], action) {
       }
       topCodex = state[state.length - 1];
       if (topCodex.accounts[address].storage[slot] !== undefined) {
+        //if we already have a value in the *top* stackframe, update *no*
+        //stackframes; don't update the top (no need, it's just a load, not a
+        //store), don't update the rest (that would be wrong, you might be
+        //loading a value that will get reverted later)
         return state;
       } else {
+        //if we *don't* already have a value in the top stackframe, that means
+        //we're loading a value from a previous transaction!  That's not a
+        //value that will get reverted if this call fails, so update *every*
+        //stackframe
         return state.map(frame =>
           updateFrameStorage(frame, address, slot, value)
         );

--- a/packages/truffle-debugger/test/context.js
+++ b/packages/truffle-debugger/test/context.js
@@ -116,21 +116,19 @@ describe("Contexts", function() {
     );
     debug("affectedInstances: %o", affectedInstances);
 
-    let affectedAddresses = Object.keys(affectedInstances).map(address =>
-      address.toLowerCase()
-    );
+    let affectedAddresses = Object.keys(affectedInstances);
 
     assert.equal(2, affectedAddresses.length);
 
     assert.include(
       affectedAddresses,
-      outer.address.toLowerCase(),
+      outer.address,
       "OuterContract should be an affected address"
     );
 
     assert.include(
       affectedAddresses,
-      inner.address.toLowerCase(),
+      inner.address,
       "InnerContract should be an affected address"
     );
   });

--- a/packages/truffle-debugger/test/data/codex.js
+++ b/packages/truffle-debugger/test/data/codex.js
@@ -32,9 +32,11 @@ pragma solidity ^0.5.4;
 contract RevertTest {
 
   uint x;
+  uint y;
 
   function() external {
     x = 2;
+    y = x;
     revert();
   }
 
@@ -47,9 +49,11 @@ contract RevertTest {
 contract RevertTest2 {
 
   uint x;
+  uint y;
 
   function() external {
     x = 2;
+    y = x;
     assert(false);
   }
 

--- a/packages/truffle-debugger/test/data/ids.js
+++ b/packages/truffle-debugger/test/data/ids.js
@@ -222,6 +222,7 @@ describe("Variable IDs", function() {
   });
 
   it("Stays at correct stackframe after contract call", async function() {
+    this.timeout(3000);
     let instance = await abstractions.Intervening.deployed();
     let receipt = await instance.run();
     let txHash = receipt.tx;
@@ -246,6 +247,7 @@ describe("Variable IDs", function() {
   });
 
   it("Stays at correct stackframe after library call", async function() {
+    this.timeout(3000);
     let instance = await abstractions.Intervening.deployed();
     let receipt = await instance.runLib();
     let txHash = receipt.tx;


### PR DESCRIPTION
This PR is just a slight update to #1855.  I decided that the `LOAD` case of the `codex` reducer wasn't commented enough so I added some comments.  (Specifically, I was worried that some future person looking at it would think it looks wrong and attempt to "fix" it, so I added some comments explaining why it works the way it does.)  Also, I added a bit more to the tests I added in that PR, so that now some of the `LOAD` case is tested as well, not just the `STORE` case.  Finally, while doing this I noticed that an old test was still lowercasing addresses before comparison, which should no longer be necessary, so I removed the conversion to lowercase.  That's all, just minor internal stuff.