### PR TITLE
Replace a manual array join with a single call to join

### DIFF
--- a/packages/truffle-debugger/lib/web3/sagas/index.js
+++ b/packages/truffle-debugger/lib/web3/sagas/index.js
@@ -142,7 +142,7 @@ export function* obtainBinaries(addresses, block) {
   yield all(addresses.map(address => put(actions.fetchBinary(address, block))));
 
   let binaries = [];
-  binaries = yield all(tasks.map(task => join(task)));
+  binaries = yield join(tasks);
 
   debug("binaries %o", binaries);
 


### PR DESCRIPTION
This PR just uses `join([...tasks])` instead of this manual replication of its functionality.  I'm hoping it might also address #2013, although it's a little unclear what's going on there, so we'll see.