### PR TITLE
Quorum Exploration

### DIFF
--- a/packages/truffle-contract/test/quorum.js
+++ b/packages/truffle-contract/test/quorum.js
@@ -1,0 +1,53 @@
+var assert = require("chai").assert;
+var util = require("./util");
+
+describe("Quorum", function() {
+  var Example;
+  var accounts;
+  var providerOptions = { vmErrorsOnRPCResponse: false };
+
+  before(async function() {
+    this.timeout(10000);
+
+    Example = await util.createExample();
+
+    return util.setUpProvider(Example, providerOptions).then(result => {
+      accounts = result.accounts;
+    });
+  });
+
+  it("should accept tx params (send)", async function() {
+    const originalProvider = Example.currentProvider;
+    const privateID = "ROAZBWtSacxXQrOe3FGAqJDyJjFePR5ce4TSIzmJ0Bc=";
+
+    var transactionPayloads = [];
+
+    var hookedProvider = {
+      sendAsync: function() {
+        const payload = arguments[0];
+
+        if (payload.method == "eth_sendTransaction") {
+          transactionPayloads.push(payload);
+        }
+
+        originalProvider.sendAsync.apply(originalProvider, arguments);
+      }
+    };
+
+    Example.setProvider(hookedProvider);
+
+    // Without `from` in the options, Web3 complains there are too many params!
+    const example = await Example.new(1, {
+      from: accounts[0],
+      privateFor: [privateID]
+    });
+    await example.setValue(5, { from: accounts[0], privateFor: [privateID] });
+
+    assert.equal(transactionPayloads.length, 2);
+
+    transactionPayloads.forEach(payload => {
+      assert.isNotNull(payload.params[0].privateFor);
+      assert.equal(payload.params[0].privateFor[0], privateID);
+    });
+  });
+});


### PR DESCRIPTION
This is the start of exploration to see how `privateFor` works within Truffle.

My first attempt was to ensure `privateFor` gets passed all the way down, past web3 and through the provider. I added a test to ensure this was the case, and I found that it does, but conditionally. You'll see in the test that without a parameter web3 expects (like `from`) `privateFor` is ignored. 

I don't yet know the problems Quorum users are having. Will add more to this PR as I explore. 

-------------

Issues identified (check-mark means fixed): 

- [ ] Lone `privateFor` transaction parameter without any other parameters
- [x] Gas limit size interfering with BN.js (fixed by https://github.com/trufflesuite/truffle/pull/1806)
- [x] Timestamp format validation issues (fixed by https://github.com/trufflesuite/truffle/pull/1806)