### PR TITLE
Loader playground functionality

### DIFF
--- a/packages/truffle-db/bin/server.js
+++ b/packages/truffle-db/bin/server.js
@@ -1,11 +1,17 @@
 const { ApolloServer } = require("apollo-server");
 
 const { TruffleDB } = require("truffle-db");
+const Config = require("truffle-config");
 
 const port = 4444;
 
+const config = Config.detect({
+  workingDirectory: process.argv[2] || process.cwd()
+});
+
 const db = new TruffleDB({
-  contracts_build_directory: process.argv[2] || process.cwd()
+  contracts_build_directory: config.contracts_build_directory,
+  contracts_directory: config.contracts_directory
 });
 
 const { schema, context } = db;

--- a/packages/truffle-db/src/data/schema.ts
+++ b/packages/truffle-db/src/data/schema.ts
@@ -4,7 +4,7 @@ import { scopeSchemas } from "./utils";
 
 import { abiSchema, schema as artifactsSchema } from "truffle-db/artifacts";
 import { schema as workspaceSchema } from "truffle-db/workspace";
-import { artifactsLoader } from "truffle-db/loaders";
+import { loaderSchema } from "truffle-db/loaders";
 
 
 import { readInstructions } from "./bytecode";
@@ -13,7 +13,7 @@ export const schema = scopeSchemas({
   subschemas: {
     artifacts: artifactsSchema,
     workspace: workspaceSchema,
-    artifactsLoader: artifactsLoader
+    loaders: loaderSchema
   },
   typeDefs: [
     // add types from abi schema

--- a/packages/truffle-db/src/db.ts
+++ b/packages/truffle-db/src/db.ts
@@ -11,13 +11,22 @@ import { Workspace } from "truffle-db/workspace";
 
 interface IConfig {
   contracts_build_directory: string,
+  contracts_directory: string,
   working_directory?: string
 }
 
 interface IContext {
   artifactsDirectory: string,
   workingDirectory: string,
-  workspace: Workspace
+  contractsDirectory: string,
+  workspace: Workspace,
+  db: ITruffleDB
+}
+
+interface ITruffleDB {
+  query: (query: DocumentNode | string,
+    variables: any) =>
+    Promise<any>
 }
 
 export class TruffleDB {
@@ -25,7 +34,7 @@ export class TruffleDB {
   context: IContext;
 
   constructor (config: IConfig) {
-    this.context = TruffleDB.createContext(config);
+    this.context = this.createContext(config);
     this.schema = schema;
   }
 
@@ -45,11 +54,13 @@ export class TruffleDB {
     );
   }
 
-  static createContext(config: IConfig): IContext {
+  createContext(config: IConfig): IContext {
     return {
       workspace: new Workspace(),
       artifactsDirectory: config.contracts_build_directory,
-      workingDirectory: config.working_directory || process.cwd()
+      workingDirectory: config.working_directory || process.cwd(),
+      contractsDirectory: config.contracts_directory,
+      db: this
     }
   }
 }

--- a/packages/truffle-db/src/helpers/generateId.ts
+++ b/packages/truffle-db/src/helpers/generateId.ts
@@ -1,0 +1,4 @@
+import { soliditySha3 } from "web3-utils";
+const jsonStableStringify = require('json-stable-stringify');
+
+export const generateId = (obj) => soliditySha3(jsonStableStringify(obj));

--- a/packages/truffle-db/src/helpers/index.ts
+++ b/packages/truffle-db/src/helpers/index.ts
@@ -1,0 +1,1 @@
+export { generateId } from "./generateId";

--- a/packages/truffle-db/src/loaders/artifacts/index.ts
+++ b/packages/truffle-db/src/loaders/artifacts/index.ts
@@ -1,7 +1,7 @@
 import gql from "graphql-tag";
 import { TruffleDB } from "truffle-db/db";
 import * as Contracts from "truffle-workflow-compile";
-import { generateId } from "test/helpers";
+import { generateId } from "truffle-db/helpers";
 
 const GetContractNames = gql`
 query GetContractNames {

--- a/packages/truffle-db/src/loaders/artifacts/test/index.ts
+++ b/packages/truffle-db/src/loaders/artifacts/test/index.ts
@@ -3,7 +3,7 @@ import path from "path";
 import gql from "graphql-tag";
 import { TruffleDB } from "truffle-db";
 import { ArtifactsLoader } from "truffle-db/loaders/artifacts";
-import { generateId } from "test/helpers";
+import { generateId } from "truffle-db/helpers";
 import * as Contracts from "truffle-workflow-compile";
 
 // mocking the truffle-workflow-compile to avoid jest timing issues

--- a/packages/truffle-db/src/loaders/index.ts
+++ b/packages/truffle-db/src/loaders/index.ts
@@ -10,8 +10,11 @@ import { gql } from "apollo-server";
 
 //dummy query here because of known issue with Apollo mutation-only schemas 
 const typeDefs = gql`
+  type ArtifactsLoadPayload {
+    success: Boolean
+  }
   type Mutation {
-    loadArtifacts: Boolean
+    artifactsLoad: ArtifactsLoadPayload
   }
   type Query {
     dummy: String
@@ -20,7 +23,7 @@ const typeDefs = gql`
 
 const resolvers = {
   Mutation: {
-    loadArtifacts: {
+    artifactsLoad: {
       resolve: async (_, args, { artifactsDirectory, contractsDirectory, db }, info) => {
         const tempDir = tmp.dirSync({ unsafeCleanup: true })
         const compilationConfig = {
@@ -28,12 +31,16 @@ const resolvers = {
           contracts_build_directory: tempDir.name,
           all: true
         }
-      
         const loader = new ArtifactsLoader(db, compilationConfig);
         await loader.load()
         tempDir.removeCallback();
         return true;
       } 
+    }
+  },
+  ArtifactsLoadPayload: {
+    success: {
+      resolve: () => true
     }
   }
 }

--- a/packages/truffle-db/src/loaders/index.ts
+++ b/packages/truffle-db/src/loaders/index.ts
@@ -22,14 +22,17 @@ const resolvers = {
   Mutation: {
     loadArtifacts: {
       resolve: async (_, args, { artifactsDirectory, contractsDirectory, db }, info) => {
+        const tempDir = tmp.dirSync({ unsafeCleanup: true })
         const compilationConfig = {
           contracts_directory: contractsDirectory,
-          contracts_build_directory: tmp.dirSync({ unsafeCleanup: true }),
+          contracts_build_directory: tempDir.name,
           all: true
         }
       
         const loader = new ArtifactsLoader(db, compilationConfig);
-        loader.load();
+        await loader.load()
+        tempDir.removeCallback();
+        return true;
       } 
     }
   }

--- a/packages/truffle-db/src/workspace/test/index.ts
+++ b/packages/truffle-db/src/workspace/test/index.ts
@@ -4,7 +4,7 @@ import gql from "graphql-tag";
 import * as graphql from "graphql";
 
 import { Workspace, schema } from "truffle-db/workspace";
-import { generateId } from "test/helpers";
+import { generateId } from "truffle-db/helpers";
 
 
 const fixturesDirectory = path.join(

--- a/packages/truffle-db/test/helpers/generateId.ts
+++ b/packages/truffle-db/test/helpers/generateId.ts
@@ -1,4 +1,0 @@
-import { soliditySha3 } from "web3-utils";
-const jsonStableStringify = require('json-stable-stringify');
-
-export const generateId = (obj) => soliditySha3(jsonStableStringify(obj));

--- a/packages/truffle-db/test/helpers/index.ts
+++ b/packages/truffle-db/test/helpers/index.ts
@@ -1,1 +1,0 @@
-export { generateId } from "./generateId";


### PR DESCRIPTION
This PR seeks to add the ability to trigger the `loader` component of the truffle-db package from Truffle DB's implementation of the GraphQL Playground. 

The following mutation, when run in the Playground on a specific Truffle project: 

```
mutation LoadArtifacts {
  loaders {
    artifactsLoad {
      success
    }
  }
}
```

will result in the Artifacts for that project as well as the compilations (as determined by manually running `truffle-workflow-compile`) being loaded into the PouchDB in-memory database currently being used by TruffleDB. 

Once this happens, the bytecodes, sources, and compilations related to the project can be queried via Workspace.