### PR TITLE
Bug fix: fix test resolver bug

### DIFF
--- a/packages/truffle-core/lib/test.js
+++ b/packages/truffle-core/lib/test.js
@@ -106,8 +106,9 @@ var Test = {
       .then(function(paths) {
         dependency_paths = paths;
 
-        testContracts = sol_tests.map(function(test_file_path) {
-          return test_resolver.require(test_file_path);
+        testContracts = sol_tests.map(function(testFilePath) {
+          const artifactName = path.basename(testFilePath).replace(".sol", "");
+          return test_resolver.require(artifactName);
         });
 
         runner = new TestRunner(config);


### PR DESCRIPTION
Give the test resolver the name of the artifact for resolution instead of an absolute path. This was causing a problem where the resolver was failing to resolve to the correct artifact.