### PR TITLE
Remove error case that is no longer applicable to prevent debugger crash

### DIFF
--- a/packages/truffle-core/lib/commands/debug.js
+++ b/packages/truffle-core/lib/commands/debug.js
@@ -107,8 +107,6 @@ var command = {
 
         sessionPromise
           .then(async function(session) {
-            if (err) return done(err);
-
             function splitLines(str) {
               // We were splitting on OS.EOL, but it turns out on Windows,
               // in some environments (perhaps?) line breaks are still denoted by just \n


### PR DESCRIPTION
This PR removes an error case that is no longer applicable as of the recent changes to `Environment.detect`.  This line wasn't removed from the debugger CLI and that causes it to crash.  This PR removes it.

(Yes, this line is already removed on `notx`, but I don't want to wait for that to be merged in!)