### PR TITLE
Fix bugs relating to constant mapping keys

### DIFF
--- a/packages/truffle-debugger/lib/data/sagas/index.js
+++ b/packages/truffle-debugger/lib/data/sagas/index.js
@@ -403,7 +403,7 @@ function* variablesAndMappingsSaga() {
           indexValue = yield* decode(splicedDefinition, indexReference);
         } else if (
           indexDefinition.referencedDeclaration &&
-          scopes[indexDefinition.referenceDeclaration]
+          scopes[indexDefinition.referencedDeclaration]
         ) {
           //there's one more reason we might have failed to decode it: it might be a
           //constant state variable.  Unfortunately, we don't know how to decode all
@@ -426,7 +426,11 @@ function* variablesAndMappingsSaga() {
               indexValue = yield* decode(keyDefinition, {
                 definition: indexConstantDeclaration.value
               });
+            } else {
+              indexValue = null; //can't decode; see below for more explanation
             }
+          } else {
+            indexValue = null; //can't decode; see below for more explanation
           }
         }
         //there's still one more reason we might have failed to decode it:

--- a/packages/truffle-debugger/test/data/more-decoding.js
+++ b/packages/truffle-debugger/test/data/more-decoding.js
@@ -97,6 +97,9 @@ contract ElementaryTest {
   mapping(string => string) stringMap;
   mapping(address => address) addressMap;
 
+  //constant state variables to try as mapping keys
+  uint constant two = 2;
+
   function run() public {
     //local variables to be tested
     byte oneByte;
@@ -114,6 +117,7 @@ contract ElementaryTest {
     bytesMap[hex"01"] = hex"01";
 
     uintMap[1] = 1;
+    uintMap[two] = two;
 
     intMap[-1] = -1;
 
@@ -340,7 +344,7 @@ describe("Further Decoding", function() {
       boolMap: new Map([[true, true]]),
       byteMap: new Map([["0x01", "0x01"]]),
       bytesMap: new Map([["0x01", "0x01"]]),
-      uintMap: new Map([[1, 1]]),
+      uintMap: new Map([[1, 1], [2, 2]]),
       intMap: new Map([[-1, -1]]),
       stringMap: new Map([["0xdeadbeef", "0xdeadbeef"], ["12345", "12345"]]),
       addressMap: new Map([[address, address]]),


### PR DESCRIPTION
So, it looks like when I implemented code to allow constant state variables to work as mapping keys, I must never have actually tested it very much, because due to a typo, they actually didn't work as mapping keys much at all.

Of course, that typo masked an infinite loop!  I forgot to set `indexValue = null` if we failed to decode a constant state variable being used as a mapping key, meaning (had the typo not prevented the case from ever coming up) any constant state variable we couldn't decode would throw the debugger into an infinite loop.

(Why did I forget that?  Because this is the only case with another nested `if` inside it, meaning it's the only case where it's necessary; other cases that fail will just get caught by the `else` at the end, but these ones won't and need their own `else`s.)

Anyway, I fixed both the typo and the loop it masked.  So now constant state variables can actually work as mapping keys (well, in more cases than previously, not in general), and when they don't, they won't kill the debugger.