### PR TITLE
Build mocha hook integration for truffle-debugger

### DIFF
--- a/packages/truffle-core/lib/debug/mocha.js
+++ b/packages/truffle-core/lib/debug/mocha.js
@@ -1,0 +1,71 @@
+const { CLIDebugger } = require("./cli");
+
+class CLIDebugHook {
+  constructor(config, runner) {
+    this.config = config;
+    this.runner = runner; // mocha runner (**not** lib/test/testrunner)
+  }
+
+  async debug(operation) {
+    // turn off timeouts for the current runnable
+    // HACK we don't turn it back on because it doesn't work...
+    // tests that take a long time _after_ debug break just won't timeout
+    this.disableTimeout();
+
+    const {
+      txHash,
+      result,
+      method: {
+        abi: { name: methodName },
+        args,
+        contract: { contractName }
+      }
+    } = await this.invoke(operation);
+
+
+    this.config.logger.log("");
+    const interpreter = await new CLIDebugger(this.config).run(txHash);
+    await interpreter.start();
+    this.config.logger.log("");
+
+    return result;
+  }
+
+  disableTimeout() {
+    this.runner.currentRunnable.timeout(0);
+  }
+
+  async invoke(operation) {
+    const method = await this.detectMethod(operation);
+    const { action } = method;
+
+    switch (action) {
+      case "send": {
+        const result = await operation;
+        const { tx: txHash } = result;
+
+        return { txHash, method, result };
+      }
+      default: {
+        throw new Error(`Unsupported action for debugging: ${action}`);
+      }
+    }
+  }
+
+  detectMethod(promiEvent) {
+    return new Promise(accept => {
+      promiEvent.on("execute:send:method", ({ abi, args, contract }) => {
+        accept({
+          abi,
+          args,
+          contract,
+          action: "send"
+        });
+      });
+    });
+  }
+}
+
+module.exports = {
+  CLIDebugHook
+};

--- a/packages/truffle-core/lib/debug/mocha.js
+++ b/packages/truffle-core/lib/debug/mocha.js
@@ -6,8 +6,9 @@ const execute = require("truffle-contract/lib/execute");
 const { DebugPrinter } = require("./printer");
 
 class CLIDebugHook {
-  constructor(config, runner) {
+  constructor(config, compilation, runner) {
     this.config = config;
+    this.compilation = compilation;
     this.runner = runner; // mocha runner (**not** lib/test/testrunner)
   }
 
@@ -29,13 +30,17 @@ class CLIDebugHook {
 
     this.printStartTestHook({ contractName, methodName, args });
 
-    const interpreter = await new CLIDebugger(this.config).run(txHash);
+    const interpreter = await new CLIDebugger(this.config, {
+      compilation: this.compilation
+    }).run(txHash);
     await interpreter.start();
 
     this.printStopTestHook(operation.method);
 
     return result;
   }
+
+  async start() {}
 
   disableTimeout() {
     this.runner.currentRunnable.timeout(0);

--- a/packages/truffle-core/lib/debug/mocha.js
+++ b/packages/truffle-core/lib/debug/mocha.js
@@ -3,7 +3,6 @@ const util = require("util");
 
 const { CLIDebugger } = require("./cli");
 const execute = require("truffle-contract/lib/execute");
-const { DebugPrinter } = require("./printer");
 
 class CLIDebugHook {
   constructor(config, compilation, runner) {
@@ -18,17 +17,9 @@ class CLIDebugHook {
     // tests that take a long time _after_ debug break just won't timeout
     this.disableTimeout();
 
-    const {
-      txHash,
-      result,
-      method: {
-        abi: { name: methodName },
-        args,
-        contract: { contractName }
-      }
-    } = await this.invoke(operation);
+    const { txHash, result, method } = await this.invoke(operation);
 
-    this.printStartTestHook({ contractName, methodName, args });
+    this.printStartTestHook(method);
 
     const interpreter = await new CLIDebugger(this.config, {
       compilation: this.compilation
@@ -51,18 +42,29 @@ class CLIDebugHook {
     const { action } = method;
 
     switch (action) {
+      case "deploy": {
+        const result = await operation;
+
+        return {
+          txHash: result.transactionHash, // different name; who knew
+          method,
+          result
+        };
+      }
       case "send": {
         const result = await operation;
 
         return { txHash: result.tx, method, result };
       }
       case "call": {
+        // replays as send
         const { contract, fn, abi, args, address } = method;
 
         // get the result of the call
         const result = await operation;
 
         // and replay it as a transaction so we can debug
+        // bit of a HACK: properly making a call act like a tx requires forking
         const { tx: txHash } = await execute.send.call(
           contract,
           fn,
@@ -80,7 +82,7 @@ class CLIDebugHook {
 
   detectMethod(promiEvent) {
     return new Promise(accept => {
-      for (let action of ["send", "call"]) {
+      for (let action of ["send", "call", "deploy"]) {
         promiEvent.on(
           `execute:${action}:method`,
           ({ fn, abi, args, contract, address }) => {
@@ -98,11 +100,27 @@ class CLIDebugHook {
     });
   }
 
-  printStartTestHook({ contractName, methodName, args }) {
-    const formatOperation = (contractName, methodName, args) =>
-      colors.bold(
-        `${contractName}.${methodName}(${args.map(util.inspect).join(", ")})`
-      );
+  printStartTestHook(method) {
+    const formatOperation = ({
+      action,
+      contract: { contractName },
+      abi,
+      args
+    }) => {
+      switch (action) {
+        case "deploy": {
+          return colors.bold(
+            `${contractName}.new(${args.map(util.inspect).join(", ")})`
+          );
+        }
+        case "call":
+        case "send": {
+          return colors.bold(
+            `${contractName}.${abi.name}(${args.map(util.inspect).join(", ")})`
+          );
+        }
+      }
+    };
 
     this.config.logger.log("");
     this.config.logger.log("  ...");
@@ -112,9 +130,7 @@ class CLIDebugHook {
       )
     );
     this.config.logger.log("  Test run interrupted.");
-    this.config.logger.log(
-      `  Debugging ${formatOperation(contractName, methodName, args)}`
-    );
+    this.config.logger.log(`  Debugging ${formatOperation(method)}`);
     this.config.logger.log(
       colors.cyan(
         ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"

--- a/packages/truffle-core/lib/debug/mocha.js
+++ b/packages/truffle-core/lib/debug/mocha.js
@@ -26,7 +26,7 @@ class CLIDebugHook {
     }).run(txHash);
     await interpreter.start();
 
-    this.printStopTestHook(operation.method);
+    this.printStopTestHook();
 
     return result;
   }

--- a/packages/truffle-core/lib/debug/mocha.js
+++ b/packages/truffle-core/lib/debug/mocha.js
@@ -1,5 +1,9 @@
+const colors = require("colors");
+const util = require("util");
+
 const { CLIDebugger } = require("./cli");
 const execute = require("truffle-contract/lib/execute");
+const { DebugPrinter } = require("./printer");
 
 class CLIDebugHook {
   constructor(config, runner) {
@@ -23,11 +27,12 @@ class CLIDebugHook {
       }
     } = await this.invoke(operation);
 
+    this.printStartTestHook({ contractName, methodName, args });
 
-    this.config.logger.log("");
     const interpreter = await new CLIDebugger(this.config).run(txHash);
     await interpreter.start();
-    this.config.logger.log("");
+
+    this.printStopTestHook(operation.method);
 
     return result;
   }
@@ -86,6 +91,49 @@ class CLIDebugHook {
         );
       }
     });
+  }
+
+  printStartTestHook({ contractName, methodName, args }) {
+    const formatOperation = (contractName, methodName, args) =>
+      colors.bold(
+        `${contractName}.${methodName}(${args.map(util.inspect).join(", ")})`
+      );
+
+    this.config.logger.log("");
+    this.config.logger.log("  ...");
+    this.config.logger.log(
+      colors.cyan(
+        ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+      )
+    );
+    this.config.logger.log("  Test run interrupted.");
+    this.config.logger.log(
+      `  Debugging ${formatOperation(contractName, methodName, args)}`
+    );
+    this.config.logger.log(
+      colors.cyan(
+        ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+      )
+    );
+    this.config.logger.log("");
+  }
+
+  printStopTestHook() {
+    this.config.logger.log("");
+    this.config.logger.log("");
+    this.config.logger.log(
+      colors.cyan(
+        "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
+      )
+    );
+    this.config.logger.log("  Debugger stopped. Test resuming");
+    this.config.logger.log(
+      colors.cyan(
+        "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
+      )
+    );
+    this.config.logger.log("  ...");
+    this.config.logger.log("");
   }
 }
 


### PR DESCRIPTION
Builds on #2251 #2073 #2255 #2260 

This defines the class `CLIDebugHook`, intended for use inside Mocha, to provide an interactive CLI debugger via test global interrupt.

- Define CLIDebugHook to wrap CLIDebugger
- Use #2251 work to capture transaction info for send, or to replay calls as tx