### PR TITLE
Make before_timeout configurable beyond 2min

### DIFF
--- a/packages/truffle-core/lib/testing/testrunner.js
+++ b/packages/truffle-core/lib/testing/testrunner.js
@@ -36,7 +36,8 @@ function TestRunner(options = {}) {
   // For each test
   this.currentTestStartBlock = null;
 
-  this.BEFORE_TIMEOUT = 120000;
+  this.BEFORE_TIMEOUT =
+    (options.mocha && options.mocha.before_timeout) || 120000;
   this.TEST_TIMEOUT = (options.mocha && options.mocha.timeout) || 300000;
 }
 


### PR DESCRIPTION
Hi @gnidan 
Testing with Kaleido and some of our private consensus algorithms, we've encountered https://github.com/trufflesuite/truffle/issues/261
I understand the suggestion there was setting `mocha.enableTimeouts` to false would solve it, such as:
https://github.com/kaleido-io/truffle-kaleido-box/blob/773f91bd3a88bc51412f28bc177e4a05a526ef65/truffle-config.js#L19-L21
However, our testing suggest that does not resolve the issue. The timeout still fires after 2mins for the `prepare suite` that contains the hard coded `this.timeout(runner.TEST_TIMEOUT)`.

Whereas the attached change, combined with adding a `before_timeout` option in the mocha section (alongside `enableTimeouts`) increases the timeout.
Do you think you could re-instate the config option, so we can set it in our truffle box?

fyi @joshmobley