### PR TITLE
Add shim for function kind for pre-0.5.0 contracts

### DIFF
--- a/packages/truffle-debugger/lib/data/selectors/index.js
+++ b/packages/truffle-debugger/lib/data/selectors/index.js
@@ -49,7 +49,8 @@ function modifierForInvocation(invocation, scopes) {
     case "ContractDefinition":
       return rawNode.nodes.find(
         node =>
-          node.nodeType === "FunctionDefinition" && node.kind === "constructor"
+          node.nodeType === "FunctionDefinition" &&
+          DecodeUtils.Definition.functionKind(node) === "constructor"
       );
     default:
       //we should never hit this case

--- a/packages/truffle-decode-utils/src/definition.ts
+++ b/packages/truffle-decode-utils/src/definition.ts
@@ -276,6 +276,25 @@ export namespace Definition {
     }
   }
 
+  //compatibility function, since pre-0.5.0 functions don't have node.kind
+  //returns undefined if you don't put in a function node
+  export function functionKind(node: AstDefinition): string | undefined {
+    if(node.nodeType !== "FunctionDefinition") {
+      return undefined;
+    }
+    if(node.kind !== undefined) {
+      //if we're dealing with 0.5.x, we can just read node.kind
+      return node.kind;
+    }
+    //otherwise, we need this little shim
+    if(node.isConstructor) {
+      return "constructor";
+    }
+    return node.name === ""
+      ? "fallback"
+      : "function";
+  }
+
   //spoofed definitions we'll need
   //we'll give them id -1 to indicate that they're spoofed
 


### PR DESCRIPTION
I recently learned that prior to Solidity 0.5.0, function definitions didn't have the `kind` property.  I've added this shim for this fact and put it in in the one place we were currently reading the `kind` property.  (There are more such places on `type-and-value` and related branches, but here's the `develop` version.)  I didn't add a similar function for `stateMutability` because I can't find anywhere we used that, but I'll add that too in the future if we want to use it.