### PR TITLE
 Add PC display to debugger CLI

### DIFF
--- a/packages/truffle-core/lib/commands/debug.js
+++ b/packages/truffle-core/lib/commands/debug.js
@@ -43,7 +43,6 @@ var command = {
     var trace = selectors.trace;
     var solidity = selectors.solidity;
     var controller = selectors.controller;
-    var evm = selectors.evm;
 
     var config = Config.detect(options);
 
@@ -175,7 +174,6 @@ var command = {
             var step = session.view(trace.step);
             var traceIndex = session.view(trace.index);
             var totalSteps = session.view(trace.steps).length;
-            var gas = session.view(evm.current.state.gas);
 
             config.logger.log("");
             config.logger.log(
@@ -185,9 +183,10 @@ var command = {
                 instruction
               )
             );
+            config.logger.log(DebugUtils.formatPC(step.pc));
             config.logger.log(DebugUtils.formatStack(step.stack));
             config.logger.log("");
-            config.logger.log(gas + " gas remaining");
+            config.logger.log(step.gas + " gas remaining");
           }
 
           function select(expr) {

--- a/packages/truffle-debug-utils/index.js
+++ b/packages/truffle-debug-utils/index.js
@@ -252,7 +252,11 @@ var DebugUtils = {
   },
 
   formatPC: function(pc) {
-    return "  PC = " + pc.toString() + " = 0x" + pc.toString(16);
+    let hex = pc.toString(16);
+    if (hex.length % 2 !== 0) {
+      hex = "0" + hex; //ensure even length
+    }
+    return "  PC = " + pc.toString() + " = 0x" + hex;
   },
 
   formatStack: function(stack) {

--- a/packages/truffle-debug-utils/index.js
+++ b/packages/truffle-debug-utils/index.js
@@ -251,6 +251,10 @@ var DebugUtils = {
     );
   },
 
+  formatPC: function(pc) {
+    return "  PC = " + pc.toString() + " = 0x" + pc.toString(16);
+  },
+
   formatStack: function(stack) {
     var formatted = stack.map(function(item, index) {
       item = "  " + item;


### PR DESCRIPTION
The lack of a PC display in the CLI had been bugging me, so this PR adds one.  Of course, it is only shown when pressing `p` or `;`.  I also got rid of a redundant use of an `evm` selector when we already had that same information available from the `trace` selector we were already using.