### PR TITLE
Fix bug with truffle test

### DIFF
--- a/packages/truffle-core/lib/commands/test.js
+++ b/packages/truffle-core/lib/commands/test.js
@@ -68,7 +68,6 @@ const command = {
 
     let ipcDisconnect;
     let files = [];
-    let readFiles;
 
     if (options.file) {
       files = [options.file];
@@ -78,13 +77,11 @@ const command = {
 
     try {
       if (files.length === 0) {
-        readFiles = dir.files(config.test_directory, { sync: true });
+        files = dir.files(config.test_directory, { sync: true }) || [];
       }
     } catch (error) {
       return done(error);
     }
-
-    if (readFiles) files = readFiles;
 
     files = files.filter(function(file) {
       return file.match(config.test_file_extension_regexp) != null;

--- a/packages/truffle-core/lib/commands/test.js
+++ b/packages/truffle-core/lib/commands/test.js
@@ -68,6 +68,7 @@ const command = {
 
     let ipcDisconnect;
     let files = [];
+    let readFiles;
 
     if (options.file) {
       files = [options.file];
@@ -77,11 +78,13 @@ const command = {
 
     try {
       if (files.length === 0) {
-        files = dir.files(config.test_directory, { sync: true });
+        readFiles = dir.files(config.test_directory, { sync: true });
       }
     } catch (error) {
       return done(error);
     }
+
+    if (readFiles) files = readFiles;
 
     files = files.filter(function(file) {
       return file.match(config.test_file_extension_regexp) != null;


### PR DESCRIPTION
Fix bug occurring when running truffle test with 0 test files. When there are 0 files that `node-dir` reads in a directory, it returns `undefined` instead of an empty array.