### PR TITLE
Revert truffle-hdwallet-provider breaking change dep update

### DIFF
--- a/packages/truffle-hdwallet-provider/package.json
+++ b/packages/truffle-hdwallet-provider/package.json
@@ -31,7 +31,7 @@
     "js-scrypt": "^0.2.0",
     "mocha": "^5.1.1",
     "web3": "1.0.0-beta.37",
-    "web3-provider-engine": "^15.0.0",
+    "web3-provider-engine": "git+https://github.com/cgewecke/provider-engine.git#web3-one",
     "webpack": "^4.24.0",
     "webpack-cli": "^3.1.2"
   },

--- a/packages/truffle-hdwallet-provider/src/index.js
+++ b/packages/truffle-hdwallet-provider/src/index.js
@@ -134,9 +134,9 @@ class HDWalletProvider {
 
     this.engine.addProvider(new FiltersSubprovider());
     if (typeof provider === "string") {
-      // shim Web3 to give it expected sendAsync method
-      Web3.providers.HttpProvider.prototype.sendAsync =
-        Web3.providers.HttpProvider.prototype.send;
+      // shim Web3 to give it expected sendAsync method. Needed if web3-engine-provider upgraded!
+      // Web3.providers.HttpProvider.prototype.sendAsync =
+      // Web3.providers.HttpProvider.prototype.send;
       this.engine.addProvider(
         new ProviderSubprovider(
           new Web3.providers.HttpProvider(provider, { keepAlive: false })


### PR DESCRIPTION
Updating `truffle-hdwallet-provider`'s `web3-engine-provider` dep in #1897 broke live deployments! It appears the API changed for `web3-engine-provider` and a quick downgrade seems in order.

Resolves #1928.