### PR TITLE
Add decoding for internal functions (debugger only)

### DIFF
--- a/packages/truffle-debugger/lib/data/sagas/index.js
+++ b/packages/truffle-debugger/lib/data/sagas/index.js
@@ -54,7 +54,9 @@ export function* decode(definition, ref) {
   let instances = yield select(data.views.instances);
   let contexts = yield select(data.views.contexts);
   let currentContext = yield select(data.current.context);
-  let internalFunctionsTable = yield select(data.current.functionsByPc);
+  let internalFunctionsTable = yield select(
+    data.current.functionsByProgramCounter
+  );
   let blockNumber = yield select(data.views.blockNumber);
 
   let ZERO_WORD = new Uint8Array(DecodeUtils.EVM.WORD_SIZE);

--- a/packages/truffle-debugger/lib/data/sagas/index.js
+++ b/packages/truffle-debugger/lib/data/sagas/index.js
@@ -53,8 +53,8 @@ export function* decode(definition, ref) {
   let allocations = yield select(data.info.allocations);
   let instances = yield select(data.views.instances);
   let contexts = yield select(data.views.contexts);
+  let currentContext = yield select(data.current.context);
   let internalFunctionsTable = yield select(data.current.functionsByPc);
-  let inConstructorContext = yield select(data.current.inConstructor);
   let blockNumber = yield select(data.views.blockNumber);
 
   let ZERO_WORD = new Uint8Array(DecodeUtils.EVM.WORD_SIZE);
@@ -69,8 +69,8 @@ export function* decode(definition, ref) {
     memoryAllocations: allocations.memory,
     calldataAllocations: allocations.calldata,
     contexts,
-    internalFunctionsTable,
-    inConstructorContext
+    currentContext,
+    internalFunctionsTable
   });
 
   let result = decoder.next();

--- a/packages/truffle-debugger/lib/data/sagas/index.js
+++ b/packages/truffle-debugger/lib/data/sagas/index.js
@@ -53,6 +53,8 @@ export function* decode(definition, ref) {
   let allocations = yield select(data.info.allocations);
   let instances = yield select(data.views.instances);
   let contexts = yield select(data.views.contexts);
+  let internalFunctionsTable = yield select(data.current.functionsByPc);
+  let inConstructorContext = yield select(data.current.inConstructor);
   let blockNumber = yield select(data.views.blockNumber);
 
   let ZERO_WORD = new Uint8Array(DecodeUtils.EVM.WORD_SIZE);
@@ -66,7 +68,9 @@ export function* decode(definition, ref) {
     storageAllocations: allocations.storage,
     memoryAllocations: allocations.memory,
     calldataAllocations: allocations.calldata,
-    contexts
+    contexts,
+    internalFunctionsTable,
+    inConstructorContext
   });
 
   let result = decoder.next();
@@ -74,7 +78,6 @@ export function* decode(definition, ref) {
     let request = result.value;
     let response;
     switch (request.type) {
-      //yes, this is a little silly right now
       case "storage":
         //the debugger supplies all storage it knows at the beginning.
         //any storage it does not know is presumed to be zero.

--- a/packages/truffle-debugger/lib/data/selectors/index.js
+++ b/packages/truffle-debugger/lib/data/selectors/index.js
@@ -222,7 +222,7 @@ const data = createSelectorTree({
         ...Object.values(contexts)
           .filter(context => !context.isConstructor)
           .map(context => ({
-            [context.contractId]: debuggerContextToDecoderContext(context)
+            [context.context]: debuggerContextToDecoderContext(context)
           }))
       )
     )

--- a/packages/truffle-debugger/lib/data/selectors/index.js
+++ b/packages/truffle-debugger/lib/data/selectors/index.js
@@ -457,6 +457,26 @@ const data = createSelectorTree({
     address: createLeaf([evm.current.call], call => call.storageAddress),
 
     /*
+     * data.current.functionsByPc
+     */
+    functionsByPc: createLeaf(
+      [solidity.current.functionsByPc],
+      functions => functions
+    ),
+
+    /*
+     * data.current.inConstructor
+     * are we currently in a constructor run, as opposed to a deployed run?
+     * Note: using evm.current.call would probably work just as well and be
+     * faster, but I figure I'll do it this way because it makes more sense
+     * structurally
+     */
+    inConstructor: createLeaf(
+      [evm.current.context],
+      ({ isConstructor }) => isConstructor
+    ),
+
+    /*
      * data.current.aboutToModify
      * HACK
      * This selector is used to catch those times when we go straight from a

--- a/packages/truffle-debugger/lib/data/selectors/index.js
+++ b/packages/truffle-debugger/lib/data/selectors/index.js
@@ -461,10 +461,10 @@ const data = createSelectorTree({
     address: createLeaf([evm.current.call], call => call.storageAddress),
 
     /*
-     * data.current.functionsByPc
+     * data.current.functionsByProgramCounter
      */
-    functionsByPc: createLeaf(
-      [solidity.current.functionsByPc],
+    functionsByProgramCounter: createLeaf(
+      [solidity.current.functionsByProgramCounter],
       functions => functions
     ),
 

--- a/packages/truffle-debugger/lib/solidity/selectors/index.js
+++ b/packages/truffle-debugger/lib/solidity/selectors/index.js
@@ -229,16 +229,13 @@ let solidity = createSelectorTree({
     instructionAtProgramCounter: createLeaf(
       ["./instructions"],
 
-      instructions => {
-        let map = {};
-        instructions.forEach(function(instruction) {
-          map[instruction.pc] = instruction;
-        });
-        //note: this will have gaps in it.  That's OK!  Those gaps are the data
-        //portions of push instructions, which it is illegal to jump into.  We
-        //don't need to assign instructions to illegal PC values.
-        return map;
-      }
+      instructions =>
+        Object.assign(
+          {},
+          ...instructions.map(instruction => ({
+            [instruction.pc]: instruction
+          }))
+        )
     ),
 
     ...createMultistepSelectors(evm.current.step),
@@ -267,6 +264,71 @@ let solidity = createSelectorTree({
           current.file != next.file
         );
       }
+    ),
+
+    /*
+     * solidity.current.functionsByPc
+     */
+    functionsByPc: createLeaf(
+      ["./instructions", "/info/sources"],
+      (instructions, sources) =>
+        Object.assign(
+          {},
+          ...instructions
+            .filter(instruction => instruction.name === "JUMPDEST")
+            .filter(instruction => instruction.file !== -1)
+            //note that the designated invalid function *does* have an associated
+            //file, so it *is* safe to just filter out the ones that don't
+            .map(instruction => {
+              debug("instruction %O", instruction);
+              let source = instruction.file;
+              debug("source %O", sources[source]);
+              let ast = sources[source].ast;
+              let range = getSourceRange(instruction);
+              let pointer = findRange(ast, range.start, range.length);
+              let node = pointer
+                ? jsonpointer.get(ast, pointer)
+                : jsonpointer.get(ast, "");
+              if (!node || node.nodeType !== "FunctionDefinition") {
+                //filter out JUMPDESTs that aren't function definitions...
+                //except for the designated invalid function
+                let nextInstruction = instructions[instruction.index + 1] || {};
+                if (nextInstruction.name === "INVALID") {
+                  //designated invalid, include it
+                  return {
+                    [instruction.pc]: {
+                      isDesignatedInvalid: true
+                    }
+                  };
+                } else {
+                  //not designated invalid, filter it out
+                  return {};
+                }
+              }
+              //otherwise, we're good to go, so let's find the contract node and
+              //put it all together
+              //to get the contract node, we go up twice from the function node;
+              //the path from one to the other should have a very specific form,
+              //so this is easy
+              let contractPointer = pointer.replace(/\/nodes\/\d+$/, "");
+              let contractNode = jsonpointer.get(ast, contractPointer);
+              return {
+                [instruction.pc]: {
+                  source,
+                  pointer,
+                  node,
+                  name: node.name,
+                  id: node.id,
+                  contractPointer,
+                  contractNode,
+                  contractName: contractNode.name,
+                  contractId: contractNode.id,
+                  contractKind: contractNode.contractKind,
+                  isDesignatedInvalid: false
+                }
+              };
+            })
+        )
     ),
 
     /**

--- a/packages/truffle-debugger/lib/solidity/selectors/index.js
+++ b/packages/truffle-debugger/lib/solidity/selectors/index.js
@@ -267,9 +267,9 @@ let solidity = createSelectorTree({
     ),
 
     /*
-     * solidity.current.functionsByPc
+     * solidity.current.functionsByProgramCounter
      */
-    functionsByPc: createLeaf(
+    functionsByProgramCounter: createLeaf(
       ["./instructions", "/info/sources"],
       (instructions, sources) =>
         Object.assign(

--- a/packages/truffle-decode-utils/src/constants.ts
+++ b/packages/truffle-decode-utils/src/constants.ts
@@ -4,6 +4,7 @@ export namespace Constants {
   export const WORD_SIZE = 0x20;
   export const ADDRESS_SIZE = 20;
   export const SELECTOR_SIZE = 4;
+  export const PC_SIZE = 4;
   export const MAX_WORD = new BN(-1).toTwos(WORD_SIZE * 8);
   export const ZERO_ADDRESS = "0x" + "00".repeat(ADDRESS_SIZE);
 }

--- a/packages/truffle-decode-utils/src/contexts.ts
+++ b/packages/truffle-decode-utils/src/contexts.ts
@@ -16,7 +16,9 @@ export namespace Contexts {
   export type Context = DecoderContext | DebuggerContext;
 
   export interface DecoderContexts {
-    [contractId: number]: DecoderContext;
+    [index: string]: DecoderContext;
+    //we'll allow this to be a hash *or* a contract ID; it's just an arbitrary
+    //identifier
   }
 
   export interface DebuggerContexts {

--- a/packages/truffle-decode-utils/src/evm.ts
+++ b/packages/truffle-decode-utils/src/evm.ts
@@ -11,6 +11,7 @@ export namespace EVM {
   export const WORD_SIZE = Constants.WORD_SIZE;
   export const ADDRESS_SIZE = Constants.ADDRESS_SIZE;
   export const SELECTOR_SIZE = Constants.SELECTOR_SIZE;
+  export const PC_SIZE = Constants.PC_SIZE;
   export const MAX_WORD = Constants.MAX_WORD;
   export const ZERO_ADDRESS = Constants.ZERO_ADDRESS;
 

--- a/packages/truffle-decoder/lib/allocate/storage.ts
+++ b/packages/truffle-decoder/lib/allocate/storage.ts
@@ -239,10 +239,7 @@ function storageSizeAndAllocate(definition: AstDefinition, referenceDeclarations
       //this case is also really two different cases
       switch (DecodeUtils.Definition.visibility(definition)) {
         case "internal":
-          return [{bytes: 8}, existingAllocations];
-            //this size occurs all of once in the code (and shouldn't occur
-            //again later) so it remains a raw number rather than a fancy
-            //named constant :P
+          return [{bytes: DecodeUtils.EVM.PC_SIZE * 2}, existingAllocations];
         case "external":
           return [{bytes: DecodeUtils.EVM.ADDRESS_SIZE + DecodeUtils.EVM.SELECTOR_SIZE}, existingAllocations];
       }

--- a/packages/truffle-decoder/lib/decode/value.ts
+++ b/packages/truffle-decoder/lib/decode/value.ts
@@ -76,7 +76,7 @@ export default function* decodeValue(definition: DecodeUtils.AstDefinition, poin
           return yield* decodeExternalFunction(address, selector, info);
         case "internal":
           let pc: Uint8Array;
-          if(info.inConstructorContext) {
+          if(info.currentContext.isConstructor) {
             //get 2nd-to-last 4 bytes
             pc = bytes.slice(-DecodeUtils.EVM.PC_SIZE * 2, -DecodeUtils.EVM.PC_SIZE);
           }

--- a/packages/truffle-decoder/lib/interface/contract-decoder.ts
+++ b/packages/truffle-decoder/lib/interface/contract-decoder.ts
@@ -196,7 +196,8 @@ export default class TruffleContractDecoder extends AsyncEventEmitter {
       mappingKeys: this.mappingKeys,
       referenceDeclarations: this.referenceDeclarations,
       storageAllocations: this.storageAllocations,
-      contexts: this.contexts
+      contexts: this.contexts,
+      inConstructorContext: false
     };
 
     const decoder: IterableIterator<any> = decode(variable.definition, variable.pointer, info);

--- a/packages/truffle-decoder/lib/interface/contract-decoder.ts
+++ b/packages/truffle-decoder/lib/interface/contract-decoder.ts
@@ -102,6 +102,7 @@ export default class TruffleContractDecoder extends AsyncEventEmitter {
   private contracts: ContractMapping = {};
   private contractNodes: AstReferences = {};
   private contexts: DecodeUtils.Contexts.DecoderContexts = {};
+  private context: DecodeUtils.Contexts.DecoderContext;
 
   private referenceDeclarations: AstReferences;
   private storageAllocations: StorageAllocations;
@@ -133,7 +134,8 @@ export default class TruffleContractDecoder extends AsyncEventEmitter {
     this.contracts[this.contractNode.id] = this.contract;
     this.contractNodes[this.contractNode.id] = this.contractNode;
     if(this.contract.deployedBinary) { //just to be safe
-      this.contexts[this.contractNode.id] = this.makeContext(this.contract, this.contractNode);
+      this.context = this.makeContext(this.contract, this.contractNode);
+      this.contexts[this.contractNode.id] = this.context;
     }
     abiDecoder.addABI(this.contract.abi);
 
@@ -197,7 +199,7 @@ export default class TruffleContractDecoder extends AsyncEventEmitter {
       referenceDeclarations: this.referenceDeclarations,
       storageAllocations: this.storageAllocations,
       contexts: this.contexts,
-      currentContext: this.contexts[this.contractNode.id]
+      currentContext: this.context
     };
 
     const decoder: IterableIterator<any> = decode(variable.definition, variable.pointer, info);

--- a/packages/truffle-decoder/lib/interface/contract-decoder.ts
+++ b/packages/truffle-decoder/lib/interface/contract-decoder.ts
@@ -197,7 +197,7 @@ export default class TruffleContractDecoder extends AsyncEventEmitter {
       referenceDeclarations: this.referenceDeclarations,
       storageAllocations: this.storageAllocations,
       contexts: this.contexts,
-      inConstructorContext: false
+      currentContext: this.contexts[this.contractNode.id]
     };
 
     const decoder: IterableIterator<any> = decode(variable.definition, variable.pointer, info);

--- a/packages/truffle-decoder/lib/types/evm.ts
+++ b/packages/truffle-decoder/lib/types/evm.ts
@@ -24,4 +24,24 @@ export interface EvmInfo {
   calldataAllocations?: CalldataAllocations;
   memoryAllocations?: MemoryAllocations;
   contexts?: Contexts.DecoderContexts;
+  internalFunctionsTable?: InternalFunctions;
+  inConstructorContext?: boolean;
+}
+
+export interface InternalFunctions {
+  [pc: number]: InternalFunction
+}
+
+export interface InternalFunction {
+  source?: number;
+  pointer?: string;
+  node?: any; //sorry
+  name?: string;
+  id?: number;
+  contractPointer?: string;
+  contractNode?: any; //sorry
+  contractName?: string;
+  contractId?: number;
+  contractKind?: string;
+  isDesignatedInvalid: boolean;
 }

--- a/packages/truffle-decoder/lib/types/evm.ts
+++ b/packages/truffle-decoder/lib/types/evm.ts
@@ -24,8 +24,8 @@ export interface EvmInfo {
   calldataAllocations?: CalldataAllocations;
   memoryAllocations?: MemoryAllocations;
   contexts?: Contexts.DecoderContexts;
+  currentContext?: Contexts.DecoderContext;
   internalFunctionsTable?: InternalFunctions;
-  inConstructorContext?: boolean;
 }
 
 export interface InternalFunctions {


### PR DESCRIPTION
This PR adds support for decoding internal function pointers.  Note that this is supported only in the debugger, not in the contract decoder; attempting to decode an internal function pointer from the contract decoder will simply result in the string `"<decoding not supported>"`.

This PR also fixes a bug in my previous PR for decoding external functions.  In that PR, contexts in the decoder were indexed by contract ID rather than by hash.  However, this causes a problem in that not every context has a contract ID.  This PR changes it so that contexts in the decoder are indexed by... whatever.  (When used from the debugger, it's back to hashes.  When used from the contract decoder, I've left it as contract IDs.)

So, why is decoding for internal functions only supported from the debugger?  Fundamentally, to decode an internal function we need to take a program counter value and find the corresponding AST node.  Well, the debugger does that all the time!  But to do that, it needs to be able to associate source indices to particular source files, and to do that, it needs the whole project to be compiled at once.  The debugger handles this by recompiling the entire project at startup, but this is slow and it only does so because it has to.  That said, having done this, it's now prepared also to decode internal function pointers.

But the contract decoder mostly does not need to recompile, and it's just not worth the performance penalty to add a recompilation step just so it can decode internal function pointers.  So, decoding of internal function pointers remains a debugger-only feature for now.  Once we have truffle-db, however, it should be possible to decode internal function pointers from the contract decoder as well, and we will have to revisit this.

So, what do internal function pointers decode to?  Well, since we don't have the new output format yet, they decode to strings containing the name of the function pointed to.  The string has the form `Contract.function`, where `Contract` is the contract the function is defined in, and `function` is the name of the function.  (Note that we need to specify the contract the function is defined in due to function overriding; a derived contract can store either the derived version or the base version of an overridden function.)

There are also some special values an internal function pointer can decode to.  The case of `"<decoding not supported>"` has already been mentioned above, but there are more.  A function pointer to program counter zero will decode to `"<zero>"`.  A function pointer to the contract's designated invalid function will decode to `"assert(false)"`.  And anything else that can't be decoded will decode to `undefined`.  That's not *really* a special value, but it can come up due to a Solidity bug -- more on that later.

Anyway, how's decoding of internal functions work?  Well, because internal function decoding is only supported from the debugger, I took the liberty of having the debugger do most of the work.  Rather than the decoder computing an AST node from the program counter, the debugger precomputes a table of internal functions (for the current context) and passes it to the decoder; the decoder can then just look up the answer in the table.  The table also contains various information the decoder doesn't use, but I didn't see any need to strip it out.

The debugger now also passes the current context (in the decoder's format) to the decoder.  Very little of this is currently used by the decoder, but more will be in the future.  The one part of the current context used by the decoder is the `isConstructor` flag.  An internal function pointer contains the deployed PC value in the lower 4 bytes and (sometimes) the constructor PC value in the upper 4 bytes; the `isConstructor` flag is used to determine which of these two to look at.  (I've added a new EVM constant, `PC_SIZE`, to truffle-decode-utils.  The storage size of an internal function pointer is now defined to be `2 * PC_SIZE`, rather than just a raw 8.)

The lookup table itself is constructed in a new selector called `solidity.current.functionsByProgramCounter`.  It's indexed by the program counter and contains information on the corresponding function and its defining contract.  It's constructed by taking `solidity.current.instructions`, restricting to `JUMPDEST` instructions with file index not equal to `-1`, and then using `findRange` to find the function node.  The contract node can then be found by going up (accomplished here by manipulation of the pointer string, chopping off the end).

Among the information in the entries of this table is a field called `isDesignatedInvalid`; this is `false` for those entries constructed as described above, but we also include not only the context's defined functions but also its designated invalid function (if it has one).  This is found by looking for `JUMPDEST` instructions that don't correspond to a node, but are followed immediately by an `INVALID` instruction.  The table entry for this function has `isDesignatedInvalid` set to `true`, with the other fields left undefined.

Finally, it's worth discussing [a Solidity bug](https://github.com/ethereum/solidity/issues/6525) I discovered while working on this PR.  Internal function pointers in constructors that are supposed to point to the designated invalid function are formatted incorrectly.  The result is that such pointers, which should decode to `"assert(false)"`, will instead decode to `"<zero>"` in the constructor where they're declared, and (probably) to `undefined` if they're stored in storage and then used in a deployed context.  (They could actually decode to basically anything, but `undefined` is the most likely outcome.)  This bug is now scheduled to be fixed in Solidity 0.5.8.

I could have written this PR to handle such pointers and decode them properly, but it would have been substantially more work, and @gnidan agreed that this case was minor enough to not require such additional work.  So, be aware that when decoding uninitialized function pointers in constructors (or originating from constructors), in any presently-existing version of Solidity, this issue may come up.

This PR also adds two tests of this new functionality.

So that's internal function decoding!  With this, the debugger can finally decode **all data types**.  This statement has substantial caveats, of course -- we still can't decode many constant state variables, for instance.  But "constant state variable" is not a data type.  Nor is "circular structure".  So, I'd say we're doing pretty good! :)