### PR TITLE
Account for exceptional halts from normal halting instructions

### DIFF
--- a/packages/truffle-core/lib/debug/interpreter.js
+++ b/packages/truffle-core/lib/debug/interpreter.js
@@ -7,7 +7,7 @@ const ora = require("ora");
 
 const DebugUtils = require("truffle-debug-utils");
 const selectors = require("truffle-debugger").selectors;
-const { solidity, trace, controller } = selectors;
+const { solidity, trace, evm, controller } = selectors;
 
 const analytics = require("../services/analytics");
 const ReplManager = require("../repl");
@@ -409,7 +409,7 @@ class DebugInterpreter {
     if (this.session.view(trace.finished) && !alreadyFinished) {
       this.printer.print("");
       //check if transaction failed
-      if (!this.session.view(selectors.session.transaction.receipt).status) {
+      if (!this.session.view(evm.transaction.status)) {
         this.printer.print("Transaction halted with a RUNTIME ERROR.");
         this.printer.print("");
         this.printer.print(

--- a/packages/truffle-debugger/lib/evm/actions/index.js
+++ b/packages/truffle-debugger/lib/evm/actions/index.js
@@ -47,6 +47,14 @@ export function saveGlobals(origin, gasprice, block) {
   };
 }
 
+export const SAVE_STATUS = "SAVE_STATUS";
+export function saveStatus(status) {
+  return {
+    type: SAVE_STATUS,
+    status
+  };
+}
+
 export const CALL = "CALL";
 export function call(address, data, storageAddress, sender, value) {
   return {

--- a/packages/truffle-debugger/lib/evm/reducers.js
+++ b/packages/truffle-debugger/lib/evm/reducers.js
@@ -116,6 +116,17 @@ const globals = combineReducers({
   block
 });
 
+function status(state = null, action) {
+  switch (action.type) {
+    case actions.SAVE_STATUS:
+      return action.status;
+    case actions.UNLOAD_TRANSACTION:
+      return null;
+    default:
+      return state;
+  }
+}
+
 function initialCall(state = null, action) {
   switch (action.type) {
     case actions.CALL:
@@ -137,6 +148,7 @@ function initialCall(state = null, action) {
 
 const transaction = combineReducers({
   globals,
+  status,
   initialCall
 });
 

--- a/packages/truffle-debugger/lib/evm/sagas/index.js
+++ b/packages/truffle-debugger/lib/evm/sagas/index.js
@@ -52,12 +52,14 @@ export function* begin({
   binary,
   data,
   storageAddress,
+  status,
   sender,
   value,
   gasprice,
   block
 }) {
   yield put(actions.saveGlobals(sender, gasprice, block));
+  yield put(actions.saveStatus(status));
   debug("codex: %O", yield select(evm.current.codex));
   if (address) {
     yield put(actions.call(address, data, storageAddress, sender, value));
@@ -122,15 +124,16 @@ export function* callstackAndCodexSaga() {
   } else if (yield select(evm.current.step.isHalting)) {
     debug("got return");
 
-    if ((yield select(evm.current.call)).binary) {
+    let { binary, storageAddress } = yield select(evm.current.call);
+
+    if (binary) {
       //if we're returning from a successful creation call, let's log the
       //result
-      let returnedAddress = yield select(evm.current.step.returnedAddress);
       let returnedBinary = yield select(evm.current.step.returnValue);
       let search = yield select(evm.info.binaries.search);
       let returnedContext = search(returnedBinary);
       yield put(
-        actions.returnCreate(returnedAddress, returnedBinary, returnedContext)
+        actions.returnCreate(storageAddress, returnedBinary, returnedContext)
       );
     } else {
       yield put(actions.returnCall());

--- a/packages/truffle-debugger/lib/evm/selectors/index.js
+++ b/packages/truffle-debugger/lib/evm/selectors/index.js
@@ -97,7 +97,7 @@ function createStepSelectors(step, state = null) {
      * .isHalting
      *
      * whether the instruction halts or returns from a calling context
-     * NOTE: this covers only orddinary halts, not exceptional halts;
+     * NOTE: this covers only ordinary halts, not exceptional halts;
      * but it doesn't check the return status, so any normal halting
      * instruction will qualify here
      */
@@ -144,8 +144,8 @@ function createStepSelectors(step, state = null) {
       callAddress: createLeaf(
         ["./isCall", state],
 
-        (matches, { stack }) => {
-          if (!matches) {
+        (isCall, { stack }) => {
+          if (!isCall) {
             return null;
           }
 
@@ -162,8 +162,8 @@ function createStepSelectors(step, state = null) {
       createBinary: createLeaf(
         ["./isCreate", state],
 
-        (matches, { stack, memory }) => {
-          if (!matches) {
+        (isCreate, { stack, memory }) => {
+          if (!isCreate) {
             return null;
           }
 
@@ -183,8 +183,8 @@ function createStepSelectors(step, state = null) {
        */
       callData: createLeaf(
         ["./isCall", "./isShortCall", state],
-        (matches, short, { stack, memory }) => {
-          if (!matches) {
+        (isCall, short, { stack, memory }) => {
+          if (!isCall) {
             return null;
           }
 
@@ -229,8 +229,8 @@ function createStepSelectors(step, state = null) {
        *
        * value for the create
        */
-      createValue: createLeaf(["./isCreate", state], (matches, { stack }) => {
-        if (!matches) {
+      createValue: createLeaf(["./isCreate", state], (isCreate, { stack }) => {
+        if (!isCreate) {
           return null;
         }
 
@@ -248,8 +248,8 @@ function createStepSelectors(step, state = null) {
       storageAffected: createLeaf(
         ["./touchesStorage", state],
 
-        (matches, { stack }) => {
-          if (!matches) {
+        (touchesStorage, { stack }) => {
+          if (!touchesStorage) {
             return null;
           }
 
@@ -268,8 +268,8 @@ function createStepSelectors(step, state = null) {
       returnValue: createLeaf(
         ["./trace", "./isHalting", state],
 
-        (step, matches, { stack, memory }) => {
-          if (!matches) {
+        (step, isHalting, { stack, memory }) => {
+          if (!isHalting) {
             return null;
           }
           if (step.op !== "RETURN") {
@@ -441,8 +441,8 @@ const evm = createSelectorTree({
        */
       createdAddress: createLeaf(
         ["./isCreate", "/nextOfSameDepth/state/stack"],
-        (matches, stack) => {
-          if (!matches) {
+        (isCreate, stack) => {
+          if (!isCreate) {
             return null;
           }
           let address = stack[stack.length - 1];
@@ -500,8 +500,8 @@ const evm = createSelectorTree({
           trace.stepsRemaining,
           "/transaction/status"
         ],
-        (matches, { stack }, remaining, finalStatus) => {
-          if (!matches) {
+        (isHalting, { stack }, remaining, finalStatus) => {
+          if (!isHalting) {
             return null; //not clear this'll do much good since this may get
             //read as false, but, oh well, may as well
           }

--- a/packages/truffle-debugger/lib/web3/sagas/index.js
+++ b/packages/truffle-debugger/lib/web3/sagas/index.js
@@ -61,6 +61,7 @@ function* fetchTransactionInfo(adapter, { txHash }) {
         address: tx.to,
         data: tx.input,
         storageAddress: tx.to,
+        status: receipt.status,
         sender: tx.from,
         value: new BN(tx.value),
         gasprice: new BN(tx.gasPrice),

--- a/packages/truffle-debugger/test/endstate.js
+++ b/packages/truffle-debugger/test/endstate.js
@@ -8,7 +8,7 @@ import Ganache from "ganache-core";
 import { prepareContracts } from "./helpers";
 import Debugger from "lib/debugger";
 
-import sessionSelector from "lib/session/selectors";
+import evm from "lib/evm/selectors";
 import data from "lib/data/selectors";
 
 import * as TruffleDecodeUtils from "truffle-decode-utils";
@@ -79,7 +79,7 @@ describe("End State", function() {
 
     let session = bugger.connect();
 
-    assert.ok(!session.view(sessionSelector.transaction.receipt).status);
+    assert.ok(!session.view(evm.transaction.status));
   });
 
   it("Gets vars at end of successful contract (and marks it successful)", async function() {
@@ -101,7 +101,7 @@ describe("End State", function() {
     debug("DCIR %O", session.view(data.current.identifiers.refs));
     debug("proc.assignments %O", session.view(data.proc.assignments));
 
-    assert.ok(session.view(sessionSelector.transaction.receipt).status);
+    assert.ok(session.view(evm.transaction.status));
     const variables = TruffleDecodeUtils.Conversion.cleanBNs(
       await session.variables()
     );


### PR DESCRIPTION
This PR accounts for the possibility that a normal halting instruction might, in fact, halt exceptionally.  In addition, it also fixes what I think is likely a bug I introduced in #2052.  (A `RETURN` can fail if there are insufficient stack arguments; a `SELFDESTRUCT` can fail that same way, or by running out of gas, or if it's inside a static call.  `STOP` is, in fact, the only EVM instruction that is guaranteed not to fail.)

So first off, let me mention a quick improvement over #2052 -- in that previous PR, when determining the address created by a returning creation call, I looked at the stack to determine the address.  But this is foolish, because we already have the address on our callstack as `storageAddress`.  So now we use that instead, and I got rid of the selector I added in #2052 for getting that address.  (This was the bug, too, btw -- it would have a problem if we were at the end of the trace.)

Anyway, the main change in this PR is to the selector `evm.current.step.isExceptionalHalting`.  Previously, a normal halting instruction was assumed to never halt exceptionally.  Now, if the current instruction is a normal halting instruction, we check its return status (another new selector, `evm.current.step.returnStatus`).  If we're not at the last step of the trace, we just read this off of `evm.next.state.stack`.  If we are, we have to check the transaction's status instead.

However, the status wasn't previously being stored in the state, so now it is, in `evm.transaction.status`, along with corresponding selector.  Well, OK, it was being stored in the copy of the receipt stored in the `session` state, but that doesn't count.  Speaking of which, in the places in the tests and the interpreter where we used that to check the status, I changed it to now check `evm.transaction.status` instead.

And, that's really it!