### PR TITLE
Generate truffle library webpack bundle for package main

### DIFF
--- a/packages/truffle-core/index.js
+++ b/packages/truffle-core/index.js
@@ -7,5 +7,6 @@ module.exports = {
   contracts: require("truffle-workflow-compile"),
   package: require("./lib/package"),
   test: require("./lib/test"),
-  version: pkg.version
+  version: pkg.version,
+  ganache: require("ganache-core")
 };

--- a/packages/truffle/cli.webpack.config.js
+++ b/packages/truffle/cli.webpack.config.js
@@ -31,6 +31,13 @@ module.exports = {
       "services",
       "analytics",
       "main.js"
+    ),
+    library: path.join(
+      __dirname,
+      "../..",
+      "node_modules",
+      "truffle-core",
+      "index.js"
     )
   },
   target: "node",
@@ -42,7 +49,9 @@ module.exports = {
   context: rootDir,
   output: {
     path: outputDir,
-    filename: "[name].bundled.js"
+    filename: "[name].bundled.js",
+    library: "",
+    libraryTarget: "commonjs"
   },
   devtool: "source-map",
   module: {
@@ -75,7 +84,8 @@ module.exports = {
     new webpack.DefinePlugin({
       BUNDLE_VERSION: JSON.stringify(pkg.version),
       BUNDLE_CHAIN_FILENAME: JSON.stringify("chain.bundled.js"),
-      BUNDLE_ANALYTICS_FILENAME: JSON.stringify("analytics.bundled.js")
+      BUNDLE_ANALYTICS_FILENAME: JSON.stringify("analytics.bundled.js"),
+      BUNDLE_LIBRARY_FILENAME: JSON.stringify("library.bundled.js")
     }),
 
     // Put the shebang back on.

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -8,6 +8,7 @@
     "url": "https://github.com/trufflesuite/truffle/issues"
   },
   "version": "5.0.29",
+  "main": "./build/library.bundled.js",
   "bin": {
     "truffle": "./build/cli.bundled.js"
   },

--- a/packages/truffle/test/scenarios/library/api.js
+++ b/packages/truffle/test/scenarios/library/api.js
@@ -1,0 +1,97 @@
+const assert = require("assert");
+
+describe("Truffle Library APIs", () => {
+  // Avoid `npm test:raw`
+  if (process.env.NO_BUILD) return;
+
+  let truffle;
+  before(function() {
+    this.timeout(5000);
+    truffle = require("../../../build/library.bundled.js");
+  });
+
+  it("truffle.build API definition", () => {
+    assert(truffle.build, "build undefined");
+    assert(truffle.build.clean, "build.clean undefined");
+    assert(truffle.build.build, "build.build undefined");
+  });
+
+  it("truffle.create API definition", () => {
+    assert(truffle.create, "create undefined");
+    assert(truffle.create.contract, "create.contract undefined");
+    assert(truffle.create.test, "create.test undefined");
+    assert(truffle.create.migration, "create.migration undefined");
+  });
+
+  it("truffle.console API definition", () => {
+    // This one returns a constructor.
+    assert(truffle.console, "console undefined");
+  });
+
+  it("truffle.contracts API definition", () => {
+    assert(truffle.contracts.compile, "contracts.compile undefined");
+    assert(
+      truffle.contracts.collectCompilations,
+      "contracts.collectCompilations undefined"
+    );
+    assert(
+      truffle.contracts.compileSources,
+      "contracts.compileSources undefined"
+    );
+    assert(
+      truffle.contracts.reportCompilationStarted,
+      "contracts.reportCompilationStarted undefined"
+    );
+    assert(
+      truffle.contracts.reportCompilationFinished,
+      "contracts.reportCompilationFinished undefined"
+    );
+    assert(
+      truffle.contracts.reportNothingToCompile,
+      "contracts.reportNothingToCompile undefined"
+    );
+    assert(
+      truffle.contracts.writeContracts,
+      "contracts.writeContracts undefined"
+    );
+  });
+
+  it("truffle.package API definition", () => {
+    assert(truffle.package.publish, "package.publish undefined");
+    assert(truffle.package.install, "package.install undefined");
+    assert(truffle.package.digest, "package.digest undefined");
+    assert(
+      truffle.package.publishable_artifacts,
+      "package.publishable_artifacts undefined"
+    );
+  });
+
+  it("truffle.test API", () => {
+    assert(truffle.test.run, "test.run undefined");
+    assert(truffle.test.createMocha, "test.createMocha undefined");
+    assert(truffle.test.getAccounts, "test.getAccounts undefined");
+    assert(
+      truffle.test.compileContractsWithTestFilesIfNeeded,
+      "test.withTestFiles undefined"
+    );
+    assert(
+      truffle.test.performInitialDeploy,
+      "test.performInitialDeploy undefined"
+    );
+    assert(
+      truffle.test.defineSolidityTests,
+      "test.defineSolidityTests undefined"
+    );
+    assert(truffle.test.setJSTestGlobals, "test.setJSTestGlobals undefined");
+  });
+
+  it("truffle.version API", () => {
+    assert(truffle.version, "truffle.version undefined");
+  });
+
+  it("truffle.ganache", () => {
+    assert(truffle.ganache, "ganache undefined");
+    assert(truffle.ganache.provider, "ganache.provider undefined");
+    assert(truffle.ganache.server, "ganache.server undefined");
+  });
+});


### PR DESCRIPTION
#2222 

Makes the following possible (in a plugin context, for example). 
```javascript
const truffle = require("truffle");
await truffle.contracts.compile(config);
```

**Implementation Details**
+ In #2222 I proposed using webpack [expose-loader](https://www.npmjs.com/package/expose-loader) for this because I was concerned about the bundle size growing a lot. The unpacked version *is* bigger here (25-30%), but the packed version sent over the wire from npm is still quite small and it doesn't affect installation speeds. I published my own version to test that issue & validate the POC in the code snippet above - everything worked. Also expose-loader is a nightmare.

+ Added `ganache-core` to the `truffle-core` exports  so consumer can spin up an in-process provider.

+ Added top layer API correctness tests - you'll get a scenario test failure if you delete/rename one of those methods. 

[cf: solidity-coverage 0.7.0](https://github.com/sc-forks/solidity-coverage/issues/346)