### PR TITLE
Move down breakpoints when placed on empty/skipped lines

### DIFF
--- a/packages/truffle-core/lib/commands/debug.js
+++ b/packages/truffle-core/lib/commands/debug.js
@@ -578,7 +578,8 @@ var command = {
             //want to adjust to make sure we don't set it on an empty line or
             //anything like that
             if (setOrClear) {
-              breakpoint = session.adjustBreakpoint(breakpoint);
+              let resolver = session.view(controller.breakpoints.resolver);
+              breakpoint = resolver(breakpoint);
               //of course, this might result in finding that there's nowhere to
               //add it after that point
               if (breakpoint === null) {

--- a/packages/truffle-core/lib/commands/debug.js
+++ b/packages/truffle-core/lib/commands/debug.js
@@ -246,12 +246,12 @@ var command = {
             let breakpoints = session.view(controller.breakpoints);
             if (breakpoints.length > 0) {
               for (let breakpoint of session.view(controller.breakpoints)) {
-                let currentSourceId = session.view(controller.current.location)
-                  .source.id;
+                let currentLocation = session.view(controller.current.location);
                 let locationMessage = DebugUtils.formatBreakpointLocation(
                   breakpoint,
-                  false,
-                  currentSourceId,
+                  currentLocation.node !== undefined &&
+                    breakpoint.node === currentLocation.node.id,
+                  currentLocation.source.id,
                   sourceNames
                 );
                 config.logger.log("  Breakpoint at " + locationMessage);

--- a/packages/truffle-core/lib/commands/debug.js
+++ b/packages/truffle-core/lib/commands/debug.js
@@ -243,16 +243,21 @@ var command = {
                 })
               )
             );
-            for (breakpoint in session.view(controller.breakpoints)) {
-              let currentSourceId = session.view(controller.current.location)
-                .source.id;
-              let locationMessage = DebugUtils.formatBreakpointLocation(
-                breakpoint,
-                false,
-                currentSourceId,
-                sourceNames
-              );
-              config.logger.log("Breakpoint at " + locationMessage);
+            let breakpoints = session.view(controller.breakpoints);
+            if (breakpoints.length > 0) {
+              for (let breakpoint of session.view(controller.breakpoints)) {
+                let currentSourceId = session.view(controller.current.location)
+                  .source.id;
+                let locationMessage = DebugUtils.formatBreakpointLocation(
+                  breakpoint,
+                  false,
+                  currentSourceId,
+                  sourceNames
+                );
+                config.logger.log("  Breakpoint at " + locationMessage);
+              }
+            } else {
+              config.logger.log("No breakpoints added.");
             }
           }
 

--- a/packages/truffle-debug-utils/index.js
+++ b/packages/truffle-debug-utils/index.js
@@ -17,7 +17,7 @@ var commandReference = {
   ":": "evaluate expression - see `v`",
   "+": "add watch expression (`+:<expr>`)",
   "-": "remove watch expression (-:<expr>)",
-  "?": "list existing watch expressions",
+  "?": "list existing watch expressions and breakpoints",
   "b": "add breakpoint",
   "B": "remove breakpoint",
   "c": "continue until breakpoint",
@@ -236,6 +236,27 @@ var DebugUtils = {
     ]);
 
     return allLines.join(OS.EOL);
+  },
+
+  formatBreakpointLocation: function(
+    breakpoint,
+    here,
+    currentSourceId,
+    sourceNames
+  ) {
+    if (breakpoint.node !== undefined) {
+      return here
+        ? `this point in line ${breakpoint.line + 1}`
+        : `a point in line ${breakpoint.line + 1}`;
+      //+1 to adjust for zero-indexing
+    } else if (breakpoint.sourceId !== currentSourceId) {
+      let sourceName = sourceNames[breakpoint.sourceId];
+      return `line ${breakpoint.line + 1} in ${sourceName}`;
+      //+1 to adjust for zero-indexing
+    } else {
+      return `line ${breakpoint.line + 1}`;
+      //+1 to adjust for zero-indexing
+    }
   },
 
   formatInstruction: function(traceIndex, traceLength, instruction) {

--- a/packages/truffle-debug-utils/index.js
+++ b/packages/truffle-debug-utils/index.js
@@ -244,18 +244,20 @@ var DebugUtils = {
     currentSourceId,
     sourceNames
   ) {
+    let baseMessage;
     if (breakpoint.node !== undefined) {
-      return here
+      baseMessage = here
         ? `this point in line ${breakpoint.line + 1}`
         : `a point in line ${breakpoint.line + 1}`;
-      //+1 to adjust for zero-indexing
-    } else if (breakpoint.sourceId !== currentSourceId) {
-      let sourceName = sourceNames[breakpoint.sourceId];
-      return `line ${breakpoint.line + 1} in ${sourceName}`;
-      //+1 to adjust for zero-indexing
+      //note we always add 1 to adjust for zero-indexing
     } else {
-      return `line ${breakpoint.line + 1}`;
-      //+1 to adjust for zero-indexing
+      baseMessage = `line ${breakpoint.line + 1}`;
+    }
+    if (breakpoint.sourceId !== currentSourceId) {
+      let sourceName = sourceNames[breakpoint.sourceId];
+      return baseMessage + ` in ${sourceName}`;
+    } else {
+      return baseMessage;
     }
   },
 

--- a/packages/truffle-debugger/lib/ast/map.js
+++ b/packages/truffle-debugger/lib/ast/map.js
@@ -3,7 +3,7 @@ const debug = debugModule("debugger:ast:map");
 
 import IntervalTree from "node-interval-tree";
 import jsonpointer from "json-pointer";
-import { SKIPPED_TYPES } from "lib/helpers";
+import { isSkippedNodeType } from "lib/helpers";
 
 /**
  * @private
@@ -81,6 +81,6 @@ export function findRange(node, sourceStart, sourceLength) {
  */
 export function anyNonSkippedInRange(node, sourceStart, sourceLength) {
   return findOverlappingRange(node, sourceStart, sourceLength).some(
-    ({ pointer }) => !SKIPPED_TYPES.has(jsonpointer.get(node, pointer).nodeType)
+    ({ pointer }) => !isSkippedNodeType(jsonpointer.get(node, pointer))
   );
 }

--- a/packages/truffle-debugger/lib/ast/map.js
+++ b/packages/truffle-debugger/lib/ast/map.js
@@ -83,8 +83,8 @@ export function anyNonSkippedInRange(node, sourceStart, sourceLength) {
   let sourceEnd = sourceStart + sourceLength;
   return findOverlappingRange(node, sourceStart, sourceLength).some(
     ({ range, pointer }) =>
-      sourceStart <= range[0] &&
-      range[0] < sourceEnd && //we want to go by starting line
+      sourceStart <= range[0] && //we want to go by starting line
+      range[0] < sourceEnd &&
       !isSkippedNodeType(jsonpointer.get(node, pointer))
     //NOTE: this doesn't actually catch everything skipped!  But doing better
     //is hard

--- a/packages/truffle-debugger/lib/ast/map.js
+++ b/packages/truffle-debugger/lib/ast/map.js
@@ -80,7 +80,13 @@ export function findRange(node, sourceStart, sourceLength) {
  * @private
  */
 export function anyNonSkippedInRange(node, sourceStart, sourceLength) {
+  let sourceEnd = sourceStart + sourceLength;
   return findOverlappingRange(node, sourceStart, sourceLength).some(
-    ({ pointer }) => !isSkippedNodeType(jsonpointer.get(node, pointer))
+    ({ range, pointer }) =>
+      sourceStart <= range[0] &&
+      range[0] < sourceEnd && //we want to go by starting line
+      !isSkippedNodeType(jsonpointer.get(node, pointer))
+    //NOTE: this doesn't actually catch everything skipped!  But doing better
+    //is hard
   );
 }

--- a/packages/truffle-debugger/lib/ast/map.js
+++ b/packages/truffle-debugger/lib/ast/map.js
@@ -2,6 +2,8 @@ import debugModule from "debug";
 const debug = debugModule("debugger:ast:map");
 
 import IntervalTree from "node-interval-tree";
+import jsonpointer from "json-pointer";
+import { SKIPPED_TYPES } from "lib/helpers";
 
 /**
  * @private
@@ -77,6 +79,8 @@ export function findRange(node, sourceStart, sourceLength) {
 /**
  * @private
  */
-export function anyInRange(node, sourceStart, sourceLength) {
-  return findOverlappingRange(node, sourceStart, sourceLength).length > 0;
+export function anyNonSkippedInRange(node, sourceStart, sourceLength) {
+  return findOverlappingRange(node, sourceStart, sourceLength).some(
+    ({ pointer }) => !SKIPPED_TYPES.has(jsonpointer.get(node, pointer).nodeType)
+  );
 }

--- a/packages/truffle-debugger/lib/controller/sagas/index.js
+++ b/packages/truffle-debugger/lib/controller/sagas/index.js
@@ -3,7 +3,7 @@ const debug = debugModule("debugger:controller:sagas");
 
 import { put, call, race, take, select } from "redux-saga/effects";
 
-import { prefixName, isSkippedNodeType } from "lib/helpers";
+import { prefixName, isDeliberatelySkippedNodeType } from "lib/helpers";
 
 import * as trace from "lib/trace/sagas";
 import * as data from "lib/data/sagas";
@@ -85,7 +85,7 @@ function* stepNext() {
     !finished &&
     (!upcoming ||
       !upcoming.node ||
-      isSkippedNodeType(upcoming.node) ||
+      isDeliberatelySkippedNodeType(upcoming.node) ||
       (upcoming.sourceRange.start == startingRange.start &&
         upcoming.sourceRange.length == startingRange.length))
   );

--- a/packages/truffle-debugger/lib/controller/sagas/index.js
+++ b/packages/truffle-debugger/lib/controller/sagas/index.js
@@ -3,7 +3,7 @@ const debug = debugModule("debugger:controller:sagas");
 
 import { put, call, race, take, select } from "redux-saga/effects";
 
-import { prefixName, SKIPPED_TYPES } from "lib/helpers";
+import { prefixName, isSkippedNodeType } from "lib/helpers";
 
 import * as trace from "lib/trace/sagas";
 import * as data from "lib/data/sagas";
@@ -85,7 +85,7 @@ function* stepNext() {
     !finished &&
     (!upcoming ||
       !upcoming.node ||
-      SKIPPED_TYPES.has(upcoming.node.nodeType) ||
+      isSkippedNodeType(upcoming.node) ||
       (upcoming.sourceRange.start == startingRange.start &&
         upcoming.sourceRange.length == startingRange.length))
   );

--- a/packages/truffle-debugger/lib/controller/sagas/index.js
+++ b/packages/truffle-debugger/lib/controller/sagas/index.js
@@ -50,7 +50,11 @@ export default prefixName("controller", saga);
 function* advance(action) {
   let count =
     action !== undefined && action.count !== undefined ? action.count : 1; //default is, as mentioned, to advance 1
-  for (let i = 0; i < count && !(yield select(controller.finished)); i++) {
+  for (
+    let i = 0;
+    i < count && !(yield select(controller.current.finished));
+    i++
+  ) {
     yield* trace.advance();
   }
 }
@@ -78,7 +82,7 @@ function* stepNext() {
       upcoming = null;
     }
 
-    finished = yield select(controller.finished);
+    finished = yield select(controller.current.finished);
 
     // if the next step's source range is still the same, keep going
   } while (
@@ -216,7 +220,7 @@ function* continueUntilBreakpoint(action) {
     previousSourceId = currentSourceId;
 
     currentLocation = yield select(controller.current.location);
-    finished = yield select(controller.finished);
+    finished = yield select(controller.current.finished);
     debug("finished %o", finished);
 
     currentNode = currentLocation.node.id;

--- a/packages/truffle-debugger/lib/controller/sagas/index.js
+++ b/packages/truffle-debugger/lib/controller/sagas/index.js
@@ -3,7 +3,7 @@ const debug = debugModule("debugger:controller:sagas");
 
 import { put, call, race, take, select } from "redux-saga/effects";
 
-import { prefixName } from "lib/helpers";
+import { prefixName, SKIPPED_TYPES } from "lib/helpers";
 
 import * as trace from "lib/trace/sagas";
 import * as data from "lib/data/sagas";
@@ -25,9 +25,6 @@ const CONTROL_SAGAS = {
   [actions.CONTINUE]: continueUntilBreakpoint,
   [actions.RESET]: reset
 };
-
-/** AST node types that are skipped to filter out some noise */
-const SKIPPED_TYPES = new Set(["ContractDefinition", "VariableDeclaration"]);
 
 export function* saga() {
   while (true) {

--- a/packages/truffle-debugger/lib/controller/selectors/index.js
+++ b/packages/truffle-debugger/lib/controller/selectors/index.js
@@ -1,11 +1,13 @@
 import debugModule from "debug";
-const debug = debugModule("debugger:controller:sagas"); //eslint-disable-line no-unused-vars
+const debug = debugModule("debugger:controller:selectors"); //eslint-disable-line no-unused-vars
 
 import { createSelectorTree, createLeaf } from "reselect-tree";
 
 import evm from "lib/evm/selectors";
 import solidity from "lib/solidity/selectors";
 import trace from "lib/trace/selectors";
+
+import { anyNonSkippedInRange } from "lib/ast/map";
 
 /**
  * @private
@@ -62,23 +64,72 @@ const controller = createSelectorTree({
        * controller.current.location.isMultiline
        */
       isMultiline: createLeaf([solidity.current.isMultiline], identity)
-    }
+    },
+
+    /**
+     * controller.current.finished
+     */
+    finished: createLeaf([trace.finished], identity)
   },
 
   /**
-   * controller.breakpoints
+   * controller.breakpoints (namespace)
    */
-  breakpoints: createLeaf(["./state"], state => state.breakpoints),
+  breakpoints: {
+    /**
+     * controller.breakpoints (selector)
+     */
+    _: createLeaf(["/state"], state => state.breakpoints),
+
+    /**
+     * controller.breakpoints.resolver (selector)
+     * this selector returns a function that adjusts a given line-based
+     * breakpoint (on node-based breakpoints it simply returns the input) by
+     * repeatedly moving it down a line until it lands on a line where there's
+     * actually somewhere to break.  if no such line exists beyond that point, it
+     * returns null instead.
+     */
+    resolver: createLeaf([solidity.info.sources], sources => breakpoint => {
+      let adjustedBreakpoint;
+      if (breakpoint.node === undefined) {
+        let line = breakpoint.line;
+        let { source, ast } = sources[breakpoint.sourceId];
+        let lineLengths = source.split("\n").map(line => line.length);
+        //why does neither JS nor lodash have a scan function like Haskell??
+        //guess we'll have to do our scan manually
+        let lineStarts = [0];
+        for (let length of lineLengths) {
+          lineStarts.push(lineStarts[lineStarts.length - 1] + length + 1);
+          //+1 for the /n itself
+        }
+        debug(
+          "line: %s",
+          source.slice(lineStarts[line], lineStarts[line] + lineLengths[line])
+        );
+        while (
+          line < lineLengths.length &&
+          !anyNonSkippedInRange(ast, lineStarts[line], lineLengths[line])
+        ) {
+          debug("incrementing");
+          line++;
+        }
+        if (line >= lineLengths.length) {
+          adjustedBreakpoint = null;
+        } else {
+          adjustedBreakpoint = { ...breakpoint, line };
+        }
+      } else {
+        debug("node-based breakpoint");
+        adjustedBreakpoint = breakpoint;
+      }
+      return adjustedBreakpoint;
+    })
+  },
 
   /**
    * controller.isStepping
    */
-  isStepping: createLeaf(["./state"], state => state.isStepping),
-
-  /**
-   * controller.finished
-   */
-  finished: createLeaf([trace.finished], identity)
+  isStepping: createLeaf(["./state"], state => state.isStepping)
 });
 
 export default controller;

--- a/packages/truffle-debugger/lib/controller/selectors/index.js
+++ b/packages/truffle-debugger/lib/controller/selectors/index.js
@@ -127,6 +127,12 @@ const controller = createSelectorTree({
   },
 
   /**
+   * controller.finished
+   * deprecated alias for controller.current.finished
+   */
+  finished: createLeaf(["/current/finished"], finished => finished),
+
+  /**
    * controller.isStepping
    */
   isStepping: createLeaf(["./state"], state => state.isStepping)

--- a/packages/truffle-debugger/lib/helpers/index.js
+++ b/packages/truffle-debugger/lib/helpers/index.js
@@ -3,9 +3,20 @@ import * as utils from "truffle-decode-utils";
 const stringify = require("json-stable-stringify");
 
 /** AST node types that are skipped by stepNext() to filter out some noise */
-export function isSkippedNodeType(node) {
+export function isDeliberatelySkippedNodeType(node) {
   const skippedTypes = ["ContractDefinition", "VariableDeclaration"];
   return skippedTypes.includes(node.nodeType);
+}
+
+export function isSkippedNodeType(node) {
+  return (
+    isDeliberatelySkippedNodeType(node) ||
+    (node.typeDescriptions !== undefined && //seems this sometimes happens?
+      utils.Definition.typeClass(node) === "stringliteral")
+  );
+  //HACK
+  //these aren't the only types of skipped nodes, but determining all skipped
+  //nodes would be too difficult
 }
 
 export function prefixName(prefix, fn) {

--- a/packages/truffle-debugger/lib/helpers/index.js
+++ b/packages/truffle-debugger/lib/helpers/index.js
@@ -2,6 +2,12 @@ import * as utils from "truffle-decode-utils";
 
 const stringify = require("json-stable-stringify");
 
+/** AST node types that are skipped by stepNext() to filter out some noise */
+export const SKIPPED_TYPES = new Set([
+  "ContractDefinition",
+  "VariableDeclaration"
+]);
+
 export function prefixName(prefix, fn) {
   Object.defineProperty(fn, "name", {
     value: `${prefix}.${fn.name}`,

--- a/packages/truffle-debugger/lib/helpers/index.js
+++ b/packages/truffle-debugger/lib/helpers/index.js
@@ -3,10 +3,10 @@ import * as utils from "truffle-decode-utils";
 const stringify = require("json-stable-stringify");
 
 /** AST node types that are skipped by stepNext() to filter out some noise */
-export const SKIPPED_TYPES = new Set([
-  "ContractDefinition",
-  "VariableDeclaration"
-]);
+export function isSkippedNodeType(node) {
+  const skippedTypes = ["ContractDefinition", "VariableDeclaration"];
+  return skippedTypes.includes(node.nodeType);
+}
 
 export function prefixName(prefix, fn) {
   Object.defineProperty(fn, "name", {

--- a/packages/truffle-debugger/lib/helpers/index.js
+++ b/packages/truffle-debugger/lib/helpers/index.js
@@ -8,15 +8,19 @@ export function isDeliberatelySkippedNodeType(node) {
   return skippedTypes.includes(node.nodeType);
 }
 
+//HACK
+//these aren't the only types of skipped nodes, but determining all skipped
+//nodes would be too difficult
 export function isSkippedNodeType(node) {
+  const otherSkippedTypes = ["VariableDeclarationStatement", "Mapping"];
   return (
     isDeliberatelySkippedNodeType(node) ||
+    otherSkippedTypes.includes(node.nodeType) ||
+    node.nodeType.includes("TypeName") || //HACK
+    //skip string literals too -- we'll handle that manually
     (node.typeDescriptions !== undefined && //seems this sometimes happens?
       utils.Definition.typeClass(node) === "stringliteral")
   );
-  //HACK
-  //these aren't the only types of skipped nodes, but determining all skipped
-  //nodes would be too difficult
 }
 
 export function prefixName(prefix, fn) {

--- a/packages/truffle-debugger/lib/session/index.js
+++ b/packages/truffle-debugger/lib/session/index.js
@@ -229,6 +229,7 @@ export default class Session {
         line < lineLengths.length &&
         !anyNonSkippedInRange(ast, lineStarts[line], lineLengths[line])
       ) {
+        debug("incrementing");
         line++;
       }
       if (line >= lineLengths.length) {
@@ -237,6 +238,7 @@ export default class Session {
         adjustedBreakpoint = { ...breakpoint, line };
       }
     } else {
+      debug("node-based breakpoint");
       adjustedBreakpoint = breakpoint;
     }
     return adjustedBreakpoint;

--- a/packages/truffle-debugger/lib/session/index.js
+++ b/packages/truffle-debugger/lib/session/index.js
@@ -221,6 +221,10 @@ export default class Session {
         lineStarts.push(lineStarts[lineStarts.length - 1] + length + 1);
         //+1 for the /n itself
       }
+      debug(
+        "line: %s",
+        source.slice(lineStarts[line], lineStarts[line] + lineLengths[line])
+      );
       while (
         line < lineLengths.length &&
         !anyNonSkippedInRange(ast, lineStarts[line], lineLengths[line])

--- a/packages/truffle-debugger/lib/session/index.js
+++ b/packages/truffle-debugger/lib/session/index.js
@@ -6,10 +6,13 @@ import configureStore from "lib/store";
 import * as controller from "lib/controller/actions";
 import * as actions from "./actions";
 import data from "lib/data/selectors";
+import solidity from "lib/solidity/selectors";
 import controllerSelector from "lib/controller/selectors";
 
 import rootSaga from "./sagas";
 import reducer from "./reducers";
+
+import { anyNonSkippedInRange } from "lib/ast/map";
 
 /**
  * Debugger Session
@@ -196,7 +199,43 @@ export default class Session {
   }
 
   async addBreakpoint(breakpoint) {
-    return this.dispatch(controller.addBreakpoint(breakpoint));
+    this.dispatch(controller.addBreakpoint(breakpoint));
+  }
+
+  //this function adjusts a given line-based breakpoint (on node-based
+  //breakpoints it simply returns the input) by repeatedly moving it down a
+  //line until it lands on a line where there's actually somewhere to break.
+  //if no such line exists beyond that point, it returns null instead.
+  adjustBreakpoint(breakpoint) {
+    let adjustedBreakpoint;
+    if (breakpoint.node === undefined) {
+      let line = breakpoint.line;
+      let { source, ast } = this.view(solidity.info.sources)[
+        breakpoint.sourceId
+      ];
+      let lineLengths = source.split("\n").map(line => line.length);
+      //why does neither JS nor lodash have a scan function like Haskell??
+      //guess we'll have to do our scan manually
+      let lineStarts = [0];
+      for (let length of lineLengths) {
+        lineStarts.push(lineStarts[lineStarts.length - 1] + length + 1);
+        //+1 for the /n itself
+      }
+      while (
+        line < lineLengths.length &&
+        !anyNonSkippedInRange(ast, lineStarts[line], lineLengths[line])
+      ) {
+        line++;
+      }
+      if (line >= lineLengths.length) {
+        adjustedBreakpoint = null;
+      } else {
+        adjustedBreakpoint = { ...breakpoint, line };
+      }
+    } else {
+      adjustedBreakpoint = breakpoint;
+    }
+    return adjustedBreakpoint;
   }
 
   async removeBreakpoint(breakpoint) {


### PR DESCRIPTION
This PR addresses issue #1317, at least partially.  It introduces a selector, `controller.breakpoints.resolver`, that, given a breakpoint, returns where it should be moved down to.  The CLI now runs all breakpoints through `controller.breakpoints.resolver` before adding them (and reports back to the user where the breakpoint was *actually* added).  Note that the resolver may return `null` if there is nowhere suitable below to place a breakpoint; in this case the CLI will not add a breakpoint.

Note that the resolver does not work perfectly -- it's something of a hack -- but it should be good enough for common cases; see below for more explanation.  Also note that attempts to *remove* breakpoints are not run through the resolver.  But that's OK, because (in addition to the messages above), **also** added in this PR is (finally) a way to view all breakpoints!  Now, typing `?` will print not only all watch expressions, but also all breakpoints.

(For node-based breakpoints, the location will simply be reported as "a point in line [number]" (or "a point in line [number] in [file]" if it's in a different file), unless you're currently standing on the breakpoint, in which case it will be reported as "*this* point in line n" (emphasis added).)

One more change in this PR: I decided that the selector `controller.finished` should probably really be `controller.current.finished`.  Of course, if this is considered too much of a breaking change, that'll be an easy change to revert!  Let me know if I should.

So, how's the resolver work?

Well, for a node-based breakpoint, it simply returns the breakpoint that was entered.  (Yes, even if you're currently standing on a skipped node, due to use of `;`; perhaps such breakpoints should also be moved down, but I'm assuming that that case just isn't going to happen that often.)  For line-based breakpoints, it checks whether there any nodes starting on that line that it judges to be non-skipped.  If not, it moves it down a line and repeats, until it either finds a place to put it or runs out of lines.  (Note we go by what line the node *starts* on because that's what `continueUntilBreakpoint` goes by.)

This leaves two questions: How does it determine what nodes start on that line, and how does it determine whether a node is skipped or not?

For the first question, I altered `ast/map.js` a bit.  I took the bit where it finds which nodes overlap the range and factored that out into its own function, `findOverlappingRange`, which `findRange` now calls.  I then added `anyNonSkippedInRange`, which calls `findOverlappingRange` (here the range passed in is a full line), and checks if any of the results *start* in that range and are non-skipped.

Here's the hacky part -- what counts as a skipped node?  We can't really determine this with perfect reliability; for instance, references to constant state variables are often skipped, but I didn't think it was worth it to include that case here (especially as that's unlikely to be a full line); and certain type conversions are skipped, but it was *definitely* not worth it to include that (determining whether we're dealing with a skipped or non-skipped type conversion would just be a pain).

And what about, say, pragmas?  Surely one shouldn't be able to place a breakpoint on a line with only a pragma!  But on the other hand, probably nobody's going to attempt to do that.  So I didn't bother marking those as skipped.  One could go on in that vein -- event declarations? custom type declarations? -- but again, not worth it.

So what *did* I mark as skipped?  I decided to mark as skipped:
1. The node types we deliberately skip over: `ContractDefinition` and `VariableDeclaration`.
2. Anything else that was necessary to make skipping over variable declarations work, which meant `VariableDeclarationStatement`, and the various `[...]TypeName` nodes (and `Mapping`, because a mapping type name node is called `Mapping`, not `MappingTypeName`, for whatever reason).
3. String literals, because those are kind of infamous for their skippedness.

Note by the way that the list of deliberately skipped nodes has been moved out of `controller/sagas` and into `helpers` since that's no longer the only place that uses it (it's also been replaced with a function).

Like I said, it's not perfect, but I think it should be good enough for the common cases that originally gave rise to #1317.

(I also added a test.)