### PR TITLE
Remove postinstall script to install solc

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "build:truffle-contract-schema": "cd packages/truffle-contract-schema && npm run build",
     "lerna:bootstrap": "lerna bootstrap",
     "bootstrap": "./scripts/bootstrap.sh",
-    "postinstall": "truffle obtain --solc=0.5.4",
     "test": "lerna run test --stream --concurrency=1 -- --colors",
     "ci": "./scripts/ci.sh",
     "geth": "./scripts/geth.sh",


### PR DESCRIPTION
This postinstall script is unnecessary and can be removed. It was originally mistakenly intended to be a post-install hook for users installing Truffle from npm. However, this is actually a post-install hook for users cloning Truffle and installing the dependencies through npm.