### PR TITLE
Throw exception if contract decoder can't locate contract's node

### DIFF
--- a/packages/truffle-decoder/lib/interface/contract-decoder.ts
+++ b/packages/truffle-decoder/lib/interface/contract-decoder.ts
@@ -13,6 +13,7 @@ import { StoragePointer, isStoragePointer } from "../types/pointer";
 import { StorageAllocations, StorageMemberAllocations, StorageMemberAllocation } from "../types/allocation";
 import { Slot, isWordsLength } from "../types/storage";
 import { DecoderRequest, isStorageRequest, isCodeRequest } from "../types/request";
+import { ContractBeingDecodedHasNoNodeError } from "../types/errors";
 import decode from "../decode";
 import { Definition as DefinitionUtils, EVM, AstDefinition, AstReferences } from "truffle-decode-utils";
 import { BlockType, Transaction } from "web3/eth/types";
@@ -145,6 +146,9 @@ export default class TruffleContractDecoder extends AsyncEventEmitter {
       this.contractAddress = address;
     }
     this.contractNode = getContractNode(this.contract);
+    if(this.contractNode === undefined) {
+      throw new ContractBeingDecodedHasNoNodeError();
+    }
 
     this.contracts[this.contractNode.id] = this.contract;
     this.contractNodes[this.contractNode.id] = this.contractNode;

--- a/packages/truffle-decoder/lib/types/errors.ts
+++ b/packages/truffle-decoder/lib/types/errors.ts
@@ -27,3 +27,12 @@ export class UnknownUserDefinedTypeError extends Error {
     this.typeString = typeString;
   }
 }
+
+export class ContractBeingDecodedHasNoNodeError extends Error {
+  public name: string;
+  constructor() {
+    const message = "Contract does not appear to have been compiled with Solidity (cannot locate contract node)";
+    super(message);
+    this.name = "ContractBeingDecodedHasNoNodeError";
+  }
+}


### PR DESCRIPTION
This PR causes the contract decoder constructor to throw an exception in case it can't locate the contract node for the contract being decoded, so that this case doesn't crash Ganache.

(Note that if a contract node can't be located *other* than the one for the contract being decoded, it's simply skipped; this is already existing behavior.  But you can't just skip the contract which is supposed to be decoded!)