### PR TITLE
Feature/hdwallet/validation

### DIFF
--- a/packages/truffle-hdwallet-provider/src/index.js
+++ b/packages/truffle-hdwallet-provider/src/index.js
@@ -10,19 +10,15 @@ const ProviderSubprovider = require("web3-provider-engine/subproviders/provider.
 const Web3 = require("web3");
 const Transaction = require("ethereumjs-tx");
 const ethUtil = require("ethereumjs-util");
+const Url = require("url");
 
 const validateProvider = provider => {
-  // Validate url for protocols
-  if (typeof provider === "string") {
-    const validUrlDescription = [
-      "https?://", // protocol section
-      "\\S", // a non-whitespace char
-      "[\\S/]*" // 0 or more occurences of non-whitespaces and slashes
-    ].join("");
-    const validUrl = RegExp(validUrlDescription, "gmi");
+  const validProtocols = ["http:", "https:", "ws:", "wss:"];
 
-    if (!provider.match(validUrl)) {
-      console.log("provider", provider);
+  if (typeof provider === "string") {
+    const url = Url.parse(provider.toLowerCase());
+
+    if (!validProtocols.includes(url.protocol)) {
       throw new Error(
         "Invalid url format. Did you specify the http or https protocol?"
       );

--- a/packages/truffle-hdwallet-provider/src/index.js
+++ b/packages/truffle-hdwallet-provider/src/index.js
@@ -185,13 +185,13 @@ class HDWalletProvider {
 
 HDWalletProvider.isValidProvider = provider => {
   const validProtocols = ["http:", "https:", "ws:", "wss:"];
-  let isValid = true;
 
   if (typeof provider === "string") {
     const url = Url.parse(provider.toLowerCase());
-    isValid = validProtocols.includes(url.protocol);
+    return validProtocols.includes(url.protocol);
   }
-  return isValid;
+
+  return true;
 };
 
 module.exports = HDWalletProvider;

--- a/packages/truffle-hdwallet-provider/src/index.js
+++ b/packages/truffle-hdwallet-provider/src/index.js
@@ -11,6 +11,25 @@ const Web3 = require("web3");
 const Transaction = require("ethereumjs-tx");
 const ethUtil = require("ethereumjs-util");
 
+const validateProvider = provider => {
+  // Validate url for protocols
+  if (typeof provider === "string") {
+    const validUrlDescription = [
+      "https?://", // protocol section
+      "\\S", // a non-whitespace char
+      "[\\S/]*" // 0 or more occurences of non-whitespaces and slashes
+    ].join("");
+    const validUrl = RegExp(validUrlDescription, "gmi");
+
+    if (!provider.match(validUrl)) {
+      console.log("provider", provider);
+      throw new Error(
+        "Invalid url format. Did you specify the http or https protocol?"
+      );
+    }
+  }
+};
+
 // This line shares nonce state across multiple provider instances. Necessary
 // because within truffle the wallet is repeatedly newed if it's declared in the config within a
 // function, resetting nonce from tx to tx. An instance can opt out
@@ -32,6 +51,8 @@ class HDWalletProvider {
     this.wallets = {};
     this.addresses = [];
     this.engine = new ProviderEngine();
+
+    validateProvider(provider);
 
     // private helper to normalize given mnemonic
     const normalizePrivateKeys = mnemonic => {

--- a/packages/truffle-hdwallet-provider/src/index.js
+++ b/packages/truffle-hdwallet-provider/src/index.js
@@ -36,7 +36,11 @@ class HDWalletProvider {
 
     if (!HDWalletProvider.isValidProvider(provider)) {
       throw new Error(
-        "Invalid url format. Please specify an appropriate protocol.\n\tValid protocols are: http | https | ws | wss"
+        [
+          `Malformed provider URL: '${provider}'`,
+          "Please specify a correct URL, using the http, https, ws, or wss protocol.",
+          ""
+        ].join("\n")
       );
     }
 

--- a/packages/truffle-hdwallet-provider/src/index.js
+++ b/packages/truffle-hdwallet-provider/src/index.js
@@ -12,20 +12,6 @@ const Transaction = require("ethereumjs-tx");
 const ethUtil = require("ethereumjs-util");
 const Url = require("url");
 
-const validateProvider = provider => {
-  const validProtocols = ["http:", "https:", "ws:", "wss:"];
-
-  if (typeof provider === "string") {
-    const url = Url.parse(provider.toLowerCase());
-
-    if (!validProtocols.includes(url.protocol)) {
-      throw new Error(
-        "Invalid url format. Did you specify the http or https protocol?"
-      );
-    }
-  }
-};
-
 // This line shares nonce state across multiple provider instances. Necessary
 // because within truffle the wallet is repeatedly newed if it's declared in the config within a
 // function, resetting nonce from tx to tx. An instance can opt out
@@ -48,7 +34,11 @@ class HDWalletProvider {
     this.addresses = [];
     this.engine = new ProviderEngine();
 
-    validateProvider(provider);
+    if (!HDWalletProvider.isValidProvider(provider)) {
+      throw new Error(
+        "Invalid url format. Please specify an appropriate protocol.\n\tValid protocols are: http | https | ws | wss"
+      );
+    }
 
     // private helper to normalize given mnemonic
     const normalizePrivateKeys = mnemonic => {
@@ -188,5 +178,16 @@ class HDWalletProvider {
     return this.addresses;
   }
 }
+
+HDWalletProvider.isValidProvider = provider => {
+  const validProtocols = ["http:", "https:", "ws:", "wss:"];
+  let isValid = true;
+
+  if (typeof provider === "string") {
+    const url = Url.parse(provider.toLowerCase());
+    isValid = validProtocols.includes(url.protocol);
+  }
+  return isValid;
+};
 
 module.exports = HDWalletProvider;

--- a/packages/truffle-hdwallet-provider/test/urlValidatation.js
+++ b/packages/truffle-hdwallet-provider/test/urlValidatation.js
@@ -55,5 +55,20 @@ describe("HD Wallet Provider", () => {
         assert.fail("Should not throw ");
       }
     });
+
+    it("a valid https url endpoint", done => {
+      try {
+        const goodUrl = `https://localhost:${port}`;
+        provider = new WalletProvider(mnemonic, goodUrl, 4, 10);
+        web3.setProvider(provider);
+
+        web3.eth.getBlockNumber((_, number) => {
+          assert(number === 0);
+          done();
+        });
+      } catch (e) {
+        assert.fail("Should not throw ");
+      }
+    });
   });
 });

--- a/packages/truffle-hdwallet-provider/test/urlValidatation.js
+++ b/packages/truffle-hdwallet-provider/test/urlValidatation.js
@@ -1,0 +1,59 @@
+const Ganache = require("ganache-core");
+const assert = require("assert");
+const WalletProvider = require("../src/index.js");
+
+describe("HD Wallet Provider", () => {
+  const Web3 = require("web3");
+  const web3 = new Web3();
+  const port = 8545;
+  let server;
+  let provider;
+
+  before(done => {
+    server = Ganache.server();
+    server.listen(port, done);
+  });
+
+  after(done => {
+    setTimeout(() => server.close(done), 100);
+  });
+
+  it("detects an invalid url endpoint", () => {
+    try {
+      const mnemonic = "";
+      const badUrl = "ropsten.infura.io/v3/fe93a046954a42839acb5f235f123456";
+      provider = new WalletProvider(mnemonic, badUrl, 4, 10);
+      assert.fail("Should throw invalid provider url");
+    } catch (e) {
+      assert.equal(
+        e.message,
+        "Invalid url format. Did you specify the http or https protocol?"
+      );
+    }
+  });
+
+  describe("detects", () => {
+    const mnemonic =
+      "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat";
+
+    afterEach(() => {
+      web3.setProvider(null);
+      provider.engine.stop();
+    });
+
+    it("a valid http url endpoint", done => {
+      try {
+        const goodUrl = `http://localhost:${port}`;
+        provider = new WalletProvider(mnemonic, goodUrl, 4, 10);
+        web3.setProvider(provider);
+
+        web3.eth.getBlockNumber((_, number) => {
+          assert(number === 0);
+          done();
+        });
+      } catch (e) {
+        assert.fail("Should not throw ");
+      }
+    });
+  });
+});

--- a/packages/truffle-hdwallet-provider/test/urlValidatation.js
+++ b/packages/truffle-hdwallet-provider/test/urlValidatation.js
@@ -17,8 +17,11 @@ describe("HD Wallet Provider Validator", () => {
       new WalletProvider("", badUrl, 0, 100);
       assert.fail("did not throw!");
     } catch (e) {
-      const expectedMessage =
-        "Invalid url format. Please specify an appropriate protocol.\n\tValid protocols are: http | https | ws | wss";
+      const expectedMessage = [
+        `Malformed provider URL: '${badUrl}'`,
+        "Please specify a correct URL, using the http, https, ws, or wss protocol.",
+        ""
+      ].join("\n");
       assert.equal(e.message, expectedMessage);
     }
   });


### PR DESCRIPTION
Add simple validation to hdwallet provider so that it errors out when a provider url doesn't start with http or https protocol.

Currently blocked by failing test to verify HTTPS. Can ganache handle https://localhost:8545?
