### PR TITLE
Update tsconfig files to specify explicit @types dependencies

### DIFF
--- a/packages/truffle-decode-utils/tsconfig.json
+++ b/packages/truffle-decode-utils/tsconfig.json
@@ -10,9 +10,17 @@
     "baseUrl": ".",
     "lib": ["es2017"],
     "paths": {
-      "web3": ["../../node_modules/@types/web3/index", "node_modules/web3/index"]
+      "web3": [
+        "../../node_modules/@types/web3/index",
+        "node_modules/web3/index"
+      ]
     },
-    "rootDir": "src"
+    "rootDir": "src",
+    "typeRoots": [
+      "../../**/node_modules/@types/bn.js",
+      "../../**/node_modules/@types/lodash.clonedeep",
+      "../../**/node_modules/@types/lodash.escaperegexp"
+    ]
   },
   "include": [
     "./src/*.ts"

--- a/packages/truffle-decoder/tsconfig.json
+++ b/packages/truffle-decoder/tsconfig.json
@@ -14,7 +14,17 @@
       "web3/types": ["../../node_modules/@types/web3/types", "node_modules/web3/types"],
       "web3/eth/types": ["../../node_modules/@types/web3/eth/types", "node_modules/web3/eth/types"]
     },
-    "rootDir": "lib"
+    "rootDir": "lib",
+    "typeRoots": [
+      "./typings",
+      "../../**/node_modules/@types/bn.js",
+      "../../**/node_modules/@types/debug",
+      "../../**/node_modules/@types/lodash",
+      "../../**/node_modules/@types/lodash.clonedeep",
+      "../../**/node_modules/@types/lodash.isequal",
+      "../../**/node_modules/@types/lodash.merge"
+    ]
+
   },
   "include": [
     "./lib/**/*.ts",

--- a/packages/truffle-interface-adapter/tsconfig.json
+++ b/packages/truffle-interface-adapter/tsconfig.json
@@ -10,10 +10,17 @@
     "baseUrl": ".",
     "lib": ["es2017"],
     "paths": {
-      "web3": ["../../node_modules/@types/web3/index", "node_modules/web3/index"]
+      "web3": [
+        "../../node_modules/@types/web3/index",
+        "node_modules/web3/index"
+      ]
     },
     "rootDir": "lib",
-    "typeRoots": ["./typings", "./node_modules/@types", "../../node_modules/@types"],
+    "typeRoots": [
+      "./typings",
+      "../../**/node_modules/@types/bn.js",
+      "../../**/node_modules/@types/mocha"
+    ]
   },
   "include": [
     "./lib/**/*.ts",


### PR DESCRIPTION
(internal improvement)

Noticed this when pulling `develop` into `truffle-db` cause `@types/mocha` conflicts with `@types/jest`.

Targeting `develop` to nip this in the bud.