### PR TITLE
Default evm version

### DIFF
--- a/packages/truffle-artifactor/test/contracts.js
+++ b/packages/truffle-artifactor/test/contracts.js
@@ -42,7 +42,7 @@ describe("artifactor + require", () => {
               enabled: false,
               runs: 200
             },
-            evmVersion: "byzantium"
+            evmVersion: "constantinople"
           }
         }
       }

--- a/packages/truffle-artifactor/test/contracts.js
+++ b/packages/truffle-artifactor/test/contracts.js
@@ -41,8 +41,7 @@ describe("artifactor + require", () => {
             optimizer: {
               enabled: false,
               runs: 200
-            },
-            evmVersion: "constantinople"
+            }
           }
         }
       }

--- a/packages/truffle-compile/index.js
+++ b/packages/truffle-compile/index.js
@@ -31,13 +31,11 @@ const compile = function(sources, options, callback) {
     options.compilationTargets && options.compilationTargets.length;
 
   expect.options(options, ["contracts_directory", "compilers"]);
-
   expect.options(options.compilers, ["solc"]);
 
   options.compilers.solc.settings.evmVersion =
     options.compilers.solc.settings.evmVersion ||
-    options.compilers.solc.evmVersion ||
-    {};
+    options.compilers.solc.evmVersion;
   options.compilers.solc.settings.optimizer =
     options.compilers.solc.settings.optimizer ||
     options.compilers.solc.optimizer ||

--- a/packages/truffle-compile/test/test_ordering.js
+++ b/packages/truffle-compile/test/test_ordering.js
@@ -22,7 +22,7 @@ describe("Compile - solidity ^0.4.0", function() {
             enabled: false,
             runs: 200
           },
-          evmVersion: "byzantium"
+          evmVersion: "constantinople"
         }
       }
     },

--- a/packages/truffle-compile/test/test_ordering.js
+++ b/packages/truffle-compile/test/test_ordering.js
@@ -21,8 +21,7 @@ describe("Compile - solidity ^0.4.0", function() {
           optimizer: {
             enabled: false,
             runs: 200
-          },
-          evmVersion: "constantinople"
+          }
         }
       }
     },

--- a/packages/truffle-compile/test/test_supplier.js
+++ b/packages/truffle-compile/test/test_supplier.js
@@ -241,8 +241,7 @@ describe("CompilerSupplier", function() {
                 optimizer: {
                   enabled: false,
                   runs: 200
-                },
-                evmVersion: "constantinople"
+                }
               }
             }
           },

--- a/packages/truffle-compile/test/test_supplier.js
+++ b/packages/truffle-compile/test/test_supplier.js
@@ -242,7 +242,7 @@ describe("CompilerSupplier", function() {
                   enabled: false,
                   runs: 200
                 },
-                evmVersion: "byzantium"
+                evmVersion: "constantinople"
               }
             }
           },

--- a/packages/truffle-config/index.js
+++ b/packages/truffle-config/index.js
@@ -54,7 +54,7 @@ function Config(truffle_directory, working_directory, network) {
             enabled: false,
             runs: 200
           },
-          evmVersion: "byzantium"
+          evmVersion: "petersburg"
         }
       },
       vyper: {}

--- a/packages/truffle-config/index.js
+++ b/packages/truffle-config/index.js
@@ -53,8 +53,7 @@ function Config(truffle_directory, working_directory, network) {
           optimizer: {
             enabled: false,
             runs: 200
-          },
-          evmVersion: "constantinople"
+          }
         }
       },
       vyper: {}

--- a/packages/truffle-config/index.js
+++ b/packages/truffle-config/index.js
@@ -54,7 +54,7 @@ function Config(truffle_directory, working_directory, network) {
             enabled: false,
             runs: 200
           },
-          evmVersion: "petersburg"
+          evmVersion: "constantinople"
         }
       },
       vyper: {}

--- a/packages/truffle-contract/test/linking.js
+++ b/packages/truffle-contract/test/linking.js
@@ -152,7 +152,7 @@ describe("Library linking with contract objects", function() {
               enabled: false,
               runs: 200
             },
-            evmVersion: "byzantium"
+            evmVersion: "constantinople"
           }
         }
       }

--- a/packages/truffle-contract/test/linking.js
+++ b/packages/truffle-contract/test/linking.js
@@ -151,8 +151,7 @@ describe("Library linking with contract objects", function() {
             optimizer: {
               enabled: false,
               runs: 200
-            },
-            evmVersion: "constantinople"
+            }
           }
         }
       }

--- a/packages/truffle-contract/test/util.js
+++ b/packages/truffle-contract/test/util.js
@@ -50,7 +50,7 @@ var util = {
               enabled: false,
               runs: 200
             },
-            evmVersion: "byzantium"
+            evmVersion: "constantinople"
           }
         }
       }

--- a/packages/truffle-contract/test/util.js
+++ b/packages/truffle-contract/test/util.js
@@ -49,8 +49,7 @@ var util = {
             optimizer: {
               enabled: false,
               runs: 200
-            },
-            evmVersion: "constantinople"
+            }
           }
         }
       }

--- a/packages/truffle-debugger/test/helpers.js
+++ b/packages/truffle-debugger/test/helpers.js
@@ -28,7 +28,7 @@ export async function prepareContracts(provider, sources = {}, migrations) {
       version: "0.5.4",
       settings: {
         optimizer: { enabled: false, runs: 200 },
-        evmVersion: "byzantium"
+        evmVersion: "constantinople"
       }
     }
   };

--- a/packages/truffle-decoder/test/truffle-config.js
+++ b/packages/truffle-decoder/test/truffle-config.js
@@ -64,7 +64,7 @@ module.exports = {
       //    enabled: false,
       //    runs: 200
       //  },
-      //  evmVersion: "byzantium"
+      //  evmVersion: "constantinople"
       // }
     }
   }

--- a/packages/truffle-interface-adapter/typings/ganache-core/index.d.ts
+++ b/packages/truffle-interface-adapter/typings/ganache-core/index.d.ts
@@ -14,7 +14,7 @@ declare module "ganache-core" {
       fork_block_number?: string | number;
       gasLimit?: number;
       gasPrice?: string;
-      hardfork?: "byzantium" | "constantinople" | "petersberg";
+      hardfork?: "byzantium" | "constantinople" | "petersburg";
       hd_path?: string;
       locked?: boolean;
       logger?: {


### PR DESCRIPTION
Remove default evm version setting for solc in Truffle so that it uses the default unless specified otherwise by the user.