### PR TITLE
Dry run edit

### DIFF
--- a/packages/truffle-core/lib/commands/migrate.js
+++ b/packages/truffle-core/lib/commands/migrate.js
@@ -199,13 +199,13 @@ var command = {
       Environment.detect(conf, async function(err) {
         if (err) return done(err);
 
-        var dryRun = options.dryRun === true;
-        var production =
+        const dryRunOnly = options.dryRun === true;
+        const production =
           networkWhitelist.includes(parseInt(conf.network_id)) ||
           conf.production;
 
         // Dry run only
-        if (dryRun) {
+        if (dryRunOnly) {
           try {
             await setupDryRunEnvironmentThenRunMigrations(conf);
             done();

--- a/packages/truffle-core/lib/commands/migrate.js
+++ b/packages/truffle-core/lib/commands/migrate.js
@@ -36,7 +36,9 @@ var command = {
   },
   help: {
     usage:
-      "truffle migrate [--reset] [--f <number> | --from <number>] [--to <number>] [--network <name>] [--compile-all] [--verbose-rpc] [--interactive] [--dry-run [boolean]]",
+      "truffle migrate [--reset] [--f <number> | --from <number>] [--to <number>] " +
+      "[--network <name>]\n                                [--compile-all] " +
+      "[--verbose-rpc] [--interactive] [--dry-run] [--skip-dry-run]",
     options: [
       {
         option: "--reset",
@@ -78,8 +80,12 @@ var command = {
           "Prompt to confirm that the user wants to proceed after the dry run."
       },
       {
-        option: "--dry-run [boolean]",
-        description: "Do a test run before performing an actual migration."
+        option: "--dry-run",
+        description: "Only perform a test or 'dry run' migration."
+      },
+      {
+        option: "--skip-dry-run",
+        description: "Do not run a test or 'dry run' migration."
       }
     ]
   },
@@ -207,8 +213,8 @@ var command = {
         const production =
           networkWhitelist.includes(parseInt(conf.network_id)) ||
           conf.production;
+        const dryRunAndMigration = production && !conf.skipDryRun;
 
-        // Dry run only
         if (dryRunOnly) {
           try {
             await setupDryRunEnvironmentThenRunMigrations(conf);
@@ -216,9 +222,7 @@ var command = {
           } catch (err) {
             done(err);
           }
-
-          // Production: dry-run then real run
-        } else if (production && !conf.skipDryRun) {
+        } else if (dryRunAndMigration) {
           const currentBuild = conf.contracts_build_directory;
           conf.dryRun = true;
 


### PR DESCRIPTION
Edit the help for the migrate command. Document the `--dry-run` and `--skip-dry-run` flags.

In addition, rename a few variables to make the code a bit clearer and update some syntax.