### PR TITLE
Warn/error about unsupported flags #468

### DIFF
--- a/packages/truffle-core/lib/command.js
+++ b/packages/truffle-core/lib/command.js
@@ -117,19 +117,18 @@ class Command {
         }
       });
 
-      let notValidOptions = inputOptions.filter(
+      let invalidOptions = inputOptions.filter(
         opt => !validOptions.includes(opt)
       );
 
-      if (notValidOptions.length > 0) {
-        console.log(
-          "Unsupported (Undocumented) command line option: " + notValidOptions
-        );
-        // return callback(
-        //   new TaskError(
-        //     "Unsupported (Undocumented) command line option: " + notValidOptions
-        //   )
-        // );
+      if (invalidOptions.length > 0) {
+        if (options.logger) {
+          const warn = options.logger.warn || options.logger.log;
+          warn(
+            "warning: possilble unsupported (undocumented in help) command line option: " +
+              invalidOptions
+          );
+        }
       }
 
       const newOptions = Object.assign({}, clone, argv);

--- a/packages/truffle-core/lib/command.js
+++ b/packages/truffle-core/lib/command.js
@@ -102,20 +102,22 @@ class Command {
 
     //Check unsupported command line flag according to the option list in help
     try {
-      const inputOptions = [];
-      inputStrings.map(i => {
-        if (i.startsWith("--")) {
-          inputOptions.push(i);
-        }
-      });
+      const inputOptions = inputStrings
+        .map(string => {
+          return string.startsWith("--") ? string : null;
+        })
+        .filter(item => {
+          return item != null;
+        });
 
-      const validOptions = [];
-      result.command.help.options.map(item => {
-        let opt = item.option.split(" ")[0];
-        if (opt.startsWith("--")) {
-          validOptions.push(opt);
-        }
-      });
+      const validOptions = result.command.help.options
+        .map(item => {
+          let opt = item.option.split(" ")[0];
+          return opt.startsWith("--") ? opt : null;
+        })
+        .filter(item => {
+          return item != null;
+        });
 
       let invalidOptions = inputOptions.filter(
         opt => !validOptions.includes(opt)

--- a/packages/truffle-core/lib/command.js
+++ b/packages/truffle-core/lib/command.js
@@ -100,45 +100,14 @@ class Command {
       }
     });
 
-    try {
-      const inputOptions = [];
-      inputStrings.map(i => {
-        if (i.startsWith("--")) {
-          inputOptions.push(i);
-        }
-      });
+    const newOptions = Object.assign({}, clone, argv);
 
-      const validOptions = [];
-      result.command.help.options.map(item => {
-        let opt = item.option.split(" ")[0];
-        if (opt.startsWith("--")) {
-          validOptions.push(opt);
-        }
-      });
-
-      let notValidOptions = inputOptions.filter(
-        opt => !validOptions.includes(opt)
-      );
-
-      if (notValidOptions.length > 0) {
-        return callback(
-          new TaskError(
-            "Unsupported (Undocumented) command line option: " + notValidOptions
-          )
-        );
-      }
-
-      const newOptions = Object.assign({}, clone, argv);
-
-      result.command.run(newOptions, callback);
-      analytics.send({
-        command: result.name ? result.name : "other",
-        args: result.argv._,
-        version: bundled || "(unbundled) " + core
-      });
-    } catch (err) {
-      callback(err);
-    }
+    result.command.run(newOptions, callback);
+    analytics.send({
+      command: result.name ? result.name : "other",
+      args: result.argv._,
+      version: bundled || "(unbundled) " + core
+    });
   }
 
   displayGeneralHelp() {

--- a/packages/truffle-core/lib/command.js
+++ b/packages/truffle-core/lib/command.js
@@ -100,46 +100,14 @@ class Command {
       }
     });
 
-    //Check unsupported command line flag according to the option list in help
-    try {
-      const inputOptions = [];
-      inputStrings.map(i => {
-        if (i.startsWith("--")) {
-          inputOptions.push(i);
-        }
-      });
+    const newOptions = Object.assign({}, clone, argv);
 
-      const validOptions = [];
-      result.command.help.options.map(item => {
-        let opt = item.option.split(" ")[0];
-        if (opt.startsWith("--")) {
-          validOptions.push(opt);
-        }
-      });
-
-      let notValidOptions = inputOptions.filter(
-        opt => !validOptions.includes(opt)
-      );
-
-      if (notValidOptions.length > 0) {
-        return callback(
-          new TaskError(
-            "Unsupported (Undocumented) command line option: " + notValidOptions
-          )
-        );
-      }
-
-      const newOptions = Object.assign({}, clone, argv);
-
-      result.command.run(newOptions, callback);
-      analytics.send({
-        command: result.name ? result.name : "other",
-        args: result.argv._,
-        version: bundled || "(unbundled) " + core
-      });
-    } catch (err) {
-      callback(err);
-    }
+    result.command.run(newOptions, callback);
+    analytics.send({
+      command: result.name ? result.name : "other",
+      args: result.argv._,
+      version: bundled || "(unbundled) " + core
+    });
   }
 
   displayGeneralHelp() {

--- a/packages/truffle-core/lib/command.js
+++ b/packages/truffle-core/lib/command.js
@@ -100,14 +100,49 @@ class Command {
       }
     });
 
-    const newOptions = Object.assign({}, clone, argv);
+    //Check unsupported command line flag according to the option list in help
+    try {
+      const inputOptions = [];
+      inputStrings.map(i => {
+        if (i.startsWith("--")) {
+          inputOptions.push(i);
+        }
+      });
 
-    result.command.run(newOptions, callback);
-    analytics.send({
-      command: result.name ? result.name : "other",
-      args: result.argv._,
-      version: bundled || "(unbundled) " + core
-    });
+      const validOptions = [];
+      result.command.help.options.map(item => {
+        let opt = item.option.split(" ")[0];
+        if (opt.startsWith("--")) {
+          validOptions.push(opt);
+        }
+      });
+
+      let notValidOptions = inputOptions.filter(
+        opt => !validOptions.includes(opt)
+      );
+
+      if (notValidOptions.length > 0) {
+        console.log(
+          "Unsupported (Undocumented) command line option: " + notValidOptions
+        );
+        // return callback(
+        //   new TaskError(
+        //     "Unsupported (Undocumented) command line option: " + notValidOptions
+        //   )
+        // );
+      }
+
+      const newOptions = Object.assign({}, clone, argv);
+
+      result.command.run(newOptions, callback);
+      analytics.send({
+        command: result.name ? result.name : "other",
+        args: result.argv._,
+        version: bundled || "(unbundled) " + core
+      });
+    } catch (err) {
+      callback(err);
+    }
   }
 
   displayGeneralHelp() {

--- a/packages/truffle-core/lib/command.js
+++ b/packages/truffle-core/lib/command.js
@@ -100,9 +100,36 @@ class Command {
       }
     });
 
-    const newOptions = Object.assign({}, clone, argv);
-
     try {
+      const inputOptions = [];
+      inputStrings.map(i => {
+        if (i.startsWith("--")) {
+          inputOptions.push(i);
+        }
+      });
+
+      const validOptions = [];
+      result.command.help.options.map(item => {
+        let opt = item.option.split(" ")[0];
+        if (opt.startsWith("--")) {
+          validOptions.push(opt);
+        }
+      });
+
+      let notValidOptions = inputOptions.filter(
+        opt => !validOptions.includes(opt)
+      );
+
+      if (notValidOptions.length > 0) {
+        return callback(
+          new TaskError(
+            "Unsupported (Undocumented) command line option: " + notValidOptions
+          )
+        );
+      }
+
+      const newOptions = Object.assign({}, clone, argv);
+
       result.command.run(newOptions, callback);
       analytics.send({
         command: result.name ? result.name : "other",

--- a/packages/truffle-core/lib/command.js
+++ b/packages/truffle-core/lib/command.js
@@ -125,7 +125,7 @@ class Command {
         if (options.logger) {
           const log = options.logger.log || options.logger.debug;
           log(
-            "warning: possilble unsupported (undocumented in help) command line option: " +
+            "> Warning: possible unsupported (undocumented in help) command line option: " +
               invalidOptions
           );
         }

--- a/packages/truffle-core/lib/command.js
+++ b/packages/truffle-core/lib/command.js
@@ -100,14 +100,46 @@ class Command {
       }
     });
 
-    const newOptions = Object.assign({}, clone, argv);
+    //Check unsupported command line flag according to the option list in help
+    try {
+      const inputOptions = [];
+      inputStrings.map(i => {
+        if (i.startsWith("--")) {
+          inputOptions.push(i);
+        }
+      });
 
-    result.command.run(newOptions, callback);
-    analytics.send({
-      command: result.name ? result.name : "other",
-      args: result.argv._,
-      version: bundled || "(unbundled) " + core
-    });
+      const validOptions = [];
+      result.command.help.options.map(item => {
+        let opt = item.option.split(" ")[0];
+        if (opt.startsWith("--")) {
+          validOptions.push(opt);
+        }
+      });
+
+      let notValidOptions = inputOptions.filter(
+        opt => !validOptions.includes(opt)
+      );
+
+      if (notValidOptions.length > 0) {
+        return callback(
+          new TaskError(
+            "Unsupported (Undocumented) command line option: " + notValidOptions
+          )
+        );
+      }
+
+      const newOptions = Object.assign({}, clone, argv);
+
+      result.command.run(newOptions, callback);
+      analytics.send({
+        command: result.name ? result.name : "other",
+        args: result.argv._,
+        version: bundled || "(unbundled) " + core
+      });
+    } catch (err) {
+      callback(err);
+    }
   }
 
   displayGeneralHelp() {

--- a/packages/truffle-core/lib/command.js
+++ b/packages/truffle-core/lib/command.js
@@ -123,8 +123,8 @@ class Command {
 
       if (invalidOptions.length > 0) {
         if (options.logger) {
-          const warn = options.logger.warn || options.logger.log;
-          warn(
+          const log = options.logger.log || options.logger.debug;
+          log(
             "warning: possilble unsupported (undocumented in help) command line option: " +
               invalidOptions
           );

--- a/packages/truffle-core/lib/commands/obtain.js
+++ b/packages/truffle-core/lib/commands/obtain.js
@@ -2,19 +2,11 @@ module.exports = {
   command: "obtain",
   description: "Fetch and cache a specified compiler",
   help: {
-    usage: "truffle obtain <--<compiler_name> <version>>",
+    usage: "truffle obtain [--solc <version>]",
     options: [
       {
-        option: "<--<compiler_name> <version>>",
-        description:
-          `Download and cache a version of the specified compiler.\n` +
-          `                    compiler_name must be one of the following: ` +
-          `'solc'.(required)`
-      },
-      {
         option: "--solc <version>",
-        description:
-          `Download and cache a version of the solc compiler.`
+        description: `Download and cache a version of the solc compiler. (required)`
       }
     ]
   },

--- a/packages/truffle-core/lib/commands/obtain.js
+++ b/packages/truffle-core/lib/commands/obtain.js
@@ -10,6 +10,11 @@ module.exports = {
           `Download and cache a version of the specified compiler.\n` +
           `                    compiler_name must be one of the following: ` +
           `'solc'.(required)`
+      },
+      {
+        option: "--solc <version>",
+        description:
+          `Download and cache a version of the solc compiler.`
       }
     ]
   },

--- a/packages/truffle-core/test/commands.js
+++ b/packages/truffle-core/test/commands.js
@@ -55,7 +55,9 @@ describe("Commander", function() {
         "--network",
         "localhost",
         "--unsupportedflag",
-        "invalidoption"
+        "invalidoption",
+        "--unsupportedflag2",
+        "invalidflag2"
       ],
       { noAliases: true, logger: console },
       function() {
@@ -65,7 +67,7 @@ describe("Commander", function() {
 
     assert.equal(
       warning,
-      "> Warning: possible unsupported (undocumented in help) command line option: --unsupportedflag"
+      "> Warning: possible unsupported (undocumented in help) command line option: --unsupportedflag,--unsupportedflag2"
     );
   });
 });

--- a/packages/truffle-core/test/commands.js
+++ b/packages/truffle-core/test/commands.js
@@ -37,42 +37,4 @@ describe("Commander", function() {
     var actualCommand = commander.getCommand("console").command;
     assert.equal(actualCommand, commands.console);
   });
-
-  // Travis-CI build will failed if the following test cases are uncomment.
-
-  // it("will stop and display error for unsupported flags in commands", function() {
-  //   var actualCommand = commander.getCommand("mig").command;
-  //   assert.equal(actualCommand, commands.migrate);
-  //   commander.run(
-  //     [
-  //       "migrate",
-  //       "--network",
-  //       "localhost",
-  //       "--unsupportedflag",
-  //       "invalidoption"
-  //     ],
-  //     { noAliases: true },
-  //     function(err) {
-  //       assert.equal(
-  //         err.message.split(":")[0],
-  //         "Unsupported (Undocumented) command line option"
-  //       );
-  //     }
-  //   );
-  // });
-
-  // it("will stop and display error for unsupported flags in commands", function() {
-  //   var actualCommand = commander.getCommand("config").command;
-  //   assert.equal(actualCommand, commands.config);
-  //   commander.run(
-  //     ["config", "--enable-analytics", "--unsupportedflag", "invalidoption"],
-  //     { noAliases: true },
-  //     function(err) {
-  //       assert.equal(
-  //         err.message.split(":")[0],
-  //         "Unsupported (Undocumented) command line option"
-  //       );
-  //     }
-  //   );
-  // });
 });

--- a/packages/truffle-core/test/commands.js
+++ b/packages/truffle-core/test/commands.js
@@ -37,4 +37,30 @@ describe("Commander", function() {
     var actualCommand = commander.getCommand("console").command;
     assert.equal(actualCommand, commands.console);
   });
+
+  it("will warn and display error for unsupported flags in commands", function() {
+    var actualCommand = commander.getCommand("mig").command;
+    assert.equal(actualCommand, commands.migrate);
+
+    console.warn = function(msg) {
+      assert.equal(
+        msg,
+        "warning: possilble unsupported (undocumented in help) command line option: --unsupportedflag"
+      );
+    };
+
+    commander.run(
+      [
+        "migrate",
+        "--network",
+        "localhost",
+        "--unsupportedflag",
+        "invalidoption"
+      ],
+      { noAliases: true, logger: console },
+      function(err) {
+        assert.fail(err);
+      }
+    );
+  });
 });

--- a/packages/truffle-core/test/commands.js
+++ b/packages/truffle-core/test/commands.js
@@ -38,6 +38,8 @@ describe("Commander", function() {
     assert.equal(actualCommand, commands.console);
   });
 
+  // Travis-CI build will failed if the following test cases are uncomment.
+
   // it("will stop and display error for unsupported flags in commands", function() {
   //   var actualCommand = commander.getCommand("mig").command;
   //   assert.equal(actualCommand, commands.migrate);
@@ -59,18 +61,18 @@ describe("Commander", function() {
   //   );
   // });
 
-  it("will stop and display error for unsupported flags in commands", function() {
-    var actualCommand = commander.getCommand("config").command;
-    assert.equal(actualCommand, commands.config);
-    commander.run(
-      ["config", "--enable-analytics", "--unsupportedflag", "invalidoption"],
-      { noAliases: true },
-      function(err) {
-        assert.equal(
-          err.message.split(":")[0],
-          "Unsupported (Undocumented) command line option"
-        );
-      }
-    );
-  });
+  // it("will stop and display error for unsupported flags in commands", function() {
+  //   var actualCommand = commander.getCommand("config").command;
+  //   assert.equal(actualCommand, commands.config);
+  //   commander.run(
+  //     ["config", "--enable-analytics", "--unsupportedflag", "invalidoption"],
+  //     { noAliases: true },
+  //     function(err) {
+  //       assert.equal(
+  //         err.message.split(":")[0],
+  //         "Unsupported (Undocumented) command line option"
+  //       );
+  //     }
+  //   );
+  // });
 });

--- a/packages/truffle-core/test/commands.js
+++ b/packages/truffle-core/test/commands.js
@@ -58,4 +58,19 @@ describe("Commander", function() {
   //     }
   //   );
   // });
+
+  it("will stop and display error for unsupported flags in commands", function() {
+    var actualCommand = commander.getCommand("config").command;
+    assert.equal(actualCommand, commands.config);
+    commander.run(
+      ["config", "--enable-analytics", "--unsupportedflag", "invalidoption"],
+      { noAliases: true },
+      function(err) {
+        assert.equal(
+          err.message.split(":")[0],
+          "Unsupported (Undocumented) command line option"
+        );
+      }
+    );
+  });
 });

--- a/packages/truffle-core/test/commands.js
+++ b/packages/truffle-core/test/commands.js
@@ -37,4 +37,25 @@ describe("Commander", function() {
     var actualCommand = commander.getCommand("console").command;
     assert.equal(actualCommand, commands.console);
   });
+
+  it("will stop and display error for unsupported flags in commands", function() {
+    var actualCommand = commander.getCommand("mig").command;
+    assert.equal(actualCommand, commands.migrate);
+    commander.run(
+      [
+        "migrate",
+        "--network",
+        "localhost",
+        "--unsupportedflag",
+        "invalidoption"
+      ],
+      { noAliases: true },
+      function(err) {
+        assert.equal(
+          err.message.split(":")[0],
+          "Unsupported (Undocumented) command line option"
+        );
+      }
+    );
+  });
 });

--- a/packages/truffle-core/test/commands.js
+++ b/packages/truffle-core/test/commands.js
@@ -64,6 +64,6 @@ describe("Commander", function() {
         //ignore. not part of test
       }
     );
-    console.warn = originalLog;
+    console.log = originalLog;
   });
 });

--- a/packages/truffle-core/test/commands.js
+++ b/packages/truffle-core/test/commands.js
@@ -64,6 +64,5 @@ describe("Commander", function() {
         //ignore. not part of test
       }
     );
-    console.log = originalLog;
   });
 });

--- a/packages/truffle-core/test/commands.js
+++ b/packages/truffle-core/test/commands.js
@@ -37,25 +37,4 @@ describe("Commander", function() {
     var actualCommand = commander.getCommand("console").command;
     assert.equal(actualCommand, commands.console);
   });
-
-  it("will stop and display error for unsupported flags in commands", function() {
-    var actualCommand = commander.getCommand("mig").command;
-    assert.equal(actualCommand, commands.migrate);
-    commander.run(
-      [
-        "migrate",
-        "--network",
-        "localhost",
-        "--unsupportedflag",
-        "invalidoption"
-      ],
-      { noAliases: true },
-      function(err) {
-        assert.equal(
-          err.message.split(":")[0],
-          "Unsupported (Undocumented) command line option"
-        );
-      }
-    );
-  });
 });

--- a/packages/truffle-core/test/commands.js
+++ b/packages/truffle-core/test/commands.js
@@ -43,12 +43,10 @@ describe("Commander", function() {
     assert.equal(actualCommand, commands.migrate);
 
     const originalLog = console.log || console.debug;
+    let warning = "";
     console.log = function(msg) {
-      assert.equal(
-        msg,
-        "warning: possilble unsupported (undocumented in help) command line option: --unsupportedflag"
-      );
       console.log = originalLog;
+      warning = msg;
     };
 
     commander.run(
@@ -63,6 +61,11 @@ describe("Commander", function() {
       function() {
         //ignore. not part of test
       }
+    );
+
+    assert.equal(
+      warning,
+      "> Warning: possible unsupported (undocumented in help) command line option: --unsupportedflag"
     );
   });
 });

--- a/packages/truffle-core/test/commands.js
+++ b/packages/truffle-core/test/commands.js
@@ -42,11 +42,13 @@ describe("Commander", function() {
     var actualCommand = commander.getCommand("mig").command;
     assert.equal(actualCommand, commands.migrate);
 
-    console.warn = function(msg) {
+    const originalLog = console.log || console.debug;
+    console.log = function(msg) {
       assert.equal(
         msg,
         "warning: possilble unsupported (undocumented in help) command line option: --unsupportedflag"
       );
+      console.log = originalLog;
     };
 
     commander.run(
@@ -58,9 +60,10 @@ describe("Commander", function() {
         "invalidoption"
       ],
       { noAliases: true, logger: console },
-      function(err) {
-        assert.fail(err);
+      function() {
+        //ignore. not part of test
       }
     );
+    console.warn = originalLog;
   });
 });

--- a/packages/truffle-core/test/commands.js
+++ b/packages/truffle-core/test/commands.js
@@ -37,4 +37,25 @@ describe("Commander", function() {
     var actualCommand = commander.getCommand("console").command;
     assert.equal(actualCommand, commands.console);
   });
+
+  // it("will stop and display error for unsupported flags in commands", function() {
+  //   var actualCommand = commander.getCommand("mig").command;
+  //   assert.equal(actualCommand, commands.migrate);
+  //   commander.run(
+  //     [
+  //       "migrate",
+  //       "--network",
+  //       "localhost",
+  //       "--unsupportedflag",
+  //       "invalidoption"
+  //     ],
+  //     { noAliases: true },
+  //     function(err) {
+  //       assert.equal(
+  //         err.message.split(":")[0],
+  //         "Unsupported (Undocumented) command line option"
+  //       );
+  //     }
+  //   );
+  // });
 });


### PR DESCRIPTION
I opened a pull request #2116 and Travis CI build failed. I was thinking not having the latest from develop branch and the git force command cause the issue close while using it on my branch so I have to open a new pull request.

After investigation I found out that the newly implementation for unsupported option validation broke the build. The truffle command that trying to obtain the solc has a bit different help documentation due to the nature of the dynamic option.

I can update the truffle obtain command help so the CI build won't break but this is not a good solution because any future command document with a bit different format will potential break the build or prevent user to run the command.

I think the better approach is to warn the user about the potential problem when an unsupported options are detected so I change it from return TaskError to just use the options logger to warn the user.
