### PR TITLE
Internal improvement: leverage travis apt addons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,13 @@ dist: trusty
 sudo: required
 language: node_js
 
+addons:
+  apt:
+    sources:
+      - sourceline: 'ppa:ethereum/ethereum'
+    packages: dpkg
+
 before_install:
-  - sudo add-apt-repository --yes ppa:ethereum/ethereum
-  - sudo apt-get update
-  - sudo apt-get install -y dpkg
   - npm list -g lerna --depth=0 || npm install -g lerna
   - npm install -g yarn
 


### PR DESCRIPTION
Fixes an issue where `sudo apt-get update` was pulling an outdated link from `ethereum/ethereum`.