### PR TITLE
Discard padding when decoding numeric types

### DIFF
--- a/packages/truffle-debugger/test/data/more-decoding.js
+++ b/packages/truffle-debugger/test/data/more-decoding.js
@@ -191,11 +191,44 @@ contract ComplexMappingTest {
 }
 `;
 
+const __OVERFLOW = `
+pragma solidity ^0.5.0;
+
+contract OverflowTest {
+
+  event Unsigned(uint8);
+  event Raw(byte);
+  event Signed(int8);
+
+  function unsignedTest() public {
+    uint8[1] memory memoryByte;
+    uint8 byte1 = 255;
+    uint8 byte2 = 255;
+    uint8 sum = byte1 + byte2;
+    emit Unsigned(sum); //BREAK UNSIGNED
+  }
+
+  function rawTest() public {
+    byte full = 0xff;
+    byte right = full >> 1;
+    emit Raw(right); //BREAK RAW
+  }
+
+  function signedTest() public {
+    int8 byte1 = -128;
+    int8 byte2 = -128;
+    int8 sum = byte1 + byte2;
+    emit Signed(sum); //BREAK SIGNED
+  }
+}
+`;
+
 let sources = {
   "ContainersTest.sol": __CONTAINERS,
   "ElementaryTest.sol": __KEYSANDBYTES,
   "SpliceTest.sol": __SPLICING,
-  "ComplexMappingsTest.sol": __INNERMAPS
+  "ComplexMappingsTest.sol": __INNERMAPS,
+  "OverflowTest.sol": __OVERFLOW
 };
 
 describe("Further Decoding", function() {
@@ -483,5 +516,112 @@ describe("Further Decoding", function() {
       //the top-level variables
       assert.deepInclude(startingOffsets, slot.offset);
     }
+  });
+
+  describe("Overflow", function() {
+    it("Discards padding on unsigned integers", async function() {
+      let instance = await abstractions.OverflowTest.deployed();
+      let receipt = await instance.unsignedTest();
+      let txHash = receipt.tx;
+
+      let bugger = await Debugger.forTx(txHash, {
+        provider,
+        files,
+        contracts: artifacts
+      });
+
+      let session = bugger.connect();
+
+      let sourceId = session.view(solidity.current.source).id;
+      let source = session.view(solidity.current.source).source;
+      await session.addBreakpoint({
+        sourceId,
+        line: lineOf("BREAK UNSIGNED", source)
+      });
+
+      await session.continueUntilBreakpoint();
+
+      const variables = TruffleDecodeUtils.Conversion.cleanBNs(
+        await session.variables()
+      ); //get rid of BNs for simplicity
+      debug("variables %O", variables);
+
+      const expectedResult = {
+        byte1: 255,
+        byte2: 255,
+        sum: 254
+      };
+
+      assert.include(variables, expectedResult);
+    });
+
+    it("Discards padding on signed integers", async function() {
+      let instance = await abstractions.OverflowTest.deployed();
+      let receipt = await instance.signedTest();
+      let txHash = receipt.tx;
+
+      let bugger = await Debugger.forTx(txHash, {
+        provider,
+        files,
+        contracts: artifacts
+      });
+
+      let session = bugger.connect();
+
+      let sourceId = session.view(solidity.current.source).id;
+      let source = session.view(solidity.current.source).source;
+      await session.addBreakpoint({
+        sourceId,
+        line: lineOf("BREAK SIGNED", source)
+      });
+
+      await session.continueUntilBreakpoint();
+
+      const variables = TruffleDecodeUtils.Conversion.cleanBNs(
+        await session.variables()
+      ); //get rid of BNs for simplicity
+      debug("variables %O", variables);
+
+      const expectedResult = {
+        byte1: -128,
+        byte2: -128,
+        sum: 0
+      };
+
+      assert.include(variables, expectedResult);
+    });
+
+    it("Discards padding on static bytestrings", async function() {
+      let instance = await abstractions.OverflowTest.deployed();
+      let receipt = await instance.rawTest();
+      let txHash = receipt.tx;
+
+      let bugger = await Debugger.forTx(txHash, {
+        provider,
+        files,
+        contracts: artifacts
+      });
+
+      let session = bugger.connect();
+
+      let sourceId = session.view(solidity.current.source).id;
+      let source = session.view(solidity.current.source).source;
+      await session.addBreakpoint({
+        sourceId,
+        line: lineOf("BREAK RAW", source)
+      });
+
+      await session.continueUntilBreakpoint();
+
+      const variables = await session.variables();
+      debug("variables %O", variables);
+
+      const expectedResult = {
+        full: "0xff",
+        right: "0x7f"
+      };
+
+      assert.include(variables, expectedResult);
+    });
   });
 });

--- a/packages/truffle-decoder/lib/decode/value.ts
+++ b/packages/truffle-decoder/lib/decode/value.ts
@@ -20,6 +20,8 @@ export default function* decodeValue(definition: DecodeUtils.AstDefinition, poin
     return undefined;
   }
 
+  let length;
+
   debug("definition %O", definition);
   debug("pointer %o", pointer);
 
@@ -28,9 +30,13 @@ export default function* decodeValue(definition: DecodeUtils.AstDefinition, poin
       return !DecodeUtils.Conversion.toBN(bytes).isZero();
 
     case "uint":
+      length = DecodeUtils.Definition.specifiedSize(definition);
+      bytes = bytes.slice(-length); //chop off padding
       return DecodeUtils.Conversion.toBN(bytes);
 
     case "int":
+      length = DecodeUtils.Definition.specifiedSize(definition);
+      bytes = bytes.slice(-length); //chop off padding
       return DecodeUtils.Conversion.toSignedBN(bytes);
 
     case "address":
@@ -42,7 +48,7 @@ export default function* decodeValue(definition: DecodeUtils.AstDefinition, poin
     case "bytes":
       debug("typeIdentifier %s %o", DecodeUtils.Definition.typeIdentifier(definition), bytes);
       //if there's a static size, we want to truncate to that length
-      let length = DecodeUtils.Definition.specifiedSize(definition);
+      length = DecodeUtils.Definition.specifiedSize(definition);
       if(length !== null) {
         bytes = bytes.slice(0, length);
       }


### PR DESCRIPTION
This PR causes the decoder to discard padding before attempting to decode variables of `uint` or `int` type.  Previously the padding was left in on the theory that it wouldn't affect the result.  However, it turns out that when using short integer types (or short bytestring types), Solidity doesn't actually restore correct padding after an operation that overflows; it only restores correct padding when it performs an operation that requires it to.  So, if you have add two `uint8`s of value 255, the result will be stored as, and currently decode to, a 510, rather than 254 like you might expect; however for practical purposes it acts like a 254 in Solidity, and as such it should decode to such (particularly so that it's handled correctly as a mapping key!).

We already discard padding for short bytestring types for other reasons, so I just needed to add code to discard it for short integer types as well.

Notionally we could add similar code for other types, but I think these are the only types that can be operated on in a way that potentially overflows into the padding.  (Presumably once fixed-point types are added this issue will come up there too, but right now we don't support those, so whatever.)

I also added some tests of this feature.