### PR TITLE
Fix Geth in CI

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -21,6 +21,7 @@ run_geth() {
     --nodiscover \
     --dev \
     --dev.period 0 \
+    --allow-insecure-unlock \
     --targetgaslimit '7000000' \
     js ./scripts/geth-accounts.js \
     > /dev/null &

--- a/scripts/geth.sh
+++ b/scripts/geth.sh
@@ -19,5 +19,6 @@ docker run \
     --nodiscover \
     --dev \
     --dev.period 0 \
+    --allow-insecure-unlock \
     --targetgaslimit '7000000' \
     js ./scripts/geth-accounts.js


### PR DESCRIPTION
The geth CI job has been broken for a [few weeks](https://travis-ci.org/trufflesuite/truffle/builds/516498633) because geth now [requires](https://ethereum.stackexchange.com/questions/69435/error-account-unlock-with-http-access-is-forbidden-when-unlock-an-account-in-ge) you explicitly allow accounts to be unlocked via web3.  CI creates and funds several accounts using this method in [geth-accounts.js](https://github.com/trufflesuite/truffle/blob/develop/scripts/geth-accounts.js) 

There *is* a test failure in the production migrations tests [here](https://travis-ci.org/trufflesuite/truffle/jobs/526705708#L1418), but it's legit - there's actually a problem there. 