### PR TITLE
Replace truffle-core/mnemonic require with a relative one

### DIFF
--- a/packages/truffle-core/lib/commands/develop.js
+++ b/packages/truffle-core/lib/commands/develop.js
@@ -1,5 +1,5 @@
 const emoji = require("node-emoji");
-const mnemonicInfo = require("truffle-core/lib/mnemonics/mnemonic");
+const mnemonicInfo = require("../mnemonics/mnemonic");
 
 const command = {
   command: "develop",


### PR DESCRIPTION
This hardcoded `truffle-core` prevents running `truffle` from my forked version of `truffle-core` package.