### PR TITLE
Internal improvement: Fix `before` on deployment scenario tests

### DIFF
--- a/packages/truffle/test/scenarios/commands/deploy.js
+++ b/packages/truffle/test/scenarios/commands/deploy.js
@@ -7,13 +7,19 @@ const path = require("path");
 describe("truffle deploy (alias for migrate)", () => {
   let config, projectPath;
 
-  before("before all setup", async () => {
-    await Server.start();
+  before("before all setup", done => {
     projectPath = path.join(__dirname, "../../sources/migrations/init");
-    config = await sandbox.create(projectPath);
-    config.logger = { log: () => {} };
+    sandbox
+      .create(projectPath)
+      .then(conf => {
+        config = conf;
+        config.network = "development";
+        config.logger = { log: () => {} };
+      })
+      .then(() => Server.start(done));
   });
-  after(async () => await Server.stop());
+
+  after(done => Server.stop(done));
 
   describe("when run on the most basic truffle project", () => {
     it("doesn't throw", done => {

--- a/packages/truffle/test/scenarios/commands/migrate.js
+++ b/packages/truffle/test/scenarios/commands/migrate.js
@@ -7,13 +7,19 @@ const path = require("path");
 describe("truffle migrate", () => {
   let config, projectPath;
 
-  before("before all setup", async () => {
-    await Server.start();
+  before("before all setup", done => {
     projectPath = path.join(__dirname, "../../sources/migrations/init");
-    config = await sandbox.create(projectPath);
-    config.logger = { log: () => {} };
+    sandbox
+      .create(projectPath)
+      .then(conf => {
+        config = conf;
+        config.network = "development";
+        config.logger = { log: () => {} };
+      })
+      .then(() => Server.start(done));
   });
-  after(async () => await Server.stop());
+
+  after(done => Server.stop(done));
 
   describe("when run on the most basic truffle project", () => {
     it("doesn't throw", done => {


### PR DESCRIPTION
Looks like `Server.start/stop` currently expects a `done` callback to be passed to it.

This PR fixes two currently uncaught failing `geth` tests (https://travis-ci.org/trufflesuite/truffle/jobs/534960586#L760) & (https://travis-ci.org/trufflesuite/truffle/jobs/534960586#L785).