### PR TITLE
Throw error instead of catching and hiding it

### DIFF
--- a/packages/truffle-box/lib/utils/index.js
+++ b/packages/truffle-box/lib/utils/index.js
@@ -71,6 +71,7 @@ module.exports = {
       setUpSpinner.succeed();
     } catch (error) {
       setUpSpinner.fail();
+      throw new Error(error);
     }
   }
 };


### PR DESCRIPTION
When the `setUpBox` method failed, it would previously catch the error. This caused this step to fail and ultimately swallow the error, continue unboxing, and report a successful unbox. The error is now thrown and will cause the failure to be reported to the user.