### PR TITLE
Handle unmatched solc parsing error output 

### DIFF
--- a/packages/truffle-compile/profiler.js
+++ b/packages/truffle-compile/profiler.js
@@ -346,13 +346,17 @@ module.exports = {
               imports = self.getImports(result.file, result, solc);
             } catch (err) {
               if (err.message.includes("requires different compiler version")) {
-                const contractSolcVer = err.message.match(
+                const contractSolcPragma = err.message.match(
                   /pragma solidity[^;]*/gm
-                )[0];
-                const configSolcVer = semver.valid(solc.version());
-                err.message = err.message.concat(
-                  `\n\nError: Truffle is currently using solc ${configSolcVer}, but one or more of your contracts specify "${contractSolcVer}".\nPlease update your truffle config or pragma statement(s).\n(See https://truffleframework.com/docs/truffle/reference/configuration#compiler-configuration for information on\nconfiguring Truffle to use a specific solc compiler version.)\n`
                 );
+                // if there's a match provide the helpful error, otherwise return solc's error output
+                if (contractSolcPragma) {
+                  const contractSolcVer = contractSolcPragma[0];
+                  const configSolcVer = semver.valid(solc.version());
+                  err.message = err.message.concat(
+                    `\n\nError: Truffle is currently using solc ${configSolcVer}, but one or more of your contracts specify "${contractSolcVer}".\nPlease update your truffle config or pragma statement(s).\n(See https://truffleframework.com/docs/truffle/reference/configuration#compiler-configuration for information on\nconfiguring Truffle to use a specific solc compiler version.)\n`
+                  );
+                }
               }
               return finished(err);
             }
@@ -387,11 +391,10 @@ module.exports = {
     const imports = Parser.parseImports(body, solc);
 
     // Convert explicitly relative dependencies of modules back into module paths.
-    return imports.map(
-      dependencyPath =>
-        self.isExplicitlyRelative(dependencyPath)
-          ? source.resolve_dependency_path(file, dependencyPath)
-          : dependencyPath
+    return imports.map(dependencyPath =>
+      self.isExplicitlyRelative(dependencyPath)
+        ? source.resolve_dependency_path(file, dependencyPath)
+        : dependencyPath
     );
   },
 


### PR DESCRIPTION
Handles scenarios where solc doesn't output the pragma statement for source files requiring a different solc compiler version. (Known bug for 0.5.2 thru 0.5.6, but fixed in 0.5.7 [ethereum/solidity#6331]).

Resolves #1896 .