### PR TITLE
Internal improvement: Add basic migration tests for migrate and deploy

### DIFF
--- a/packages/truffle-core/lib/commands/deploy.js
+++ b/packages/truffle-core/lib/commands/deploy.js
@@ -1,6 +1,6 @@
-var migrate = require("./migrate");
+const migrate = require("./migrate");
 
-var command = {
+const command = {
   command: "deploy",
   description: "(alias for migrate)",
   builder: migrate.builder,
@@ -9,7 +9,7 @@ var command = {
       "truffle deploy [--reset] [-f <number>] [--network <name>] [--compile-all] [--verbose-rpc]",
     options: migrate.help.options
   },
-  run: migrate.run.bind(migrate)
+  run: migrate.run
 };
 
 module.exports = command;

--- a/packages/truffle-core/lib/commands/deploy.js
+++ b/packages/truffle-core/lib/commands/deploy.js
@@ -9,7 +9,7 @@ var command = {
       "truffle deploy [--reset] [-f <number>] [--network <name>] [--compile-all] [--verbose-rpc]",
     options: migrate.help.options
   },
-  run: migrate.run
+  run: migrate.run.bind(migrate)
 };
 
 module.exports = command;

--- a/packages/truffle-core/lib/commands/migrate.js
+++ b/packages/truffle-core/lib/commands/migrate.js
@@ -181,7 +181,7 @@ const command = {
         const {
           dryRunOnly,
           dryRunAndMigrations
-        } = this.determineDryRunSettings(conf, options);
+        } = command.determineDryRunSettings(conf, options);
 
         if (dryRunOnly) {
           conf.dryRun = true;
@@ -191,7 +191,10 @@ const command = {
           conf.dryRun = true;
 
           await setupDryRunEnvironmentThenRunMigrations(conf);
-          let { config, proceed } = await this.prepareConfigForRealMigrations(
+          let {
+            config,
+            proceed
+          } = await command.prepareConfigForRealMigrations(
             currentBuild,
             options
           );

--- a/packages/truffle/test/scenarios/commands/deploy.js
+++ b/packages/truffle/test/scenarios/commands/deploy.js
@@ -1,27 +1,19 @@
 const { assert } = require("chai");
 const CommandRunner = require("../commandrunner");
+const sandbox = require("../sandbox");
 const Server = require("../server");
-const tmp = require("tmp");
-const fse = require("fs-extra");
 const path = require("path");
 
 describe("truffle deploy (alias for migrate)", () => {
-  let config, sourcePath;
+  let config, projectPath;
 
-  before(done => Server.start(done));
-  after(done => Server.stop(done));
-
-  beforeEach("set up config for logger", () => {
-    tempDir = tmp.dirSync({ unsafeCleanup: true });
-    sourcePath = path.join(__dirname, "../../sources/migrations/init");
-    fse.copySync(sourcePath, tempDir.name);
-    config = { working_directory: tempDir.name };
-    config.logger = logger;
+  before("before all setup", async () => {
+    await Server.start();
+    projectPath = path.join(__dirname, "../../sources/migrations/init");
+    config = await sandbox.create(projectPath);
+    config.logger = { log: () => {} };
   });
-
-  afterEach("clear working_directory", () => {
-    tempDir.removeCallback();
-  });
+  after(async () => await Server.stop());
 
   describe("when run on the most basic truffle project", () => {
     it("doesn't throw", done => {

--- a/packages/truffle/test/scenarios/commands/deploy.js
+++ b/packages/truffle/test/scenarios/commands/deploy.js
@@ -24,7 +24,8 @@ describe("truffle deploy (alias for migrate)", () => {
   describe("when run on the most basic truffle project", () => {
     it("doesn't throw", done => {
       CommandRunner.run("deploy", config, error => {
-        assert.isNotOk(error, "error should be falsy here");
+        console.log(error);
+        assert(error === undefined, "error should be undefined here");
         done();
       });
     }).timeout(20000);

--- a/packages/truffle/test/scenarios/commands/deploy.js
+++ b/packages/truffle/test/scenarios/commands/deploy.js
@@ -1,0 +1,32 @@
+const { assert } = require("chai");
+const CommandRunner = require("../commandrunner");
+const MemoryLogger = require("../memorylogger");
+const tmp = require("tmp");
+const fse = require("fs-extra");
+const path = require("path");
+
+describe("truffle deploy (alias for migrate)", () => {
+  let config, sourcePath;
+  const logger = new MemoryLogger();
+
+  beforeEach("set up config for logger", () => {
+    tempDir = tmp.dirSync({ unsafeCleanup: true });
+    sourcePath = path.join(__dirname, "../../sources/migrations/init");
+    fse.copySync(sourcePath, tempDir.name);
+    config = { working_directory: tempDir.name };
+    config.logger = logger;
+  });
+
+  afterEach("clear working_directory", () => {
+    tempDir.removeCallback();
+  });
+
+  describe("when run on the most basic truffle project", () => {
+    it("doesn't throw", done => {
+      CommandRunner.run("deploy", config, error => {
+        assert.isNotOk(error, "error should be falsy here");
+        done();
+      });
+    }).timeout(20000);
+  });
+});

--- a/packages/truffle/test/scenarios/commands/deploy.js
+++ b/packages/truffle/test/scenarios/commands/deploy.js
@@ -1,13 +1,15 @@
 const { assert } = require("chai");
 const CommandRunner = require("../commandrunner");
-const MemoryLogger = require("../memorylogger");
+const Server = require("../server");
 const tmp = require("tmp");
 const fse = require("fs-extra");
 const path = require("path");
 
 describe("truffle deploy (alias for migrate)", () => {
   let config, sourcePath;
-  const logger = new MemoryLogger();
+
+  before(done => Server.start(done));
+  after(done => Server.stop(done));
 
   beforeEach("set up config for logger", () => {
     tempDir = tmp.dirSync({ unsafeCleanup: true });
@@ -24,7 +26,6 @@ describe("truffle deploy (alias for migrate)", () => {
   describe("when run on the most basic truffle project", () => {
     it("doesn't throw", done => {
       CommandRunner.run("deploy", config, error => {
-        console.log(error);
         assert(error === undefined, "error should be undefined here");
         done();
       });

--- a/packages/truffle/test/scenarios/commands/migrate.js
+++ b/packages/truffle/test/scenarios/commands/migrate.js
@@ -1,27 +1,19 @@
 const { assert } = require("chai");
 const CommandRunner = require("../commandrunner");
 const Server = require("../server");
-const tmp = require("tmp");
-const fse = require("fs-extra");
+const sandbox = require("../sandbox");
 const path = require("path");
 
 describe("truffle migrate", () => {
-  let config, sourcePath;
+  let config, projectPath;
 
-  before(done => Server.start(done));
-  after(done => Server.stop(done));
-
-  beforeEach("set up config for logger", () => {
-    tempDir = tmp.dirSync({ unsafeCleanup: true });
-    sourcePath = path.join(__dirname, "../../sources/migrations/init");
-    fse.copySync(sourcePath, tempDir.name);
-    config = { working_directory: tempDir.name };
+  before("before all setup", async () => {
+    await Server.start();
+    projectPath = path.join(__dirname, "../../sources/migrations/init");
+    config = await sandbox.create(projectPath);
     config.logger = { log: () => {} };
   });
-
-  afterEach("clear working_directory", () => {
-    tempDir.removeCallback();
-  });
+  after(async () => await Server.stop());
 
   describe("when run on the most basic truffle project", () => {
     it("doesn't throw", done => {

--- a/packages/truffle/test/scenarios/commands/migrate.js
+++ b/packages/truffle/test/scenarios/commands/migrate.js
@@ -1,20 +1,22 @@
 const { assert } = require("chai");
 const CommandRunner = require("../commandrunner");
-const MemoryLogger = require("../memorylogger");
+const Server = require("../server");
 const tmp = require("tmp");
 const fse = require("fs-extra");
 const path = require("path");
 
 describe("truffle migrate", () => {
   let config, sourcePath;
-  const logger = new MemoryLogger();
+
+  before(done => Server.start(done));
+  after(done => Server.stop(done));
 
   beforeEach("set up config for logger", () => {
     tempDir = tmp.dirSync({ unsafeCleanup: true });
     sourcePath = path.join(__dirname, "../../sources/migrations/init");
     fse.copySync(sourcePath, tempDir.name);
     config = { working_directory: tempDir.name };
-    config.logger = logger;
+    config.logger = { log: () => {} };
   });
 
   afterEach("clear working_directory", () => {
@@ -24,7 +26,6 @@ describe("truffle migrate", () => {
   describe("when run on the most basic truffle project", () => {
     it("doesn't throw", done => {
       CommandRunner.run("migrate", config, error => {
-        console.log(error);
         assert(error === undefined, "error should be undefined here");
         done();
       });

--- a/packages/truffle/test/scenarios/commands/migrate.js
+++ b/packages/truffle/test/scenarios/commands/migrate.js
@@ -24,7 +24,8 @@ describe("truffle migrate", () => {
   describe("when run on the most basic truffle project", () => {
     it("doesn't throw", done => {
       CommandRunner.run("migrate", config, error => {
-        assert.isNotOk(error, "error should be falsy here");
+        console.log(error);
+        assert(error === undefined, "error should be undefined here");
         done();
       });
     }).timeout(20000);

--- a/packages/truffle/test/scenarios/commands/migrate.js
+++ b/packages/truffle/test/scenarios/commands/migrate.js
@@ -1,0 +1,32 @@
+const { assert } = require("chai");
+const CommandRunner = require("../commandrunner");
+const MemoryLogger = require("../memorylogger");
+const tmp = require("tmp");
+const fse = require("fs-extra");
+const path = require("path");
+
+describe("truffle migrate", () => {
+  let config, sourcePath;
+  const logger = new MemoryLogger();
+
+  beforeEach("set up config for logger", () => {
+    tempDir = tmp.dirSync({ unsafeCleanup: true });
+    sourcePath = path.join(__dirname, "../../sources/migrations/init");
+    fse.copySync(sourcePath, tempDir.name);
+    config = { working_directory: tempDir.name };
+    config.logger = logger;
+  });
+
+  afterEach("clear working_directory", () => {
+    tempDir.removeCallback();
+  });
+
+  describe("when run on the most basic truffle project", () => {
+    it("doesn't throw", done => {
+      CommandRunner.run("migrate", config, error => {
+        assert.isNotOk(error, "error should be falsy here");
+        done();
+      });
+    }).timeout(20000);
+  });
+});


### PR DESCRIPTION
This PR adds two very basic tests for `truffle migrate` and `truffle deploy`. These just ensure that both `migrate` and `deploy` run on a fresh `truffle init` without throwing an error.