### PR TITLE
Fix spoofing of "this" definition

### DIFF
--- a/packages/truffle-debugger/lib/session/index.js
+++ b/packages/truffle-debugger/lib/session/index.js
@@ -249,11 +249,13 @@ export default class Session {
     let refs = this.view(data.current.identifiers.refs);
     let decoded = {};
     for (let [identifier, ref] of Object.entries(refs)) {
-      decoded[identifier] = await this._runSaga(
-        decode,
-        definitions[identifier],
-        ref
-      );
+      if (identifier in definitions) {
+        decoded[identifier] = await this._runSaga(
+          decode,
+          definitions[identifier],
+          ref
+        );
+      }
     }
     return decoded;
   }


### PR DESCRIPTION
This PR fixes the spoofing of the definition of `this` so that it's based what contract one is in in terms of what node one is on, rather than based on `evm.current.context`.  I originally based it on `evm.current.context` because this meant that we didn't need to be on a node to have a definition.  However, I failed to notice that this does not always yield the correct result, if inheritance or library `internal` functions are involved.

So, I have fixed it to be based on what node one is on.  Note that if one is in unmapped code, there will be no definition, and so `this` will be excluded from the current variables.  That could be considered a regression, I suppose, but I think it's probably OK.  (Remember, until recently attempting to get the variables while in unmapped code simply caused an error!)

To accomplish this, a new selector has been added, `data.current.contract`.  It uses the `findAncestorOfType` function I introduced earlier.

Also, because of the problem of unmapped code, I modified `session.variables` so it will only decode those variables that have both a definition *and* a ref.  Previously it just went by what variables had refs; since every variable with a ref necessarily also had a definition, there was no problem.  Now, that's not the case, so it makes sure to check both.

One last note -- this is really at the moment just an internal improvement.  At present, the precise definition of `this` doesn't actually affect the decoder output.  But since the new decoder output format is coming up, I figured I should get this right in preparation.