### PR TITLE
Fix ethpm bug

### DIFF
--- a/packages/truffle-core/lib/commands/install.js
+++ b/packages/truffle-core/lib/commands/install.js
@@ -1,29 +1,30 @@
-var command = {
-  command: 'install',
-  description: 'Install a package from the Ethereum Package Registry',
+const command = {
+  command: "install",
+  description: "Install a package from the Ethereum Package Registry",
   builder: {},
   help: {
     usage: "truffle install <package_name>[@<version>]",
     options: [
       {
         option: "package_name",
-        description: "Name of the package as listed in the Ethereum Package Registry. (required)",
-      },{
-        option: "<@version>",
-        description: "When specified, will install a specific version of the package, otherwise " +
-          "will install\n                    the latest version.",
+        description:
+          "Name of the package as listed in the Ethereum Package Registry. (required)"
       },
+      {
+        option: "<@version>",
+        description:
+          "When specified, will install a specific version of the package, otherwise " +
+          "will install\n                    the latest version."
+      }
     ]
   },
-  run: function (options, done) {
-    var Config = require("truffle-config");
-    var Package = require("../package");
+  run: function(options, done) {
+    const Config = require("truffle-config");
+    const Package = require("../package");
 
-    if (options._ && options._.length > 0) {
-      options.packages = options._;
-    }
+    if (options._ && options._.length > 0) options.packages = options._;
 
-    var config = Config.detect(options);
+    const config = Config.detect(options);
     Package.install(config, done);
   }
 };

--- a/packages/truffle/test/scenarios/commands/install.js
+++ b/packages/truffle/test/scenarios/commands/install.js
@@ -1,0 +1,30 @@
+const CommandRunner = require("../commandrunner");
+const sandbox = require("../sandbox");
+const assert = require("assert");
+const fse = require("fs-extra");
+const path = require("path");
+let config;
+
+describe("truffle install", () => {
+  before(async () => {
+    config = await sandbox.create(
+      path.join(__dirname, "../../sources/install/init")
+    );
+    config.logger = { log: () => {} };
+  });
+
+  it("unboxes successfully", done => {
+    CommandRunner.run("install zeppelin", config, error => {
+      if (error) {
+        console.log("%o", error);
+        assert(false, "An error occured while installing");
+      }
+
+      const theInstallDirExists = fse.pathExistsSync(
+        path.join(config.working_directory, "installed_contracts")
+      );
+      assert(theInstallDirExists);
+      done();
+    });
+  }).timeout(20000);
+});

--- a/packages/truffle/test/scenarios/sandbox.js
+++ b/packages/truffle/test/scenarios/sandbox.js
@@ -19,20 +19,21 @@ module.exports = {
       if (!fs.existsSync(source))
         return reject(`Sandbox failed: source: ${source} does not exist`);
 
-      tmp.dir((err, dir) => {
-        if (err) return reject(err);
-
+      try {
+        const tempDir = tmp.dirSync({ unsafeCleanup: true });
         self
-          .copyDirectory(source, dir)
+          .copyDirectory(source, tempDir.name)
           .then(() => {
             const conf = config.load(
-              path.join(dir, subPath, "truffle-config.js"),
+              path.join(tempDir.name, subPath, "truffle-config.js"),
               {}
             );
             resolve(conf);
           })
           .catch(reject);
-      });
+      } catch (error) {
+        reject(error);
+      }
     });
   },
 

--- a/packages/truffle/test/sources/install/init/contracts/Migrations.sol
+++ b/packages/truffle/test/sources/install/init/contracts/Migrations.sol
@@ -1,0 +1,23 @@
+pragma solidity ^0.5.0;
+
+contract Migrations {
+  address public owner;
+  uint public last_completed_migration;
+
+  constructor() public {
+    owner = msg.sender;
+  }
+
+  modifier restricted() {
+    if (msg.sender == owner) _;
+  }
+
+  function setCompleted(uint completed) public restricted {
+    last_completed_migration = completed;
+  }
+
+  function upgrade(address new_address) public restricted {
+    Migrations upgraded = Migrations(new_address);
+    upgraded.setCompleted(last_completed_migration);
+  }
+}

--- a/packages/truffle/test/sources/install/init/migrations/1_initial_migration.js
+++ b/packages/truffle/test/sources/install/init/migrations/1_initial_migration.js
@@ -1,0 +1,5 @@
+var Migrations = artifacts.require("./Migrations.sol");
+
+module.exports = function(deployer) {
+  deployer.deploy(Migrations);
+};

--- a/packages/truffle/test/sources/install/init/truffle-config.js
+++ b/packages/truffle/test/sources/install/init/truffle-config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  // See <http://truffleframework.com/docs/advanced/configuration>
+  // to customize your Truffle configuration!
+  networks: {
+    development: {
+      host: "127.0.0.1",
+      port: 8545,
+      network_id: "*",
+      gas: 4700000,
+      gasPrice: 20000000000
+    }
+  }
+};


### PR DESCRIPTION
When implementing the Web3Shim (I think), a Web3 require statement was removed in `packages/truffle-core/lib/package.js`. This caused `truffle install` to fail. This PR adds the require statement back in. In addition it provides some pretty output at the end of the job stating that packages were installed.

The output for this command now will look like the following:
<img width="1106" alt="Screen Shot 2019-05-17 at 6 31 56 PM" src="https://user-images.githubusercontent.com/14827965/57947013-0a285900-78de-11e9-818f-7f2a8e1c51fa.png">

It also adds a basic test for `truffle install`, ensuring that `truffle install zeppelin` completes successfully and a basic `truffle init` project has the "installed_contracts" directory that `truffle install xxx` creates.