### PR TITLE
Correctly decode UTF-8

### DIFF
--- a/packages/truffle-decoder/lib/decode/value.ts
+++ b/packages/truffle-decoder/lib/decode/value.ts
@@ -4,6 +4,7 @@ const debug = debugModule("decoder:decode:value");
 import read from "../read";
 import * as DecodeUtils from "truffle-decode-utils";
 import BN from "bn.js";
+import utf8 from "utf8";
 import { DataPointer } from "../types/pointer";
 import { EvmInfo } from "../types/evm";
 import { EvmEnum } from "../interface/contract-decoder";
@@ -60,7 +61,15 @@ export default function* decodeValue(definition: DecodeUtils.AstDefinition, poin
       if (typeof bytes == "string") {
         return bytes;
       }
-      return String.fromCharCode.apply(undefined, bytes);
+      try {
+        return utf8.decode(String.fromCharCode.apply(undefined, bytes));
+      }
+      catch(error) {
+        return null; //HACK: we use null as our error value here rather than
+        //undefined to prevent potentially throwing the debugger into an
+        //infinite loop
+        //(this will be saner in 5.1 :P )
+      }
 
     case "enum":
       const numRepresentation = DecodeUtils.Conversion.toBN(bytes).toNumber();

--- a/packages/truffle-decoder/package.json
+++ b/packages/truffle-decoder/package.json
@@ -33,6 +33,7 @@
     "@types/lodash.clonedeep": "^4.5.4",
     "@types/lodash.isequal": "^4.5.4",
     "@types/lodash.merge": "^4.6.4",
+    "@types/utf8": "^2.1.6",
     "@types/web3": "^1.0.5",
     "json-schema-to-typescript": "^5.5.0",
     "truffle-contract-schema": "^3.0.11",
@@ -47,6 +48,7 @@
     "lodash.isequal": "^4.5.0",
     "lodash.merge": "^4.6.1",
     "truffle-decode-utils": "^1.0.14",
+    "utf8": "^3.0.0",
     "web3": "1.0.0-beta.37"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1069,6 +1069,11 @@
   resolved "https://registry.yarnpkg.com/@types/underscore/-/underscore-1.8.18.tgz#025371cfe062439aaa088d2b64af87cbcfe3c2b7"
   integrity sha512-mXQ8u416FWMPjp2zWrcVmOZtzKQM6IeyVcuE+RGF/04JLBrMjfnmNKn74VN8fIkFzU97TpzkP0ny0p0h65eC7w==
 
+"@types/utf8@^2.1.6":
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/@types/utf8/-/utf8-2.1.6.tgz#430cabb71a42d0a3613cce5621324fe4f5a25753"
+  integrity sha512-pRs2gYF5yoKYrgSaira0DJqVg2tFuF+Qjp838xS7K+mJyY2jJzjsrl6y17GbIa4uMRogMbxs+ghNCvKg6XyNrA==
+
 "@types/web3@^1.0.18", "@types/web3@^1.0.5":
   version "1.0.18"
   resolved "https://registry.yarnpkg.com/@types/web3/-/web3-1.0.18.tgz#87a8651041d21fc37602ff02327df2c7ecf105d1"


### PR DESCRIPTION
I originally made this change on `type-and-value`, then realized it was worth backporting to `develop`.  (I'm setting myself up for a merge conflict, but...)

This PR fixes an issue in string decoding by using the `utf8` library to convert Solidity's UTF-8 to Javascript's UTF-16.  Note that Solidity does allow *malformed* UTF-8; in this case, we simply return `null`.  (Note that we detect this case by seeing whether `utf8.decode` throws an error; it doesn't seem to have a check function separate from the decode.)

Why `null` rather than `undefined`?  To avoid throwing the debugger into an infinite loop in case a mapping key is a malformed string.  Yes, this is a bit of a hack, but don't worry, it'll be gone in 5.1; on `type-and-value` we return an object representing the particular malformed string rather than a simple null.  But here on `develop`, without the new output format, `null` will have to suffice.