### PR TITLE
Fix solidity unit test import_paths

### DIFF
--- a/packages/truffle-core/lib/test.js
+++ b/packages/truffle-core/lib/test.js
@@ -108,8 +108,7 @@ var Test = {
         dependency_paths = paths;
 
         testContracts = sol_tests.map(function(test_file_path) {
-          var built_name = "./" + path.basename(test_file_path);
-          return test_resolver.require(built_name);
+          return test_resolver.require(test_file_path);
         });
 
         runner = new TestRunner(config);


### PR DESCRIPTION
Currently `truffle test` turns `import_paths` of solidity unit tests into relative file basename paths.

Instead, it should use the full `test_file_path` like the rest of truffle to accurately resolve `import_paths` and return contract artifacts.

Potentially resolves #700, #450, & #1795.