### PR TITLE
Fix interaction of continue command with unmapped code

### DIFF
--- a/packages/truffle-debugger/lib/controller/sagas/index.js
+++ b/packages/truffle-debugger/lib/controller/sagas/index.js
@@ -196,10 +196,6 @@ function* stepOver() {
  * continueUntilBreakpoint - step through execution until a breakpoint
  */
 function* continueUntilBreakpoint(action) {
-  var currentLocation, currentNode, currentLine, currentSourceId;
-  var finished;
-  var previousLine, previousSourceId;
-
   //if breakpoints was not specified, use the stored list from the state.
   //if it was, override that with the specified list.
   //note that explicitly specifying an empty list will advance to the end.
@@ -210,19 +206,22 @@ function* continueUntilBreakpoint(action) {
 
   let breakpointHit = false;
 
-  currentLocation = yield select(controller.current.location);
-  currentLine = currentLocation.sourceRange.lines.start.line;
-  currentSourceId = currentLocation.source.id;
+  let currentLocation = yield select(controller.current.location);
+  let currentLine = currentLocation.sourceRange.lines.start.line;
+  let currentSourceId = currentLocation.source.id;
 
   do {
     yield* stepNext();
 
-    previousLine = currentLine;
-    previousSourceId = currentSourceId;
+    //note these two have not been updated yet; they'll be updated a
+    //few lines down.  but at this point these are still the previous
+    //values.
+    let previousLine = currentLine;
+    let previousSourceId = currentSourceId;
 
     currentLocation = yield select(controller.current.location);
     debug("currentLocation: %O", currentLocation);
-    finished = yield select(controller.current.trace.finished);
+    let finished = yield select(controller.current.trace.finished);
     if (finished) {
       break; //can break immediately if finished
     }
@@ -231,7 +230,7 @@ function* continueUntilBreakpoint(action) {
     if (currentSourceId === undefined) {
       continue; //never stop on an unmapped instruction
     }
-    currentNode = currentLocation.node.id;
+    let currentNode = currentLocation.node.id;
     currentLine = currentLocation.sourceRange.lines.start.line;
 
     breakpointHit =

--- a/packages/truffle-debugger/lib/solidity/sagas/index.js
+++ b/packages/truffle-debugger/lib/solidity/sagas/index.js
@@ -18,6 +18,7 @@ function* tickSaga() {
   debug("got TICK");
 
   yield* functionDepthSaga();
+  debug("instruction: %O", yield select(solidity.current.instruction));
   yield* trace.signalTickSagaCompletion();
 }
 


### PR DESCRIPTION
This PR fixes some issues resulting from using the `c` command when there is unmapped code.  You could get a problem if you used it from within unmapped code, or if you continued to the end when the end is unmapped.  I fixed this by adding a `break` to the loop if you're already finished (so that the rest of the loop, that could cause a problem, never runs) and by adding a `continue` to the loop if you're in unmapped code (for the same reason) and rearranged other checks so that this works.  Pretty straightforward.