### PR TITLE
Retain clean artifacts by removing function signatures during schema normalization

### DIFF
--- a/packages/truffle-contract-schema/index.js
+++ b/packages/truffle-contract-schema/index.js
@@ -41,6 +41,8 @@ var properties = {
         } catch (e) {
           value = undefined;
         }
+      } else if (typeof value === "object") {
+        value.forEach(item => delete item.signature);
       }
       return value;
     }

--- a/packages/truffle-contract-schema/index.js
+++ b/packages/truffle-contract-schema/index.js
@@ -28,6 +28,18 @@ var abiSchema = require("./spec/abi.spec.json");
  * The optional `transform` parameter standardizes value regardless of source,
  * for purposes of ensuring data type and/or string schemas.
  */
+
+// helper that ensures abi's do not contain function signatures
+const sanitizedValue = dirtyValueArray => {
+  let sanitizedValueArray = [];
+  dirtyValueArray.forEach(item => {
+    let sanitizedItem = Object.assign({}, item);
+    delete sanitizedItem.signature;
+    sanitizedValueArray.push(sanitizedItem);
+  });
+  return sanitizedValueArray;
+};
+
 var properties = {
   contractName: {
     sources: ["contractName", "contract_name"]
@@ -41,8 +53,9 @@ var properties = {
         } catch (e) {
           value = undefined;
         }
-      } else if (typeof value === "object") {
-        value.forEach(item => delete item.signature);
+      }
+      if (Array.isArray(value)) {
+        return sanitizedValue(value);
       }
       return value;
     }


### PR DESCRIPTION
Somewhere (maybe in `truffle-contract`) there's a bug that adds function `signature`s to the ABI during migrations. By adding a check to `transform` and removing any present `signature` key in an `abi` array, this PR ensures that artifacts stay clean and `signature` free!

Potentially resolves #1889 by ensuring `signature`s aren't saved to the artifacts.