### PR TITLE
Fix: ensure `console` & `develop` are passed commands as an array

### DIFF
--- a/packages/truffle-core/lib/command.js
+++ b/packages/truffle-core/lib/command.js
@@ -100,8 +100,10 @@ class Command {
       }
     });
 
-    //Check unsupported command line flag according to the option list in help
+    // Check unsupported command line flag according to the option list in help
     try {
+      // while in `console` & `develop`, input is passed as a string, not as an array
+      if (!Array.isArray(inputStrings)) inputStrings = inputStrings.split(" ")
       const inputOptions = inputStrings
         .map(string => {
           return string.startsWith("--") ? string : null;


### PR DESCRIPTION
This PR fixes a regression introduced in #2125, while building on top of the enhancement.

Makes sure commands initiated within the `develop` and `console` context are passed as expected arrays of strings.