### PR TITLE
De-dupe Truffle's mocha dependencies

### DIFF
--- a/packages/truffle-compile-vyper/package.json
+++ b/packages/truffle-compile-vyper/package.json
@@ -1,8 +1,14 @@
 {
   "name": "truffle-compile-vyper",
-  "version": "1.0.17",
   "description": "Vyper compiler support",
+  "license": "MIT",
+  "author": "Evgeniy Filatov <evgeniyfilatov@gmail.com>",
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-compile-vyper",
+  "version": "1.0.17",
   "main": "index.js",
+  "scripts": {
+    "test": "mocha"
+  },
   "dependencies": {
     "async": "2.6.1",
     "colors": "^1.1.2",
@@ -11,21 +17,15 @@
     "truffle-compile": "^4.1.0"
   },
   "devDependencies": {
-    "mocha": "^5.2.0",
+    "mocha": "5.2.0",
     "truffle-config": "^1.1.13"
   },
-  "scripts": {
-    "test": "mocha"
-  },
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-compile-vyper",
   "keywords": [
+    "compile",
     "ethereum",
     "truffle",
-    "compile",
     "vyper"
   ],
-  "author": "Evgeniy Filatov <evgeniyfilatov@gmail.com>",
-  "license": "MIT",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/truffle-core/package.json
+++ b/packages/truffle-core/package.json
@@ -14,7 +14,6 @@
     "cpr": "^3.0.1",
     "debug": "^4.1.0",
     "del": "^2.2.0",
-    "diff": "1.4.0",
     "ethereumjs-wallet": "^0.6.2",
     "ethpm": "0.0.16",
     "ethpm-registry": "0.1.0-next.2",

--- a/packages/truffle-hdwallet-provider/package.json
+++ b/packages/truffle-hdwallet-provider/package.json
@@ -1,26 +1,25 @@
 {
   "name": "truffle-hdwallet-provider",
-  "version": "1.0.10",
   "description": "HD Wallet-enabled Web3 provider",
-  "main": "dist/index.js",
-  "scripts": {
-    "test": "mocha --timeout 5000",
-    "prepare": "npx webpack --config webpack/webpack.config.js"
-  },
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-hdwallet-provider",
-  "keywords": [
-    "etheruem",
-    "hd",
-    "wallet",
-    "mnemonic",
-    "provider"
-  ],
-  "author": "Tim Coulter <tim.coulter@consensys.net>",
   "license": "MIT",
+  "author": "Tim Coulter <tim.coulter@consensys.net>",
+  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-hdwallet-provider#readme",
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-hdwallet-provider",
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"
   },
-  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle-hdwallet-provider#readme",
+  "version": "1.0.10",
+  "main": "dist/index.js",
+  "scripts": {
+    "prepare": "npx webpack --config webpack/webpack.config.js",
+    "test": "mocha --timeout 5000"
+  },
+  "dependencies": {
+    "any-promise": "^1.3.0",
+    "bindings": "^1.3.1",
+    "web3": "1.0.0-beta.37",
+    "websocket": "^1.0.28"
+  },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",
     "bip39": "^2.2.0",
@@ -29,17 +28,18 @@
     "ethereumjs-wallet": "^0.6.2",
     "ganache-core": "2.5.5",
     "js-scrypt": "^0.2.0",
-    "mocha": "^5.1.1",
+    "mocha": "5.2.0",
     "web3": "1.0.0-beta.37",
     "web3-provider-engine": "https://github.com/trufflesuite/provider-engine#web3-one",
     "webpack": "^4.24.0",
     "webpack-cli": "^3.1.2"
   },
-  "gitHead": "b207efb3c1409746537293b3e0fc27350029188e",
-  "dependencies": {
-    "any-promise": "^1.3.0",
-    "bindings": "^1.3.1",
-    "web3": "1.0.0-beta.37",
-    "websocket": "^1.0.28"
-  }
+  "keywords": [
+    "etheruem",
+    "hd",
+    "mnemonic",
+    "provider",
+    "wallet"
+  ],
+  "gitHead": "b207efb3c1409746537293b3e0fc27350029188e"
 }

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -5,7 +5,7 @@
   "description": "Truffle - Simple development framework for Ethereum",
   "dependencies": {
     "app-module-path": "^2.2.0",
-    "mocha": "^4.1.0",
+    "mocha": "5.2.0",
     "original-require": "1.0.1"
   },
   "devDependencies": {
@@ -21,7 +21,6 @@
     "js-scrypt": "^0.2.0",
     "meta-npm": "^0.0.22",
     "meta-pkgs": "^0.2.0",
-    "mocha": "5.2.0",
     "nyc": "^13.0.1",
     "prepend-file": "^1.3.1",
     "semver": "^5.6.0",

--- a/packages/truffle/test/scenarios/reporter.js
+++ b/packages/truffle/test/scenarios/reporter.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 // This is a direct copy of the following reporter changed
 // such that logger commands are switched to a configurable logger.
@@ -10,13 +10,11 @@ var OS = require("os");
  * Module dependencies.
  */
 
-var ms = require('mocha/lib/ms.js');
-var Base = require('mocha/lib/reporters/base.js');
-var utils = require('mocha/lib/utils');
+var ms = require("mocha/lib/ms.js");
+var Base = require("mocha/lib/reporters/base.js");
+var utils = require("mocha/lib/utils");
 var inherits = utils.inherits;
 var color = Base.color;
-var diff = require('diff');
-
 
 /**
  * Expose `Spec`.
@@ -34,62 +32,64 @@ exports = module.exports = function(logger) {
    * @api public
    * @param {Runner} runner
    */
-  function Spec (runner) {
+  function Spec(runner) {
     Base.call(this, runner);
 
     var self = this;
     var indents = 0;
     var n = 0;
 
-    function indent () {
-      return Array(indents).join('  ');
+    function indent() {
+      return Array(indents).join("  ");
     }
 
-    runner.on('start', function () {
+    runner.on("start", function() {
       logger.log();
     });
 
-    runner.on('suite', function (suite) {
+    runner.on("suite", function(suite) {
       ++indents;
-      logger.log(color('suite', '%s%s'), indent(), suite.title);
+      logger.log(color("suite", "%s%s"), indent(), suite.title);
     });
 
-    runner.on('suite end', function () {
+    runner.on("suite end", function() {
       --indents;
       if (indents === 1) {
         logger.log();
       }
     });
 
-    runner.on('pending', function (test) {
-      var fmt = indent() + color('pending', '  - %s');
+    runner.on("pending", function(test) {
+      var fmt = indent() + color("pending", "  - %s");
       logger.log(fmt, test.title);
     });
 
-    runner.on('pass', function (test) {
+    runner.on("pass", function(test) {
       var fmt;
-      if (test.speed === 'fast') {
-        fmt = indent() +
-          color('checkmark', '  ' + Base.symbols.ok) +
-          color('pass', ' %s');
+      if (test.speed === "fast") {
+        fmt =
+          indent() +
+          color("checkmark", "  " + Base.symbols.ok) +
+          color("pass", " %s");
         logger.log(fmt, test.title);
       } else {
-        fmt = indent() +
-          color('checkmark', '  ' + Base.symbols.ok) +
-          color('pass', ' %s') +
-          color(test.speed, ' (%dms)');
+        fmt =
+          indent() +
+          color("checkmark", "  " + Base.symbols.ok) +
+          color("pass", " %s") +
+          color(test.speed, " (%dms)");
         logger.log(fmt, test.title, test.duration);
       }
     });
 
-    runner.on('fail', function (test) {
-      logger.log(indent() + color('fail', '  %d) %s'), ++n, test.title);
+    runner.on("fail", function(test) {
+      logger.log(indent() + color("fail", "  %d) %s"), ++n, test.title);
     });
 
-    runner.on('end', function() {
+    runner.on("end", function() {
       self.epilogue();
     });
-  };
+  }
 
   // This is a direct copy of Base.epilogue, replacing logger with logger.
   Spec.prototype.epilogue = function() {
@@ -99,25 +99,23 @@ exports = module.exports = function(logger) {
     logger.log();
 
     // passes
-    fmt = color('bright pass', ' ') +
-      color('green', ' %d passing') +
-      color('light', ' (%s)');
+    fmt =
+      color("bright pass", " ") +
+      color("green", " %d passing") +
+      color("light", " (%s)");
 
-    logger.log(fmt,
-      stats.passes || 0,
-      ms(stats.duration));
+    logger.log(fmt, stats.passes || 0, ms(stats.duration));
 
     // pending
     if (stats.pending) {
-      fmt = color('pending', ' ') +
-        color('pending', ' %d pending');
+      fmt = color("pending", " ") + color("pending", " %d pending");
 
       logger.log(fmt, stats.pending);
     }
 
     // failures
     if (stats.failures) {
-      fmt = color('fail', '  %d failing');
+      fmt = color("fail", "  %d failing");
 
       logger.log(fmt, stats.failures);
 
@@ -133,141 +131,29 @@ exports = module.exports = function(logger) {
   // https://github.com/mochajs/mocha/blob/master/lib/reporters/base.js
   var objToString = Object.prototype.toString;
 
-  function sameType (a, b) {
+  function sameType(a, b) {
     return objToString.call(a) === objToString.call(b);
   }
 
-  /**
-   * Return a character diff for `err`.
-   *
-   * @api private
-   * @param {Error} err
-   * @param {string} type
-   * @param {boolean} escape
-   * @return {string}
-   */
-  function errorDiff (err, type, escape) {
-    var actual = escape ? escapeInvisibles(err.actual) : err.actual;
-    var expected = escape ? escapeInvisibles(err.expected) : err.expected;
-    return diff['diff' + type](actual, expected).map(function (str) {
-      if (str.added) {
-        return colorLines('diff added', str.value);
-      }
-      if (str.removed) {
-        return colorLines('diff removed', str.value);
-      }
-      return str.value;
-    }).join('');
-  }
-
-  /**
-   * Returns an inline diff between 2 strings with coloured ANSI output
-   *
-   * @api private
-   * @param {Error} err with actual/expected
-   * @param {boolean} escape
-   * @return {string} Diff
-   */
-  function inlineDiff (err, escape) {
-    var msg = errorDiff(err, 'WordsWithSpace', escape);
-
-    // linenos
-    var lines = msg.split('\n');
-    if (lines.length > 4) {
-      var width = String(lines.length).length;
-      msg = lines.map(function (str, i) {
-        return pad(++i, width) + ' |' + ' ' + str;
-      }).join('\n');
-    }
-
-    // legend
-    msg = '\n' +
-      color('diff removed', 'actual') +
-      ' ' +
-      color('diff added', 'expected') +
-      '\n\n' +
-      msg +
-      '\n';
-
-    // indent
-    msg = msg.replace(/^/gm, '      ');
-    return msg;
-  }
-
-
-  /**
-   * Color lines for `str`, using the color `name`.
-   *
-   * @api private
-   * @param {string} name
-   * @param {string} str
-   * @return {string}
-   */
-  function colorLines (name, str) {
-    return str.split('\n').map(function (str) {
-      return color(name, str);
-    }).join('\n');
-  }
-
-  /**
-   * Returns a unified diff between two strings.
-   *
-   * @api private
-   * @param {Error} err with actual/expected
-   * @param {boolean} escape
-   * @return {string} The diff.
-   */
-  function unifiedDiff (err, escape) {
-    var indent = '      ';
-    function cleanUp (line) {
-      if (escape) {
-        line = escapeInvisibles(line);
-      }
-      if (line[0] === '+') {
-        return indent + colorLines('diff added', line);
-      }
-      if (line[0] === '-') {
-        return indent + colorLines('diff removed', line);
-      }
-      if (line.match(/@@/)) {
-        return null;
-      }
-      if (line.match(/\\ No newline/)) {
-        return null;
-      }
-      return indent + line;
-    }
-    function notBlank (line) {
-      return typeof line !== 'undefined' && line !== null;
-    }
-    var msg = diff.createPatch('string', err.actual, err.expected);
-    var lines = msg.split('\n').splice(4);
-    return '\n      ' +
-      colorLines('diff added', '+ expected') + ' ' +
-      colorLines('diff removed', '- actual') +
-      '\n\n' +
-      lines.map(cleanUp).filter(notBlank).join('\n');
-  }
-
-
   Spec.prototype.list = function(failures) {
     logger.log();
-    failures.forEach(function (test, i) {
+    failures.forEach(function(test, i) {
       // format
-      var fmt = color('error title', '  %s) %s:\n') +
-        color('error message', '     %s') +
-        color('error stack', '\n%s\n');
+      var fmt =
+        color("error title", "  %s) %s:\n") +
+        color("error message", "     %s") +
+        color("error stack", "\n%s\n");
 
       // msg
       var msg;
       var err = test.err;
       var message;
-      if (err.message && typeof err.message.toString === 'function') {
-        message = err.message + '';
-      } else if (typeof err.inspect === 'function') {
-        message = err.inspect() + '';
+      if (err.message && typeof err.message.toString === "function") {
+        message = err.message + "";
+      } else if (typeof err.inspect === "function") {
+        message = err.inspect() + "";
       } else {
-        message = '';
+        message = "";
       }
       var stack = err.stack || message;
       var index = message ? stack.indexOf(message) : -1;
@@ -286,31 +172,33 @@ exports = module.exports = function(logger) {
 
       // uncaught
       if (err.uncaught) {
-        msg = 'Uncaught ' + msg;
+        msg = "Uncaught " + msg;
       }
       // explicitly show diff
-      if (err.showDiff !== false && sameType(actual, expected) && expected !== undefined) {
+      if (
+        err.showDiff !== false &&
+        sameType(actual, expected) &&
+        expected !== undefined
+      ) {
         escape = false;
         if (!(utils.isString(actual) && utils.isString(expected))) {
           err.actual = actual = utils.stringify(actual);
           err.expected = expected = utils.stringify(expected);
         }
 
-        fmt = color('error title', '  %s) %s:\n%s') + color('error stack', '\n%s\n');
+        fmt =
+          color("error title", "  %s) %s:\n%s") +
+          color("error stack", "\n%s\n");
         var match = message.match(/^([^:]+): expected/);
-        msg = '\n      ' + color('error message', match ? match[1] : msg);
+        msg = "\n      " + color("error message", match ? match[1] : msg);
 
-        if (exports.inlineDiffs) {
-          msg += inlineDiff(err, escape);
-        } else {
-          msg += unifiedDiff(err, escape);
-        }
+        msg += Base.generateDiff(err, escape);
       }
 
       // indent stack trace
-      stack = stack.replace(/^/gm, '  ');
+      stack = stack.replace(/^/gm, "  ");
 
-      logger.log(fmt, (i + 1), test.fullTitle(), msg, stack);
+      logger.log(fmt, i + 1, test.fullTitle(), msg, stack);
     });
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2771,11 +2771,6 @@ browser-resolve@^1.11.0, browser-resolve@^1.7.0:
   dependencies:
     resolve "1.1.7"
 
-browser-stdout@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
-  integrity sha1-81HTKWnTL6XXpVZxVCY9korjvR8=
-
 browser-stdout@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
@@ -3696,11 +3691,6 @@ command-exists@^1.2.8:
   resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.8.tgz#715acefdd1223b9c9b37110a149c6392c2852291"
   integrity sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw==
 
-commander@2.11.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
-  integrity sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==
-
 commander@2.15.1:
   version "2.15.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
@@ -4554,16 +4544,6 @@ dezalgo@^1.0.0:
   dependencies:
     asap "^2.0.0"
     wrappy "1"
-
-diff@1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
-  integrity sha1-fyjS657nsVqX79ic5j3P2qPMur8=
-
-diff@3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.1.tgz#aa8567a6eed03c531fc89d3f711cd0e5259dec75"
-  integrity sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==
 
 diff@3.5.0, diff@^3.5.0:
   version "3.5.0"
@@ -7051,11 +7031,6 @@ graphql@^0.13.0:
   integrity sha512-QZ5BL8ZO/B20VA8APauGBg3GyEgZ19eduvpLWoq5x7gMmWnHoy8rlQWPLmWgFvo1yNgjSEFMesmS4R6pPr7xog==
   dependencies:
     iterall "^1.2.1"
-
-growl@1.10.3:
-  version "1.10.3"
-  resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.3.tgz#1926ba90cf3edfe2adb4927f5880bc22c66c790f"
-  integrity sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==
 
 growl@1.10.5, "growl@~> 1.10.0":
   version "1.10.5"
@@ -10000,7 +9975,7 @@ mocha-webpack@^1.1.0:
     toposort "^1.0.0"
     yargs "^4.8.0"
 
-mocha@5.2.0, mocha@^5.1.1, mocha@^5.2.0:
+mocha@5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-5.2.0.tgz#6d8ae508f59167f940f2b5b3c4a612ae50c90ae6"
   integrity sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==
@@ -10016,22 +9991,6 @@ mocha@5.2.0, mocha@^5.1.1, mocha@^5.2.0:
     minimatch "3.0.4"
     mkdirp "0.5.1"
     supports-color "5.4.0"
-
-mocha@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-4.1.0.tgz#7d86cfbcf35cb829e2754c32e17355ec05338794"
-  integrity sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==
-  dependencies:
-    browser-stdout "1.3.0"
-    commander "2.11.0"
-    debug "3.1.0"
-    diff "3.3.1"
-    escape-string-regexp "1.0.5"
-    glob "7.1.2"
-    growl "1.10.3"
-    he "1.1.1"
-    mkdirp "0.5.1"
-    supports-color "4.4.0"
 
 mocha@^6.0.0, mocha@^6.0.2, mocha@^6.1.4:
   version "6.1.4"
@@ -13839,13 +13798,6 @@ subcomandante@^1.0.5:
     duplexer "^0.1.1"
     end-of-stream "^1.4.1"
     is-running "^1.0.5"
-
-supports-color@4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.4.0.tgz#883f7ddabc165142b2a61427f3352ded195d1a3e"
-  integrity sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==
-  dependencies:
-    has-flag "^2.0.0"
 
 supports-color@5.4.0:
   version "5.4.0"


### PR DESCRIPTION
This started out as just an upgrade to `diff` to fix the [security vulnerability](https://github.com/trufflesuite/truffle/network/alert/packages/truffle-core/package.json/diff/closed), but turns out we don't even need to use `diff` directly anymore.

- Get rid of awkward v4.1.0 (not used by truffle-core, but installed as a dep for bundled Truffle)
- For every package dependent on mocha@^5, use mocha@5.2.0
- Ignore packages that depend on mocha@^6
- Remove truffle-core's `diff` dependency, use exported function from newer mocha instead