### PR TITLE
Enhancement: Remove solc-js compiler from the bundle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ cache:
   directories:
     - node_modules
     - $(npm config get prefix)/lib/node_modules # globally installed stuff (i.e. lerna)
+    - ~/.config/truffle/compilers
 
 script:
   - yarn ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
 
 install:
   - yarn bootstrap
+  - truffle obtain --solc=0.5.0
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
 
 install:
   - yarn bootstrap
-  - truffle obtain --solc=0.5.0
+  - truffle obtain --solc=0.5.8
 
 cache:
   directories:

--- a/packages/truffle-compile/compilerSupplier/index.js
+++ b/packages/truffle-compile/compilerSupplier/index.js
@@ -2,18 +2,12 @@ const path = require("path");
 const fs = require("fs");
 const semver = require("semver");
 
-const {
-  Bundled,
-  Docker,
-  Local,
-  Native,
-  VersionRange
-} = require("./loadingStrategies");
+const { Docker, Local, Native, VersionRange } = require("./loadingStrategies");
 
 class CompilerSupplier {
   constructor(_config) {
     _config = _config || {};
-    const defaultConfig = { version: null };
+    const defaultConfig = { version: "0.5.0" };
     this.config = Object.assign({}, defaultConfig, _config);
     this.strategyOptions = { version: this.config.version };
   }
@@ -50,7 +44,6 @@ class CompilerSupplier {
       let strategy;
       const useDocker = this.config.docker;
       const useNative = userSpecification === "native";
-      const useBundledSolc = !userSpecification;
       const useSpecifiedLocal =
         userSpecification && this.fileExists(userSpecification);
       const isValidVersionRange = semver.validRange(userSpecification);
@@ -59,8 +52,6 @@ class CompilerSupplier {
         strategy = new Docker(this.strategyOptions);
       } else if (useNative) {
         strategy = new Native(this.strategyOptions);
-      } else if (useBundledSolc) {
-        strategy = new Bundled(this.strategyOptions);
       } else if (useSpecifiedLocal) {
         strategy = new Local(this.strategyOptions);
       } else if (isValidVersionRange) {

--- a/packages/truffle-compile/compilerSupplier/index.js
+++ b/packages/truffle-compile/compilerSupplier/index.js
@@ -7,7 +7,7 @@ const { Docker, Local, Native, VersionRange } = require("./loadingStrategies");
 class CompilerSupplier {
   constructor(_config) {
     _config = _config || {};
-    const defaultConfig = { version: "0.5.0" };
+    const defaultConfig = { version: "0.5.8" };
     this.config = Object.assign({}, defaultConfig, _config);
     this.strategyOptions = { version: this.config.version };
   }

--- a/packages/truffle-compile/compilerSupplier/loadingStrategies/VersionRange.js
+++ b/packages/truffle-compile/compilerSupplier/loadingStrategies/VersionRange.js
@@ -5,7 +5,7 @@ const ora = require("ora");
 const originalRequire = require("original-require");
 const request = require("request-promise");
 const semver = require("semver");
-const solcWrap = require("solc/wrapper");
+const solcWrap = require("truffle-solc-wrapper");
 const LoadingStrategy = require("./LoadingStrategy");
 
 class VersionRange extends LoadingStrategy {

--- a/packages/truffle-compile/compilerSupplier/loadingStrategies/VersionRange.js
+++ b/packages/truffle-compile/compilerSupplier/loadingStrategies/VersionRange.js
@@ -5,7 +5,7 @@ const ora = require("ora");
 const originalRequire = require("original-require");
 const request = require("request-promise");
 const semver = require("semver");
-const solcWrap = require("truffle-solc-wrapper");
+const solcWrap = require("solc/wrapper");
 const LoadingStrategy = require("./LoadingStrategy");
 
 class VersionRange extends LoadingStrategy {

--- a/packages/truffle-compile/compilerSupplier/loadingStrategies/index.js
+++ b/packages/truffle-compile/compilerSupplier/loadingStrategies/index.js
@@ -1,5 +1,4 @@
 module.exports = {
-  Bundled: require("./Bundled"),
   Docker: require("./Docker"),
   LoadingStrategy: require("./LoadingStrategy"),
   Local: require("./Local"),

--- a/packages/truffle-compile/package.json
+++ b/packages/truffle-compile/package.json
@@ -13,6 +13,7 @@
     "request-promise": "^4.2.2",
     "require-from-string": "^2.0.2",
     "semver": "^5.6.0",
+    "solc": "^0.5.0",
     "truffle-config": "^1.1.12",
     "truffle-contract-sources": "^0.1.3",
     "truffle-error": "^0.0.4",

--- a/packages/truffle-compile/package.json
+++ b/packages/truffle-compile/package.json
@@ -17,8 +17,7 @@
     "truffle-config": "^1.1.12",
     "truffle-contract-sources": "^0.1.3",
     "truffle-error": "^0.0.4",
-    "truffle-expect": "^0.0.8",
-    "truffle-solc-wrapper": "https://github.com/trufflesuite/truffle-solc-wrapper"
+    "truffle-expect": "^0.0.8"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",

--- a/packages/truffle-compile/package.json
+++ b/packages/truffle-compile/package.json
@@ -13,11 +13,11 @@
     "request-promise": "^4.2.2",
     "require-from-string": "^2.0.2",
     "semver": "^5.6.0",
-    "solc": "0.5.0",
     "truffle-config": "^1.1.12",
     "truffle-contract-sources": "^0.1.3",
     "truffle-error": "^0.0.4",
-    "truffle-expect": "^0.0.8"
+    "truffle-expect": "^0.0.8",
+    "truffle-solc-wrapper": "https://github.com/trufflesuite/truffle-solc-wrapper"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",

--- a/packages/truffle-compile/test/compilerSupplier/index.js
+++ b/packages/truffle-compile/test/compilerSupplier/index.js
@@ -5,7 +5,6 @@ const {
   Docker,
   Native,
   Local,
-  Bundled,
   VersionRange
 } = require("../../compilerSupplier/loadingStrategies");
 let supplier, config;
@@ -68,17 +67,19 @@ describe("CompilerSupplier", () => {
     describe("when no version is specified in the config", () => {
       beforeEach(() => {
         supplier = new CompilerSupplier();
-        sinon.stub(Bundled.prototype, "load").returns("called Bundled");
+        sinon
+          .stub(VersionRange.prototype, "load")
+          .returns("called VersionRange");
       });
       afterEach(() => {
-        Bundled.prototype.load.restore();
+        VersionRange.prototype.load.restore();
       });
 
-      it("calls load on the Bundled strategy", done => {
+      it("calls load on the VersionRange strategy", done => {
         supplier
           .load()
           .then(result => {
-            assert(result === "called Bundled");
+            assert(result === "called VersionRange");
             done();
           })
           .catch(() => {

--- a/packages/truffle-contract/package.json
+++ b/packages/truffle-contract/package.json
@@ -46,7 +46,6 @@
     "debug": "^4.1.0",
     "ganache-core": "2.5.5",
     "mocha": "5.2.0",
-    "solc": "0.5.0",
     "temp": "^0.8.3",
     "truffle-compile": "^4.0.15",
     "uglify-es": "^3.3.9"

--- a/packages/truffle-deployer/test/deployer.js
+++ b/packages/truffle-deployer/test/deployer.js
@@ -265,7 +265,7 @@ describe("Deployer (sync)", function() {
       deployer.then(async function() {
         await deployer._startBlockPolling(web3);
         await utils.waitMS(9000);
-        deployer._startBlockPolling();
+        await deployer._startBlockPolling(web3);
       });
     };
 

--- a/packages/truffle/cli.webpack.config.js
+++ b/packages/truffle/cli.webpack.config.js
@@ -62,11 +62,6 @@ module.exports = {
         return callback(null, "commonjs original-require");
       }
 
-      // We want to leave solc as an eternal dependency as well (for now)
-      if (/^solc$/.test(request)) {
-        return callback(null, "commonjs solc");
-      }
-
       // Mocha doesn't seem to bundle well either. This is a stop-gap until
       // I can look into it further.
       if (/^mocha$/.test(request)) {

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -6,8 +6,7 @@
   "dependencies": {
     "app-module-path": "^2.2.0",
     "mocha": "^4.1.0",
-    "original-require": "1.0.1",
-    "solc": "0.5.0"
+    "original-require": "1.0.1"
   },
   "devDependencies": {
     "clean-webpack-plugin": "^0.1.16",
@@ -47,6 +46,7 @@
     "build": "yarn build-cli",
     "build-cli": "webpack --config ./cli.webpack.config.js",
     "test": "./scripts/test.sh",
+    "postinstall": "node ./build/cli.bundled.js obtain --solc=0.5.4",
     "publish:byoc": "node ./scripts/prereleaseVersion.js byoc-safe byoc",
     "publish:external-compiler": "node ./scripts/prereleaseVersion.js external-compiler external-compiler",
     "publish:next": "node ./scripts/prereleaseVersion.js next next",

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -46,7 +46,7 @@
     "build": "yarn build-cli",
     "build-cli": "webpack --config ./cli.webpack.config.js",
     "test": "./scripts/test.sh",
-    "postinstall": "node ./build/cli.bundled.js obtain --solc=0.5.4",
+    "postinstall": "node ./scripts/postinstall.js",
     "publish:byoc": "node ./scripts/prereleaseVersion.js byoc-safe byoc",
     "publish:external-compiler": "node ./scripts/prereleaseVersion.js external-compiler external-compiler",
     "publish:next": "node ./scripts/prereleaseVersion.js next next",

--- a/packages/truffle/scripts/postinstall.js
+++ b/packages/truffle/scripts/postinstall.js
@@ -1,0 +1,22 @@
+const { statSync } = require("fs");
+const { execSync } = require("child_process");
+
+const bundledCLI = "./build/cli.bundled.js";
+const unbundledCLI = "../truffle-core/cli.js";
+
+const postinstallObtain = () => {
+  try {
+    statSync(bundledCLI);
+    execSync(`node ${bundledCLI} obtain --solc=0.5.0`);
+  } catch ({ message }) {
+    if (message.includes("no such file"))
+      return execSync(`node ${unbundledCLI} obtain --solc=0.5.0`);
+    throw new Error(message);
+  }
+};
+
+try {
+  postinstallObtain();
+} catch (error) {
+  throw error;
+}

--- a/packages/truffle/scripts/postinstall.js
+++ b/packages/truffle/scripts/postinstall.js
@@ -2,15 +2,13 @@ const { statSync } = require("fs");
 const { execSync } = require("child_process");
 
 const bundledCLI = "./build/cli.bundled.js";
-const unbundledCLI = "../truffle-core/cli.js";
 
 const postinstallObtain = () => {
   try {
     statSync(bundledCLI);
     execSync(`node ${bundledCLI} obtain --solc=0.5.0`);
   } catch ({ message }) {
-    if (message.includes("no such file"))
-      return execSync(`node ${unbundledCLI} obtain --solc=0.5.0`);
+    if (message.includes("no such file")) return;
     throw new Error(message);
   }
 };

--- a/packages/truffle/scripts/postinstall.js
+++ b/packages/truffle/scripts/postinstall.js
@@ -2,14 +2,17 @@ const { statSync } = require("fs");
 const { execSync } = require("child_process");
 
 const bundledCLI = "./build/cli.bundled.js";
+const defaultSolc = "0.5.0";
 
 const postinstallObtain = () => {
   try {
     statSync(bundledCLI);
-    execSync(`node ${bundledCLI} obtain --solc=0.5.0`);
+    execSync(`node ${bundledCLI} obtain --solc=${defaultSolc}`);
   } catch ({ message }) {
     if (message.includes("no such file")) return;
-    throw new Error(message);
+    throw new Error(
+      `Error while attempting to download and cache solc ${defaultSolc}: ${message}`
+    );
   }
 };
 

--- a/packages/truffle/scripts/postinstall.js
+++ b/packages/truffle/scripts/postinstall.js
@@ -2,7 +2,7 @@ const { statSync } = require("fs");
 const { execSync } = require("child_process");
 
 const bundledCLI = "./build/cli.bundled.js";
-const defaultSolc = "0.5.0";
+const defaultSolc = "0.5.8";
 
 const postinstallObtain = () => {
   try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7616,16 +7616,6 @@ keccak@^1.0.2:
     nan "^2.2.1"
     safe-buffer "^5.1.0"
 
-keccak@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/keccak/-/keccak-2.0.0.tgz#7456ea5023284271e6f362b4397e8df4d2bb994c"
-  integrity sha512-rKe/lRr0KGhjoz97cwg+oeT1Rj/Y4cjae6glArioUC8JBF9ROGZctwIaaruM7d7naovME4Q8WcQSO908A8qcyQ==
-  dependencies:
-    bindings "^1.2.1"
-    inherits "^2.0.3"
-    nan "^2.2.1"
-    safe-buffer "^5.1.0"
-
 keccakjs@^0.2.0, keccakjs@^0.2.1:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/keccakjs/-/keccakjs-0.2.3.tgz#5e4e969ce39689a3861f445d7752ee3477f9fe72"
@@ -11750,6 +11740,20 @@ solc@^0.4.2:
     semver "^5.3.0"
     yargs "^4.7.1"
 
+solc@^0.5.0:
+  version "0.5.8"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.5.8.tgz#a0aa2714082fc406926f5cb384376d7408080611"
+  integrity sha512-RQ2SlwPBOBSV7ktNQJkvbiQks3t+3V9dsqD014EdstxnJzSxBuOvbt3P5QXpNPYW1DsEmF7dhOaT3JL7yEae/A==
+  dependencies:
+    command-exists "^1.2.8"
+    fs-extra "^0.30.0"
+    keccak "^1.0.2"
+    memorystream "^0.3.1"
+    require-from-string "^2.0.0"
+    semver "^5.5.0"
+    tmp "0.0.33"
+    yargs "^11.0.0"
+
 solidity-sha3@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/solidity-sha3/-/solidity-sha3-0.4.1.tgz#17577e93f6cfd58489c4ec7f2da3047530329ec1"
@@ -12704,14 +12708,6 @@ truffle-init@^1.0.7:
     rimraf "^2.5.4"
     temp "^0.8.3"
     truffle-config "^1.0.1"
-
-"truffle-solc-wrapper@https://github.com/trufflesuite/truffle-solc-wrapper":
-  version "1.0.0"
-  resolved "https://github.com/trufflesuite/truffle-solc-wrapper#f4a6201804d1d78f93f2ba95a634495170f0e9ba"
-  dependencies:
-    keccak "^2.0.0"
-    memorystream "^0.3.1"
-    require-from-string "^2.0.2"
 
 tryer@^1.0.0:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7616,6 +7616,16 @@ keccak@^1.0.2:
     nan "^2.2.1"
     safe-buffer "^5.1.0"
 
+keccak@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/keccak/-/keccak-2.0.0.tgz#7456ea5023284271e6f362b4397e8df4d2bb994c"
+  integrity sha512-rKe/lRr0KGhjoz97cwg+oeT1Rj/Y4cjae6glArioUC8JBF9ROGZctwIaaruM7d7naovME4Q8WcQSO908A8qcyQ==
+  dependencies:
+    bindings "^1.2.1"
+    inherits "^2.0.3"
+    nan "^2.2.1"
+    safe-buffer "^5.1.0"
+
 keccakjs@^0.2.0, keccakjs@^0.2.1:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/keccakjs/-/keccakjs-0.2.3.tgz#5e4e969ce39689a3861f445d7752ee3477f9fe72"
@@ -12694,6 +12704,14 @@ truffle-init@^1.0.7:
     rimraf "^2.5.4"
     temp "^0.8.3"
     truffle-config "^1.0.1"
+
+"truffle-solc-wrapper@https://github.com/trufflesuite/truffle-solc-wrapper":
+  version "1.0.0"
+  resolved "https://github.com/trufflesuite/truffle-solc-wrapper#f4a6201804d1d78f93f2ba95a634495170f0e9ba"
+  dependencies:
+    keccak "^2.0.0"
+    memorystream "^0.3.1"
+    require-from-string "^2.0.2"
 
 tryer@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
This PR seeks to resolve #2034 by removing the `solc-js` compiler component completely from the bundle.

This is handled by:

- leveraging `truffle obtain` in a postinstall to download and cache a default soljson when installing truffle via npm.
- Importing only the `solc/wrapper` to parse soljson's.
- Removing the `Bundled` strategy from the CompilerSupplier.

The current implementation of this can be tested at `truffle@unbundled-solc`.