### PR TITLE
Store code returned by creation calls

### DIFF
--- a/packages/truffle-core/lib/debug/printer.js
+++ b/packages/truffle-core/lib/debug/printer.js
@@ -40,7 +40,7 @@ class DebugPrinter {
     const affectedInstances = this.session.view(session.info.affectedInstances);
 
     this.config.logger.log("");
-    this.config.logger.log("Addresses affected:");
+    this.config.logger.log("Addresses called: (not created)");
     this.config.logger.log(
       DebugUtils.formatAffectedInstances(affectedInstances)
     );

--- a/packages/truffle-debugger/lib/data/sagas/index.js
+++ b/packages/truffle-debugger/lib/data/sagas/index.js
@@ -665,6 +665,10 @@ function fetchBasePath(
     astId: baseNode.id,
     stackframe: currentDepth
   });
+  debug("astId: %d", baseNode.id);
+  debug("stackframe: %d", currentDepth);
+  debug("fullId: %s", fullId);
+  debug("currentAssignments: %O", currentAssignments);
   //base expression is an expression, and so has a literal assigned to
   //it
   let offset = DecodeUtils.Conversion.toBN(

--- a/packages/truffle-debugger/lib/data/selectors/index.js
+++ b/packages/truffle-debugger/lib/data/selectors/index.js
@@ -193,10 +193,10 @@ const data = createSelectorTree({
 
     /*
      * data.views.instances
-     * same as evm.info.instances, but we just map address => binary,
-     * we don't bother with context
+     * same as evm.current.codex.instances, but we just map address => binary,
+     * we don't bother with context, and also the code is a Uint8Array
      */
-    instances: createLeaf([evm.transaction.instances], instances =>
+    instances: createLeaf([evm.current.codex.instances], instances =>
       Object.assign(
         {},
         ...Object.entries(instances).map(([address, { binary }]) => ({
@@ -222,7 +222,7 @@ const data = createSelectorTree({
         ...Object.values(contexts)
           .filter(context => !context.isConstructor)
           .map(context => ({
-            [context.context]: debuggerContextToDecoderContext(context)
+            [context.contractId]: debuggerContextToDecoderContext(context)
           }))
       )
     )

--- a/packages/truffle-debugger/lib/evm/actions/index.js
+++ b/packages/truffle-debugger/lib/evm/actions/index.js
@@ -70,10 +70,19 @@ export function create(binary, storageAddress, sender, value) {
   };
 }
 
-export const RETURN = "RETURN";
+export const RETURN_CALL = "RETURN_CALL";
 export function returnCall() {
   return {
-    type: RETURN
+    type: RETURN_CALL
+  };
+}
+
+export const RETURN_CREATE = "RETURN_CREATE";
+export function returnCreate(address, code) {
+  return {
+    type: RETURN_CREATE,
+    address,
+    code
   };
 }
 

--- a/packages/truffle-debugger/lib/evm/actions/index.js
+++ b/packages/truffle-debugger/lib/evm/actions/index.js
@@ -78,11 +78,12 @@ export function returnCall() {
 }
 
 export const RETURN_CREATE = "RETURN_CREATE";
-export function returnCreate(address, code) {
+export function returnCreate(address, code, context) {
   return {
     type: RETURN_CREATE,
     address,
-    code
+    code,
+    context
   };
 }
 

--- a/packages/truffle-debugger/lib/evm/reducers.js
+++ b/packages/truffle-debugger/lib/evm/reducers.js
@@ -71,49 +71,9 @@ function contexts(state = DEFAULT_CONTEXTS, action) {
   }
 }
 
-const DEFAULT_INSTANCES = {
-  byAddress: {},
-  byContext: {}
-};
-
-function instances(state = DEFAULT_INSTANCES, action) {
-  switch (action.type) {
-    /*
-     * Adding a new address for context
-     */
-    case actions.ADD_INSTANCE:
-      let { address, context, binary } = action;
-
-      // get known addresses for this context
-      let otherInstances = state.byContext[context] || [];
-      let otherAddresses = otherInstances.map(({ address }) => address);
-
-      return {
-        byAddress: {
-          ...state.byAddress,
-
-          [address]: { address, context, binary }
-        },
-
-        byContext: {
-          ...state.byContext,
-
-          // reconstruct context instances to include new address
-          [context]: Array.from(new Set(otherAddresses).add(address)).map(
-            address => ({ address })
-          )
-        }
-      };
-    case actions.UNLOAD_TRANSACTION:
-      return DEFAULT_INSTANCES;
-
-    /*
-     * Default case
-     */
-    default:
-      return state;
-  }
-}
+const info = combineReducers({
+  contexts
+});
 
 const DEFAULT_TX = {
   gasprice: new BN(0),
@@ -156,13 +116,28 @@ const globals = combineReducers({
   block
 });
 
-const info = combineReducers({
-  contexts
-});
+function initialCall(state = null, action) {
+  switch (action.type) {
+    case actions.CALL:
+    case actions.CREATE:
+      //we only want to save the initial call, so return
+      //the current state if it's not null
+      if (state !== null) {
+        return state;
+      } else {
+        //we'll just store the action itself in the state
+        return action;
+      }
+    case actions.UNLOAD_TRANSACTION:
+      return null;
+    default:
+      return state;
+  }
+}
 
 const transaction = combineReducers({
-  instances,
-  globals
+  globals,
+  initialCall
 });
 
 function callstack(state = [], action) {
@@ -180,15 +155,14 @@ function callstack(state = [], action) {
       );
     }
 
-    case actions.RETURN:
+    case actions.RETURN_CALL:
+    case actions.RETURN_CREATE:
     case actions.FAIL:
       //pop the stack... unless (HACK) that would leave it empty (this will
       //only happen at the end when we want to keep the last one around)
       return state.length > 1 ? state.slice(0, -1) : state;
 
     case actions.RESET:
-      return [state[0]]; //leave the initial call still on the stack
-
     case actions.UNLOAD_TRANSACTION:
       return [];
 
@@ -197,33 +171,31 @@ function callstack(state = [], action) {
   }
 }
 
-//default codex stackframe with a single address (or none if address not
-//supplied)
-function defaultCodexFrame(address) {
-  if (address !== undefined) {
-    return {
-      //there will be more here in the future!
-      accounts: {
-        [address]: {
-          //there will be more here in the future!
-          storage: {},
-          code: undefined //undefined code means no override, just look at
-          //evm.transaction.instances for the code
-        }
-      }
-    };
-  } else {
-    return {
-      //there will be more here in the future!
-      accounts: {}
-    };
+const DEFAULT_CODEX = [
+  {
+    accounts: {}
+    //will be more here in the future!
   }
-}
+];
 
-function codex(state = [], action) {
+function codex(state = DEFAULT_CODEX, action) {
   let newState, topCodex;
 
-  const updateFrameStorage = (frame, address, slot, value) => {
+  const updateFrameStorage = (frame, address, slot, value) => ({
+    ...frame,
+    accounts: {
+      ...frame.accounts,
+      [address]: {
+        ...frame.accounts[address],
+        storage: {
+          ...frame.accounts[address].storage,
+          [slot]: value
+        }
+      }
+    }
+  });
+
+  const updateFrameCode = (frame, address, code, context) => {
     let existingPage = frame.accounts[address] || { storage: {} };
     return {
       ...frame,
@@ -231,39 +203,38 @@ function codex(state = [], action) {
         ...frame.accounts,
         [address]: {
           ...existingPage,
-          storage: {
-            ...existingPage.storage,
-            [slot]: value
-          }
+          code: code,
+          context: context
         }
       }
     };
   };
 
-  const updateFrameCode = (frame, address, code) => ({
-    ...frame,
-    accounts: {
-      ...frame.accounts,
-      [address]: {
-        ...frame.accounts[address],
-        code: code
-      }
-    }
-  });
+  //later: will add "force" parameter
+  const safePop = array => (array.length > 2 ? array.slice(0, -1) : array);
+
+  //later: will add "force" parameter
+  const safeSave = array =>
+    array.length > 2
+      ? array.slice(0, -2).concat([array[array.length - 1]])
+      : array;
 
   switch (action.type) {
     case actions.CALL:
+      debug("call action");
+      debug("codex: %O", state);
+      //on a call, we can just make a new stackframe by cloning the top
+      //stackframe; there should already be an account for the address we're
+      //calling into, so we don't need to make one
+      return [...state, state[state.length - 1]];
+
     case actions.CREATE:
-      //on a call or create, make a new stackframe, then add a new pages to the
+      //on a create, make a new stackframe, then add a new pages to the
       //codex if necessary; don't add a zero page though (or pages that already
       //exist)
 
-      //first, add a new stackframe; if there's an existing stackframe, clone
-      //that, otherwise make one from scratch
-      newState =
-        state.length > 0
-          ? [...state, state[state.length - 1]]
-          : [defaultCodexFrame()];
+      //first, add a new stackframe by cloning the top one
+      newState = [...state, state[state.length - 1]];
       topCodex = newState[newState.length - 1];
       //now, do we need to add a new address to this stackframe?
       if (
@@ -280,7 +251,8 @@ function codex(state = [], action) {
           ...topCodex.accounts,
           [action.storageAddress]: {
             storage: {},
-            code: undefined //no override
+            code: "0x",
+            context: null
             //there will be more here in the future!
           }
         }
@@ -333,36 +305,49 @@ function codex(state = [], action) {
       }
     }
 
-    case actions.RETURN_CREATE: {
-      //we're going to do the same things in this case as in the usual return
-      //case, but first we need to record the code that was returned
-      const { address, code } = action;
-      newState = state.slice(); //clone the state
-      //NOTE: since this is only for RETURN_CREATE, and not FAIL, we shouldn't
-      //have to worry about accidentally getting a zero address here
-      newState = updateFrameCode(state[state.length - 1], address, code); //update
-      state = newState; //store this back in the state variable so that the
-      //fall-through works
-    }
-    //NOTE: DELIBERATE FALL-THROUGH
     case actions.RETURN_CALL:
       //we want to pop the top while making the new top a copy of the old top;
       //that is to say, we want to drop just the element *second* from the top
-      //(although, HACK, if the stack only has one element, just leave it alone)
-      return state.length > 1
-        ? state.slice(0, -2).concat([state[state.length - 1]])
-        : state;
+      //NOTE: we don't ever go down to 1 element!
+      return safeSave(state);
+
+    case actions.RETURN_CREATE: {
+      //we're going to do the same things in this case as in the usual return
+      //case, but first we need to record the code that was returned
+      const { address, code, context } = action;
+      newState = state.slice(); //clone the state
+      //NOTE: since this is only for RETURN_CREATE, and not FAIL, we shouldn't
+      //have to worry about accidentally getting a zero address here
+      newState[newState.length - 1] = updateFrameCode(
+        newState[newState.length - 1],
+        address,
+        code,
+        context
+      );
+      debug("newState: %O", newState);
+      return safeSave(newState);
+    }
 
     case actions.FAIL:
-      //pop the stack... unless (HACK) that would leave it empty (this will
-      //only happen at the end when we want to keep the last one around)
-      return state.length > 1 ? state.slice(0, -1) : state;
+      //pop the stack
+      //NOTE: we don't ever go down to 1 element!
+      return safePop(state);
 
     case actions.RESET:
-      return [defaultCodexFrame(action.storageAddress)];
+      return [state[0]]; //leave the -1 frame on the stack
 
     case actions.UNLOAD_TRANSACTION:
-      return [];
+      return DEFAULT_CODEX;
+
+    case actions.ADD_INSTANCE: {
+      //add the instance to every frame
+      //(this is a little HACKy, but it *should* be fine)
+      debug("adding instance");
+      const { address, binary, context } = action;
+      return state.map(frame =>
+        updateFrameCode(frame, address, binary, context)
+      );
+    }
 
     default:
       return state;

--- a/packages/truffle-debugger/lib/evm/sagas/index.js
+++ b/packages/truffle-debugger/lib/evm/sagas/index.js
@@ -131,7 +131,15 @@ export function* callstackAndCodexSaga() {
   } else if (yield select(evm.current.step.isHalting)) {
     debug("got return");
 
-    yield put(actions.returnCall());
+    if ((yield select(evm.current.call)).binary) {
+      //if we're returning from a successful creation call, let's log the
+      //result
+      let returnedAddress = yield select(evm.current.step.returnedAddress);
+      let returnedBinary = yield select(evm.current.step.returnValue);
+      yield put(actions.returnCreate(returnedAddress, returnedBinary));
+    } else {
+      yield put(actions.returnCall());
+    }
   } else if (yield select(evm.current.step.touchesStorage)) {
     let storageAddress = (yield select(evm.current.call)).storageAddress;
     let slot = yield select(evm.current.step.storageAffected);

--- a/packages/truffle-debugger/lib/session/sagas/index.js
+++ b/packages/truffle-debugger/lib/session/sagas/index.js
@@ -109,9 +109,6 @@ function* fetchTx(txHash) {
     return result.error;
   }
 
-  debug("sending initial call");
-  yield* evm.begin(result);
-
   //get addresses created/called during transaction
   debug("processing trace for addresses");
   let addresses = yield* trace.processTrace(result.trace);
@@ -136,6 +133,9 @@ function* fetchTx(txHash) {
   yield all(
     addresses.map((address, i) => call(recordInstance, address, binaries[i]))
   );
+
+  debug("sending initial call");
+  yield* evm.begin(result);
 }
 
 function* recordContexts(...contexts) {

--- a/packages/truffle-debugger/lib/session/selectors/index.js
+++ b/packages/truffle-debugger/lib/session/selectors/index.js
@@ -21,27 +21,35 @@ const session = createSelectorTree({
      * session.info.affectedInstances
      */
     affectedInstances: createLeaf(
-      [evm.transaction.instances, evm.info.contexts, solidity.info.sources],
+      [evm.current.codex.instances, evm.info.contexts, solidity.info.sources],
 
       (instances, contexts, sources) =>
         Object.assign(
           {},
-          ...Object.entries(instances).map(([address, { context, binary }]) => {
-            debug("instances %O", instances);
-            debug("contexts %O", contexts);
-            let { contractName, primarySource } = contexts[context];
-
-            let source =
-              primarySource !== undefined ? sources[primarySource] : undefined;
-
-            return {
-              [address]: {
-                contractName,
-                source,
-                binary
+          ...Object.entries(instances).map(
+            ([address, { context: contextId, binary }]) => {
+              debug("instances %O", instances);
+              debug("contexts %O", contexts);
+              let context = contexts[contextId];
+              if (!context) {
+                return { [address]: { binary } };
               }
-            };
-          })
+              let { contractName, primarySource } = context;
+
+              let source =
+                primarySource !== undefined
+                  ? sources[primarySource]
+                  : undefined;
+
+              return {
+                [address]: {
+                  contractName,
+                  source,
+                  binary
+                }
+              };
+            }
+          )
         )
     )
   },

--- a/packages/truffle-debugger/lib/trace/sagas/index.js
+++ b/packages/truffle-debugger/lib/trace/sagas/index.js
@@ -2,7 +2,7 @@ import debugModule from "debug";
 const debug = debugModule("debugger:trace:sagas");
 
 import { take, takeEvery, put, select } from "redux-saga/effects";
-import { prefixName, isCallMnemonic, isCreateMnemonic } from "lib/helpers";
+import { prefixName, isCallMnemonic } from "lib/helpers";
 
 import * as DecodeUtils from "truffle-decode-utils";
 
@@ -66,24 +66,15 @@ export function* processTrace(steps) {
   let addresses = [
     ...new Set(
       steps
-        .map(({ op, stack, depth }, index) => {
-          if (isCallMnemonic(op)) {
-            //if it's a call, just fetch the address off the stack
-            return DecodeUtils.Conversion.toAddress(stack[stack.length - 2]);
-          } else if (isCreateMnemonic(op)) {
-            //if it's a create, look ahead to when it returns and get the
-            //address off the stack
-            let returnStack = steps
-              .slice(index + 1)
-              .find(step => step.depth === depth).stack;
-            return DecodeUtils.Conversion.toAddress(
-              returnStack[returnStack.length - 1]
-            );
-          } else {
-            //if it's not a call or create, there's no address to get
-            return undefined;
-          }
-        })
+        .map(
+          ({ op, stack }) =>
+            isCallMnemonic(op)
+              ? //if it's a call, just fetch the address off the stack
+                DecodeUtils.Conversion.toAddress(stack[stack.length - 2])
+              : //if it's not a call, just return undefined (we've gone back to
+                //skipping creates)
+                undefined
+        )
         //filter out zero addresses from failed creates (as well as undefineds)
         .filter(
           address =>

--- a/packages/truffle-decode-utils/src/contexts.ts
+++ b/packages/truffle-decode-utils/src/contexts.ts
@@ -16,9 +16,7 @@ export namespace Contexts {
   export type Context = DecoderContext | DebuggerContext;
 
   export interface DecoderContexts {
-    [index: string]: DecoderContext;
-    //we'll allow this to be a hash *or* a contract ID; it's just an arbitrary
-    //identifier
+    [contractId: number]: DecoderContext;
   }
 
   export interface DebuggerContexts {


### PR DESCRIPTION
The immediate purpose of this PR is to fix issue #2028.  However, if I just wanted to do that, I could've done it an easier way.  The broader purpose is to lay some more foundations for the reconstruct mode that's eventually coming.

So, as I said, the primary visible effect of this PR is to fix issue #2028.  Now, when a creation call successfully returns, we store in the state the code and address that it returned, so that other parts of the debugger will have access to it.  So, if you then enter a message call to a contract you just created, we will be able to sourcemap it and properly debug it, even if the transaction (or some part of it) later reverts, or even if the contract eventually selfdestructs.  (Note that selfdestructs are still a problem if you *didn't* just create the contract; that will require reconstruct mode to handle, I'm afraid.)

So, where in the state are we storing it?  Well, the relevant state has been reorganized a fair bit.  The old `evm.transaction.instances` is gone, along with its corresponding selector.  Instead, the code attached to each account is now stored in the codex.  (The selector `evm.current.codex.instances` has taken the place of the old selector.)    The `ADD_INSTANCE` action still exists, but it's the codex that responds to it.

Meanwhile, the old `evm` action `RETURN` has been split into `RETURN_CALL` and `RETURN_CREATE`.  The effect of `RETURN_CALL` is unchanged (other than an adjustment I'll get to later), but `RETURN_CREATE` first records the returned code in the codex before saving the stackframe.

(Note that there's no separate action for selfdestructs, because there's simply no need to track selfdestructs when you're only dealing with a single transaction; that will have to be split off when reconstruct mode is implemented, however.)

It addition to the code, it also records the context for easy lookup, so let's discus contexts.  Contexts for unknown contracts have been basically eliminated.  The selector `evm.current.context` will of course return something useful whether you're in a known context or not -- it won't return `null` unless no transaction is loaded -- but there are no more *stored* contexts for unknown contracts.  (Because of this, I was able to make a slight decoder alteration -- once again it is now always the case that in the decoder contexts are indexed by contract ID, rather than sometimes by ID and sometimes by hash.)

This together with the elimination of the old `instances` does mean we're no longer storing any easy way to look up, given an address, what other addresses share its context -- but, well, we weren't using that anywhere anyway.

But, like I was saying above, I didn't just do all that; I also took the time to make some other preparations for reconstruct mode.

Previously, the bottom stackframe in the codex represented the 0 stackframe, the outermost call of the transaction.  But now, the bottom stackframe represents the "-1 stackframe" -- the blockchain itself.  We don't really need this yet, because, as mentioned, the real purpose is for reconstruct mode, where at transaction's end we have to save the result to the -1 stackframe (or discard it in case of failure) but it's nice to have.

(The adjustment I mentioned to `RETURN_CALL` is that now we make sure to always leave *two* frames on the stack, not just one.  Similarly with `RETURN_CREATE` and `FAIL`, obviously.)

However, adding this necessitated some changes to how the reset button works.  Previously the reset button worked by resetting the codex to a default state.  But not a *fully* default state, like the unload transaction action; because resetting isn't followed by a call to *evm.begin*, so I had to keep around the results of that on the codex.

With these changes, that approach was no longer practical.  So, instead, the `evm.reset` saga now issues *two* actions.  The first is the `RESET` action, which pops the whole codex except for the -1 stackframe.  (Actually, because it's possible for `LOAD`s to modify the -1 stackframe, this means that now, after resetting, the debugger will remember any storage values it saw but didn't modify, rather than listing them as the default 0.  I'd consider this an improvement, but if you think this is confusing, well, we can figure something out, I guess.)

The second is a replay of the action issued by `evm.begin`.  How is that possible?  Well, we store it in the state!  There's a new component to the state, `evm.transaction.initialCall`, with corresponding selector.  It starts out as null, and when the first `CALL` or `CREATE` occurs, it becomes set to that action (yes, the action itself), and then stays as such until the transaction is unloaded.  So the `evm.reset` saga now first issues a `RESET` action, and then looks up the initial call and replays it, resetting the codex to its starting state.  (The `callstack` reducer has been appropriately adjusted for this as well.)

Let's say a bit more about the debugger startup.  There's been a sequencing change -- `evm.begin` now happens *after* recording the instances, to make all this work.  Also, since we add instances at the beginning for everything we call into, this means creating accounts for them in the codex, which means the `CALL` action no longer checks whether it needs to create an account for the address it calls into, because, well, it can be sure that one already exists.

Also during start up I changed back the fetching of binaries back to how it used to be, where it only fetches them for accounts we call into, not ones we only create.  Because why make extra RPC requests?  (Really we never needed those, I just added them for consistency, but now it strikes me as kind of dumb.)  This does mean the startup display is a bit worse, but, well, what are you going to do.  I modified the text a little to compensate?  This can maybe be changed.

Finally, I want to discuss the potential for weird interactions between this and decoding.  Because there's one other way an `ADD_INSTANCE` action can occur, other than at startup, and that's when we need to decode a variable of contract type or external function type, but we don't already have the code loaded for the corresponding contract.  Can this potentially create weird path-dependent effects?

I think the answer is basically no.  In reconstruct mode it will be definitely no, since we'd be fetching the code from the *previous* block, not the current one.  But even outside of reconstruct mode I'm pretty sure it's fine, even if this is less obvious.  Maybe if you had some crazy thing where `CREATE2` was used to create a contract on top of an old self-destructed one you could get a problem or something.  Honestly, I didn't bother worrying about that.  I don't think there's any reliable way to deal with such problems outside of reconstruct mode.

But the skeleton of that mode is starting to come together!