### PR TITLE
Update reselect-tree version

### DIFF
--- a/packages/truffle-debugger/package.json
+++ b/packages/truffle-debugger/package.json
@@ -29,7 +29,7 @@
     "redux-cli-logger": "^2.0.1",
     "redux-saga": "1.0.0",
     "remote-redux-devtools": "^0.5.12",
-    "reselect-tree": "^1.3.0",
+    "reselect-tree": "^1.3.1",
     "truffle-code-utils": "^1.2.2",
     "truffle-decode-utils": "^1.0.12",
     "truffle-decoder": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10961,9 +10961,10 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
-reselect-tree@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/reselect-tree/-/reselect-tree-1.3.0.tgz#baba80a04b855dcdec672a8c602ae13c337c2858"
+reselect-tree@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/reselect-tree/-/reselect-tree-1.3.1.tgz#e721f4c110d0e3d50edf24f0347e9e85e7d3c617"
+  integrity sha512-odL2qQPc5Wu5fGLH0zAWn3vLh9IOvrWEckvQL/mDiKAV48t3mpsTYbIZsNcu0CcVYAvkDxvcMvRB+19TOgyODg==
   dependencies:
     debug "^3.1.0"
     esdoc "^1.0.4"


### PR DESCRIPTION
This PR just updates the version of reselect-tree from 1.3.0 to 1.3.1.