### PR TITLE
Use current AST format instead of legacy for ordering ABI output

### DIFF
--- a/packages/truffle-compile/index.js
+++ b/packages/truffle-compile/index.js
@@ -280,72 +280,38 @@ function replaceLinkReferences(bytecode, linkReferences, libraryName) {
   return bytecode;
 }
 
-function orderABI(contract) {
-  var contract_definition;
-  var ordered_function_names = [];
+function orderABI({ abi, contract_name: contractName, legacyAST }) {
+  // AST can have multiple contract definitions, make sure we have the
+  // one that matches our contract
+  const contractDefinition = legacyAST.children.filter(
+    ({ name: nodeType, attributes: { name } }) =>
+      nodeType === "ContractDefinition" && name === contractName
+  )[0];
 
-  for (var i = 0; i < contract.legacyAST.children.length; i++) {
-    var definition = contract.legacyAST.children[i];
-
-    // AST can have multiple contract definitions, make sure we have the
-    // one that matches our contract
-    if (
-      definition.name !== "ContractDefinition" ||
-      definition.attributes.name !== contract.contract_name
-    ) {
-      continue;
-    }
-
-    contract_definition = definition;
-    break;
+  if (!contractDefinition || !contractDefinition.children) {
+    return abi;
   }
 
-  if (!contract_definition) return contract.abi;
-  if (!contract_definition.children) return contract.abi;
-
-  contract_definition.children.forEach(function(child) {
-    if (child.name === "FunctionDefinition") {
-      ordered_function_names.push(child.attributes.name);
-    }
-  });
+  const orderedFunctionNames = contractDefinition.children
+    .filter(({ name: nodeType }) => nodeType === "FunctionDefinition")
+    .map(({ attributes: { name: functionName } }) => functionName);
 
   // Put function names in a hash with their order, lowest first, for speed.
-  var functions_to_remove = ordered_function_names.reduce(function(
-    obj,
-    value,
-    index
-  ) {
-    obj[value] = index;
-    return obj;
-  },
-  {});
+  const functionIndexes = orderedFunctionNames
+    .map((functionName, index) => ({ [functionName]: index }))
+    .reduce((a, b) => Object.assign({}, a, b), {});
 
-  // Filter out functions from the abi
-  var function_definitions = contract.abi.filter(function(item) {
-    return functions_to_remove[item.name] !== undefined;
-  });
+  // Construct new ABI with functions at the end in source order
+  return [
+    ...abi.filter(({ name }) => functionIndexes[name] === undefined),
 
-  // Sort removed function defintions
-  function_definitions = function_definitions.sort(function(item_a, item_b) {
-    var a = functions_to_remove[item_a.name];
-    var b = functions_to_remove[item_b.name];
-
-    if (a > b) return 1;
-    if (a < b) return -1;
-    return 0;
-  });
-
-  // Create a new ABI, placing ordered functions at the end.
-  var newABI = [];
-  contract.abi.forEach(function(item) {
-    if (functions_to_remove[item.name] !== undefined) return;
-    newABI.push(item);
-  });
-
-  // Now pop the ordered functions definitions on to the end of the abi..
-  Array.prototype.push.apply(newABI, function_definitions);
-
-  return newABI;
+    // followed by the functions in the source order
+    ...abi
+      .filter(({ name }) => functionIndexes[name] !== undefined)
+      .sort(
+        ({ name: a }, { name: b }) => functionIndexes[a] - functionIndexes[b]
+      )
+  ];
 }
 
 // contracts_directory: String. Directory where .sol files can be found.

--- a/packages/truffle-compile/index.js
+++ b/packages/truffle-compile/index.js
@@ -283,10 +283,10 @@ function replaceLinkReferences(bytecode, linkReferences, libraryName) {
 function orderABI({ abi, contract_name: contractName, ast }) {
   // AST can have multiple contract definitions, make sure we have the
   // one that matches our contract
-  const contractDefinition = ast.nodes.filter(
+  const contractDefinition = ast.nodes.find(
     ({ nodeType, name }) =>
       nodeType === "ContractDefinition" && name === contractName
-  )[0];
+  );
 
   if (!contractDefinition || !contractDefinition.nodes) {
     return abi;

--- a/packages/truffle-compile/index.js
+++ b/packages/truffle-compile/index.js
@@ -280,21 +280,22 @@ function replaceLinkReferences(bytecode, linkReferences, libraryName) {
   return bytecode;
 }
 
-function orderABI({ abi, contract_name: contractName, legacyAST }) {
+function orderABI({ abi, contract_name: contractName, ast }) {
   // AST can have multiple contract definitions, make sure we have the
   // one that matches our contract
-  const contractDefinition = legacyAST.children.filter(
-    ({ name: nodeType, attributes: { name } }) =>
+  const contractDefinition = ast.nodes.filter(
+    ({ nodeType, name }) =>
       nodeType === "ContractDefinition" && name === contractName
   )[0];
 
-  if (!contractDefinition || !contractDefinition.children) {
+  if (!contractDefinition || !contractDefinition.nodes) {
     return abi;
   }
 
-  const orderedFunctionNames = contractDefinition.children
-    .filter(({ name: nodeType }) => nodeType === "FunctionDefinition")
-    .map(({ attributes: { name: functionName } }) => functionName);
+  // Find all function definitions
+  const orderedFunctionNames = contractDefinition.nodes
+    .filter(({ nodeType }) => nodeType === "FunctionDefinition")
+    .map(({ name: functionName }) => functionName);
 
   // Put function names in a hash with their order, lowest first, for speed.
   const functionIndexes = orderedFunctionNames


### PR DESCRIPTION
(Internal improvement)

Truffle's compilation process orders output ABI in source-defined order using the AST parse info. This PR switches to using the current `ast` compilation source property instead of the `legacyAST` compilation source property.

+some refactoring