### PR TITLE
Support command-line argument `--option=value`

### DIFF
--- a/packages/truffle-core/lib/command.js
+++ b/packages/truffle-core/lib/command.js
@@ -114,7 +114,7 @@ class Command {
 
       const validOptions = result.command.help.options
         .map(item => {
-          let opt = item.option.split(" ")[0];
+          let opt = item.option.replace("=", " ").split(" ")[0];
           return opt.startsWith("--") ? opt : null;
         })
         .filter(item => {

--- a/packages/truffle-core/lib/console.js
+++ b/packages/truffle-core/lib/console.js
@@ -42,7 +42,7 @@ class Console extends EventEmitter {
     this.repl.on("exit", () => this.emit("exit"));
   }
 
-  async start(callback) {
+  start(callback) {
     if (!this.repl) this.repl = new Repl(this.options);
 
     // TODO: This should probalby be elsewhere.
@@ -55,8 +55,7 @@ class Console extends EventEmitter {
       this.repl.start({
         prompt: "truffle(" + this.options.network + ")> ",
         context: {
-          web3: this.web3,
-          accounts: await this.web3.eth.getAccounts()
+          web3: this.web3
         },
         interpreter: this.interpret.bind(this),
         done: callback

--- a/packages/truffle-core/lib/console.js
+++ b/packages/truffle-core/lib/console.js
@@ -42,7 +42,7 @@ class Console extends EventEmitter {
     this.repl.on("exit", () => this.emit("exit"));
   }
 
-  start(callback) {
+  async start(callback) {
     if (!this.repl) this.repl = new Repl(this.options);
 
     // TODO: This should probalby be elsewhere.
@@ -55,7 +55,8 @@ class Console extends EventEmitter {
       this.repl.start({
         prompt: "truffle(" + this.options.network + ")> ",
         context: {
-          web3: this.web3
+          web3: this.web3,
+          accounts: await this.web3.eth.getAccounts()
         },
         interpreter: this.interpret.bind(this),
         done: callback


### PR DESCRIPTION
This PR relates to #2173 
This supports command-line argument `--option=value` syntax (not just `--option value`).
It is designed to replace the first occurence of "=" to " ".