### PR TITLE
Add error for failure to locate struct or enum during storage allocation

### DIFF
--- a/packages/truffle-decode-utils/src/definition.ts
+++ b/packages/truffle-decode-utils/src/definition.ts
@@ -12,6 +12,10 @@ export namespace Definition {
     return definition.typeDescriptions.typeIdentifier;
   }
 
+  export function typeString(definition: AstDefinition): string {
+    return definition.typeDescriptions.typeString;
+  }
+
   /**
    * returns basic type class for a variable definition node
    * e.g.:

--- a/packages/truffle-decoder/lib/types/errors.ts
+++ b/packages/truffle-decoder/lib/types/errors.ts
@@ -14,3 +14,16 @@ export class UnknownBaseContractIdError extends Error {
     this.baseId = baseId;
   }
 }
+
+export class UnknownUserDefinedTypeError extends Error {
+  public name: string;
+  public typeString: string;
+  public id: number;
+  constructor(id: number, typeString: string) {
+    const message = `Cannot locate definition for ${typeString}$ (ID ${id})`;
+    super(message);
+    this.name = "UnknownUserDefinedTypeError";
+    this.id = id;
+    this.typeString = typeString;
+  }
+}


### PR DESCRIPTION
A quick addendum to the earlier #1933, this PR adds a similar error when we can't find an enum or struct definition during storage allocation.  Again, this is not a real fix, it's just throwing a specific error so that Ganache can catch it rather than crash.  But, this should provide a band-aid for such situations as [this old Ganache issue](https://github.com/trufflesuite/ganache/issues/1193).  So, @davidmurdoch, once again, consider yourself alerted, you now have a second type of error to catch.  Again, the workaround for now is to recompile (and if necessary redeploy) the project.