### PR TITLE
Internal improvement: exclude notes from coverage

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -11,6 +11,7 @@
     "**/webpack",
     "**/*webpack.config*",
     "packages/truffle/nil.js",
-    "packages/truffle-debugger"
+    "packages/truffle-debugger",
+    "notes/"
   ]
 }


### PR DESCRIPTION
Currently the `notes` directory is being included on Coveralls as a source file! (https://coveralls.io/github/trufflesuite/truffle)