### PR TITLE
Failing test for #2007

### DIFF
--- a/packages/truffle/test/sources/inheritance/contracts/Branch.sol
+++ b/packages/truffle/test/sources/inheritance/contracts/Branch.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.4.24;
 
 import "./LeafA.sol";
 import "./LeafB.sol";

--- a/packages/truffle/test/sources/inheritance/contracts/LeafA.sol
+++ b/packages/truffle/test/sources/inheritance/contracts/LeafA.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.4.24;
 
 import "./LeafC.sol";
 

--- a/packages/truffle/test/sources/inheritance/contracts/LeafB.sol
+++ b/packages/truffle/test/sources/inheritance/contracts/LeafB.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.4.24;
 
 import "./LeafC.sol";
 

--- a/packages/truffle/test/sources/inheritance/contracts/LeafC.sol
+++ b/packages/truffle/test/sources/inheritance/contracts/LeafC.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.4.24;
 
 contract LeafC {
   uint leafC;

--- a/packages/truffle/test/sources/inheritance/contracts/LibraryA.sol
+++ b/packages/truffle/test/sources/inheritance/contracts/LibraryA.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.4.24;
 
 
 library LibraryA {

--- a/packages/truffle/test/sources/inheritance/contracts/Migrations.sol
+++ b/packages/truffle/test/sources/inheritance/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.4.24;
 
 contract Migrations {
   address public owner;

--- a/packages/truffle/test/sources/inheritance/contracts/Root.sol
+++ b/packages/truffle/test/sources/inheritance/contracts/Root.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.4.24;
 
 import "./Branch.sol";
 import "./LeafC.sol";
@@ -9,5 +9,9 @@ contract Root is Branch {
 
   function addToRoot(uint a, uint b) public {
     root = LibraryA.add(a, b);
+  }
+
+  function seeRoot() constant returns (uint) {
+    return root;
   }
 }

--- a/packages/truffle/test/sources/inheritance/contracts/SameFile.sol
+++ b/packages/truffle/test/sources/inheritance/contracts/SameFile.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.4.24;
 
 import "./LeafC.sol";
 

--- a/packages/truffle/test/sources/inheritance/truffle.js
+++ b/packages/truffle/test/sources/inheritance/truffle.js
@@ -1,7 +1,7 @@
 module.exports = {
   compilers: {
     solc: {
-      version: "0.5.0"
+      version: "0.4.24"
     }
   }
 };


### PR DESCRIPTION
**DO NOT MERGE -- EXAMPLE ONLY**

#2007 

@CruzMolina Worth sanity-checking this against develop to make sure it passes there - currently has merge conflicts from #2009. 

The [tests that fail](https://travis-ci.org/trufflesuite/truffle/jobs/531623403#L753-L758) make sure the profiler selects the correct compilation set. When that doesn't happen people have to constantly `rm -rf build` to get their code code changes to persist between edits. 

Watched the profiler working through this case and it's very confusing because there are repeated compilation events, the inheritance set is complicated, etc. But I *think* the problem is the one described in #2007 - an import isn't being picked up by the error-injection strategy because another error takes precedence. Not 100% confident though. 

Also apologies for harping on about bad import paths initially - you're absolutely right about those being resolved in the 'real' compilation step. 