### PR TITLE
Invalid artifacts error

### DIFF
--- a/packages/truffle-compile/profiler.js
+++ b/packages/truffle-compile/profiler.js
@@ -71,16 +71,16 @@ module.exports = {
                   "utf8",
                   (err, body) => {
                     if (err) return finished(err);
-                    finished(null, body);
+                    finished(null, { file: buildFile, body });
                   }
                 );
               },
               (err, jsonData) => {
                 if (err) return c(err);
 
-                try {
-                  for (let i = 0; i < jsonData.length; i++) {
-                    const data = JSON.parse(jsonData[i]);
+                for (let i = 0; i < jsonData.length; i++) {
+                  try {
+                    const data = JSON.parse(jsonData[i].body);
 
                     // In case there are artifacts from other source locations.
                     if (sourceFilesArtifacts[data.sourcePath] == null) {
@@ -88,9 +88,12 @@ module.exports = {
                     }
 
                     sourceFilesArtifacts[data.sourcePath].push(data);
+                  } catch (e) {
+                    // JSON.parse throws SyntaxError objects
+                    return e instanceof SyntaxError
+                      ? c(new Error("Invalid artifact: " + jsonData[i].file))
+                      : c(e);
                   }
-                } catch (e) {
-                  return c(e);
                 }
 
                 c();

--- a/packages/truffle-compile/profiler.js
+++ b/packages/truffle-compile/profiler.js
@@ -91,7 +91,11 @@ module.exports = {
                   } catch (e) {
                     // JSON.parse throws SyntaxError objects
                     return e instanceof SyntaxError
-                      ? c(new Error("Invalid artifact: " + jsonData[i].file))
+                      ? c(
+                          new Error(
+                            "Problem parsing artifact: " + jsonData[i].file
+                          )
+                        )
                       : c(e);
                   }
                 }


### PR DESCRIPTION
I had this truffle error a few days ago :
```
Compiling your contracts...
===========================
SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at async.map (/Users/mathew/.nvm/versions/node/v10.15.3/lib/node_modules/truffle/build/webpack:/packages/truffle-compile/profiler.js:83:1)
    at /Users/mathew/.nvm/versions/node/v10.15.3/lib/node_modules/truffle/build/webpack:/packages/truffle-compile/~/async/dist/async.js:1140:1
    at /Users/mathew/.nvm/versions/node/v10.15.3/lib/node_modules/truffle/build/webpack:/packages/truffle-compile/~/async/dist/async.js:473:1
    at iteratorCallback (/Users/mathew/.nvm/versions/node/v10.15.3/lib/node_modules/truffle/build/webpack:/packages/truffle-compile/~/async/dist/async.js:1064:1)
    at /Users/mathew/.nvm/versions/node/v10.15.3/lib/node_modules/truffle/build/webpack:/packages/truffle-compile/~/async/dist/async.js:969:1
    at /Users/mathew/.nvm/versions/node/v10.15.3/lib/node_modules/truffle/build/webpack:/packages/truffle-compile/~/async/dist/async.js:1137:1
    at fs.readFile (/Users/mathew/.nvm/versions/node/v10.15.3/lib/node_modules/truffle/build/webpack:/packages/truffle-compile/profiler.js:74:1)
    at FSReqWrap.readFileAfterClose [as oncomplete] (internal/fs/read_file_context.js:53:3)
```

It turns out that I had an empty JSON artifact file in my `build/contracts` folder. Truffle tries to parse the file but it is considered to be invalid json. 

I thought I must not be the only one to whom this kind of error happens so this is a small pull request to make the message a bit clearer.

You can find a sample project that replicates the error here:  https://github.com/macor161/truffle-empty-artifact