### PR TITLE
Fix: Output instead of throw on postinstall errors

### DIFF
--- a/packages/truffle/scripts/postinstall.js
+++ b/packages/truffle/scripts/postinstall.js
@@ -19,5 +19,5 @@ const postinstallObtain = () => {
 try {
   postinstallObtain();
 } catch (error) {
-  throw error;
+  console.error(error);
 }


### PR DESCRIPTION
This PR attempts to resolve #2069 by outputting `postinstall` errors rather than throwing them.