### PR TITLE
Parse string numbers from config.network_id during dry-run check

### DIFF
--- a/packages/truffle-core/lib/commands/migrate.js
+++ b/packages/truffle-core/lib/commands/migrate.js
@@ -201,7 +201,8 @@ var command = {
 
         var dryRun = options.dryRun === true;
         var production =
-          networkWhitelist.includes(conf.network_id) || conf.production;
+          networkWhitelist.includes(parseInt(conf.network_id)) ||
+          conf.production;
 
         // Dry run only
         if (dryRun) {


### PR DESCRIPTION
This PR adds a tiny fix to make sure we `parseInt` `config.network_id` before checking if the given network is in the `networkWhitelist`.

Based on the truffle config provided in #1322 (https://github.com/DataBrokerDAO/dtx-crowdsale-contracts/blob/master/truffle.js), it looks like this fix resolves that issue.