### PR TITLE
Fix equalSlots function; give names to pair objects

### DIFF
--- a/packages/truffle-decode-utils/src/types/types.ts
+++ b/packages/truffle-decode-utils/src/types/types.ts
@@ -135,6 +135,11 @@ export namespace Types {
 
   export type StructType = StructTypeLocal | StructTypeGlobal;
 
+  export interface NameTypePair {
+    name: string;
+    type: Type;
+  }
+
   export interface StructTypeLocal {
     typeClass: "struct";
     kind: "local";
@@ -151,7 +156,7 @@ export namespace Types {
     kind: "global";
     id: number;
     typeName: string;
-    memberTypes?: {name: string, type: Type}[]; //these should be in order
+    memberTypes?: NameTypePair[]; //these should be in order
     location?: Ast.Location;
   }
 

--- a/packages/truffle-decode-utils/src/types/values.ts
+++ b/packages/truffle-decode-utils/src/types/values.ts
@@ -436,7 +436,7 @@ export namespace Values {
     kind: "value";
     //note that since mappings live in storage, a circular
     //mapping is impossible
-    value: {key: ElementaryValue, value: Result}[]; //order of key-value pairs is irrelevant
+    value: KeyValuePair[]; //order is irrelevant
     //note that key is not allowed to be an error!
     [util.inspect.custom](depth: number | null, options: InspectOptions): string {
       return util.inspect(new Map(this.value.map(
@@ -455,6 +455,11 @@ export namespace Values {
     }
   }
 
+  export interface KeyValuePair {
+    key: ElementaryValue; //note must be a value, not an error!
+    value: Result;
+  }
+
   //Structs
   export type StructResult = StructValue | Errors.StructErrorResult;
 
@@ -462,7 +467,7 @@ export namespace Values {
     type: Types.StructType;
     kind: "value";
     reference?: number; //will be used in the future for circular values
-    value: {name: string, value: Result}[]; //these should be stored in order!
+    value: NameValuePair[]; //these should be stored in order!
     [util.inspect.custom](depth: number | null, options: InspectOptions): string {
       if(this.reference !== undefined) {
         return formatCircular(this.reference, options);
@@ -485,6 +490,11 @@ export namespace Values {
       this.value = value;
       this.reference = reference;
     }
+  }
+
+  export interface NameValuePair {
+    name: string;
+    value: Result;
   }
 
   //Magic variables

--- a/packages/truffle-decode-utils/src/types/values.ts
+++ b/packages/truffle-decode-utils/src/types/values.ts
@@ -448,7 +448,7 @@ export namespace Values {
         ({[key.toString()]: value.nativize()})
       ));
     }
-    constructor(mappingType: Types.MappingType, value: {key: ElementaryValue, value: Result}[]) {
+    constructor(mappingType: Types.MappingType, value: KeyValuePair[]) {
       this.type = mappingType;
       this.kind = "value";
       this.value = value;
@@ -484,7 +484,7 @@ export namespace Values {
         ({name, value}) => ({[name]: value.nativize()})
       ));
     }
-    constructor(structType: Types.StructType, value: {name: string, value: Result}[], reference?: number) {
+    constructor(structType: Types.StructType, value: NameValuePair[], reference?: number) {
       this.type = structType;
       this.kind = "value";
       this.value = value;

--- a/packages/truffle-decoder-core/lib/decode/calldata.ts
+++ b/packages/truffle-decoder-core/lib/decode/calldata.ts
@@ -203,7 +203,7 @@ function* decodeCalldataStructByPosition(dataType: Types.StructType, startPositi
     );
   }
 
-  let decodedMembers: {name: string, value: Values.Result}[] = [];
+  let decodedMembers: Values.NameValuePair[] = [];
   for(let index = 0; index < structAllocation.members.length; index++) {
     const memberAllocation = structAllocation.members[index];
     const memberPointer = memberAllocation.pointer;

--- a/packages/truffle-decoder-core/lib/decode/memory.ts
+++ b/packages/truffle-decoder-core/lib/decode/memory.ts
@@ -113,7 +113,7 @@ export function* decodeMemoryReferenceByAddress(dataType: Types.ReferenceType, p
 
       debug("structAllocation %O", structAllocation);
 
-      let decodedMembers: {name: string, value: Values.Result}[] = [];
+      let decodedMembers: Values.NameValuePair[] = [];
       for(let index = 0; index < structAllocation.members.length; index++) {
         const memberAllocation = structAllocation.members[index];
         const memberPointer = memberAllocation.pointer;

--- a/packages/truffle-decoder-core/lib/decode/storage.ts
+++ b/packages/truffle-decoder-core/lib/decode/storage.ts
@@ -244,7 +244,7 @@ export function* decodeStorageReference(dataType: Types.ReferenceType, pointer: 
         );
       }
 
-      let decodedMembers: {name: string, value: Values.Result}[] = [];
+      let decodedMembers: Values.NameValuePair[] = [];
       const members = structAllocation.members;
 
       for(let index = 0; index < members.length; index++) {
@@ -306,7 +306,7 @@ export function* decodeStorageReference(dataType: Types.ReferenceType, pointer: 
         return Errors.makeGenericErrorResult(dataType, error.error);
       }
 
-      let decodedEntries: {key: Values.ElementaryValue, value: Values.Result}[] = [];
+      let decodedEntries: Values.KeyValuePair[] = [];
 
       const baseSlot: StorageTypes.Slot = pointer.storage.from.slot;
       debug("baseSlot %o", baseSlot);

--- a/packages/truffle-decoder-core/lib/types/storage.ts
+++ b/packages/truffle-decoder-core/lib/types/storage.ts
@@ -64,5 +64,6 @@ export function equalSlots(slot1: Slot | undefined, slot2: Slot | undefined): bo
   //if they do have keys, though...
   let { type: type1, value: value1 } = slot1.key.toSoliditySha3Input();
   let { type: type2, value: value2 } = slot2.key.toSoliditySha3Input();
-  return type1 === type2 && value1 === value2;
+  return type1 === type2 && value1.toString() === value2.toString(); //HACK: since values may be
+  //BNs, we compare by toString instead of by the value itself
 }


### PR DESCRIPTION
Two quick but unrelated fixes that should have been in `type-and-value`.

Number one, I made a mistake writing the `equalSlots` function; it compared things via `==` when they might be `BN`s.  So, as a quick fix, I now apply `toString` before comparing.

Secondly, the various pair objects now have named interfaces so that TypeDoc can handle them better.  (They're now `NameTypePair`, `NameValuePair`, and `KeyValuePair`.)