### PR TITLE
Internal improvement: Profiler update

### DIFF
--- a/packages/truffle-compile/package.json
+++ b/packages/truffle-compile/package.json
@@ -7,6 +7,7 @@
     "async": "2.6.1",
     "colors": "^1.1.2",
     "debug": "^4.1.0",
+    "fs-extra": "^8.0.1",
     "ora": "^3.0.0",
     "original-require": "^1.0.1",
     "request": "^2.85.0",

--- a/packages/truffle-compile/package.json
+++ b/packages/truffle-compile/package.json
@@ -4,7 +4,6 @@
   "description": "Compiler helper and artifact manager",
   "main": "index.js",
   "dependencies": {
-    "async": "2.6.1",
     "colors": "^1.1.2",
     "debug": "^4.1.0",
     "fs-extra": "^8.0.1",

--- a/packages/truffle-compile/profiler.js
+++ b/packages/truffle-compile/profiler.js
@@ -3,7 +3,7 @@
 
 const path = require("path");
 const async = require("async");
-const fs = require("fs");
+const fse = require("fs-extra");
 const Parser = require("./parser");
 const CompilerSupplier = require("./compilerSupplier");
 const expect = require("truffle-expect");
@@ -48,7 +48,7 @@ module.exports = {
         },
         // Get all the artifact files, and read them, parsing them as JSON
         c => {
-          fs.readdir(build_directory, (err, build_files) => {
+          fse.readdir(build_directory, (err, build_files) => {
             if (err) {
               // The build directory may not always exist.
               if (err.message.includes("ENOENT: no such file or directory")) {
@@ -66,7 +66,7 @@ module.exports = {
             async.map(
               build_files,
               (buildFile, finished) => {
-                fs.readFile(
+                fse.readFile(
                   path.join(build_directory, buildFile),
                   "utf8",
                   (err, body) => {
@@ -142,7 +142,7 @@ module.exports = {
           async.map(
             sourceFiles,
             (sourceFile, finished) => {
-              fs.stat(sourceFile, (err, stat) => {
+              fse.stat(sourceFile, (err, stat) => {
                 if (err) {
                   // Ignore it. This means the source file was removed
                   // but the artifact file possibly exists. Return null
@@ -387,11 +387,10 @@ module.exports = {
     const imports = Parser.parseImports(body, solc);
 
     // Convert explicitly relative dependencies of modules back into module paths.
-    return imports.map(
-      dependencyPath =>
-        self.isExplicitlyRelative(dependencyPath)
-          ? source.resolve_dependency_path(file, dependencyPath)
-          : dependencyPath
+    return imports.map(dependencyPath =>
+      self.isExplicitlyRelative(dependencyPath)
+        ? source.resolve_dependency_path(file, dependencyPath)
+        : dependencyPath
     );
   },
 

--- a/packages/truffle-compile/profiler.js
+++ b/packages/truffle-compile/profiler.js
@@ -134,15 +134,16 @@ module.exports = {
           async.map(
             sourceFiles,
             (sourceFile, finished) => {
-              fse.stat(sourceFile, (err, stat) => {
-                if (err) {
-                  // Ignore it. This means the source file was removed
-                  // but the artifact file possibly exists. Return null
-                  // to signfy that we should ignore it.
-                  stat = null;
-                }
+              try {
+                let stat = fse.statSync(sourceFile);
                 finished(null, stat);
-              });
+              } catch (error) {
+                // Ignore it. This means the source file was removed
+                // but the artifact file possibly exists. Return null
+                // to signfy that we should ignore it.
+                stat = null;
+                finished(null, stat);
+              }
             },
             (err, sourceFileStats) => {
               if (err) return callback(err);

--- a/packages/truffle-compile/profiler.js
+++ b/packages/truffle-compile/profiler.js
@@ -15,8 +15,7 @@ module.exports = {
   updated(options, callback) {
     expect.options(options, ["resolver"]);
 
-    const contracts_directory = options.contracts_directory;
-    const build_directory = options.contracts_build_directory;
+    const { contracts_directory, contracts_build_directory } = options;
 
     async function getFiles() {
       if (options.files) {
@@ -42,25 +41,23 @@ module.exports = {
       })
       .then(() => {
         // Get all the artifact files, and read them, parsing them as JSON
-        let build_files;
+        let buildFiles;
         try {
-          build_files = fse.readdirSync(build_directory);
+          buildFiles = fse.readdirSync(contracts_build_directory);
         } catch (error) {
           // The build directory may not always exist.
           if (error.message.includes("ENOENT: no such file or directory")) {
             // Ignore it.
-            build_files = [];
+            buildFiles = [];
           } else {
             throw error;
           }
         }
 
-        build_files = build_files.filter(
-          build_file => path.extname(build_file) === ".json"
-        );
-        const jsonData = build_files.map(file => {
+        buildFiles = buildFiles.filter(file => path.extname(file) === ".json");
+        const jsonData = buildFiles.map(file => {
           const body = fse.readFileSync(
-            path.join(build_directory, file),
+            path.join(contracts_build_directory, file),
             "utf8"
           );
           return { file, body };

--- a/packages/truffle-compile/profiler/findUpdatedFiles.js
+++ b/packages/truffle-compile/profiler/findUpdatedFiles.js
@@ -1,0 +1,38 @@
+const fse = require("fs-extra");
+
+module.exports = (sourceFilesArtifacts, sourceFilesArtifactsUpdatedTimes) => {
+  let updatedFiles = [];
+  // Stat all the source files, getting there updated times, and comparing them to
+  // the artifact updated times.
+  const sourceFiles = Object.keys(sourceFilesArtifacts);
+
+  let sourceFileStats;
+  sourceFileStats = sourceFiles.map(file => {
+    try {
+      return fse.statSync(file);
+    } catch (error) {
+      // Ignore it. This means the source file was removed
+      // but the artifact file possibly exists. Return null
+      // to signfy that we should ignore it.
+      return null;
+    }
+  });
+
+  sourceFiles.forEach((sourceFile, index) => {
+    const sourceFileStat = sourceFileStats[index];
+
+    // Ignore updating artifacts if source file has been removed.
+    if (sourceFileStat == null) return;
+
+    const artifactsUpdatedTime =
+      sourceFilesArtifactsUpdatedTimes[sourceFile] || 0;
+    const sourceFileUpdatedTime = (
+      sourceFileStat.mtime || sourceFileStat.ctime
+    ).getTime();
+
+    if (sourceFileUpdatedTime > artifactsUpdatedTime) {
+      updatedFiles.push(sourceFile);
+    }
+  });
+  return updatedFiles;
+};

--- a/packages/truffle-compile/profiler/findUpdatedFiles.js
+++ b/packages/truffle-compile/profiler/findUpdatedFiles.js
@@ -4,7 +4,6 @@ const findUpdatedFiles = (
   sourceFilesArtifacts,
   sourceFilesArtifactsUpdatedTimes
 ) => {
-  let updatedFiles = [];
   // Stat all the source files, getting there updated times, and comparing them to
   // the artifact updated times.
   const sourceFiles = Object.keys(sourceFilesArtifacts);
@@ -21,23 +20,22 @@ const findUpdatedFiles = (
     }
   });
 
-  sourceFiles.forEach((sourceFile, index) => {
-    const sourceFileStat = sourceFileStats[index];
+  return sourceFiles
+    .map((sourceFile, index) => {
+      const sourceFileStat = sourceFileStats[index];
 
-    // Ignore updating artifacts if source file has been removed.
-    if (sourceFileStat == null) return;
+      // Ignore updating artifacts if source file has been removed.
+      if (sourceFileStat == null) return;
 
-    const artifactsUpdatedTime =
-      sourceFilesArtifactsUpdatedTimes[sourceFile] || 0;
-    const sourceFileUpdatedTime = (
-      sourceFileStat.mtime || sourceFileStat.ctime
-    ).getTime();
+      const artifactsUpdatedTime =
+        sourceFilesArtifactsUpdatedTimes[sourceFile] || 0;
+      const sourceFileUpdatedTime = (
+        sourceFileStat.mtime || sourceFileStat.ctime
+      ).getTime();
 
-    if (sourceFileUpdatedTime > artifactsUpdatedTime) {
-      updatedFiles.push(sourceFile);
-    }
-  });
-  return updatedFiles;
+      if (sourceFileUpdatedTime > artifactsUpdatedTime) return sourceFile;
+    })
+    .filter(file => file);
 };
 
 module.exports = {

--- a/packages/truffle-compile/profiler/findUpdatedFiles.js
+++ b/packages/truffle-compile/profiler/findUpdatedFiles.js
@@ -1,6 +1,9 @@
 const fse = require("fs-extra");
 
-module.exports = (sourceFilesArtifacts, sourceFilesArtifactsUpdatedTimes) => {
+const findUpdatedFiles = (
+  sourceFilesArtifacts,
+  sourceFilesArtifactsUpdatedTimes
+) => {
   let updatedFiles = [];
   // Stat all the source files, getting there updated times, and comparing them to
   // the artifact updated times.
@@ -35,4 +38,8 @@ module.exports = (sourceFilesArtifacts, sourceFilesArtifactsUpdatedTimes) => {
     }
   });
   return updatedFiles;
+};
+
+module.exports = {
+  findUpdatedFiles
 };

--- a/packages/truffle-compile/profiler/getImports.js
+++ b/packages/truffle-compile/profiler/getImports.js
@@ -1,0 +1,21 @@
+const { isExplicitlyRelative } = require("./isExplicitlyRelative");
+const Parser = require("../parser");
+const path = require("path");
+
+const getImports = (file, { body, source }, solc) => {
+  // No imports in vyper!
+  if (path.extname(file) === ".vy") return [];
+
+  const imports = Parser.parseImports(body, solc);
+
+  // Convert explicitly relative dependencies of modules back into module paths.
+  return imports.map(dependencyPath =>
+    isExplicitlyRelative(dependencyPath)
+      ? source.resolve_dependency_path(file, dependencyPath)
+      : dependencyPath
+  );
+};
+
+module.exports = {
+  getImports
+};

--- a/packages/truffle-compile/profiler/index.js
+++ b/packages/truffle-compile/profiler/index.js
@@ -11,6 +11,7 @@ const find_contracts = require("truffle-contract-sources");
 const semver = require("semver");
 const debug = require("debug")("compile:profiler");
 const readAndParseArtifactFiles = require("./readAndParseArtifactFiles");
+const minimumUpdatedTimePerSource = require("./minimumUpdatedTimePerSource");
 
 module.exports = {
   updated(options, callback) {
@@ -27,7 +28,7 @@ module.exports = {
     }
 
     let sourceFilesArtifacts = {};
-    const sourceFilesArtifactsUpdatedTimes = {};
+    let sourceFilesArtifactsUpdatedTimes = {};
 
     const updatedFiles = [];
 
@@ -40,31 +41,9 @@ module.exports = {
         return;
       })
       .then(() => {
-        // Get the minimum updated time for all of a source file's artifacts
-        // (note: one source file might have multiple artifacts).
-        Object.keys(sourceFilesArtifacts).forEach(sourceFile => {
-          const artifacts = sourceFilesArtifacts[sourceFile];
-
-          sourceFilesArtifactsUpdatedTimes[sourceFile] = artifacts.reduce(
-            (minimum, current) => {
-              const updatedAt = new Date(current.updatedAt).getTime();
-
-              if (updatedAt < minimum) {
-                return updatedAt;
-              }
-              return minimum;
-            },
-            Number.MAX_SAFE_INTEGER
-          );
-
-          // Empty array?
-          if (
-            sourceFilesArtifactsUpdatedTimes[sourceFile] ===
-            Number.MAX_SAFE_INTEGER
-          ) {
-            sourceFilesArtifactsUpdatedTimes[sourceFile] = 0;
-          }
-        });
+        sourceFilesArtifactsUpdatedTimes = minimumUpdatedTimePerSource(
+          sourceFilesArtifacts
+        );
         return;
       })
       .then(() => {

--- a/packages/truffle-compile/profiler/index.js
+++ b/packages/truffle-compile/profiler/index.js
@@ -14,6 +14,7 @@ const {
   minimumUpdatedTimePerSource
 } = require("./minimumUpdatedTimePerSource");
 const { findUpdatedFiles } = require("./findUpdatedFiles");
+const { isExplicitlyRelative } = require("./isExplicitlyRelative");
 
 module.exports = {
   updated(options, callback) {
@@ -249,8 +250,6 @@ module.exports = {
   },
 
   getImports(file, { body, source }, solc) {
-    const self = this;
-
     // No imports in vyper!
     if (path.extname(file) === ".vy") return [];
 
@@ -258,7 +257,7 @@ module.exports = {
 
     // Convert explicitly relative dependencies of modules back into module paths.
     return imports.map(dependencyPath =>
-      self.isExplicitlyRelative(dependencyPath)
+      isExplicitlyRelative(dependencyPath)
         ? source.resolve_dependency_path(file, dependencyPath)
         : dependencyPath
     );
@@ -272,20 +271,15 @@ module.exports = {
   },
 
   convert_to_absolute_paths(paths, base) {
-    const self = this;
     return paths.map(p => {
       // If it's anabsolute paths, leave it alone.
       if (path.isAbsolute(p)) return p;
 
       // If it's not explicitly relative, then leave it alone (i.e., it's a module).
-      if (!self.isExplicitlyRelative(p)) return p;
+      if (!isExplicitlyRelative(p)) return p;
 
       // Path must be explicitly releative, therefore make it absolute.
       return path.resolve(path.join(base, p));
     });
-  },
-
-  isExplicitlyRelative(import_path) {
-    return import_path.indexOf(".") === 0;
   }
 };

--- a/packages/truffle-compile/profiler/index.js
+++ b/packages/truffle-compile/profiler/index.js
@@ -9,9 +9,11 @@ const expect = require("truffle-expect");
 const find_contracts = require("truffle-contract-sources");
 const semver = require("semver");
 const debug = require("debug")("compile:profiler");
-const readAndParseArtifactFiles = require("./readAndParseArtifactFiles");
-const minimumUpdatedTimePerSource = require("./minimumUpdatedTimePerSource");
-const findUpdatedFiles = require("./findUpdatedFiles");
+const { readAndParseArtifactFiles } = require("./readAndParseArtifactFiles");
+const {
+  minimumUpdatedTimePerSource
+} = require("./minimumUpdatedTimePerSource");
+const { findUpdatedFiles } = require("./findUpdatedFiles");
 
 module.exports = {
   updated(options, callback) {

--- a/packages/truffle-compile/profiler/index.js
+++ b/packages/truffle-compile/profiler/index.js
@@ -33,8 +33,6 @@ module.exports = {
     let sourceFilesArtifacts = {};
     let sourceFilesArtifactsUpdatedTimes = {};
 
-    let updatedFiles = [];
-
     getFiles()
       .then(sourceFiles => {
         sourceFilesArtifacts = readAndParseArtifactFiles(
@@ -50,7 +48,7 @@ module.exports = {
         return;
       })
       .then(() => {
-        updatedFiles = findUpdatedFiles(
+        const updatedFiles = findUpdatedFiles(
           sourceFilesArtifacts,
           sourceFilesArtifactsUpdatedTimes
         );

--- a/packages/truffle-compile/profiler/index.js
+++ b/packages/truffle-compile/profiler/index.js
@@ -10,6 +10,7 @@ const expect = require("truffle-expect");
 const find_contracts = require("truffle-contract-sources");
 const semver = require("semver");
 const debug = require("debug")("compile:profiler");
+const readAndParseArtifactFiles = require("./readAndParseArtifactFiles");
 
 module.exports = {
   updated(options, callback) {
@@ -25,63 +26,17 @@ module.exports = {
       }
     }
 
-    const sourceFilesArtifacts = {};
+    let sourceFilesArtifacts = {};
     const sourceFilesArtifactsUpdatedTimes = {};
 
     const updatedFiles = [];
 
     getFiles()
-      .then(files => {
-        // Get all the source files and create an object out of them.
-        // Use an object for O(1) access.
-        files.forEach(sourceFile => {
-          sourceFilesArtifacts[sourceFile] = [];
-        });
-        return;
-      })
-      .then(() => {
-        // Get all the artifact files, and read them, parsing them as JSON
-        let buildFiles;
-        try {
-          buildFiles = fse.readdirSync(contracts_build_directory);
-        } catch (error) {
-          // The build directory may not always exist.
-          if (error.message.includes("ENOENT: no such file or directory")) {
-            // Ignore it.
-            buildFiles = [];
-          } else {
-            throw error;
-          }
-        }
-
-        buildFiles = buildFiles.filter(file => path.extname(file) === ".json");
-        const jsonData = buildFiles.map(file => {
-          const body = fse.readFileSync(
-            path.join(contracts_build_directory, file),
-            "utf8"
-          );
-          return { file, body };
-        });
-
-        for (let i = 0; i < jsonData.length; i++) {
-          try {
-            const data = JSON.parse(jsonData[i].body);
-
-            // In case there are artifacts from other source locations.
-            if (sourceFilesArtifacts[data.sourcePath] == null) {
-              sourceFilesArtifacts[data.sourcePath] = [];
-            }
-
-            sourceFilesArtifacts[data.sourcePath].push(data);
-          } catch (error) {
-            // JSON.parse throws SyntaxError objects
-            if (e instanceof SyntaxError) {
-              throw new Error("Problem parsing artifact: " + jsonData[i].file);
-            } else {
-              throw error;
-            }
-          }
-        }
+      .then(sourceFiles => {
+        sourceFilesArtifacts = readAndParseArtifactFiles(
+          sourceFiles,
+          contracts_build_directory
+        );
         return;
       })
       .then(() => {

--- a/packages/truffle-compile/profiler/index.js
+++ b/packages/truffle-compile/profiler/index.js
@@ -6,7 +6,7 @@ const async = require("async");
 const Parser = require("../parser");
 const CompilerSupplier = require("../compilerSupplier");
 const expect = require("truffle-expect");
-const find_contracts = require("truffle-contract-sources");
+const findContracts = require("truffle-contract-sources");
 const semver = require("semver");
 const debug = require("debug")("compile:profiler");
 const { readAndParseArtifactFiles } = require("./readAndParseArtifactFiles");
@@ -25,7 +25,7 @@ module.exports = {
       if (options.files) {
         return options.files;
       } else {
-        return find_contracts(contracts_directory);
+        return findContracts(contracts_directory);
       }
     }
 
@@ -70,7 +70,7 @@ module.exports = {
     const resolver = options.resolver;
 
     // Fetch the whole contract set
-    find_contracts(options.contracts_directory, (err, allPaths) => {
+    findContracts(options.contracts_directory, (err, allPaths) => {
       if (err) return callback(err);
 
       // Solidity test files might have been injected. Include them in the known set.

--- a/packages/truffle-compile/profiler/index.js
+++ b/packages/truffle-compile/profiler/index.js
@@ -4,12 +4,12 @@
 const path = require("path");
 const async = require("async");
 const fse = require("fs-extra");
-const Parser = require("./parser");
-const CompilerSupplier = require("./compilerSupplier");
+const Parser = require("../parser");
+const CompilerSupplier = require("../compilerSupplier");
 const expect = require("truffle-expect");
 const find_contracts = require("truffle-contract-sources");
 const semver = require("semver");
-const debug = require("debug")("compile:profiler"); // eslint-disable-line no-unused-vars
+const debug = require("debug")("compile:profiler");
 
 module.exports = {
   updated(options, callback) {

--- a/packages/truffle-compile/profiler/isExplicitlyRelative.js
+++ b/packages/truffle-compile/profiler/isExplicitlyRelative.js
@@ -1,0 +1,7 @@
+const isExplicitlyRelative = importPath => {
+  return importPath.indexOf(".") === 0;
+};
+
+module.exports = {
+  isExplicitlyRelative
+};

--- a/packages/truffle-compile/profiler/minimumUpdatedTimePerSource.js
+++ b/packages/truffle-compile/profiler/minimumUpdatedTimePerSource.js
@@ -1,0 +1,28 @@
+module.exports = sourceFilesArtifacts => {
+  let sourceFilesArtifactsUpdatedTimes = {};
+  // Get the minimum updated time for all of a source file's artifacts
+  // (note: one source file might have multiple artifacts).
+  Object.keys(sourceFilesArtifacts).forEach(sourceFile => {
+    const artifacts = sourceFilesArtifacts[sourceFile];
+
+    sourceFilesArtifactsUpdatedTimes[sourceFile] = artifacts.reduce(
+      (minimum, current) => {
+        const updatedAt = new Date(current.updatedAt).getTime();
+
+        if (updatedAt < minimum) {
+          return updatedAt;
+        }
+        return minimum;
+      },
+      Number.MAX_SAFE_INTEGER
+    );
+
+    // Empty array?
+    if (
+      sourceFilesArtifactsUpdatedTimes[sourceFile] === Number.MAX_SAFE_INTEGER
+    ) {
+      sourceFilesArtifactsUpdatedTimes[sourceFile] = 0;
+    }
+  });
+  return sourceFilesArtifactsUpdatedTimes;
+};

--- a/packages/truffle-compile/profiler/minimumUpdatedTimePerSource.js
+++ b/packages/truffle-compile/profiler/minimumUpdatedTimePerSource.js
@@ -1,4 +1,4 @@
-module.exports = sourceFilesArtifacts => {
+const minimumUpdatedTimePerSource = sourceFilesArtifacts => {
   let sourceFilesArtifactsUpdatedTimes = {};
   // Get the minimum updated time for all of a source file's artifacts
   // (note: one source file might have multiple artifacts).
@@ -25,4 +25,8 @@ module.exports = sourceFilesArtifacts => {
     }
   });
   return sourceFilesArtifactsUpdatedTimes;
+};
+
+module.exports = {
+  minimumUpdatedTimePerSource
 };

--- a/packages/truffle-compile/profiler/readAndParseArtifactFiles.js
+++ b/packages/truffle-compile/profiler/readAndParseArtifactFiles.js
@@ -1,0 +1,53 @@
+const fse = require("fs-extra");
+const path = require("path");
+
+module.exports = (sourceFiles, contracts_build_directory) => {
+  let sourceFilesArtifacts = {};
+  // Get all the source files and create an object out of them.
+  sourceFiles.forEach(sourceFile => {
+    sourceFilesArtifacts[sourceFile] = [];
+  });
+  // Get all the artifact files, and read them, parsing them as JSON
+  let buildFiles;
+  try {
+    buildFiles = fse.readdirSync(contracts_build_directory);
+  } catch (error) {
+    // The build directory may not always exist.
+    if (error.message.includes("ENOENT: no such file or directory")) {
+      // Ignore it.
+      buildFiles = [];
+    } else {
+      throw error;
+    }
+  }
+
+  buildFiles = buildFiles.filter(file => path.extname(file) === ".json");
+  const jsonData = buildFiles.map(file => {
+    const body = fse.readFileSync(
+      path.join(contracts_build_directory, file),
+      "utf8"
+    );
+    return { file, body };
+  });
+
+  for (let i = 0; i < jsonData.length; i++) {
+    try {
+      const data = JSON.parse(jsonData[i].body);
+
+      // In case there are artifacts from other source locations.
+      if (sourceFilesArtifacts[data.sourcePath] == null) {
+        sourceFilesArtifacts[data.sourcePath] = [];
+      }
+
+      sourceFilesArtifacts[data.sourcePath].push(data);
+    } catch (error) {
+      // JSON.parse throws SyntaxError objects
+      if (e instanceof SyntaxError) {
+        throw new Error("Problem parsing artifact: " + jsonData[i].file);
+      } else {
+        throw error;
+      }
+    }
+  }
+  return sourceFilesArtifacts;
+};

--- a/packages/truffle-compile/profiler/readAndParseArtifactFiles.js
+++ b/packages/truffle-compile/profiler/readAndParseArtifactFiles.js
@@ -1,7 +1,7 @@
 const fse = require("fs-extra");
 const path = require("path");
 
-module.exports = (sourceFiles, contracts_build_directory) => {
+const readAndParseArtifactFiles = (sourceFiles, contracts_build_directory) => {
   let sourceFilesArtifacts = {};
   // Get all the source files and create an object out of them.
   sourceFiles.forEach(sourceFile => {
@@ -50,4 +50,8 @@ module.exports = (sourceFiles, contracts_build_directory) => {
     }
   }
   return sourceFilesArtifacts;
+};
+
+module.exports = {
+  readAndParseArtifactFiles
 };

--- a/packages/truffle-contract-sources/index.js
+++ b/packages/truffle-contract-sources/index.js
@@ -1,11 +1,13 @@
 const debug = require("debug")("contract-sources");
-
 const path = require("path");
 const glob = require("glob");
+const { promisify } = require("util");
+const promisifiedGlob = promisify(glob);
 
 const DEFAULT_PATTERN = "**/*.{sol,vy}";
 
 module.exports = (pattern, callback) => {
+  const callbackPassed = typeof callback === "function";
   // pattern is either a directory (contracts directory), or an absolute path
   // with a glob expression
   if (!glob.hasMagic(pattern)) {
@@ -16,5 +18,9 @@ module.exports = (pattern, callback) => {
     follow: true // follow symlinks
   };
 
-  glob(pattern, globOptions, callback);
+  if (callbackPassed) {
+    glob(pattern, globOptions, callback);
+  } else {
+    return promisifiedGlob(pattern, globOptions);
+  }
 };

--- a/packages/truffle-contract-sources/index.js
+++ b/packages/truffle-contract-sources/index.js
@@ -17,7 +17,7 @@ module.exports = (pattern, callback) => {
     follow: true // follow symlinks
   };
 
-  return promisify(glob(pattern, globOptions))
+  return promisify(glob)(pattern, globOptions)
     .then(files => {
       if (callbackPassed) {
         callback(null, files);

--- a/packages/truffle-core/lib/test.js
+++ b/packages/truffle-core/lib/test.js
@@ -11,7 +11,7 @@ const TestSource = require("./testing/testsource");
 const SolidityTest = require("./testing/soliditytest");
 const expect = require("truffle-expect");
 const Migrate = require("truffle-migrate");
-const Profiler = require("truffle-compile/profiler.js");
+const Profiler = require("truffle-compile/profiler");
 const originalrequire = require("original-require");
 
 chai.use(require("./assertions"));

--- a/packages/truffle-core/test/profiler.js
+++ b/packages/truffle-core/test/profiler.js
@@ -2,13 +2,13 @@ var assert = require("chai").assert;
 var fs = require("fs-extra");
 var glob = require("glob");
 var Box = require("truffle-box");
-var Profiler = require("truffle-compile/profiler.js");
+var Profiler = require("truffle-compile/profiler");
 var Resolver = require("truffle-resolver");
 var Artifactor = require("truffle-artifactor");
 
 // TOOD: Move this to truffle-compile!
 
-describe('profiler', function() {
+describe("profiler", function() {
   var config;
 
   before("Create a sandbox", function(done) {
@@ -23,24 +23,27 @@ describe('profiler', function() {
     });
   });
 
-  after("Cleanup tmp files", function(done){
-    glob('tmp-*', (err, files) => {
-      if(err) done(err);
+  after("Cleanup tmp files", function(done) {
+    glob("tmp-*", (err, files) => {
+      if (err) done(err);
       files.forEach(file => fs.removeSync(file));
       done();
     });
   });
 
-  it('profiles example project successfully', function(done) {
-    Profiler.required_sources(config.with({
-      paths: ["./ConvertLib.sol"],
-      base_path: config.contracts_directory
-    }), function(err, allSources, compilationTargets) {
-      if (err) return done(err);
+  it("profiles example project successfully", function(done) {
+    Profiler.required_sources(
+      config.with({
+        paths: ["./ConvertLib.sol"],
+        base_path: config.contracts_directory
+      }),
+      function(err, allSources, compilationTargets) {
+        if (err) return done(err);
 
-      assert.equal(Object.keys(allSources).length, 3);
-      assert.equal(compilationTargets.length, 2);
-      done();
-    });
+        assert.equal(Object.keys(allSources).length, 3);
+        assert.equal(compilationTargets.length, 2);
+        done();
+      }
+    );
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6316,6 +6316,15 @@ fs-extra@^7.0.0, fs-extra@^7.0.1:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.0.1.tgz#90294081f978b1f182f347a440a209154344285b"
+  integrity sha512-W+XLrggcDzlle47X/XnS7FXrXu9sDo+Ze9zpndeBxdgv88FHLm1HtmkhEwavruS6koanBjp098rUpHs65EmG7A==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-extra@~0.6.1:
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.6.4.tgz#f46f0c75b7841f8d200b3348cd4d691d5a099d15"


### PR DESCRIPTION
This PR reorganizes the `updated` method for the `Profiler` in truffle-compile. All uses of the `async` module are eliminated. Also much of the logic has been extracted into helper files.

Another change (not truffle-compile related) that this makes is that it allows the main method exposed by truffle-contract-sources to have a Promise interface as well as its old callback one.