### PR TITLE
fix(truffle-core/cli): logs now to STDERR

### DIFF
--- a/packages/truffle-core/cli.js
+++ b/packages/truffle-core/cli.js
@@ -38,7 +38,13 @@ const command = new Command(require("./lib/commands"));
 const listeners = process.listeners("warning");
 listeners.forEach(listener => process.removeListener("warning", listener));
 
-let options = { logger: console };
+let options = { 
+  logger: {
+    log: function(message) {
+      console.error(message);
+    }
+  }
+};
 
 const inputArguments = process.argv.slice(2);
 const userWantsGeneralHelp =


### PR DESCRIPTION
I believe all logs are supposed to be outputted to `STDERR`, instead of `STDOUT`.