### PR TITLE
Make out-of-range enums not an error; put "AsBN" on state output

### DIFF
--- a/packages/truffle-codec-utils/src/conversion.ts
+++ b/packages/truffle-codec-utils/src/conversion.ts
@@ -209,6 +209,7 @@ export namespace Conversion {
             ([key, value]) => ({[key]: nativize(value)})
         ));
       case "enum":
+        //note: if it's out of range, this will just be undefined
         return enumFullName(<Values.EnumValue>result);
       case "contract": {
         let coercedResult = <Values.ContractValue> result;

--- a/packages/truffle-codec-utils/src/types/errors.ts
+++ b/packages/truffle-codec-utils/src/types/errors.ts
@@ -232,18 +232,12 @@ export namespace Errors {
     error: GenericError | EnumError;
   }
 
-  export type EnumError = EnumPaddingError | EnumOutOfRangeError | EnumNotFoundDecodingError;
+  export type EnumError = EnumPaddingError | EnumNotFoundDecodingError;
 
   export interface EnumPaddingError {
     kind: "EnumPaddingError";
     type: Types.EnumType;
     raw: string; //should be hex string
-  }
-
-  export interface EnumOutOfRangeError {
-    kind: "EnumOutOfRangeError";
-    type: Types.EnumType;
-    rawAsBN: BN;
   }
 
   export interface EnumNotFoundDecodingError {

--- a/packages/truffle-codec-utils/src/types/values.ts
+++ b/packages/truffle-codec-utils/src/types/values.ts
@@ -244,11 +244,21 @@ export namespace Values {
   export interface EnumValue {
     type: Types.EnumType;
     kind: "value";
-    value: {
-      name: string;
-      numericAsBN: BN;
-    };
+    value: EnumValueInfo;
   };
+
+  export type EnumValueInfo = EnumValueInfoValid | EnumValueInfoInvalid;
+
+  export interface EnumValueInfoValid {
+    kind: "valid";
+    name: string;
+    numericAsBN: BN;
+  }
+
+  export interface EnumValueInfoInvalid {
+    kind: "invalid";
+    numericAsBN: BN;
+  }
 
   /*
    * SECTION 5: CONTRACTS

--- a/packages/truffle-codec/lib/decode/value.ts
+++ b/packages/truffle-codec/lib/decode/value.ts
@@ -320,24 +320,20 @@ export default function* decodeValue(dataType: Types.Type, pointer: DataPointer,
           type: fullType,
           kind: "value",
           value: {
+            kind: "valid",
             name,
             numericAsBN: numeric
           }
         };
       }
       else {
-        let error = {
-          kind: "EnumOutOfRangeError" as "EnumOutOfRangeError",
-          type: fullType,
-          rawAsBN: numeric
-        };
-        if(strict) {
-          throw new StopDecodingError(error);
-        }
         return {
           type: fullType,
-          kind: "error",
-          error
+          kind: "value",
+          value: {
+            kind: "invalid",
+            numericAsBN: numeric
+          }
         };
       }
     }

--- a/packages/truffle-decoder/lib/contract.ts
+++ b/packages/truffle-decoder/lib/contract.ts
@@ -235,8 +235,8 @@ export default class TruffleContractDecoder extends AsyncEventEmitter {
     let result: DecoderTypes.ContractState = {
       name: this.contract.contractName,
       code: this.contractCode,
-      balance: new BN(await this.web3.eth.getBalance(this.contractAddress, blockNumber)),
-      nonce: new BN(await this.web3.eth.getTransactionCount(this.contractAddress, blockNumber)),
+      balanceAsBN: new BN(await this.web3.eth.getBalance(this.contractAddress, blockNumber)),
+      nonceAsBN: new BN(await this.web3.eth.getTransactionCount(this.contractAddress, blockNumber)),
       variables: {}
     };
 

--- a/packages/truffle-decoder/lib/types.ts
+++ b/packages/truffle-decoder/lib/types.ts
@@ -7,8 +7,8 @@ import { Log } from "web3/types";
 
 export interface ContractState {
   name: string;
-  balance: BN;
-  nonce: BN;
+  balanceAsBN: BN;
+  nonceAsBN: BN;
   code: string;
   variables: {
     [name: string]: Values.Result


### PR DESCRIPTION
OK, I decided to make out-of-range enums not an error after all.  I'll explain why in a moment.  Also, I realized that for consistency, the fields in `state` that are `BN`'s should have `AsBN` in their field name, which is unrelated but I decided to toss it in there.

Anyway, the reason I changed this isn't actually for decoding now, but for encoding later.  Or rather, for wrapping.  I thought it would be confusing if the wrapping-procedure *would* let you wrap an out-of-range value as an enum if it only has ABI information, but wouldn't if it has full definition information.  This might lead to people going, how do I force ABI-only encoding mode so this will work?  Etc.  I don't want to deal with that, so I made out-of-range no longer an error.

Basically, things get confusing if a type acts too differently -- in particular, has a different set of legal encodings -- from its underlying ABI type (when such a thing exists).  So I decided to make it line up.

Note that padding errors are still errors, though, because, well, the above gives no reason to make them not errors.