### PR TITLE
Fix: appropriately assign & merge artifact properties

### DIFF
--- a/packages/truffle-artifactor/index.js
+++ b/packages/truffle-artifactor/index.js
@@ -34,7 +34,11 @@ class Artifactor {
       const normalizedExistingArtifact = Schema.normalize(
         existingArtifactObject
       );
-      _.merge(completeArtifact, normalizedExistingArtifact, normalizedArtifact);
+      _.assign(
+        completeArtifact,
+        normalizedExistingArtifact,
+        normalizedArtifact
+      );
       writeArtifact(completeArtifact);
     } catch (e) {
       // if artifact doesn't already exist, write new file

--- a/packages/truffle-artifactor/index.js
+++ b/packages/truffle-artifactor/index.js
@@ -10,8 +10,8 @@ class Artifactor {
   }
 
   async save(artifactObject) {
-    const normalizedArtifact = Schema.normalize(artifactObject);
-    const contractName = normalizedArtifact.contractName;
+    const normalizedNewArtifact = Schema.normalize(artifactObject);
+    const contractName = normalizedNewArtifact.contractName;
 
     if (!contractName) throw new Error("You must specify a contract name.");
 
@@ -37,12 +37,12 @@ class Artifactor {
       _.assign(
         completeArtifact,
         normalizedExistingArtifact,
-        normalizedArtifact
+        normalizedNewArtifact
       );
       writeArtifact(completeArtifact);
     } catch (e) {
       // if artifact doesn't already exist, write new file
-      if (e.code === "ENOENT") return writeArtifact(normalizedArtifact);
+      if (e.code === "ENOENT") return writeArtifact(normalizedNewArtifact);
       else if (e instanceof SyntaxError) throw e; // catches improperly formatted artifact json
       throw e; // catch all other errors
     }

--- a/packages/truffle-artifactor/index.js
+++ b/packages/truffle-artifactor/index.js
@@ -2,6 +2,7 @@ const Schema = require("truffle-contract-schema");
 const fse = require("fs-extra");
 const path = require("path");
 const _ = require("lodash");
+const writeArtifact = require("./utils");
 const debug = require("debug")("artifactor");
 
 class Artifactor {
@@ -16,16 +17,6 @@ class Artifactor {
     if (!contractName) throw new Error("You must specify a contract name.");
 
     const outputPath = path.join(this.destination, `${contractName}.json`);
-
-    // private helper for writing artifacts
-    const writeArtifact = _completeArtifact => {
-      _completeArtifact.updatedAt = new Date().toISOString();
-      fse.writeFileSync(
-        outputPath,
-        JSON.stringify(_completeArtifact, null, 2),
-        "utf8"
-      );
-    };
 
     try {
       const existingArtifact = fse.readFileSync(outputPath, "utf8"); // check if artifact already exists
@@ -45,10 +36,12 @@ class Artifactor {
         normalizedNewArtifact,
         { networks: knownNetworks }
       );
-      writeArtifact(completeArtifact);
+
+      writeArtifact(completeArtifact, outputPath);
     } catch (e) {
       // if artifact doesn't already exist, write new file
-      if (e.code === "ENOENT") return writeArtifact(normalizedNewArtifact);
+      if (e.code === "ENOENT")
+        return writeArtifact(normalizedNewArtifact, outputPath);
       else if (e instanceof SyntaxError) throw e; // catches improperly formatted artifact json
       throw e; // catch all other errors
     }

--- a/packages/truffle-artifactor/index.js
+++ b/packages/truffle-artifactor/index.js
@@ -43,8 +43,8 @@ class Artifactor {
     } catch (e) {
       // if artifact doesn't already exist, write new file
       if (e.code === "ENOENT") return writeArtifact(normalizedArtifact);
-      else if (e instanceof SyntaxError) throw new Error(e); // catches improperly formatted artifact json
-      throw new Error(e); // catch all other errors
+      else if (e instanceof SyntaxError) throw e; // catches improperly formatted artifact json
+      throw e; // catch all other errors
     }
   }
 
@@ -67,7 +67,7 @@ class Artifactor {
       if (e.code === "ENOENT")
         // if destination doesn't exist, throw error
         throw new Error(`Destination "${this.destination}" doesn't exist!`);
-      throw new Error(e); // throw on all other errors
+      throw e; // throw on all other errors
     }
 
     Object.keys(newArtifactObjects).forEach(contractName => {

--- a/packages/truffle-artifactor/index.js
+++ b/packages/truffle-artifactor/index.js
@@ -1,8 +1,8 @@
-var Schema = require("truffle-contract-schema");
-var fs = require("fs-extra");
-var path = require("path");
-var _ = require("lodash");
-var debug = require("debug")("artifactor");
+const Schema = require("truffle-contract-schema");
+const fs = require("fs-extra");
+const path = require("path");
+const _ = require("lodash");
+const debug = require("debug")("artifactor");
 
 class Artifactor {
   constructor(destination) {

--- a/packages/truffle-artifactor/index.js
+++ b/packages/truffle-artifactor/index.js
@@ -1,5 +1,5 @@
 const Schema = require("truffle-contract-schema");
-const fs = require("fs-extra");
+const fse = require("fs-extra");
 const path = require("path");
 const _ = require("lodash");
 const debug = require("debug")("artifactor");
@@ -20,7 +20,7 @@ class Artifactor {
     // private helper for writing artifacts
     const writeArtifact = _completeArtifact => {
       _completeArtifact.updatedAt = new Date().toISOString();
-      fs.writeFileSync(
+      fse.writeFileSync(
         output_path,
         JSON.stringify(_completeArtifact, null, 2),
         "utf8"
@@ -28,7 +28,7 @@ class Artifactor {
     };
 
     try {
-      const existingArtifact = fs.readFileSync(output_path, "utf8"); // check if artifact already exists
+      const existingArtifact = fse.readFileSync(output_path, "utf8"); // check if artifact already exists
       const existingArtifactObject = JSON.parse(existingArtifact); // parse existing artifact
       const normalizedExistingArtifact = Schema.normalize(
         existingArtifactObject
@@ -68,7 +68,7 @@ class Artifactor {
     }
 
     try {
-      fs.statSync(this.destination); // check if destination exists
+      fse.statSync(this.destination); // check if destination exists
     } catch (e) {
       if (e.code === "ENOENT")
         // if destination doesn't exist, throw error

--- a/packages/truffle-artifactor/index.js
+++ b/packages/truffle-artifactor/index.js
@@ -15,20 +15,20 @@ class Artifactor {
 
     if (!contractName) throw new Error("You must specify a contract name.");
 
-    const output_path = path.join(this.destination, `${contractName}.json`);
+    const outputPath = path.join(this.destination, `${contractName}.json`);
 
     // private helper for writing artifacts
     const writeArtifact = _completeArtifact => {
       _completeArtifact.updatedAt = new Date().toISOString();
       fse.writeFileSync(
-        output_path,
+        outputPath,
         JSON.stringify(_completeArtifact, null, 2),
         "utf8"
       );
     };
 
     try {
-      const existingArtifact = fse.readFileSync(output_path, "utf8"); // check if artifact already exists
+      const existingArtifact = fse.readFileSync(outputPath, "utf8"); // check if artifact already exists
       const existingArtifactObject = JSON.parse(existingArtifact); // parse existing artifact
       const normalizedExistingArtifact = Schema.normalize(
         existingArtifactObject

--- a/packages/truffle-artifactor/index.js
+++ b/packages/truffle-artifactor/index.js
@@ -2,7 +2,7 @@ const Schema = require("truffle-contract-schema");
 const fse = require("fs-extra");
 const path = require("path");
 const _ = require("lodash");
-const writeArtifact = require("./utils");
+const { writeArtifact } = require("./utils");
 const debug = require("debug")("artifactor");
 
 class Artifactor {

--- a/packages/truffle-artifactor/index.js
+++ b/packages/truffle-artifactor/index.js
@@ -16,7 +16,6 @@ class Artifactor {
     if (!contractName) throw new Error("You must specify a contract name.");
 
     const output_path = path.join(this.destination, `${contractName}.json`);
-    let completeArtifact = {};
 
     // private helper for writing artifacts
     const writeArtifact = _completeArtifact => {
@@ -34,10 +33,17 @@ class Artifactor {
       const normalizedExistingArtifact = Schema.normalize(
         existingArtifactObject
       );
-      _.assign(
-        completeArtifact,
+
+      const knownNetworks = _.merge(
+        {},
+        normalizedExistingArtifact.networks,
+        normalizedNewArtifact.networks
+      );
+      const completeArtifact = _.assign(
+        {},
         normalizedExistingArtifact,
-        normalizedNewArtifact
+        normalizedNewArtifact,
+        { networks: knownNetworks }
       );
       writeArtifact(completeArtifact);
     } catch (e) {

--- a/packages/truffle-artifactor/templates/class.js
+++ b/packages/truffle-artifactor/templates/class.js
@@ -1,5 +1,0 @@
-{{ABSTRACTION}}
-
-var BINARIES = {{BINARIES}};
-
-module.exports = contract.clone(BINARIES);

--- a/packages/truffle-artifactor/utils.js
+++ b/packages/truffle-artifactor/utils.js
@@ -9,4 +9,4 @@ const writeArtifact = (_completeArtifact, _outputPath) => {
   );
 };
 
-module.exports = writeArtifact;
+module.exports = { writeArtifact };

--- a/packages/truffle-artifactor/utils.js
+++ b/packages/truffle-artifactor/utils.js
@@ -1,0 +1,12 @@
+const fse = require("fs-extra");
+
+const writeArtifact = (_completeArtifact, _outputPath) => {
+  _completeArtifact.updatedAt = new Date().toISOString();
+  fse.writeFileSync(
+    _outputPath,
+    JSON.stringify(_completeArtifact, null, 2),
+    "utf8"
+  );
+};
+
+module.exports = writeArtifact;


### PR DESCRIPTION
This PR fixes an oversight implemented in #1894 to simply `_.merge` existing and new compiled artifacts rather than `_.merge` their known networks before `_.assign`ing other properties. Also cleans up the pkg a bit.

Resolves #2048 .