### PR TITLE
Factor out mapping key decoding into its own saga

### DIFF
--- a/packages/truffle-debugger/lib/data/sagas/index.js
+++ b/packages/truffle-debugger/lib/data/sagas/index.js
@@ -349,122 +349,14 @@ function* variablesAndMappingsSaga() {
         baseExpression,
         scopes
       );
-      //if we're dealing with an array, this will just hack up a uint definition
+      //if we're dealing with an array, this will just spoof up a uint definition
       //:)
 
-      //begin subsection: key decoding
-      //(I tried factoring this out into its own saga but it didn't work when I
-      //did :P )
-
-      let indexValue;
-      let indexDefinition = node.indexExpression;
-
-      //why the loop? see the end of the block it heads for an explanatory
-      //comment
-      while (indexValue === undefined) {
-        let indexId = indexDefinition.id;
-        //indices need to be identified by stackframe
-        let indexIdObj = { astId: indexId, stackframe: currentDepth };
-        let fullIndexId = stableKeccak256(indexIdObj);
-
-        const indexReference = (currentAssignments.byId[fullIndexId] || {}).ref;
-
-        if (DecodeUtils.Definition.isSimpleConstant(indexDefinition)) {
-          //while the main case is the next one, where we look for a prior
-          //assignment, we need this case (and need it first) for two reasons:
-          //1. some constant expressions (specifically, string and hex literals)
-          //aren't sourcemapped to and so won't have a prior assignment
-          //2. if the key type is bytesN but the expression is constant, the
-          //value will go on the stack *left*-padded instead of right-padded,
-          //so looking for a prior assignment will read the wrong value.
-          //so instead it's preferable to use the constant directly.
-          debug("about to decode simple literal");
-          indexValue = yield* decode(keyDefinition, {
-            definition: indexDefinition
-          });
-        } else if (indexReference) {
-          //if a prior assignment is found
-          let splicedDefinition;
-          //in general, we want to decode using the key definition, not the index
-          //definition. however, the key definition may have the wrong location
-          //on it.  so, when applicable, we splice the index definition location
-          //onto the key definition location.
-          if (DecodeUtils.Definition.isReference(indexDefinition)) {
-            splicedDefinition = DecodeUtils.Definition.spliceLocation(
-              keyDefinition,
-              DecodeUtils.Definition.referenceType(indexDefinition)
-            );
-            //we could put code here to add on the "_ptr" ending when absent,
-            //but we presently ignore that ending, so we'll skip that
-          } else {
-            splicedDefinition = keyDefinition;
-          }
-          debug("about to decode");
-          indexValue = yield* decode(splicedDefinition, indexReference);
-        } else if (
-          indexDefinition.referencedDeclaration &&
-          scopes[indexDefinition.referencedDeclaration]
-        ) {
-          //there's one more reason we might have failed to decode it: it might be a
-          //constant state variable.  Unfortunately, we don't know how to decode all
-          //those at the moment, but we can handle the ones we do know how to decode.
-          //In the future hopefully we will decode all of them
-          debug(
-            "referencedDeclaration %d",
-            indexDefinition.referencedDeclaration
-          );
-          let indexConstantDeclaration =
-            scopes[indexDefinition.referencedDeclaration].definition;
-          debug("indexConstantDeclaration %O", indexConstantDeclaration);
-          if (indexConstantDeclaration.constant) {
-            let indexConstantDefinition = indexConstantDeclaration.value;
-            //next line filters out constants we don't know how to handle
-            if (
-              DecodeUtils.Definition.isSimpleConstant(indexConstantDefinition)
-            ) {
-              debug("about to decode simple constant");
-              indexValue = yield* decode(keyDefinition, {
-                definition: indexConstantDeclaration.value
-              });
-            } else {
-              indexValue = null; //can't decode; see below for more explanation
-            }
-          } else {
-            indexValue = null; //can't decode; see below for more explanation
-          }
-        }
-        //there's still one more reason we might have failed to decode it:
-        //certain (silent) type conversions aren't sourcemapped either.
-        //(thankfully, any type conversion that actually *does* something seems
-        //to be sourcemapped.)  So if we've failed to decode it, we try again
-        //with the argument of the type conversion, if it is one; we leave
-        //indexValue undefined so the loop will continue
-        //(note that this case is last for a reason; if this were earlier, it
-        //would catch *non*-silent type conversions, which we want to just read
-        //off the stack)
-        else if (indexDefinition.kind === "typeConversion") {
-          indexDefinition = indexDefinition.arguments[0];
-        }
-        //...also prior to 0.5.0, unary + was legal, which needs to be accounted
-        //for for the same reason
-        else if (
-          indexDefinition.nodeType === "UnaryOperation" &&
-          indexDefinition.operator === "+"
-        ) {
-          indexDefinition = indexDefinition.subExpression;
-        }
-        //otherwise, we've just totally failed to decode it, so we mark
-        //indexValue as null (as distinct from undefined) to indicate this.  In
-        //the future, we should be able to decode all mapping keys, but we're
-        //not quite there yet, sorry (because we can't yet handle all constant
-        //state variables)
-        else {
-          indexValue = null;
-        }
-        //now, as mentioned, retry in the typeConversion case
-      }
-
-      //end subsection: key decoding
+      //now... the decoding! (this is messy)
+      let indexValue = yield* decodeMappingKeySaga(
+        node.indexExpression,
+        keyDefinition
+      );
 
       debug("index value %O", indexValue);
       debug("keyDefinition %o", keyDefinition);
@@ -474,7 +366,7 @@ function* variablesAndMappingsSaga() {
       //OK, not an actual path -- we're just going to use a simple offset for
       //the path.  But that's OK, because the mappedPaths reducer will turn
       //it into an actual path.
-      if (indexValue !== null) {
+      if (indexValue != null) {
         path = fetchBasePath(
           baseExpression,
           mappedPaths,
@@ -597,6 +489,113 @@ function* variablesAndMappingsSaga() {
       };
       yield put(actions.assign(assignments));
       break;
+  }
+}
+
+function* decodeMappingKeySaga(indexDefinition, keyDefinition) {
+  let scopes = yield select(data.views.scopes.inlined);
+  let currentAssignments = yield select(data.proc.assignments);
+  let currentDepth = yield select(data.current.functionDepth);
+
+  //why the loop? see the end of the block it heads for an explanatory
+  //comment
+  while (true) {
+    let indexId = indexDefinition.id;
+    //indices need to be identified by stackframe
+    let indexIdObj = { astId: indexId, stackframe: currentDepth };
+    let fullIndexId = stableKeccak256(indexIdObj);
+
+    const indexReference = (currentAssignments.byId[fullIndexId] || {}).ref;
+
+    if (DecodeUtils.Definition.isSimpleConstant(indexDefinition)) {
+      //while the main case is the next one, where we look for a prior
+      //assignment, we need this case (and need it first) for two reasons:
+      //1. some constant expressions (specifically, string and hex literals)
+      //aren't sourcemapped to and so won't have a prior assignment
+      //2. if the key type is bytesN but the expression is constant, the
+      //value will go on the stack *left*-padded instead of right-padded,
+      //so looking for a prior assignment will read the wrong value.
+      //so instead it's preferable to use the constant directly.
+      debug("about to decode simple literal");
+      return yield* decode(keyDefinition, {
+        definition: indexDefinition
+      });
+    } else if (indexReference) {
+      //if a prior assignment is found
+      let splicedDefinition;
+      //in general, we want to decode using the key definition, not the index
+      //definition. however, the key definition may have the wrong location
+      //on it.  so, when applicable, we splice the index definition location
+      //onto the key definition location.
+      if (DecodeUtils.Definition.isReference(indexDefinition)) {
+        splicedDefinition = DecodeUtils.Definition.spliceLocation(
+          keyDefinition,
+          DecodeUtils.Definition.referenceType(indexDefinition)
+        );
+        //we could put code here to add on the "_ptr" ending when absent,
+        //but we presently ignore that ending, so we'll skip that
+      } else {
+        splicedDefinition = keyDefinition;
+      }
+      debug("about to decode");
+      return yield* decode(splicedDefinition, indexReference);
+    } else if (
+      indexDefinition.referencedDeclaration &&
+      scopes[indexDefinition.referencedDeclaration]
+    ) {
+      //there's one more reason we might have failed to decode it: it might be a
+      //constant state variable.  Unfortunately, we don't know how to decode all
+      //those at the moment, but we can handle the ones we do know how to decode.
+      //In the future hopefully we will decode all of them
+      debug("referencedDeclaration %d", indexDefinition.referencedDeclaration);
+      let indexConstantDeclaration =
+        scopes[indexDefinition.referencedDeclaration].definition;
+      debug("indexConstantDeclaration %O", indexConstantDeclaration);
+      if (indexConstantDeclaration.constant) {
+        let indexConstantDefinition = indexConstantDeclaration.value;
+        //next line filters out constants we don't know how to handle
+        if (DecodeUtils.Definition.isSimpleConstant(indexConstantDefinition)) {
+          debug("about to decode simple constant");
+          return yield* decode(keyDefinition, {
+            definition: indexConstantDeclaration.value
+          });
+        } else {
+          return null; //can't decode; see below for more explanation
+        }
+      } else {
+        return null; //can't decode; see below for more explanation
+      }
+    }
+    //there's still one more reason we might have failed to decode it:
+    //certain (silent) type conversions aren't sourcemapped either.
+    //(thankfully, any type conversion that actually *does* something seems
+    //to be sourcemapped.)  So if we've failed to decode it, we try again
+    //with the argument of the type conversion, if it is one; we leave
+    //indexValue undefined so the loop will continue
+    //(note that this case is last for a reason; if this were earlier, it
+    //would catch *non*-silent type conversions, which we want to just read
+    //off the stack)
+    else if (indexDefinition.kind === "typeConversion") {
+      indexDefinition = indexDefinition.arguments[0];
+    }
+    //...also prior to 0.5.0, unary + was legal, which needs to be accounted
+    //for for the same reason
+    else if (
+      indexDefinition.nodeType === "UnaryOperation" &&
+      indexDefinition.operator === "+"
+    ) {
+      indexDefinition = indexDefinition.subExpression;
+    }
+    //otherwise, we've just totally failed to decode it, so we mark
+    //indexValue as null (as distinct from undefined) to indicate this.  In
+    //the future, we should be able to decode all mapping keys, but we're
+    //not quite there yet, sorry (because we can't yet handle all constant
+    //state variables)
+    else {
+      return null;
+    }
+    //now, as mentioned, retry in the typeConversion case
+    //(or unary + case)
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8977,6 +8977,11 @@ lodash@4.17.11, lodash@^4.1.0, lodash@^4.11.2, lodash@^4.14.0, lodash@^4.15.0, l
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
+lodash@^4.17.13:
+  version "4.17.14"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
+  integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
+
 log-driver@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.7.tgz#63b95021f0702fedfa2c9bb0a24e7797d71871d8"


### PR DESCRIPTION
The main data saga is a monster, and the most monstrous part of it is almost certainly the decoding of mapping keys.  This should have been factored out into its own saga long ago.  Actually, I tried a while back, but for some reason it didn't work -- presumably I didn't yet sufficiently understand generators and invoked it wrong as a result.  Anyway, now I factored it out for real.  The main data saga is still a monster, mind you, but at least it's less of one.

As long as I was doing this on a branch off of `develop` rather than `next`, I thought about changing the fact that on `develop` malformed UTF-8 just decodes to `null`, and using replacement characters instead.  However I realized that due to the information loss such decoded strings would actually fail to work as mapping keys, which I think is a worse outcome than them just failing to decode.  (Anyway we'll probably be merging in `next` before too long.)

Also I thought about rewriting the decoding loop so as not to use a `while(true)`, because that doesn't really tell you anything, but... hell with it.  I can leave writing a clearer loop for a later time.  In the meantime, of course, my long explanatory comments remain.