### PR TITLE
Add Support for Tuples (aka Structs) in the ABI Contract Schema

### DIFF
--- a/packages/truffle-contract-schema/package.json
+++ b/packages/truffle-contract-schema/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/trufflesuite/truffle/blob/develop/packages/truffle-contract-schema#readme",
   "dependencies": {
-    "ajv": "^5.1.1",
+    "ajv": "^6.10.0",
     "crypto-js": "^3.1.9-1",
     "debug": "^4.1.0"
   },

--- a/packages/truffle-contract-schema/spec/abi.spec.json
+++ b/packages/truffle-contract-schema/spec/abi.spec.json
@@ -26,7 +26,8 @@
         { "type": "string", "pattern": "^bytes(0|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32)(\\[[0-9]*\\])*$" },
         { "type": "string", "pattern": "^bytes(\\[[0-9]*\\])*$" },
         { "type": "string", "pattern": "^function(\\[[0-9]*\\])*$" },
-        { "type": "string", "pattern": "^string(\\[[0-9]*\\])*$" }
+        { "type": "string", "pattern": "^string(\\[[0-9]*\\])*$" },
+        { "type": "string", "pattern": "^tuple$" }
       ]
     },
 
@@ -128,9 +129,23 @@
       "type": "object",
       "properties": {
         "name": { "$ref": "#/definitions/Name" },
-        "type": { "$ref": "#/definitions/Type" }
+        "type": { "$ref": "#/definitions/Type" },
+        "components": {
+          "type": "array",
+          "items": { "type": "object" }
+        }
       },
-      "required": ["name", "type"]
+      "if": {
+        "properties": {
+          "type": {
+            "oneOf": [
+              { "pattern": "^tuple$" }
+            ]
+          }
+        }
+      },
+      "then": { "required": ["name", "type", "components"] },
+      "else": { "required": ["name", "type"] }
     },
 
     "EventParameter": {

--- a/packages/truffle-contract-schema/spec/abi.spec.json
+++ b/packages/truffle-contract-schema/spec/abi.spec.json
@@ -1,5 +1,5 @@
 {
-  "id": "abi.spec.json",
+  "$id": "abi.spec.json",
   "$schema": "http://json-schema.org/schema#",
   "title": "ABI",
 

--- a/packages/truffle-contract-schema/spec/contract-object.spec.json
+++ b/packages/truffle-contract-schema/spec/contract-object.spec.json
@@ -1,5 +1,5 @@
 {
-  "id": "contract-object.spec.json",
+  "$id": "contract-object.spec.json",
   "$schema": "http://json-schema.org/schema#",
   "title": "Contract Object",
   "description": "Describes a contract consumable by Truffle, possibly including deployed instances on networks",

--- a/packages/truffle-contract-schema/spec/network-object.spec.json
+++ b/packages/truffle-contract-schema/spec/network-object.spec.json
@@ -1,5 +1,5 @@
 {
-  "id": "network-object.spec.json",
+  "$id": "network-object.spec.json",
   "$schema": "http://json-schema.org/schema#",
   "title": "Network Object",
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1275,7 +1275,7 @@ ajv@^5.0.0, ajv@^5.1.1, ajv@^5.2.3, ajv@^5.3.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
 
-ajv@^6.1.0, ajv@^6.5.5, ajv@^6.9.1:
+ajv@^6.1.0, ajv@^6.10.0, ajv@^6.5.5, ajv@^6.9.1:
   version "6.10.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
   dependencies:


### PR DESCRIPTION
This PR upgrades `ajv` to `v6` which implements `draft07` of the JSON Schema. It also adds support for tuples (which is how `struct` Solidity types are represented) as a parameter type.

You'll see https://github.com/trufflesuite/truffle/pull/2064/files#diff-da060bd5170ce9e90e14ece903806d3eR135 says that the `components` property has an array of `object` types. This is *supposed to be* `"items": { "$ref": "#/definitions/Parameter" }`, but the https://github.com/bcherny/json-schema-to-typescript dependency we use to generate typings fails due to the recursion  (gets a `Maximum call stack size exceeded` error when building), despite the schema supports this recursion.

The dependency has known about this issue for 2 years now (https://github.com/bcherny/json-schema-to-typescript/issues/76 which depends on another dependency issue https://github.com/APIDevTools/json-schema-ref-parser/issues/37), but a fix has yet to come.

https://github.com/trufflesuite/truffle/issues/2065 tracks this issue