### PR TITLE
Internal improvement: Update truffle test code

### DIFF
--- a/packages/truffle-core/lib/commands/test.js
+++ b/packages/truffle-core/lib/commands/test.js
@@ -107,12 +107,11 @@ const command = {
       // TODO: Make the test artifactor configurable.
       config.artifactor = new Artifactor(temporaryDirectory);
 
-      Test.run(
-        config.with({
-          test_files: files,
-          contracts_build_directory: temporaryDirectory
-        })
-      )
+      const testConfig = config.with({
+        test_files: files,
+        contracts_build_directory: temporaryDirectory
+      });
+      Test.run(testConfig)
         .then(runCallback)
         .catch(runCallback);
     }

--- a/packages/truffle-core/lib/commands/test.js
+++ b/packages/truffle-core/lib/commands/test.js
@@ -111,9 +111,10 @@ const command = {
         config.with({
           test_files: files,
           contracts_build_directory: temporaryDirectory
-        }),
-        runCallback
-      );
+        })
+      )
+        .then(runCallback)
+        .catch(runCallback);
     }
 
     const environmentCallback = function() {

--- a/packages/truffle-core/lib/commands/test.js
+++ b/packages/truffle-core/lib/commands/test.js
@@ -69,7 +69,7 @@ const command = {
 
     var ipcDisconnect;
 
-    var files = [];
+    let files = [];
 
     if (options.file) {
       files = [options.file];
@@ -77,97 +77,93 @@ const command = {
       Array.prototype.push.apply(files, options._);
     }
 
-    function getFiles(callback) {
-      if (files.length !== 0) {
-        return callback(null, files);
+    try {
+      if (files.length === 0) {
+        files = dir.files(config.test_directory, { sync: true });
       }
-
-      dir.files(config.test_directory, callback);
+    } catch (error) {
+      return done(error);
     }
 
-    getFiles(function(err, files) {
+    files = files.filter(function(file) {
+      return file.match(config.test_file_extension_regexp) != null;
+    });
+
+    temp.mkdir("test-", function(err, temporaryDirectory) {
       if (err) return done(err);
 
-      files = files.filter(function(file) {
-        return file.match(config.test_file_extension_regexp) != null;
-      });
+      function runCallback() {
+        var args = arguments;
+        // Ensure directory cleanup.
+        done.apply(null, args);
+        if (ipcDisconnect) {
+          ipcDisconnect();
+        }
+      }
 
-      temp.mkdir("test-", function(err, temporaryDirectory) {
+      function run() {
+        // Set a new artifactor; don't rely on the one created by Environments.
+        // TODO: Make the test artifactor configurable.
+        config.artifactor = new Artifactor(temporaryDirectory);
+
+        Test.run(
+          config.with({
+            test_files: files,
+            contracts_build_directory: temporaryDirectory
+          }),
+          runCallback
+        );
+      }
+
+      const environmentCallback = function(err) {
         if (err) return done(err);
-
-        function runCallback() {
-          var args = arguments;
-          // Ensure directory cleanup.
-          done.apply(null, args);
-          if (ipcDisconnect) {
-            ipcDisconnect();
-          }
+        // Copy all the built files over to a temporary directory, because we
+        // don't want to save any tests artifacts. Only do this if the build directory
+        // exists.
+        try {
+          fs.statSync(config.contracts_build_directory);
+        } catch (_error) {
+          return run();
         }
 
-        function run() {
-          // Set a new artifactor; don't rely on the one created by Environments.
-          // TODO: Make the test artifactor configurable.
-          config.artifactor = new Artifactor(temporaryDirectory);
+        promisifiedCopy(config.contracts_build_directory, temporaryDirectory)
+          .then(() => {
+            config.logger.log(
+              "Using network '" + config.network + "'." + OS.EOL
+            );
 
-          Test.run(
-            config.with({
-              test_files: files,
-              contracts_build_directory: temporaryDirectory
-            }),
-            runCallback
-          );
-        }
+            run();
+          })
+          .catch(done);
+      };
 
-        const environmentCallback = function(err) {
-          if (err) return done(err);
-          // Copy all the built files over to a temporary directory, because we
-          // don't want to save any tests artifacts. Only do this if the build directory
-          // exists.
-          try {
-            fs.statSync(config.contracts_build_directory);
-          } catch (_error) {
-            return run();
-          }
+      if (config.networks[config.network]) {
+        Environment.detect(config)
+          .then(() => environmentCallback())
+          .catch(environmentCallback);
+      } else {
+        const ipcOptions = { network: "test" };
 
-          promisifiedCopy(config.contracts_build_directory, temporaryDirectory)
-            .then(() => {
-              config.logger.log(
-                "Using network '" + config.network + "'." + OS.EOL
-              );
-
-              run();
-            })
-            .catch(done);
+        const ganacheOptions = {
+          host: "127.0.0.1",
+          port: 7545,
+          network_id: 4447,
+          mnemonic:
+            "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat",
+          gasLimit: config.gas,
+          noVMErrorsOnRPCResponse: true
         };
-
-        if (config.networks[config.network]) {
-          Environment.detect(config)
-            .then(() => environmentCallback())
-            .catch(environmentCallback);
-        } else {
-          const ipcOptions = { network: "test" };
-
-          const ganacheOptions = {
-            host: "127.0.0.1",
-            port: 7545,
-            network_id: 4447,
-            mnemonic:
-              "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat",
-            gasLimit: config.gas,
-            noVMErrorsOnRPCResponse: true
-          };
-          Develop.connectOrStart(
-            ipcOptions,
-            ganacheOptions,
-            (started, disconnect) => {
-              ipcDisconnect = disconnect;
-              Environment.develop(config, ganacheOptions)
-                .then(() => environmentCallback())
-                .catch(environmentCallback);
-            }
-          );
-        }
-      });
+        Develop.connectOrStart(
+          ipcOptions,
+          ganacheOptions,
+          (started, disconnect) => {
+            ipcDisconnect = disconnect;
+            Environment.develop(config, ganacheOptions)
+              .then(() => environmentCallback())
+              .catch(environmentCallback);
+          }
+        );
+      }
     });
   }
 };

--- a/packages/truffle-core/lib/commands/test.js
+++ b/packages/truffle-core/lib/commands/test.js
@@ -116,8 +116,7 @@ const command = {
       );
     }
 
-    const environmentCallback = function(err) {
-      if (err) return done(err);
+    const environmentCallback = function() {
       // Copy all the built files over to a temporary directory, because we
       // don't want to save any tests artifacts. Only do this if the build directory
       // exists.
@@ -139,7 +138,7 @@ const command = {
     if (config.networks[config.network]) {
       Environment.detect(config)
         .then(() => environmentCallback())
-        .catch(environmentCallback);
+        .catch(done);
     } else {
       const ipcOptions = { network: "test" };
 
@@ -159,7 +158,7 @@ const command = {
           ipcDisconnect = disconnect;
           Environment.develop(config, ganacheOptions)
             .then(() => environmentCallback())
-            .catch(environmentCallback);
+            .catch(done);
         }
       );
     }

--- a/packages/truffle-core/lib/commands/test.js
+++ b/packages/truffle-core/lib/commands/test.js
@@ -54,7 +54,7 @@ const command = {
     const promisifiedCopy = promisify(require("../copy"));
     const Environment = require("../environment");
 
-    var config = Config.detect(options);
+    const config = Config.detect(options);
 
     // if "development" exists, default to using that for testing
     if (!config.network && config.networks.development) {
@@ -67,8 +67,7 @@ const command = {
       Environment.detect(config).catch(done);
     }
 
-    var ipcDisconnect;
-
+    let ipcDisconnect;
     let files = [];
 
     if (options.file) {
@@ -100,9 +99,7 @@ const command = {
       var args = arguments;
       // Ensure directory cleanup.
       done.apply(null, args);
-      if (ipcDisconnect) {
-        ipcDisconnect();
-      }
+      if (ipcDisconnect) ipcDisconnect();
     }
 
     function run() {

--- a/packages/truffle-core/lib/test.js
+++ b/packages/truffle-core/lib/test.js
@@ -177,21 +177,12 @@ const Test = {
   },
 
   performInitialDeploy: function(config, resolver) {
-    return new Promise(function(accept, reject) {
-      Migrate.run(
-        config.with({
-          reset: true,
-          resolver: resolver,
-          quiet: true
-        })
-      )
-        .then(() => {
-          accept();
-        })
-        .catch(error => {
-          reject(error);
-        });
+    const migrateConfig = config.with({
+      reset: true,
+      resolver: resolver,
+      quiet: true
     });
+    return Migrate.run(migrateConfig);
   },
 
   defineSolidityTests: function(mocha, contracts, dependency_paths, runner) {

--- a/packages/truffle-core/lib/test.js
+++ b/packages/truffle-core/lib/test.js
@@ -90,8 +90,8 @@ const Test = {
       testResolver
     );
 
-    const testContracts = solTests.map(test_file_path => {
-      return testResolver.require(test_file_path);
+    const testContracts = solTests.map(testFilePath => {
+      return testResolver.require(testFilePath);
     });
 
     const runner = new TestRunner(config);
@@ -113,7 +113,7 @@ const Test = {
     });
 
     return new Promise(resolve => {
-      mocha.run(function(failures) {
+      mocha.run(failures => {
         config.logger.warn = warn;
 
         resolve(failures);

--- a/packages/truffle-core/lib/test.js
+++ b/packages/truffle-core/lib/test.js
@@ -1,18 +1,18 @@
-var Mocha = require("mocha");
-var chai = require("chai");
-var path = require("path");
-var Web3 = require("web3");
-var Config = require("truffle-config");
-var Contracts = require("truffle-workflow-compile");
-var Resolver = require("truffle-resolver");
-var TestRunner = require("./testing/testrunner");
-var TestResolver = require("./testing/testresolver");
-var TestSource = require("./testing/testsource");
-var SolidityTest = require("./testing/soliditytest");
-var expect = require("truffle-expect");
-var Migrate = require("truffle-migrate");
-var Profiler = require("truffle-compile/profiler.js");
-var originalrequire = require("original-require");
+const Mocha = require("mocha");
+const chai = require("chai");
+const path = require("path");
+const Web3 = require("web3");
+const Config = require("truffle-config");
+const Contracts = require("truffle-workflow-compile");
+const Resolver = require("truffle-resolver");
+const TestRunner = require("./testing/testrunner");
+const TestResolver = require("./testing/testresolver");
+const TestSource = require("./testing/testsource");
+const SolidityTest = require("./testing/soliditytest");
+const expect = require("truffle-expect");
+const Migrate = require("truffle-migrate");
+const Profiler = require("truffle-compile/profiler.js");
+const originalrequire = require("original-require");
 
 chai.use(require("./assertions"));
 
@@ -150,32 +150,29 @@ const Test = {
     testResolver
   ) {
     return new Promise(function(accept, reject) {
-      Profiler.updated(
-        config.with({
-          resolver: testResolver
-        }),
-        function(err, updated) {
-          if (err) return reject(err);
+      Profiler.updated(config.with({ resolver: testResolver }), function(
+        err,
+        updated
+      ) {
+        if (err) return reject(err);
 
-          updated = updated || [];
+        updated = updated || [];
 
-          // Compile project contracts and test contracts
-          Contracts.compile(
-            config.with({
-              all: config.compileAll === true,
-              files: updated.concat(solidityTestFiles),
-              resolver: testResolver,
-              quiet: false,
-              quietWrite: true
-            }),
-            function(err, result) {
-              if (err) return reject(err);
-              const paths = result.outputs.solc;
-              accept(paths);
-            }
-          );
-        }
-      );
+        const compileConfig = config.with({
+          all: config.compileAll === true,
+          files: updated.concat(solidityTestFiles),
+          resolver: testResolver,
+          quiet: false,
+          quietWrite: true
+        });
+        // Compile project contracts and test contracts
+        Contracts.compile(compileConfig)
+          .then(result => {
+            const paths = result.outputs.solc;
+            accept(paths);
+          })
+          .catch(reject);
+      });
     });
   },
 

--- a/packages/truffle-core/lib/test.js
+++ b/packages/truffle-core/lib/test.js
@@ -18,8 +18,6 @@ chai.use(require("./assertions"));
 
 const Test = {
   run: async function(options) {
-    const self = this;
-
     expect.options(options, [
       "contracts_directory",
       "contracts_build_directory",
@@ -87,7 +85,7 @@ const Test = {
     );
     testResolver.cache_on = false;
 
-    const dependencyPaths = await self.compileContractsWithTestFilesIfNeeded(
+    const dependencyPaths = await this.compileContractsWithTestFilesIfNeeded(
       solTests,
       config,
       testResolver
@@ -99,16 +97,16 @@ const Test = {
 
     runner = new TestRunner(config);
 
-    await self.performInitialDeploy(config, testResolver);
+    await this.performInitialDeploy(config, testResolver);
 
-    await self.defineSolidityTests(
+    await this.defineSolidityTests(
       mocha,
       testContracts,
       dependencyPaths,
       runner
     );
 
-    await self.setJSTestGlobals(web3, accounts, testResolver, runner);
+    await this.setJSTestGlobals(web3, accounts, testResolver, runner);
 
     // Finally, run mocha.
     process.on("unhandledRejection", reason => {

--- a/packages/truffle-core/lib/test.js
+++ b/packages/truffle-core/lib/test.js
@@ -51,7 +51,7 @@ const Test = {
       }
     };
 
-    var mocha = this.createMocha(config);
+    const mocha = this.createMocha(config);
 
     const jsTests = config.test_files.filter(file => {
       return path.extname(file) !== ".sol";
@@ -72,13 +72,12 @@ const Test = {
       mocha.addFile(file);
     });
 
-    let runner, testResolver;
     const accounts = await this.getAccounts(web3);
 
     if (!config.resolver) config.resolver = new Resolver(config);
 
     const testSource = new TestSource(config);
-    testResolver = new TestResolver(
+    const testResolver = new TestResolver(
       config.resolver,
       testSource,
       config.contracts_build_directory
@@ -95,7 +94,7 @@ const Test = {
       return testResolver.require(test_file_path);
     });
 
-    runner = new TestRunner(config);
+    const runner = new TestRunner(config);
 
     await this.performInitialDeploy(config, testResolver);
 

--- a/packages/truffle-core/lib/test.js
+++ b/packages/truffle-core/lib/test.js
@@ -185,28 +185,26 @@ const Test = {
     return Migrate.run(migrateConfig);
   },
 
-  defineSolidityTests: function(mocha, contracts, dependency_paths, runner) {
-    return new Promise(function(accept) {
-      contracts.forEach(function(contract) {
-        SolidityTest.define(contract, dependency_paths, runner, mocha);
+  defineSolidityTests: function(mocha, contracts, dependencyPaths, runner) {
+    return new Promise(resolve => {
+      contracts.forEach(contract => {
+        SolidityTest.define(contract, dependencyPaths, runner, mocha);
       });
 
-      accept();
+      resolve();
     });
   },
 
-  setJSTestGlobals: function(web3, accounts, test_resolver, runner) {
+  setJSTestGlobals: function(web3, accounts, testResolver, runner) {
     return new Promise(function(accept) {
       global.web3 = web3;
       global.assert = chai.assert;
       global.expect = chai.expect;
       global.artifacts = {
-        require: function(import_path) {
-          return test_resolver.require(import_path);
-        }
+        require: import_path => testResolver.require(import_path)
       };
 
-      var template = function(tests) {
+      const template = function(tests) {
         this.timeout(runner.TEST_TIMEOUT);
 
         before("prepare suite", function(done) {

--- a/packages/truffle-core/lib/test.js
+++ b/packages/truffle-core/lib/test.js
@@ -78,7 +78,7 @@ const Test = {
     let testContracts = [];
     let accounts = [];
     let runner, testResolver;
-    this.getAccounts(web3)
+    return this.getAccounts(web3)
       .then(function(accs) {
         accounts = accs;
 
@@ -126,10 +126,12 @@ const Test = {
           throw reason;
         });
 
-        mocha.run(function(failures) {
-          config.logger.warn = warn;
+        return new Promise(resolve => {
+          mocha.run(function(failures) {
+            config.logger.warn = warn;
 
-          callback(failures);
+            resolve(failures);
+          });
         });
       })
       .catch(callback);

--- a/packages/truffle-core/lib/testing/testsource.js
+++ b/packages/truffle-core/lib/testing/testsource.js
@@ -1,8 +1,8 @@
-var Deployed = require("./deployed");
-var path = require("path");
-var fs = require("fs");
-var contract = require("truffle-contract");
-var find_contracts = require("truffle-contract-sources");
+const Deployed = require("./deployed");
+const path = require("path");
+const fse = require("fs-extra");
+const contract = require("truffle-contract");
+const find_contracts = require("truffle-contract-sources");
 
 function TestSource(config) {
   this.config = config;
@@ -24,7 +24,7 @@ TestSource.prototype.resolve = function(import_path, callback) {
 
       let abstraction_files;
       try {
-        abstraction_files = fs.readdirSync(
+        abstraction_files = fse.readdirSync(
           self.config.contracts_build_directory
         );
       } catch (error) {
@@ -50,16 +50,10 @@ TestSource.prototype.resolve = function(import_path, callback) {
       });
 
       const promises = abstraction_files.map(file => {
-        return new Promise((accept, reject) => {
-          fs.readFile(
-            path.join(self.config.contracts_build_directory, file),
-            "utf8",
-            function(err, body) {
-              if (err) return reject(err);
-              accept(body);
-            }
-          );
-        });
+        return fse.readFile(
+          path.join(self.config.contracts_build_directory, file),
+          "utf8"
+        );
       });
 
       Promise.all(promises)
@@ -111,7 +105,7 @@ TestSource.prototype.resolve = function(import_path, callback) {
 
   for (const lib of assertLibraries) {
     if (import_path === `truffle/${lib}.sol`)
-      return fs.readFile(
+      return fse.readFile(
         path.resolve(path.join(__dirname, `${lib}.sol`)),
         { encoding: "utf8" },
         (err, body) => callback(err, body, import_path)

--- a/packages/truffle-core/lib/testing/testsource.js
+++ b/packages/truffle-core/lib/testing/testsource.js
@@ -43,14 +43,14 @@ TestSource.prototype.resolve = function(import_path, callback) {
         mapping[name] = false;
       });
 
-      abstraction_files.forEach(function(file) {
+      abstraction_files.forEach(file => {
         var name = path.basename(file, ".json");
         if (blacklist.indexOf(name) >= 0) return;
         mapping[name] = false;
       });
 
-      var promises = abstraction_files.map(function(file) {
-        return new Promise(function(accept, reject) {
+      var promises = abstraction_files.map(file => {
+        return new Promise((accept, reject) => {
           fs.readFile(
             path.join(self.config.contracts_build_directory, file),
             "utf8",
@@ -63,24 +63,18 @@ TestSource.prototype.resolve = function(import_path, callback) {
       });
 
       Promise.all(promises)
-        .then(function(files_data) {
-          var addresses = files_data
-            .map(function(data) {
-              return JSON.parse(data);
-            })
-            .map(function(json) {
-              return contract(json);
-            })
-            .map(function(c) {
+        .then(files_data => {
+          const addresses = files_data
+            .map(data => JSON.parse(data))
+            .map(json => contract(json))
+            .map(c => {
               c.setNetwork(self.config.network_id);
-              if (c.isDeployed()) {
-                return c.address;
-              }
+              if (c.isDeployed()) return c.address;
               return null;
             });
 
-          addresses.forEach(function(address, i) {
-            var name = path.basename(abstraction_files[i], ".json");
+          addresses.forEach((address, i) => {
+            const name = path.basename(abstraction_files[i], ".json");
 
             if (blacklist.indexOf(name) >= 0) return;
 
@@ -92,7 +86,7 @@ TestSource.prototype.resolve = function(import_path, callback) {
             self.config.compilers
           );
         })
-        .then(function(addressSource) {
+        .then(addressSource => {
           callback(null, addressSource, import_path);
         })
         .catch(callback);

--- a/packages/truffle-core/lib/testing/testsource.js
+++ b/packages/truffle-core/lib/testing/testsource.js
@@ -13,12 +13,12 @@ TestSource.prototype.require = function() {
 };
 
 TestSource.prototype.resolve = function(import_path, callback) {
-  var self = this;
+  const self = this;
 
   if (import_path === "truffle/DeployedAddresses.sol") {
     return find_contracts(this.config.contracts_directory, function(
       err,
-      source_files
+      sourceFiles
     ) {
       // Ignore this error. Continue on.
 
@@ -31,25 +31,25 @@ TestSource.prototype.resolve = function(import_path, callback) {
         return callback(error);
       }
 
-      var mapping = {};
+      const mapping = {};
 
-      var blacklist = ["Assert", "DeployedAddresses"];
+      const blacklist = ["Assert", "DeployedAddresses"];
 
       // Ensure we have a mapping for source files and abstraction files
       // to prevent any compile errors in tests.
-      source_files.forEach(function(file) {
-        var name = path.basename(file, ".sol");
+      sourceFiles.forEach(file => {
+        const name = path.basename(file, ".sol");
         if (blacklist.indexOf(name) >= 0) return;
         mapping[name] = false;
       });
 
       abstraction_files.forEach(file => {
-        var name = path.basename(file, ".json");
+        const name = path.basename(file, ".json");
         if (blacklist.indexOf(name) >= 0) return;
         mapping[name] = false;
       });
 
-      var promises = abstraction_files.map(file => {
+      const promises = abstraction_files.map(file => {
         return new Promise((accept, reject) => {
           fs.readFile(
             path.join(self.config.contracts_build_directory, file),
@@ -63,8 +63,8 @@ TestSource.prototype.resolve = function(import_path, callback) {
       });
 
       Promise.all(promises)
-        .then(files_data => {
-          const addresses = files_data
+        .then(filesData => {
+          const addresses = filesData
             .map(data => JSON.parse(data))
             .map(json => contract(json))
             .map(c => {

--- a/packages/truffle-core/lib/testing/testsource.js
+++ b/packages/truffle-core/lib/testing/testsource.js
@@ -12,19 +12,19 @@ TestSource.prototype.require = function() {
   return null; // FSSource will get it.
 };
 
-TestSource.prototype.resolve = function(import_path, callback) {
+TestSource.prototype.resolve = function(importPath, callback) {
   const self = this;
 
-  if (import_path === "truffle/DeployedAddresses.sol") {
+  if (importPath === "truffle/DeployedAddresses.sol") {
     return find_contracts(this.config.contracts_directory, function(
       err,
       sourceFiles
     ) {
       // Ignore this error. Continue on.
 
-      let abstraction_files;
+      let abstractionFiles;
       try {
-        abstraction_files = fse.readdirSync(
+        abstractionFiles = fse.readdirSync(
           self.config.contracts_build_directory
         );
       } catch (error) {
@@ -43,13 +43,13 @@ TestSource.prototype.resolve = function(import_path, callback) {
         mapping[name] = false;
       });
 
-      abstraction_files.forEach(file => {
+      abstractionFiles.forEach(file => {
         const name = path.basename(file, ".json");
         if (blacklist.indexOf(name) >= 0) return;
         mapping[name] = false;
       });
 
-      const promises = abstraction_files.map(file => {
+      const promises = abstractionFiles.map(file => {
         return fse.readFile(
           path.join(self.config.contracts_build_directory, file),
           "utf8"
@@ -68,7 +68,7 @@ TestSource.prototype.resolve = function(import_path, callback) {
             });
 
           addresses.forEach((address, i) => {
-            const name = path.basename(abstraction_files[i], ".json");
+            const name = path.basename(abstractionFiles[i], ".json");
 
             if (blacklist.indexOf(name) >= 0) return;
 
@@ -81,7 +81,7 @@ TestSource.prototype.resolve = function(import_path, callback) {
           );
         })
         .then(addressSource => {
-          callback(null, addressSource, import_path);
+          callback(null, addressSource, importPath);
         })
         .catch(callback);
     });
@@ -104,22 +104,19 @@ TestSource.prototype.resolve = function(import_path, callback) {
   ];
 
   for (const lib of assertLibraries) {
-    if (import_path === `truffle/${lib}.sol`)
+    if (importPath === `truffle/${lib}.sol`)
       return fse.readFile(
         path.resolve(path.join(__dirname, `${lib}.sol`)),
         { encoding: "utf8" },
-        (err, body) => callback(err, body, import_path)
+        (err, body) => callback(err, body, importPath)
       );
   }
 
   return callback();
 };
 
-TestSource.prototype.resolve_dependency_path = function(
-  import_path,
-  dependency_path
-) {
-  return dependency_path;
+TestSource.prototype.resolve_dependency_path = (importPath, dependencyPath) => {
+  return dependencyPath;
 };
 
 module.exports = TestSource;


### PR DESCRIPTION
In the interest of making the code for truffle test more readable and maintainable, this PR was created! It removes the callback being passed to the run method for `packages/truffle-core/lib/test.js` and instead adopts a Promise-based interface. The callback is now being handled in `packages/truffle-core/lib/commands/test.js`. The war on callbacks wages on!