### PR TITLE
Throw specific error when can't find base contract during allocation

### DIFF
--- a/packages/truffle-decoder/lib/allocate/general.ts
+++ b/packages/truffle-decoder/lib/allocate/general.ts
@@ -3,8 +3,7 @@ import { AstDefinition, AstReferences } from "truffle-decode-utils";
 function getDeclarationsForTypes(contracts: AstDefinition[], types: string[]): AstReferences {
   let result: AstReferences = {};
 
-  for (let i = 0; i < contracts.length; i++) {
-    const contract = contracts[i];
+  for (let contract of contracts) {
     if (contract) {
       for (const node of contract.nodes) {
         if (types.includes(node.nodeType)) {

--- a/packages/truffle-decoder/lib/types/errors.ts
+++ b/packages/truffle-decoder/lib/types/errors.ts
@@ -1,0 +1,16 @@
+export class UnknownBaseContractIdError extends Error {
+  public name: string;
+  public derivedId: number;
+  public derivedName: string;
+  public derivedKind: string;
+  public baseId: number;
+  constructor(derivedId: number, derivedName: string, derivedKind: string, baseId: number) {
+    const message = `Cannot locate base contract ID ${baseId}$ of ${derivedKind}$ ${derivedName} (ID ${derivedId})`;
+    super(message);
+    this.name = "UnknownBaseContractIdError";
+    this.derivedId = derivedId;
+    this.derivedName = derivedName;
+    this.derivedKind = derivedKind;
+    this.baseId = baseId;
+  }
+}


### PR DESCRIPTION
This PR is to help address [Ganache issue 1169](https://github.com/trufflesuite/ganache/issues/1169) and related issues.  It is *not* a fix; truly fixing it would require changes to `truffle compile`, so I'll have to talk to @eggplantzzz about that, although it may turn out that a proper fix is not feasible until truffle-db is ready (hopefully not though).

In any case, what this PR *does* do is to throw a specific error type when this error condition occurs -- an `UnknownBaseContractIdError` -- so that Ganache can catch it and respond appropriately (such as by simply not decoding that contract's state) rather than crashing.  So, @davidmurdoch, consider yourself alerted!

Anyway hopefully we'll have a proper fix soon, otherwise for now we can tell people to use the workaround of recompiling everything with `truffle compile --all` or recompiling/redploying with `truffle migrate --compile-all --reset`.