### PR TITLE
Add working_directory option for external compiler

### DIFF
--- a/packages/truffle-external-compile/index.js
+++ b/packages/truffle-external-compile/index.js
@@ -253,7 +253,9 @@ const compile = callbackify(async function(options) {
 
   const { command, targets } = options.compilers.external;
   const cwd =
-    options.compilers.external.working_directory || options.working_directory;
+    options.compilers.external.workingDirectory ||
+    options.compilers.external.working_directory || // just in case
+    options.working_directory;
   const logger = options.logger;
 
   debug("running compile command: %s", command);


### PR DESCRIPTION
Ref: #1956 

This adds a new `working_directory` option for external compilers, changing the default directory for external commands as well as their outputs.