### PR TITLE
Internal improvement: Add coverage for box.js

### DIFF
--- a/packages/truffle-box/box.js
+++ b/packages/truffle-box/box.js
@@ -97,8 +97,8 @@ const Box = {
   //   Recursively removes the created temporary directory, even when it's not empty. default is false
   // options.setGracefulCleanup
   //   Cleanup temporary files even when an uncaught exception occurs
-  sandbox: function(options, callback) {
-    var self = this;
+  sandbox: (options, callback) => {
+    const self = this;
     const { name, unsafeCleanup, setGracefulCleanup } = parseSandboxOptions(
       options
     );
@@ -111,17 +111,17 @@ const Box = {
       tmp.setGracefulCleanup();
     }
 
-    tmp.dir({ unsafeCleanup }, function(err, dir) {
+    tmp.dir({ unsafeCleanup }, (err, dir) => {
       if (err) return callback(err);
 
       self
         .unbox(
-          "https://github.com/trufflesuite/truffle-init-" + name,
+          `https://github.com/trufflesuite/truffle-init-${name}`,
           dir,
           options
         )
-        .then(function() {
-          var config = Config.load(path.join(dir, "truffle-config.js"), {});
+        .then(() => {
+          const config = Config.load(path.join(dir, "truffle-config.js"), {});
           callback(null, config);
         })
         .catch(callback);

--- a/packages/truffle-box/box.js
+++ b/packages/truffle-box/box.js
@@ -110,20 +110,20 @@ const Box = {
       tmp.setGracefulCleanup();
     }
 
-    tmp.dir({ unsafeCleanup }, (err, dir) => {
-      if (err) return callback(err);
-
-      Box.unbox(
-        `https://github.com/trufflesuite/truffle-init-${name}`,
-        dir,
-        options
-      )
-        .then(() => {
-          const config = Config.load(path.join(dir, "truffle-config.js"), {});
-          callback(null, config);
-        })
-        .catch(callback);
-    });
+    const tmpDir = tmp.dirSync({ unsafeCleanup });
+    Box.unbox(
+      `https://github.com/trufflesuite/truffle-init-${name}`,
+      tmpDir.name,
+      options
+    )
+      .then(() => {
+        const config = Config.load(
+          path.join(tmpDir.name, "truffle-config.js"),
+          {}
+        );
+        callback(null, config);
+      })
+      .catch(callback);
   }
 };
 

--- a/packages/truffle-box/box.js
+++ b/packages/truffle-box/box.js
@@ -98,7 +98,6 @@ const Box = {
   // options.setGracefulCleanup
   //   Cleanup temporary files even when an uncaught exception occurs
   sandbox: (options, callback) => {
-    const self = this;
     const { name, unsafeCleanup, setGracefulCleanup } = parseSandboxOptions(
       options
     );
@@ -114,12 +113,11 @@ const Box = {
     tmp.dir({ unsafeCleanup }, (err, dir) => {
       if (err) return callback(err);
 
-      self
-        .unbox(
-          `https://github.com/trufflesuite/truffle-init-${name}`,
-          dir,
-          options
-        )
+      Box.unbox(
+        `https://github.com/trufflesuite/truffle-init-${name}`,
+        dir,
+        options
+      )
         .then(() => {
           const config = Config.load(path.join(dir, "truffle-config.js"), {});
           callback(null, config);

--- a/packages/truffle-box/box.js
+++ b/packages/truffle-box/box.js
@@ -66,7 +66,7 @@ const Box = {
       return boxConfig;
     } catch (error) {
       if (tempDirCleanup) tempDirCleanup();
-      throw new Error(error);
+      throw error;
     }
   },
 

--- a/packages/truffle-box/box.js
+++ b/packages/truffle-box/box.js
@@ -3,7 +3,7 @@ const tmp = require("tmp");
 const path = require("path");
 const Config = require("truffle-config");
 const ora = require("ora");
-const fs = require("fs");
+const fse = require("fs-extra");
 const inquirer = require("inquirer");
 
 function parseSandboxOptions(options) {
@@ -73,7 +73,7 @@ const Box = {
   checkDir: async (options = {}, destination) => {
     let logger = options.logger || console;
     if (!options.force) {
-      const unboxDir = fs.readdirSync(destination);
+      const unboxDir = fse.readdirSync(destination);
       if (unboxDir.length) {
         logger.log(`This directory is non-empty...`);
         const prompt = [

--- a/packages/truffle-box/test/box.js
+++ b/packages/truffle-box/test/box.js
@@ -1,6 +1,5 @@
 const path = require("path");
-const regularFs = require("fs");
-const fs = require("fs-extra");
+const fse = require("fs-extra");
 const assert = require("assert");
 const inquirer = require("inquirer");
 const sinon = require("sinon");
@@ -14,16 +13,16 @@ describe("truffle-box Box", () => {
   const destination = path.join(__dirname, ".truffle_test_tmp");
 
   beforeEach(() => {
-    fs.ensureDirSync(destination);
+    fse.ensureDirSync(destination);
   });
   afterEach(() => {
-    fs.removeSync(destination);
+    fse.removeSync(destination);
   });
 
   describe(".unbox()", () => {
     beforeEach(() => {
       sinon.stub(Box, "checkDir").returns(Promise.resolve());
-      fs.emptyDirSync(destination);
+      fse.emptyDirSync(destination);
     });
     afterEach(() => {
       Box.checkDir.restore();
@@ -34,7 +33,7 @@ describe("truffle-box Box", () => {
         assert.ok(truffleConfig);
 
         assert(
-          fs.existsSync(path.join(destination, "truffle-config.js")),
+          fse.existsSync(path.join(destination, "truffle-config.js")),
           "Unboxed project should have truffle config."
         );
         done();
@@ -44,17 +43,17 @@ describe("truffle-box Box", () => {
     it("does not copy the config files or ignored files in the config", () => {
       // Assert the file is not there first.
       assert(
-        fs.existsSync(path.join(destination, "truffle-init.json")) === false,
+        fse.existsSync(path.join(destination, "truffle-init.json")) === false,
         "truffle-init.json shouldn't be available to the user!"
       );
 
       // Now assert the README.md and the .gitignore file were removed.
       assert(
-        fs.existsSync(path.join(destination, "README.md")) === false,
+        fse.existsSync(path.join(destination, "README.md")) === false,
         "README.md didn't get removed!"
       );
       assert(
-        fs.existsSync(path.join(destination, ".gitignore")) === false,
+        fse.existsSync(path.join(destination, ".gitignore")) === false,
         ".gitignore didn't get removed!"
       );
     });
@@ -100,7 +99,7 @@ describe("truffle-box Box", () => {
           assert.ok(truffleConfig);
 
           assert(
-            fs.existsSync(path.join(destination, "truffle-config.js")),
+            fse.existsSync(path.join(destination, "truffle-config.js")),
             "Unboxed project should have truffle config."
           );
           done();
@@ -110,7 +109,6 @@ describe("truffle-box Box", () => {
 
     it("runs without a prompt", done => {
       Box.unbox(TRUFFLE_BOX_DEFAULT, destination, { force: true }).then(() => {
-        console.log("the inquirer value %o", inquirer.prompt.called);
         assert.strictEqual(inquirer.prompt.called, false);
         done();
       });
@@ -120,23 +118,23 @@ describe("truffle-box Box", () => {
       const truffleConfigPath = path.join(destination, "truffle-config.js");
 
       // preconditions
-      fs.writeFileSync(
+      fse.writeFileSync(
         truffleConfigPath,
         "this truffle-config.js file is different than the default box file",
         "utf8"
       );
       assert(
-        fs.existsSync(truffleConfigPath),
+        fse.existsSync(truffleConfigPath),
         "mock truffle-config.js wasn't created!"
       );
-      const mockConfig = fs.readFileSync(truffleConfigPath, "utf8");
+      const mockConfig = fse.readFileSync(truffleConfigPath, "utf8");
 
       Box.unbox(TRUFFLE_BOX_DEFAULT, destination, { force: true }).then(() => {
         assert(
-          fs.existsSync(truffleConfigPath),
+          fse.existsSync(truffleConfigPath),
           "truffle-config.js wasn't recreated!"
         );
-        const newConfig = fs.readFileSync(truffleConfigPath, "utf8");
+        const newConfig = fse.readFileSync(truffleConfigPath, "utf8");
         assert(
           newConfig !== mockConfig,
           "truffle-config.js wasn't overwritten!"
@@ -154,16 +152,16 @@ describe("truffle-box Box", () => {
       // preconditions
       sinon
         .stub(inquirer, "prompt")
-        .returns(Promise.resolve({ proceed: true }));
-      fs.ensureDirSync(contractDirPath);
+        .returns(Promise.resolve({ proceed: true, overwrite: true }));
+      fse.ensureDirSync(contractDirPath);
       assert(
-        fs.existsSync(contractDirPath),
+        fse.existsSync(contractDirPath),
         "contracts folder wasn't created!"
       );
     });
     afterEach(() => {
       inquirer.prompt.restore();
-      fs.removeSync(contractDirPath);
+      fse.removeSync(contractDirPath);
     });
 
     it("prompts when redundant files/folders exist in target directory", done => {
@@ -195,30 +193,30 @@ describe("truffle-box Box", () => {
       inquirer.prompt.restore();
     });
 
-    describe("when the directory is empty", () => {
-      beforeEach(() => {
-        sinon.stub(regularFs, "readdirSync").returns([]);
+    describe("when directory is empty", () => {
+      before(() => {
+        sinon.stub(fse, "readdirSync").returns([]);
       });
-      afterEach(() => {
-        regularFs.readdirSync.restore();
+      after(() => {
+        fse.readdirSync.restore();
       });
 
-      it("doesn't prompt the user", async () => {
+      it("doesn't prompt user", async () => {
         await Box.checkDir();
         assert.strictEqual(inquirer.prompt.called, false);
       });
     });
 
-    describe("when the directory is non-empty", () => {
-      beforeEach(() => {
-        sinon.stub(regularFs, "readdirSync").returns(["someCrappyFile.js"]);
+    describe("when directory is non-empty", () => {
+      before(() => {
+        sinon.stub(fse, "readdirSync").returns(["someCrappyFile.js"]);
       });
-      afterEach(() => {
-        regularFs.readdirSync.restore();
+      after(() => {
+        fse.readdirSync.restore();
       });
 
-      it("prompts the user", () => {
-        Box.checkDir();
+      it("prompts user", () => {
+        Box.checkDir(options);
         assert(inquirer.prompt.called);
       });
     });

--- a/packages/truffle-box/test/box.js
+++ b/packages/truffle-box/test/box.js
@@ -279,6 +279,7 @@ describe("truffle-box Box", () => {
         assert(inquirer.prompt.called);
         assert(options.logger.loggedStuff.includes("Unbox cancelled"));
         assert(process.exit.called);
+        assert.deepStrictEqual(fse.readdirSync(), ["someCrappyFile.js"]);
       });
     });
   });

--- a/packages/truffle-box/test/box.js
+++ b/packages/truffle-box/test/box.js
@@ -181,6 +181,36 @@ describe("truffle-box Box", () => {
         done();
       });
     });
+
+    it("overwrites redundant files when prompted and user confirms", done => {
+      const truffleConfigPath = path.join(destination, "truffle-config.js");
+
+      // preconditions
+      fse.writeFileSync(
+        truffleConfigPath,
+        "this truffle-config.js file is different than the default box file",
+        "utf8"
+      );
+      assert(
+        fse.existsSync(truffleConfigPath),
+        "mock truffle-config.js wasn't created!"
+      );
+      const mockConfig = fse.readFileSync(truffleConfigPath, "utf8");
+
+      Box.unbox(TRUFFLE_BOX_DEFAULT, destination, options).then(() => {
+        assert(inquirer.prompt.called);
+        assert(
+          fse.existsSync(truffleConfigPath),
+          "truffle-config.js wasn't recreated!"
+        );
+        const newConfig = fse.readFileSync(truffleConfigPath, "utf8");
+        assert(
+          newConfig !== mockConfig,
+          "truffle-config.js wasn't overwritten!"
+        );
+        done();
+      });
+    });
   });
 
   describe("Box.checkDir()", () => {

--- a/packages/truffle-box/test/box.js
+++ b/packages/truffle-box/test/box.js
@@ -259,5 +259,27 @@ describe("truffle-box Box", () => {
         assert(inquirer.prompt.called);
       });
     });
+
+    describe("when directory is non-empty and user declines to unbox", () => {
+      before(() => {
+        sinon.stub(fse, "readdirSync").returns(["someCrappyFile.js"]);
+        sinon.stub(process, "exit").returns(1);
+      });
+      after(() => {
+        fse.readdirSync.restore();
+        process.exit.restore();
+      });
+
+      it("Exits unbox process", async () => {
+        inquirer.prompt.restore();
+        sinon
+          .stub(inquirer, "prompt")
+          .returns(Promise.resolve({ proceed: false }));
+        await Box.checkDir(options);
+        assert(inquirer.prompt.called);
+        assert(options.logger.loggedStuff.includes("Unbox cancelled"));
+        assert(process.exit.called);
+      });
+    });
   });
 });

--- a/packages/truffle-box/test/box.js
+++ b/packages/truffle-box/test/box.js
@@ -214,6 +214,15 @@ describe("truffle-box Box", () => {
   });
 
   describe("Box.checkDir()", () => {
+    let options = {
+      logger: {
+        log(stringToLog) {
+          this.loggedStuff = this.loggedStuff + stringToLog;
+        },
+        loggedStuff: ""
+      }
+    };
+
     beforeEach(() => {
       sinon
         .stub(inquirer, "prompt")


### PR DESCRIPTION
This PR mainly adds some coverage for `truffle-box/box.js`. Also swaps `fs` for `fs-extra` and modernizes the code a tiny bit.