### PR TITLE
Factor out wire decoder from contract decoder

### DIFF
--- a/packages/truffle-codec-utils/src/contexts.ts
+++ b/packages/truffle-codec-utils/src/contexts.ts
@@ -12,7 +12,7 @@ import { CompilerVersion } from "./compiler";
 
 export namespace Contexts {
 
-  export type Contexts = DecoderContexts | DebuggerContexts;
+  export type Contexts = DecoderContexts | DebuggerContexts | DecoderContextsById;
 
   export type Context = DecoderContext | DebuggerContext;
 

--- a/packages/truffle-decoder/lib/index.ts
+++ b/packages/truffle-decoder/lib/index.ts
@@ -7,7 +7,10 @@ import { Provider } from "web3/providers";
 import { ContractObject } from "truffle-contract-schema/spec";
 
 export async function forContract(contract: ContractObject, relevantContracts: ContractObject[], provider: Provider, address?: string): Promise<TruffleContractDecoder> {
-  let wireDecoder = new TruffleWireDecoder([contract, ...relevantContracts], provider);
+  let contracts = relevantContracts.includes(contract)
+    ? relevantContracts
+    : [contract, ...relevantContracts];
+  let wireDecoder = new TruffleWireDecoder(contracts, provider);
   let contractDecoder = new TruffleContractDecoder(contract, wireDecoder, address);
   await contractDecoder.init();
   return contractDecoder;

--- a/packages/truffle-decoder/lib/index.ts
+++ b/packages/truffle-decoder/lib/index.ts
@@ -7,13 +7,18 @@ import { Provider } from "web3/providers";
 import { ContractObject } from "truffle-contract-schema/spec";
 
 export async function forContract(contract: ContractObject, relevantContracts: ContractObject[], provider: Provider, address?: string): Promise<TruffleContractDecoder> {
-  let decoder = new TruffleContractDecoder(contract, relevantContracts, provider, address);
-  await decoder.init();
-  return decoder;
+  let wireDecoder = new TruffleWireDecoder([contract, ...relevantContracts], provider);
+  let contractDecoder = new TruffleContractDecoder(contract, wireDecoder, address);
+  await contractDecoder.init();
+  return contractDecoder;
 }
 
 export async function forProject(contracts: ContractObject[], provider: Provider): Promise<TruffleWireDecoder> {
-  let decoder = new TruffleWireDecoder(contracts, provider);
-  await decoder.init();
-  return decoder;
+  return new TruffleWireDecoder(contracts, provider);
+}
+
+export async function forContractWithDecoder(contract: ContractObject, decoder: TruffleWireDecoder, address?: string): Promise<TruffleContractDecoder> {
+  let contractDecoder = new TruffleContractDecoder(contract, decoder, address);
+  await contractDecoder.init();
+  return contractDecoder;
 }


### PR DESCRIPTION
This PR factors out the wire-decoder functions from the contract decoder, in order to reduce the amount of copypasted code.  In the process, I made a few minor improvements/fixes as well.

Rather than having `TruffleContractDecoder` extend `TruffleWireDecoder`, I took @gnidan's advice and had it contain one internally instead.  This way, multiple contract decoders can be made from the same wire decoder, without having to recompute ABI allocations, etc.  Basically this is potentially useful if you want to have contract decoders for multiple contracts in the same project.

The contract decoder now just delegates to the wire decoder for all wire-decoding functions; its only major function still handled internally is decoding contract state.  This also means the wire-decoding functions no longer have the restrictions I placed on them earlier -- they have the full power of the wire decoder.  (Also I realized such restrictions don't really make sense because, say, one contract can cause another to emit an event.)

The `events` method does make one change before delegating to the wire decoder -- it (by default) sets the `address` option to the contract's address.  However the user can override this, including by passing in `address: undefined` to turn off filtering by address.

The contract now also delegates much of the setup to the wire decoder -- the wire decoder now has functions to extract the info that the contract decoder will need.  Unfortunately, since the contract decoder doesn't extend the wire decoder, these have to be made public -- TypeScript doesn't have an access modifier to restrict access to the same package, like C# or Java -- but I've at least put a comment marking these functions as intended for internal use only.

The file `index.ts` now contains three functions:

1. `forProject`, which makes a wire decoder;

2. `forContract`, which makes a contract decoder just as before;

3. `forContractWithDecoder`, which makes a contract decoder, but takes a `TruffleWireDecoder` instead of a provider and array of `relevantContracts`.

Of these, (1) works just like before (except that I've eliminated `TruffleWireDecoder`'s `init` function and just moved that code into the constructor; there's no real reason for it to have a separate `init` function).  Number (3) is new, and works by just invoking the `TruffleContractDecoder` constructor, which has been changed to now take arguments in the form of (3).  (Well, and then waiting for `init()`, of course.)

Number (2), therefore, now works a little differently.  First, it makes a list of all contracts passed in -- i.e., it takes `relevantContracts` and (if it's not already there) prepends `contract` to it.  Then it creates a `TruffleWireDecoder` with the given `provider` and the just-constructed list of contracts.  Then it creates a `TruffleContractDecoder` from that (with the given `contract` and, if supplied, `address`).

Other minor changes: The decoder now excludes contracts with empty bytecode (`0x`) when setting up contexts.  Also, as with the wire-decoder, I moved into the constructor all the setup that doesn't need to be `async`; only the async stuff remains in `init`.  (Edit: Getting rid of `init` in the wire-decoder actually now seems foolish to me due to future stuff I have planned but  didn't think of that... oh well -- leaving it how it is for now; I can move it back in the future, that's easy enough.)

Actually, it's not clear that all of the contexts stuff that I included needs to actually be there -- some of it is unused at the moment -- but I decided to leave it alone as I'm planning on possibly redoing that soon, so I figured it's not worth it to change it right now.

Thought for the future: This was a good thing to do but I think we should go even further in this direction, honestly.  Why is the contract decoder restricted to a single address?  Like, you've got to make a whole new contract decoder, redo allocation and all, if you've got multiple instances of the same contract?  That seems silly.  Seems to me we ought to have some new sort of decoder class, one that works for a contract *class*, not a contract *instance*.  Alternatively, turn the `WireDecoder` into a full-blown `ProjectDecoder`, and have it decode state as well.  Do all allocations upfront and have it recognize contract class by the bytecode.  Although you'd still want something like the `ContractDecoder` for when you don't have the bytecode available, I guess.  Anyway, just idle thoughts; certainly not doing that in this PR, which is basically just some factoring.