### PR TITLE
Enable Quorum Privacy Transactions

### DIFF
--- a/packages/truffle-contract/lib/utils.js
+++ b/packages/truffle-contract/lib/utils.js
@@ -26,7 +26,8 @@ var Utils = {
       gasPrice: true,
       value: true,
       data: true,
-      nonce: true
+      nonce: true,
+      privateFor: true
     };
 
     for (field_name of Object.keys(val)) {

--- a/packages/truffle-contract/test/quorum.js
+++ b/packages/truffle-contract/test/quorum.js
@@ -1,0 +1,53 @@
+var assert = require("chai").assert;
+var util = require("./util");
+
+describe("Quorum", function() {
+  var Example;
+  var accounts;
+  var providerOptions = { vmErrorsOnRPCResponse: false };
+
+  before(async function() {
+    this.timeout(10000);
+
+    Example = await util.createExample();
+
+    return util.setUpProvider(Example, providerOptions).then(result => {
+      accounts = result.accounts;
+    });
+  });
+
+  it("should accept tx params (send)", async function() {
+    const originalProvider = Example.currentProvider;
+    const privateID = "ROAZBWtSacxXQrOe3FGAqJDyJjFePR5ce4TSIzmJ0Bc=";
+
+    var transactionPayloads = [];
+
+    var hookedProvider = {
+      sendAsync: function() {
+        const payload = arguments[0];
+
+        if (payload.method == "eth_sendTransaction") {
+          transactionPayloads.push(payload);
+        }
+
+        originalProvider.sendAsync.apply(originalProvider, arguments);
+      }
+    };
+
+    Example.setProvider(hookedProvider);
+
+    // Without `from` in the options, Web3 complains there are too many params!
+    const example = await Example.new(1, {
+      from: accounts[0],
+      privateFor: [privateID]
+    });
+    await example.setValue(5, { from: accounts[0], privateFor: [privateID] });
+
+    assert.equal(transactionPayloads.length, 2);
+
+    transactionPayloads.forEach(payload => {
+      assert.isNotNull(payload.params[0].privateFor);
+      assert.equal(payload.params[0].privateFor[0], privateID);
+    });
+  });
+});

--- a/packages/truffle-contract/test/quorum.js
+++ b/packages/truffle-contract/test/quorum.js
@@ -3,7 +3,6 @@ var util = require("./util");
 
 describe("Quorum", function() {
   var Example;
-  var accounts;
   var providerOptions = { vmErrorsOnRPCResponse: false };
 
   before(async function() {
@@ -11,12 +10,10 @@ describe("Quorum", function() {
 
     Example = await util.createExample();
 
-    return util.setUpProvider(Example, providerOptions).then(result => {
-      accounts = result.accounts;
-    });
+    return util.setUpProvider(Example, providerOptions);
   });
 
-  it("should accept tx params (send)", async function() {
+  it("privateFor accepted as valid tx_param (send)", async function() {
     const originalProvider = Example.currentProvider;
     const privateID = "ROAZBWtSacxXQrOe3FGAqJDyJjFePR5ce4TSIzmJ0Bc=";
 
@@ -36,12 +33,10 @@ describe("Quorum", function() {
 
     Example.setProvider(hookedProvider);
 
-    // Without `from` in the options, Web3 complains there are too many params!
     const example = await Example.new(1, {
-      from: accounts[0],
       privateFor: [privateID]
     });
-    await example.setValue(5, { from: accounts[0], privateFor: [privateID] });
+    await example.setValue(5, { privateFor: [privateID] });
 
     assert.equal(transactionPayloads.length, 2);
 


### PR DESCRIPTION
This PR enables Quorum private transactions by whitelisting the `privateFor` key as a valid transaction parameter.

Works toward resolving #1657.
