### PR TITLE
Redo output format with interfaces instead of classes (also some bugfixes)

### DIFF
--- a/packages/truffle-codec-utils/src/conversion.ts
+++ b/packages/truffle-codec-utils/src/conversion.ts
@@ -189,7 +189,8 @@ export namespace Conversion {
             return coercedResult.value.asString;
           case "malformed":
             // this will turn malformed utf-8 into replacement characters (U+FFFD) (WARNING)
-            return Buffer.from(coercedResult.value.asHex, 'hex').toString();
+            // note we need to cut off the 0x prefix
+            return Buffer.from(coercedResult.value.asHex.slice(2), 'hex').toString();
         }
       }
       //fixed and ufixed are skipped for now

--- a/packages/truffle-codec-utils/src/conversion.ts
+++ b/packages/truffle-codec-utils/src/conversion.ts
@@ -194,18 +194,18 @@ export namespace Conversion {
         }
       }
       //fixed and ufixed are skipped for now
-      case "array": //WARNING: circular case not handled
+      case "array": //WARNING: circular case not handled; will loop infinitely
         return (<Values.ArrayValue>result).value.map(nativize);
       case "mapping":
         return Object.assign({}, ...(<Values.MappingValue>result).value.map(
           ({key, value}) => ({[nativize(key).toString()]: nativize(value)})
         ));
-      case "struct": //WARNING: circular case not handled
+      case "struct": //WARNING: circular case not handled; will loop infinitely
         return Object.assign({}, ...(<Values.StructValue>result).value.map(
           ({name, value}) => ({[name]: nativize(value)})
         ));
       case "magic":
-        Object.assign({}, ...Object.entries((<Values.MagicValue>result).value).map(
+        return Object.assign({}, ...Object.entries((<Values.MagicValue>result).value).map(
             ([key, value]) => ({[key]: nativize(value)})
         ));
       case "enum":

--- a/packages/truffle-codec-utils/src/conversion.ts
+++ b/packages/truffle-codec-utils/src/conversion.ts
@@ -188,7 +188,8 @@ export namespace Conversion {
           case "valid":
             return coercedResult.value.asString;
           case "malformed":
-            return coercedResult.value.asHex; //WARNING
+            // this will turn malformed utf-8 into replacement characters (U+FFFD) (WARNING)
+            return Buffer.from(coercedResult.value.asHex, 'hex').toString();
         }
       }
       //fixed and ufixed are skipped for now

--- a/packages/truffle-codec-utils/src/definition.ts
+++ b/packages/truffle-codec-utils/src/definition.ts
@@ -143,7 +143,10 @@ export namespace Definition {
     if(compiler === null) {
       return false;
     }
-    if(semver.satisfies(compiler.version, ">=0.5.0", {includePrerelease: true})) {
+    if(semver.satisfies(compiler.version, "~0.5 || >=0.5.0", {includePrerelease: true})) {
+      //note that we use ~0.5 || >=0.5.0 to make sure we include prerelease versions of
+      //0.5.0 (no, that is *not* what the includePrerelease flag doesn; that allows
+      //prerelease versions to be included *at all*)
       return typeIdentifier(definition) === "t_address_payable";
     }
     else {

--- a/packages/truffle-codec-utils/src/index.ts
+++ b/packages/truffle-codec-utils/src/index.ts
@@ -6,6 +6,8 @@ export * from "./contexts";
 export * from "./abi";
 export * from "./compiler";
 export * from "./errors";
+export * from "./wrap";
 export * from "./types/types";
 export * from "./types/values";
 export * from "./types/errors";
+export * from "./types/inspect";

--- a/packages/truffle-codec-utils/src/types/errors.ts
+++ b/packages/truffle-codec-utils/src/types/errors.ts
@@ -202,6 +202,15 @@ export namespace Errors {
 
   export type StructError = never;
 
+  //Tuples
+  export interface TupleErrorResult {
+    type: Types.TupleType;
+    kind: "error";
+    error: GenericError | TupleError;
+  }
+
+  export type TupleError = never;
+
   //Magic variables
   export interface MagicErrorResult {
     type: Types.MagicType;

--- a/packages/truffle-codec-utils/src/types/errors.ts
+++ b/packages/truffle-codec-utils/src/types/errors.ts
@@ -387,13 +387,20 @@ export namespace Errors {
   }
 
   /* SECTION 9: Internal use errors */
+  /* you should never see these returned.
+   * they are only for internal use. */
 
-  export type InternalUseError = OverlongArrayOrStringError | InternalFunctionInABIError;
+  export type InternalUseError = OverlongArrayOrStringError | PointerTooLargeError | InternalFunctionInABIError;
 
-  //you should never see this returned.  this is only for internal use.
   export interface OverlongArrayOrStringError {
     kind: "OverlongArrayOrStringError";
     lengthAsBN: BN;
+    dataLength: number;
+  }
+
+  export interface PointerTooLargeError {
+    kind: "PointerTooLargeError";
+    pointerAsBN: BN;
     dataLength: number;
   }
 

--- a/packages/truffle-codec-utils/src/types/errors.ts
+++ b/packages/truffle-codec-utils/src/types/errors.ts
@@ -23,10 +23,10 @@ export namespace Errors {
   //For when we need to throw an error, here's a wrapper class that extends Error.
   //Apologies about the confusing name, but I wanted something that would make
   //sense should it not be caught and thus accidentally exposed to the outside.
-  export class DecodingError extends Error {
-    error: GenericError;
-    constructor(error: GenericError) {
-      super(error.message());
+  export class DecodingError extends Error{
+    error: ErrorForThrowing;
+    constructor(error: ErrorForThrowing) {
+      super(message(error));
       this.error = error;
       this.name = "DecodingError";
     }
@@ -38,38 +38,13 @@ export namespace Errors {
     | ContractErrorResult | FunctionExternalErrorResult | FunctionInternalErrorResult;
 
   export type DecoderError = GenericError
-    | UintError | IntError | BoolError | BytesStaticError | AddressError
-    | FixedError | UfixedError
+    | UintError | IntError | BoolError | BytesStaticError | BytesDynamicError | AddressError
+    | StringError | FixedError | UfixedError
+    | ArrayError | MappingError | StructError | MagicError
     | EnumError | ContractError | FunctionExternalError | FunctionInternalError
     | InternalUseError;
   //note that at the moment, no reference type has its own error category, so
   //no reference types are listed here; this also includes Magic
-
-  //for internal use only! just here to facilitate code reuse!
-  //please use the union types for actual use!
-  //this class doesn't even have the error field!
-  abstract class ErrorResultBase {
-    type: Types.Type;
-    kind: "error";
-    error: DecoderErrorBase;
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      return util.inspect(this.error, options);
-    }
-    nativize(): any {
-      return undefined;
-    }
-    toSoliditySha3Input(): {type: string; value: any} {
-      return undefined; //will cause an error! should not occur!
-    }
-    constructor() {
-      this.kind = "error";
-    }
-  }
-
-  //also just for internal use to make things easier!
-  abstract class DecoderErrorBase {
-    kind: string;
-  }
 
   /*
    * SECTION 2: Elementary values
@@ -81,242 +56,160 @@ export namespace Errors {
   export type BytesErrorResult = BytesStaticErrorResult | BytesDynamicErrorResult;
 
   //Uints
-  export class UintErrorResult extends ErrorResultBase {
-    constructor(
-      public uintType: Types.UintType,
-      public error: GenericError | UintError
-    ) {
-      super();
-    }
+  export interface UintErrorResult {
+    type: Types.UintType;
+    kind: "error";
+    error: GenericError | UintError;
   }
 
   export type UintError = UintPaddingError;
 
-  export class UintPaddingError extends DecoderErrorBase {
+  export interface UintPaddingError {
     raw: string; //hex string
     kind: "UintPaddingError";
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      return `Uint has extra leading bytes (padding error) (raw value ${this.raw})`;
-    }
-    constructor(raw: string) {
-      super();
-      this.raw = raw;
-      this.kind = "UintPaddingError";
-    }
   }
 
   //Ints
-  export class IntErrorResult extends ErrorResultBase {
-    constructor(
-      public intType: Types.IntType,
-      public error: GenericError | IntError
-    ) {
-      super();
-    }
+  export interface IntErrorResult {
+    type: Types.IntType;
+    kind: "error";
+    error: GenericError | IntError;
   }
 
   export type IntError = IntPaddingError;
 
-  export class IntPaddingError extends DecoderErrorBase {
+  export interface IntPaddingError {
     raw: string; //hex string
     kind: "IntPaddingError";
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      return `Int out of range (padding error) (numeric value ${this.raw})`;
-    }
-    constructor(raw: string) {
-      super();
-      this.raw = raw;
-      this.kind = "IntPaddingError";
-    }
   }
 
   //Bools
-  export class BoolErrorResult extends ErrorResultBase {
-    constructor(
-      public boolType: Types.BoolType,
-      public error: GenericError | BoolError
-    ) {
-      super();
-    }
+  export interface BoolErrorResult {
+    type: Types.BoolType;
+    kind: "error";
+    error: GenericError | BoolError;
   }
 
   export type BoolError = BoolPaddingError | BoolOutOfRangeError;
 
-  export class BoolPaddingError extends DecoderErrorBase {
+  export interface BoolPaddingError {
     raw: string; //should be hex string
     kind: "BoolPaddingError";
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      return `Bool has extra leading bytes (padding error) (raw value ${this.raw})`;
-    }
-    constructor(raw: string) {
-      super();
-      this.raw = raw;
-      this.kind = "BoolPaddingError";
-    }
   }
 
-  export class BoolOutOfRangeError extends DecoderErrorBase {
-    rawAsBN: BN;
+  export interface BoolOutOfRangeError {
+    rawAsNumber: number;
     kind: "BoolOutOfRangeError";
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      return `Invalid boolean (numeric value ${this.rawAsBN.toString()})`;
-    }
-    constructor(raw: BN) {
-      super();
-      this.rawAsBN = raw;
-      this.kind = "BoolOutOfRangeError";
-    }
   }
 
   //bytes (static)
-  export class BytesStaticErrorResult extends ErrorResultBase {
-    constructor(
-      public bytesType: Types.BytesTypeStatic,
-      public error: GenericError | BytesStaticError
-    ) {
-      super();
-    }
+  export interface BytesStaticErrorResult {
+    type: Types.BytesTypeStatic;
+    kind: "error";
+    error: GenericError | BytesStaticError;
   }
 
   export type BytesStaticError = BytesPaddingError;
 
-  export class BytesPaddingError extends DecoderErrorBase {
+  export interface BytesPaddingError {
     raw: string; //should be hex string
     kind: "BytesPaddingError";
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      return `Bytestring has extra trailing bytes (padding error) (raw value ${this.raw})`;
-    }
-    constructor(raw: string) {
-      super();
-      this.raw = raw;
-      this.kind = "BytesPaddingError";
-    }
   }
 
   //bytes (dynamic)
-  export class BytesDynamicErrorResult extends ErrorResultBase {
-    constructor(
-      public bytesType: Types.BytesTypeDynamic,
-      public error: GenericError
-    ) {
-      super();
-    }
+  export interface BytesDynamicErrorResult {
+    type: Types.BytesTypeDynamic;
+    kind: "error";
+    error: GenericError | BytesDynamicError;
   }
 
+  export type BytesDynamicError = never; //bytes dynamic has no specific errors atm
+
   //addresses
-  export class AddressErrorResult extends ErrorResultBase {
-    constructor(
-      public addressType: Types.AddressType,
-      public error: GenericError | AddressError
-    ) {
-      super();
-    }
+  export interface AddressErrorResult {
+    type: Types.AddressType;
+    kind: "error";
+    error: GenericError | AddressError;
   }
 
   export type AddressError = AddressPaddingError;
 
-  export class AddressPaddingError extends DecoderErrorBase {
+  export interface AddressPaddingError {
     raw: string; //should be hex string
     kind: "AddressPaddingError";
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      return `Address has extra leading bytes (padding error) (raw value ${this.raw})`;
-    }
-    constructor(raw: string) {
-      super();
-      this.raw = raw;
-      this.kind = "AddressPaddingError";
-    }
   }
 
   //strings
-  export class StringErrorResult extends ErrorResultBase {
-    constructor(
-      public stringType: Types.StringType,
-      public error: GenericError
-    ) {
-      super();
-    }
+  export interface StringErrorResult {
+    type: Types.StringType;
+    kind: "error";
+    error: GenericError | StringError;
   }
+
+  export type StringError = never; //again, string has no specific errors
 
   //Fixed & Ufixed
   //These don't have a value format yet, so they just decode to errors for now!
-  export class FixedErrorResult extends ErrorResultBase {
-    constructor(
-      public fixedType: Types.FixedType,
-      public error: GenericError | FixedError
-    ) {
-      super();
-    }
+  export interface FixedErrorResult {
+    type: Types.FixedType;
+    kind: "error";
+    error: GenericError | FixedError;
   }
-  export class UfixedErrorResult extends ErrorResultBase {
-    constructor(
-      public ufixedType: Types.UfixedType,
-      public error: GenericError | UfixedError
-    ) {
-      super();
-    }
+  export interface UfixedErrorResult {
+    type: Types.UfixedType;
+    kind: "error";
+    error: GenericError | UfixedError;
   }
 
   export type FixedError = FixedPointNotYetSupportedError;
   export type UfixedError = FixedPointNotYetSupportedError;
 
-  export class FixedPointNotYetSupportedError extends DecoderErrorBase {
+  export interface FixedPointNotYetSupportedError {
     raw: string; //hex string
     kind: "FixedPointNotYetSupportedError";
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      return `Fixed-point decoding not yet supported (raw value: ${this.raw})`;
-    }
-    constructor(raw: string) {
-      super();
-      this.raw = raw;
-      this.kind = "FixedPointNotYetSupportedError";
-    }
   }
   //no separate padding error here, that would be pointless right now; will make later
 
   /*
    * SECTION 3: CONTAINER TYPES (including magic)
+   * none of these have type-specific errors
    */
 
   //Arrays
-  export class ArrayErrorResult extends ErrorResultBase {
-    constructor(
-      public arrayType: Types.ArrayType,
-      public error: GenericError
-    ) {
-      super();
-    }
+  export interface ArrayErrorResult {
+    type: Types.ArrayType;
+    kind: "error";
+    error: GenericError | ArrayError;
   }
+
+  export type ArrayError = never;
 
   //Mappings
-  export class MappingErrorResult extends ErrorResultBase {
-    constructor(
-      public mappingType: Types.MappingType,
-      public error: GenericError
-    ) {
-      super();
-    }
+  export interface MappingErrorResult {
+    type: Types.MappingType;
+    kind: "error";
+    error: GenericError | MappingError;
   }
+
+  export type MappingError = never;
 
   //Structs
-  export class StructErrorResult extends ErrorResultBase {
-    constructor(
-      public structType: Types.StructType,
-      public error: GenericError
-    ) {
-      super();
-    }
+  export interface StructErrorResult {
+    type: Types.StructType;
+    kind: "error";
+    error: GenericError | StructError;
   }
 
+  export type StructError = never;
+
   //Magic variables
-  export class MagicErrorResult extends ErrorResultBase {
-    constructor(
-      public magicType: Types.MagicType,
-      public error: GenericError
-    ) {
-      super();
-    }
+  export interface MagicErrorResult {
+    type: Types.MagicType;
+    kind: "error";
+    error: GenericError | MagicError;
   }
+
+  export type MagicError = never;
 
   /*
    * SECTION 4: ENUMS
@@ -324,63 +217,30 @@ export namespace Errors {
    */
 
   //Enums
-  export class EnumErrorResult extends ErrorResultBase {
-    constructor(
-      public enumType: Types.EnumType,
-      public error: GenericError | EnumError
-    ) {
-      super();
-    }
+  export interface EnumErrorResult {
+    type: Types.EnumType;
+    kind: "error";
+    error: GenericError | EnumError;
   }
 
   export type EnumError = EnumPaddingError | EnumOutOfRangeError | EnumNotFoundDecodingError;
 
-  export class EnumPaddingError extends DecoderErrorBase {
+  export interface EnumPaddingError {
     kind: "EnumPaddingError";
     type: Types.EnumType;
     raw: string; //should be hex string
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      let typeName = (this.type.kind === "local" ? (this.type.definingContractName + ".") : "") + this.type.typeName;
-      return `${typeName} has extra leading bytes (padding error) (raw value ${this.raw})`;
-    }
-    constructor(enumType: Types.EnumType, raw: string) {
-      super();
-      this.type = enumType;
-      this.raw = raw;
-      this.kind = "EnumPaddingError";
-    }
   }
 
-  export class EnumOutOfRangeError extends DecoderErrorBase {
+  export interface EnumOutOfRangeError {
     kind: "EnumOutOfRangeError";
     type: Types.EnumType;
     rawAsBN: BN;
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      let typeName = (this.type.kind === "local" ? (this.type.definingContractName + ".") : "") + this.type.typeName;
-      return `Invalid ${typeName} (numeric value ${this.rawAsBN.toString()})`;
-    }
-    constructor(enumType: Types.EnumType, raw: BN) {
-      super();
-      this.type = enumType;
-      this.rawAsBN = raw;
-      this.kind = "EnumOutOfRangeError";
-    }
   }
 
-  export class EnumNotFoundDecodingError extends DecoderErrorBase {
+  export interface EnumNotFoundDecodingError {
     kind: "EnumNotFoundDecodingError";
     type: Types.EnumType;
     rawAsBN: BN;
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      let typeName = (this.type.kind === "local" ? (this.type.definingContractName + ".") : "") + this.type.typeName;
-      return `Unknown enum type ${typeName} of id ${this.type.id} (numeric value ${this.rawAsBN.toString()})`;
-    }
-    constructor(enumType: Types.EnumType, raw: BN) {
-      super();
-      this.type = enumType;
-      this.rawAsBN = raw;
-      this.kind = "EnumNotFoundDecodingError";
-    }
   }
 
   /*
@@ -388,28 +248,17 @@ export namespace Errors {
    */
 
   //Contracts
-  export class ContractErrorResult extends ErrorResultBase {
-    constructor(
-      public contractType: Types.ContractType,
-      public error: GenericError | ContractError
-    ) {
-      super();
-    }
+  export interface ContractErrorResult {
+    type: Types.ContractType;
+    kind: "error";
+    error: GenericError | ContractError;
   }
 
   export type ContractError = ContractPaddingError;
 
-  export class ContractPaddingError extends DecoderErrorBase {
+  export interface ContractPaddingError {
     raw: string; //should be hex string
     kind: "ContractPaddingError";
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      return `Contract address has extra leading bytes (padding error) (raw value ${this.raw})`;
-    }
-    constructor(raw: string) {
-      super();
-      this.raw = raw;
-      this.kind = "ContractPaddingError";
-    }
   }
 
   /*
@@ -417,43 +266,23 @@ export namespace Errors {
    */
 
   //external functions
-  export class FunctionExternalErrorResult extends ErrorResultBase {
-    constructor(
-      public functionType: Types.FunctionExternalType,
-      public error: GenericError | FunctionExternalError
-    ) {
-      super();
-    }
+  export interface FunctionExternalErrorResult {
+    type: Types.FunctionExternalType;
+    kind: "error";
+    error: GenericError | FunctionExternalError;
   }
 
   export type FunctionExternalError = FunctionExternalNonStackPaddingError | FunctionExternalStackPaddingError;
 
-  export class FunctionExternalNonStackPaddingError extends DecoderErrorBase {
+  export interface FunctionExternalNonStackPaddingError {
     raw: string; //should be hex string
     kind: "FunctionExternalNonStackPaddingError";
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      return `External function has extra trailing bytes (padding error) (raw value ${this.raw})`;
-    }
-    constructor(raw: string) {
-      super();
-      this.raw = raw;
-      this.kind = "FunctionExternalNonStackPaddingError";
-    }
   }
 
-  export class FunctionExternalStackPaddingError extends DecoderErrorBase {
+  export interface FunctionExternalStackPaddingError {
     rawAddress: string;
     rawSelector: string;
     kind: "FunctionExternalStackPaddingError";
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      return `External function address or selector has extra leading bytes (padding error) (raw address ${this.rawAddress}, raw selector ${this.rawSelector})`;
-    }
-    constructor(rawAddress: string, rawSelector: string) {
-      super();
-      this.rawAddress = rawAddress;
-      this.rawSelector = rawSelector;
-      this.kind = "FunctionExternalStackPaddingError";
-    }
   }
 
   /*
@@ -461,80 +290,39 @@ export namespace Errors {
    */
 
   //Internal functions
-  export class FunctionInternalErrorResult extends ErrorResultBase {
-    constructor(
-      public functionType: Types.FunctionInternalType,
-      public error: GenericError | FunctionInternalError
-    ) {
-      super();
-    }
+  export interface FunctionInternalErrorResult {
+    type: Types.FunctionInternalType;
+    kind: "error";
+    error: GenericError | FunctionInternalError;
   }
 
   export type FunctionInternalError = FunctionInternalPaddingError | NoSuchInternalFunctionError
     | DeployedFunctionInConstructorError | MalformedInternalFunctionError;
 
-  export class FunctionInternalPaddingError extends DecoderErrorBase {
+  export interface FunctionInternalPaddingError {
     raw: string; //should be hex string
     kind: "FunctionInternalPaddingError";
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      return `Internal function has extra leading bytes (padding error) (raw value ${this.raw})`;
-    }
-    constructor(raw: string) {
-      super();
-      this.raw = raw;
-      this.kind = "FunctionInternalPaddingError";
-    }
   }
 
-  export class NoSuchInternalFunctionError extends DecoderErrorBase {
+  export interface NoSuchInternalFunctionError {
     kind: "NoSuchInternalFunctionError";
     context: Types.ContractType;
     deployedProgramCounter: number;
     constructorProgramCounter: number;
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      return `Invalid function (Deployed PC=${this.deployedProgramCounter}, constructor PC=${this.constructorProgramCounter}) of contract ${this.context.typeName}`;
-    }
-    constructor(context: Types.ContractType, deployedProgramCounter: number, constructorProgramCounter: number) {
-      super();
-      this.context = context;
-      this.deployedProgramCounter = deployedProgramCounter;
-      this.constructorProgramCounter = constructorProgramCounter;
-      this.kind = "NoSuchInternalFunctionError";
-    }
   }
 
-  export class DeployedFunctionInConstructorError extends DecoderErrorBase {
+  export interface DeployedFunctionInConstructorError {
     kind: "DeployedFunctionInConstructorError";
     context: Types.ContractType;
     deployedProgramCounter: number;
     constructorProgramCounter: number;
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      return `Deployed-style function (PC=${this.deployedProgramCounter}) in constructor`;
-    }
-    constructor(context: Types.ContractType, deployedProgramCounter: number) {
-      super();
-      this.context = context;
-      this.deployedProgramCounter = deployedProgramCounter;
-      this.constructorProgramCounter = 0;
-      this.kind = "DeployedFunctionInConstructorError";
-    }
   }
 
-  export class MalformedInternalFunctionError extends DecoderErrorBase {
+  export interface MalformedInternalFunctionError {
     kind: "MalformedInternalFunctionError";
     context: Types.ContractType;
     deployedProgramCounter: number;
     constructorProgramCounter: number;
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      return `Malformed internal function w/constructor PC only (value: ${this.constructorProgramCounter})`;
-    }
-    constructor(context: Types.ContractType, constructorProgramCounter: number) {
-      super();
-      this.context = context;
-      this.deployedProgramCounter = 0;
-      this.constructorProgramCounter = constructorProgramCounter;
-      this.kind = "MalformedInternalFunctionError";
-    }
   }
 
   /*
@@ -542,126 +330,50 @@ export namespace Errors {
    */
 
   export type GenericError = UserDefinedTypeNotFoundError | IndexedReferenceTypeError
-    | UnsupportedConstantError | ReadErrorStack | ReadErrorTopic;
+    | UnsupportedConstantError | ReadErrorStack;
 
-  //type-location error
-  export class UserDefinedTypeNotFoundError extends DecoderErrorBase {
-    kind: "UserDefinedTypeNotFoundError";
-    type: Types.UserDefinedType;
-    message() {
-      let typeName = Types.isContractDefinedType(this.type)
-        ? this.type.definingContractName + "." + this.type.typeName
-        : this.type.typeName;
-      return `Unknown ${this.type.typeClass} type ${typeName} of id ${this.type.id}`;
-    }
-    constructor(unknownType: Types.UserDefinedType) {
-      super();
-      this.type = unknownType;
-      this.kind = "UserDefinedTypeNotFoundError";
-    }
-  }
+  export type ErrorForThrowing = UserDefinedTypeNotFoundError |
+    UnsupportedConstantError | ReadErrorStack;
 
   //attempted to decode an indexed parameter of reference type error
-  export class IndexedReferenceTypeError extends DecoderErrorBase {
+  export interface IndexedReferenceTypeError {
     kind: "IndexedReferenceTypeError";
     type: Types.ReferenceType;
     raw: string; //should be hex string
-    message() {
-      return `Cannot decode indexed parameter of reference type ${this.type.typeClass} (raw value ${this.raw})`;
-    }
-    constructor(referenceType: Types.ReferenceType, raw: string) {
-      super();
-      this.type = referenceType;
-      this.raw = raw;
-      this.kind = "IndexedReferenceTypeError";
-    }
+  }
+
+  //type-location error
+  export interface UserDefinedTypeNotFoundError {
+    kind: "UserDefinedTypeNotFoundError";
+    type: Types.UserDefinedType;
   }
 
   //Read errors
-  export class UnsupportedConstantError extends DecoderErrorBase {
+  export interface UnsupportedConstantError {
     kind: "UnsupportedConstantError";
     definition: AstDefinition;
-    message() {
-      return `Unsupported constant type ${DefinitionUtils.typeClass(this.definition)}$`;
-    }
-    constructor(definition: AstDefinition) {
-      super();
-      this.definition = definition;
-      this.kind = "UnsupportedConstantError";
-    }
   }
 
-  export class ReadErrorStack extends DecoderErrorBase {
+  export interface ReadErrorStack {
     kind: "ReadErrorStack";
     from: number;
     to: number;
-    message() {
-      return `Can't read stack from position ${this.from} to ${this.to}`;
-    }
-    constructor(from: number, to: number) {
-      super();
-      this.from = from;
-      this.to = to;
-      this.kind = "ReadErrorStack";
-    }
   }
 
-  export class ReadErrorTopic extends DecoderErrorBase {
-    kind: "ReadErrorTopic";
-    topic: number;
-    message() {
-      return `Can't read event topic ${this.topic}`;
-    }
-    constructor(topic: number) {
-      super();
-      this.topic = topic;
-      this.kind = "ReadErrorTopic";
-    }
-  }
-
-  //finally, a convenience function for constructing generic errors
-  export function makeGenericErrorResult(dataType: Types.Type, error: GenericError): ErrorResult {
-    switch(dataType.typeClass) {
-      case "uint":
-        return new UintErrorResult(dataType, error);
-      case "int":
-        return new IntErrorResult(dataType, error);
-      case "bool":
-        return new BoolErrorResult(dataType, error);
-      case "bytes":
-        switch(dataType.kind) {
-          case "static":
-            return new BytesStaticErrorResult(dataType, error);
-          case "dynamic":
-            return new BytesDynamicErrorResult(dataType, error);
-        }
-      case "address":
-        return new AddressErrorResult(dataType, error);
-      case "fixed":
-        return new FixedErrorResult(dataType, error);
-      case "ufixed":
-        return new UfixedErrorResult(dataType, error);
-      case "string":
-        return new StringErrorResult(dataType, error);
-      case "array":
-        return new ArrayErrorResult(dataType, error);
-      case "mapping":
-        return new MappingErrorResult(dataType, error);
-      case "struct":
-        return new StructErrorResult(dataType, error);
-      case "enum":
-        return new EnumErrorResult(dataType, error);
-      case "contract":
-        return new ContractErrorResult(dataType, error);
-      case "magic":
-        return new MagicErrorResult(dataType, error);
-      case "function":
-        switch(dataType.visibility) {
-          case "external":
-            return new FunctionExternalErrorResult(dataType, error);
-          case "internal":
-            return new FunctionInternalErrorResult(dataType, error);
-        }
+  //this function gives an error message
+  //for those errors that are meant to possibly
+  //be wrapped in a DecodingError and thrown
+  export function message(error: ErrorForThrowing) {
+    switch(error.kind) {
+      case "UserDefinedTypeNotFoundError":
+        let typeName = Types.isContractDefinedType(error.type)
+          ? error.type.definingContractName + "." + error.type.typeName
+          : error.type.typeName;
+        return `Unknown ${error.type.typeClass} type ${typeName} of id ${error.type.id}`;
+      case "UnsupportedConstantError":
+        return `Unsupported constant type ${DefinitionUtils.typeClass(error.definition)}$`;
+      case "ReadErrorStack":
+        return `Can't read stack from position ${error.from} to ${error.to}`;
     }
   }
 
@@ -670,25 +382,15 @@ export namespace Errors {
   export type InternalUseError = OverlongArrayOrStringError | InternalFunctionInABIError;
 
   //you should never see this returned.  this is only for internal use.
-  export class OverlongArrayOrStringError extends DecoderErrorBase {
+  export interface OverlongArrayOrStringError {
     kind: "OverlongArrayOrStringError";
     lengthAsBN: BN;
     dataLength: number;
-    constructor(length: BN, dataLength: number) {
-      super();
-      this.lengthAsBN = length;
-      this.dataLength = dataLength;
-      this.kind = "OverlongArrayOrStringError";
-    }
   }
 
   //this one should never come up at all, but just to be sure...
-  export class InternalFunctionInABIError extends DecoderErrorBase {
+  export interface InternalFunctionInABIError {
     kind: "InternalFunctionInABIError";
-    constructor() {
-      super();
-      this.kind = "InternalFunctionInABIError";
-    }
   }
 
 }

--- a/packages/truffle-codec-utils/src/types/inspect.ts
+++ b/packages/truffle-codec-utils/src/types/inspect.ts
@@ -44,7 +44,7 @@ export class ResultInspector {
               case "static":
                 return options.stylize(hex, "number");
               case "dynamic":
-                return styleHexString(hex, options);
+                return options.stylize(`hex'${hex.slice(2)}'`, "string");
             }
           case "address":
             return options.stylize((<Values.AddressValue>this.result).value.asAddress, "number");
@@ -54,7 +54,8 @@ export class ResultInspector {
               case "valid":
                 return util.inspect(coercedResult.value.asString, options);
               case "malformed":
-                return styleHexString(coercedResult.value.asHex, options) + " (malformed)";
+                //note: this will turn malformed utf-8 into replacement characters (U+FFFD)
+                return util.inspect(Buffer.from(coercedResult.value.asHex, 'hex').toString());
             }
           }
           case "array": {

--- a/packages/truffle-codec-utils/src/types/inspect.ts
+++ b/packages/truffle-codec-utils/src/types/inspect.ts
@@ -55,7 +55,8 @@ export class ResultInspector {
                 return util.inspect(coercedResult.value.asString, options);
               case "malformed":
                 //note: this will turn malformed utf-8 into replacement characters (U+FFFD)
-                return util.inspect(Buffer.from(coercedResult.value.asHex, 'hex').toString());
+                //note we need to cut off the 0x prefix
+                return util.inspect(Buffer.from(coercedResult.value.asHex.slice(2), 'hex').toString());
             }
           }
           case "array": {

--- a/packages/truffle-codec-utils/src/types/inspect.ts
+++ b/packages/truffle-codec-utils/src/types/inspect.ts
@@ -2,6 +2,9 @@ import debugModule from "debug";
 const debug = debugModule("codec-utils:types:inspect");
 
 import util from "util";
+import { Types } from "./types";
+import { Values } from "./values";
+import { Errors } from "./errors";
 
 //we'll need to write a typing for the options type ourself, it seems; just
 //going to include the relevant properties here
@@ -19,4 +22,224 @@ export function cleanStylize(options: InspectOptions) {
         ? {}
         : {[key]: value}
   ));
+}
+
+export class ResultInspector {
+  result: Values.Result;
+  constructor(result: Values.Result) {
+    this.result = result;
+  }
+  [util.inspect.custom](depth: number | null, options: InspectOptions): string {
+    switch(this.result.kind) {
+      case "value":
+        switch(this.result.type.typeClass) {
+          case "uint":
+          case "int":
+            return options.stylize((<Values.UintValue|Values.IntValue>this.result).value.asBN.toString(), "number");
+          case "bool":
+            return util.inspect((<Values.BoolValue>this.result).value.asBool, options);
+          case "bytes":
+            let hex = (<Values.BytesValue>this.result).value.asHex;
+            switch(this.result.type.kind) {
+              case "static":
+                return options.stylize(hex, "number");
+              case "dynamic":
+                return styleHexString(hex, options);
+            }
+          case "address":
+            return options.stylize((<Values.AddressValue>this.result).value.asAddress, "number");
+          case "string": {
+            let coercedResult = <Values.StringValue> this.result;
+            switch(coercedResult.value.kind) {
+              case "valid":
+                return util.inspect(coercedResult.value.asString, options);
+              case "malformed":
+                return styleHexString(coercedResult.value.asHex, options) + " (malformed)";
+            }
+          }
+          case "array": {
+            let coercedResult = <Values.ArrayValue> this.result;
+            if(coercedResult.reference !== undefined) {
+              return formatCircular(coercedResult.reference, options);
+            }
+            return util.inspect(
+              coercedResult.value.map(
+                element => new ResultInspector(element)
+              ),
+              options
+            );
+          }
+          case "mapping":
+            return util.inspect(
+              new Map(
+                (<Values.MappingValue>this.result).value.map(
+                  ({key, value}) => [new ResultInspector(key), new ResultInspector(value)]
+                )
+              ),
+              options
+            );
+          case "struct": {
+            let coercedResult = <Values.StructValue> this.result;
+            if(coercedResult.reference !== undefined) {
+              return formatCircular(coercedResult.reference, options);
+            }
+            return util.inspect(
+              Object.assign({}, ...coercedResult.value.map(
+                ({name, value}) => ({[name]: new ResultInspector(value)})
+              )),
+              options
+            );
+          }
+          case "magic":
+            return util.inspect(
+              Object.assign({}, ...Object.entries((<Values.MagicValue>this.result).value).map(
+                ([key, value]) => ({[key]: new ResultInspector(value)})
+              )),
+              options
+            )
+          case "enum": {
+            return enumFullName(<Values.EnumValue>this.result); //not stylized
+          }
+          case "contract": {
+            return util.inspect(
+              new ContractInfoInspector(
+                (<Values.ContractValue>this.result).value
+              ),
+              options
+            );
+          }
+          case "function":
+            switch(this.result.type.visibility) {
+              case "external": {
+                let coercedResult = <Values.FunctionExternalValue> this.result;
+                let contractString = util.inspect(
+                  new ContractInfoInspector(
+                    coercedResult.value.contract
+                  ),
+                  { ...cleanStylize(options), colors: false }
+                );
+                let firstLine: string;
+                switch(coercedResult.value.kind) {
+                  case "known":
+                    firstLine = `[Function: ${coercedResult.value.abi.name} of`;
+                    break;
+                  case "invalid":
+                  case "unknown":
+                    firstLine = `[Function: Unknown selector ${coercedResult.value.selector} of`;
+                    break;
+                }
+                let secondLine = `${contractString}]`;
+                let breakingSpace = firstLine.length >= options.breakLength ? "\n" : " ";
+                //now, put it together
+                return options.stylize(firstLine + breakingSpace + secondLine, "special");
+              }
+              case "internal": {
+                let coercedResult = <Values.FunctionInternalValue> this.result;
+                switch(coercedResult.value.kind) {
+                  case "function":
+                    return options.stylize(
+                      `[Function: ${coercedResult.value.definedIn.typeName}.${coercedResult.value.name}]`,
+                      "special"
+                    );
+                  case "exception":
+                    return coercedResult.value.deployedProgramCounter === 0
+                      ? options.stylize(`[Function: <zero>]`, "special")
+                      : options.stylize(`[Function: assert(false)]`, "special");
+                  case "unknown":
+                    let firstLine = `[Function: decoding not supported (raw info:`;
+                    let secondLine = `deployed PC=${coercedResult.value.deployedProgramCounter}, constructor PC=${coercedResult.value.constructorProgramCounter})]`;
+                    let breakingSpace = firstLine.length >= options.breakLength ? "\n" : " ";
+                    //now, put it together
+                    return options.stylize(firstLine + breakingSpace + secondLine, "special");
+                }
+              }
+            }
+        }
+      case "error": {
+        debug("this.result: %O", this.result);
+        let errorResult = <Errors.ErrorResult> this.result; //the hell?? why couldn't it make this inference??
+        switch(errorResult.error.kind) {
+          case "UintPaddingError":
+            return `Uint has extra leading bytes (padding error) (raw value ${errorResult.error.raw})`;
+          case "IntPaddingError":
+            return `Int out of range (padding error) (numeric value ${errorResult.error.raw})`;
+          case "BoolPaddingError":
+            return `Bool has extra leading bytes (padding error) (raw value ${errorResult.error.raw})`;
+          case "BoolOutOfRangeError":
+            return `Invalid boolean (numeric value ${errorResult.error.rawAsNumber})`;
+          case "BytesPaddingError":
+            return `Bytestring has extra trailing bytes (padding error) (raw value ${errorResult.error.raw})`;
+          case "AddressPaddingError":
+            return `Address has extra leading bytes (padding error) (raw value ${errorResult.error.raw})`;
+          case "FixedPointNotYetSupportedError":
+            return `Fixed-point decoding not yet supported (raw value: ${errorResult.error.raw})`;
+          case "EnumPaddingError":
+            return `${enumTypeName(errorResult.error.type)} has extra leading bytes (padding error) (raw value ${errorResult.error.raw})`;
+          case "EnumOutOfRangeError":
+            return `Invalid ${enumTypeName(errorResult.error.type)} (numeric value ${errorResult.error.rawAsBN.toString()})`;
+          case "EnumNotFoundDecodingError":
+            return `Unknown enum type ${enumTypeName(errorResult.error.type)} of id ${errorResult.error.type.id} (numeric value ${errorResult.error.rawAsBN.toString()})`;
+          case "ContractPaddingError":
+            return `Contract address has extra leading bytes (padding error) (raw value ${errorResult.error.raw})`;
+          case "FunctionExternalNonStackPaddingError":
+            return `External function has extra trailing bytes (padding error) (raw value ${errorResult.error.raw})`;
+          case "FunctionExternalStackPaddingError":
+            return `External function address or selector has extra leading bytes (padding error) (raw address ${errorResult.error.rawAddress}, raw selector ${errorResult.error.rawSelector})`;
+          case "FunctionInternalPaddingError":
+            return `Internal function has extra leading bytes (padding error) (raw value ${errorResult.error.raw})`;
+          case "NoSuchInternalFunctionError":
+            return `Invalid function (Deployed PC=${errorResult.error.deployedProgramCounter}, constructor PC=${errorResult.error.constructorProgramCounter}) of contract ${errorResult.error.context.typeName}`;
+          case "DeployedFunctionInConstructorError":
+            return `Deployed-style function (PC=${errorResult.error.deployedProgramCounter}) in constructor`;
+          case "MalformedInternalFunctionError":
+            return `Malformed internal function w/constructor PC only (value: ${errorResult.error.constructorProgramCounter})`;
+          case "IndexedReferenceTypeError":
+            return `Cannot decode indexed parameter of reference type ${errorResult.error.type.typeClass} (raw value ${errorResult.error.raw})`;
+          case "UserDefinedTypeNotFoundError":
+          case "UnsupportedConstantError":
+          case "ReadErrorStack":
+            return Errors.message(errorResult.error); //yay, these three are already defined!
+        }
+      }
+    }
+  }
+}
+
+//these get there own class to deal with a minor complication
+class ContractInfoInspector {
+  value: Values.ContractValueInfo;
+  constructor(value: Values.ContractValueInfo) {
+    this.value = value;
+  }
+  [util.inspect.custom](depth: number | null, options: InspectOptions): string {
+    switch(this.value.kind) {
+      case "known":
+        return options.stylize(this.value.address, "number") + ` (${this.value.class.typeName})`;
+      case "unknown":
+        return options.stylize(this.value.address, "number") + " of unknown class";
+    }
+  }
+}
+
+function enumTypeName(enumType: Types.EnumType) {
+  return (enumType.kind === "local" ? (enumType.definingContractName + ".") : "") + enumType.typeName;
+}
+
+function styleHexString(hex: string, options: InspectOptions): string {
+  return options.stylize(`hex'${hex.slice(2)}'`, "string");
+}
+
+//this function will be used in the future for displaying circular
+//structures
+function formatCircular(loopLength: number, options: InspectOptions): string {
+  return options.stylize(`[Circular (=up ${this.loopLength})]`, "special");
+}
+
+export function enumFullName(value: Values.EnumValue): string {
+  switch(value.type.kind) {
+    case "local":
+      return `${value.type.definingContractName}.${value.type.typeName}.${value.value.name}`;
+    case "global":
+      return `${value.type.typeName}.${value.value.name}`;
+  }
 }

--- a/packages/truffle-codec-utils/src/types/types.ts
+++ b/packages/truffle-codec-utils/src/types/types.ts
@@ -33,11 +33,14 @@ export namespace Types {
 
   export type Type = UintType | IntType | BoolType | BytesType | AddressType
     | FixedType | UfixedType | StringType | ArrayType | MappingType | FunctionType
-    | StructType | EnumType | ContractType | MagicType;
+    | StructType | EnumType | ContractType | MagicType | TupleType;
 
   export interface UintType {
     typeClass: "uint";
     bits: number;
+    enumTypeNameHint?: string;
+    enumKindHint?: "local" | "global";
+    enumDefiningContractHint?: string;
   }
 
   export interface IntType {
@@ -66,6 +69,7 @@ export namespace Types {
   export interface AddressType {
     typeClass: "address";
     payable: boolean;
+    contractTypeNameHint?: string;
   }
 
   export interface StringType {
@@ -159,7 +163,7 @@ export namespace Types {
     typeName: string;
     definingContractName: string;
     definingContract?: ContractTypeNative;
-    memberTypes?: {name: string, type: Type}[]; //these should be in order
+    memberTypes?: NameTypePair[]; //these should be in order
     location?: Ast.Location;
   }
 
@@ -170,6 +174,19 @@ export namespace Types {
     typeName: string;
     memberTypes?: NameTypePair[]; //these should be in order
     location?: Ast.Location;
+  }
+
+  export interface OptionallyNamedType {
+    name?: string;
+    type: Type;
+  }
+
+  export interface TupleType {
+    typeClass: "tuple";
+    memberTypes: OptionallyNamedType[];
+    structTypeNameHint?: string;
+    structKindHint?: "local" | "global";
+    structDefiningContractHint?: string;
   }
 
   export type EnumType = EnumTypeLocal | EnumTypeGlobal;

--- a/packages/truffle-codec-utils/src/types/values.ts
+++ b/packages/truffle-codec-utils/src/types/values.ts
@@ -20,7 +20,6 @@ const debug = debugModule("codec-utils:types:values");
 import BN from "bn.js";
 import { Types } from "./types";
 import { Errors } from "./errors";
-import { InspectOptions, cleanStylize } from "./inspect";
 import util from "util";
 import { AstDefinition, Mutability } from "../ast";
 import { Definition as DefinitionUtils } from "../definition";
@@ -64,190 +63,70 @@ export namespace Values {
   //Uints
   export type UintResult = UintValue | Errors.UintErrorResult;
 
-  export class UintValue {
+  export interface UintValue {
     type: Types.UintType;
     kind: "value";
     value: {
       asBN: BN;
       rawAsBN?: BN;
     };
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      return options.stylize(this.toString(), "number");
-    }
-    toSoliditySha3Input() {
-      return {
-        type: "uint",
-        value: this.value.asBN
-      }
-    }
-    nativize(): any {
-      return this.value.asBN.toNumber(); //beware!
-    }
-    toString(): string {
-      return this.value.asBN.toString();
-    }
-    constructor(uintType: Types.UintType, value: BN, rawValue?: BN) {
-      this.type = uintType;
-      this.kind = "value";
-      this.value = { asBN: value, rawAsBN: rawValue };
-    }
   }
 
   //Ints
   export type IntResult = IntValue | Errors.IntErrorResult;
 
-  export class IntValue {
+  export interface IntValue {
     type: Types.IntType;
     kind: "value";
     value: {
       asBN: BN;
       rawAsBN?: BN;
     };
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      return options.stylize(this.toString(), "number");
-    }
-    toSoliditySha3Input() {
-      return {
-        type: "int",
-        value: this.value.asBN
-      }
-    }
-    nativize(): any {
-      return this.value.asBN.toNumber(); //beware!
-    }
-    toString(): string {
-      return this.value.asBN.toString();
-    }
-    constructor(intType: Types.IntType, value: BN, rawValue?: BN) {
-      this.type = intType;
-      this.kind = "value";
-      this.value = { asBN: value, rawAsBN: rawValue };
-    }
   }
 
   //Bools
   export type BoolResult = BoolValue | Errors.BoolErrorResult;
 
-  export class BoolValue {
+  export interface BoolValue {
     type: Types.BoolType;
     kind: "value";
     value: {
       asBool: boolean;
     };
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      return util.inspect(this.value.asBool, options);
-    }
-    toSoliditySha3Input() {
-      return {
-        type: "uint", //used to achieve left-padding
-        value: this.value.asBool ? new BN(1) : new BN(0) //true & false won't work here
-      }
-    }
-    nativize(): any {
-      return this.value.asBool;
-    }
-    toString(): string {
-      return this.value.asBool.toString();
-    }
-    constructor(boolType: Types.BoolType, value: boolean) {
-      this.type = boolType;
-      this.kind = "value";
-      this.value = { asBool: value };
-    }
   }
 
   //bytes (static)
   export type BytesStaticResult = BytesStaticValue | Errors.BytesStaticErrorResult;
 
-  export class BytesStaticValue {
+  export interface BytesStaticValue {
     type: Types.BytesTypeStatic;
     kind: "value";
     value: {
       asHex: string; //should be hex-formatted, with leading "0x"
-      rawAsHex: string;
+      rawAsHex?: string;
     };
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      return options.stylize(this.value.asHex, "number");
-    }
-    toSoliditySha3Input() {
-      return {
-        type: "bytes32", //used to achieve right-padding
-        value: this.value.asHex
-      };
-    }
-    nativize(): any {
-      return this.value.asHex;
-    }
-    toString(): string {
-      return this.value.asHex;
-    }
-    constructor(bytesType: Types.BytesTypeStatic, value: string, rawValue?: string) {
-      this.type = bytesType;
-      this.kind = "value";
-      this.value = { asHex: value, rawAsHex: rawValue };
-    }
   }
 
   //bytes (dynamic)
   export type BytesDynamicResult = BytesDynamicValue | Errors.BytesDynamicErrorResult;
 
-  export class BytesDynamicValue {
+  export interface BytesDynamicValue {
     type: Types.BytesTypeDynamic;
     kind: "value";
     value: {
       asHex: string; //should be hex-formatted, with leading "0x"
     };
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      return options.stylize(`hex'${this.value.asHex.slice(2)}'`, "string")
-    }
-    toSoliditySha3Input() {
-      return {
-        type: "bytes",
-        value: this.value.asHex
-      };
-    }
-    nativize(): any {
-      return this.value.asHex;
-    }
-    toString(): string {
-      return this.value.asHex;
-    }
-    constructor(bytesType: Types.BytesTypeDynamic, value: string) {
-      this.type = bytesType;
-      this.kind = "value";
-      this.value = { asHex: value };
-    }
   }
 
   //addresses
   export type AddressResult = AddressValue | Errors.AddressErrorResult;
 
-  export class AddressValue {
+  export interface AddressValue {
     type: Types.AddressType;
     kind: "value";
     value: {
       asAddress: string; //should have 0x and be checksum-cased
-      rawAsHex: string;
-    }
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      return options.stylize(this.value.asAddress, "number");
-    }
-    toSoliditySha3Input() {
-      return {
-        type: "uint", //used to achieve left-padding
-        value: this.value.asAddress
-      }
-    }
-    nativize(): any {
-      return this.value.asAddress;
-    }
-    toString(): string {
-      return this.value.asAddress;
-    }
-    constructor(addressType: Types.AddressType, value: string, rawValue?: string) {
-      this.type = addressType;
-      this.kind = "value";
-      this.value = { asAddress: value, rawAsHex: rawValue };
+      rawAsHex?: string;
     }
   }
 
@@ -255,80 +134,25 @@ export namespace Values {
   export type StringResult = StringValue | Errors.StringErrorResult;
 
   //strings have a special new type as their value: StringValueInfo
-  export class StringValue {
+  export interface StringValue {
     type: Types.StringType;
     kind: "value";
     value: StringValueInfo;
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      return util.inspect(this.value, options);
-    }
-    toSoliditySha3Input() {
-      return this.value.toSoliditySha3Input();
-    }
-    nativize(): any {
-      return this.value.nativize();
-    }
-    toString(): string {
-      return this.value.toString();
-    }
-    constructor(stringType: Types.StringType, value: StringValueInfo) {
-      this.type = stringType;
-      this.kind = "value";
-      this.value = value;
-    }
   }
 
   //these come in two types: valid strings and malformed strings
   export type StringValueInfo = StringValueInfoValid | StringValueInfoMalformed;
 
   //valid strings
-  export class StringValueInfoValid {
+  export interface StringValueInfoValid {
     kind: "valid";
     asString: string;
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      return util.inspect(this.asString, options);
-    }
-    toSoliditySha3Input() {
-      return {
-        type: "string",
-        value: this.asString
-      };
-    }
-    nativize(): any {
-      return this.asString;
-    }
-    toString(): string {
-      return this.asString;
-    }
-    constructor(value: string) {
-      this.kind = "valid";
-      this.asString = value;
-    }
   }
 
   //malformed strings
-  export class StringValueInfoMalformed {
+  export interface StringValueInfoMalformed {
     kind: "malformed";
     asHex: string;
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      return options.stylize(`hex'${this.asHex.slice(2)}'`, "string") + " (malformed)";
-    }
-    toSoliditySha3Input() {
-      return {
-        type: "bytes",
-        value: this.asHex
-      };
-    }
-    nativize(): any {
-      return this.asHex; //warning!
-    }
-    toString(): string {
-      return this.asHex; //warning!
-    }
-    constructor(value: string) {
-      this.kind = "malformed";
-      this.asHex = value;
-    }
   }
 
   //Fixed & Ufixed
@@ -337,119 +161,30 @@ export namespace Values {
   export type FixedResult = Errors.FixedErrorResult;
   export type UfixedResult = Errors.UfixedErrorResult;
 
-  //Function for wrapping a value as an ElementaryValue
-  //WARNING: this function does not check its inputs! Please check before using!
-  //How to use:
-  //numbers may be BN, number, or numeric string
-  //strings should be given as strings. duh.
-  //bytes should be given as hex strings beginning with "0x"
-  //addresses are like bytes; checksum case is not required
-  //booleans may be given either as booleans, or as string "true" or "false"
-  //[NOTE: in the future this function will:
-  //1. be moved to truffle-codec/lib/encode,
-  //2. check its inputs,
-  //3. take a slightly different input format]
-  export function wrapElementaryValue(value: any, definition: AstDefinition): ElementaryValue {
-    //force location to undefined, force address to nonpayable
-    //(we force address to nonpayable since address payable can't be declared
-    //as a mapping key type)
-    let dataType = Types.definitionToType(definition, null, null);
-    switch(dataType.typeClass) {
-      case "string":
-        return new StringValue(dataType, new StringValueInfoValid(value));
-      case "bytes":
-        switch(dataType.kind) {
-          case "static":
-            return new BytesStaticValue(dataType, value);
-          case "dynamic":
-            return new BytesDynamicValue(dataType, value);
-        }
-      case "address":
-        return new AddressValue(dataType, value);
-      case "int":
-        if(value instanceof BN) {
-          value = value.clone();
-        }
-        else {
-          value = new BN(value);
-        }
-        return new IntValue(dataType, value);
-      case "uint":
-        if(value instanceof BN) {
-          value = value.clone();
-        }
-        else {
-          value = new BN(value);
-        }
-        return new UintValue(dataType, value);
-      case "bool":
-        if(typeof value === "string") {
-          value = value !== "false";
-        }
-        return new BoolValue(dataType, value);
-    }
-  }
-
   /*
    * SECTION 3: CONTAINER TYPES (including magic)
    */
 
-  //this function will be used in the future for displaying circular
-  //structures
-  function formatCircular(loopLength: number, options: InspectOptions) {
-    return options.stylize(`[Circular (=up ${this.loopLength})]`, "special");
-  }
-
   //Arrays
   export type ArrayResult = ArrayValue | Errors.ArrayErrorResult;
 
-  export class ArrayValue {
+  export interface ArrayValue {
     type: Types.ArrayType;
     kind: "value";
     reference?: number; //will be used in the future for circular values
     value: Result[];
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      if(this.reference !== undefined) {
-        return formatCircular(this.reference, options);
-      }
-      return util.inspect(this.value, options)
-    }
-    nativize(): any {
-      return this.value.map(element => element.nativize());
-    }
-    constructor(arrayType: Types.ArrayType, value: Result[], reference?: number) {
-      this.type = arrayType;
-      this.kind = "value";
-      this.value = value;
-      this.reference = reference;
-    }
   }
 
   //Mappings
   export type MappingResult = MappingValue | Errors.MappingErrorResult;
 
-  export class MappingValue {
+  export interface MappingValue {
     type: Types.MappingType;
     kind: "value";
     //note that since mappings live in storage, a circular
     //mapping is impossible
     value: KeyValuePair[]; //order is irrelevant
     //note that key is not allowed to be an error!
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      return util.inspect(new Map(this.value.map(
-        ({key, value}) => [key, value]
-      )), options);
-    }
-    nativize(): any {
-      return Object.assign({}, ...this.value.map(({key, value}) =>
-        ({[key.toString()]: value.nativize()})
-      ));
-    }
-    constructor(mappingType: Types.MappingType, value: KeyValuePair[]) {
-      this.type = mappingType;
-      this.kind = "value";
-      this.value = value;
-    }
   }
 
   export interface KeyValuePair {
@@ -460,33 +195,11 @@ export namespace Values {
   //Structs
   export type StructResult = StructValue | Errors.StructErrorResult;
 
-  export class StructValue {
+  export interface StructValue {
     type: Types.StructType;
     kind: "value";
     reference?: number; //will be used in the future for circular values
     value: NameValuePair[]; //these should be stored in order!
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      if(this.reference !== undefined) {
-        return formatCircular(this.reference, options);
-      }
-      return util.inspect(
-        Object.assign({}, ...this.value.map(
-          ({name, value}) => ({[name]: value})
-        )),
-        options
-      );
-    }
-    nativize(): any {
-      return Object.assign({}, ...this.value.map(
-        ({name, value}) => ({[name]: value.nativize()})
-      ));
-    }
-    constructor(structType: Types.StructType, value: NameValuePair[], reference?: number) {
-      this.type = structType;
-      this.kind = "value";
-      this.value = value;
-      this.reference = reference;
-    }
   }
 
   export interface NameValuePair {
@@ -497,26 +210,13 @@ export namespace Values {
   //Magic variables
   export type MagicResult = MagicValue | Errors.MagicErrorResult;
 
-  export class MagicValue {
+  export interface MagicValue {
     type: Types.MagicType;
     kind: "value";
     //a magic variable can't be circular, duh!
     value: {
       [field: string]: Result
     };
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      return util.inspect(this.value, options);
-    }
-    nativize(): any {
-      return Object.assign({}, ...Object.entries(this.value).map(
-        ([key, value]) => ({[key]: value.nativize()})
-      ));
-    }
-    constructor(magicType: Types.MagicType, value: {[field: string]: Result}) {
-      this.type = magicType;
-      this.kind = "value";
-      this.value = value;
-    }
   }
 
   /*
@@ -527,32 +227,13 @@ export namespace Values {
   //Enums
   export type EnumResult = EnumValue | Errors.EnumErrorResult;
 
-  export class EnumValue {
+  export interface EnumValue {
     type: Types.EnumType;
     kind: "value";
     value: {
       name: string;
       numericAsBN: BN;
     };
-    fullName(): string {
-      switch(this.type.kind) {
-        case "local":
-          return `${this.type.definingContractName}.${this.type.typeName}.${this.value.name}`;
-        case "global":
-          return `${this.type.typeName}.${this.value.name}`;
-      }
-    }
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      return this.fullName();
-    }
-    nativize(): any {
-      return this.fullName();
-    }
-    constructor(enumType: Types.EnumType, numeric: BN, name: string) {
-      this.type = enumType;
-      this.kind = "value";
-      this.value = { name, numericAsBN: numeric };
-    }
   };
 
   /*
@@ -563,21 +244,10 @@ export namespace Values {
   export type ContractResult = ContractValue | Errors.ContractErrorResult;
 
   //Contract values have a special new type as their value: ContractValueInfo.
-  export class ContractValue {
+  export interface ContractValue {
     type: Types.ContractType;
     kind: "value";
     value: ContractValueInfo;
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      return util.inspect(this.value, options);
-    }
-    nativize(): any {
-      return this.value.nativize();
-    }
-    constructor(contractType: Types.ContractType, value: ContractValueInfo) {
-      this.type = contractType;
-      this.kind = "value";
-      this.value = value;
-    }
   }
 
   //There are two types -- one for contracts whose class we can identify, and one
@@ -585,45 +255,21 @@ export namespace Values {
   export type ContractValueInfo = ContractValueInfoKnown | ContractValueInfoUnknown;
 
   //when we can identify the class
-  export class ContractValueInfoKnown {
+  export interface ContractValueInfoKnown {
     kind: "known";
     address: string; //should be formatted as address
     //NOT an AddressResult, note
     rawAddress?: string;
     class: Types.ContractType;
     //may have more optional members defined later, but I'll leave these out for now
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      return options.stylize(this.address, "number") + ` (${this.class.typeName})`;
-    }
-    nativize(): any {
-      return `${this.class.typeName}(${this.address})`;
-    }
-    constructor(address: string, contractClass: Types.ContractType, rawAddress?: string) {
-      this.kind = "known";
-      this.address = address;
-      this.class = contractClass;
-      this.rawAddress = rawAddress;
-    }
   }
 
   //when we can't
-  export class ContractValueInfoUnknown {
+  export interface ContractValueInfoUnknown {
     kind: "unknown";
     address: string; //should be formatted as address
     //NOT an AddressResult, note
     rawAddress?: string;
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      debug("options: %O", options);
-      return options.stylize(this.address, "number") + " of unknown class";
-    }
-    nativize(): any {
-      return this.address;
-    }
-    constructor(address: string, rawAddress?: string) {
-      this.kind = "unknown";
-      this.address = address;
-      this.rawAddress = rawAddress;
-    }
   }
 
   /*
@@ -633,21 +279,10 @@ export namespace Values {
   //external functions
   export type FunctionExternalResult = FunctionExternalValue | Errors.FunctionExternalErrorResult;
 
-  export class FunctionExternalValue {
+  export interface FunctionExternalValue {
     type: Types.FunctionExternalType;
     kind: "value";
     value: FunctionExternalValueInfo;
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      return util.inspect(this.value, options);
-    }
-    nativize(): any {
-      return this.value.nativize();
-    }
-    constructor(functionType: Types.FunctionExternalType, value: FunctionExternalValueInfo) {
-      this.type = functionType;
-      this.kind = "value";
-      this.value = value;
-    }
   }
 
   //External function values come in 3 types:
@@ -657,79 +292,26 @@ export namespace Values {
     | FunctionExternalValueInfoUnknown; //can't determine class
 
   //known function of known class
-  export class FunctionExternalValueInfoKnown {
+  export interface FunctionExternalValueInfoKnown {
     kind: "known";
     contract: ContractValueInfoKnown;
     selector: string; //formatted as a bytes4
     abi: AbiUtils.FunctionAbiEntry;
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      //first, let's inspect that contract, but w/o color
-      let contractString = util.inspect(this.contract, { ...cleanStylize(options), colors: false });
-      let firstLine = `[Function: ${this.abi.name} of`;
-      let secondLine = `${contractString}]`;
-      let breakingSpace = firstLine.length >= options.breakLength ? "\n" : " ";
-      //now, put it together
-      return options.stylize(firstLine + breakingSpace + secondLine, "special");
-    }
-    nativize(): any {
-      return `${this.contract.nativize()}.${this.abi.name}`
-    }
-    constructor(contract: ContractValueInfoKnown, selector: string, abi: AbiUtils.FunctionAbiEntry) {
-      this.kind = "known";
-      this.contract = contract;
-      this.selector = selector;
-      this.abi = abi;
-    }
+    //may have more optional fields added later, I'll leave these out for now
   }
 
   //known class but can't locate function
-  export class FunctionExternalValueInfoInvalid {
+  export interface FunctionExternalValueInfoInvalid {
     kind: "invalid";
     contract: ContractValueInfoKnown;
     selector: string; //formatted as a bytes4
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      //first, let's inspect that contract, but w/o color
-      let contractString = util.inspect(this.contract, { ...cleanStylize(options), colors: false });
-      let selectorString = `Unknown selector 0x${this.selector}`;
-      let firstLine = `[Function: ${selectorString} of`;
-      let secondLine = `${contractString}]`;
-      let breakingSpace = firstLine.length >= options.breakLength ? "\n" : " ";
-      //now, put it together
-      return options.stylize(firstLine + breakingSpace + secondLine, "special");
-    }
-    nativize(): any {
-      return `${this.contract.nativize()}.call(${this.selector}...)`
-    }
-    constructor(contract: ContractValueInfoKnown, selector: string) {
-      this.kind = "invalid";
-      this.contract = contract;
-      this.selector = selector;
-    }
   }
 
   //can't even locate class
-  export class FunctionExternalValueInfoUnknown {
+  export interface FunctionExternalValueInfoUnknown {
     kind: "unknown";
     contract: ContractValueInfoUnknown;
     selector: string; //formatted as a bytes4
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      //first, let's inspect that contract, but w/o color
-      let contractString = util.inspect(this.contract, { ...cleanStylize(options), colors: false });
-      let selectorString = `Unknown selector 0x${this.selector}`;
-      let firstLine = `[Function: ${selectorString} of`;
-      let secondLine = `${contractString}]`;
-      let breakingSpace = firstLine.length >= options.breakLength ? "\n" : " ";
-      //now, put it together
-      return options.stylize(firstLine + breakingSpace + secondLine, "special");
-    }
-    nativize(): any {
-      return `${this.contract.nativize()}.call(${this.selector}...)`
-    }
-    constructor(contract: ContractValueInfoUnknown, selector: string) {
-      this.kind = "unknown";
-      this.contract = contract;
-      this.selector = selector;
-    }
   }
 
   /*
@@ -739,21 +321,10 @@ export namespace Values {
   //Internal functions
   export type FunctionInternalResult = FunctionInternalValue | Errors.FunctionInternalErrorResult;
 
-  export class FunctionInternalValue {
+  export interface FunctionInternalValue {
     type: Types.FunctionInternalType;
     kind: "value";
     value: FunctionInternalValueInfo;
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      return util.inspect(this.value, options);
-    }
-    nativize(): any {
-      return this.value.nativize();
-    }
-    constructor(functionType: Types.FunctionInternalType, value: FunctionInternalValueInfo) {
-      this.type = functionType;
-      this.kind = "value";
-      this.value = value;
-    }
   }
 
   //these also come in 3 types
@@ -763,7 +334,7 @@ export namespace Values {
     | FunctionInternalValueInfoUnknown; //decoding not supported in this context
 
   //actual function
-  export class FunctionInternalValueInfoKnown {
+  export interface FunctionInternalValueInfoKnown {
     kind: "function"
     context: Types.ContractType;
     deployedProgramCounter: number;
@@ -771,79 +342,22 @@ export namespace Values {
     name: string;
     definedIn: Types.ContractType;
     mutability?: Mutability;
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      return options.stylize(`[Function: ${this.definedIn.typeName}.${this.name}]`, "special");
-    }
-    nativize(): any {
-      return `${this.definedIn.typeName}.${this.name}`;
-    }
-    constructor(
-      context: Types.ContractType,
-      deployedProgramCounter: number,
-      constructorProgramCounter: number,
-      name: string,
-      definedIn: Types.ContractType,
-      mutability?: Mutability
-    ) {
-      this.kind = "function";
-      this.context = context;
-      this.deployedProgramCounter = deployedProgramCounter;
-      this.constructorProgramCounter = constructorProgramCounter;
-      this.name = name;
-      this.definedIn = definedIn;
-      this.mutability = mutability;
-    }
+    //may have more optional fields added later
   }
 
   //default value
-  export class FunctionInternalValueInfoException {
+  export interface FunctionInternalValueInfoException {
     kind: "exception"
     context: Types.ContractType;
     deployedProgramCounter: number;
     constructorProgramCounter: number;
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      return this.deployedProgramCounter === 0
-        ? options.stylize(`[Function: <zero>]`, "special")
-        : options.stylize(`[Function: assert(false)]`, "special");
-    }
-    nativize(): any {
-      return this.deployedProgramCounter === 0
-        ? `<zero>`
-        : `assert(false)`;
-    }
-    constructor(
-      context: Types.ContractType,
-      deployedProgramCounter: number,
-      constructorProgramCounter: number
-    ) {
-      this.kind = "exception";
-      this.context = context;
-      this.deployedProgramCounter = deployedProgramCounter;
-      this.constructorProgramCounter = constructorProgramCounter;
-    }
   }
 
   //value returned to indicate that decoding is not supported outside the debugger
-  export class FunctionInternalValueInfoUnknown {
+  export interface FunctionInternalValueInfoUnknown {
     kind: "unknown"
     context: Types.ContractType;
     deployedProgramCounter: number;
     constructorProgramCounter: number;
-    [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-      return options.stylize(`[Function: decoding not supported (raw info: deployed PC=${this.deployedProgramCounter}, constructor PC=${this.constructorProgramCounter})]`, "special");
-    }
-    nativize(): any {
-      return `<decoding not supported>`;
-    }
-    constructor(
-      context: Types.ContractType,
-      deployedProgramCounter: number,
-      constructorProgramCounter: number
-    ) {
-      this.kind = "unknown";
-      this.context = context;
-      this.deployedProgramCounter = deployedProgramCounter;
-      this.constructorProgramCounter = constructorProgramCounter;
-    }
   }
 }

--- a/packages/truffle-codec-utils/src/types/values.ts
+++ b/packages/truffle-codec-utils/src/types/values.ts
@@ -207,6 +207,20 @@ export namespace Values {
     value: Result;
   }
 
+  //Tuples
+  export type TupleResult = TupleValue | Errors.TupleErrorResult;
+
+  export interface TupleValue {
+    type: Types.TupleType;
+    kind: "value";
+    value: OptionallyNamedValue[];
+  }
+
+  export interface OptionallyNamedValue {
+    name?: string;
+    value: Result;
+  }
+
   //Magic variables
   export type MagicResult = MagicValue | Errors.MagicErrorResult;
 

--- a/packages/truffle-codec-utils/src/wrap.ts
+++ b/packages/truffle-codec-utils/src/wrap.ts
@@ -1,0 +1,86 @@
+import debugModule from "debug";
+const debug = debugModule("codec-utils:wrap");
+
+import Web3 from "web3";
+import BN from "bn.js";
+import { AstDefinition } from "./ast";
+import { Types } from "./types/types";
+import { Values } from "./types/values";
+
+//Function for wrapping a value as an ElementaryValue
+//WARNING: this function does not check its inputs! Please check before using!
+//How to use:
+//numbers may be BN, number, or numeric string
+//strings should be given as strings. duh.
+//bytes should be given as hex strings beginning with "0x"
+//addresses are like bytes; checksum case is not required
+//booleans may be given either as booleans, or as string "true" or "false"
+//[NOTE: in the future this function will:
+//1. check its inputs,
+//2. take a slightly different input format,
+//3. also be named differently and... it'll be different :P ]
+export function wrapElementaryViaDefinition(value: any, definition: AstDefinition): Values.ElementaryValue {
+  //force location to undefined, force address to nonpayable
+  //(we force address to nonpayable since address payable can't be declared
+  //as a mapping key type)
+  let dataType = Types.definitionToType(definition, null, null);
+  return wrapElementaryValue(value, dataType);
+}
+
+export function wrapElementaryValue(value: any, dataType: Types.Type): Values.ElementaryValue {
+  switch(dataType.typeClass) {
+    case "string":
+      return {
+        type: dataType,
+        kind: "value",
+        value: {
+          kind: "valid",
+          asString: <string>value
+        }
+      };
+    case "bytes":
+      //NOTE: in the future should add padding for static case
+      return <Values.BytesValue> { //TS is so bad at unions
+        type: dataType,
+        kind: "value",
+        value: {
+          asHex: value
+        }
+      };
+    case "address":
+      value = Web3.utils.toChecksumAddress(value);
+      return {
+        type: dataType,
+        kind: "value",
+        value: {
+          asAddress: <string>value
+        }
+      };
+    case "uint":
+    case "int":
+      if(value instanceof BN) {
+        value = value.clone();
+      }
+      else {
+        value = new BN(value);
+      }
+      return <Values.UintValue|Values.IntValue> { //TS remains bad at unions
+        type: dataType,
+        kind: "value",
+        value: {
+          asBN: value
+        }
+      };
+    case "bool":
+      if(typeof value === "string") {
+        value = value !== "false";
+      }
+      return {
+        type: dataType,
+        kind: "value",
+        value: {
+          asBool: <boolean>value
+        }
+      };
+  }
+}

--- a/packages/truffle-codec/lib/allocate/abi.ts
+++ b/packages/truffle-codec/lib/allocate/abi.ts
@@ -213,7 +213,10 @@ export function abiSizeForType(dataType: CodecUtils.Types.Type, allocations?: Al
       const allocation = allocations[dataType.id];
       if(!allocation) {
         throw new CodecUtils.Errors.DecodingError(
-          new CodecUtils.Errors.UserDefinedTypeNotFoundError(dataType)
+          {
+            kind: "UserDefinedTypeNotFoundError",
+            type: dataType
+          }
         );
       }
       return allocation.length;
@@ -235,7 +238,10 @@ export function isTypeDynamic(dataType: CodecUtils.Types.Type, allocations?: All
       const allocation = allocations[dataType.id];
       if(!allocation) {
         throw new CodecUtils.Errors.DecodingError(
-          new CodecUtils.Errors.UserDefinedTypeNotFoundError(dataType)
+          {
+            kind: "UserDefinedTypeNotFoundError",
+            type: dataType
+          }
         );
       }
       return allocation.dynamic;

--- a/packages/truffle-codec/lib/allocate/storage.ts
+++ b/packages/truffle-codec/lib/allocate/storage.ts
@@ -368,7 +368,10 @@ export function storageSizeForType(dataType: CodecUtils.Types.Type, userDefinedT
       let fullType = <CodecUtils.Types.EnumType>CodecUtils.Types.fullType(dataType, userDefinedTypes);
       if(!fullType.options) {
         throw new CodecUtils.Errors.DecodingError(
-          new CodecUtils.Errors.UserDefinedTypeNotFoundError(dataType)
+          {
+            kind: "UserDefinedTypeNotFoundError",
+            type: dataType
+          }
         );
       }
       return {bytes: Math.ceil(Math.log2(fullType.options.length) / 8)};
@@ -417,7 +420,10 @@ export function storageSizeForType(dataType: CodecUtils.Types.Type, userDefinedT
       let allocation = allocations[dataType.id];
       if(!allocation) {
         throw new CodecUtils.Errors.DecodingError(
-          new CodecUtils.Errors.UserDefinedTypeNotFoundError(dataType)
+          {
+            kind: "UserDefinedTypeNotFoundError",
+            type: dataType
+          }
         );
       }
       return allocation.size;

--- a/packages/truffle-codec/lib/decode/abi.ts
+++ b/packages/truffle-codec/lib/decode/abi.ts
@@ -68,7 +68,20 @@ export function* decodeAbiReferenceByAddress(dataType: Types.ReferenceType, poin
     };
   }
 
-  let startPosition = CodecUtils.Conversion.toBN(rawValue).toNumber() + base;
+  let rawValueAsBN = CodecUtils.Conversion.toBN(rawValue);
+  if(strict && rawValueAsBN.gtn(state[location].length)) {
+    //why is this check here??
+    //it's really just to protect us against the toNumber()
+    //conversion :)
+    throw new StopDecodingError(
+      { 
+        kind: "PointerTooLargeError",
+        pointerAsBN: rawValueAsBN,
+        dataLength: state[location].length
+      }
+    );
+  }
+  let startPosition = rawValueAsBN.toNumber() + base;
   debug("startPosition %d", startPosition);
 
   let dynamic: boolean;
@@ -132,7 +145,7 @@ export function* decodeAbiReferenceByAddress(dataType: Types.ReferenceType, poin
         };
       }
       let lengthAsBN = CodecUtils.Conversion.toBN(rawLength);
-      if(strict && lengthAsBN.gtn(info.state[location].length)) {
+      if(strict && lengthAsBN.gtn(state[location].length)) {
         //you may notice that the comparison is a bit crude; that's OK, this is
         //just to prevent huge numbers from DOSing us, other errors will still
         //be caught regardless
@@ -140,7 +153,7 @@ export function* decodeAbiReferenceByAddress(dataType: Types.ReferenceType, poin
           { 
             kind: "OverlongArrayOrStringError",
             lengthAsBN,
-            dataLength: info.state[location].length
+            dataLength: state[location].length
           }
         );
       }
@@ -177,7 +190,7 @@ export function* decodeAbiReferenceByAddress(dataType: Types.ReferenceType, poin
             };
           }
           let lengthAsBN = CodecUtils.Conversion.toBN(rawLength);
-          if(strict && lengthAsBN.gtn(info.state[location].length)) {
+          if(strict && lengthAsBN.gtn(state[location].length)) {
             //you may notice that the comparison is a bit crude; that's OK, this is
             //just to prevent huge numbers from DOSing us, other errors will still
             //be caught regardless
@@ -185,7 +198,7 @@ export function* decodeAbiReferenceByAddress(dataType: Types.ReferenceType, poin
               { 
                 kind: "OverlongArrayOrStringError",
                 lengthAsBN,
-                dataLength: info.state[location].length
+                dataLength: state[location].length
               }
             );
           }

--- a/packages/truffle-codec/lib/decode/event.ts
+++ b/packages/truffle-codec/lib/decode/event.ts
@@ -3,7 +3,7 @@ const debug = debugModule("codec:decode:event");
 
 import decodeValue from "./value";
 import read from "../read";
-import { Types, Values, Errors, Conversion as ConversionUtils } from "truffle-codec-utils";
+import { Types, Values, Conversion as ConversionUtils } from "truffle-codec-utils";
 import { EventTopicPointer } from "../types/pointer";
 import { EvmInfo, DecoderOptions } from "../types/evm";
 import { DecoderRequest, GeneratorJunk } from "../types/request";
@@ -12,25 +12,18 @@ import { StopDecodingError } from "../types/errors";
 export default function* decodeTopic(dataType: Types.Type, pointer: EventTopicPointer, info: EvmInfo, options: DecoderOptions = {}): IterableIterator<Values.Result | DecoderRequest | GeneratorJunk> {
   if(Types.isReferenceType(dataType)) {
     //we cannot decode reference types "stored" in topics; we have to just return an error
-    let bytes: Uint8Array;
-    try {
-      bytes = yield* read(pointer, info.state);
-    }
-    catch(error) { //error: Values.DecodingError
-      if(options.strictAbiMode) {
-        throw new StopDecodingError(error.error);
-      }
-      return Errors.makeGenericErrorResult(dataType, error.error);
-    }
+    let bytes: Uint8Array = yield* read(pointer, info.state);
     let raw: string = ConversionUtils.toHexString(bytes);
     //NOTE: even in strict mode we want to just return this, not throw an error here
-    return Errors.makeGenericErrorResult(
-      dataType,
-      new Errors.IndexedReferenceTypeError(
-        dataType,
+    return {
+      type: dataType,
+      kind: "error",
+      error: {
+	kind: "IndexedReferenceTypeError",
+        type: dataType,
         raw
-      )
-    );
+      }
+    };
   }
   //otherwise, dispatch to decodeValue
   return yield* decodeValue(dataType, pointer, info, options);

--- a/packages/truffle-codec/lib/decode/special.ts
+++ b/packages/truffle-codec/lib/decode/special.ts
@@ -24,69 +24,77 @@ export function* decodeMagic(dataType: Types.MagicType, pointer: SpecialPointer,
 
   switch(pointer.special) {
     case "msg":
-      return new Values.MagicValue(dataType, {
-        data: <Values.BytesDynamicResult> (yield* decodeValue(
-          {
-            typeClass: "bytes",
-            kind: "dynamic",
-            location: "calldata"
-          },
-          {
-            location: "calldata",
-            start: 0,
-            length: state.calldata.length
-          },
-          info
-        )),
-        sig: <Values.BytesStaticResult> (yield* decodeValue(
-          {
-            typeClass: "bytes",
-            kind: "static",
-            length: CodecUtils.EVM.SELECTOR_SIZE
-          },
-          {
-            location: "calldata",
-            start: 0,
-            length: CodecUtils.EVM.SELECTOR_SIZE,
-          },
-          info
-        )),
-        sender: <Values.AddressResult> (yield* decodeValue(
-          {
-            typeClass: "address",
-            payable: true
-          },
-          {location: "special", special: "sender"},
-          info
-        )),
-        value: <Values.UintResult> (yield* decodeValue(
-          {
-            typeClass: "uint",
-            bits: 256
-          },
-          {location: "special", special: "value"},
-          info
-        ))
-      });
+      return {
+        type: dataType,
+        kind: "value",
+        value: {
+          data: <Values.BytesDynamicResult> (yield* decodeValue(
+            {
+              typeClass: "bytes",
+              kind: "dynamic",
+              location: "calldata"
+            },
+            {
+              location: "calldata",
+              start: 0,
+              length: state.calldata.length
+            },
+            info
+          )),
+          sig: <Values.BytesStaticResult> (yield* decodeValue(
+            {
+              typeClass: "bytes",
+              kind: "static",
+              length: CodecUtils.EVM.SELECTOR_SIZE
+            },
+            {
+              location: "calldata",
+              start: 0,
+              length: CodecUtils.EVM.SELECTOR_SIZE,
+            },
+            info
+          )),
+          sender: <Values.AddressResult> (yield* decodeValue(
+            {
+              typeClass: "address",
+              payable: true
+            },
+            {location: "special", special: "sender"},
+            info
+          )),
+          value: <Values.UintResult> (yield* decodeValue(
+            {
+              typeClass: "uint",
+              bits: 256
+            },
+            {location: "special", special: "value"},
+            info
+          ))
+        }
+      };
     case "tx":
-      return new Values.MagicValue(dataType, {
-        origin: <Values.AddressResult> (yield* decodeValue(
-          {
-            typeClass: "address",
-            payable: true
-          },
-          {location: "special", special: "origin"},
-          info
-        )),
-        gasprice: <Values.UintResult> (yield* decodeValue(
-          {
-            typeClass: "uint",
-            bits: 256
-          },
-          {location: "special", special: "gasprice"},
-          info
-        ))
-      });
+      return {
+        type: dataType,
+        kind: "value",
+        value: {
+          origin: <Values.AddressResult> (yield* decodeValue(
+            {
+              typeClass: "address",
+              payable: true
+            },
+            {location: "special", special: "origin"},
+            info
+          )),
+          gasprice: <Values.UintResult> (yield* decodeValue(
+            {
+              typeClass: "uint",
+              bits: 256
+            },
+            {location: "special", special: "gasprice"},
+            info
+          ))
+        }
+      };
     case "block":
       let block: {[field: string]: Values.Result} = {
         coinbase: <Values.AddressResult> (yield* decodeValue(
@@ -111,6 +119,10 @@ export function* decodeMagic(dataType: Types.MagicType, pointer: SpecialPointer,
           info
         ));
       }
-      return new Values.MagicValue(dataType, block);
+      return {
+        type: dataType,
+        kind: "value",
+        value: block
+      };
   }
 }

--- a/packages/truffle-codec/lib/decode/value.ts
+++ b/packages/truffle-codec/lib/decode/value.ts
@@ -3,7 +3,7 @@ const debug = debugModule("codec:decode:value");
 
 import read from "../read";
 import * as CodecUtils from "truffle-codec-utils";
-import { Types, Values, Errors } from "truffle-codec-utils";
+import { Types, Values } from "truffle-codec-utils";
 import BN from "bn.js";
 import utf8 from "utf8";
 import { DataPointer } from "../types/pointer";
@@ -25,7 +25,11 @@ export default function* decodeValue(dataType: Types.Type, pointer: DataPointer,
     if(strict) {
       throw new StopDecodingError(error.error);
     }
-    return Errors.makeGenericErrorResult(dataType, error.error);
+    return {
+      type: dataType,
+      kind: "error",
+      error: error.error
+    };
   }
   rawBytes = bytes;
 
@@ -36,142 +40,238 @@ export default function* decodeValue(dataType: Types.Type, pointer: DataPointer,
 
     case "bool": {
       if(!checkPaddingLeft(bytes, 1)) {
-        let error = new Errors.BoolPaddingError(CodecUtils.Conversion.toHexString(bytes));
+        let error = {
+          kind: "BoolPaddingError" as "BoolPaddingError",
+          raw: CodecUtils.Conversion.toHexString(bytes)
+        };
         if(strict) {
           throw new StopDecodingError(error);
         }
-        return new Errors.BoolErrorResult(dataType, error);
+        return {
+          type: dataType,
+          kind: "error",
+          error
+        };
       }
       const numeric = CodecUtils.Conversion.toBN(bytes);
       if(numeric.eqn(0)) {
-        return new Values.BoolValue(dataType, false);
+        return {
+          type: dataType,
+          kind: "value",
+          value: { asBool: false }
+        };
       }
       else if(numeric.eqn(1)) {
-        return new Values.BoolValue(dataType, true);
+        return {
+          type: dataType,
+          kind: "value",
+          value: { asBool: true }
+        };
       }
       else {
-        let error = new Errors.BoolOutOfRangeError(numeric);
+        let error = { 
+          kind: "BoolOutOfRangeError" as "BoolOutOfRangeError",
+          rawAsNumber: numeric.toNumber() //cannot fail, it's only 1 byte
+        };
         if(strict) {
           throw new StopDecodingError(error);
         }
-        return new Errors.BoolErrorResult(dataType, error);
+        return {
+          type: dataType,
+          kind: "error",
+          error
+        };
       }
     }
 
     case "uint":
       //first, check padding (if needed)
       if(!permissivePadding && !checkPaddingLeft(bytes, dataType.bits/8)) {
-        let error = new Errors.UintPaddingError(CodecUtils.Conversion.toHexString(bytes));
+        let error = { 
+          kind: "UintPaddingError" as "UintPaddingError",
+          raw: CodecUtils.Conversion.toHexString(bytes)
+        };
         if(strict) {
           throw new StopDecodingError(error);
         }
-        return new Errors.UintErrorResult(dataType, error);
+        return {
+          type: dataType,
+          kind: "error",
+          error
+        };
       }
       //now, truncate to appropriate length (keeping the bytes on the right)
       bytes = bytes.slice(-dataType.bits/8);
-      return new Values.UintValue(
-        dataType,
-        CodecUtils.Conversion.toBN(bytes),
-        CodecUtils.Conversion.toBN(rawBytes)
-      );
+      return {
+        type: dataType,
+        kind: "value",
+        value: {
+          asBN: CodecUtils.Conversion.toBN(bytes),
+          rawAsBN: CodecUtils.Conversion.toBN(rawBytes)
+        }
+      };
     case "int":
       //first, check padding (if needed)
       if(!permissivePadding && !checkPaddingSigned(bytes, dataType.bits/8)) {
-        let error = new Errors.IntPaddingError(CodecUtils.Conversion.toHexString(bytes));
+        let error = { 
+          kind: "IntPaddingError" as "IntPaddingError",
+          raw: CodecUtils.Conversion.toHexString(bytes)
+        };
         if(strict) {
           throw new StopDecodingError(error);
         }
-        return new Errors.IntErrorResult(dataType, error);
+        return {
+          type: dataType,
+          kind: "error",
+          error
+        };
       }
       //now, truncate to appropriate length (keeping the bytes on the right)
       bytes = bytes.slice(-dataType.bits/8);
-      return new Values.IntValue(
-        dataType,
-        CodecUtils.Conversion.toSignedBN(bytes),
-        CodecUtils.Conversion.toSignedBN(rawBytes)
-      );
+      return {
+        type: dataType,
+        kind: "value",
+        value: {
+          asBN: CodecUtils.Conversion.toSignedBN(bytes),
+          rawAsBN: CodecUtils.Conversion.toSignedBN(rawBytes)
+        }
+      };
 
     case "address":
       if(!permissivePadding && !checkPaddingLeft(bytes, CodecUtils.EVM.ADDRESS_SIZE)) {
-        let error = new Errors.AddressPaddingError(CodecUtils.Conversion.toHexString(bytes));
+        let error = { 
+          kind: "AddressPaddingError" as "AddressPaddingError",
+          raw: CodecUtils.Conversion.toHexString(bytes)
+        };
         if(strict) {
           throw new StopDecodingError(error);
         }
-        return new Errors.AddressErrorResult(dataType, error);
+        return {
+          type: dataType,
+          kind: "error",
+          error
+        };
       }
-      return new Values.AddressValue(
-        dataType,
-        CodecUtils.Conversion.toAddress(bytes),
-        CodecUtils.Conversion.toHexString(rawBytes)
-      );
+      return {
+        type: dataType,
+        kind: "value",
+        value: {
+          asAddress: CodecUtils.Conversion.toAddress(bytes),
+          rawAsHex: CodecUtils.Conversion.toHexString(rawBytes)
+        }
+      };
 
     case "contract":
       if(!permissivePadding && !checkPaddingLeft(bytes, CodecUtils.EVM.ADDRESS_SIZE)) {
-        let error = new Errors.ContractPaddingError(CodecUtils.Conversion.toHexString(bytes));
+        let error = { 
+          kind: "ContractPaddingError" as "ContractPaddingError",
+          raw: CodecUtils.Conversion.toHexString(bytes)
+        };
         if(strict) {
           throw new StopDecodingError(error);
         }
-        return new Errors.ContractErrorResult(dataType, error);
+        return {
+          type: dataType,
+          kind: "error",
+          error
+        };
       }
       const fullType = <Types.ContractType>Types.fullType(dataType, info.userDefinedTypes);
       const contractValueInfo = <Values.ContractValueInfo> (yield* decodeContract(bytes, info));
-      return new Values.ContractValue(fullType, contractValueInfo);
+      return {
+        type: fullType,
+        kind: "value",
+        value: contractValueInfo
+      };
 
     case "bytes":
       switch(dataType.kind) {
         case "static":
           //first, check padding (if needed)
           if(!permissivePadding && !checkPaddingRight(bytes, dataType.length)) {
-            let error = new Errors.BytesPaddingError(CodecUtils.Conversion.toHexString(bytes));
+            let error = { 
+              kind: "BytesPaddingError" as "BytesPaddingError",
+              raw: CodecUtils.Conversion.toHexString(bytes)
+            };
             if(strict) {
               throw new StopDecodingError(error);
             }
-            return new Errors.BytesStaticErrorResult(dataType, error);
+            return {
+              type: dataType,
+              kind: "error",
+              error
+            };
           }
           //now, truncate to appropriate length
           bytes = bytes.slice(0, dataType.length);
-          return new Values.BytesStaticValue(
-            dataType,
-            CodecUtils.Conversion.toHexString(bytes),
-            CodecUtils.Conversion.toHexString(rawBytes)
-          );
+          return {
+            type: dataType,
+            kind: "value",
+            value: {
+              asHex: CodecUtils.Conversion.toHexString(bytes),
+              rawAsHex: CodecUtils.Conversion.toHexString(rawBytes)
+            }
+          };
         case "dynamic":
           //no need to check padding here
-          return new Values.BytesDynamicValue(dataType, CodecUtils.Conversion.toHexString(bytes));
+          return {
+            type: dataType,
+            kind: "value",
+            value: {
+              asHex: CodecUtils.Conversion.toHexString(bytes),
+            }
+          };
       }
 
     case "string":
       //there is no padding check for strings
-      return new Values.StringValue(dataType, decodeString(bytes));
+      return {
+        type: dataType,
+        kind: "value",
+        value: decodeString(bytes)
+      };
 
     case "function":
       switch(dataType.visibility) {
         case "external":
           if(!checkPaddingRight(bytes, CodecUtils.EVM.ADDRESS_SIZE + CodecUtils.EVM.SELECTOR_SIZE)) {
-            let error = new Errors.FunctionExternalNonStackPaddingError(CodecUtils.Conversion.toHexString(bytes));
+            let error = { 
+              kind: "FunctionExternalNonStackPaddingError" as "FunctionExternalNonStackPaddingError",
+              raw: CodecUtils.Conversion.toHexString(bytes)
+            };
             if(strict) {
               throw new StopDecodingError(error);
             }
-            return new Errors.FunctionExternalErrorResult(dataType, error);
+            return {
+              type: dataType,
+              kind: "error",
+              error
+            };
           }
           const address = bytes.slice(0, CodecUtils.EVM.ADDRESS_SIZE);
           const selector = bytes.slice(CodecUtils.EVM.ADDRESS_SIZE, CodecUtils.EVM.ADDRESS_SIZE + CodecUtils.EVM.SELECTOR_SIZE);
-          return new Values.FunctionExternalValue(dataType,
-            <Values.FunctionExternalValueInfo> (yield* decodeExternalFunction(address, selector, info))
-          );
+          return {
+            type: dataType,
+            kind: "value",
+            value: <Values.FunctionExternalValueInfo> (yield* decodeExternalFunction(address, selector, info))
+          };
         case "internal":
           if(strict) {
             //internal functions don't go in the ABI!
             //this should never happen, but just to be sure...
             throw new StopDecodingError(
-              new Errors.InternalFunctionInABIError()
+              { kind: "InternalFunctionInABIError" }
             );
           }
           if(!checkPaddingLeft(bytes, 2 * CodecUtils.EVM.PC_SIZE)) {
-            return new Errors.FunctionInternalErrorResult(
-              dataType,
-              new Errors.FunctionInternalPaddingError(CodecUtils.Conversion.toHexString(bytes))
-            );
+            return {
+              type: dataType,
+              kind: "error",
+              error: {
+                kind: "FunctionInternalPaddingError",
+                raw: CodecUtils.Conversion.toHexString(bytes)
+              }
+            };
           }
           const deployedPc = bytes.slice(-CodecUtils.EVM.PC_SIZE);
           const constructorPc = bytes.slice(-CodecUtils.EVM.PC_SIZE * 2, -CodecUtils.EVM.PC_SIZE);
@@ -183,51 +283,81 @@ export default function* decodeValue(dataType: Types.Type, pointer: DataPointer,
       const numeric = CodecUtils.Conversion.toBN(bytes);
       const fullType = <Types.EnumType>Types.fullType(dataType, info.userDefinedTypes);
       if(!fullType.options) {
-        let error = new Errors.EnumNotFoundDecodingError(fullType, numeric);
+        let error = {
+          kind: "EnumNotFoundDecodingError" as "EnumNotFoundDecodingError",
+          type: fullType,
+          rawAsBN: numeric
+        };
         if(strict) {
           throw new StopDecodingError(error);
         }
-        return new Errors.EnumErrorResult(fullType, error);
+        return {
+          type: fullType,
+          kind: "error",
+          error
+        };
       }
       const numOptions = fullType.options.length;
       const numBytes = Math.ceil(Math.log2(numOptions) / 8);
       if(!checkPaddingLeft(bytes, numBytes)) {
-        let error = new Errors.EnumPaddingError(fullType, CodecUtils.Conversion.toHexString(bytes));
+        let error = {
+          kind: "EnumPaddingError" as "EnumPaddingError",
+          type: fullType,
+          raw: CodecUtils.Conversion.toHexString(bytes)
+        };
         if(strict) {
           throw new StopDecodingError(error);
         }
-        return new Errors.EnumErrorResult(fullType, error);
+        return {
+          type: fullType,
+          kind: "error",
+          error
+        };
       }
       if(numeric.ltn(numOptions)) {
         const name = fullType.options[numeric.toNumber()];
-        return new Values.EnumValue(fullType, numeric, name);
+        return {
+          type: fullType,
+          kind: "value",
+          value: {
+            name,
+            numericAsBN: numeric
+          }
+        };
       }
       else {
-        let error = new Errors.EnumOutOfRangeError(fullType, numeric);
+        let error = {
+          kind: "EnumOutOfRangeError" as "EnumOutOfRangeError",
+          type: fullType,
+          rawAsBN: numeric
+        };
         if(strict) {
           throw new StopDecodingError(error);
         }
-        return new Errors.EnumErrorResult(fullType, error);
+        return {
+          type: fullType,
+          kind: "error",
+          error
+        };
       }
     }
-
-    case "fixed": {
-      //skipping padding check as we don't support this anyway
-      const hex = CodecUtils.Conversion.toHexString(bytes);
-      let error = new Errors.FixedPointNotYetSupportedError(hex);
-      if(strict) {
-        throw new StopDecodingError(error);
-      }
-      return new Errors.FixedErrorResult(dataType, error);
-    }
+    //will have to split these once we actually support fixed-point
+    case "fixed":
     case "ufixed": {
       //skipping padding check as we don't support this anyway
       const hex = CodecUtils.Conversion.toHexString(bytes);
-      let error = new Errors.FixedPointNotYetSupportedError(hex);
+      let error = {
+        kind: "FixedPointNotYetSupportedError" as "FixedPointNotYetSupportedError",
+        raw: hex
+      };
       if(strict) {
         throw new StopDecodingError(error);
       }
-      return new Errors.UfixedErrorResult(dataType, error);
+      return {
+        type: dataType,
+        kind: "error",
+        error
+      };
     }
   }
 }
@@ -239,13 +369,19 @@ export function decodeString(bytes: Uint8Array): Values.StringValueInfo {
   try {
     //this will throw an error if we have malformed UTF-8
     let correctlyEncodedString = utf8.decode(badlyEncodedString);
-    return new Values.StringValueInfoValid(correctlyEncodedString);
+    return {
+      kind: "valid",
+      asString: correctlyEncodedString
+    };
   }
   catch(_) {
     //we're going to ignore the precise error and just assume it's because
     //the string was malformed (what else could it be?)
     let hexString = CodecUtils.Conversion.toHexString(bytes);
-    return new Values.StringValueInfoMalformed(hexString);
+    return {
+      kind: "malformed",
+      asHex: hexString
+    };
   }
 }
 
@@ -260,14 +396,19 @@ export function* decodeContract(addressBytes: Uint8Array, info: EvmInfo): Iterab
   let code = CodecUtils.Conversion.toHexString(codeBytes);
   let context = CodecUtils.Contexts.findDecoderContext(info.contexts, code);
   if(context !== null && context.contractName !== undefined) {
-    return new Values.ContractValueInfoKnown(
+    return {
+      kind: "known",
       address,
-      CodecUtils.Contexts.contextToType(context),
-      rawAddress
-    );
+      rawAddress,
+      class: CodecUtils.Contexts.contextToType(context)
+    };
   }
   else {
-    return new Values.ContractValueInfoUnknown(address, rawAddress);
+    return {
+      kind: "unknown",
+      address,
+      rawAddress
+    };
   }
 }
 
@@ -277,7 +418,11 @@ export function* decodeExternalFunction(addressBytes: Uint8Array, selectorBytes:
   let contract = <Values.ContractValueInfo> (yield* decodeContract(addressBytes, info));
   let selector = CodecUtils.Conversion.toHexString(selectorBytes);
   if(contract.kind === "unknown") {
-    return new Values.FunctionExternalValueInfoUnknown(contract, selector)
+    return {
+      kind: "unknown",
+      contract,
+      selector
+    };
   }
   let contractId = (<Types.ContractTypeNative> contract.class).id; //sorry! will be fixed soon!
   let context = Object.values(info.contexts).find(
@@ -287,9 +432,18 @@ export function* decodeExternalFunction(addressBytes: Uint8Array, selectorBytes:
     ? context.abi[selector]
     : undefined;
   if(abiEntry === undefined) {
-    return new Values.FunctionExternalValueInfoInvalid(contract, selector)
+    return {
+      kind: "invalid",
+      contract,
+      selector
+    };
   }
-  return new Values.FunctionExternalValueInfoKnown(contract, selector, abiEntry)
+  return {
+    kind: "known",
+    contract,
+    selector,
+    abi: abiEntry
+  };
 }
 
 //this one works a bit differently -- in order to handle errors, it *does* return a FunctionInternalResult
@@ -307,31 +461,55 @@ export function decodeInternalFunction(dataType: Types.FunctionInternalType, dep
   //before anything else: do we even have an internal functions table?
   //if not, we'll just return the info we have without really attemting to decode
   if(!info.internalFunctionsTable) {
-    return new Values.FunctionInternalValue(
-      dataType,
-      new Values.FunctionInternalValueInfoUnknown(context, deployedPc, constructorPc)
-    );
+    return {
+      type: dataType,
+      kind: "value",
+      value: {
+        kind: "unknown",
+        context,
+        deployedProgramCounter: deployedPc,
+        constructorProgramCounter: constructorPc
+      }
+    };
   }
   //also before we continue: is the PC zero? if so let's just return that
   if(deployedPc === 0 && constructorPc === 0) {
-    return new Values.FunctionInternalValue(
-      dataType,
-      new Values.FunctionInternalValueInfoException(context, deployedPc, constructorPc)
-    );
+    return {
+      type: dataType,
+      kind: "value",
+      value: {
+        kind: "exception",
+        context,
+        deployedProgramCounter: deployedPc,
+        constructorProgramCounter: constructorPc
+      }
+    };
   }
   //another check: is only the deployed PC zero?
   if(deployedPc === 0 && constructorPc !== 0) {
-    return new Errors.FunctionInternalErrorResult(
-      dataType,
-      new Errors.MalformedInternalFunctionError(context, constructorPc)
-    );
+    return {
+      type: dataType,
+      kind: "error",
+      error: {
+        kind: "MalformedInternalFunctionError",
+        context,
+        deployedProgramCounter: 0,
+        constructorProgramCounter: constructorPc
+      }
+    };
   }
   //one last pre-check: is this a deployed-format pointer in a constructor?
   if(info.currentContext.isConstructor && constructorPc === 0) {
-    return new Errors.FunctionInternalErrorResult(
-      dataType,
-      new Errors.DeployedFunctionInConstructorError(context, deployedPc)
-    );
+    return {
+      type: dataType,
+      kind: "error",
+      error: {
+        kind: "DeployedFunctionInConstructorError",
+        context,
+        deployedProgramCounter: deployedPc,
+        constructorProgramCounter: 0
+      }
+    };
   }
   //otherwise, we get our function
   let pc = info.currentContext.isConstructor
@@ -340,16 +518,28 @@ export function decodeInternalFunction(dataType: Types.FunctionInternalType, dep
   let functionEntry = info.internalFunctionsTable[pc];
   if(!functionEntry) {
     //if it's not zero and there's no entry... error!
-    return new Errors.FunctionInternalErrorResult(
-      dataType,
-      new Errors.NoSuchInternalFunctionError(context, deployedPc, constructorPc)
-    );
+    return {
+      type: dataType,
+      kind: "error",
+      error: {
+        kind: "NoSuchInternalFunctionError",
+        context,
+        deployedProgramCounter: deployedPc,
+        constructorProgramCounter: constructorPc
+      }
+    };
   }
   if(functionEntry.isDesignatedInvalid) {
-    return new Values.FunctionInternalValue(
-      dataType,
-      new Values.FunctionInternalValueInfoException(context, deployedPc, constructorPc)
-    );
+    return {
+      type: dataType,
+      kind: "value",
+      value: {
+        kind: "exception",
+        context,
+        deployedProgramCounter: deployedPc,
+        constructorProgramCounter: constructorPc
+      }
+    };
   }
   let name = functionEntry.name;
   let mutability = functionEntry.mutability;
@@ -361,10 +551,19 @@ export function decodeInternalFunction(dataType: Types.FunctionInternalType, dep
     contractKind: functionEntry.contractKind,
     payable: functionEntry.contractPayable
   };
-  return new Values.FunctionInternalValue(
-    dataType,
-    new Values.FunctionInternalValueInfoKnown(context, deployedPc, constructorPc, name, definedIn, mutability)
-  );
+  return {
+    type: dataType,
+    kind: "value",
+    value: {
+      kind: "function",
+      context,
+      deployedProgramCounter: deployedPc,
+      constructorProgramCounter: constructorPc,
+      name,
+      definedIn,
+      mutability
+    }
+  };
 }
 
 function checkPaddingRight(bytes: Uint8Array, length: number): boolean {

--- a/packages/truffle-codec/lib/decode/value.ts
+++ b/packages/truffle-codec/lib/decode/value.ts
@@ -369,6 +369,10 @@ export function decodeString(bytes: Uint8Array): Values.StringValueInfo {
   try {
     //this will throw an error if we have malformed UTF-8
     let correctlyEncodedString = utf8.decode(badlyEncodedString);
+    //NOTE: we don't use node's builtin Buffer class to do the UTF-8 decoding
+    //here, because that handles malformed UTF-8 by means of replacement characters
+    //(U+FFFD).  That loses information.  So we use the utf8 package instead,
+    //and... well, see the catch block below.
     return {
       kind: "valid",
       asString: correctlyEncodedString

--- a/packages/truffle-codec/lib/encode/abi.ts
+++ b/packages/truffle-codec/lib/encode/abi.ts
@@ -1,4 +1,4 @@
-import { Types, Values, Conversion as ConversionUtils, EVM as EVMUtils } from "truffle-codec-utils";
+import { Values, Conversion as ConversionUtils, EVM as EVMUtils } from "truffle-codec-utils";
 import { AbiAllocations } from "../types/allocation";
 import { isTypeDynamic, abiSizeForType } from "../allocate/abi";
 import sum from "lodash.sum";
@@ -101,7 +101,7 @@ export function encodeAbi(input: Values.Result, allocations?: AbiAllocations): U
   }
 }
 
-function stringToBytes(input: string): Uint8Array {
+export function stringToBytes(input: string): Uint8Array {
   input = utf8.encode(input);
   let bytes = new Uint8Array(input.length);
   for(let i = 0; i < input.length; i++) {

--- a/packages/truffle-codec/lib/encode/abi.ts
+++ b/packages/truffle-codec/lib/encode/abi.ts
@@ -8,6 +8,8 @@ import utf8 from "utf8";
 //see: https://github.com/microsoft/TypeScript/issues/18758
 //so, I'm just going to have to throw in a bunch of type coercions >_>
 
+//NOTE: Tuple (as opposed to struct) is not supported yet!
+//Coming soon though!
 export function encodeAbi(input: Values.Result, allocations?: AbiAllocations): Uint8Array | undefined {
   //errors can't be encoded
   if(input.kind === "error") {

--- a/packages/truffle-codec/lib/encode/key.ts
+++ b/packages/truffle-codec/lib/encode/key.ts
@@ -1,0 +1,107 @@
+import { Values, Conversion as ConversionUtils, EVM as EVMUtils } from "truffle-codec-utils";
+import { stringToBytes } from "./abi";
+
+//UGH -- it turns out TypeScript can't handle nested tagged unions
+//see: https://github.com/microsoft/TypeScript/issues/18758
+//so, I'm just going to have to throw in a bunch of type coercions >_>
+
+export function encodeMappingKey(input: Values.ElementaryValue): Uint8Array {
+  let bytes: Uint8Array;
+  //TypeScript can at least infer in the rest of this that we're looking
+  //at a value, not an error!  But that's hardly enough...
+  switch(input.type.typeClass) {
+    case "uint":
+    case "int":
+      return ConversionUtils.toBytes((<Values.UintValue|Values.IntValue>input).value.asBN, EVMUtils.WORD_SIZE);
+    case "bool": {
+      bytes = new Uint8Array(EVMUtils.WORD_SIZE); //is initialized to zeroes
+      if((<Values.BoolValue>input).value.asBool) {
+        bytes[EVMUtils.WORD_SIZE - 1] = 1;
+      }
+      return bytes;
+    }
+    case "bytes":
+      bytes = ConversionUtils.toBytes((<Values.BytesValue>input).value.asHex);
+      switch(input.type.kind) {
+        case "static":
+          let padded = new Uint8Array(EVMUtils.WORD_SIZE); //initialized to zeroes
+          padded.set(bytes);
+          return padded;
+        case "dynamic":
+          return bytes; //NO PADDING IS USED
+      }
+    case "address":
+      return ConversionUtils.toBytes((<Values.AddressValue>input).value.asAddress, EVMUtils.WORD_SIZE);
+    case "string": {
+      let coercedInput: Values.StringValue = <Values.StringValue> input;
+      switch(coercedInput.value.kind) { //NO PADDING IS USED
+        case "valid":
+          return stringToBytes(coercedInput.value.asString);
+        case "malformed":
+          return ConversionUtils.toBytes(coercedInput.value.asHex);
+      }
+    }
+    //fixed and ufixed are skipped for now
+  }
+}
+
+export function mappingKeyAsHex(input: Values.ElementaryValue): string {
+  return ConversionUtils.toHexString(encodeMappingKey(input));
+}
+
+//this is like the old toSoliditySha3Input, but for debugging purposes ONLY
+//it will NOT produce correct input to soliditySha3
+//please use mappingKeyAsHex instead if you wish to encode a mapping key.
+export function keyInfoForPrinting(input: Values.ElementaryValue): {type: string, value: string} {
+  switch(input.type.typeClass) {
+    case "uint":
+      return {
+        type: "uint",
+        value: (<Values.UintValue>input).value.asBN.toString()
+      };
+    case "int":
+      return {
+        type: "int",
+        value: (<Values.IntValue>input).value.asBN.toString()
+      };
+    case "bool":
+      //this is the case that won't work as valid input to soliditySha3 :)
+      return {
+        type: "uint",
+        value: (<Values.BoolValue>input).value.asBool.toString()
+      };
+    case "bytes":
+      switch(input.type.kind) {
+        case "static":
+          return {
+            type: "bytes32",
+            value: (<Values.BytesValue>input).value.asHex
+          };
+        case "dynamic":
+          return {
+            type: "bytes",
+            value: (<Values.BytesValue>input).value.asHex
+          };
+      }
+    case "address":
+      return {
+        type: "address",
+        value: (<Values.AddressValue>input).value.asAddress
+      };
+    case "string":
+      let coercedInput: Values.StringValue = <Values.StringValue> input;
+      switch(coercedInput.value.kind) {
+        case "valid":
+          return {
+            type: "string",
+            value: coercedInput.value.asString
+          };
+        case "malformed":
+          return {
+            type: "bytes",
+            value: coercedInput.value.asHex
+          };
+      }
+    //fixed and ufixed are skipped for now
+  }
+}

--- a/packages/truffle-codec/lib/read/constant.ts
+++ b/packages/truffle-codec/lib/read/constant.ts
@@ -24,7 +24,10 @@ export function readDefinition(definition: CodecUtils.AstDefinition): Uint8Array
       //handle right now.  sorry.
       debug("unsupported constant definition type");
       throw new Errors.DecodingError(
-        new Errors.UnsupportedConstantError(definition)
+        {
+          kind: "UnsupportedConstantError",
+          definition
+        }
       );
   }
 }

--- a/packages/truffle-codec/lib/read/index.ts
+++ b/packages/truffle-codec/lib/read/index.ts
@@ -27,30 +27,20 @@ export default function* read(pointer: Pointer.DataPointer, state: EvmState): It
       return bytes.readBytes(state.eventdata, pointer.start, pointer.length);
 
     case "stackliteral":
+      //nothing to do, just return it
       return pointer.literal;
 
     case "definition":
       return constant.readDefinition(pointer.definition);
 
     case "special":
-      //not bothering with error handling on this oen as I don't expect errors
+      //this one is simple enough to inline
+      //not bothering with error handling on this one as I don't expect errors
       return state.specials[pointer.special];
 
     case "eventtopic":
-      return readTopic(state.eventtopics, pointer.topic);
-
-    //...and in the case of "abi", which shouldn't happen, we'll just fall off
-    //the end and cause a problem :P
+      //this one is simple enough to inline as well; similarly not bothering
+      //with error handling
+      return state.eventtopics[pointer.topic];
   }
-}
-
-//this one is simple enough I'm keeping it in the same file
-function readTopic(topics: Uint8Array[], index: number) {
-  let topic = topics[index];
-  if(topic === undefined) {
-    throw new Errors.DecodingError(
-      new Errors.ReadErrorTopic(index)
-    );
-  }
-  return topic;
 }

--- a/packages/truffle-codec/lib/read/stack.ts
+++ b/packages/truffle-codec/lib/read/stack.ts
@@ -6,7 +6,11 @@ import * as CodecUtils from "truffle-codec-utils";
 export function readStack(stack: Uint8Array[], from: number, to: number): Uint8Array {
   if(from < 0 || to >= stack.length) {
     throw new CodecUtils.Errors.DecodingError(
-      new CodecUtils.Errors.ReadErrorStack(from, to)
+      {
+        kind: "ReadErrorStack",
+        from,
+        to
+      }
     );
   }
   //unforunately, Uint8Arrays don't support concat; if they did the rest of

--- a/packages/truffle-codec/lib/types/storage.ts
+++ b/packages/truffle-codec/lib/types/storage.ts
@@ -2,6 +2,7 @@ import debugModule from "debug";
 const debug = debugModule("codec:types:storage");
 
 import * as CodecUtils from "truffle-codec-utils";
+import { encodeMappingKey } from "../encode/key";
 import BN from "bn.js";
 
 export type StorageLength = {bytes: number} | {words: number};
@@ -53,7 +54,7 @@ export function equalSlots(slot1: Slot | undefined, slot2: Slot | undefined): bo
   if(!equalSlots(slot1.path, slot2.path)) {
     return false;
   }
-  //to compare keys, we'll just compare their toSoliditySha3Input (HACK?)
+  //to compare keys, we'll just compare their hex encodings
   //(yes, that leaves some wiggle room, as it could consider different
   //*types* of keys to be equal, but if keys are the only difference then
   //that should determine those types, so it shouldn't be a problem)
@@ -62,8 +63,8 @@ export function equalSlots(slot1: Slot | undefined, slot2: Slot | undefined): bo
     return !slot1.key && !slot2.key;
   }
   //if they do have keys, though...
-  let { type: type1, value: value1 } = slot1.key.toSoliditySha3Input();
-  let { type: type2, value: value2 } = slot2.key.toSoliditySha3Input();
-  return type1 === type2 && value1.toString() === value2.toString(); //HACK: since values may be
-  //BNs, we compare by toString instead of by the value itself
+  return CodecUtils.EVM.equalData(
+    encodeMappingKey(slot1.key),
+    encodeMappingKey(slot2.key)
+  );
 }

--- a/packages/truffle-codec/lib/types/wire.ts
+++ b/packages/truffle-codec/lib/types/wire.ts
@@ -3,12 +3,15 @@ import * as CodecUtils from "truffle-codec-utils";
 export type CalldataDecoding = FunctionDecoding | ConstructorDecoding | FallbackDecoding | UnknownDecoding;
 export type LogDecoding = EventDecoding | AnonymousDecoding;
 
+export type DecodingMode = "full" | "abi";
+
 export interface FunctionDecoding {
   kind: "function";
   class: CodecUtils.Types.ContractType;
   arguments: AbiArgument[];
   name: string;
   selector: string;
+  decodingMode: DecodingMode;
 }
 
 export interface ConstructorDecoding {
@@ -16,16 +19,19 @@ export interface ConstructorDecoding {
   class: CodecUtils.Types.ContractType;
   arguments: AbiArgument[];
   bytecode: string;
+  decodingMode: DecodingMode;
 }
 
 export interface FallbackDecoding {
   kind: "fallback";
   class: CodecUtils.Types.ContractType;
   data: string;
+  decodingMode: DecodingMode;
 }
 
 export interface UnknownDecoding {
   kind: "unknown";
+  decodingMode: DecodingMode;
 }
 
 export interface EventDecoding {
@@ -34,6 +40,7 @@ export interface EventDecoding {
   arguments: AbiArgument[];
   name: string;
   selector: string;
+  decodingMode: DecodingMode;
 }
 
 export interface AnonymousDecoding {
@@ -41,6 +48,7 @@ export interface AnonymousDecoding {
   class: CodecUtils.Types.ContractType;
   arguments: AbiArgument[];
   name: string;
+  decodingMode: DecodingMode;
 }
 
 export interface AbiArgument {

--- a/packages/truffle-debug-utils/index.js
+++ b/packages/truffle-debug-utils/index.js
@@ -5,6 +5,7 @@ var async = require("async");
 var debug = require("debug")("lib:debug");
 var BN = require("bn.js");
 var util = require("util");
+var CodecUtils = require("truffle-codec-utils");
 
 var commandReference = {
   "o": "step over",
@@ -318,7 +319,7 @@ var DebugUtils = {
 
   formatValue: function(value, indent = 0) {
     return util
-      .inspect(value, {
+      .inspect(new CodecUtils.ResultInspector(value), {
         colors: true,
         depth: null,
         maxArrayLength: null,

--- a/packages/truffle-debugger/lib/data/selectors/index.js
+++ b/packages/truffle-debugger/lib/data/selectors/index.js
@@ -150,16 +150,14 @@ const data = createSelectorTree({
     userDefinedTypes: {
       //user-defined types for passing to the decoder
       _: createLeaf(
-        ["../referenceDeclarations", "../scopes/inlined", "../contexts"],
-        (referenceDeclarations, scopes, contexts) => {
-          const types = ["ContractDefinition", "SourceUnit"];
-          //SourceUnit included as fallback
+        ["../referenceDeclarations", "/info/scopes", solidity.info.sources],
+        (referenceDeclarations, scopes, sources) => {
           return Object.assign(
             {},
             ...Object.entries(referenceDeclarations).map(([id, node]) => ({
               [id]: CodecUtils.Types.definitionToStoredType(
                 node,
-                contexts[findAncestorOfType(node, types, scopes).id].compiler,
+                sources[scopes[node.id].sourceId].compiler,
                 referenceDeclarations
               )
             }))

--- a/packages/truffle-debugger/test/data/codex.js
+++ b/packages/truffle-debugger/test/data/codex.js
@@ -2,6 +2,7 @@ import debugModule from "debug";
 const debug = debugModule("test:data:codex");
 
 import { assert } from "chai";
+import { Conversion as ConversionUtils } from "truffle-codec-utils";
 
 import Ganache from "ganache-core";
 
@@ -126,7 +127,7 @@ describe("Codex", function() {
     await session.continueUntilBreakpoint(); //run till end
     debug("made it to end of transaction");
 
-    const surface = (await session.variable("surface")).nativize();
+    const surface = ConversionUtils.nativize(await session.variable("surface"));
 
     assert.equal(surface["ping"], 1);
   });
@@ -147,7 +148,7 @@ describe("Codex", function() {
 
     await session.continueUntilBreakpoint(); //run till end
 
-    const x = (await session.variable("x")).nativize();
+    const x = ConversionUtils.nativize(await session.variable("x"));
 
     assert.equal(x, 1);
   });
@@ -168,7 +169,7 @@ describe("Codex", function() {
 
     await session.continueUntilBreakpoint(); //run till end
 
-    const x = (await session.variable("x")).nativize();
+    const x = ConversionUtils.nativize(await session.variable("x"));
 
     assert.equal(x, 1);
   });

--- a/packages/truffle-debugger/test/data/helpers.js
+++ b/packages/truffle-debugger/test/data/helpers.js
@@ -4,6 +4,7 @@ const debug = debugModule("test:data:decode");
 import Ganache from "ganache-core";
 import { assert } from "chai";
 import changeCase from "change-case";
+import { Conversion as ConversionUtils } from "truffle-codec-utils";
 
 import { prepareContracts } from "test/helpers";
 
@@ -84,9 +85,7 @@ async function prepareDebugger(testName, sources) {
 }
 
 async function decode(name) {
-  let result = await this.session.variable(name);
-
-  return result.nativize();
+  return ConversionUtils.nativize(await this.session.variable(name));
 }
 
 export function describeDecoding(testName, fixtures, selector, generateSource) {

--- a/packages/truffle-debugger/test/data/ids.js
+++ b/packages/truffle-debugger/test/data/ids.js
@@ -10,6 +10,7 @@ import Debugger from "lib/debugger";
 
 import trace from "lib/trace/selectors";
 import solidity from "lib/solidity/selectors";
+import { Conversion as ConversionUtils } from "truffle-codec-utils";
 
 const __FACTORIAL = `
 pragma solidity ^0.5.0;
@@ -214,7 +215,7 @@ describe("Variable IDs", function() {
 
     await session.continueUntilBreakpoint();
     while (!session.view(trace.finished)) {
-      values.push((await session.variable("nbang")).nativize());
+      values.push(ConversionUtils.nativize(await session.variable("nbang")));
       await session.continueUntilBreakpoint();
     }
 

--- a/packages/truffle-decoder/lib/contract.ts
+++ b/packages/truffle-decoder/lib/contract.ts
@@ -2,7 +2,7 @@ import debugModule from "debug";
 const debug = debugModule("decoder:contract");
 
 import * as CodecUtils from "truffle-codec-utils";
-import { Types, Values } from "truffle-codec-utils";
+import { Types, Values, wrapElementaryViaDefinition } from "truffle-codec-utils";
 import AsyncEventEmitter from "async-eventemitter";
 import Web3 from "web3";
 import { ContractObject } from "truffle-contract-schema/spec";
@@ -543,7 +543,7 @@ export default class TruffleContractDecoder extends AsyncEventEmitter {
         break;
       case "mapping":
         let keyDefinition = parentDefinition.keyType || parentDefinition.typeName.keyType;
-        key = Values.wrapElementaryValue(rawIndex, keyDefinition);
+        key = wrapElementaryViaDefinition(rawIndex, keyDefinition);
         definition = parentDefinition.valueType || parentDefinition.typeName.valueType;
         slot = {
           path: parentSlot,

--- a/packages/truffle-decoder/test/test/wire-test.js
+++ b/packages/truffle-decoder/test/test/wire-test.js
@@ -3,6 +3,7 @@ const assert = require("chai").assert;
 const BN = require("bn.js");
 
 const TruffleDecoder = require("../../../truffle-decoder");
+const ConversionUtils = require("../../../truffle-codec-utils").Conversion;
 
 const WireTest = artifacts.require("WireTest");
 const WireTestParent = artifacts.require("WireTestParent");
@@ -95,15 +96,18 @@ contract("WireTest", _accounts => {
     assert.strictEqual(constructorDecoding.class.typeName, "WireTest");
     assert.lengthOf(constructorDecoding.arguments, 3);
     assert.strictEqual(constructorDecoding.arguments[0].name, "status");
-    assert.strictEqual(constructorDecoding.arguments[0].value.nativize(), true);
+    assert.strictEqual(
+      ConversionUtils.nativize(constructorDecoding.arguments[0].value),
+      true
+    );
     assert.strictEqual(constructorDecoding.arguments[1].name, "info");
     assert.strictEqual(
-      constructorDecoding.arguments[1].value.nativize(),
+      ConversionUtils.nativize(constructorDecoding.arguments[1].value),
       "0xdeadbeef"
     );
     assert.strictEqual(constructorDecoding.arguments[2].name, "whoknows");
     assert.strictEqual(
-      constructorDecoding.arguments[2].value.nativize(),
+      ConversionUtils.nativize(constructorDecoding.arguments[2].value),
       "WireTest.Ternary.MaybeSo"
     );
 
@@ -113,17 +117,17 @@ contract("WireTest", _accounts => {
     assert.lengthOf(emitStuffDecoding.arguments, 3);
     assert.strictEqual(emitStuffDecoding.arguments[0].name, "p");
     assert.deepEqual(
-      emitStuffDecoding.arguments[0].value.nativize(),
+      ConversionUtils.nativize(emitStuffDecoding.arguments[0].value),
       emitStuffArgs[0]
     );
     assert.strictEqual(emitStuffDecoding.arguments[1].name, "precompiles");
     assert.deepEqual(
-      emitStuffDecoding.arguments[1].value.nativize(),
+      ConversionUtils.nativize(emitStuffDecoding.arguments[1].value),
       emitStuffArgs[1]
     );
     assert.strictEqual(emitStuffDecoding.arguments[2].name, "strings");
     assert.deepEqual(
-      emitStuffDecoding.arguments[2].value.nativize(),
+      ConversionUtils.nativize(emitStuffDecoding.arguments[2].value),
       emitStuffArgs[2]
     );
 
@@ -133,12 +137,12 @@ contract("WireTest", _accounts => {
     assert.lengthOf(moreStuffDecoding.arguments, 2);
     assert.strictEqual(moreStuffDecoding.arguments[0].name, "notThis");
     assert.strictEqual(
-      moreStuffDecoding.arguments[0].value.nativize(),
+      ConversionUtils.nativize(moreStuffDecoding.arguments[0].value),
       `WireTest(${moreStuffArgs[0]})`
     );
     assert.strictEqual(moreStuffDecoding.arguments[1].name, "bunchOfInts");
     assert.deepEqual(
-      moreStuffDecoding.arguments[1].value.nativize(),
+      ConversionUtils.nativize(moreStuffDecoding.arguments[1].value),
       moreStuffArgs[1]
     );
 
@@ -148,7 +152,7 @@ contract("WireTest", _accounts => {
     assert.lengthOf(inheritedDecoding.arguments, 1);
     assert.isUndefined(inheritedDecoding.arguments[0].name);
     assert.deepEqual(
-      inheritedDecoding.arguments[0].value.nativize(),
+      ConversionUtils.nativize(inheritedDecoding.arguments[0].value),
       inheritedArg
     );
 
@@ -165,12 +169,12 @@ contract("WireTest", _accounts => {
     assert.lengthOf(getterDecoding1.arguments, 2);
     assert.isUndefined(getterDecoding1.arguments[0].name);
     assert.strictEqual(
-      getterDecoding1.arguments[0].value.nativize(),
+      ConversionUtils.nativize(getterDecoding1.arguments[0].value),
       getter1Args[0]
     );
     assert.isUndefined(getterDecoding1.arguments[1].name);
     assert.strictEqual(
-      getterDecoding1.arguments[1].value.nativize(),
+      ConversionUtils.nativize(getterDecoding1.arguments[1].value),
       getter1Args[1]
     );
 
@@ -180,12 +184,12 @@ contract("WireTest", _accounts => {
     assert.lengthOf(getterDecoding2.arguments, 2);
     assert.isUndefined(getterDecoding2.arguments[0].name);
     assert.strictEqual(
-      getterDecoding2.arguments[0].value.nativize(),
+      ConversionUtils.nativize(getterDecoding2.arguments[0].value),
       getter2Args[0]
     );
     assert.isUndefined(getterDecoding2.arguments[1].name);
     assert.strictEqual(
-      getterDecoding2.arguments[1].value.nativize(),
+      ConversionUtils.nativize(getterDecoding2.arguments[1].value),
       getter2Args[1]
     );
 
@@ -274,17 +278,17 @@ contract("WireTest", _accounts => {
     assert.lengthOf(constructorEventDecoding.arguments, 3);
     assert.strictEqual(constructorEventDecoding.arguments[0].name, "bit");
     assert.strictEqual(
-      constructorEventDecoding.arguments[0].value.nativize(),
+      ConversionUtils.nativize(constructorEventDecoding.arguments[0].value),
       true
     );
     assert.isUndefined(constructorEventDecoding.arguments[1].name);
     assert.strictEqual(
-      constructorEventDecoding.arguments[1].value.nativize(),
+      ConversionUtils.nativize(constructorEventDecoding.arguments[1].value),
       "0xdeadbeef"
     );
     assert.isUndefined(constructorEventDecoding.arguments[2].name);
     assert.strictEqual(
-      constructorEventDecoding.arguments[2].value.nativize(),
+      ConversionUtils.nativize(constructorEventDecoding.arguments[2].value),
       "WireTest.Ternary.MaybeSo"
     );
 
@@ -294,17 +298,17 @@ contract("WireTest", _accounts => {
     assert.lengthOf(emitStuffEventDecoding.arguments, 3);
     assert.isUndefined(emitStuffEventDecoding.arguments[0].name);
     assert.deepEqual(
-      emitStuffEventDecoding.arguments[0].value.nativize(),
+      ConversionUtils.nativize(emitStuffEventDecoding.arguments[0].value),
       emitStuffArgs[0]
     );
     assert.isUndefined(emitStuffEventDecoding.arguments[1].name);
     assert.deepEqual(
-      emitStuffEventDecoding.arguments[1].value.nativize(),
+      ConversionUtils.nativize(emitStuffEventDecoding.arguments[1].value),
       emitStuffArgs[1]
     );
     assert.isUndefined(emitStuffEventDecoding.arguments[2].name);
     assert.deepEqual(
-      emitStuffEventDecoding.arguments[2].value.nativize(),
+      ConversionUtils.nativize(emitStuffEventDecoding.arguments[2].value),
       emitStuffArgs[2]
     );
 
@@ -314,12 +318,12 @@ contract("WireTest", _accounts => {
     assert.lengthOf(moreStuffEventDecoding.arguments, 2);
     assert.isUndefined(moreStuffEventDecoding.arguments[0].name);
     assert.strictEqual(
-      moreStuffEventDecoding.arguments[0].value.nativize(),
+      ConversionUtils.nativize(moreStuffEventDecoding.arguments[0].value),
       `WireTest(${moreStuffArgs[0]})`
     );
     assert.strictEqual(moreStuffEventDecoding.arguments[1].name, "data");
     assert.deepEqual(
-      moreStuffEventDecoding.arguments[1].value.nativize(),
+      ConversionUtils.nativize(moreStuffEventDecoding.arguments[1].value),
       moreStuffArgs[1]
     );
 
@@ -334,27 +338,26 @@ contract("WireTest", _accounts => {
     assert.lengthOf(indexTestEventDecoding.arguments, 5);
     assert.isUndefined(indexTestEventDecoding.arguments[0].name);
     assert.strictEqual(
-      indexTestEventDecoding.arguments[0].value.nativize(),
+      ConversionUtils.nativize(indexTestEventDecoding.arguments[0].value),
       indexTestArgs[0]
     );
     assert.isUndefined(indexTestEventDecoding.arguments[1].name);
     assert.deepEqual(
-      indexTestEventDecoding.arguments[1].value.nativize(),
+      ConversionUtils.nativize(indexTestEventDecoding.arguments[1].value),
       indexTestArgs[1]
     );
     assert.isUndefined(indexTestEventDecoding.arguments[2].name);
     assert.deepEqual(
-      indexTestEventDecoding.arguments[2].value.nativize(),
+      ConversionUtils.nativize(indexTestEventDecoding.arguments[2].value),
       indexTestArgs[2]
     );
     assert.isUndefined(indexTestEventDecoding.arguments[3].name);
     assert.isUndefined(
-      indexTestEventDecoding.arguments[3].value.nativize(), //can't decode indexed reference type!
-      indexTestArgs[3]
+      ConversionUtils.nativize(indexTestEventDecoding.arguments[3].value) //can't decode indexed reference type!
     );
     assert.isUndefined(indexTestEventDecoding.arguments[4].name);
     assert.deepEqual(
-      indexTestEventDecoding.arguments[4].value.nativize(),
+      ConversionUtils.nativize(indexTestEventDecoding.arguments[4].value),
       indexTestArgs[4]
     );
 
@@ -367,7 +370,7 @@ contract("WireTest", _accounts => {
     assert.lengthOf(libraryTestEventDecoding.arguments, 1);
     assert.isUndefined(libraryTestEventDecoding.arguments[0].name);
     assert.strictEqual(
-      libraryTestEventDecoding.arguments[0].value.nativize(),
+      ConversionUtils.nativize(libraryTestEventDecoding.arguments[0].value),
       libraryTestArg
     );
 
@@ -376,7 +379,7 @@ contract("WireTest", _accounts => {
     assert.lengthOf(dangerEventDecoding.arguments, 1);
     assert.isUndefined(dangerEventDecoding.arguments[0].name);
     assert.strictEqual(
-      dangerEventDecoding.arguments[0].value.nativize(),
+      ConversionUtils.nativize(dangerEventDecoding.arguments[0].value),
       `WireTest(${address}).danger`
     );
   });
@@ -426,10 +429,12 @@ contract("WireTest", _accounts => {
     );
     assert.lengthOf(ambiguityTestContractDecoding.arguments, 2);
     assert.isUndefined(
-      ambiguityTestContractDecoding.arguments[0].value.nativize()
+      ConversionUtils.nativize(ambiguityTestContractDecoding.arguments[0].value)
     );
     assert.deepEqual(
-      ambiguityTestContractDecoding.arguments[1].value.nativize(),
+      ConversionUtils.nativize(
+        ambiguityTestContractDecoding.arguments[1].value
+      ),
       [32, 3, 17, 18, 19]
     );
 
@@ -441,11 +446,11 @@ contract("WireTest", _accounts => {
     );
     assert.lengthOf(ambiguityTestLibraryDecoding.arguments, 2);
     assert.deepEqual(
-      ambiguityTestLibraryDecoding.arguments[0].value.nativize(),
+      ConversionUtils.nativize(ambiguityTestLibraryDecoding.arguments[0].value),
       [17, 18, 19]
     );
     assert.isUndefined(
-      ambiguityTestLibraryDecoding.arguments[1].value.nativize()
+      ConversionUtils.nativize(ambiguityTestLibraryDecoding.arguments[1].value)
     );
 
     for (let decoding of unambiguousDecodings) {
@@ -455,46 +460,46 @@ contract("WireTest", _accounts => {
 
     assert.strictEqual(unambiguousDecodings[0].class.typeName, "WireTest");
     assert.lengthOf(unambiguousDecodings[0].arguments, 2);
-    assert.isUndefined(unambiguousDecodings[0].arguments[0].value.nativize());
-    assert.deepEqual(unambiguousDecodings[0].arguments[1].value.nativize(), [
-      32,
-      1e12,
-      17,
-      18,
-      19
-    ]);
+    assert.isUndefined(
+      ConversionUtils.nativize(unambiguousDecodings[0].arguments[0].value)
+    );
+    assert.deepEqual(
+      ConversionUtils.nativize(unambiguousDecodings[0].arguments[1].value),
+      [32, 1e12, 17, 18, 19]
+    );
 
     assert.strictEqual(unambiguousDecodings[1].class.typeName, "WireTest");
     assert.lengthOf(unambiguousDecodings[1].arguments, 2);
-    assert.isUndefined(unambiguousDecodings[1].arguments[0].value.nativize());
-    assert.deepEqual(unambiguousDecodings[1].arguments[1].value.nativize(), [
-      32,
-      3,
-      257,
-      257,
-      257
-    ]);
+    assert.isUndefined(
+      ConversionUtils.nativize(unambiguousDecodings[1].arguments[0].value)
+    );
+    assert.deepEqual(
+      ConversionUtils.nativize(unambiguousDecodings[1].arguments[1].value),
+      [32, 3, 257, 257, 257]
+    );
 
     assert.strictEqual(unambiguousDecodings[2].class.typeName, "WireTest");
     assert.lengthOf(unambiguousDecodings[2].arguments, 2);
-    assert.isUndefined(unambiguousDecodings[2].arguments[0].value.nativize());
-    assert.deepEqual(unambiguousDecodings[2].arguments[1].value.nativize(), [
-      64,
-      0,
-      2,
-      1,
-      1
-    ]);
+    assert.isUndefined(
+      ConversionUtils.nativize(unambiguousDecodings[2].arguments[0].value)
+    );
+    assert.deepEqual(
+      ConversionUtils.nativize(unambiguousDecodings[2].arguments[1].value),
+      [64, 0, 2, 1, 1]
+    );
 
     assert.strictEqual(
       unambiguousDecodings[3].class.typeName,
       "WireTestLibrary"
     );
     assert.lengthOf(unambiguousDecodings[3].arguments, 2);
-    assert.deepEqual(unambiguousDecodings[3].arguments[0].value.nativize(), [
-      107
-    ]);
-    assert.isUndefined(unambiguousDecodings[3].arguments[1].value.nativize());
+    assert.deepEqual(
+      ConversionUtils.nativize(unambiguousDecodings[3].arguments[0].value),
+      [107]
+    );
+    assert.isUndefined(
+      ConversionUtils.nativize(unambiguousDecodings[3].arguments[1].value)
+    );
   });
 
   it("Handles anonymous events", async () => {
@@ -532,7 +537,7 @@ contract("WireTest", _accounts => {
     assert.lengthOf(anonymousTestEvents[0].decodings[0].arguments, 4);
     assert.deepEqual(
       anonymousTestEvents[0].decodings[0].arguments.map(({ value }) =>
-        value.nativize()
+        ConversionUtils.nativize(value)
       ),
       [257, 1, 1, 1]
     );
@@ -547,7 +552,7 @@ contract("WireTest", _accounts => {
     assert.lengthOf(anonymousTestEvents[1].decodings[0].arguments, 4);
     assert.deepEqual(
       anonymousTestEvents[1].decodings[0].arguments.map(({ value }) =>
-        value.nativize()
+        ConversionUtils.nativize(value)
       ),
       [1, 2, 3, 4]
     );
@@ -560,7 +565,7 @@ contract("WireTest", _accounts => {
     assert.lengthOf(anonymousTestEvents[1].decodings[1].arguments, 4);
     assert.deepEqual(
       anonymousTestEvents[1].decodings[1].arguments.map(({ value }) =>
-        value.nativize()
+        ConversionUtils.nativize(value)
       ),
       [1, 2, 3, 4]
     );
@@ -575,7 +580,7 @@ contract("WireTest", _accounts => {
     assert.lengthOf(anonymousTestEvents[2].decodings[0].arguments, 3);
     assert.deepEqual(
       anonymousTestEvents[2].decodings[0].arguments.map(({ value }) =>
-        value.nativize()
+        ConversionUtils.nativize(value)
       ),
       [1, 2, 3]
     );
@@ -590,7 +595,7 @@ contract("WireTest", _accounts => {
     assert.deepEqual(
       anonymousTestEvents[2].decodings[1].arguments
         .slice(1)
-        .map(({ value }) => value.nativize()),
+        .map(({ value }) => ConversionUtils.nativize(value)),
       [1, 2, 3]
     );
     assert(
@@ -611,7 +616,9 @@ contract("WireTest", _accounts => {
     );
     assert.lengthOf(anonymousTestEvents[3].decodings[0].arguments, 1);
     assert.strictEqual(
-      anonymousTestEvents[3].decodings[0].arguments[0].value.nativize(),
+      ConversionUtils.nativize(
+        anonymousTestEvents[3].decodings[0].arguments[0].value
+      ),
       "0xfe"
     );
 
@@ -625,7 +632,9 @@ contract("WireTest", _accounts => {
     assert.strictEqual(specifiedNameDecoding.class.typeName, "WireTestLibrary");
     assert.lengthOf(specifiedNameDecoding.arguments, 4);
     assert.deepEqual(
-      specifiedNameDecoding.arguments.map(({ value }) => value.nativize()),
+      specifiedNameDecoding.arguments.map(({ value }) =>
+        ConversionUtils.nativize(value)
+      ),
       [1, 2, 3, 4]
     );
   });


### PR DESCRIPTION
This PR does two things.

Firstly, it redoes the decoder output format with interfaces instead of classes.  The format is still the same; just now it's with interfaces and functions instead of classes and method.

The reason it originally used classes was to get `util.inspect.custom` to work.  However now instead we handle this problem but having a single `ResultInspector` class which contains a single `Result`; instead of inspecting `Result`s, when we want to print them we first wrap them in a `ResultInspector`.

Similarly, the `nativize` method is now a function.  The `toSoliditySha3Input` method has been kind of split into two different functions.  There's now a mapping key encoder in addition to the ABI encoder; that's what we now use for mapping keys instead of `toSoliditySha3Input`.  However, `key.ts` also contains a debugging function returning info for printing mapping keys.  This is basically like the old `toSoliditySha3Input`, except it's freed from the constraints of having to actually work as input to that function. :)  (So don't use it for that, as it won't work for that anymore!)

Secondly, this PR contains two bug fixes regarding compiler versions, one major and one minor.  (Don't worry, these both only exist on `next`, not `develop`.)

The first bug fix is that, in order to determine what compiler a given user-defined type was compiled with, we would... do a complicated thing that was wrong, and involved looking it up in the context; this would run into a problem when the type was defined in an interface or abstract contract, as those don't get contexts.  Now we do it the right way but just looking up the source ID in `data.info.scopes` and then getting the compiler from `solidity.info.sources`.

The second (really minor) bug fix is that I altered the compiler version check so it won't mistake prerelease versions of 0.5.0 as not being 0.5.x.