### PR TITLE
Handle `null` getBlock returns during live/testnet migrations

### DIFF
--- a/packages/truffle-reporters/reporters/migrations-V5/reporter.js
+++ b/packages/truffle-reporters/reporters/migrations-V5/reporter.js
@@ -314,6 +314,9 @@ class Reporter {
         data.receipt.blockNumber
       );
 
+      // if geth returns null, try again!
+      if (!block) return this.postDeploy(data);
+
       data.timestamp = block.timestamp;
 
       const balance = await data.contract.web3.eth.getBalance(tx.from);


### PR DESCRIPTION
As discussed elsewhere (paritytech/parity-ethereum#8788, paritytech/parity-ethereum#6334, INFURA/infura/issues/43) & raised in #1895, sometimes nodes will return `null` during `getBlock` calls (usually when calling recent/latest blocks). Currently, when this happens it completely ruins the deployment experience. This PR catches falsy values & recursively calls `postDeploy` again.