### PR TITLE
Account for empty multivalue types (legal in 0.4.x) in allocator

### DIFF
--- a/packages/truffle-decoder/lib/allocate/calldata.ts
+++ b/packages/truffle-decoder/lib/allocate/calldata.ts
@@ -119,6 +119,10 @@ function calldataSizeAndAllocate(definition: AstDefinition, referenceDeclaration
       else {
         //static array case
         const length: number = DecodeUtils.Definition.staticLength(definition);
+        if(length === 0) {
+          //arrays of length 0 are static regardless of base type
+          return [0, false, existingAllocations];
+        }
         const baseDefinition: AstDefinition = definition.baseType || definition.typeName.baseType;
         const [baseSize, dynamic, allocations] = calldataSizeAndAllocate(baseDefinition, referenceDeclarations, existingAllocations);
         return [length * baseSize, dynamic, allocations];


### PR DESCRIPTION
This PR adds allocator support for empty structs and static-length arrays of length 0, which were legal prior to 0.5.0.

In storage, such types take up 1 word, not 0 words, as might be expected.  This PR accounts for that.

In calldata, a static-length array of length 0 is considered a static type regardless of the base type (normally `type[n]` is considered a static type iff `type` is); this can affect the length of other structs or arrays that contain them.  This PR accounts for that.

(OK, calldata variables didn't exist prior to 0.5.0, but we'll still want this change later for decoding transactions and events.)

There are no changes to memory.