### PR TITLE
Skip getting contract node if there's no AST

### DIFF
--- a/packages/truffle-decoder/lib/interface/contract-decoder.ts
+++ b/packages/truffle-decoder/lib/interface/contract-decoder.ts
@@ -75,18 +75,14 @@ export interface ContractMapping {
   [nodeId: number]: ContractObject;
 };
 
-export function getContractNode(contract: ContractObject): AstDefinition {
-  for (let j = 0; j < contract.ast.nodes.length; j++) {
-    const contractNode = contract.ast.nodes[j];
-    const nodeMatchesContract =
-      contractNode.name === contract.contractName ||
-      contractNode.name === contract.contract_name;
-    if (contractNode.nodeType === "ContractDefinition" && nodeMatchesContract) {
-      return contractNode;
-    }
-  }
-
-  return undefined;
+//note: may return undefined
+function getContractNode(contract: ContractObject): AstDefinition {
+  return (contract.ast || {nodes: []}).nodes.find(
+    (contractNode: AstDefinition) =>
+    contractNode.nodeType === "ContractDefinition"
+    && (contractNode.name === contract.contractName
+      || contractNode.name === contract.contract_name)
+  );
 }
 
 export default class TruffleContractDecoder extends AsyncEventEmitter {
@@ -133,9 +129,11 @@ export default class TruffleContractDecoder extends AsyncEventEmitter {
     abiDecoder.addABI(this.contract.abi);
     this.relevantContracts.forEach((relevantContract) => {
       let node: AstDefinition = getContractNode(relevantContract);
-      this.contracts[node.id] = relevantContract;
-      this.contractNodes[node.id] = node;
-      abiDecoder.addABI(relevantContract.abi);
+      if(node !== undefined) {
+        this.contracts[node.id] = relevantContract;
+        this.contractNodes[node.id] = node;
+        abiDecoder.addABI(relevantContract.abi);
+      }
     });
   }
 


### PR DESCRIPTION
This PR fixes [this issue](https://github.com/trufflesuite/ganache/issues/1117) that was reported over on the Ganache repo.  The problem appears to be that Ganache passes all contracts in to the contract decoder as relevant contracts, even ones that aren't Solidity.  These don't have an AST, and, as such, cause an error when we try to find their contract node.  So, I've changed the code for getting the contract nodes so it will skip any lacking an AST (or that have an AST but can't find the contract node for whatever reason).