### PR TITLE
Support source map option when compile using vyper.

### DIFF
--- a/packages/truffle-compile-vyper/index.js
+++ b/packages/truffle-compile-vyper/index.js
@@ -83,8 +83,11 @@ function checkVyper(callback) {
 }
 
 // Execute vyper for single source file
-function execVyper(source_path, callback) {
+function execVyper(options, source_path, callback) {
   const formats = ["abi", "bytecode", "bytecode_runtime"];
+  if (options.vyper && options.vyper.source_map) {
+    formats.push("source_map");
+  }
   const command = `vyper -f${formats.join(",")} ${source_path}`;
 
   exec(command, function(err, stdout, stderr) {
@@ -114,7 +117,7 @@ function compileAll(options, callback) {
   async.map(
     options.paths,
     function(source_path, c) {
-      execVyper(source_path, function(err, compiled_contract) {
+      execVyper(options, source_path, function(err, compiled_contract) {
         if (err) return c(err);
 
         // remove first extension from filename
@@ -134,6 +137,7 @@ function compileAll(options, callback) {
           abi: compiled_contract.abi,
           bytecode: compiled_contract.bytecode,
           deployedBytecode: compiled_contract.bytecode_runtime,
+          sourceMap: compiled_contract.source_map,
 
           compiler: compiler
         };

--- a/packages/truffle-compile-vyper/index.js
+++ b/packages/truffle-compile-vyper/index.js
@@ -85,7 +85,10 @@ function checkVyper(callback) {
 // Execute vyper for single source file
 function execVyper(options, source_path, callback) {
   const formats = ["abi", "bytecode", "bytecode_runtime"];
-  if (options.vyper && options.vyper.source_map) {
+  if (
+    options.compilers.vyper.settings &&
+    options.compilers.vyper.settings.sourceMap
+  ) {
     formats.push("source_map");
   }
   const command = `vyper -f${formats.join(",")} ${source_path}`;

--- a/packages/truffle-compile-vyper/test/test_compiler.js
+++ b/packages/truffle-compile-vyper/test/test_compiler.js
@@ -1,6 +1,5 @@
 const path = require("path");
 const assert = require("assert");
-
 const Config = require("truffle-config");
 const compile = require("../index");
 
@@ -89,7 +88,7 @@ describe("vyper compiler", function() {
     });
   });
 
-  describe("with external optionas check", function() {
+  describe("with external options set", function() {
     const configWithSourceMap = new Config().merge(defaultSettings).merge({
       compilers: {
         vyper: {
@@ -99,7 +98,8 @@ describe("vyper compiler", function() {
         }
       }
     });
-    it("compiles with source_map option", function(done) {
+
+    it("compiles when sourceMap option set true", function(done) {
       compile.all(configWithSourceMap, function(err, contracts) {
         [
           contracts.VyperContract1,

--- a/packages/truffle-compile-vyper/test/test_compiler.js
+++ b/packages/truffle-compile-vyper/test/test_compiler.js
@@ -1,24 +1,31 @@
-const path = require('path');
-const assert = require('assert');
+const path = require("path");
+const assert = require("assert");
+const colors = require("colors");
+const exec = require("child_process").exec;
 
-const Config = require('truffle-config');
-const compile = require('../index');
+const Config = require("truffle-config");
+const compile = require("../index");
 
-describe('vyper compiler', function () {
+describe("vyper compiler", function() {
   this.timeout(10000);
 
   const config = new Config().merge({
-    contracts_directory: path.join(__dirname, './sources/'),
+    contracts_directory: path.join(__dirname, "./sources/"),
     quiet: true,
-    all: true,
+    all: true
   });
 
-  it('compiles vyper contracts', function (done) {
-    compile.all(config, function (err, contracts, paths) {
-      assert.equal(err, null, 'Compiles without error');
+  it("compiles vyper contracts", function(done) {
+    compile.all(config, function(err, contracts, paths) {
+      assert.equal(err, null, "Compiles without error");
 
-      paths.forEach(function (path) {
-        assert(['.vy', '.v.py', '.vyper.py'].some(extension => path.indexOf(extension) !== -1), 'Paths have only vyper files');
+      paths.forEach(function(path) {
+        assert(
+          [".vy", ".v.py", ".vyper.py"].some(
+            extension => path.indexOf(extension) !== -1
+          ),
+          "Paths have only vyper files"
+        );
       });
 
       const hex_regex = /^[x0-9a-fA-F]+$/;
@@ -26,35 +33,95 @@ describe('vyper compiler', function () {
       [
         contracts.VyperContract1,
         contracts.VyperContract2,
-        contracts.VyperContract3,
+        contracts.VyperContract3
       ].forEach((contract, index) => {
-        assert.notEqual(contract, undefined, `Compiled contracts have VyperContract${index + 1}`);
-        assert.equal(contract.contract_name, `VyperContract${index + 1}`, 'Contract name is set correctly');
+        assert.notEqual(
+          contract,
+          undefined,
+          `Compiled contracts have VyperContract${index + 1}`
+        );
+        assert.equal(
+          contract.contract_name,
+          `VyperContract${index + 1}`,
+          "Contract name is set correctly"
+        );
 
-        assert.notEqual(contract.abi.indexOf('vyper_action'), -1, 'ABI has function from contract present');
+        assert.notEqual(
+          contract.abi.indexOf("vyper_action"),
+          -1,
+          "ABI has function from contract present"
+        );
 
-        assert(hex_regex.test(contract.bytecode), 'Bytecode has only hex characters');
-        assert(hex_regex.test(contract.deployedBytecode), 'Deployed bytecode has only hex characters');
+        assert(
+          hex_regex.test(contract.bytecode),
+          "Bytecode has only hex characters"
+        );
+        assert(
+          hex_regex.test(contract.deployedBytecode),
+          "Deployed bytecode has only hex characters"
+        );
 
-        assert.equal(contract.compiler.name, 'vyper', 'Compiler name set correctly');
+        assert.equal(
+          contract.compiler.name,
+          "vyper",
+          "Compiler name set correctly"
+        );
       });
 
       done();
     });
   });
 
-  it('skips solidity contracts', function (done) {
-    compile.all(config, function (err, contracts, paths) {
-      assert.equal(err, null, 'Compiles without error');
+  it("compiles with source_map option", function(done) {
+    // this test pass when vyper 0.1.0-b9 or higher
+    exec("vyper --version", function(err, stdout) {
+      let version;
+      if (!err) version = stdout.trim();
 
-      paths.forEach(function (path) {
-        assert.equal(path.indexOf('.sol'), -1, 'Paths have no .sol files');
+      if (version === "0.1.0-b9") {
+        config.merge({
+          vyper: {
+            source_map: true
+          }
+        });
+        compile.all(config, function(err, contracts) {
+          [
+            contracts.VyperContract1,
+            contracts.VyperContract2,
+            contracts.VyperContract3
+          ].forEach((contract, index) => {
+            assert(
+              contract.sourceMap,
+              `source map have to not be empty. ${index + 1}`
+            );
+          });
+
+          done();
+        });
+      } else {
+        done();
+        console.log(
+          `${colors.cyan("Skip cause vyper version is lower:")}${version}`
+        );
+      }
+    });
+  });
+
+  it("skips solidity contracts", function(done) {
+    compile.all(config, function(err, contracts, paths) {
+      assert.equal(err, null, "Compiles without error");
+
+      paths.forEach(function(path) {
+        assert.equal(path.indexOf(".sol"), -1, "Paths have no .sol files");
       });
 
-      assert.equal(contracts.SolidityContract, undefined, 'Compiled contracts have no SolidityContract');
+      assert.equal(
+        contracts.SolidityContract,
+        undefined,
+        "Compiled contracts have no SolidityContract"
+      );
 
       done();
     });
   });
-
 });


### PR DESCRIPTION
Can switching on/off by truffle-config.js for older vyper.

example:
```
module.exports = {
  vyper: {
    source_map: true
  }
}
```