### PR TITLE
Fix a regression in decoding of dynamic structs!

### DIFF
--- a/packages/truffle-debugger/test/data/calldata.js
+++ b/packages/truffle-debugger/test/data/calldata.js
@@ -13,7 +13,7 @@ import * as TruffleDecodeUtils from "truffle-decode-utils";
 import solidity from "lib/solidity/selectors";
 
 const __CALLDATA = `
-pragma solidity ^0.5.4;
+pragma solidity ^0.5.6;
 pragma experimental ABIEncoderV2;
 
 contract CalldataTest {
@@ -23,6 +23,10 @@ contract CalldataTest {
   struct Pair {
     uint x;
     uint y;
+  }
+
+  struct StringBox {
+    string it;
   }
 
   function simpleTest(string calldata hello) external {
@@ -59,6 +63,10 @@ contract CalldataTest {
     pair.x = 321;
     pair.y = 2049;
     this.multiTest("hello", someInts, pair);
+  }
+
+  function stringBoxTest(StringBox calldata stringBox) external returns (string memory) {
+    return stringBox.it; //break stringBox
   }
 
 }
@@ -178,6 +186,40 @@ describe("Calldata Decoding", function() {
     };
 
     assert.include(variables, expectedResult);
+  });
+
+  it("Decodes dynamic structs correctly", async function() {
+    this.timeout(6000);
+    let instance = await abstractions.CalldataTest.deployed();
+    let receipt = await instance.stringBoxTest({ it: "hello world" });
+    let txHash = receipt.tx;
+
+    let bugger = await Debugger.forTx(txHash, {
+      provider,
+      files,
+      contracts: artifacts
+    });
+
+    let session = bugger.connect();
+
+    let sourceId = session.view(solidity.current.source).id;
+    let source = session.view(solidity.current.source).source;
+    await session.addBreakpoint({
+      sourceId,
+      line: lineOf("break stringBox", source)
+    });
+
+    await session.continueUntilBreakpoint();
+
+    const variables = await session.variables();
+
+    const expectedResult = {
+      stringBox: {
+        it: "hello world"
+      }
+    };
+
+    assert.deepInclude(variables, expectedResult);
   });
 
   it("Decodes correctly in a pure call", async function() {

--- a/packages/truffle-debugger/test/helpers.js
+++ b/packages/truffle-debugger/test/helpers.js
@@ -25,7 +25,7 @@ export async function prepareContracts(provider, sources = {}, migrations) {
 
   config.compilers = {
     solc: {
-      version: "0.5.4",
+      version: "0.5.10",
       settings: {
         optimizer: { enabled: false, runs: 200 },
         evmVersion: "constantinople"

--- a/packages/truffle-decoder/lib/decode/calldata.ts
+++ b/packages/truffle-decoder/lib/decode/calldata.ts
@@ -177,7 +177,8 @@ function* decodeCalldataStructByPosition(definition: DecodeUtils.AstDefinition, 
     //there also used to be code here to add on the "_ptr" ending when absent, but we
     //presently ignore that ending, so we'll skip that
 
-    let decoded = yield* decodeCalldata(memberDefinition, childPointer, info);
+    let decoded = yield* decodeCalldata(memberDefinition, childPointer, info, startPosition);
+    //note that startPosition is only needed in the dynamic case, but we don't know which case we're in
 
     decodedMembers[memberDefinition.name] = decoded;
   }


### PR DESCRIPTION
It seems I accidentally broke decoding of dynamic structs in calldata a while back.  Probably when I factored out struct decoding; in combining the static and dynamic cases, I left out the `startPosition` argument in the call to `decodeAbi`, which is fine in the static case but is very wrong in the dynamic case.  Oops.

(In the static case, you're always reading the member directly, not a pointer to it, so you don't need to know what base that pointer should be considered relative to, because it's not a pointer at all.  In the dynamic case, you may be reading a relative pointer, so you need to know what it's relative to.)

As a check against this happening again, I added an additional (very simple) calldata decoding test to catch this.

Note that in order to make this work I ended up updating the Solidity version used in our debugger tests to 0.5.10.  (It was on 0.5.4; dynamic structs in calldata weren't allowed yet in 0.5.4.)