### PR TITLE
Internal improvement: Remove extra build in geth & integration job

### DIFF
--- a/packages/truffle/scripts/test.sh
+++ b/packages/truffle/scripts/test.sh
@@ -3,9 +3,9 @@
 set -o errexit
 
 if [ "$GETH" == true ]; then
-  yarn build-cli && mocha --timeout 50000 --grep @ganache --invert --colors $@
+  mocha --timeout 50000 --grep @ganache --invert --colors $@
 elif [ "$COVERAGE" == true ]; then
   NO_BUILD=true mocha --no-warnings --timeout 7000 --grep @geth --invert --colors $@
 else
-  yarn build-cli && mocha --no-warnings --timeout 7000 --grep @geth --invert --colors $@
+  mocha --no-warnings --timeout 7000 --grep @geth --invert --colors $@
 fi

--- a/packages/truffle/scripts/test.sh
+++ b/packages/truffle/scripts/test.sh
@@ -6,6 +6,8 @@ if [ "$GETH" == true ]; then
   mocha --timeout 50000 --grep @ganache --invert --colors $@
 elif [ "$COVERAGE" == true ]; then
   NO_BUILD=true mocha --no-warnings --timeout 7000 --grep @geth --invert --colors $@
-else
+elif [ "$INTEGRATION" == true ]; then
   mocha --no-warnings --timeout 7000 --grep @geth --invert --colors $@
+else
+  yarn build-cli && mocha --no-warnings --timeout 7000 --grep @geth --invert --colors $@
 fi


### PR DESCRIPTION
Now that we leverage lerna for bootstrapping, no need to build truffle twice in CI!