### PR TITLE
Add SELFDESTRUCT as normal halting

### DIFF
--- a/packages/truffle-debugger/lib/evm/selectors/index.js
+++ b/packages/truffle-debugger/lib/evm/selectors/index.js
@@ -14,7 +14,8 @@ import {
   isShortCallMnemonic,
   isDelegateCallMnemonicBroad,
   isDelegateCallMnemonicStrict,
-  isStaticCallMnemonic
+  isStaticCallMnemonic,
+  isNormalHaltingMnemonic
 } from "lib/helpers";
 
 function findContext({ address, binary }, instances, search, contexts) {
@@ -113,9 +114,8 @@ function createStepSelectors(step, state = null) {
      * whether the instruction halts or returns from a calling context
      * (covers only ordinary halds, not exceptional halts)
      */
-    isHalting: createLeaf(
-      ["./trace"],
-      step => step.op == "STOP" || step.op == "RETURN"
+    isHalting: createLeaf(["./trace"], step =>
+      isNormalHaltingMnemonic(step.op)
     ),
 
     /*

--- a/packages/truffle-debugger/lib/helpers/index.js
+++ b/packages/truffle-debugger/lib/helpers/index.js
@@ -84,3 +84,13 @@ export function isCreateMnemonic(op) {
   const creates = ["CREATE", "CREATE2"];
   return creates.includes(op);
 }
+
+/*
+ * Given a mmemonic, determine whether it's the mnemonic of a normal
+ * halting instruction
+ */
+export function isNormalHaltingMnemonic(op) {
+  const halts = ["STOP", "RETURN", "SELFDESTRUCT", "SUICIDE"];
+  //the mnemonic SUICIDE is no longer used, but just in case, I'm including it
+  return halts.includes(op);
+}


### PR DESCRIPTION
The debugger had checked for normal halting by checking for `STOP` or `RETURN`.  However, `SELFDESTRUCT` is also a normal halting instruction.  Since a contract that `SELFDESTRUCT`s is not actually deleted until the transaction is finished, this could potentially be relevant.  In any case, this PR fixes that.