### PR TITLE
Add <project-path> param to truffle init

### DIFF
--- a/packages/truffle-core/lib/commands/init.js
+++ b/packages/truffle-core/lib/commands/init.js
@@ -13,7 +13,7 @@ var command = {
           "that exist in the directory."
       },
       {
-        option: "--create-dir <anem>",
+        option: "--create-dir <name>",
         description:
           "Specify the directory name to create a directory and initialize within."
       }

--- a/packages/truffle-core/lib/commands/init.js
+++ b/packages/truffle-core/lib/commands/init.js
@@ -3,7 +3,7 @@ var command = {
   description: "Initialize new and empty Ethereum project",
   builder: {},
   help: {
-    usage: "truffle init [--force]",
+    usage: "truffle init [--force] [--create-dir <name>]",
     options: [
       {
         option: "--force",
@@ -11,6 +11,11 @@ var command = {
           "Initialize project in the current directory regardless of its " +
           "state. Be careful, this\n                    will potentially overwrite files " +
           "that exist in the directory."
+      },
+      {
+        option: "--create-dir <anem>",
+        description:
+          "Specify the directory name to create a directory and initialize within."
       }
     ]
   },
@@ -18,6 +23,7 @@ var command = {
     var Config = require("truffle-config");
     var OS = require("os");
     var UnboxCommand = require("./unbox");
+    var fs = require("fs");
 
     var config = Config.default().with({
       logger: console
@@ -34,6 +40,22 @@ var command = {
           " - Or, browse the Truffle Boxes at <http://truffleframework.com/boxes>!"
       );
       process.exit(1);
+    }
+
+    if (options["create-dir"] && options["create-dir"].length > 0) {
+      try {
+        const path = options["create-dir"];
+        fs.mkdirSync(path, { recursive: true });
+        process.chdir(path);
+        config.logger.log();
+        config.logger.log(
+          "Creating a new empty Truffle box in \x1b[32m%s\x1b[0m.",
+          path
+        );
+      } catch (err) {
+        config.logger.log(err);
+        process.exit(1);
+      }
     }
 
     // defer to `truffle unbox` command with "bare" box as arg


### PR DESCRIPTION
This PR relates to #2138 .
I also agree to this issue because create-react-app, the most common packaging tool for react, requires a parameter for the project to be unboxed.

If 'truffle init' command is intended for people who are familiar with the unboxing tools, I think this way is more intuitive for others who are familiar with create-react-app (including myself.)

TL;DR 
This PR is about changing the 'truffle init' process from

```
mkdir <project-path>
cd <project-path>
truffle init
```

to

`truffle init --create-dir <project-path>`