### PR TITLE
Refactor workspace tests and get them passing

### DIFF
--- a/packages/truffle-db/package.json
+++ b/packages/truffle-db/package.json
@@ -50,6 +50,7 @@
   "dependencies": {
     "@gnd/jsonschema2graphql": "^1.0.15",
     "graphql": "^14.0.2",
+    "graphql-tag": "^2.10.1",
     "graphql-tools": "^4.0.3",
     "module-alias": "^2.1.0",
     "pascal-case": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7765,6 +7765,11 @@ graphql-subscriptions@^1.0.0:
   dependencies:
     iterall "^1.2.1"
 
+graphql-tag@^2.10.1:
+  version "2.10.1"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.1.tgz#10aa41f1cd8fae5373eaf11f1f67260a3cad5e02"
+  integrity sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg==
+
 graphql-tag@^2.9.2:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.0.tgz#87da024be863e357551b2b8700e496ee2d4353ae"


### PR DESCRIPTION
This PR introduces a `WorkspaceClient` helper class for the workspace tests, to make it easier to issue more than one request to graphql in a single test. I added this since I discovered the problem with the tests on the target branch (#1916): compilation wasn't getting added before contract, so the lookup was failing.

This also includes the addition of the `graphql-tag` package, to enable `gql` template strings, e.g.:
```javascript
const GetContractNames = gql`query GetContractNames { contractNames }`
```

Refactoring changes:
- Re-order tests so they're organized by resource type.
- Define WorkspaceClient class to abstract the graphql inner workings
- Start using gql` ... ` tag for test queries
- Switch from using `graphql()` to using graphql's `execute()` function,
  since the former only takes a string, and the tag parses automatically
- Replace test Workspace instances with WorkspaceClient instances, and
  use the client method instead of running queries manually

Changes to fix the tests:

- In "adds contracts" tests, run the AddCompilation mutation as a precursor
- Add sourceContract to GetContract query
- Add abi to GetContractQuery
- Add ast to AddContracts mutation payload request
- Uncomment now-working assertions
- Remove property check for `compilation`, since it's not in the query