### PR TITLE
truffle-hdwallet-provider homepage and bugs links updated

### DIFF
--- a/packages/truffle-hdwallet-provider/package.json
+++ b/packages/truffle-hdwallet-provider/package.json
@@ -18,9 +18,9 @@
   "author": "Tim Coulter <tim.coulter@consensys.net>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/trufflesuite/truffle-hdwallet-provider/issues"
+    "url": "https://github.com/trufflesuite/truffle/issues"
   },
-  "homepage": "https://github.com/trufflesuite/truffle-hdwallet-provider#readme",
+  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-hdwallet-provider#readme",
   "devDependencies": {
     "@babel/core": "^7.0.0-0",
     "bip39": "^2.2.0",


### PR DESCRIPTION
The homepage and bugs links in truffle-hdwallet-provider's `package.json` file were pointing to the deprecated repo which was very confusing in npm. They now point to the `truffle-hdwallet-provider` package in the truffle monorepo.