### PR TITLE
Tear lib/commands/debug into pieces

### DIFF
--- a/packages/truffle-core/lib/commands/debug.js
+++ b/packages/truffle-core/lib/commands/debug.js
@@ -174,28 +174,6 @@ const command = {
               );
             }
 
-            function printHelp() {
-              config.logger.log("");
-              config.logger.log(DebugUtils.formatHelp());
-            }
-
-            function printFile() {
-              let message = "";
-
-              debug("about to determine sourcePath");
-              const sourcePath = session.view(solidity.current.source)
-                .sourcePath;
-
-              if (sourcePath) {
-                message += path.basename(sourcePath);
-              } else {
-                message += "?";
-              }
-
-              config.logger.log("");
-              config.logger.log(message + ":");
-            }
-
             function printState() {
               const source = session.view(solidity.current.source).source;
               const range = session.view(solidity.current.sourceRange);

--- a/packages/truffle-core/lib/commands/debug.js
+++ b/packages/truffle-core/lib/commands/debug.js
@@ -17,106 +17,24 @@ const command = {
     ]
   },
   run: function(options, done) {
-    command
-      .setupDebugger(options)
-      .then(interpreter => interpreter.start(done))
-      .catch(done);
-  },
-  setupDebugger: async function(options) {
     const debugModule = require("debug");
     const debug = debugModule("lib:commands:debug");
-    const util = require("util");
-    const BN = require("bn.js");
-    const ora = require("ora");
 
-    // add custom inspect options for BNs
-    BN.prototype[util.inspect.custom] = function(depth, options) {
-      return options.stylize(this.toString(), "number");
-    };
-
-    const compile = require("truffle-compile");
     const Config = require("truffle-config");
-    const Debugger = require("truffle-debugger");
-    const DebugUtils = require("truffle-debug-utils");
     const Environment = require("../environment");
-    const { DebugInterpreter } = require("../debug");
 
-    const config = Config.detect(options);
+    const { CLIDebugger } = require("../debug");
 
-    config.logger.log("Starting Truffle Debugger...");
+    Promise.resolve()
+      .then(async () => {
+        const config = Config.detect(options);
+        await Environment.detect(config);
 
-    await Environment.detect(config);
-
-    const txHash = config._[0]; //may be undefined
-
-    let startSpinner; //apologies for the use of a global variable here
-    let compileSpinner; //and here
-
-    const compilation = await new Promise(function(accept, reject) {
-      //we need to set up a config object for the compiler.
-      //it's the same as the existing config, but we turn on quiet.
-      //unfortunately, we don't have Babel here, so cloning is annoying.
-      let compileConfig = Object.assign(
-        {},
-        ...Object.entries(config).map(([key, value]) => ({ [key]: value }))
-      ); //clone
-      compileConfig.quiet = true;
-
-      compileSpinner = ora("Compiling your contracts...").start();
-
-      compile.all(compileConfig, function(err, contracts, files) {
-        if (err) {
-          return reject(err);
-        }
-
-        return accept({
-          contracts: contracts,
-          files: files
-        });
-      });
-    });
-
-    compileSpinner.succeed();
-
-    let startMessage = DebugUtils.formatStartMessage(txHash !== undefined);
-    startSpinner = ora(startMessage).start();
-
-    let debuggerOptions = {
-      provider: config.provider,
-      files: compilation.files,
-      contracts: Object.keys(compilation.contracts).map(function(name) {
-        const contract = compilation.contracts[name];
-        return {
-          contractName: contract.contractName || contract.contract_name,
-          source: contract.source,
-          sourcePath: contract.sourcePath,
-          ast: contract.ast,
-          binary: contract.binary || contract.bytecode,
-          sourceMap: contract.sourceMap,
-          deployedBinary: contract.deployedBinary || contract.deployedBytecode,
-          deployedSourceMap: contract.deployedSourceMap,
-          compiler: contract.compiler,
-          abi: contract.abi
-        };
+        const txHash = config._[0]; //may be undefined
+        return await new CLIDebugger(config).run(txHash);
       })
-    };
-
-    const bugger =
-      txHash !== undefined
-        ? await Debugger.forTx(txHash, debuggerOptions)
-        : await Debugger.forProject(debuggerOptions);
-
-    debug("about to connect");
-    const session = bugger.connect();
-
-    const interpreter = new DebugInterpreter(
-      config,
-      session,
-      startSpinner,
-      txHash
-    );
-
-    return interpreter;
+      .then(interpreter => interpreter.start(done))
+      .catch(done);
   }
 };
 

--- a/packages/truffle-core/lib/commands/debug.js
+++ b/packages/truffle-core/lib/commands/debug.js
@@ -17,12 +17,16 @@ const command = {
     ]
   },
   run: function(options, done) {
-    const path = require("path");
+    command
+      .setupDebugger(options)
+      .then(interpreter => interpreter.start(done))
+      .catch(done);
+  },
+  setupDebugger: async function(options) {
     const debugModule = require("debug");
     const debug = debugModule("lib:commands:debug");
     const util = require("util");
     const BN = require("bn.js");
-    const analytics = require("../services/analytics");
     const ora = require("ora");
 
     // add custom inspect options for BNs
@@ -35,622 +39,84 @@ const command = {
     const Debugger = require("truffle-debugger");
     const DebugUtils = require("truffle-debug-utils");
     const Environment = require("../environment");
-    const ReplManager = require("../repl");
-    const selectors = require("truffle-debugger").selectors;
-    const { DebugPrinter } = require("../debug");
-
-    // Debugger Session properties
-    const trace = selectors.trace;
-    const solidity = selectors.solidity;
-    const controller = selectors.controller;
+    const { DebugInterpreter } = require("../debug");
 
     const config = Config.detect(options);
 
     config.logger.log("Starting Truffle Debugger...");
 
-    Environment.detect(config)
-      .then(() => {
-        const txHash = config._[0]; //may be undefined
+    await Environment.detect(config);
 
-        let lastCommand = "n";
-        const enabledExpressions = new Set();
-        let startSpinner; //apologies for the use of a global variable here
-        let compileSpinner; //and here
+    const txHash = config._[0]; //may be undefined
 
-        let compilePromise = new Promise(function(accept, reject) {
-          //we need to set up a config object for the compiler.
-          //it's the same as the existing config, but we turn on quiet.
-          //unfortunately, we don't have Babel here, so cloning is annoying.
-          let compileConfig = Object.assign(
-            {},
-            ...Object.entries(config).map(([key, value]) => ({ [key]: value }))
-          ); //clone
-          compileConfig.quiet = true;
+    let startSpinner; //apologies for the use of a global variable here
+    let compileSpinner; //and here
 
-          compileSpinner = ora("Compiling your contracts...").start();
+    const compilation = await new Promise(function(accept, reject) {
+      //we need to set up a config object for the compiler.
+      //it's the same as the existing config, but we turn on quiet.
+      //unfortunately, we don't have Babel here, so cloning is annoying.
+      let compileConfig = Object.assign(
+        {},
+        ...Object.entries(config).map(([key, value]) => ({ [key]: value }))
+      ); //clone
+      compileConfig.quiet = true;
 
-          compile.all(compileConfig, function(err, contracts, files) {
-            if (err) {
-              return reject(err);
-            }
+      compileSpinner = ora("Compiling your contracts...").start();
 
-            return accept({
-              contracts: contracts,
-              files: files
-            });
-          });
+      compile.all(compileConfig, function(err, contracts, files) {
+        if (err) {
+          return reject(err);
+        }
+
+        return accept({
+          contracts: contracts,
+          files: files
         });
-
-        const sessionPromise = compilePromise
-          .then(function(result) {
-            compileSpinner.succeed();
-            let startMessage = DebugUtils.formatStartMessage(
-              txHash !== undefined
-            );
-            startSpinner = ora(startMessage).start();
-
-            let debuggerOptions = {
-              provider: config.provider,
-              files: result.files,
-              contracts: Object.keys(result.contracts).map(function(name) {
-                const contract = result.contracts[name];
-                return {
-                  contractName: contract.contractName || contract.contract_name,
-                  source: contract.source,
-                  sourcePath: contract.sourcePath,
-                  ast: contract.ast,
-                  binary: contract.binary || contract.bytecode,
-                  sourceMap: contract.sourceMap,
-                  deployedBinary:
-                    contract.deployedBinary || contract.deployedBytecode,
-                  deployedSourceMap: contract.deployedSourceMap,
-                  compiler: contract.compiler,
-                  abi: contract.abi
-                };
-              })
-            };
-
-            return txHash !== undefined
-              ? Debugger.forTx(txHash, debuggerOptions)
-              : Debugger.forProject(debuggerOptions);
-          })
-          .then(function(bugger) {
-            debug("about to connect");
-            return bugger.connect();
-          })
-          .catch(done);
-
-        sessionPromise
-          .then(async function(session) {
-            const printer = new DebugPrinter(config, session);
-
-            function watchExpressionAnalytics(raw) {
-              if (raw.includes("!<")) {
-                //don't send analytics for watch expressions involving selectors
-                return;
-              }
-              let expression = raw.trim();
-              //legal Solidity identifiers (= legal JS identifiers)
-              let identifierRegex = /^[a-zA-Z_$][a-zA-Z_$0-9]*$/;
-              let isVariable = expression.match(identifierRegex) !== null;
-              analytics.send({
-                command: "debug: watch expression",
-                args: { isVariable }
-              });
-            }
-
-            async function setOrClearBreakpoint(args, setOrClear) {
-              //setOrClear: true for set, false for clear
-              const currentLocation = session.view(controller.current.location);
-              const breakpoints = session.view(controller.breakpoints);
-
-              const currentNode = currentLocation.node
-                ? currentLocation.node.id
-                : null;
-              const currentLine = currentLocation.sourceRange
-                ? currentLocation.sourceRange.lines.start.line
-                : null;
-              const currentSourceId = currentLocation.source
-                ? currentLocation.source.id
-                : null;
-
-              let breakpoint = {};
-
-              if (args.length === 0) {
-                //no arguments, want currrent node
-                debug("node case");
-                if (currentNode === null) {
-                  config.logger.log("Cannot determine current location.");
-                  return;
-                }
-                breakpoint.node = currentNode;
-                breakpoint.line = currentLine;
-                breakpoint.sourceId = currentSourceId;
-              }
-
-              //the special case of "B all"
-              else if (args[0] === "all") {
-                if (setOrClear) {
-                  // only "B all" is legal, not "b all"
-                  config.logger.log("Cannot add breakpoint everywhere.\n");
-                  return;
-                }
-                await session.removeAllBreakpoints();
-                config.logger.log("Removed all breakpoints.\n");
-                return;
-              }
-
-              //if the argument starts with a "+" or "-", we have a relative
-              //line number
-              else if (args[0][0] === "+" || args[0][0] === "-") {
-                debug("relative case");
-                if (currentLine === null) {
-                  config.logger.log("Cannot determine current location.");
-                  return;
-                }
-                let delta = parseInt(args[0], 10); //want an integer
-                debug("delta %d", delta);
-
-                if (isNaN(delta)) {
-                  config.logger.log("Offset must be an integer.\n");
-                  return;
-                }
-
-                breakpoint.sourceId = currentSourceId;
-                breakpoint.line = currentLine + delta;
-              }
-
-              //if it contains a colon, it's in the form source:line
-              else if (args[0].includes(":")) {
-                debug("source case");
-                let sourceArgs = args[0].split(":");
-                let sourceArg = sourceArgs[0];
-                let lineArg = sourceArgs[1];
-                debug("sourceArgs %O", sourceArgs);
-
-                //first let's get the line number as usual
-                let line = parseInt(lineArg, 10); //want an integer
-                if (isNaN(line)) {
-                  config.logger.log("Line number must be an integer.\n");
-                  return;
-                }
-
-                //search sources for given string
-                let sources = session.view(solidity.info.sources);
-
-                //we will indeed need the sources here, not just IDs
-                let matchingSources = Object.values(sources).filter(source =>
-                  source.sourcePath.includes(sourceArg)
-                );
-
-                if (matchingSources.length === 0) {
-                  config.logger.log(
-                    `No source file found matching ${sourceArg}.\n`
-                  );
-                  return;
-                } else if (matchingSources.length > 1) {
-                  config.logger.log(
-                    `Multiple source files found matching ${sourceArg}.  Which did you mean?`
-                  );
-                  matchingSources.forEach(source =>
-                    config.logger.log(source.sourcePath)
-                  );
-                  config.logger.log("");
-                  return;
-                }
-
-                //otherwise, we found it!
-                breakpoint.sourceId = matchingSources[0].id;
-                breakpoint.line = line - 1; //adjust for zero-indexing!
-              }
-
-              //otherwise, it's a simple line number
-              else {
-                debug("absolute case");
-                if (currentSourceId === null) {
-                  config.logger.log("Cannot determine current file.");
-                  return;
-                }
-                let line = parseInt(args[0], 10); //want an integer
-                debug("line %d", line);
-
-                if (isNaN(line)) {
-                  config.logger.log("Line number must be an integer.\n");
-                  return;
-                }
-
-                breakpoint.sourceId = currentSourceId;
-                breakpoint.line = line - 1; //adjust for zero-indexing!
-              }
-
-              //OK, we've constructed the breakpoint!  But if we're adding, we'll
-              //want to adjust to make sure we don't set it on an empty line or
-              //anything like that
-              if (setOrClear) {
-                let resolver = session.view(controller.breakpoints.resolver);
-                breakpoint = resolver(breakpoint);
-                //of course, this might result in finding that there's nowhere to
-                //add it after that point
-                if (breakpoint === null) {
-                  config.logger.log(
-                    "Nowhere to add breakpoint at or beyond that location.\n"
-                  );
-                  return;
-                }
-              }
-
-              //having constructed and adjusted breakpoint, here's now a
-              //user-readable message describing its location
-              let sourceNames = Object.assign(
-                {},
-                ...Object.values(session.view(solidity.info.sources)).map(
-                  ({ id, sourcePath }) => ({
-                    [id]: path.basename(sourcePath)
-                  })
-                )
-              );
-              let locationMessage = DebugUtils.formatBreakpointLocation(
-                breakpoint,
-                true,
-                currentSourceId,
-                sourceNames
-              );
-
-              //one last check -- does this breakpoint already exist?
-              let alreadyExists =
-                breakpoints.filter(
-                  existingBreakpoint =>
-                    existingBreakpoint.sourceId === breakpoint.sourceId &&
-                    existingBreakpoint.line === breakpoint.line &&
-                    existingBreakpoint.node === breakpoint.node //may be undefined
-                ).length > 0;
-
-              //NOTE: in the "set breakpoint" case, the above check is somewhat
-              //redundant, as we're going to check again when we actually make the
-              //call to add or remove the breakpoint!  But we need to check here so
-              //that we can display the appropriate message.  Hopefully we can find
-              //some way to avoid this redundant check in the future.
-
-              //if it already exists and is being set, or doesn't and is being
-              //cleared, report back that we can't do that
-              if (setOrClear === alreadyExists) {
-                if (setOrClear) {
-                  config.logger.log(
-                    `Breakpoint at ${locationMessage} already exists.\n`
-                  );
-                  return;
-                } else {
-                  config.logger.log(
-                    `No breakpoint at ${locationMessage} to remove.\n`
-                  );
-                  return;
-                }
-              }
-
-              //finally, if we've reached this point, do it!
-              //also report back to the user on what happened
-              if (setOrClear) {
-                await session.addBreakpoint(breakpoint);
-                config.logger.log(`Breakpoint added at ${locationMessage}.\n`);
-              } else {
-                await session.removeBreakpoint(breakpoint);
-                config.logger.log(
-                  `Breakpoint removed at ${locationMessage}.\n`
-                );
-              }
-              return;
-            }
-
-            function setPrompt(prompt) {
-              repl.activate.bind(repl)({
-                prompt,
-                context: {},
-                //this argument only *adds* things, so it's safe to set it to {}
-                ignoreUndefined: true
-                //set to true because it's set to true below :P
-              });
-            }
-
-            async function interpreter(cmd) {
-              cmd = cmd.trim();
-              let cmdArgs, splitArgs;
-              debug("cmd %s", cmd);
-
-              if (cmd === ".exit") {
-                cmd = "q";
-              }
-
-              //split arguments for commands that want that; split on runs of spaces
-              splitArgs = cmd
-                .trim()
-                .split(/ +/)
-                .slice(1);
-              debug("splitArgs %O", splitArgs);
-
-              //warning: this bit *alters* cmd!
-              if (cmd.length > 0) {
-                cmdArgs = cmd.slice(1).trim();
-                cmd = cmd[0];
-              }
-
-              if (cmd === "") {
-                cmd = lastCommand;
-                cmdArgs = "";
-                splitArgs = [];
-              }
-
-              //quit if that's what we were given
-              if (cmd === "q") {
-                return await util.promisify(repl.stop.bind(repl))();
-              }
-
-              let alreadyFinished = session.view(trace.finishedOrUnloaded);
-              let loadFailed = false;
-
-              // If not finished, perform commands that require state changes
-              // (other than quitting or resetting)
-              if (!alreadyFinished) {
-                let stepSpinner = ora("Stepping...").start();
-                switch (cmd) {
-                  case "o":
-                    await session.stepOver();
-                    break;
-                  case "i":
-                    await session.stepInto();
-                    break;
-                  case "u":
-                    await session.stepOut();
-                    break;
-                  case "n":
-                    await session.stepNext();
-                    break;
-                  case ";":
-                    //two cases -- parameterized and unparameterized
-                    if (cmdArgs !== "") {
-                      let count = parseInt(cmdArgs, 10);
-                      debug("cmdArgs=%s", cmdArgs);
-                      if (isNaN(count)) {
-                        config.logger.log(
-                          "Number of steps must be an integer."
-                        );
-                        break;
-                      }
-                      await session.advance(count);
-                    } else {
-                      await session.advance();
-                    }
-                    break;
-                  case "c":
-                    await session.continueUntilBreakpoint();
-                    break;
-                }
-                stepSpinner.stop();
-              } //otherwise, inform the user we can't do that
-              else {
-                switch (cmd) {
-                  case "o":
-                  case "i":
-                  case "u":
-                  case "n":
-                  case "c":
-                    //are we "finished" because we've reached the end, or because
-                    //nothing is loaded?
-                    if (session.view(selectors.session.status.loaded)) {
-                      config.logger.log(
-                        "Transaction has halted; cannot advance."
-                      );
-                      config.logger.log("");
-                    } else {
-                      config.logger.log("No transaction loaded.");
-                      config.logger.log("");
-                    }
-                }
-              }
-              if (cmd === "r") {
-                //reset if given the reset command
-                //(but not if nothing is loaded)
-                if (session.view(selectors.session.status.loaded)) {
-                  await session.reset();
-                } else {
-                  config.logger.log("No transaction loaded.");
-                  config.logger.log("");
-                }
-              }
-              if (cmd === "t") {
-                if (!session.view(selectors.session.status.loaded)) {
-                  let txSpinner = ora(
-                    DebugUtils.formatTransactionStartMessage()
-                  ).start();
-                  await session.load(cmdArgs);
-                  //if load succeeded
-                  if (session.view(selectors.session.status.success)) {
-                    txSpinner.succeed();
-                    //if successful, change prompt
-                    setPrompt(DebugUtils.formatPrompt(config.network, cmdArgs));
-                  } else {
-                    txSpinner.fail();
-                    loadFailed = true;
-                  }
-                } else {
-                  loadFailed = true;
-                  config.logger.log(
-                    "Please unload the current transaction before loading a new one."
-                  );
-                }
-              }
-              if (cmd === "T") {
-                if (session.view(selectors.session.status.loaded)) {
-                  await session.unload();
-                  config.logger.log("Transaction unloaded.");
-                  setPrompt(DebugUtils.formatPrompt(config.network));
-                } else {
-                  config.logger.log("No transaction to unload.");
-                  config.logger.log("");
-                }
-              }
-
-              // Check if execution has (just now) stopped.
-              if (session.view(trace.finished) && !alreadyFinished) {
-                config.logger.log("");
-                //check if transaction failed
-                if (
-                  !session.view(selectors.session.transaction.receipt).status
-                ) {
-                  config.logger.log("Transaction halted with a RUNTIME ERROR.");
-                  config.logger.log("");
-                  config.logger.log(
-                    "This is likely due to an intentional halting expression, like assert(), require() or revert(). It can also be due to out-of-gas exceptions. Please inspect your transaction parameters and contract code to determine the meaning of this error."
-                  );
-                } else {
-                  //case if transaction succeeded
-                  config.logger.log("Transaction completed successfully.");
-                }
-              }
-
-              // Perform post printing
-              // (we want to see if execution stopped before printing state).
-              switch (cmd) {
-                case "+":
-                  if (cmdArgs[0] === ":") {
-                    watchExpressionAnalytics(cmdArgs.substring(1));
-                  }
-                  enabledExpressions.add(cmdArgs);
-                  await printer.printWatchExpressionResult(cmdArgs);
-                  break;
-                case "-":
-                  enabledExpressions.delete(cmdArgs);
-                  break;
-                case "!":
-                  printer.printSelector(cmdArgs);
-                  break;
-                case "?":
-                  printer.printWatchExpressions(enabledExpressions);
-                  printer.printBreakpoints();
-                  break;
-                case "v":
-                  await printer.printVariables();
-                  break;
-                case ":":
-                  watchExpressionAnalytics(cmdArgs);
-                  printer.evalAndPrintExpression(cmdArgs);
-                  break;
-                case "b":
-                  await setOrClearBreakpoint(splitArgs, true);
-                  break;
-                case "B":
-                  await setOrClearBreakpoint(splitArgs, false);
-                  break;
-                case ";":
-                case "p":
-                  if (session.view(selectors.session.status.loaded)) {
-                    printer.printFile();
-                    printer.printInstruction();
-                    printer.printState();
-                  }
-                  await printer.printWatchExpressionsResults(
-                    enabledExpressions
-                  );
-                  break;
-                case "o":
-                case "i":
-                case "u":
-                case "n":
-                case "c":
-                  if (!session.view(trace.finishedOrUnloaded)) {
-                    if (!session.view(solidity.current.source).source) {
-                      printer.printInstruction();
-                    }
-                    printer.printFile();
-                    printer.printState();
-                  }
-                  await printer.printWatchExpressionsResults(
-                    enabledExpressions
-                  );
-                  break;
-                case "r":
-                  if (session.view(selectors.session.status.loaded)) {
-                    printer.printAddressesAffected();
-                    printer.printFile();
-                    printer.printState();
-                  }
-                  break;
-                case "t":
-                  if (!loadFailed) {
-                    printer.printAddressesAffected();
-                    printer.printFile();
-                    printer.printState();
-                  } else if (session.view(selectors.session.status.isError)) {
-                    let loadError = session.view(
-                      selectors.session.status.error
-                    );
-                    config.logger.log(loadError);
-                  }
-                  break;
-                case "T":
-                  //nothing to print
-                  break;
-                default:
-                  printer.printHelp();
-              }
-
-              if (
-                cmd !== "i" &&
-                cmd !== "u" &&
-                cmd !== "b" &&
-                cmd !== "B" &&
-                cmd !== "v" &&
-                cmd !== "h" &&
-                cmd !== "p" &&
-                cmd !== "?" &&
-                cmd !== "!" &&
-                cmd !== ":" &&
-                cmd !== "+" &&
-                cmd !== "r" &&
-                cmd !== "-" &&
-                cmd !== "t" &&
-                cmd !== "T"
-              ) {
-                lastCommand = cmd;
-              }
-            }
-
-            let prompt;
-
-            if (session.view(selectors.session.status.loaded)) {
-              startSpinner.succeed();
-              printer.printAddressesAffected();
-              printer.printHelp();
-              debug("Help printed");
-              printer.printFile();
-              debug("File printed");
-              printer.printState();
-              debug("State printed");
-              prompt = DebugUtils.formatPrompt(config.network, txHash);
-            } else {
-              if (session.view(selectors.session.status.isError)) {
-                startSpinner.fail();
-                config.logger.log(session.view(selectors.session.status.error));
-              } else {
-                startSpinner.succeed();
-              }
-              printer.printHelp();
-              prompt = DebugUtils.formatPrompt(config.network);
-            }
-
-            const repl = options.repl || new ReplManager(config);
-
-            repl.start({
-              prompt,
-              interpreter: util.callbackify(interpreter),
-              ignoreUndefined: true,
-              done: done
-            });
-          })
-          .catch(done);
-      })
-      .catch(error => {
-        done(error);
       });
+    });
+
+    compileSpinner.succeed();
+
+    let startMessage = DebugUtils.formatStartMessage(txHash !== undefined);
+    startSpinner = ora(startMessage).start();
+
+    let debuggerOptions = {
+      provider: config.provider,
+      files: compilation.files,
+      contracts: Object.keys(compilation.contracts).map(function(name) {
+        const contract = compilation.contracts[name];
+        return {
+          contractName: contract.contractName || contract.contract_name,
+          source: contract.source,
+          sourcePath: contract.sourcePath,
+          ast: contract.ast,
+          binary: contract.binary || contract.bytecode,
+          sourceMap: contract.sourceMap,
+          deployedBinary: contract.deployedBinary || contract.deployedBytecode,
+          deployedSourceMap: contract.deployedSourceMap,
+          compiler: contract.compiler,
+          abi: contract.abi
+        };
+      })
+    };
+
+    const bugger =
+      txHash !== undefined
+        ? await Debugger.forTx(txHash, debuggerOptions)
+        : await Debugger.forProject(debuggerOptions);
+
+    debug("about to connect");
+    const session = bugger.connect();
+
+    const interpreter = new DebugInterpreter(
+      config,
+      session,
+      startSpinner,
+      txHash
+    );
+
+    return interpreter;
   }
 };
 

--- a/packages/truffle-core/lib/commands/debug.js
+++ b/packages/truffle-core/lib/commands/debug.js
@@ -1,4 +1,4 @@
-var command = {
+const command = {
   command: "debug",
   description:
     "Interactively debug any transaction on the blockchain (experimental)",
@@ -17,12 +17,12 @@ var command = {
     ]
   },
   run: function(options, done) {
-    var OS = require("os");
-    var path = require("path");
-    var debugModule = require("debug");
-    var debug = debugModule("lib:commands:debug");
-    var safeEval = require("safe-eval");
-    var util = require("util");
+    const OS = require("os");
+    const path = require("path");
+    const debugModule = require("debug");
+    const debug = debugModule("lib:commands:debug");
+    const safeEval = require("safe-eval");
+    const util = require("util");
     const BN = require("bn.js");
     const analytics = require("../services/analytics");
     const ora = require("ora");
@@ -32,31 +32,31 @@ var command = {
       return options.stylize(this.toString(), "number");
     };
 
-    var compile = require("truffle-compile");
-    var Config = require("truffle-config");
-    var Debugger = require("truffle-debugger");
-    var DebugUtils = require("truffle-debug-utils");
-    var Environment = require("../environment");
-    var ReplManager = require("../repl");
-    var selectors = require("truffle-debugger").selectors;
+    const compile = require("truffle-compile");
+    const Config = require("truffle-config");
+    const Debugger = require("truffle-debugger");
+    const DebugUtils = require("truffle-debug-utils");
+    const Environment = require("../environment");
+    const ReplManager = require("../repl");
+    const selectors = require("truffle-debugger").selectors;
 
     // Debugger Session properties
-    var trace = selectors.trace;
-    var solidity = selectors.solidity;
-    var controller = selectors.controller;
+    const trace = selectors.trace;
+    const solidity = selectors.solidity;
+    const controller = selectors.controller;
 
-    var config = Config.detect(options);
+    const config = Config.detect(options);
 
     config.logger.log("Starting Truffle Debugger...");
 
     Environment.detect(config)
       .then(() => {
-        var txHash = config._[0]; //may be undefined
+        const txHash = config._[0]; //may be undefined
 
-        var lastCommand = "n";
-        var enabledExpressions = new Set();
-        var startSpinner; //apologies for the use of a global variable here
-        var compileSpinner; //and here
+        let lastCommand = "n";
+        const enabledExpressions = new Set();
+        let startSpinner; //apologies for the use of a global variable here
+        let compileSpinner; //and here
 
         let compilePromise = new Promise(function(accept, reject) {
           //we need to set up a config object for the compiler.
@@ -82,7 +82,7 @@ var command = {
           });
         });
 
-        var sessionPromise = compilePromise
+        const sessionPromise = compilePromise
           .then(function(result) {
             compileSpinner.succeed();
             let startMessage = DebugUtils.formatStartMessage(
@@ -94,7 +94,7 @@ var command = {
               provider: config.provider,
               files: result.files,
               contracts: Object.keys(result.contracts).map(function(name) {
-                var contract = result.contracts[name];
+                const contract = result.contracts[name];
                 return {
                   contractName: contract.contractName || contract.contract_name,
                   source: contract.source,
@@ -130,7 +130,7 @@ var command = {
             }
 
             function printAddressesAffected() {
-              var affectedInstances = session.view(
+              const affectedInstances = session.view(
                 selectors.session.info.affectedInstances
               );
 
@@ -147,10 +147,11 @@ var command = {
             }
 
             function printFile() {
-              var message = "";
+              let message = "";
 
               debug("about to determine sourcePath");
-              var sourcePath = session.view(solidity.current.source).sourcePath;
+              const sourcePath = session.view(solidity.current.source)
+                .sourcePath;
 
               if (sourcePath) {
                 message += path.basename(sourcePath);
@@ -163,7 +164,7 @@ var command = {
             }
 
             function printAddressesAffected() {
-              var affectedInstances = session.view(
+              const affectedInstances = session.view(
                 selectors.session.info.affectedInstances
               );
 
@@ -179,10 +180,11 @@ var command = {
             }
 
             function printFile() {
-              var message = "";
+              let message = "";
 
               debug("about to determine sourcePath");
-              var sourcePath = session.view(solidity.current.source).sourcePath;
+              const sourcePath = session.view(solidity.current.source)
+                .sourcePath;
 
               if (sourcePath) {
                 message += path.basename(sourcePath);
@@ -195,8 +197,8 @@ var command = {
             }
 
             function printState() {
-              var source = session.view(solidity.current.source).source;
-              var range = session.view(solidity.current.sourceRange);
+              const source = session.view(solidity.current.source).source;
+              const range = session.view(solidity.current.sourceRange);
               debug("source: %o", source);
               debug("range: %o", range);
 
@@ -207,7 +209,7 @@ var command = {
                 return;
               }
 
-              var lines = splitLines(source);
+              const lines = splitLines(source);
 
               config.logger.log("");
 
@@ -219,10 +221,10 @@ var command = {
             }
 
             function printInstruction() {
-              var instruction = session.view(solidity.current.instruction);
-              var step = session.view(trace.step);
-              var traceIndex = session.view(trace.index);
-              var totalSteps = session.view(trace.steps).length;
+              const instruction = session.view(solidity.current.instruction);
+              const step = session.view(trace.step);
+              const traceIndex = session.view(trace.index);
+              const totalSteps = session.view(trace.steps).length;
 
               config.logger.log("");
               config.logger.log(
@@ -264,8 +266,8 @@ var command = {
              * @param {string} selector
              */
             function printSelector(selector) {
-              var result = select(selector);
-              var debugSelector = debugModule(selector);
+              const result = select(selector);
+              const debugSelector = debugModule(selector);
               debugSelector.enabled = true;
               debugSelector("%O", result);
             }
@@ -327,8 +329,8 @@ var command = {
             }
 
             async function printWatchExpressionResult(expression) {
-              var type = expression[0];
-              var exprArgs = expression.substring(1);
+              const type = expression[0];
+              const exprArgs = expression.substring(1);
 
               if (type === "!") {
                 printSelector(exprArgs);
@@ -353,7 +355,7 @@ var command = {
                 .split(/\r?\n/g)
                 .map(function(line, i) {
                   // don't indent first line
-                  var padding = i > 0 ? Array(indent).join(" ") : "";
+                  const padding = i > 0 ? Array(indent).join(" ") : "";
                   return padding + line;
                 })
                 .join(OS.EOL);
@@ -365,7 +367,7 @@ var command = {
               debug("variables %o", variables);
 
               // Get the length of the longest name.
-              var longestNameLength = Math.max.apply(
+              const longestNameLength = Math.max.apply(
                 null,
                 Object.keys(variables).map(function(name) {
                   return name.length;
@@ -375,14 +377,14 @@ var command = {
               config.logger.log();
 
               Object.keys(variables).forEach(function(name) {
-                var paddedName = name + ":";
+                let paddedName = name + ":";
 
                 while (paddedName.length <= longestNameLength) {
                   paddedName = " " + paddedName;
                 }
 
-                var value = variables[name];
-                var formatted = formatValue(value, longestNameLength + 5);
+                const value = variables[name];
+                const formatted = formatValue(value, longestNameLength + 5);
 
                 config.logger.log("  " + paddedName, formatted);
               });
@@ -434,7 +436,7 @@ var command = {
               //using them is closer to the Solidity syntax
               variables = DebugUtils.nativize(variables);
 
-              var context = Object.assign(
+              let context = Object.assign(
                 { $: select },
 
                 variables
@@ -473,9 +475,9 @@ var command = {
               expr = preprocessSelectors(expr);
 
               try {
-                var result = safeEval(expr, context);
+                let result = safeEval(expr, context);
                 result = DebugUtils.cleanConstructors(result); //HACK
-                var formatted = formatValue(result, indent);
+                const formatted = formatValue(result, indent);
                 config.logger.log(formatted);
                 config.logger.log();
               } catch (e) {
@@ -517,20 +519,20 @@ var command = {
 
             async function setOrClearBreakpoint(args, setOrClear) {
               //setOrClear: true for set, false for clear
-              var currentLocation = session.view(controller.current.location);
-              var breakpoints = session.view(controller.breakpoints);
+              const currentLocation = session.view(controller.current.location);
+              const breakpoints = session.view(controller.breakpoints);
 
-              var currentNode = currentLocation.node
+              const currentNode = currentLocation.node
                 ? currentLocation.node.id
                 : null;
-              var currentLine = currentLocation.sourceRange
+              const currentLine = currentLocation.sourceRange
                 ? currentLocation.sourceRange.lines.start.line
                 : null;
-              var currentSourceId = currentLocation.source
+              const currentSourceId = currentLocation.source
                 ? currentLocation.source.id
                 : null;
 
-              var breakpoint = {};
+              let breakpoint = {};
 
               if (args.length === 0) {
                 //no arguments, want currrent node
@@ -729,7 +731,7 @@ var command = {
 
             async function interpreter(cmd) {
               cmd = cmd.trim();
-              var cmdArgs, splitArgs;
+              let cmdArgs, splitArgs;
               debug("cmd %s", cmd);
 
               if (cmd === ".exit") {
@@ -1009,7 +1011,7 @@ var command = {
               prompt = DebugUtils.formatPrompt(config.network);
             }
 
-            var repl = options.repl || new ReplManager(config);
+            const repl = options.repl || new ReplManager(config);
 
             repl.start({
               prompt,

--- a/packages/truffle-core/lib/debug.js
+++ b/packages/truffle-core/lib/debug.js
@@ -1,0 +1,322 @@
+const debugModule = require("debug");
+const debug = debugModule("lib:debug");
+
+const path = require("path");
+const safeEval = require("safe-eval");
+
+const DebugUtils = require("truffle-debug-utils");
+
+const selectors = require("truffle-debugger").selectors;
+const { session, solidity, trace, controller } = selectors;
+
+class DebugPrinter {
+  constructor(config, session) {
+    this.config = config;
+    this.session = session;
+    this.select = expr => {
+      let selector, result;
+
+      try {
+        selector = expr
+          .split(".")
+          .filter(next => next.length > 0)
+          .reduce((sel, next) => sel[next], selectors);
+      } catch (_) {
+        throw new Error("Unknown selector: %s", expr);
+      }
+
+      // throws its own exception
+      result = this.session.view(selector);
+
+      return result;
+    };
+  }
+
+  printAddressesAffected() {
+    const affectedInstances = this.session.view(session.info.affectedInstances);
+
+    this.config.logger.log("");
+    this.config.logger.log("Addresses affected:");
+    this.config.logger.log(
+      DebugUtils.formatAffectedInstances(affectedInstances)
+    );
+  }
+
+  printHelp() {
+    this.config.logger.log("");
+    this.config.logger.log(DebugUtils.formatHelp());
+  }
+
+  printFile() {
+    let message = "";
+
+    debug("about to determine sourcePath");
+    const sourcePath = this.session.view(solidity.current.source).sourcePath;
+
+    if (sourcePath) {
+      message += path.basename(sourcePath);
+    } else {
+      message += "?";
+    }
+
+    this.config.logger.log("");
+    this.config.logger.log(message + ":");
+  }
+
+  printState() {
+    const source = this.session.view(solidity.current.source).source;
+    const range = this.session.view(solidity.current.sourceRange);
+    debug("source: %o", source);
+    debug("range: %o", range);
+
+    // We were splitting on OS.EOL, but it turns out on Windows,
+    // in some environments (perhaps?) line breaks are still denoted by just \n
+    const splitLines = str => str.split(/\r?\n/g);
+
+    if (!source) {
+      this.config.logger.log();
+      this.config.logger.log("1: // No source code found.");
+      this.config.logger.log("");
+      return;
+    }
+
+    const lines = splitLines(source);
+
+    this.config.logger.log("");
+
+    this.config.logger.log(DebugUtils.formatRangeLines(lines, range.lines));
+
+    this.config.logger.log("");
+  }
+
+  printInstruction() {
+    const instruction = this.session.view(solidity.current.instruction);
+    const step = this.session.view(trace.step);
+    const traceIndex = this.session.view(trace.index);
+    const totalSteps = this.session.view(trace.steps).length;
+
+    this.config.logger.log("");
+    this.config.logger.log(
+      DebugUtils.formatInstruction(traceIndex + 1, totalSteps, instruction)
+    );
+    this.config.logger.log(DebugUtils.formatPC(step.pc));
+    this.config.logger.log(DebugUtils.formatStack(step.stack));
+    this.config.logger.log("");
+    this.config.logger.log(step.gas + " gas remaining");
+  }
+
+  /**
+   * @param {string} selector
+   */
+  printSelector(selector) {
+    const result = this.select(selector);
+    const debugSelector = debugModule(selector);
+    debugSelector.enabled = true;
+    debugSelector("%O", result);
+  }
+
+  printWatchExpressions(expressions) {
+    if (expressions.size === 0) {
+      this.config.logger.log("No watch expressions added.");
+      return;
+    }
+
+    this.config.logger.log("");
+    expressions.forEach(function(expression) {
+      this.config.logger.log("  " + expression);
+    });
+  }
+
+  printBreakpoints() {
+    let sourceNames = Object.assign(
+      {},
+      ...Object.values(this.session.view(solidity.info.sources)).map(
+        ({ id, sourcePath }) => ({
+          [id]: path.basename(sourcePath)
+        })
+      )
+    );
+    let breakpoints = this.session.view(controller.breakpoints);
+    if (breakpoints.length > 0) {
+      for (let breakpoint of this.session.view(controller.breakpoints)) {
+        let currentLocation = this.session.view(controller.current.location);
+        let locationMessage = DebugUtils.formatBreakpointLocation(
+          breakpoint,
+          currentLocation.node !== undefined &&
+            breakpoint.node === currentLocation.node.id,
+          currentLocation.source.id,
+          sourceNames
+        );
+        this.config.logger.log("  Breakpoint at " + locationMessage);
+      }
+    } else {
+      this.config.logger.log("No breakpoints added.");
+    }
+  }
+
+  async printWatchExpressionsResults(expressions) {
+    debug("expressions %o", expressions);
+    for (let expression of expressions) {
+      this.config.logger.log(expression);
+      // Add some padding. Note: This won't work with all loggers,
+      // meaning it's not portable. But doing this now so we can get something
+      // pretty until we can build more architecture around this.
+      // Note: Selector results already have padding, so this isn't needed.
+      if (expression[0] === ":") {
+        process.stdout.write("  ");
+      }
+      await this.printWatchExpressionResult(expression);
+    }
+  }
+
+  async printWatchExpressionResult(expression) {
+    const type = expression[0];
+    const exprArgs = expression.substring(1);
+
+    if (type === "!") {
+      this.printSelector(exprArgs);
+    } else {
+      await this.evalAndPrintExpression(exprArgs, 2, true);
+    }
+  }
+
+  async printVariables() {
+    let variables = await this.session.variables();
+
+    debug("variables %o", variables);
+
+    // Get the length of the longest name.
+    const longestNameLength = Math.max.apply(
+      null,
+      Object.keys(variables).map(function(name) {
+        return name.length;
+      })
+    );
+
+    this.config.logger.log();
+
+    Object.keys(variables).forEach(function(name) {
+      let paddedName = name + ":";
+
+      while (paddedName.length <= longestNameLength) {
+        paddedName = " " + paddedName;
+      }
+
+      const value = variables[name];
+      const formatted = DebugUtils.formatValue(value, longestNameLength + 5);
+
+      this.config.logger.log("  " + paddedName, formatted);
+    });
+
+    this.config.logger.log();
+  }
+
+  /**
+   * @param {string} raw - user input for watch expression
+   *
+   * performs pre-processing on `raw`, using !<...> delimeters to refer
+   * to selector expressions.
+   *
+   * e.g., to see a particular part of the current trace step's stack:
+   *
+   *    debug(development:0x4228cdd1...)>
+   *
+   *        :!<trace.step.stack>[1]
+   */
+  async evalAndPrintExpression(raw, indent, suppress) {
+    let variables = await this.session.variables();
+
+    // converts all !<...> expressions to JS-valid selector requests
+    const preprocessSelectors = expr => {
+      const regex = /!<([^>]+)>/g;
+      const select = "$"; // expect repl context to have this func
+      const replacer = (_, selector) => `${select}("${selector}")`;
+
+      return expr.replace(regex, replacer);
+    };
+
+    //if we're just dealing with a single variable, handle that case
+    //separately (so that we can do things in a better way for that
+    //case)
+    let variable = raw.trim();
+    if (variable in variables) {
+      let formatted = DebugUtils.formatValue(variables[variable], indent);
+      this.config.logger.log(formatted);
+      this.config.logger.log();
+      return;
+    }
+
+    //HACK
+    //if we're not in the single-variable case, we'll need to do some
+    //things to Javascriptify our variables so that the JS syntax for
+    //using them is closer to the Solidity syntax
+    variables = DebugUtils.nativize(variables);
+
+    let context = Object.assign(
+      { $: this.select },
+
+      variables
+    );
+
+    //HACK -- we can't use "this" as a variable name, so we're going to
+    //find an available replacement name, and then modify the context
+    //and expression appropriately
+    let pseudoThis = "_this";
+    while (pseudoThis in context) {
+      pseudoThis = "_" + pseudoThis;
+    }
+    //in addition to pseudoThis, which replaces this, we also have
+    //pseudoPseudoThis, which replaces pseudoThis in order to ensure
+    //that any uses of pseudoThis yield an error instead of showing this
+    let pseudoPseudoThis = "thereisnovariableofthatname";
+    while (pseudoPseudoThis in context) {
+      pseudoPseudoThis = "_" + pseudoPseudoThis;
+    }
+    context = DebugUtils.cleanThis(context, pseudoThis);
+    let expr = raw.replace(
+      //those characters in [] are the legal JS variable name characters
+      //note that pseudoThis contains no special characters
+      new RegExp("(?<![a-zA-Z0-9_$])" + pseudoThis + "(?![a-zA-Z0-9_$])"),
+      pseudoPseudoThis
+    );
+    expr = expr.replace(
+      //those characters in [] are the legal JS variable name characters
+      /(?<![a-zA-Z0-9_$])this(?![a-zA-Z0-9_$])/,
+      pseudoThis
+    );
+    //note that pseudoThis contains no dollar signs to screw things up
+
+    expr = preprocessSelectors(expr);
+
+    try {
+      let result = safeEval(expr, context);
+      result = DebugUtils.cleanConstructors(result); //HACK
+      const formatted = DebugUtils.formatValue(result, indent);
+      this.config.logger.log(formatted);
+      this.config.logger.log();
+    } catch (e) {
+      // HACK: safeEval edits the expression to capture the result, which
+      // produces really weird output when there are errors. e.g.,
+      //
+      //   evalmachine.<anonymous>:1
+      //   SAFE_EVAL_857712=a
+      //   ^
+      //
+      //   ReferenceError: a is not defined
+      //     at evalmachine.<anonymous>:1:1
+      //     at ContextifyScript.Script.runInContext (vm.js:59:29)
+      //
+      // We want to hide this from the user if there's an error.
+      e.stack = e.stack.replace(/SAFE_EVAL_\d+=/, "");
+      if (!suppress) {
+        this.config.logger.log(e);
+      } else {
+        this.config.logger.log(DebugUtils.formatValue(undefined));
+      }
+    }
+  }
+}
+
+module.exports = {
+  DebugPrinter
+};

--- a/packages/truffle-core/lib/debug/compiler.js
+++ b/packages/truffle-core/lib/debug/compiler.js
@@ -6,16 +6,18 @@ class DebugCompiler {
   }
 
   async compile() {
-    const { contracts, files } = await new Promise((accept, reject) => {
-      //we need to set up a config object for the compiler.
-      //it's the same as the existing config, but we turn on quiet.
-      //unfortunately, we don't have Babel here, so cloning is annoying.
-      let compileConfig = Object.assign(
-        {},
-        ...Object.entries(this.config).map(([key, value]) => ({ [key]: value }))
-      ); //clone
-      compileConfig.quiet = true;
+    //we need to set up a config object for the compiler.
+    //it's the same as the existing config, but we turn on quiet.
+    //unfortunately, we don't have Babel here, so cloning is annoying.
+    const compileConfig = Object.assign(
+      {},
+      ...Object.entries(this.config).map(([key, value]) => ({ [key]: value }))
+    ); //clone
+    compileConfig.quiet = true;
 
+    // since `compile.all()` returns two results, we can't use promisify
+    // and are instead stuck with using an explicit Promise constructor
+    const { contracts, files } = await new Promise((accept, reject) => {
       compile.all(compileConfig, (err, contracts, files) => {
         if (err) {
           return reject(err);

--- a/packages/truffle-core/lib/debug/compiler.js
+++ b/packages/truffle-core/lib/debug/compiler.js
@@ -1,0 +1,34 @@
+const compile = require("truffle-compile");
+
+class DebugCompiler {
+  constructor(config) {
+    this.config = config;
+  }
+
+  async compile() {
+    const { contracts, files } = await new Promise((accept, reject) => {
+      //we need to set up a config object for the compiler.
+      //it's the same as the existing config, but we turn on quiet.
+      //unfortunately, we don't have Babel here, so cloning is annoying.
+      let compileConfig = Object.assign(
+        {},
+        ...Object.entries(this.config).map(([key, value]) => ({ [key]: value }))
+      ); //clone
+      compileConfig.quiet = true;
+
+      compile.all(compileConfig, (err, contracts, files) => {
+        if (err) {
+          return reject(err);
+        }
+
+        return accept({ contracts, files });
+      });
+    });
+
+    return { contracts, files };
+  }
+}
+
+module.exports = {
+  DebugCompiler
+};

--- a/packages/truffle-core/lib/debug/index.js
+++ b/packages/truffle-core/lib/debug/index.js
@@ -1,0 +1,10 @@
+const debugModule = require("debug");
+const debug = debugModule("lib:debug");
+
+const { DebugPrinter } = require("./printer");
+const { DebugInterpreter } = require("./interpreter");
+
+module.exports = {
+  DebugPrinter,
+  DebugInterpreter
+};

--- a/packages/truffle-core/lib/debug/index.js
+++ b/packages/truffle-core/lib/debug/index.js
@@ -1,10 +1,103 @@
 const debugModule = require("debug");
 const debug = debugModule("lib:debug");
 
-const { DebugPrinter } = require("./printer");
+const util = require("util");
+
+const BN = require("bn.js");
+const ora = require("ora");
+
+const Debugger = require("truffle-debugger");
+const DebugUtils = require("truffle-debug-utils");
+
 const { DebugInterpreter } = require("./interpreter");
+const { DebugCompiler } = require("./compiler");
+
+class CLIDebugger {
+  constructor(config) {
+    this.config = config;
+  }
+
+  async run(txHash) {
+    this.config.logger.log("Starting Truffle Debugger...");
+
+    // override BN display
+    this._setupCustomInspect();
+
+    // compile contracts
+    const compilation = await this.compileSources();
+
+    // invoke truffle-debugger
+    const session = await this.startDebugger(compilation, txHash);
+
+    // initialize prompt/breakpoints/ui logic
+    const interpreter = await this.buildInterpreter(session, txHash);
+
+    return interpreter;
+  }
+
+  async compileSources() {
+    const compileSpinner = ora("Compiling your contracts...").start();
+
+    const compilation = await new DebugCompiler(this.config).compile();
+
+    compileSpinner.succeed();
+
+    return compilation;
+  }
+
+  async startDebugger(compilation, txHash) {
+    const startMessage = DebugUtils.formatStartMessage(txHash !== undefined);
+    const startSpinner = ora(startMessage).start();
+
+    let debuggerOptions = {
+      provider: this.config.provider,
+      files: compilation.files,
+      contracts: Object.keys(compilation.contracts).map(function(name) {
+        const contract = compilation.contracts[name];
+        return {
+          contractName: contract.contractName || contract.contract_name,
+          source: contract.source,
+          sourcePath: contract.sourcePath,
+          ast: contract.ast,
+          binary: contract.binary || contract.bytecode,
+          sourceMap: contract.sourceMap,
+          deployedBinary: contract.deployedBinary || contract.deployedBytecode,
+          deployedSourceMap: contract.deployedSourceMap,
+          compiler: contract.compiler,
+          abi: contract.abi
+        };
+      })
+    };
+
+    const bugger =
+      txHash !== undefined
+        ? await Debugger.forTx(txHash, debuggerOptions)
+        : await Debugger.forProject(debuggerOptions);
+
+    const session = bugger.connect();
+
+    // check
+    if (session.view(Debugger.selectors.session.status.isError)) {
+      startSpinner.fail();
+    } else {
+      startSpinner.succeed();
+    }
+
+    return session;
+  }
+
+  async buildInterpreter(session, txHash) {
+    return new DebugInterpreter(this.config, session, txHash);
+  }
+
+  _setupCustomInspect() {
+    // add custom inspect options for BNs
+    BN.prototype[util.inspect.custom] = function(depth, options) {
+      return options.stylize(this.toString(), "number");
+    };
+  }
+}
 
 module.exports = {
-  DebugPrinter,
-  DebugInterpreter
+  CLIDebugger
 };

--- a/packages/truffle-core/lib/debug/index.js
+++ b/packages/truffle-core/lib/debug/index.js
@@ -76,7 +76,7 @@ class CLIDebugger {
 
     const session = bugger.connect();
 
-    // check
+    // check for error
     if (session.view(Debugger.selectors.session.status.isError)) {
       startSpinner.fail();
     } else {

--- a/packages/truffle-core/lib/debug/interpreter.js
+++ b/packages/truffle-core/lib/debug/interpreter.js
@@ -31,8 +31,8 @@ function watchExpressionAnalytics(raw) {
 
 class DebugInterpreter {
   constructor(config, session, txHash) {
-    this.config = config;
     this.session = session;
+    this.network = config.network;
     this.printer = new DebugPrinter(config, session);
     this.txHash = txHash;
     this.lastCommand = "n";
@@ -246,13 +246,13 @@ class DebugInterpreter {
       debug("File printed");
       this.printer.printState();
       debug("State printed");
-      prompt = DebugUtils.formatPrompt(this.config.network, this.txHash);
+      prompt = DebugUtils.formatPrompt(this.network, this.txHash);
     } else {
       if (this.session.view(selectors.session.status.isError)) {
         this.printer.print(this.session.view(selectors.session.status.error));
       }
       this.printer.printHelp();
-      prompt = DebugUtils.formatPrompt(this.config.network);
+      prompt = DebugUtils.formatPrompt(this.network);
     }
 
     this.repl.start({
@@ -382,7 +382,7 @@ class DebugInterpreter {
         if (this.session.view(selectors.session.status.success)) {
           txSpinner.succeed();
           //if successful, change prompt
-          this.setPrompt(DebugUtils.formatPrompt(this.config.network, cmdArgs));
+          this.setPrompt(DebugUtils.formatPrompt(this.network, cmdArgs));
         } else {
           txSpinner.fail();
           loadFailed = true;
@@ -398,7 +398,7 @@ class DebugInterpreter {
       if (this.session.view(selectors.session.status.loaded)) {
         await this.session.unload();
         this.printer.print("Transaction unloaded.");
-        this.setPrompt(DebugUtils.formatPrompt(this.config.network));
+        this.setPrompt(DebugUtils.formatPrompt(this.network));
       } else {
         this.printer.print("No transaction to unload.");
         this.printer.print("");

--- a/packages/truffle-core/lib/debug/interpreter.js
+++ b/packages/truffle-core/lib/debug/interpreter.js
@@ -254,7 +254,6 @@ class DebugInterpreter {
         this.config.logger.log(
           this.session.view(selectors.session.status.error)
         );
-      } else {
       }
       this.printer.printHelp();
       prompt = DebugUtils.formatPrompt(this.config.network);

--- a/packages/truffle-core/lib/debug/interpreter.js
+++ b/packages/truffle-core/lib/debug/interpreter.js
@@ -7,7 +7,7 @@ const ora = require("ora");
 
 const DebugUtils = require("truffle-debug-utils");
 const selectors = require("truffle-debugger").selectors;
-const { session, solidity, trace, controller } = selectors;
+const { solidity, trace, controller } = selectors;
 
 const analytics = require("../services/analytics");
 const ReplManager = require("../repl");
@@ -116,7 +116,7 @@ class DebugInterpreter {
       }
 
       //search sources for given string
-      let sources = session.view(solidity.info.sources);
+      let sources = this.session.view(solidity.info.sources);
 
       //we will indeed need the sources here, not just IDs
       let matchingSources = Object.values(sources).filter(source =>

--- a/packages/truffle-core/lib/debug/interpreter.js
+++ b/packages/truffle-core/lib/debug/interpreter.js
@@ -60,7 +60,7 @@ class DebugInterpreter {
       //no arguments, want currrent node
       debug("node case");
       if (currentNode === null) {
-        this.config.logger.log("Cannot determine current location.");
+        this.printer.print("Cannot determine current location.");
         return;
       }
       breakpoint.node = currentNode;
@@ -72,11 +72,11 @@ class DebugInterpreter {
     else if (args[0] === "all") {
       if (setOrClear) {
         // only "B all" is legal, not "b all"
-        this.config.logger.log("Cannot add breakpoint everywhere.\n");
+        this.printer.print("Cannot add breakpoint everywhere.\n");
         return;
       }
       await this.session.removeAllBreakpoints();
-      this.config.logger.log("Removed all breakpoints.\n");
+      this.printer.print("Removed all breakpoints.\n");
       return;
     }
 
@@ -85,14 +85,14 @@ class DebugInterpreter {
     else if (args[0][0] === "+" || args[0][0] === "-") {
       debug("relative case");
       if (currentLine === null) {
-        this.config.logger.log("Cannot determine current location.");
+        this.printer.print("Cannot determine current location.");
         return;
       }
       let delta = parseInt(args[0], 10); //want an integer
       debug("delta %d", delta);
 
       if (isNaN(delta)) {
-        this.config.logger.log("Offset must be an integer.\n");
+        this.printer.print("Offset must be an integer.\n");
         return;
       }
 
@@ -111,7 +111,7 @@ class DebugInterpreter {
       //first let's get the line number as usual
       let line = parseInt(lineArg, 10); //want an integer
       if (isNaN(line)) {
-        this.config.logger.log("Line number must be an integer.\n");
+        this.printer.print("Line number must be an integer.\n");
         return;
       }
 
@@ -124,16 +124,16 @@ class DebugInterpreter {
       );
 
       if (matchingSources.length === 0) {
-        this.config.logger.log(`No source file found matching ${sourceArg}.\n`);
+        this.printer.print(`No source file found matching ${sourceArg}.\n`);
         return;
       } else if (matchingSources.length > 1) {
-        this.config.logger.log(
+        this.printer.print(
           `Multiple source files found matching ${sourceArg}.  Which did you mean?`
         );
         matchingSources.forEach(source =>
-          this.config.logger.log(source.sourcePath)
+          this.printer.print(source.sourcePath)
         );
-        this.config.logger.log("");
+        this.printer.print("");
         return;
       }
 
@@ -146,14 +146,14 @@ class DebugInterpreter {
     else {
       debug("absolute case");
       if (currentSourceId === null) {
-        this.config.logger.log("Cannot determine current file.");
+        this.printer.print("Cannot determine current file.");
         return;
       }
       let line = parseInt(args[0], 10); //want an integer
       debug("line %d", line);
 
       if (isNaN(line)) {
-        this.config.logger.log("Line number must be an integer.\n");
+        this.printer.print("Line number must be an integer.\n");
         return;
       }
 
@@ -170,7 +170,7 @@ class DebugInterpreter {
       //of course, this might result in finding that there's nowhere to
       //add it after that point
       if (breakpoint === null) {
-        this.config.logger.log(
+        this.printer.print(
           "Nowhere to add breakpoint at or beyond that location.\n"
         );
         return;
@@ -213,14 +213,12 @@ class DebugInterpreter {
     //cleared, report back that we can't do that
     if (setOrClear === alreadyExists) {
       if (setOrClear) {
-        this.config.logger.log(
+        this.printer.print(
           `Breakpoint at ${locationMessage} already exists.\n`
         );
         return;
       } else {
-        this.config.logger.log(
-          `No breakpoint at ${locationMessage} to remove.\n`
-        );
+        this.printer.print(`No breakpoint at ${locationMessage} to remove.\n`);
         return;
       }
     }
@@ -229,10 +227,10 @@ class DebugInterpreter {
     //also report back to the user on what happened
     if (setOrClear) {
       await this.session.addBreakpoint(breakpoint);
-      this.config.logger.log(`Breakpoint added at ${locationMessage}.\n`);
+      this.printer.print(`Breakpoint added at ${locationMessage}.\n`);
     } else {
       await this.session.removeBreakpoint(breakpoint);
-      this.config.logger.log(`Breakpoint removed at ${locationMessage}.\n`);
+      this.printer.print(`Breakpoint removed at ${locationMessage}.\n`);
     }
     return;
   }
@@ -251,9 +249,7 @@ class DebugInterpreter {
       prompt = DebugUtils.formatPrompt(this.config.network, this.txHash);
     } else {
       if (this.session.view(selectors.session.status.isError)) {
-        this.config.logger.log(
-          this.session.view(selectors.session.status.error)
-        );
+        this.printer.print(this.session.view(selectors.session.status.error));
       }
       this.printer.printHelp();
       prompt = DebugUtils.formatPrompt(this.config.network);
@@ -336,7 +332,7 @@ class DebugInterpreter {
             let count = parseInt(cmdArgs, 10);
             debug("cmdArgs=%s", cmdArgs);
             if (isNaN(count)) {
-              this.config.logger.log("Number of steps must be an integer.");
+              this.printer.print("Number of steps must be an integer.");
               break;
             }
             await this.session.advance(count);
@@ -360,11 +356,11 @@ class DebugInterpreter {
           //are we "finished" because we've reached the end, or because
           //nothing is loaded?
           if (this.session.view(selectors.session.status.loaded)) {
-            this.config.logger.log("Transaction has halted; cannot advance.");
-            this.config.logger.log("");
+            this.printer.print("Transaction has halted; cannot advance.");
+            this.printer.print("");
           } else {
-            this.config.logger.log("No transaction loaded.");
-            this.config.logger.log("");
+            this.printer.print("No transaction loaded.");
+            this.printer.print("");
           }
       }
     }
@@ -374,8 +370,8 @@ class DebugInterpreter {
       if (this.session.view(selectors.session.status.loaded)) {
         await this.session.reset();
       } else {
-        this.config.logger.log("No transaction loaded.");
-        this.config.logger.log("");
+        this.printer.print("No transaction loaded.");
+        this.printer.print("");
       }
     }
     if (cmd === "t") {
@@ -393,7 +389,7 @@ class DebugInterpreter {
         }
       } else {
         loadFailed = true;
-        this.config.logger.log(
+        this.printer.print(
           "Please unload the current transaction before loading a new one."
         );
       }
@@ -401,27 +397,27 @@ class DebugInterpreter {
     if (cmd === "T") {
       if (this.session.view(selectors.session.status.loaded)) {
         await this.session.unload();
-        this.config.logger.log("Transaction unloaded.");
+        this.printer.print("Transaction unloaded.");
         this.setPrompt(DebugUtils.formatPrompt(this.config.network));
       } else {
-        this.config.logger.log("No transaction to unload.");
-        this.config.logger.log("");
+        this.printer.print("No transaction to unload.");
+        this.printer.print("");
       }
     }
 
     // Check if execution has (just now) stopped.
     if (this.session.view(trace.finished) && !alreadyFinished) {
-      this.config.logger.log("");
+      this.printer.print("");
       //check if transaction failed
       if (!this.session.view(selectors.session.transaction.receipt).status) {
-        this.config.logger.log("Transaction halted with a RUNTIME ERROR.");
-        this.config.logger.log("");
-        this.config.logger.log(
+        this.printer.print("Transaction halted with a RUNTIME ERROR.");
+        this.printer.print("");
+        this.printer.print(
           "This is likely due to an intentional halting expression, like assert(), require() or revert(). It can also be due to out-of-gas exceptions. Please inspect your transaction parameters and contract code to determine the meaning of this error."
         );
       } else {
         //case if transaction succeeded
-        this.config.logger.log("Transaction completed successfully.");
+        this.printer.print("Transaction completed successfully.");
       }
     }
 
@@ -499,7 +495,7 @@ class DebugInterpreter {
           this.printer.printState();
         } else if (this.session.view(selectors.session.status.isError)) {
           let loadError = this.session.view(selectors.session.status.error);
-          this.config.logger.log(loadError);
+          this.printer.print(loadError);
         }
         break;
       case "T":

--- a/packages/truffle-core/lib/debug/interpreter.js
+++ b/packages/truffle-core/lib/debug/interpreter.js
@@ -1,0 +1,541 @@
+const debugModule = require("debug");
+const debug = debugModule("lib:debug:interpreter");
+
+const path = require("path");
+const util = require("util");
+const ora = require("ora");
+
+const DebugUtils = require("truffle-debug-utils");
+const selectors = require("truffle-debugger").selectors;
+const { session, solidity, trace, controller } = selectors;
+
+const analytics = require("../services/analytics");
+const ReplManager = require("../repl");
+
+const { DebugPrinter } = require("./printer");
+
+function watchExpressionAnalytics(raw) {
+  if (raw.includes("!<")) {
+    //don't send analytics for watch expressions involving selectors
+    return;
+  }
+  let expression = raw.trim();
+  //legal Solidity identifiers (= legal JS identifiers)
+  let identifierRegex = /^[a-zA-Z_$][a-zA-Z_$0-9]*$/;
+  let isVariable = expression.match(identifierRegex) !== null;
+  analytics.send({
+    command: "debug: watch expression",
+    args: { isVariable }
+  });
+}
+
+class DebugInterpreter {
+  constructor(config, session, spinner, txHash) {
+    this.config = config;
+    this.session = session;
+    this.spinner = spinner;
+    this.printer = new DebugPrinter(config, session);
+    this.txHash = txHash;
+    this.lastCommand = "n";
+
+    this.repl = config.repl || new ReplManager(config);
+    this.enabledExpressions = new Set();
+  }
+
+  async setOrClearBreakpoint(args, setOrClear) {
+    //setOrClear: true for set, false for clear
+    const currentLocation = this.session.view(controller.current.location);
+    const breakpoints = this.session.view(controller.breakpoints);
+
+    const currentNode = currentLocation.node ? currentLocation.node.id : null;
+    const currentLine = currentLocation.sourceRange
+      ? currentLocation.sourceRange.lines.start.line
+      : null;
+    const currentSourceId = currentLocation.source
+      ? currentLocation.source.id
+      : null;
+
+    let breakpoint = {};
+
+    if (args.length === 0) {
+      //no arguments, want currrent node
+      debug("node case");
+      if (currentNode === null) {
+        this.config.logger.log("Cannot determine current location.");
+        return;
+      }
+      breakpoint.node = currentNode;
+      breakpoint.line = currentLine;
+      breakpoint.sourceId = currentSourceId;
+    }
+
+    //the special case of "B all"
+    else if (args[0] === "all") {
+      if (setOrClear) {
+        // only "B all" is legal, not "b all"
+        this.config.logger.log("Cannot add breakpoint everywhere.\n");
+        return;
+      }
+      await this.session.removeAllBreakpoints();
+      this.config.logger.log("Removed all breakpoints.\n");
+      return;
+    }
+
+    //if the argument starts with a "+" or "-", we have a relative
+    //line number
+    else if (args[0][0] === "+" || args[0][0] === "-") {
+      debug("relative case");
+      if (currentLine === null) {
+        this.config.logger.log("Cannot determine current location.");
+        return;
+      }
+      let delta = parseInt(args[0], 10); //want an integer
+      debug("delta %d", delta);
+
+      if (isNaN(delta)) {
+        this.config.logger.log("Offset must be an integer.\n");
+        return;
+      }
+
+      breakpoint.sourceId = currentSourceId;
+      breakpoint.line = currentLine + delta;
+    }
+
+    //if it contains a colon, it's in the form source:line
+    else if (args[0].includes(":")) {
+      debug("source case");
+      let sourceArgs = args[0].split(":");
+      let sourceArg = sourceArgs[0];
+      let lineArg = sourceArgs[1];
+      debug("sourceArgs %O", sourceArgs);
+
+      //first let's get the line number as usual
+      let line = parseInt(lineArg, 10); //want an integer
+      if (isNaN(line)) {
+        this.config.logger.log("Line number must be an integer.\n");
+        return;
+      }
+
+      //search sources for given string
+      let sources = session.view(solidity.info.sources);
+
+      //we will indeed need the sources here, not just IDs
+      let matchingSources = Object.values(sources).filter(source =>
+        source.sourcePath.includes(sourceArg)
+      );
+
+      if (matchingSources.length === 0) {
+        this.config.logger.log(`No source file found matching ${sourceArg}.\n`);
+        return;
+      } else if (matchingSources.length > 1) {
+        this.config.logger.log(
+          `Multiple source files found matching ${sourceArg}.  Which did you mean?`
+        );
+        matchingSources.forEach(source =>
+          this.config.logger.log(source.sourcePath)
+        );
+        this.config.logger.log("");
+        return;
+      }
+
+      //otherwise, we found it!
+      breakpoint.sourceId = matchingSources[0].id;
+      breakpoint.line = line - 1; //adjust for zero-indexing!
+    }
+
+    //otherwise, it's a simple line number
+    else {
+      debug("absolute case");
+      if (currentSourceId === null) {
+        this.config.logger.log("Cannot determine current file.");
+        return;
+      }
+      let line = parseInt(args[0], 10); //want an integer
+      debug("line %d", line);
+
+      if (isNaN(line)) {
+        this.config.logger.log("Line number must be an integer.\n");
+        return;
+      }
+
+      breakpoint.sourceId = currentSourceId;
+      breakpoint.line = line - 1; //adjust for zero-indexing!
+    }
+
+    //OK, we've constructed the breakpoint!  But if we're adding, we'll
+    //want to adjust to make sure we don't set it on an empty line or
+    //anything like that
+    if (setOrClear) {
+      let resolver = this.session.view(controller.breakpoints.resolver);
+      breakpoint = resolver(breakpoint);
+      //of course, this might result in finding that there's nowhere to
+      //add it after that point
+      if (breakpoint === null) {
+        this.config.logger.log(
+          "Nowhere to add breakpoint at or beyond that location.\n"
+        );
+        return;
+      }
+    }
+
+    //having constructed and adjusted breakpoint, here's now a
+    //user-readable message describing its location
+    let sourceNames = Object.assign(
+      {},
+      ...Object.values(this.session.view(solidity.info.sources)).map(
+        ({ id, sourcePath }) => ({
+          [id]: path.basename(sourcePath)
+        })
+      )
+    );
+    let locationMessage = DebugUtils.formatBreakpointLocation(
+      breakpoint,
+      true,
+      currentSourceId,
+      sourceNames
+    );
+
+    //one last check -- does this breakpoint already exist?
+    let alreadyExists =
+      breakpoints.filter(
+        existingBreakpoint =>
+          existingBreakpoint.sourceId === breakpoint.sourceId &&
+          existingBreakpoint.line === breakpoint.line &&
+          existingBreakpoint.node === breakpoint.node //may be undefined
+      ).length > 0;
+
+    //NOTE: in the "set breakpoint" case, the above check is somewhat
+    //redundant, as we're going to check again when we actually make the
+    //call to add or remove the breakpoint!  But we need to check here so
+    //that we can display the appropriate message.  Hopefully we can find
+    //some way to avoid this redundant check in the future.
+
+    //if it already exists and is being set, or doesn't and is being
+    //cleared, report back that we can't do that
+    if (setOrClear === alreadyExists) {
+      if (setOrClear) {
+        this.config.logger.log(
+          `Breakpoint at ${locationMessage} already exists.\n`
+        );
+        return;
+      } else {
+        this.config.logger.log(
+          `No breakpoint at ${locationMessage} to remove.\n`
+        );
+        return;
+      }
+    }
+
+    //finally, if we've reached this point, do it!
+    //also report back to the user on what happened
+    if (setOrClear) {
+      await this.session.addBreakpoint(breakpoint);
+      this.config.logger.log(`Breakpoint added at ${locationMessage}.\n`);
+    } else {
+      await this.session.removeBreakpoint(breakpoint);
+      this.config.logger.log(`Breakpoint removed at ${locationMessage}.\n`);
+    }
+    return;
+  }
+
+  start(terminate) {
+    let prompt;
+
+    if (this.session.view(selectors.session.status.loaded)) {
+      this.spinner.succeed();
+      this.printer.printAddressesAffected();
+      this.printer.printHelp();
+      debug("Help printed");
+      this.printer.printFile();
+      debug("File printed");
+      this.printer.printState();
+      debug("State printed");
+      prompt = DebugUtils.formatPrompt(this.config.network, this.txHash);
+    } else {
+      if (this.session.view(selectors.session.status.isError)) {
+        this.spinner.fail();
+        this.config.logger.log(
+          this.session.view(selectors.session.status.error)
+        );
+      } else {
+        this.spinner.succeed();
+      }
+      this.printer.printHelp();
+      prompt = DebugUtils.formatPrompt(this.config.network);
+    }
+
+    this.repl.start({
+      prompt,
+      interpreter: util.callbackify(this.interpreter.bind(this)),
+      ignoreUndefined: true,
+      done: terminate
+    });
+  }
+
+  setPrompt(prompt) {
+    this.repl.activate.bind(this.repl)({
+      prompt,
+      context: {},
+      //this argument only *adds* things, so it's safe to set it to {}
+      ignoreUndefined: true
+      //set to true because it's set to true below :P
+    });
+  }
+
+  async interpreter(cmd) {
+    cmd = cmd.trim();
+    let cmdArgs, splitArgs;
+    debug("cmd %s", cmd);
+
+    if (cmd === ".exit") {
+      cmd = "q";
+    }
+
+    //split arguments for commands that want that; split on runs of spaces
+    splitArgs = cmd
+      .trim()
+      .split(/ +/)
+      .slice(1);
+    debug("splitArgs %O", splitArgs);
+
+    //warning: this bit *alters* cmd!
+    if (cmd.length > 0) {
+      cmdArgs = cmd.slice(1).trim();
+      cmd = cmd[0];
+    }
+
+    if (cmd === "") {
+      cmd = this.lastCommand;
+      cmdArgs = "";
+      splitArgs = [];
+    }
+
+    //quit if that's what we were given
+    if (cmd === "q") {
+      return await util.promisify(this.repl.stop.bind(this.repl))();
+    }
+
+    let alreadyFinished = this.session.view(trace.finishedOrUnloaded);
+    let loadFailed = false;
+
+    // If not finished, perform commands that require state changes
+    // (other than quitting or resetting)
+    if (!alreadyFinished) {
+      let stepSpinner = ora("Stepping...").start();
+      switch (cmd) {
+        case "o":
+          await this.session.stepOver();
+          break;
+        case "i":
+          await this.session.stepInto();
+          break;
+        case "u":
+          await this.session.stepOut();
+          break;
+        case "n":
+          await this.session.stepNext();
+          break;
+        case ";":
+          //two cases -- parameterized and unparameterized
+          if (cmdArgs !== "") {
+            let count = parseInt(cmdArgs, 10);
+            debug("cmdArgs=%s", cmdArgs);
+            if (isNaN(count)) {
+              this.config.logger.log("Number of steps must be an integer.");
+              break;
+            }
+            await this.session.advance(count);
+          } else {
+            await this.session.advance();
+          }
+          break;
+        case "c":
+          await this.session.continueUntilBreakpoint();
+          break;
+      }
+      stepSpinner.stop();
+    } //otherwise, inform the user we can't do that
+    else {
+      switch (cmd) {
+        case "o":
+        case "i":
+        case "u":
+        case "n":
+        case "c":
+          //are we "finished" because we've reached the end, or because
+          //nothing is loaded?
+          if (this.session.view(selectors.session.status.loaded)) {
+            this.config.logger.log("Transaction has halted; cannot advance.");
+            this.config.logger.log("");
+          } else {
+            this.config.logger.log("No transaction loaded.");
+            this.config.logger.log("");
+          }
+      }
+    }
+    if (cmd === "r") {
+      //reset if given the reset command
+      //(but not if nothing is loaded)
+      if (this.session.view(selectors.session.status.loaded)) {
+        await this.session.reset();
+      } else {
+        this.config.logger.log("No transaction loaded.");
+        this.config.logger.log("");
+      }
+    }
+    if (cmd === "t") {
+      if (!this.session.view(selectors.session.status.loaded)) {
+        let txSpinner = ora(DebugUtils.formatTransactionStartMessage()).start();
+        await this.session.load(cmdArgs);
+        //if load succeeded
+        if (this.session.view(selectors.session.status.success)) {
+          txSpinner.succeed();
+          //if successful, change prompt
+          this.setPrompt(DebugUtils.formatPrompt(this.config.network, cmdArgs));
+        } else {
+          txSpinner.fail();
+          loadFailed = true;
+        }
+      } else {
+        loadFailed = true;
+        this.config.logger.log(
+          "Please unload the current transaction before loading a new one."
+        );
+      }
+    }
+    if (cmd === "T") {
+      if (this.session.view(selectors.session.status.loaded)) {
+        await this.session.unload();
+        this.config.logger.log("Transaction unloaded.");
+        this.setPrompt(DebugUtils.formatPrompt(this.config.network));
+      } else {
+        this.config.logger.log("No transaction to unload.");
+        this.config.logger.log("");
+      }
+    }
+
+    // Check if execution has (just now) stopped.
+    if (this.session.view(trace.finished) && !alreadyFinished) {
+      this.config.logger.log("");
+      //check if transaction failed
+      if (!this.session.view(selectors.session.transaction.receipt).status) {
+        this.config.logger.log("Transaction halted with a RUNTIME ERROR.");
+        this.config.logger.log("");
+        this.config.logger.log(
+          "This is likely due to an intentional halting expression, like assert(), require() or revert(). It can also be due to out-of-gas exceptions. Please inspect your transaction parameters and contract code to determine the meaning of this error."
+        );
+      } else {
+        //case if transaction succeeded
+        this.config.logger.log("Transaction completed successfully.");
+      }
+    }
+
+    // Perform post printing
+    // (we want to see if execution stopped before printing state).
+    switch (cmd) {
+      case "+":
+        if (cmdArgs[0] === ":") {
+          watchExpressionAnalytics(cmdArgs.substring(1));
+        }
+        this.enabledExpressions.add(cmdArgs);
+        await this.printer.printWatchExpressionResult(cmdArgs);
+        break;
+      case "-":
+        this.enabledExpressions.delete(cmdArgs);
+        break;
+      case "!":
+        this.printer.printSelector(cmdArgs);
+        break;
+      case "?":
+        this.printer.printWatchExpressions(this.enabledExpressions);
+        this.printer.printBreakpoints();
+        break;
+      case "v":
+        await this.printer.printVariables();
+        break;
+      case ":":
+        watchExpressionAnalytics(cmdArgs);
+        this.printer.evalAndPrintExpression(cmdArgs);
+        break;
+      case "b":
+        await this.setOrClearBreakpoint(splitArgs, true);
+        break;
+      case "B":
+        await this.setOrClearBreakpoint(splitArgs, false);
+        break;
+      case ";":
+      case "p":
+        if (this.session.view(selectors.session.status.loaded)) {
+          this.printer.printFile();
+          this.printer.printInstruction();
+          this.printer.printState();
+        }
+        await this.printer.printWatchExpressionsResults(
+          this.enabledExpressions
+        );
+        break;
+      case "o":
+      case "i":
+      case "u":
+      case "n":
+      case "c":
+        if (!this.session.view(trace.finishedOrUnloaded)) {
+          if (!this.session.view(solidity.current.source).source) {
+            this.printer.printInstruction();
+          }
+          this.printer.printFile();
+          this.printer.printState();
+        }
+        await this.printer.printWatchExpressionsResults(
+          this.enabledExpressions
+        );
+        break;
+      case "r":
+        if (this.session.view(selectors.session.status.loaded)) {
+          this.printer.printAddressesAffected();
+          this.printer.printFile();
+          this.printer.printState();
+        }
+        break;
+      case "t":
+        if (!loadFailed) {
+          this.printer.printAddressesAffected();
+          this.printer.printFile();
+          this.printer.printState();
+        } else if (this.session.view(selectors.session.status.isError)) {
+          let loadError = this.session.view(selectors.session.status.error);
+          this.config.logger.log(loadError);
+        }
+        break;
+      case "T":
+        //nothing to print
+        break;
+      default:
+        this.printer.printHelp();
+    }
+
+    if (
+      cmd !== "i" &&
+      cmd !== "u" &&
+      cmd !== "b" &&
+      cmd !== "B" &&
+      cmd !== "v" &&
+      cmd !== "h" &&
+      cmd !== "p" &&
+      cmd !== "?" &&
+      cmd !== "!" &&
+      cmd !== ":" &&
+      cmd !== "+" &&
+      cmd !== "r" &&
+      cmd !== "-" &&
+      cmd !== "t" &&
+      cmd !== "T"
+    ) {
+      this.lastCommand = cmd;
+    }
+  }
+}
+
+module.exports = {
+  DebugInterpreter
+};

--- a/packages/truffle-core/lib/debug/interpreter.js
+++ b/packages/truffle-core/lib/debug/interpreter.js
@@ -30,10 +30,9 @@ function watchExpressionAnalytics(raw) {
 }
 
 class DebugInterpreter {
-  constructor(config, session, spinner, txHash) {
+  constructor(config, session, txHash) {
     this.config = config;
     this.session = session;
-    this.spinner = spinner;
     this.printer = new DebugPrinter(config, session);
     this.txHash = txHash;
     this.lastCommand = "n";
@@ -242,7 +241,6 @@ class DebugInterpreter {
     let prompt;
 
     if (this.session.view(selectors.session.status.loaded)) {
-      this.spinner.succeed();
       this.printer.printAddressesAffected();
       this.printer.printHelp();
       debug("Help printed");
@@ -253,12 +251,10 @@ class DebugInterpreter {
       prompt = DebugUtils.formatPrompt(this.config.network, this.txHash);
     } else {
       if (this.session.view(selectors.session.status.isError)) {
-        this.spinner.fail();
         this.config.logger.log(
           this.session.view(selectors.session.status.error)
         );
       } else {
-        this.spinner.succeed();
       }
       this.printer.printHelp();
       prompt = DebugUtils.formatPrompt(this.config.network);

--- a/packages/truffle-core/lib/debug/printer.js
+++ b/packages/truffle-core/lib/debug/printer.js
@@ -195,7 +195,7 @@ class DebugPrinter {
 
     this.config.logger.log();
 
-    Object.keys(variables).forEach(function(name) {
+    Object.keys(variables).forEach(name => {
       let paddedName = name + ":";
 
       while (paddedName.length <= longestNameLength) {

--- a/packages/truffle-core/lib/debug/printer.js
+++ b/packages/truffle-core/lib/debug/printer.js
@@ -32,6 +32,10 @@ class DebugPrinter {
     };
   }
 
+  print(...args) {
+    this.config.logger.log(...args);
+  }
+
   printAddressesAffected() {
     const affectedInstances = this.session.view(session.info.affectedInstances);
 

--- a/packages/truffle-core/lib/debug/printer.js
+++ b/packages/truffle-core/lib/debug/printer.js
@@ -1,5 +1,5 @@
 const debugModule = require("debug");
-const debug = debugModule("lib:debug");
+const debug = debugModule("lib:debug:printer");
 
 const path = require("path");
 const safeEval = require("safe-eval");

--- a/packages/truffle-debug-utils/index.js
+++ b/packages/truffle-debug-utils/index.js
@@ -4,6 +4,7 @@ var path = require("path");
 var async = require("async");
 var debug = require("debug")("lib:debug");
 var BN = require("bn.js");
+var util = require("util");
 
 var commandReference = {
   "o": "step over",
@@ -313,6 +314,26 @@ var DebugUtils = {
     }
 
     return formatted.join(OS.EOL);
+  },
+
+  formatValue: function(value, indent) {
+    if (!indent) {
+      indent = 0;
+    }
+
+    return util
+      .inspect(value, {
+        colors: true,
+        depth: null,
+        breakLength: 30
+      })
+      .split(/\r?\n/g)
+      .map(function(line, i) {
+        // don't indent first line
+        const padding = i > 0 ? Array(indent).join(" ") : "";
+        return padding + line;
+      })
+      .join(OS.EOL);
   },
 
   //HACK


### PR DESCRIPTION
That's it. I couldn't take it anymore. #2025 was the last straw.

- Switch to `const`s and `let`s instead of `var`s
- Move a function to debug-utils (`formatValue`)
- Split up lib/commands/debug into:
  - a thing that does the compilation (DebugCompiler)
  - a thing that houses all the copious print methods (DebugPrinter)
  - a thing that inelegantly wraps the giant repl interpreter function that does all that printing (DebugInterpreter)
  - a CLIDebugger class that does compilation and sets up the interpreter
- Make the code not gosh darn impossible to read.
- Expose how the heck this could actually be organized in the future.