### PR TITLE
 Prevent debugger from landing on pseudo-nodes with no id 

### DIFF
--- a/packages/truffle-debugger/lib/ast/map.js
+++ b/packages/truffle-debugger/lib/ast/map.js
@@ -30,7 +30,12 @@ export function rangeNodes(node, pointer = "") {
   } else if (node instanceof Object) {
     let results = [];
 
-    if (node.src) {
+    if (node.src !== undefined && node.id !== undefined) {
+      //there are some "pseudo-nodes" with a src but no id.
+      //these will cause problems, so we want to exclude them.
+      //(to my knowledge this only happens with the externalReferences
+      //to an InlineAssembly node, so excluding them just means we find
+      //the InlineAssembly node instead, which is fine)
       results.push({ pointer, range: getRange(node) });
     }
 
@@ -51,11 +56,10 @@ export function findOverlappingRange(node, sourceStart, sourceLength) {
   let ranges = rangeNodes(node);
   let tree = new IntervalTree();
 
-  ranges.forEach(({ range, pointer }) => {
+  for (let { range, pointer } of ranges) {
     let [start, end] = range;
-
     tree.insert(start, end, { range, pointer });
-  });
+  }
 
   let sourceEnd = sourceStart + sourceLength;
 


### PR DESCRIPTION
This PR fixes a crash that could occur when debugging contracts with inline assembly.  One of the attributes of an `InlineAssembly` node is `externalReferences`, and nested inside `externalReferences` one can find certain objects I'm calling "pseudo-nodes".  They're not actual nodes -- they lack an `id` and a `nodeType`.  But they do have a `src`, which could cause the debugger to land on them.  The lack of `id` would then cause a crash.

This PR fixes the problem by excluding such pseudo-nodes from the set of nodes the debugger can land on, by only putting nodes with actual IDs into the `IntervalTree`.  This means that instead of landing on these pseudo-nodes, the debugger will land on the `InlineAssembly` node they're a part of.

Note that I'm assuming that this is the only way to get "pseudo-nodes".  If it's not, this might not be the correct solution for those other cases.  But it should be fine here.