### PR TITLE
change: Change maxBuffer size to 600KB.

### DIFF
--- a/packages/truffle-compile-vyper/index.js
+++ b/packages/truffle-compile-vyper/index.js
@@ -87,7 +87,7 @@ function execVyper(source_path, callback) {
   const formats = ["abi", "bytecode", "bytecode_runtime"];
   const command = `vyper -f${formats.join(",")} ${source_path}`;
 
-  exec(command, function(err, stdout, stderr) {
+  exec(command, { maxBuffer: 600 * 1024 }, function(err, stdout, stderr) {
     if (err)
       return callback(
         `${stderr}\n${colors.red(


### PR DESCRIPTION
For fixed error of `exceeded maxBuffer` when compiled too large Contract that has over 20KB bytecodes.
Maybe this error happens at apply the `sourceMap` option.