### PR TITLE
Fix: Detect test network existence before test run

### DIFF
--- a/packages/truffle-core/lib/commands/test.js
+++ b/packages/truffle-core/lib/commands/test.js
@@ -63,6 +63,8 @@ var command = {
 
     if (!config.network) {
       config.network = "test";
+    } else {
+      Environment.detect(config).catch(done);
     }
 
     var ipcDisconnect;


### PR DESCRIPTION
Currently users can pass whatever network they like during testing (i.e. `truffle test --network ghostNetwork`). Regardless of whether network configs are present in their truffle config file, truffle will act as if that network actually exists 👻 .

Per #1993 , this behavior can be confusing 😕 so this PR ensures if a network is passed during testing, truffle will proceed to check if the network actually exists.

In general this code should probably be cleaned up and revamped, but for now I think this will suffice.