### PR TITLE
Fix truffle-solidity-loader bug & update pkg (docs & codebase)

### DIFF
--- a/packages/truffle-core/lib/commands/migrate.js
+++ b/packages/truffle-core/lib/commands/migrate.js
@@ -20,10 +20,6 @@ var command = {
       describe: "Specify a migration number to run from",
       type: "number"
     },
-    "from": {
-      describe: "Specify a migration number to run from",
-      type: "number"
-    },
     "to": {
       describe: "Specify a migration number to run to",
       type: "number"
@@ -36,7 +32,7 @@ var command = {
   },
   help: {
     usage:
-      "truffle migrate [--reset] [--f <number> | --from <number>] [--to <number>] [--network <name>] [--compile-all] [--verbose-rpc] [--interactive]",
+      "truffle migrate [--reset] [--f <number>] [--to <number>] [--network <name>] [--compile-all] [--verbose-rpc] [--interactive]",
     options: [
       {
         option: "--reset",
@@ -45,7 +41,7 @@ var command = {
           "completed migration."
       },
       {
-        option: "--f <number> | --from <number>",
+        option: "--f <number>",
         description:
           "Run contracts from a specific migration. The number refers to the prefix of " +
           "the migration file."
@@ -145,11 +141,8 @@ var command = {
     function runMigrations(config, callback) {
       Migrate.launchReporter();
 
-      // check --f && --from flag usage
-      const from = options.f || options.from;
-
-      if (from) {
-        Migrate.runFrom(from, config, done);
+      if (options.f) {
+        Migrate.runFrom(options.f, config, done);
       } else {
         Migrate.needsMigrating(config, function(err, needsMigrating) {
           if (err) return callback(err);

--- a/packages/truffle-solidity-loader/README.md
+++ b/packages/truffle-solidity-loader/README.md
@@ -1,27 +1,23 @@
 ## truffle-solidity-loader
 
-A Webpack loader allows importing a solidity contract that return a truffle artifact json object. This allows you to develop your contracts with Hot Reloading support, and have your migrations automatically re-run on change. When you run a production build, the contracts will be bundled into your main bundle for easy deployment.
+A Webpack loader that allows importing a solidity contract directly. Importing returns a truffle artifact json object. This allows smart contract development with Hot Reloading support and enables migrations to automatically re-run on change. When running a production build, contracts will be bundled into main bundle for easy deployment.
 
 ## Example
 
 ```javascript
-var provider = new Web3.providers.HttpProvider("http://localhost:8545");
-var contract = require("truffle-contract");
+const Web3 = require("web3"); // currently compatible up to web3@1.0.0-beta.37
+const provider = new Web3.providers.HttpProvider("http://localhost:8545");
+const contract = require("truffle-contract");
 
-// Instead of including a built json file
-import myContract_artifacts from '../build/contracts/MyContract.json'
-var MyContract = contract(myContract_artifacts)
-
-//You can import the solidity contract directly
-import myContract_artifacts from '../contracts/MyContract.sol'
-var MyContract = contract(myContract_artifacts)
+import myContractArtifact from '../contracts/MyContract.sol';
+const MyContract = contract(myContractArtifact);
 
 MyContract.setProvider(provider);
 ```
 
 You can see this plugin in operation in the [Truffle+Webpack Demo App](https://github.com/ConsenSys/truffle-webpack-demo). The demo is for Truffle 4.0 & Webpack 4.
 
-This pacakge will re-run the migration script whenever a solidity file is modified. If you have multiple solidity files, the entire project will be overridden.
+This package will re-run migration scripts whenever solidity files are modified. If you have multiple solidity files, the entire project will be redeployed.
 
 ## Installation
 
@@ -71,7 +67,7 @@ The loader will auto detect a `truffle-config.js` (or `truffle.js`) config file 
       options: {
         network: 'ganache',
         migrations_directory: path.resolve(__dirname, './migrations'),
-        contracts_build_directory: path.resolve(__dirname, '../build/contracts')
+        contracts_build_directory: path.resolve(__dirname, './build/contracts')
       }
     }
   ]
@@ -81,7 +77,7 @@ The loader will auto detect a `truffle-config.js` (or `truffle.js`) config file 
 
 ## Contributing
 
-- Write issue in the Issue Tracker.
+- Open an issue to report bugs or provide feedback.
 - Submit PRs.
 - Respect the project coding style: StandardJS.
 

--- a/packages/truffle-solidity-loader/index.js
+++ b/packages/truffle-solidity-loader/index.js
@@ -1,19 +1,22 @@
-const path = require('path');
-const fs = require('fs');
-const { getOptions } = require('loader-utils');
-const validateOptions = require('schema-utils');
-const truffleMigrator = require('truffle-core/lib/commands/migrate');
+const path = require("path");
+const fs = require("fs");
+const { getOptions } = require("loader-utils");
+const validateOptions = require("schema-utils");
+const truffleMigrator = require("truffle-core/lib/commands/migrate");
 
-const Logger = require('./lib/logDecorator');
-const genBuildOptions = require('./lib/genBuildOptions');
+const Logger = require("./lib/logDecorator");
+const genBuildOptions = require("./lib/genBuildOptions");
 
-function parseContractName (resourcePath) {
-  var contractFileName = path.basename(resourcePath);
-  return contractFileName.charAt(0).toUpperCase() + contractFileName.slice(1, contractFileName.length - 4);
+function parseContractName(resourcePath) {
+  const contractFileName = path.basename(resourcePath);
+  return (
+    contractFileName.charAt(0).toUpperCase() +
+    contractFileName.slice(1, contractFileName.length - 4)
+  );
 }
 
-function returnContractAsSource (filePath, callback) {
-  return fs.readFile(filePath, 'utf8', function (err, solJSON) {
+function returnContractAsSource(filePath, callback) {
+  return fs.readFile(filePath, "utf8", (err, solJSON) => {
     if (err) {
       Logger.error(err);
       return callback(err, null);
@@ -22,42 +25,49 @@ function returnContractAsSource (filePath, callback) {
   });
 }
 
-function compiledContractExists (filePath) {
+function compiledContractExists(filePath) {
   try {
     fs.statSync(filePath);
   } catch (err) {
-    if (err.code === 'ENOENT') return false;
+    if (err.code === "ENOENT") return false;
   }
   return true;
 }
 
 const schema = {
-  'type': 'object',
-  'required': ['network'],
-  'properties': {
-    'migrations_directory': {
-      'type': 'string'
+  type: "object",
+  required: ["network"],
+  properties: {
+    migrations_directory: {
+      type: "string"
     },
-    'network': {
-      'type': 'string'
+    network: {
+      type: "string"
     },
-    'contracts_build_directory': {
-      'type': 'string'
+    contracts_build_directory: {
+      type: "string"
     }
   },
-  'additionalProperties': false
+  additionalProperties: false
 };
 
-var isCompilingContracts = false; // Global mutex variable
-module.exports = function (source, map, meta) {
+let isCompilingContracts = false; // Global mutex variable
+module.exports = (source, map, meta) => {
   let WebpackOptions = getOptions(this) || {};
-  validateOptions(schema, WebpackOptions, 'truffle-solidity-loader');
+  validateOptions(schema, WebpackOptions, "truffle-solidity-loader");
 
   let buildOpts = genBuildOptions(WebpackOptions);
-  let migrationsDirectory = WebpackOptions.migrations_directory || `${buildOpts.working_directory}/migrations`;
-  let contractsBuildDirectory = WebpackOptions.contracts_build_directory || `${buildOpts.working_directory}/build/contracts`;
+  let migrationsDirectory =
+    WebpackOptions.migrations_directory ||
+    `${buildOpts.working_directory}/migrations`;
+  let contractsBuildDirectory =
+    WebpackOptions.contracts_build_directory ||
+    `${buildOpts.working_directory}/build/contracts`;
   let contractName = parseContractName(this.resourcePath); // this.resourcePath will be the path to the .sol file
-  let contractJsonPath = path.resolve(buildOpts.contracts_build_directory, contractName + '.json');
+  let contractJsonPath = path.resolve(
+    buildOpts.contracts_build_directory,
+    `${contractName}.json`
+  );
 
   this.addDependency(this.resource);
 
@@ -71,8 +81,8 @@ module.exports = function (source, map, meta) {
 
   let callback = this.async();
 
-  function waitForContractCompilation () {
-    setTimeout(function () {
+  function waitForContractCompilation() {
+    setTimeout(() => {
       if (compiledContractExists(contractJsonPath)) {
         isCompilingContracts = false;
         returnContractAsSource(contractJsonPath, callback);
@@ -87,7 +97,7 @@ module.exports = function (source, map, meta) {
     waitForContractCompilation();
   } else {
     isCompilingContracts = true;
-    truffleMigrator.run(buildOpts, function (err) {
+    truffleMigrator.run(buildOpts, err => {
       isCompilingContracts = false;
       if (err) {
         return callback(err);

--- a/packages/truffle-solidity-loader/lib/genBuildOptions.js
+++ b/packages/truffle-solidity-loader/lib/genBuildOptions.js
@@ -1,17 +1,19 @@
-const TruffleConfig = require('truffle-config');
-const Logger = require('./logDecorator');
-const getTruffleConfig = require('./getTruffleConfig');
+const TruffleConfig = require("truffle-config");
+const Logger = require("./logDecorator");
+const getTruffleConfig = require("./getTruffleConfig");
 
-const genBuildOptions = function (buildOpts) {
+const genBuildOptions = buildOpts => {
   if (!buildOpts.network) {
-    throw new Error('You must specify the network name to deploy to. (network)');
+    throw new Error(
+      "You must specify the network name to deploy to. (network)"
+    );
   }
 
-  var truffleConfig = getTruffleConfig();
+  const truffleConfig = getTruffleConfig();
   if (truffleConfig) {
     var config = TruffleConfig.load(truffleConfig, buildOpts);
   } else {
-    throw new Error('No Truffle Config file found!');
+    throw new Error("No Truffle Config file found!");
   }
 
   config.reset = true; // TODO make this configurable

--- a/packages/truffle-solidity-loader/lib/getTruffleConfig.js
+++ b/packages/truffle-solidity-loader/lib/getTruffleConfig.js
@@ -1,21 +1,33 @@
-const findUp = require('find-up');
-const Logger = require('./logDecorator');
+const findUp = require("find-up");
+const Logger = require("./logDecorator");
 
-const getTruffleConfig = function () {
+const DEFAULT_CONFIG_FILENAME = "truffle-config.js";
+const BACKUP_CONFIG_FILENAME = "truffle.js";
+
+const getTruffleConfig = () => {
   const isWin = /^win/.test(process.platform);
-  let file;
+  const defaultConfig = findUp.sync(DEFAULT_CONFIG_FILENAME);
+  const backupConfig = findUp.sync(BACKUP_CONFIG_FILENAME);
+  let configFile;
 
-  if (isWin) {
-    file = findUp.sync('truffle-config.js');
+  if (defaultConfig && backupConfig) {
+    Logger.log(
+      `Warning: Both ${DEFAULT_CONFIG_FILENAME} and ${BACKUP_CONFIG_FILENAME} were found. Using ${DEFAULT_CONFIG_FILENAME}.`
+    );
+    configFile = defaultConfig;
+  } else if (backupConfig && !defaultConfig) {
+    if (isWin)
+      Logger.log(
+        `Warning: Please rename ${BACKUP_CONFIG_FILENAME} to ${DEFAULT_CONFIG_FILENAME} to ensure Windows compatibility.`
+      );
+    configFile = backupConfig;
   } else {
-    file = findUp.sync('truffle.js');
+    configFile = defaultConfig;
   }
 
-  if (file) {
-    return file;
-  }
+  if (configFile) return configFile;
 
-  Logger.log('No Truffle config file found.');
+  return false;
 };
 
 module.exports = getTruffleConfig;

--- a/packages/truffle-solidity-loader/lib/logDecorator.js
+++ b/packages/truffle-solidity-loader/lib/logDecorator.js
@@ -1,14 +1,15 @@
-const chalk = require('chalk');
+const chalk = require("chalk");
 
 const Logger = {
-  log: function (msg) {
-    console.log('[TRUFFLE SOLIDITY] ' + msg);
+  log: function(msg) {
+    // sometimes reporter msg is undefined
+    if (msg) console.log("[TRUFFLE SOLIDITY] " + msg);
   },
-  error: function (msg) {
-    console.log(chalk.red('[! TRUFFLE SOLIDITY ERROR] ' + msg));
+  error: function(msg) {
+    console.log(chalk.red("[! TRUFFLE SOLIDITY ERROR] " + msg));
   },
-  debug: function (msg) {
-    console.debug(chalk.red('[! TRUFFLE SOLIDITY DEBUGGER] ' + msg));
+  debug: function(msg) {
+    console.debug(chalk.red("[! TRUFFLE SOLIDITY DEBUGGER] " + msg));
   }
 };
 

--- a/packages/truffle-solidity-loader/lib/logDecorator.js
+++ b/packages/truffle-solidity-loader/lib/logDecorator.js
@@ -1,15 +1,15 @@
 const chalk = require("chalk");
 
 const Logger = {
-  log: function(msg) {
+  log(msg) {
     // sometimes reporter msg is undefined
-    if (msg) console.log("[TRUFFLE SOLIDITY] " + msg);
+    if (msg) console.log(`[TRUFFLE SOLIDITY] ${msg}`);
   },
-  error: function(msg) {
-    console.log(chalk.red("[! TRUFFLE SOLIDITY ERROR] " + msg));
+  error(msg) {
+    console.log(chalk.red(`[! TRUFFLE SOLIDITY ERROR] ${msg}`));
   },
-  debug: function(msg) {
-    console.debug(chalk.red("[! TRUFFLE SOLIDITY DEBUGGER] " + msg));
+  debug(msg) {
+    console.debug(chalk.red(`[! TRUFFLE SOLIDITY DEBUGGER] ${msg}`));
   }
 };
 


### PR DESCRIPTION
This PR primarily reverts #1841 which introduced a bug by aliasing the `--from` flag to `--f`. Doing so, blocked the ability to use `truffle-core` as a standalone pkg which can be passed an address in the form of `config.from` or `options.from`. While in the weeds, I went ahead and updated the documentation & some of the codebase.

Resolves #1870.