### PR TITLE
Improve mismatched solc version & pragma statement erroring

### DIFF
--- a/packages/truffle-compile/compileerror.js
+++ b/packages/truffle-compile/compileerror.js
@@ -6,11 +6,12 @@ inherits(CompileError, TruffleError);
 
 function CompileError(message) {
   // Note we trim() because solc likes to add extra whitespace.
-  var fancy_message = message.trim() + "\n" + colors.red("Compilation failed. See above.");
+  var fancy_message =
+    message.trim() + "\n\n" + colors.red("Compilation failed. See above.");
   var normal_message = message.trim();
 
   CompileError.super_.call(this, normal_message);
   this.message = fancy_message;
-};
+}
 
 module.exports = CompileError;

--- a/packages/truffle-compile/index.js
+++ b/packages/truffle-compile/index.js
@@ -6,6 +6,7 @@ const CompilerSupplier = require("./compilerSupplier");
 const expect = require("truffle-expect");
 const find_contracts = require("truffle-contract-sources");
 const Config = require("truffle-config");
+const semver = require("semver");
 const debug = require("debug")("compile"); // eslint-disable-line no-unused-vars
 
 // Most basic of the compile commands. Takes a hash of sources, where
@@ -151,11 +152,16 @@ const compile = function(sources, options, callback) {
 
       if (errors.length > 0) {
         options.logger.log("");
-        return callback(
-          new CompileError(
-            standardOutput.errors.map(error => error.formattedMessage).join()
-          )
-        );
+        errors = errors.map(error => error.formattedMessage).join();
+        if (errors.includes("requires different compiler version")) {
+          const contractSolcVer = errors.match(/pragma solidity[^;]*/gm)[0];
+          const configSolcVer =
+            options.compilers.solc.version || semver.valid(solc.version());
+          errors = errors.concat(
+            `\nError: Truffle is currently using solc ${configSolcVer}, but one or more of your contracts specify "${contractSolcVer}".\nPlease update your truffle config or pragma statement(s).\n(See https://truffleframework.com/docs/truffle/reference/configuration#compiler-configuration for information on\nconfiguring Truffle to use a specific solc compiler version.)`
+          );
+        }
+        return callback(new CompileError(errors));
       }
 
       var contracts = standardOutput.contracts;


### PR DESCRIPTION
This PR attempts to provide more helpful output when attempting to compile a truffle project using pragma solidity statements incompatible with the currently loaded solc compiler.

<details><summary>Example using truffle out-of-the-box on a solc 0.4.25 file:
</summary>

```

$ truffle compile

Compiling your contracts...
===========================
> Compiling ./contracts/ConvertLib.sol

/Users/cruzmolina/Code/truffle-projects/metacoin/contracts/ConvertLib.sol:2:1: SyntaxError: Source file requires different compiler version (current compiler is 0.5.0+commit.1d4f565a.Emscripten.clang - note that nightly builds are considered to be strictly less than the released version
pragma solidity 0.4.25;
^---------------------^

Error: Truffle is currently using solc 0.5.0, but one or more of your contracts specify "pragma solidity 0.4.25".
Please update your truffle config or pragma statement(s).
(See https://truffleframework.com/docs/truffle/reference/configuration#compiler-configuration for information on
configuring Truffle to use a specific solc compiler version.)

Compilation failed. See above.
Truffle v5.0.9 (core: 5.0.9)
Node v11.4.0
```
</details>
<details><summary>Example using truffle configured to use solc 0.5.7 on a solc 0.4.25 file:
</summary>

```
$ truffle compile

Compiling your contracts...
===========================
Error: CompileError: ParsedContract.sol:2:1: ParserError: Source file requires different compiler version (current compiler is 0.5.7+commit.6da8b019.Emscripten.clang - note that nightly builds are considered to be strictly less than the released version
pragma solidity 0.4.25;
^---------------------^

Compilation failed. See above.

Error: Truffle is currently using solc 0.5.7, but one or more of your contracts specify "pragma solidity 0.4.25".
Please update your truffle config or pragma statement(s).
(See https://truffleframework.com/docs/truffle/reference/configuration#compiler-configuration for information on
configuring Truffle to use a specific solc compiler version.)

    at async.whilst.error (/Users/cruzmolina/Code/truffle-projects/truffle/packages/truffle/build/webpack:/packages/truffle-compile/profiler.js:371:1)
    at /Users/cruzmolina/Code/truffle-projects/truffle/packages/truffle/build/webpack:/packages/truffle-compile/~/async/dist/async.js:969:1
    at next (/Users/cruzmolina/Code/truffle-projects/truffle/packages/truffle/build/webpack:/packages/truffle-compile/~/async/dist/async.js:5222:1)
    at Promise.all.then.results (/Users/cruzmolina/Code/truffle-projects/truffle/packages/truffle/build/webpack:/packages/truffle-compile/profiler.js:353:1)
Truffle v5.0.9 (core: 5.0.9)
Node v11.4.0
```
</details>


Inspired by @wbt in #1818. ☕️ 