### PR TITLE
Get revert reason from Geth clients

### DIFF
--- a/packages/truffle-contract/lib/reason.js
+++ b/packages/truffle-contract/lib/reason.js
@@ -37,9 +37,9 @@ const reason = {
    */
   get: function(params, web3){
     const packet = {
-      jsonrpc: "2.0",
-      method: "eth_call",
-      params: [params],
+      jsonrpc: '2.0',
+      method: 'eth_call',
+      params: [params, 'latest'],
       id: new Date().getTime(),
     };
 

--- a/packages/truffle-contract/test/methods.js
+++ b/packages/truffle-contract/test/methods.js
@@ -453,6 +453,29 @@ describe("Methods", function() {
       }
     });
 
+    it("errors with a revert reason", async function() {
+      const example = await Example.new(1);
+      try {
+        // At the moment, this test can't rely on truffle-contract's
+        // gas estimation when running with geth.
+        await example.triggerRequireWithReasonError({gas: 1000000});
+        assert.fail();
+      } catch (e) {
+        assert(
+          e.reason === "reasonstring",
+          "Triggered require result should have revert reason field"
+        );
+        assert(
+          e.message.includes("reasonstring"),
+          "Triggered require should include reason in error message"
+        );
+        assert(
+          e.receipt.status === false,
+          "Triggered require should have receipt status:`false`"
+        )
+      }
+    });
+
     it("errors when setting `numberFormat` to invalid value", async function() {
       try {
         Example.numberFormat = "bigNumber";


### PR DESCRIPTION
Continuation of #1652 (cherry picked its first commit). That PR is marked Quorum/Enterprise but this problem affects truffle-contract use with geth generally.  

Geth [requires that eth_call use a block param](https://github.com/ethereum/go-ethereum/issues/2472) and its absence means that `truffle-contract` isn't able to correctly replay  failed transactions and get a reason returned as data. 

Believe 'latest' is the right value here - should work with both instamining dev clients and regular networks. Truffle-contract fetches the reason in a call immediately following a failed tx - 'latest' will be typically be the relevant block.

Have added a test in the [ @ geth ] methods suite.

Additional notes:
+  Ganache returns a gas estimate for transactions that fail, geth doesn't. If you're using `truffle-contract` *outside the truffle cli context* (e.g. a browser), targeting geth, and relying on automatic gas estimation, you won't be able to fetch the reason string because your tx will always OOG.

+ Still doesn't seem possible to get a reason string from a failing `require` in a contract constructor with Geth. This needs more investigation but it might be an issue in web3 1.0.0-beta.37. 