### PR TITLE
Fix yarn warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,8 @@ matrix:
     - node_js: 8
       env: COVERAGE=true
 
-
 install:
-  - npm run bootstrap
+  - yarn bootstrap
 
 cache:
   directories:
@@ -36,7 +35,7 @@ cache:
     - $(npm config get prefix)/lib/node_modules # globally installed stuff (i.e. lerna)
 
 script:
-  - npm run ci
+  - yarn ci
 
 notifications:
   slack:

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ We welcome pull requests. To get started, just fork this repo, clone it locally,
 # Install
 npm install -g lerna@3.4.3
 npm install -g yarn
-npm run bootstrap
+yarn bootstrap
 
 # Test
 npm test

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "private": true,
   "scripts": {
-    "build:debugger": "cd packages/truffle-debugger && npm run build",
-    "build:decode-utils": "cd packages/truffle-decode-utils && npm run build",
-    "build:decoder": "cd packages/truffle-decoder && npm run build",
-    "build:truffle-contract-schema": "cd packages/truffle-contract-schema && npm run build",
-    "build:interface-adapter": "cd packages/truffle-interface-adapter && npm run build",
+    "build:debugger": "cd packages/truffle-debugger && yarn build",
+    "build:decode-utils": "cd packages/truffle-decode-utils && yarn build",
+    "build:decoder": "cd packages/truffle-decoder && yarn build",
+    "build:truffle-contract-schema": "cd packages/truffle-contract-schema && yarn build",
+    "build:interface-adapter": "cd packages/truffle-interface-adapter && yarn build",
     "lerna:bootstrap": "lerna bootstrap",
     "bootstrap": "./scripts/bootstrap.sh",
     "test": "lerna run test --stream --concurrency=1 -- --colors",

--- a/packages/truffle-contract-schema/package.json
+++ b/packages/truffle-contract-schema/package.json
@@ -4,7 +4,7 @@
   "description": "JSON schema for contract artifacts",
   "main": "index.js",
   "scripts": {
-    "prepare": "npm run build",
+    "prepare": "yarn run build",
     "build": "cd spec && json2ts -i contract-object.spec.json -o ./index.d.ts",
     "test": "mocha"
   },

--- a/packages/truffle-contract/package.json
+++ b/packages/truffle-contract/package.json
@@ -4,7 +4,7 @@
   "description": "A better contract abstraction for Ethereum (formerly EtherPudding)",
   "main": "index.js",
   "scripts": {
-    "prepare": "npm run compile",
+    "prepare": "yarn compile",
     "publish:next": "node ../truffle/scripts/prereleaseVersion.js next next",
     "test": "./scripts/test.sh",
     "test:debug": "$(npm bin)/mocha --inspect-brk",

--- a/packages/truffle-contract/package.json
+++ b/packages/truffle-contract/package.json
@@ -7,8 +7,8 @@
     "prepare": "yarn compile",
     "publish:next": "node ../truffle/scripts/prereleaseVersion.js next next",
     "test": "./scripts/test.sh",
-    "test:debug": "$(npm bin)/mocha --inspect-brk",
-    "test:trace": "$(npm bin)/mocha --trace-warnings",
+    "test:debug": "$(yarn bin)/mocha --inspect-brk",
+    "test:trace": "$(yarn bin)/mocha --trace-warnings",
     "compile": "mkdir -p dist && browserify ./index.js -o ./dist/truffle-contract.js && uglifyjs ./dist/truffle-contract.js -o ./dist/truffle-contract.min.js"
   },
   "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-contract",

--- a/packages/truffle-debugger/package.json
+++ b/packages/truffle-debugger/package.json
@@ -5,7 +5,7 @@
   "main": "dist/debugger.js",
   "scripts": {
     "docs": "esdoc",
-    "prepare": "npm run build",
+    "prepare": "yarn build",
     "build": "webpack --config webpack/webpack.config.js",
     "start": "node ./webpack/dev-server.js",
     "test": "mocha-webpack --webpack-config webpack/webpack.config-test.js --recursive",

--- a/packages/truffle-decode-utils/package.json
+++ b/packages/truffle-decode-utils/package.json
@@ -12,7 +12,7 @@
   "main": "dist/index.js",
   "types": "src/index.ts",
   "scripts": {
-    "prepare": "npm run build",
+    "prepare": "yarn build",
     "build": "node_modules/.bin/tsc",
     "start": "node_modules/.bin/tsc --watch",
     "test": "echo \"No test specified\" && exit 0;"

--- a/packages/truffle-decoder/package.json
+++ b/packages/truffle-decoder/package.json
@@ -8,7 +8,7 @@
     "lib": "lib"
   },
   "scripts": {
-    "prepare": "npm run build",
+    "prepare": "yarn build",
     "build": "node_modules/.bin/tsc",
     "start": "node_modules/.bin/tsc --watch",
     "test": "cd test && truffle test"

--- a/packages/truffle-decoder/package.json
+++ b/packages/truffle-decoder/package.json
@@ -35,7 +35,6 @@
     "@types/lodash.merge": "^4.6.4",
     "@types/web3": "^1.0.5",
     "json-schema-to-typescript": "^5.5.0",
-    "truffle": "^5.0.14",
     "truffle-contract-schema": "^3.0.8",
     "typescript": "^3.1.3"
   },
@@ -49,6 +48,9 @@
     "lodash.merge": "^4.6.1",
     "truffle-decode-utils": "^1.0.11",
     "web3": "1.0.0-beta.37"
+  },
+  "peerDependencies": {
+    "truffle": "^5.0.14"
   },
   "gitHead": "b207efb3c1409746537293b3e0fc27350029188e"
 }

--- a/packages/truffle-resolver/package.json
+++ b/packages/truffle-resolver/package.json
@@ -23,13 +23,15 @@
     "async": "2.6.1",
     "detect-installed": "^2.0.4",
     "get-installed-path": "^4.0.8",
-    "truffle-contract": "^4.0.13",
     "truffle-expect": "^0.0.7",
     "truffle-provisioner": "^0.1.4"
   },
   "devDependencies": {
     "mocha": "5.2.0",
     "sinon": "^7.3.1"
+  },
+  "peerDependencies": {
+    "truffle-contract": "^4.0.13"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -42,8 +42,8 @@
   },
   "scripts": {
     "analyze": "./scripts/analyze.sh",
-    "prepare": "npm run build",
-    "build": "npm run build-cli",
+    "prepare": "yarn build",
+    "build": "yarn build-cli",
     "build-cli": "webpack --config ./cli.webpack.config.js",
     "test": "./scripts/test.sh",
     "publish:byoc": "node ./scripts/prereleaseVersion.js byoc-safe byoc",

--- a/packages/truffle/scripts/prereleaseVersion.js
+++ b/packages/truffle/scripts/prereleaseVersion.js
@@ -12,33 +12,32 @@
  *   node ./scripts/prereleaseVersion.js <branch> <tag>
  *
  * ALSO:
- *   npm run publish:byoc
- *   npm run publish:next
+ *   yarn publish:byoc
+ *   yarn publish:next
  */
-const fs = require('fs');
-const exec = require('child_process').execSync;
-const semver = require('semver');
-const readline = require('readline');
+const fs = require("fs");
+const exec = require("child_process").execSync;
+const semver = require("semver");
+const readline = require("readline");
 
 const args = process.argv.slice(2);
 const branch = args[0];
 const tag = args[1];
-const premajor = 'premajor';
-const prerelease = 'prerelease';
-const opts = {stdio:[0,1,2]};
+const premajor = "premajor";
+const prerelease = "prerelease";
+const opts = { stdio: [0, 1, 2] };
 
 // Validate args
-if (!branch || !tag ){
+if (!branch || !tag) {
   const help =
-  `** You forgot to pass in some arguments **\n\n` +
-  `USAGE:\n` +
-  `   node ./scripts/prereleaseVersion.js <branch> <tag>\n\n` +
-
-  `Ex: node ./scripts/prereleaseVersion.js next next\n` +
-  `>>  truffle@4.1.12-next.0  truffle@next\n`;
+    `** You forgot to pass in some arguments **\n\n` +
+    `USAGE:\n` +
+    `   node ./scripts/prereleaseVersion.js <branch> <tag>\n\n` +
+    `Ex: node ./scripts/prereleaseVersion.js next next\n` +
+    `>>  truffle@4.1.12-next.0  truffle@next\n`;
 
   console.log(help);
-  return;
+  process.exit(1);
 }
 
 // Checkout branch
@@ -46,27 +45,30 @@ exec(`git checkout ${branch}`, opts);
 console.log();
 
 // Read package
-let pkg = fs.readFileSync('./package.json');
+let pkg = fs.readFileSync("./package.json");
 pkg = JSON.parse(pkg);
 
 // Get semver increment string
 let version;
 
-(!pkg.version.includes(tag))
-  ? version = semver.inc(pkg.version, premajor)
-  : version = pkg.version;
+!pkg.version.includes(tag)
+  ? (version = semver.inc(pkg.version, premajor))
+  : (version = pkg.version);
 
 version = semver.inc(version, prerelease, tag);
 
 // Describe actions:
-const warn = `You are about to:\n` +
-             `  + increment the package version to ${version}\n` +
-             `  + publish the package on npm at tag: '${tag}'\n` +
-             `  + commit and push this change to branch: '${branch}'\n\n` +
-             `  ------------------------------------------\n` +
-             '  Version'.padEnd(25) + '| Tag\n' +
-             `  ------------------------------------------\n` +
-             `  truffle@${version}`.padEnd(25) + `| truffle@${tag}\n\n`;
+const warn =
+  `You are about to:\n` +
+  `  + increment the package version to ${version}\n` +
+  `  + publish the package on npm at tag: '${tag}'\n` +
+  `  + commit and push this change to branch: '${branch}'\n\n` +
+  `  ------------------------------------------\n` +
+  "  Version".padEnd(25) +
+  "| Tag\n" +
+  `  ------------------------------------------\n` +
+  `  truffle@${version}`.padEnd(25) +
+  `| truffle@${tag}\n\n`;
 
 const quest = `Are you sure you want to publish: (y/n) >> `;
 
@@ -76,18 +78,27 @@ const input = readline.createInterface({
 });
 
 // Confirm
-input.question(warn + quest, (answer) => {
-  const reminder = `\n` +
-  `** Remember: don't overwrite this version in the 'package.json' when you merge develop in. **\n`;
+input.question(warn + quest, answer => {
+  const reminder =
+    `\n` +
+    `** Remember: don't overwrite this version in the 'package.json' when you merge develop in. **\n`;
 
   const affirmations = [
-    'y', 'yes', 'YES', 'Yes', 'OK', 'Ok', 'ok', 'peace', 'almost'
+    "y",
+    "yes",
+    "YES",
+    "Yes",
+    "OK",
+    "Ok",
+    "ok",
+    "peace",
+    "almost"
   ];
 
   const exit = `Exiting without publishing.`;
 
   // npm version updates the package and commits
-  if (affirmations.includes(answer.trim())){
+  if (affirmations.includes(answer.trim())) {
     exec(`npm version ${version}`, opts);
     exec(`npm publish --tag ${tag}`, opts);
 
@@ -97,7 +108,7 @@ input.question(warn + quest, (answer) => {
     // and this is just a noop that errors exec.
     try {
       exec(`git commit -a -m 'Upgrade version to ${version}'`, opts);
-    } catch(err){
+    } catch (err) {
       // ignore
     }
 

--- a/packages/truffle/scripts/test.sh
+++ b/packages/truffle/scripts/test.sh
@@ -7,5 +7,5 @@ if [ "$GETH" == true ]; then
 elif [ "$COVERAGE" == true ]; then
   NO_BUILD=true mocha --no-warnings --timeout 7000 --grep @geth --invert --colors $@
 else
-  yarn run build-cli && mocha --no-warnings --timeout 7000 --grep @geth --invert --colors $@
+  yarn build-cli && mocha --no-warnings --timeout 7000 --grep @geth --invert --colors $@
 fi

--- a/packages/truffle/scripts/test.sh
+++ b/packages/truffle/scripts/test.sh
@@ -3,9 +3,9 @@
 set -o errexit
 
 if [ "$GETH" == true ]; then
-  npm run build-cli && mocha --timeout 50000 --grep @ganache --invert --colors $@
+  yarn build-cli && mocha --timeout 50000 --grep @ganache --invert --colors $@
 elif [ "$COVERAGE" == true ]; then
   NO_BUILD=true mocha --no-warnings --timeout 7000 --grep @geth --invert --colors $@
 else
-  npm run build-cli && mocha --no-warnings --timeout 7000 --grep @geth --invert --colors $@
+  yarn run build-cli && mocha --no-warnings --timeout 7000 --grep @geth --invert --colors $@
 fi

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -3,9 +3,9 @@
 # The below tells bash to stop the script if any of the commands fail
 set -ex
 
-npm run lerna:bootstrap
-npm run build:interface-adapter
-npm run build:truffle-contract-schema # must come before decode-utils
-npm run build:decode-utils # must come before decoder
-npm run build:decoder # must come before debugger
-npm run build:debugger
+yarn lerna:bootstrap
+yarn build:interface-adapter
+yarn build:truffle-contract-schema # must come before decode-utils
+yarn build:decode-utils # must come before decoder
+yarn build:decoder # must come before debugger
+yarn build:debugger

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -53,7 +53,7 @@ elif [ "$COVERAGE" = true ]; then
   sudo apt-get install -y jq snapd solc
   export PATH=$PATH:/snap/bin
   sudo snap install vyper --beta --devmode
-  cd packages/truffle-debugger && npm run test:coverage && \
+  cd packages/truffle-debugger && yarn test:coverage && \
   cd ../../ && nyc lerna run --ignore truffle-debugger test && \
   cat ./packages/truffle-debugger/coverage/lcov.info >> ./coverage/lcov.info && \
   cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js


### PR DESCRIPTION
Firstly, this fixes the circular dependency warnings by making the following packages into peer dependencies:
- truffle-resolver's truffle-contract
- truffle-decoder's truffle

Additionally, this fixes warnings about inconsistent node executables by finding and replacing all instances of package.json files defining scripts in terms of `npm run <script>`. `yarn <script>` is used instead in all cases now.