### PR TITLE
Emit method information for truffle-contract operations

### DIFF
--- a/packages/truffle-contract/lib/execute.js
+++ b/packages/truffle-contract/lib/execute.js
@@ -170,6 +170,12 @@ var execute = {
           params.to = address;
           params.data = fn ? fn(...args).encodeABI() : undefined;
 
+          promiEvent.eventEmitter.emit("execute:send:method", {
+            abi: methodABI,
+            args: args,
+            contract: constructor
+          });
+
           try {
             params.gas = await execute.getGasEstimate.call(
               constructor,


### PR DESCRIPTION
Part of #2211 

Adds syntax to listen for method names and arguments.

Example syntax:
```javascript
const instance = await MyContract.deployed();
instance.myMethod().on("execute:send:method", ({ fn, abi, args, contract, address }) => {
  // access the abi item information, the arguments used, etc.
}
```

Note: this does not appear to directly conflict with #2035, but there may be reconciliation required later, once truffle-contract is instrumented for the event system.