### PR TITLE
Remove solc-js as an NPM dependency

### DIFF
--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -6,8 +6,7 @@
   "dependencies": {
     "app-module-path": "^2.2.0",
     "mocha": "^4.1.0",
-    "original-require": "1.0.1",
-    "solc": "0.5.0"
+    "original-require": "1.0.1"
   },
   "devDependencies": {
     "clean-webpack-plugin": "^0.1.16",


### PR DESCRIPTION
PR removes `solc` as a separate bundle dep. `solc` is already bundled within `truffle-compile`.