### PR TITLE
Fix getting network in contract decoder

### DIFF
--- a/packages/truffle-decoder/lib/interface/contract-decoder.ts
+++ b/packages/truffle-decoder/lib/interface/contract-decoder.ts
@@ -123,11 +123,9 @@ export default class TruffleContractDecoder extends AsyncEventEmitter {
     this.contract = contract;
     this.relevantContracts = relevantContracts;
 
-    this.contractNetwork = Object.keys(this.contract.networks)[0];
-    this.contractAddress = address !== undefined
-      ? address
-      : this.contract.networks[this.contractNetwork].address;
-
+    if(address !== undefined) {
+      this.contractAddress === address;
+    }
     this.contractNode = getContractNode(this.contract);
 
     this.contracts[this.contractNode.id] = this.contract;
@@ -165,6 +163,11 @@ export default class TruffleContractDecoder extends AsyncEventEmitter {
   }
 
   public async init(): Promise<void> {
+    this.contractNetwork = (await this.web3.eth.net.getId()).toString();
+    if(this.contractAddress === undefined) {
+      this.contractAddress = this.contract.networks[this.contractNetwork].address;
+    }
+
     debug("init called");
     this.referenceDeclarations = general.getReferenceDeclarations(Object.values(this.contractNodes));
 

--- a/packages/truffle-decoder/lib/interface/contract-decoder.ts
+++ b/packages/truffle-decoder/lib/interface/contract-decoder.ts
@@ -124,7 +124,7 @@ export default class TruffleContractDecoder extends AsyncEventEmitter {
     this.relevantContracts = relevantContracts;
 
     if(address !== undefined) {
-      this.contractAddress === address;
+      this.contractAddress = address;
     }
     this.contractNode = getContractNode(this.contract);
 


### PR DESCRIPTION
This PR fixes how the network ID is obtained in the contract decoder.  Rather than reading the first network ID from the artifact, instead it uses a `web3` call.  Note this is now done in `init` (which, recall, is now `async`) rather than in the constructor.  This also means that, if an address was not passed in manually, the address will not be obtained until `init` is run.