### PR TITLE
Enable native solc usage for solidity unit testing

### DIFF
--- a/packages/truffle-core/lib/testing/deployed.js
+++ b/packages/truffle-core/lib/testing/deployed.js
@@ -1,6 +1,7 @@
 // Using web3 for its sha function...
 var Web3 = require("web3");
 const semver = require("semver");
+const Native = require("truffle-compile/compilerSupplier/loadingStrategies/Native");
 
 var Deployed = {
   makeSolidityDeployedAddressesLibrary: function(
@@ -35,6 +36,7 @@ var Deployed = {
     source += "}";
 
     if (version) {
+      if (version === "native") version = new Native().load().version();
       const v = semver.coerce(version);
       if (semver.lt(v, "0.5.0")) source = source.replace(/ payable/gm, "");
       source = source.replace(/0.5.0/gm, v);

--- a/packages/truffle-core/lib/testing/soliditytest.js
+++ b/packages/truffle-core/lib/testing/soliditytest.js
@@ -7,6 +7,7 @@ const abi = require("web3-eth-abi");
 const series = require("async").series;
 const path = require("path");
 const semver = require("semver");
+const Native = require("truffle-compile/compilerSupplier/loadingStrategies/Native");
 
 let SafeSend;
 
@@ -115,8 +116,10 @@ const SolidityTest = {
       if (err) return callback(err);
 
       const config = runner.config;
-      if (!config.compilers.solc.version) SafeSend = "NewSafeSend.sol";
-      else if (semver.lt(semver.coerce(config.compilers.solc.version), "0.5.0"))
+      let solcVersion = config.compilers.solc.version;
+      if (solcVersion === "native") solcVersion = new Native().load().version();
+      if (!solcVersion) SafeSend = "NewSafeSend.sol";
+      else if (semver.lt(semver.coerce(solcVersion), "0.5.0"))
         SafeSend = "OldSafeSend.sol";
       else SafeSend = "NewSafeSend.sol";
 
@@ -147,11 +150,11 @@ const SolidityTest = {
 
           // Set network values.
           Object.keys(contracts).forEach(name => {
-            contracts[name].network_id = runner.config.network_id;
-            contracts[name].default_network = runner.config.default_network;
+            contracts[name].network_id = config.network_id;
+            contracts[name].default_network = config.default_network;
           });
 
-          runner.config.artifactor
+          config.artifactor
             .saveAll(contracts)
             .then(() => {
               callback();


### PR DESCRIPTION
This PR enables `native` solc usage during solidity unit testing.

🌴 