### PR TITLE
Add native tag to parser test needing docker/native

### DIFF
--- a/packages/truffle-compile/test/test_parser.js
+++ b/packages/truffle-compile/test/test_parser.js
@@ -38,7 +38,7 @@ describe("Parser", () => {
     assert.deepEqual(imports, expected);
   });
 
-  it("should return correct imports with native solc", () => {
+  it("should return correct imports with native solc [ @native ]", () => {
     const config = { version: "native" };
     const nativeSupplier = new CompilerSupplier(config);
     nativeSupplier.load().then(nativeSolc => {
@@ -58,7 +58,7 @@ describe("Parser", () => {
     });
   });
 
-  it("should return correct imports with docker solc", () => {
+  it("should return correct imports with docker solc [ @native ]", () => {
     const config = { docker: true, version: "0.4.25" };
     const dockerSupplier = new CompilerSupplier(config);
     dockerSupplier.load().then(dockerSolc => {


### PR DESCRIPTION
_(Internal improvement)_

Mark a few truffle-compile tests as being `@native` because they use Docker. I've seen this done elsewhere so I assume it's kosher?