### PR TITLE
Add support for unary + in mapping keys (0.4.x. compatibility)

### DIFF
--- a/packages/truffle-debugger/lib/data/sagas/index.js
+++ b/packages/truffle-debugger/lib/data/sagas/index.js
@@ -441,6 +441,14 @@ function* variablesAndMappingsSaga() {
         else if (indexDefinition.kind === "typeConversion") {
           indexDefinition = indexDefinition.arguments[0];
         }
+        //...also prior to 0.5.0, unary + was legal, which needs to be accounted
+        //for for the same reason
+        else if (
+          indexDefinition.nodeType === "UnaryOperation" &&
+          indexDefinition.operator === "+"
+        ) {
+          indexDefinition = indexDefinition.subExpression;
+        }
         //otherwise, we've just totally failed to decode it, so we mark
         //indexValue as null (as distinct from undefined) to indicate this.  In
         //the future, we should be able to decode all mapping keys, but we're


### PR DESCRIPTION
This PR allows mapping keys that begin with a unary `+` to work.  Unary `+` isn't legal anymore, but it was legal prior to 0.4.18.

As you may recall, our system for recording mapping keys doesn't work if the outermost operation in the index expression is (on the bytecode level) a no-op.  Obviously, that includes unary `+`.  I didn't account for this earlier because I didn't realize it was legal in old versions.  Well, it is, so I've accounted for it, in the same way I've accounted for other no-ops.