### PR TITLE
Update truffle-artifactor (docs & codebase)

### DIFF
--- a/packages/truffle-artifactor/README.md
+++ b/packages/truffle-artifactor/README.md
@@ -38,28 +38,28 @@ const Artifactor = require("truffle-artifactor");
 const artifactor = new Artifactor(__dirname);
 
 // See truffle-schema for more info: https://github.com/trufflesuite/truffle/tree/develop/packages/truffle-contract-schema
-const contract_data = {
+const contractData = {
   abi: ...,              // Array; required.
-  unlinked_binary: "..." // String; optional.
+  unlinkedBinary: "..." // String; optional.
   address: "..."         // String; optional.
 };
 
-artifactor.save(contract_data);
+artifactor.save(contractData);
 // The file ./MyContract.json now exists, which you can
 // import into your project like any other Javascript file.
 ```
 
 # API
 
-#### `artifactor.save(contract_data)`
+#### `artifactor.save(contractData)`
 
 Save contract data as a `.json` file. Returns a Promise.
 
-* `contract_data`: Object. Data that represents this contract:
+* `contractData`: Object. Data that represents this contract:
 
     ```javascript
     {
-      contract_name: "MyContract",  // String; optional. Defaults to "Contract"
+      contractName: "MyContract",  // String; optional. Defaults to "Contract"
       abi: ...,                     // Array; required.  Application binary interface.
       unlinked_binary: "...",       // String; optional. Binary without resolve library links.
       address: "...",               // String; optional. Deployed address of contract.
@@ -72,7 +72,7 @@ Save contract data as a `.json` file. Returns a Promise.
 
 Save many contracts to the filesystem at once. Returns a Promise.
 
-* `contracts`: Object. Keys are the contract names and the values are `contract_data` objects, as in the `save()` function above:
+* `contracts`: Object. Keys are the contract names and the values are `contractData` objects, as in the `save()` function above:
 
     ```javascript
     {

--- a/packages/truffle-artifactor/README.md
+++ b/packages/truffle-artifactor/README.md
@@ -39,10 +39,11 @@ const artifactor = new Artifactor(__dirname);
 
 // See truffle-schema for more info: https://github.com/trufflesuite/truffle/tree/develop/packages/truffle-contract-schema
 const contractData = {
-  contractName: "...",   // String; optional.
-  abi: ...,              // Array; required.
-  metadata: "...",       // String; optional.
-  bytecode: "..."        // String; optional.
+  contractName: "...",        // String; optional.
+  abi: ...,                   // Array; required.
+  metadata: "...",            // String; optional.
+  bytecode: "...",            // String; optional.
+  "x-some-dependency": ...    // String, Number, Object, or Array: optional.
 };
 
 artifactor.save(contractData);
@@ -76,7 +77,8 @@ Save contract data as a `.json` file. Returns a Promise.
       schemaVersion: "...",         // String; optional. Schema version used by contract object representation.
       updatedAt: "...",             // String; optional. Time contract object representation was generated/most recently updated.
       devdoc: "...",                // String; optional. Developer documentation.
-      userdoc: "..."                // String; optional. User documentation.
+      userdoc: "...",               // String; optional. User documentation.
+      "x-custom-property": ...      // String, Number, Object, or Array: optional. Custom property. Keys must be prefixed with "x-".
     }
     ```
 

--- a/packages/truffle-artifactor/README.md
+++ b/packages/truffle-artifactor/README.md
@@ -39,9 +39,10 @@ const artifactor = new Artifactor(__dirname);
 
 // See truffle-schema for more info: https://github.com/trufflesuite/truffle/tree/develop/packages/truffle-contract-schema
 const contractData = {
+  contractName: "...",   // String; optional.
   abi: ...,              // Array; required.
-  unlinkedBinary: "..." // String; optional.
-  address: "..."         // String; optional.
+  metadata: "...",       // String; optional.
+  bytecode: "..."        // String; optional.
 };
 
 artifactor.save(contractData);
@@ -59,12 +60,23 @@ Save contract data as a `.json` file. Returns a Promise.
 
     ```javascript
     {
-      contractName: "MyContract",  // String; optional. Defaults to "Contract"
+      contractName: "MyContract",   // String; optional. Defaults to "Contract".
       abi: ...,                     // Array; required.  Application binary interface.
-      unlinked_binary: "...",       // String; optional. Binary without resolve library links.
-      address: "...",               // String; optional. Deployed address of contract.
-      network_id: "...",            // String; optional. ID of network being saved within abstraction.
-      default_network: "..."        // String; optional. ID of default network this abstraction should use.
+      metadata: "...",              // String; optional. Contract metadata.
+      bytecode: "...",              // String; optional. Contract-creation binary without resolve library links.
+      deployedBytecode: "...",      // String; optional. On-chain deployed binary without resolve library links.
+      sourceMap: "...",             // String; optional. Source mapping for bytecode.
+      deployedSourceMap: "...",     // String; optional. Source mapping for deployedBytecode.
+      source: "...",                // String; optional. Uncompiled source code for contract.
+      sourcePath: "...",            // String; optional. File path for uncompiled source code.
+      ast: ...,                     // Object; optional. JSON representation of contract source code, as output by compiler.
+      legacyAST: ...,               // Object; optional. Legacy JSON representation of contract source code, as output by compiler.
+      compiler: ...,                // Object; optional. Compiler "type" and "properties".
+      networks: ...,                // Object; optional. Mapping of network ID keys to network object values (address information, links to other contract instances, and/or contract event logs).
+      schemaVersion: "...",         // String; optional. Schema version used by contract object representation.
+      updatedAt: "...",             // String; optional. Time contract object representation was generated/most recently updated.
+      devdoc: "...",                // String; optional. Developer documentation.
+      userdoc: "..."                // String; optional. User documentation.
     }
     ```
 
@@ -78,7 +90,7 @@ Save many contracts to the filesystem at once. Returns a Promise.
     {
       "MyContract": {
         "abi": ...,
-        "unlinked_binary": ...
+        "bytecode": "..."
       }
       "AnotherContract": {
         // ...

--- a/packages/truffle-artifactor/README.md
+++ b/packages/truffle-artifactor/README.md
@@ -1,21 +1,11 @@
-# truffle-artifactor (formerly ether-pudding)
+# truffle-artifactor
 
-This package saves contract artifacts into into Javascript files that can be `require`'d. i.e.,
+This package saves contract artifacts into JSON files
 
 ```javascript
-var artifactor = require("truffle-artifactor");
-artifactor.save({/*...*/}, "./MyContract.sol.js") // => a promise
-
-// Later...
-var MyContract = require("./MyContract.sol.js");
-MyContract.setProvider(myWeb3Provider);
-MyContract.deployed().then(function(instance) {
-  return instance.doStuff(); // <-- matches the doStuff() function within MyContract.sol.
-}).then(function(result) {
-  // We just made a transaction, and it's been mined!
-  // We're given transaction hash, logs (events) and receipt for further processing.
-  console.log(result.tx, result.logs, result.receipt);
-});
+const Artifactor = require("truffle-artifactor");
+const artifactor = new Artifactor(__dirname);
+artifactor.save({/*...*/}); // => a promise saving MyContract.json to a given destination
 ```
 
 👏
@@ -23,12 +13,10 @@ MyContract.deployed().then(function(instance) {
 ### Features
 
 * Manages contract ABIs, binaries and deployed addresses, so you don't have to.
-* Packages up build artifacts into `.sol.js` files, which can then be included in your project with a simple `require`.
-* Includes multiple versions of the same contract in a single package, automatically detecting which artifacts to use based on the network version (more on this below).
+* Packages up build artifacts into `.json` files, which can then be included in your project with a simple `require`.
 * Manages library addresses for linked libraries.
-* Manages events, making them available on a per-transaction basis (no more `event.watch()`!)
 
-The artifactor uses [truffle-contract](https://github.com/trufflesuite/truffle-contract), which provides features above and beyond `web3`:
+The artifactor can be used with [truffle-contract](https://github.com/trufflesuite/truffle/tree/develop/packages/truffle-contract), which provides features above and beyond `web3`:
 
 * Synchronized transactions for better control flow: transactions won't be considered finished until you're guaranteed they've been mined.
 * Promises. No more callback hell. Works well with `ES6` and `async/await`.
@@ -43,30 +31,31 @@ $ npm install truffle-artifactor
 
 ### Example
 
-Here, we'll generate a `.sol.js` files given a JSON object like [truffle-schema](https://github.com/trufflesuite/truffle-schema). This will give us a file which we can later `require` into other projects and contexts.
+Here, we'll generate a `.json` files given a JSON object like [truffle-contract-schema](https://github.com/trufflesuite/truffle/tree/develop/packages/truffle-contract-schema). This will give us a file which we can later `require` into other projects and contexts.
 
 ```javascript
-var artifactor = require("truffle-artifactor");
+const Artifactor = require("truffle-artifactor");
+const artifactor = new Artifactor(__dirname);
 
-// See truffle-schema for more info: https://github.com/trufflesuite/truffle-schema
-var contract_data = {
+// See truffle-schema for more info: https://github.com/trufflesuite/truffle/tree/develop/packages/truffle-contract-schema
+const contract_data = {
   abi: ...,              // Array; required.
   unlinked_binary: "..." // String; optional.
   address: "..."         // String; optional.
 };
 
-artifactor.save(contract_data, "./MyContract.sol.js").then(function() {
-  // The file ./MyContract.sol.js now exists, which you can
-  // import into your project like any other Javascript file.
-});
+artifactor.save(contract_data);
+// The file ./MyContract.json now exists, which you can
+// import into your project like any other Javascript file.
 ```
+
 # API
 
-#### `artifactor.save(options, filename[, extra_options])`
+#### `artifactor.save(contract_data)`
 
-Save contract data as a `.sol.js` file. Returns a Promise.
+Save contract data as a `.json` file. Returns a Promise.
 
-* `options`: Object. Data that represents this contract:
+* `contract_data`: Object. Data that represents this contract:
 
     ```javascript
     {
@@ -79,20 +68,7 @@ Save contract data as a `.sol.js` file. Returns a Promise.
     }
     ```
 
-    Note: `save()` will also accept an already `require`'d contract object. i.e.,
-
-    ```javascript
-    var MyContract = require("./path/to/MyContract.sol.js");
-
-    artifactor.save(MyContract, ...).then(...);
-    ```
-
-  In this case, you can use the `extra_options` parameter to specify options that aren't managed by the contract abstraction itself.
-
-* `filename`: Path to save contract file.
-* `extra_options`: Object. Used if you need to specify other options within a separate object, for instance, when a contract abstraction is passed instead of an `options` object.
-
-#### `artifactor.saveAll(contracts, directory, options)`
+#### `artifactor.saveAll(contracts)`
 
 Save many contracts to the filesystem at once. Returns a Promise.
 
@@ -106,38 +82,6 @@ Save many contracts to the filesystem at once. Returns a Promise.
       }
       "AnotherContract": {
         // ...
-      }
-    }
-    ```
-
-* `directory`: String. Destination directory. Files will be saved via `<contract_name>.sol.js` within that directory.
-* `options`: Object. Same options listed in `save()` above.
-
-#### `artifactor.generate(options, networks)`
-
-Generate the source code that populates the `.sol.js` file. Returns a String.
-
-* `options`: Object. Subset of options listed in the `save()` function above. Expects:
-
-    ```javascript
-  {
-      abi: ...,
-      unlinked_binary: ...
-  }
-  ```
-
-* `networks`: Object. Contains the information about this contract for each network, keyed by the network id.
-
-    ```javascript
-    {
-      "1": {        // live network
-        "address": ...
-      },
-      "2": {        // morden network
-        "address": ...
-      },
-      "1337": {     // private network
-        "address": ...
       }
     }
     ```

--- a/packages/truffle-artifactor/index.js
+++ b/packages/truffle-artifactor/index.js
@@ -43,37 +43,31 @@ Artifactor.prototype.save = function(artifactObject) {
   }
 };
 
-Artifactor.prototype.saveAll = function(objects) {
-  var self = this;
+Artifactor.prototype.saveAll = function(artifactObjects) {
+  const self = this;
+  let newArtifactObjects = {};
 
-  if (Array.isArray(objects)) {
-    var array = objects;
-    objects = {};
+  if (Array.isArray(artifactObjects)) {
+    const tmpArtifactArray = artifactObjects;
 
-    array.forEach(function(item) {
-      objects[item.contract_name] = item;
+    tmpArtifactArray.forEach(function(artifactObj) {
+      newArtifactObjects[artifactObj.contract_name] = artifactObj;
     });
+  } else {
+    newArtifactObjects = artifactObjects;
   }
 
-  return new Promise(function(accept, reject) {
-    fs.stat(self.destination, function(err, stat) {
-      if (err) {
-        return reject(
-          new Error("Desination " + self.destination + " doesn't exist!")
-        );
-      }
-      accept();
-    });
-  }).then(function() {
-    var promises = [];
+  try {
+    fs.statSync(self.destination);
+  } catch (e) {
+    if (e.code === "ENOENT")
+      throw new Error(`Destination "${self.destination}" doesn't exist!`);
+    throw new Error(e);
+  }
 
-    Object.keys(objects).forEach(function(contractName) {
-      var object = objects[contractName];
-      object.contractName = contractName;
-      promises.push(self.save(object));
-    });
-
-    return Promise.all(promises);
+  Object.keys(newArtifactObjects).forEach(contractName => {
+    let artifactObject = newArtifactObjects[contractName];
+    self.save(artifactObject);
   });
 };
 

--- a/packages/truffle-artifactor/index.js
+++ b/packages/truffle-artifactor/index.js
@@ -21,7 +21,7 @@ Artifactor.prototype.save = function(artifactObject) {
 
   // helper for writing artifacts
   const writeArtifact = _completeArtifact => {
-    completeArtifact.updatedAt = new Date().toISOString();
+    _completeArtifact.updatedAt = new Date().toISOString();
     fs.writeFileSync(
       output_path,
       JSON.stringify(_completeArtifact, null, 2),

--- a/packages/truffle-artifactor/index.js
+++ b/packages/truffle-artifactor/index.js
@@ -39,8 +39,8 @@ class Artifactor {
       _.merge(completeArtifact, normalizedExistingArtifact, normalizedArtifact);
       writeArtifact(completeArtifact);
     } catch (e) {
-      if (e.code === "ENOENT") return writeArtifact(normalizedArtifact);
       // if artifact doesn't already exist, write new file
+      if (e.code === "ENOENT") return writeArtifact(normalizedArtifact);
       else if (e instanceof SyntaxError) throw new Error(e); // catches improperly formatted artifact json
       throw new Error(e); // catch all other errors
     }

--- a/packages/truffle-artifactor/index.js
+++ b/packages/truffle-artifactor/index.js
@@ -6,63 +6,41 @@ var debug = require("debug")("artifactor");
 
 function Artifactor(destination) {
   this.destination = destination;
-};
+}
 
-Artifactor.prototype.save = function(object) {
-  var self = this;
+Artifactor.prototype.save = function(artifactObject) {
+  const self = this;
 
-  return new Promise(function(accept, reject) {
-    object = Schema.normalize(object);
+  const normalizedArtifact = Schema.normalize(artifactObject);
+  const contractName = normalizedArtifact.contractName;
 
-    if (object.contractName == null) {
-      return reject(new Error("You must specify a contract name."));
-    }
+  if (!contractName) throw new Error("You must specify a contract name.");
 
-    var output_path = object.contractName;
+  const output_path = path.join(self.destination, `${contractName}.json`);
+  let completeArtifact = {};
 
-    // Create new path off of destination.
-    output_path = path.join(self.destination, output_path);
-    output_path = path.resolve(output_path);
+  // helper for writing artifacts
+  const writeArtifact = _completeArtifact => {
+    completeArtifact.updatedAt = new Date().toISOString();
+    fs.writeFileSync(
+      output_path,
+      JSON.stringify(_completeArtifact, null, 2),
+      "utf8"
+    );
+  };
 
-    // Add json extension.
-    output_path = output_path + ".json";
-
-    fs.readFile(output_path, {encoding: "utf8"}, function(err, json) {
-      // No need to handle the error. If the file doesn't exist then we'll start afresh
-      // with a new object.
-
-      var finalObject = object;
-
-      if (!err) {
-        var existingObjDirty;
-        try {
-          existingObjDirty = JSON.parse(json);
-        } catch (e) {
-          reject(e);
-        }
-
-        // normalize existing and merge into final
-        finalObject = Schema.normalize(existingObjDirty);
-
-        // merge networks
-        var finalNetworks = {};
-        _.merge(finalNetworks, finalObject.networks, object.networks);
-
-        // update existing with new
-        _.assign(finalObject, object);
-        finalObject.networks = finalNetworks;
-      }
-
-      // update timestamp
-      finalObject.updatedAt = new Date().toISOString();
-
-      // output object
-      fs.outputFile(output_path, JSON.stringify(finalObject, null, 2), "utf8", function(err) {
-        if (err) return reject(err);
-        accept();
-      });
-    });
-  });
+  try {
+    const existingArtifact = fs.readFileSync(output_path, "utf8"); // check if artifact already exists
+    const existingArtifactObject = JSON.parse(existingArtifact); // parse existing artifact
+    const normalizedExistingArtifact = Schema.normalize(existingArtifactObject);
+    _.merge(completeArtifact, normalizedExistingArtifact, normalizedArtifact);
+    writeArtifact(completeArtifact);
+  } catch (e) {
+    if (e.code === "ENOENT") return writeArtifact(normalizedArtifact);
+    // if artifact doesn't already exist, write new file
+    else if (e instanceof SyntaxError) throw new Error(e); // catches improperly formatted artifact json
+    throw new Error(e); // catch all other errors
+  }
 };
 
 Artifactor.prototype.saveAll = function(objects) {
@@ -80,7 +58,9 @@ Artifactor.prototype.saveAll = function(objects) {
   return new Promise(function(accept, reject) {
     fs.stat(self.destination, function(err, stat) {
       if (err) {
-        return reject(new Error("Desination " + self.destination + " doesn't exist!"));
+        return reject(
+          new Error("Desination " + self.destination + " doesn't exist!")
+        );
       }
       accept();
     });

--- a/packages/truffle-artifactor/index.js
+++ b/packages/truffle-artifactor/index.js
@@ -9,7 +9,7 @@ class Artifactor {
     this.destination = destination;
   }
 
-  save(artifactObject) {
+  async save(artifactObject) {
     const self = this;
 
     const normalizedArtifact = Schema.normalize(artifactObject);
@@ -46,7 +46,7 @@ class Artifactor {
     }
   }
 
-  saveAll(artifactObjects) {
+  async saveAll(artifactObjects) {
     const self = this;
     let newArtifactObjects = {};
 

--- a/packages/truffle-artifactor/index.js
+++ b/packages/truffle-artifactor/index.js
@@ -10,14 +10,12 @@ class Artifactor {
   }
 
   async save(artifactObject) {
-    const self = this;
-
     const normalizedArtifact = Schema.normalize(artifactObject);
     const contractName = normalizedArtifact.contractName;
 
     if (!contractName) throw new Error("You must specify a contract name.");
 
-    const output_path = path.join(self.destination, `${contractName}.json`);
+    const output_path = path.join(this.destination, `${contractName}.json`);
     let completeArtifact = {};
 
     // private helper for writing artifacts
@@ -47,7 +45,6 @@ class Artifactor {
   }
 
   async saveAll(artifactObjects) {
-    const self = this;
     let newArtifactObjects = {};
 
     if (Array.isArray(artifactObjects)) {
@@ -61,17 +58,17 @@ class Artifactor {
     }
 
     try {
-      fs.statSync(self.destination); // check if destinationn exists
+      fs.statSync(this.destination); // check if destination exists
     } catch (e) {
       if (e.code === "ENOENT")
         // if destination doesn't exist, throw error
-        throw new Error(`Destination "${self.destination}" doesn't exist!`);
+        throw new Error(`Destination "${this.destination}" doesn't exist!`);
       throw new Error(e); // throw on all other errors
     }
 
     Object.keys(newArtifactObjects).forEach(contractName => {
       let artifactObject = newArtifactObjects[contractName];
-      self.save(artifactObject);
+      this.save(artifactObject);
     });
   }
 }

--- a/packages/truffle-artifactor/index.js
+++ b/packages/truffle-artifactor/index.js
@@ -4,71 +4,75 @@ var path = require("path");
 var _ = require("lodash");
 var debug = require("debug")("artifactor");
 
-function Artifactor(destination) {
-  this.destination = destination;
-}
-
-Artifactor.prototype.save = function(artifactObject) {
-  const self = this;
-
-  const normalizedArtifact = Schema.normalize(artifactObject);
-  const contractName = normalizedArtifact.contractName;
-
-  if (!contractName) throw new Error("You must specify a contract name.");
-
-  const output_path = path.join(self.destination, `${contractName}.json`);
-  let completeArtifact = {};
-
-  // helper for writing artifacts
-  const writeArtifact = _completeArtifact => {
-    _completeArtifact.updatedAt = new Date().toISOString();
-    fs.writeFileSync(
-      output_path,
-      JSON.stringify(_completeArtifact, null, 2),
-      "utf8"
-    );
-  };
-
-  try {
-    const existingArtifact = fs.readFileSync(output_path, "utf8"); // check if artifact already exists
-    const existingArtifactObject = JSON.parse(existingArtifact); // parse existing artifact
-    const normalizedExistingArtifact = Schema.normalize(existingArtifactObject);
-    _.merge(completeArtifact, normalizedExistingArtifact, normalizedArtifact);
-    writeArtifact(completeArtifact);
-  } catch (e) {
-    if (e.code === "ENOENT") return writeArtifact(normalizedArtifact);
-    // if artifact doesn't already exist, write new file
-    else if (e instanceof SyntaxError) throw new Error(e); // catches improperly formatted artifact json
-    throw new Error(e); // catch all other errors
+class Artifactor {
+  constructor(destination) {
+    this.destination = destination;
   }
-};
 
-Artifactor.prototype.saveAll = function(artifactObjects) {
-  const self = this;
-  let newArtifactObjects = {};
+  save(artifactObject) {
+    const self = this;
 
-  if (Array.isArray(artifactObjects)) {
-    const tmpArtifactArray = artifactObjects;
+    const normalizedArtifact = Schema.normalize(artifactObject);
+    const contractName = normalizedArtifact.contractName;
 
-    tmpArtifactArray.forEach(function(artifactObj) {
-      newArtifactObjects[artifactObj.contract_name] = artifactObj;
+    if (!contractName) throw new Error("You must specify a contract name.");
+
+    const output_path = path.join(self.destination, `${contractName}.json`);
+    let completeArtifact = {};
+
+    // helper for writing artifacts
+    const writeArtifact = _completeArtifact => {
+      _completeArtifact.updatedAt = new Date().toISOString();
+      fs.writeFileSync(
+        output_path,
+        JSON.stringify(_completeArtifact, null, 2),
+        "utf8"
+      );
+    };
+
+    try {
+      const existingArtifact = fs.readFileSync(output_path, "utf8"); // check if artifact already exists
+      const existingArtifactObject = JSON.parse(existingArtifact); // parse existing artifact
+      const normalizedExistingArtifact = Schema.normalize(
+        existingArtifactObject
+      );
+      _.merge(completeArtifact, normalizedExistingArtifact, normalizedArtifact);
+      writeArtifact(completeArtifact);
+    } catch (e) {
+      if (e.code === "ENOENT") return writeArtifact(normalizedArtifact);
+      // if artifact doesn't already exist, write new file
+      else if (e instanceof SyntaxError) throw new Error(e); // catches improperly formatted artifact json
+      throw new Error(e); // catch all other errors
+    }
+  }
+
+  saveAll(artifactObjects) {
+    const self = this;
+    let newArtifactObjects = {};
+
+    if (Array.isArray(artifactObjects)) {
+      const tmpArtifactArray = artifactObjects;
+
+      tmpArtifactArray.forEach(artifactObj => {
+        newArtifactObjects[artifactObj.contract_name] = artifactObj;
+      });
+    } else {
+      newArtifactObjects = artifactObjects;
+    }
+
+    try {
+      fs.statSync(self.destination);
+    } catch (e) {
+      if (e.code === "ENOENT")
+        throw new Error(`Destination "${self.destination}" doesn't exist!`);
+      throw new Error(e);
+    }
+
+    Object.keys(newArtifactObjects).forEach(contractName => {
+      let artifactObject = newArtifactObjects[contractName];
+      self.save(artifactObject);
     });
-  } else {
-    newArtifactObjects = artifactObjects;
   }
-
-  try {
-    fs.statSync(self.destination);
-  } catch (e) {
-    if (e.code === "ENOENT")
-      throw new Error(`Destination "${self.destination}" doesn't exist!`);
-    throw new Error(e);
-  }
-
-  Object.keys(newArtifactObjects).forEach(contractName => {
-    let artifactObject = newArtifactObjects[contractName];
-    self.save(artifactObject);
-  });
-};
+}
 
 module.exports = Artifactor;

--- a/packages/truffle-artifactor/index.js
+++ b/packages/truffle-artifactor/index.js
@@ -20,7 +20,7 @@ class Artifactor {
     const output_path = path.join(self.destination, `${contractName}.json`);
     let completeArtifact = {};
 
-    // helper for writing artifacts
+    // private helper for writing artifacts
     const writeArtifact = _completeArtifact => {
       _completeArtifact.updatedAt = new Date().toISOString();
       fs.writeFileSync(

--- a/packages/truffle-artifactor/index.js
+++ b/packages/truffle-artifactor/index.js
@@ -61,11 +61,12 @@ class Artifactor {
     }
 
     try {
-      fs.statSync(self.destination);
+      fs.statSync(self.destination); // check if destinationn exists
     } catch (e) {
       if (e.code === "ENOENT")
+        // if destination doesn't exist, throw error
         throw new Error(`Destination "${self.destination}" doesn't exist!`);
-      throw new Error(e);
+      throw new Error(e); // throw on all other errors
     }
 
     Object.keys(newArtifactObjects).forEach(contractName => {

--- a/packages/truffle-artifactor/test/contracts.js
+++ b/packages/truffle-artifactor/test/contracts.js
@@ -15,7 +15,7 @@ describe("artifactor + require", function() {
   var Example;
   var accounts;
   var abi;
-  var binary;
+  var bytecode;
   var network_id;
   var artifactor;
   var provider = Ganache.provider();
@@ -62,7 +62,7 @@ describe("artifactor + require", function() {
 
     var compiled = Schema.normalize(result["Example"]);
     abi = compiled.abi;
-    binary = compiled.bytecode;
+    bytecode = compiled.bytecode;
 
     // Setup
     var dirPath = temp.mkdirSync({
@@ -78,9 +78,12 @@ describe("artifactor + require", function() {
       .save({
         contractName: "Example",
         abi: abi,
-        binary: binary,
-        address: "0xe6e1652a0397e078f434d6dda181b218cfd42e01",
-        network_id: network_id
+        bytecode: bytecode,
+        networks: {
+          [`${network_id}`]: {
+            address: "0xe6e1652a0397e078f434d6dda181b218cfd42e01"
+          }
+        }
       })
       .then(function() {
         var json = requireNoCache(expected_filepath);
@@ -285,7 +288,7 @@ describe("artifactor + require", function() {
   it("creates a network object when an address is set if no network specified", function(done) {
     var NewExample = contract({
       abi: abi,
-      unlinked_binary: binary
+      bytecode: bytecode
     });
 
     NewExample.setProvider(provider);
@@ -336,7 +339,7 @@ describe("artifactor + require", function() {
     var MyContract = contract({
       contractName: "MyContract",
       abi: [event_abi],
-      binary: "0x12345678"
+      bytecode: "0x12345678"
     });
 
     MyContract.setNetwork(5);

--- a/packages/truffle-artifactor/test/contracts.js
+++ b/packages/truffle-artifactor/test/contracts.js
@@ -16,13 +16,13 @@ describe("artifactor + require", () => {
   let accounts;
   let abi;
   let bytecode;
-  let network_id;
+  let networkID;
   let artifactor;
   const provider = Ganache.provider();
   const web3 = new Web3();
   web3.setProvider(provider);
 
-  before(() => web3.eth.net.getId().then(id => (network_id = id)));
+  before(() => web3.eth.net.getId().then(id => (networkID = id)));
 
   before(async function() {
     this.timeout(20000);
@@ -68,7 +68,7 @@ describe("artifactor + require", () => {
       prefix: "tmp-test-contract-"
     });
 
-    const expected_filepath = path.join(dirPath, "Example.json");
+    const expectedFilepath = path.join(dirPath, "Example.json");
 
     artifactor = new Artifactor(dirPath);
 
@@ -78,21 +78,21 @@ describe("artifactor + require", () => {
         abi,
         bytecode,
         networks: {
-          [`${network_id}`]: {
+          [`${networkID}`]: {
             address: "0xe6e1652a0397e078f434d6dda181b218cfd42e01"
           }
         }
       })
       .then(() => {
-        const json = requireNoCache(expected_filepath);
+        const json = requireNoCache(expectedFilepath);
         Example = contract(json);
         Example.setProvider(provider);
       });
   });
 
   before(() =>
-    web3.eth.getAccounts().then(accs => {
-      accounts = accs;
+    web3.eth.getAccounts().then(_accounts => {
+      accounts = _accounts;
 
       Example.defaults({
         from: accounts[0]
@@ -166,9 +166,9 @@ describe("artifactor + require", () => {
         // BigNumber passed in a call.
         return example.parrot.call(865);
       })
-      .then(parrot_value => {
+      .then(parrotValue => {
         assert.equal(
-          parseInt(parrot_value),
+          parseInt(parrotValue),
           865,
           "Parrotted value should equal 865"
         );
@@ -297,12 +297,12 @@ describe("artifactor + require", () => {
       .then(({ address }) => {
         // We have a network id in this case, with new(), since it was detected,
         // but no further configuration.
-        assert.equal(NewExample.network_id, network_id);
-        assert.equal(NewExample.toJSON().networks[network_id], null);
+        assert.equal(NewExample.network_id, networkID);
+        assert.equal(NewExample.toJSON().networks[networkID], null);
 
         NewExample.address = address;
 
-        assert.equal(NewExample.toJSON().networks[network_id].address, address);
+        assert.equal(NewExample.toJSON().networks[networkID].address, address);
 
         done();
       })
@@ -310,7 +310,7 @@ describe("artifactor + require", () => {
   });
 
   it("doesn't error when calling .links() or .events() with no network configuration", done => {
-    const event_abi = {
+    const eventABI = {
       anonymous: false,
       inputs: [
         {
@@ -330,20 +330,20 @@ describe("artifactor + require", () => {
 
     const MyContract = contract({
       contractName: "MyContract",
-      abi: [event_abi],
+      abi: [eventABI],
       bytecode: "0x12345678"
     });
 
     MyContract.setNetwork(5);
 
-    const expected_event_topic = web3.utils.sha3(
+    const expectedEventTopic = web3.utils.sha3(
       "PackageRelease(bytes32,bytes32)"
     );
 
     // We want to make sure these don't throw when a network configuration doesn't exist.
     // While we're at it, lets make sure we still get the event we expect.
     assert.deepEqual(MyContract.links, {});
-    assert.deepEqual(MyContract.events[expected_event_topic], event_abi);
+    assert.deepEqual(MyContract.events[expectedEventTopic], eventABI);
 
     done();
   });

--- a/packages/truffle-artifactor/test/contracts.js
+++ b/packages/truffle-artifactor/test/contracts.js
@@ -1,30 +1,28 @@
-var assert = require("chai").assert;
-var Artifactor = require("../");
-var contract = require("truffle-contract");
-var Schema = require("truffle-contract-schema");
-var temp = require("temp").track();
-var path = require("path");
-var fs = require("fs");
-var requireNoCache = require("require-nocache")(module);
-var Compile = require("truffle-compile");
-var Ganache = require("ganache-core");
-var Web3 = require("web3");
+const assert = require("chai").assert;
+const Artifactor = require("../");
+const contract = require("truffle-contract");
+const Schema = require("truffle-contract-schema");
+const temp = require("temp").track();
+const path = require("path");
+const fs = require("fs");
+const requireNoCache = require("require-nocache")(module);
+const Compile = require("truffle-compile");
+const Ganache = require("ganache-core");
+const Web3 = require("web3");
 const { promisify } = require("util");
 
-describe("artifactor + require", function() {
-  var Example;
-  var accounts;
-  var abi;
-  var bytecode;
-  var network_id;
-  var artifactor;
-  var provider = Ganache.provider();
-  var web3 = new Web3();
+describe("artifactor + require", () => {
+  let Example;
+  let accounts;
+  let abi;
+  let bytecode;
+  let network_id;
+  let artifactor;
+  const provider = Ganache.provider();
+  const web3 = new Web3();
   web3.setProvider(provider);
 
-  before(function() {
-    return web3.eth.net.getId().then(id => (network_id = id));
-  });
+  before(() => web3.eth.net.getId().then(id => (network_id = id)));
 
   before(async function() {
     this.timeout(20000);
@@ -51,97 +49,94 @@ describe("artifactor + require", function() {
     };
 
     // Compile first
-    var result = await promisify(Compile)(sources, options);
+    const result = await promisify(Compile)(sources, options);
 
     // Clean up after solidity. Only remove solidity's listener,
     // which happens to be the first.
     process.removeListener(
       "uncaughtException",
-      process.listeners("uncaughtException")[0] || function() {}
+      process.listeners("uncaughtException")[0] || (() => {})
     );
 
-    var compiled = Schema.normalize(result["Example"]);
+    const compiled = Schema.normalize(result["Example"]);
     abi = compiled.abi;
     bytecode = compiled.bytecode;
 
     // Setup
-    var dirPath = temp.mkdirSync({
+    const dirPath = temp.mkdirSync({
       dir: path.resolve("./"),
       prefix: "tmp-test-contract-"
     });
 
-    var expected_filepath = path.join(dirPath, "Example.json");
+    const expected_filepath = path.join(dirPath, "Example.json");
 
     artifactor = new Artifactor(dirPath);
 
     await artifactor
       .save({
         contractName: "Example",
-        abi: abi,
-        bytecode: bytecode,
+        abi,
+        bytecode,
         networks: {
           [`${network_id}`]: {
             address: "0xe6e1652a0397e078f434d6dda181b218cfd42e01"
           }
         }
       })
-      .then(function() {
-        var json = requireNoCache(expected_filepath);
+      .then(() => {
+        const json = requireNoCache(expected_filepath);
         Example = contract(json);
         Example.setProvider(provider);
       });
   });
 
-  before(function() {
-    return web3.eth.getAccounts().then(accs => {
+  before(() =>
+    web3.eth.getAccounts().then(accs => {
       accounts = accs;
 
       Example.defaults({
         from: accounts[0]
       });
-    });
-  });
+    })
+  );
 
-  after(function(done) {
+  after(done => {
     temp.cleanupSync();
     done();
   });
 
-  it("should set the transaction hash of contract instantiation", function() {
-    return Example.new(1, { gas: 3141592 }).then(function(example) {
-      assert(example.transactionHash, "transactionHash should be non-empty");
-    });
-  });
+  it("should set the transaction hash of contract instantiation", () =>
+    Example.new(1, { gas: 3141592 }).then(({ transactionHash }) => {
+      assert(transactionHash, "transactionHash should be non-empty");
+    }));
 
-  it("should get and set values via methods and get values via .call", function(done) {
-    var example;
+  it("should get and set values via methods and get values via .call", done => {
+    let example;
     Example.new(1, { gas: 3141592 })
-      .then(function(instance) {
+      .then(instance => {
         example = instance;
         return example.value.call();
       })
-      .then(function(value) {
+      .then(value => {
         assert.equal(value.valueOf(), 1, "Starting value should be 1");
         return example.setValue(5);
       })
-      .then(() => {
-        return example.value.call();
-      })
-      .then(function(value) {
+      .then(() => example.value.call())
+      .then(value => {
         assert.equal(parseInt(value), 5, "Ending value should be five");
       })
       .then(done)
       .catch(done);
   });
 
-  it("shouldn't synchronize constant functions", function(done) {
-    var example;
+  it("shouldn't synchronize constant functions", done => {
+    let example;
     Example.new(5, { gas: 3141592 })
-      .then(function(instance) {
+      .then(instance => {
         example = instance;
         return example.getValue();
       })
-      .then(function(value) {
+      .then(value => {
         assert.equal(
           value.valueOf(),
           5,
@@ -152,28 +147,26 @@ describe("artifactor + require", function() {
       .catch(done);
   });
 
-  it("should allow BigNumbers as input parameters, and not confuse them as transaction objects", function(done) {
+  it("should allow BigNumbers as input parameters, and not confuse them as transaction objects", done => {
     // BigNumber passed on new()
-    var example = null;
+    let example = null;
     Example.new("30", { gas: 3141592 })
-      .then(function(instance) {
+      .then(instance => {
         example = instance;
         return example.value.call();
       })
-      .then(function(value) {
+      .then(value => {
         assert.equal(parseInt(value), 30, "Starting value should be 30");
         // BigNumber passed in a transaction.
         return example.setValue("25", { gas: 3141592 });
       })
-      .then(() => {
-        return example.value.call();
-      })
-      .then(function(value) {
+      .then(() => example.value.call())
+      .then(value => {
         assert.equal(parseInt(value), 25, "Ending value should be twenty-five");
         // BigNumber passed in a call.
         return example.parrot.call(865);
       })
-      .then(function(parrot_value) {
+      .then(parrot_value => {
         assert.equal(
           parseInt(parrot_value),
           865,
@@ -184,32 +177,32 @@ describe("artifactor + require", function() {
       .catch(done);
   });
 
-  it("should return transaction hash, logs and receipt when using synchronised transactions", function(done) {
-    var example = null;
+  it("should return transaction hash, logs and receipt when using synchronised transactions", done => {
+    let example = null;
     Example.new("1", { gas: 3141592 })
-      .then(function(instance) {
+      .then(instance => {
         example = instance;
         return example.triggerEvent();
       })
-      .then(function(result) {
-        assert.isDefined(result.tx, "transaction hash wasn't returned");
+      .then(({ tx, logs, receipt }) => {
+        assert.isDefined(tx, "transaction hash wasn't returned");
         assert.isDefined(
-          result.logs,
+          logs,
           "synchronized transaction didn't return any logs"
         );
         assert.isDefined(
-          result.receipt,
+          receipt,
           "synchronized transaction didn't return a receipt"
         );
-        assert.isOk(result.tx.length > 42, "Unexpected transaction hash"); // There has to be a better way to do this.
+        assert.isOk(tx.length > 42, "Unexpected transaction hash"); // There has to be a better way to do this.
         assert.equal(
-          result.tx,
-          result.receipt.transactionHash,
+          tx,
+          receipt.transactionHash,
           "Transaction had different hash than receipt"
         );
-        assert.equal(result.logs.length, 1, "logs array expected to be 1");
+        assert.equal(logs.length, 1, "logs array expected to be 1");
 
-        var log = result.logs[0];
+        const log = logs[0];
 
         assert.equal("ExampleEvent", log.event);
         assert.equal(accounts[0], log.args._from);
@@ -219,14 +212,14 @@ describe("artifactor + require", function() {
       .catch(done);
   });
 
-  it("should trigger the fallback function when calling sendTransaction()", function() {
-    var example = null;
+  it("should trigger the fallback function when calling sendTransaction()", () => {
+    let example = null;
     return Example.new("1", { gas: 3141592 })
-      .then(function(instance) {
+      .then(instance => {
         example = instance;
         return example.fallbackTriggered();
       })
-      .then(function(triggered) {
+      .then(triggered => {
         assert(
           triggered === false,
           "Fallback should not have been triggered yet"
@@ -235,47 +228,49 @@ describe("artifactor + require", function() {
           value: web3.utils.toWei("1", "ether")
         });
       })
-      .then(() => {
-        return new Promise(function(accept, reject) {
-          return web3.eth.getBalance(example.address, function(err, balance) {
-            if (err) return reject(err);
-            accept(balance);
-          });
-        });
-      })
-      .then(function(balance) {
+      .then(
+        () =>
+          new Promise((accept, reject) =>
+            web3.eth.getBalance(example.address, (err, balance) => {
+              if (err) return reject(err);
+              accept(balance);
+            })
+          )
+      )
+      .then(balance => {
         assert(balance === web3.utils.toWei("1", "ether"));
       });
   });
 
-  it("should trigger the fallback function when calling send() (shorthand notation)", function() {
-    var example = null;
+  it("should trigger the fallback function when calling send() (shorthand notation)", () => {
+    let example = null;
     return Example.new("1", { gas: 3141592 })
-      .then(function(instance) {
+      .then(instance => {
         example = instance;
         return example.fallbackTriggered();
       })
-      .then(function(triggered) {
+      .then(triggered => {
         assert(
           triggered === false,
           "Fallback should not have been triggered yet"
         );
         return example.send(web3.utils.toWei("1", "ether"));
       })
-      .then(() => {
-        return new Promise(function(accept, reject) {
-          return web3.eth.getBalance(example.address, function(err, balance) {
-            if (err) return reject(err);
-            accept(balance);
-          });
-        });
-      })
-      .then(function(balance) {
+      .then(
+        () =>
+          new Promise((accept, reject) =>
+            web3.eth.getBalance(example.address, (err, balance) => {
+              if (err) return reject(err);
+              accept(balance);
+            })
+          )
+      )
+      .then(balance => {
         assert(balance === web3.utils.toWei("1", "ether"));
       });
   });
 
-  it("errors when setting an invalid provider", function(done) {
+  it("errors when setting an invalid provider", done => {
     try {
       Example.setProvider(null);
       assert.fail("setProvider() should have thrown an error");
@@ -285,10 +280,10 @@ describe("artifactor + require", function() {
     done();
   });
 
-  it("creates a network object when an address is set if no network specified", function(done) {
-    var NewExample = contract({
-      abi: abi,
-      bytecode: bytecode
+  it("creates a network object when an address is set if no network specified", done => {
+    const NewExample = contract({
+      abi,
+      bytecode
     });
 
     NewExample.setProvider(provider);
@@ -299,26 +294,23 @@ describe("artifactor + require", function() {
     assert.equal(NewExample.network_id, null);
 
     NewExample.new(1, { gas: 3141592 })
-      .then(function(instance) {
+      .then(({ address }) => {
         // We have a network id in this case, with new(), since it was detected,
         // but no further configuration.
         assert.equal(NewExample.network_id, network_id);
         assert.equal(NewExample.toJSON().networks[network_id], null);
 
-        NewExample.address = instance.address;
+        NewExample.address = address;
 
-        assert.equal(
-          NewExample.toJSON().networks[network_id].address,
-          instance.address
-        );
+        assert.equal(NewExample.toJSON().networks[network_id].address, address);
 
         done();
       })
       .catch(done);
   });
 
-  it("doesn't error when calling .links() or .events() with no network configuration", function(done) {
-    var event_abi = {
+  it("doesn't error when calling .links() or .events() with no network configuration", done => {
+    const event_abi = {
       anonymous: false,
       inputs: [
         {
@@ -336,7 +328,7 @@ describe("artifactor + require", function() {
       type: "event"
     };
 
-    var MyContract = contract({
+    const MyContract = contract({
       contractName: "MyContract",
       abi: [event_abi],
       bytecode: "0x12345678"
@@ -344,7 +336,7 @@ describe("artifactor + require", function() {
 
     MyContract.setNetwork(5);
 
-    var expected_event_topic = web3.utils.sha3(
+    const expected_event_topic = web3.utils.sha3(
       "PackageRelease(bytes32,bytes32)"
     );
 

--- a/packages/truffle-artifactor/test/customoptions.js
+++ b/packages/truffle-artifactor/test/customoptions.js
@@ -2,35 +2,38 @@ var assert = require("chai").assert;
 var Artifactor = require("../");
 var temp = require("temp").track();
 var contract = require("truffle-contract");
-var path = require('path');
+var path = require("path");
 var requireNoCache = require("require-nocache")(module);
 
 describe("Custom options", function() {
-
   it("allows custom options", function(done) {
     // Setup
     var dirPath = temp.mkdirSync({
       dir: path.resolve("./"),
-      prefix: 'tmp-test-contract-'
+      prefix: "tmp-test-contract-"
     });
 
     var expected_filepath = path.join(dirPath, "Example.json");
 
     artifactor = new Artifactor(dirPath);
 
-    artifactor.save({
-      contractName: "Example",
-      abi: [],
-      binary: "0xabcdef",
-      address: "0xe6e1652a0397e078f434d6dda181b218cfd42e01",
-      network_id: 3,
-      "x-from-dependency": "somedep"
-    }).then(function() {
-      var json = requireNoCache(expected_filepath);
-      Example = contract(json);
+    artifactor
+      .save({
+        "contractName": "Example",
+        "abi": [],
+        "bytecode": "0xabcdef",
+        "networks": {
+          3: { address: "0xe6e1652a0397e078f434d6dda181b218cfd42e01" }
+        },
+        "x-from-dependency": "somedep"
+      })
+      .then(function() {
+        var json = requireNoCache(expected_filepath);
+        Example = contract(json);
 
-      assert.equal(Example["x-from-dependency"], "somedep");
-    }).then(done).catch(done);
+        assert.equal(Example["x-from-dependency"], "somedep");
+      })
+      .then(done)
+      .catch(done);
   });
-
 });

--- a/packages/truffle-artifactor/test/customoptions.js
+++ b/packages/truffle-artifactor/test/customoptions.js
@@ -1,19 +1,19 @@
-var assert = require("chai").assert;
-var Artifactor = require("../");
-var temp = require("temp").track();
-var contract = require("truffle-contract");
-var path = require("path");
-var requireNoCache = require("require-nocache")(module);
+const assert = require("chai").assert;
+const Artifactor = require("../");
+const temp = require("temp").track();
+const contract = require("truffle-contract");
+const path = require("path");
+const requireNoCache = require("require-nocache")(module);
 
-describe("Custom options", function() {
-  it("allows custom options", function(done) {
+describe("Custom options", () => {
+  it("allows custom options", done => {
     // Setup
-    var dirPath = temp.mkdirSync({
+    const dirPath = temp.mkdirSync({
       dir: path.resolve("./"),
       prefix: "tmp-test-contract-"
     });
 
-    var expected_filepath = path.join(dirPath, "Example.json");
+    const expected_filepath = path.join(dirPath, "Example.json");
 
     artifactor = new Artifactor(dirPath);
 
@@ -27,8 +27,8 @@ describe("Custom options", function() {
         },
         "x-from-dependency": "somedep"
       })
-      .then(function() {
-        var json = requireNoCache(expected_filepath);
+      .then(() => {
+        const json = requireNoCache(expected_filepath);
         Example = contract(json);
 
         assert.equal(Example["x-from-dependency"], "somedep");

--- a/packages/truffle-artifactor/test/networksave.js
+++ b/packages/truffle-artifactor/test/networksave.js
@@ -16,13 +16,16 @@ const thirdNetworkObj = {
   2: { address: "0x6a90f4263739e4e20146ee4b5691d5b0fe5d48ec" }
 };
 
-const dirPath = temp.mkdirSync({
-  dir: path.resolve("./"),
-  prefix: "tmp-test-contract-"
-});
-const expected_filepath = path.join(dirPath, "Example.json");
+let dirPath, expected_filepath;
 
 describe("if artifact file doesn't already exist...", () => {
+  before(() => {
+    dirPath = temp.mkdirSync({
+      dir: path.resolve("./"),
+      prefix: "tmp-test-contract-"
+    });
+    expected_filepath = path.join(dirPath, "Example.json");
+  });
   it("...artifactor merges a passed network object to json", done => {
     // make sure the artifact file doesn't already exist
     assert(!fs.existsSync(expected_filepath));

--- a/packages/truffle-artifactor/test/networksave.js
+++ b/packages/truffle-artifactor/test/networksave.js
@@ -1,0 +1,100 @@
+const assert = require("chai").assert;
+const Artifactor = require("../");
+const temp = require("temp").track();
+const contract = require("truffle-contract");
+const path = require("path");
+const fs = require("fs");
+const requireNoCache = require("require-nocache")(module);
+
+const firstNetworkObj = {
+  3: { address: "0xe6e1652a0397e078f434d6dda181b218cfd42e01" }
+};
+const secondNetworkObj = {
+  2: { address: "0xe5e1652a0397e078f434d6dda181b218cfd42e01" }
+};
+const thirdNetworkObj = {
+  2: { address: "0x6a90f4263739e4e20146ee4b5691d5b0fe5d48ec" }
+};
+
+const dirPath = temp.mkdirSync({
+  dir: path.resolve("./"),
+  prefix: "tmp-test-contract-"
+});
+const expected_filepath = path.join(dirPath, "Example.json");
+
+describe("if artifact file doesn't already exist...", () => {
+  it("...artifactor merges a passed network object to json", done => {
+    // make sure the artifact file doesn't already exist
+    assert(!fs.existsSync(expected_filepath));
+
+    artifactor = new Artifactor(dirPath);
+
+    artifactor
+      .save({
+        contractName: "Example",
+        abi: [],
+        bytecode: "0xabcdef",
+        networks: firstNetworkObj
+      })
+      .then(() => {
+        const json = requireNoCache(expected_filepath);
+        Example = contract(json);
+
+        assert.deepStrictEqual(Example.networks, firstNetworkObj);
+      })
+      .then(done)
+      .catch(done);
+  });
+});
+
+describe("if artifact file already exists...", () => {
+  it("...artifactor merges a different network object w/o overwriting an older one to json", done => {
+    // make sure the artifact file already exists
+    assert(fs.existsSync(expected_filepath));
+
+    artifactor = new Artifactor(dirPath);
+
+    artifactor
+      .save({
+        contractName: "Example",
+        abi: [],
+        bytecode: "0xabcdef",
+        networks: secondNetworkObj
+      })
+      .then(() => {
+        const json = requireNoCache(expected_filepath);
+        Example = contract(json);
+
+        assert.deepStrictEqual(Example.networks[2], secondNetworkObj[2]);
+        assert.deepStrictEqual(Example.networks[3], firstNetworkObj[3]);
+        assert.notDeepEqual(Example.networks[2], Example.networks[3]);
+      })
+      .then(done)
+      .catch(done);
+  });
+
+  it("...artifactor overwrites an older network object using the same network_id to json", done => {
+    // make sure the artifact file already exists
+    assert(fs.existsSync(expected_filepath));
+
+    artifactor = new Artifactor(dirPath);
+
+    artifactor
+      .save({
+        contractName: "Example",
+        abi: [],
+        bytecode: "0xabcdef",
+        networks: thirdNetworkObj
+      })
+      .then(() => {
+        const json = requireNoCache(expected_filepath);
+        Example = contract(json);
+
+        assert.deepStrictEqual(Example.networks[2], thirdNetworkObj[2]);
+        assert.notDeepEqual(Example.networks[2], secondNetworkObj[2]);
+        assert.notDeepEqual(thirdNetworkObj, secondNetworkObj);
+      })
+      .then(done)
+      .catch(done);
+  });
+});

--- a/packages/truffle-core/lib/testing/soliditytest.js
+++ b/packages/truffle-core/lib/testing/soliditytest.js
@@ -151,12 +151,8 @@ const SolidityTest = {
             contracts[name].default_network = runner.config.default_network;
           });
 
-          runner.config.artifactor
-            .saveAll(contracts, runner.config.contracts_build_directory)
-            .then(() => {
-              callback();
-            })
-            .catch(callback);
+          runner.config.artifactor.saveAll(contracts);
+          callback();
         }
       );
     });

--- a/packages/truffle-core/lib/testing/soliditytest.js
+++ b/packages/truffle-core/lib/testing/soliditytest.js
@@ -151,8 +151,12 @@ const SolidityTest = {
             contracts[name].default_network = runner.config.default_network;
           });
 
-          runner.config.artifactor.saveAll(contracts);
-          callback();
+          runner.config.artifactor
+            .saveAll(contracts)
+            .then(() => {
+              callback();
+            })
+            .catch(callback);
         }
       );
     });

--- a/packages/truffle-workflow-compile/index.js
+++ b/packages/truffle-workflow-compile/index.js
@@ -167,8 +167,7 @@ const Contracts = {
 
   writeContracts: async (contracts, options) => {
     await promisify(mkdirp)(options.contracts_build_directory);
-    const extra_opts = { network_id: options.network_id };
-    await options.artifactor.saveAll(contracts, extra_opts);
+    await options.artifactor.saveAll(contracts);
   }
 };
 


### PR DESCRIPTION
This PR updates the documentation to `truffle-artifactor`'s current behavior & API. Also burns some code bringing the package up to ES6, converts the API into async methods, & intends to make the code easier to reason while debugging.

Resolves #1096.