### PR TITLE
Enhancement: enable 'fork' as a config option for use within `truffle develop`

### DIFF
--- a/packages/truffle-core/lib/commands/develop.js
+++ b/packages/truffle-core/lib/commands/develop.js
@@ -68,6 +68,7 @@ const command = {
       total_accounts: customConfig.accounts || 10,
       default_balance_ether: customConfig.defaultEtherBalance || 100,
       blockTime: customConfig.blockTime || 0,
+      fork: customConfig.fork,
       mnemonic,
       gasLimit: customConfig.gas || 0x6691b7,
       gasPrice: customConfig.gasPrice || 0x77359400,


### PR DESCRIPTION
This PR allows passing a `fork` ganacheOption from `truffle-config.js` to enable `ganache-core`'s forking feature within the `truffle develop` context.

🍴 