### PR TITLE
allow compile of an object

### DIFF
--- a/packages/truffle-core/lib/debug/index.js
+++ b/packages/truffle-core/lib/debug/index.js
@@ -11,6 +11,7 @@ const DebugUtils = require("truffle-debug-utils");
 
 const { DebugInterpreter } = require("./interpreter");
 const { DebugCompiler } = require("./compiler");
+const { DebugObjectCompiler } = require("./object-compiler");
 
 class CLIDebugger {
   constructor(config) {
@@ -38,7 +39,11 @@ class CLIDebugger {
   async compileSources() {
     const compileSpinner = ora("Compiling your contracts...").start();
 
-    const compilation = await new DebugCompiler(this.config).compile();
+    // if debugObjects we compile the files as properties of an object
+    // otherwise we debug them as files
+    const compilation = this.config.debugObjects
+      ? await new DebugObjectCompiler(this.config).compile()
+      : await new DebugCompiler(this.config).compile();
 
     compileSpinner.succeed();
 

--- a/packages/truffle-core/lib/debug/interpreter.js
+++ b/packages/truffle-core/lib/debug/interpreter.js
@@ -7,7 +7,7 @@ const ora = require("ora");
 
 const DebugUtils = require("truffle-debug-utils");
 const selectors = require("truffle-debugger").selectors;
-const { session, solidity, trace, controller } = selectors;
+const { solidity, trace, controller } = selectors;
 
 const analytics = require("../services/analytics");
 const ReplManager = require("../repl");
@@ -116,7 +116,7 @@ class DebugInterpreter {
       }
 
       //search sources for given string
-      let sources = session.view(solidity.info.sources);
+      let sources = this.session.view(solidity.info.sources);
 
       //we will indeed need the sources here, not just IDs
       let matchingSources = Object.values(sources).filter(source =>

--- a/packages/truffle-core/lib/debug/object-compiler.js
+++ b/packages/truffle-core/lib/debug/object-compiler.js
@@ -13,10 +13,7 @@ class DebugObjectCompiler {
   async compile() {
     // all the file names
     const fileNames = await new Promise((resolve, reject) =>
-      fs.readdir(`${this.config.working_directory}/contracts`, function(
-        err,
-        filePaths
-      ) {
+      fs.readdir(this.config.contracts_directory, function(err, filePaths) {
         if (err) {
           return reject(err);
         }
@@ -29,7 +26,7 @@ class DebugObjectCompiler {
       fileNames.map(file =>
         new Promise((resolve, reject) =>
           fs.readFile(
-            `${this.config.working_directory}/contracts/${file}`,
+            `${this.config.contracts_directory}/${file}`,
             (err, text) => {
               if (err) {
                 return reject(err);

--- a/packages/truffle-core/lib/debug/object-compiler.js
+++ b/packages/truffle-core/lib/debug/object-compiler.js
@@ -1,0 +1,76 @@
+const compile = require("truffle-compile");
+const fs = require("fs");
+
+// this class copes with a directory of .sol files each if which
+// becomes a property of an object which is then compiled
+// the imports in these files will be in the form
+// import "file"
+// rather than import "file.sol"
+class DebugObjectCompiler {
+  constructor(config) {
+    this.config = config;
+  }
+  async compile() {
+    // all the file names
+    const fileNames = await new Promise((resolve, reject) =>
+      fs.readdir(`${this.config.working_directory}/contracts`, function(
+        err,
+        filePaths
+      ) {
+        if (err) {
+          return reject(err);
+        }
+        return resolve(filePaths);
+      })
+    );
+    // this is an object containing solidity code as properties
+    // hence imports can be without the .sol extension
+    const objectToCompile = await Promise.all(
+      fileNames.map(file =>
+        new Promise((resolve, reject) =>
+          fs.readFile(
+            `${this.config.working_directory}/contracts/${file}`,
+            (err, text) => {
+              if (err) {
+                return reject(err);
+              }
+              resolve(text);
+            }
+          )
+        ).then(text => ({
+          file,
+          text
+        }))
+      )
+    ).then(files =>
+      files.reduce((acc, { file, text }) => {
+        // nasty mutate as no object spread operator
+        acc[file.substring(0, file.indexOf(".sol"))] = text.toString();
+        return acc;
+      }, {})
+    );
+    const { contracts, files } = await new Promise((accept, reject) => {
+      //we need to set up a config object for the compiler.
+      //it's the same as the existing config, but we turn on quiet.
+      //unfortunately, we don't have Babel here, so cloning is annoying.
+      let compileConfig = Object.assign(
+        {},
+        ...Object.entries(this.config).map(([key, value]) => ({ [key]: value }))
+      ); //clone
+      compileConfig.quiet = true;
+
+      compile(objectToCompile, compileConfig, (err, contracts, files) => {
+        if (err) {
+          return reject(err);
+        }
+
+        return accept({ contracts, files });
+      });
+    });
+    return { contracts, files };
+  }
+}
+
+module.exports = {
+  DebugObjectCompiler
+};


### PR DESCRIPTION
as per #2025 - this allows the .sol files to specify properties of an object hence allowing imports without the .sol extension.

a config property "debugObjects" if truthy controls if this happens.