### PR TITLE
Update truffle-expect (mostly docs)

### DIFF
--- a/packages/truffle-expect/README.md
+++ b/packages/truffle-expect/README.md
@@ -10,14 +10,17 @@ $ npm install truffle-expect
 ### Usage
 
 ```javascript
-var expect = require("truffle-expect");
+const expect = require("truffle-expect");
 
-// The object you're testing
-var options = {
-  example: "exists"
+// the object you're testing
+const options = {
+  example: "exists",
   another: 5
 };
 
-expect.options(options, ["example", "another"]); // does nothing
+expect.options(options, ["example", "another"]); // does nothing because both key values exist
 expect.options(options, ["example", "another", "some_other_key"]); // errors because options["some_other_key"] is undefined
+
+expect.one(options, ["example", "optional_key"]); // does nothing because at least one key value exists
+expect.one(options, ["optional_key", "other_optional_key"]); // errors because both key values are undefined
 ```

--- a/packages/truffle-expect/index.js
+++ b/packages/truffle-expect/index.js
@@ -1,16 +1,16 @@
-var Expect = {
-  options: function(options, expected_keys) {
-    expected_keys.forEach(function(key) {
+const Expect = {
+  options(options, expected_keys) {
+    expected_keys.forEach(key => {
       if (options[key] == null) {
-        throw new Error("Expected parameter '" + key + "' not passed to function.");
+        throw new Error(`Expected parameter '${key}' not passed to function.`);
       }
     });
   },
 
-  one: function(options, expected_keys) {
-    var found = [];
+  one(options, expected_keys) {
+    const found = [];
 
-    expected_keys.forEach(function(key) {
+    expected_keys.forEach(key => {
       if (options[key] != null) {
         found.push(1);
       } else {
@@ -18,15 +18,17 @@ var Expect = {
       }
     });
 
-    var total = found.reduce(function(t, value) {
-      return t + value;
-    });
+    const total = found.reduce((t, value) => t + value);
 
     // If this doesn't work in all cases, perhaps we should
     // create an expect.onlyOne() function.
     if (total >= 1) return;
 
-    throw new Error("Expected one of the following parameters, but found none: " + expected_keys.join(", "));
+    throw new Error(
+      `Expected one of the following parameters, but found none: ${expected_keys.join(
+        ", "
+      )}`
+    );
   }
 };
 

--- a/packages/truffle-expect/index.js
+++ b/packages/truffle-expect/index.js
@@ -22,13 +22,13 @@ const Expect = {
 
     // If this doesn't work in all cases, perhaps we should
     // create an expect.onlyOne() function.
-    if (total >= 1) return;
-
-    throw new Error(
-      `Expected one of the following parameters, but found none: ${expected_keys.join(
-        ", "
-      )}`
-    );
+    if (total < 1) {
+      throw new Error(
+        `Expected one of the following parameters, but found none: ${expected_keys.join(
+          ", "
+        )}`
+      );
+    }
   }
 };
 

--- a/packages/truffle-expect/package.json
+++ b/packages/truffle-expect/package.json
@@ -17,7 +17,7 @@
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"
   },
-  "homepage": "https://github.com/trufflesuite/truffle/blob/master/packages/truffle-expect/README.md",
+  "homepage": "https://github.com/trufflesuite/truffle/blob/master/packages/truffle-expect#readme",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/truffle-expect/package.json
+++ b/packages/truffle-expect/package.json
@@ -13,9 +13,9 @@
   "author": "Tim Coulter <tim.coulter@consensys.net>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/trufflesuite/truffle-expect/issues"
+    "url": "https://github.com/trufflesuite/truffle/issues"
   },
-  "homepage": "https://github.com/trufflesuite/truffle-expect#readme",
+  "homepage": "https://github.com/trufflesuite/truffle/blob/master/packages/truffle-expect/README.md",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/truffle-expect/package.json
+++ b/packages/truffle-expect/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.7",
   "description": "Simple module for ensuring specific options are passed to a function",
   "main": "index.js",
-  "scripts": {},
+  "scripts": {
+    "test": "mocha"
+  },
   "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-expect",
   "keywords": [
     "truffle",
@@ -19,5 +21,8 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "b207efb3c1409746537293b3e0fc27350029188e"
+  "gitHead": "b207efb3c1409746537293b3e0fc27350029188e",
+  "devDependencies": {
+    "mocha": "5.2.0"
+  }
 }

--- a/packages/truffle-expect/test/index.js
+++ b/packages/truffle-expect/test/index.js
@@ -9,14 +9,8 @@ const options = {
 
 describe("expect.options", () => {
   it("does nothing when expected key values exist", () => {
-    assert.doesNotThrow(
-      () => expect.options(options, ["example", "another"]),
-      "Should not have thrown!"
-    );
-    assert.doesNotThrow(
-      () => expect.options(options, ["another", "example"]),
-      "Should not have thrown!"
-    );
+    expect.options(options, ["example", "another"]);
+    expect.options(options, ["another", "example"]);
   });
 
   it("throws when passed an undefined key value", () => {
@@ -35,15 +29,8 @@ describe("expect.options", () => {
 
 describe("expect.one", () => {
   it("does nothing when at least one key value exists", () => {
-    assert.doesNotThrow(
-      () => expect.one(options, ["example", "optional_key"]),
-      "Should not have thrown!"
-    );
-    assert.doesNotThrow(
-      () =>
-        expect.one(options, ["optional_key", "example", "other_optional_key"]),
-      "Should not have thrown!"
-    );
+    expect.one(options, ["example", "optional_key"]),
+      expect.one(options, ["optional_key", "example", "other_optional_key"]);
   });
 
   it("throws when all key values are undefined", () => {

--- a/packages/truffle-expect/test/index.js
+++ b/packages/truffle-expect/test/index.js
@@ -7,44 +7,10 @@ const options = {
   another: 5
 };
 
-describe("expect.options", () => {
-  it("does nothing when expected key values exist", () => {
-    expect.options(options, ["example", "another"]);
-    expect.options(options, ["another", "example"]);
-  });
-
-  it("throws when passed an undefined key value", () => {
-    assert.throws(
-      () =>
-        expect.options(options, ["example", "another", "missing_key_value"]),
-      "Should have thrown!"
-    );
-    assert.throws(
-      () =>
-        expect.options(options, ["another", "missing_key_value", "example"]),
-      "Should have thrown!"
-    );
-  });
-});
-
 describe("expect.one", () => {
-  it("does nothing when at least one key value exists", () => {
-    expect.one(options, ["example", "optional_key"]),
-      expect.one(options, ["optional_key", "example", "other_optional_key"]);
-  });
-
-  it("throws when all key values are undefined", () => {
+  it("throws when given key values are undefined", () => {
     assert.throws(
       () => expect.options(options, ["optional_key", "other_optional_key"]),
-      "Should have thrown!"
-    );
-    assert.throws(
-      () =>
-        expect.options(options, [
-          "other_optional_key",
-          "optional_key",
-          "another_optional_key"
-        ]),
       "Should have thrown!"
     );
   });

--- a/packages/truffle-expect/test/index.js
+++ b/packages/truffle-expect/test/index.js
@@ -1,0 +1,64 @@
+const expect = require("../index");
+const assert = require("assert");
+
+// object being testing
+const options = {
+  example: "exists",
+  another: 5
+};
+
+describe("expect.options", () => {
+  it("does nothing when expected key values exist", () => {
+    assert.doesNotThrow(
+      () => expect.options(options, ["example", "another"]),
+      "Should not have thrown!"
+    );
+    assert.doesNotThrow(
+      () => expect.options(options, ["another", "example"]),
+      "Should not have thrown!"
+    );
+  });
+
+  it("throws when passed an undefined key value", () => {
+    assert.throws(
+      () =>
+        expect.options(options, ["example", "another", "missing_key_value"]),
+      "Should have thrown!"
+    );
+    assert.throws(
+      () =>
+        expect.options(options, ["another", "missing_key_value", "example"]),
+      "Should have thrown!"
+    );
+  });
+});
+
+describe("expect.one", () => {
+  it("does nothing when at least one key value exists", () => {
+    assert.doesNotThrow(
+      () => expect.one(options, ["example", "optional_key"]),
+      "Should not have thrown!"
+    );
+    assert.doesNotThrow(
+      () =>
+        expect.one(options, ["optional_key", "example", "other_optional_key"]),
+      "Should not have thrown!"
+    );
+  });
+
+  it("throws when all key values are undefined", () => {
+    assert.throws(
+      () => expect.options(options, ["optional_key", "other_optional_key"]),
+      "Should have thrown!"
+    );
+    assert.throws(
+      () =>
+        expect.options(options, [
+          "other_optional_key",
+          "optional_key",
+          "another_optional_key"
+        ]),
+      "Should have thrown!"
+    );
+  });
+});


### PR DESCRIPTION
This PR updates `truffle-expect`'s documentation, reworks a tiny bit of code & adds a bit of code coverage.