### PR TITLE
Reformat migrations and implement cleaner dry run behavior

### DIFF
--- a/packages/truffle-config/index.js
+++ b/packages/truffle-config/index.js
@@ -248,20 +248,6 @@ function Config(truffle_directory, working_directory, network) {
           "Don't set config.timeoutBlocks directly. Instead, set config.networks and then config.networks[<network name>].timeoutBlocks"
         );
       }
-    },
-    skipDryRun: {
-      get: function() {
-        try {
-          return self.network_config.skipDryRun;
-        } catch (e) {
-          return false;
-        }
-      },
-      set: function() {
-        throw new Error(
-          "Don't set config.skipDryRun directly. Instead, set config.networks and then config.networks[<network name>].skipDryRun"
-        );
-      }
     }
   };
 
@@ -327,16 +313,17 @@ Config.prototype.with = function(obj) {
 };
 
 Config.prototype.merge = function(obj) {
-  var self = this;
-  var clone = this.normalize(obj);
+  let clone = this.normalize(obj);
 
   // Only set keys for values that don't throw.
-  Object.keys(obj).forEach(function(key) {
+  const propertyNames = Object.keys(obj);
+
+  propertyNames.forEach(key => {
     try {
-      if (typeof clone[key] === "object" && self._deepCopy.includes(key)) {
-        self[key] = _.merge(self[key], clone[key]);
+      if (typeof clone[key] === "object" && this._deepCopy.includes(key)) {
+        this[key] = _.merge(this[key], clone[key]);
       } else {
-        self[key] = clone[key];
+        this[key] = clone[key];
       }
     } catch (e) {
       // Do nothing.
@@ -371,14 +358,14 @@ Config.detect = (options = {}, filename) => {
 };
 
 Config.load = function(file, options) {
-  var config = new Config();
+  const config = new Config();
 
   config.working_directory = path.dirname(path.resolve(file));
 
   // The require-nocache module used to do this for us, but
   // it doesn't bundle very well. So we've pulled it out ourselves.
   delete require.cache[Module._resolveFilename(file, module)];
-  var static_config = originalrequire(file);
+  const static_config = originalrequire(file);
 
   config.merge(static_config);
   config.merge(options);

--- a/packages/truffle-core/lib/commands/migrate.js
+++ b/packages/truffle-core/lib/commands/migrate.js
@@ -206,14 +206,14 @@ const command = {
       });
     }
 
-    function runMigrations(config, callback) {
+    async function runMigrations(config, callback) {
       Migrate.launchReporter();
 
       if (options.f) {
         Migrate.runFrom(options.f, config, done);
       } else {
-        Migrate.needsMigrating(config, function(err, needsMigrating) {
-          if (err) return callback(err);
+        try {
+          const needsMigrating = await Migrate.needsMigrating(config);
 
           if (needsMigrating) {
             Migrate.run(config, callback);
@@ -221,7 +221,9 @@ const command = {
             config.logger.log("Network up to date.");
             callback();
           }
-        });
+        } catch (error) {
+          callback(error);
+        }
       }
     }
 
@@ -235,6 +237,7 @@ const command = {
 
       if (dryRunOnly) {
         try {
+          conf.dryRun = true;
           await setupDryRunEnvironmentThenRunMigrations(conf);
           done();
         } catch (err) {

--- a/packages/truffle-core/lib/commands/migrate.js
+++ b/packages/truffle-core/lib/commands/migrate.js
@@ -107,7 +107,7 @@ const command = {
       61717561 // Aquachain
     ];
 
-    let dryRunOnly;
+    let dryRunOnly, skipDryRun;
     const networkSettingsInConfig = config.networks[config.network];
     if (networkSettingsInConfig) {
       dryRunOnly =

--- a/packages/truffle-core/lib/commands/migrate.js
+++ b/packages/truffle-core/lib/commands/migrate.js
@@ -16,6 +16,11 @@ var command = {
       type: "boolean",
       default: false
     },
+    "skip-dry-run": {
+      describe: "Skip the test or 'dry run' migrations",
+      type: "boolean",
+      default: false
+    },
     "f": {
       describe: "Specify a migration number to run from",
       type: "number"

--- a/packages/truffle-core/lib/commands/migrate.js
+++ b/packages/truffle-core/lib/commands/migrate.js
@@ -210,7 +210,12 @@ const command = {
       Migrate.launchReporter();
 
       if (options.f) {
-        Migrate.runFrom(options.f, config, done);
+        try {
+          await Migrate.runFrom(options.f, config);
+          done();
+        } catch (error) {
+          done(error);
+        }
       } else {
         try {
           const needsMigrating = await Migrate.needsMigrating(config);

--- a/packages/truffle-core/lib/commands/migrate.js
+++ b/packages/truffle-core/lib/commands/migrate.js
@@ -1,8 +1,3 @@
-const Config = require("truffle-config");
-const Migrate = require("truffle-migrate");
-const Resolver = require("truffle-resolver");
-const Artifactor = require("truffle-artifactor");
-
 const command = {
   command: "migrate",
   description: "Run migrations to deploy contracts",
@@ -135,6 +130,10 @@ const command = {
   },
 
   executePostDryRunMigration: async function(buildDir, options, done) {
+    const Artifactor = require("truffle-artifactor");
+    const Resolver = require("truffle-resolver");
+    const Migrate = require("truffle-migrate");
+    const Config = require("truffle-config");
     let accept = true;
 
     if (options.interactive) {
@@ -161,8 +160,12 @@ const command = {
   },
 
   run: function(options, done) {
+    const Artifactor = require("truffle-artifactor");
+    const Resolver = require("truffle-resolver");
+    const Migrate = require("truffle-migrate");
     const Contracts = require("truffle-workflow-compile");
     const Environment = require("../environment");
+    const Config = require("truffle-config");
     const temp = require("temp");
     const copy = require("../copy");
 

--- a/packages/truffle-core/test/migrate.js
+++ b/packages/truffle-core/test/migrate.js
@@ -219,43 +219,33 @@ describe("migrate", function() {
     });
   });
 
-  it("should ignore files that don't start with a number", function(done) {
+  it("should ignore files that don't start with a number", () => {
     fs.writeFileSync(
       path.join(config.migrations_directory, "~2_deploy_contracts.js"),
       "module.exports = function() {};",
       "utf8"
     );
 
-    Migrate.assemble(config, function(err, migrations) {
-      if (err) return done(err);
-
-      assert.equal(
-        migrations.length,
-        2,
-        "~2_deploy_contracts.js should have been ignored!"
-      );
-
-      done();
-    });
+    const migrations = Migrate.assemble(config);
+    assert.equal(
+      migrations.length,
+      2,
+      "~2_deploy_contracts.js should have been ignored!"
+    );
   });
 
-  it("should ignore non-js extensions", function(done) {
+  it("should ignore non-js extensions", () => {
     fs.writeFileSync(
       path.join(config.migrations_directory, "2_deploy_contracts.js~"),
       "module.exports = function() {};",
       "utf8"
     );
 
-    Migrate.assemble(config, function(err, migrations) {
-      if (err) return done(err);
-
-      assert.equal(
-        migrations.length,
-        2,
-        "2_deploy_contracts.js~ should have been ignored!"
-      );
-
-      done();
-    });
+    const migrations = Migrate.assemble(config);
+    assert.equal(
+      migrations.length,
+      2,
+      "2_deploy_contracts.js~ should have been ignored!"
+    );
   });
 });

--- a/packages/truffle-migrate/index.js
+++ b/packages/truffle-migrate/index.js
@@ -102,14 +102,10 @@ const Migrate = {
     // changing the original options object passed in.
     const clone = {};
 
-    Object.keys(options).forEach(function(key) {
-      clone[key] = options[key];
-    });
+    Object.keys(options).forEach(key => (clone[key] = options[key]));
 
     if (options.quiet) {
-      clone.logger = {
-        log: function() {}
-      };
+      clone.logger = { log: function() {} };
     }
 
     clone.provider = this.wrapProvider(options.provider, clone.logger);

--- a/packages/truffle-migrate/index.js
+++ b/packages/truffle-migrate/index.js
@@ -62,7 +62,9 @@ const Migrate = {
 
     if (options.reset === true) {
       return this.runAll(options)
-        .then(callback)
+        .then(() => {
+          callback();
+        })
         .catch(callback);
     }
 

--- a/packages/truffle-migrate/index.js
+++ b/packages/truffle-migrate/index.js
@@ -127,7 +127,6 @@ const Migrate = {
           });
         },
         error => {
-          console.log("in the migration callback --> %o", error);
           if (error) return reject(error);
           return resolve();
         }

--- a/packages/truffle-migrate/index.js
+++ b/packages/truffle-migrate/index.js
@@ -202,23 +202,24 @@ const Migrate = {
     return parseInt(completedMigration);
   },
 
-  needsMigrating: function(options, callback) {
-    if (options.reset === true) return callback(null, true);
+  needsMigrating: function(options) {
+    return new Promise((resolve, reject) => {
+      if (options.reset === true) return resolve(true);
 
-    return this.lastCompletedMigration(options)
-      .then(number => {
-        const migrations = this.assemble(options);
-        while (migrations.length > 0) {
-          if (migrations[0].number >= number) break;
-          migrations.shift();
-        }
+      return this.lastCompletedMigration(options)
+        .then(number => {
+          const migrations = this.assemble(options);
+          while (migrations.length > 0) {
+            if (migrations[0].number >= number) break;
+            migrations.shift();
+          }
 
-        callback(
-          null,
-          migrations.length > 1 || (migrations.length && number === 0)
-        );
-      })
-      .catch(callback);
+          return resolve(
+            migrations.length > 1 || (migrations.length && number === 0)
+          );
+        })
+        .catch(error => reject(error));
+    });
   }
 };
 

--- a/packages/truffle-migrate/index.js
+++ b/packages/truffle-migrate/index.js
@@ -69,8 +69,9 @@ const Migrate = {
     return this.lastCompletedMigration(options)
       .then(lastMigration => {
         // Don't rerun the last completed migration.
-        return this.runFrom(lastMigration + 1, options, callback);
+        return this.runFrom(lastMigration + 1, options);
       })
+      .then(callback)
       .catch(callback);
   },
 


### PR DESCRIPTION
Remove `skipDryRun` from the props in the config so that it can be set on the command line as a flag.