### PR TITLE
Provide in-test debugging interrupts for Solidity inside JS tests

### DIFF
--- a/packages/truffle-core/lib/commands/test.js
+++ b/packages/truffle-core/lib/commands/test.js
@@ -6,11 +6,20 @@ const command = {
       describe: "Show all test logs",
       type: "boolean",
       default: false
+    },
+    "debug": {
+      describe: "Enable in-test debugging",
+      type: "boolean",
+      default: false
+    },
+    "debug-global": {
+      describe: "Specify debug global function name",
+      default: "debug"
     }
   },
   help: {
     usage:
-      "truffle test [<test_file>] [--compile-all] [--network <name>] [--verbose-rpc] [--show-events]",
+      "truffle test [<test_file>] [--compile-all] [--network <name>] [--verbose-rpc] [--show-events] [--debug] [--debug-global <identifier>]",
     options: [
       {
         option: "<test_file>",
@@ -38,6 +47,17 @@ const command = {
       {
         option: "--show-events",
         description: "Log all contract events."
+      },
+      {
+        option: "--debug",
+        description:
+          "Provides global debug() function for in-test debugging. " +
+          "JS tests only; implies --compile-all."
+      },
+      {
+        option: "--debug-global <identifier>",
+        description:
+          'Specify global identifier for debug function. Default: "debug"'
       }
     ]
   },
@@ -66,8 +86,14 @@ const command = {
       Environment.detect(config).catch(done);
     }
 
-    let ipcDisconnect;
-    let files = [];
+    // enables in-test debug() interrupt, forcing compileAll
+    if (config.debug) {
+      config.compileAll = true;
+    }
+
+    var ipcDisconnect;
+
+    var files = [];
 
     if (options.file) {
       files = [options.file];

--- a/packages/truffle-core/lib/commands/test.js
+++ b/packages/truffle-core/lib/commands/test.js
@@ -91,9 +91,9 @@ const command = {
       config.compileAll = true;
     }
 
-    var ipcDisconnect;
+    let ipcDisconnect;
 
-    var files = [];
+    let files = [];
 
     if (options.file) {
       files = [options.file];

--- a/packages/truffle-core/lib/debug/interpreter.js
+++ b/packages/truffle-core/lib/debug/interpreter.js
@@ -236,6 +236,7 @@ class DebugInterpreter {
   }
 
   start(terminate) {
+    // if terminate is not passed, return a Promise instead
     if (terminate === undefined) {
       return util.promisify(this.start.bind(this))();
     }

--- a/packages/truffle-core/lib/test.js
+++ b/packages/truffle-core/lib/test.js
@@ -105,13 +105,13 @@ const Test = {
       runner
     );
 
-    await this.setJSTestGlobals(
+    await this.setJSTestGlobals({
       config,
       web3,
       accounts,
       testResolver,
       runner
-    );
+    });
 
     // Finally, run mocha.
     process.on("unhandledRejection", reason => {
@@ -196,7 +196,13 @@ const Test = {
     });
   },
 
-  setJSTestGlobals: function(config, web3, accounts, testResolver, runner) {
+  setJSTestGlobals: function({
+    config,
+    web3,
+    accounts,
+    testResolver,
+    runner
+  }) {
     return new Promise(function(accept) {
       global.web3 = web3;
       global.assert = chai.assert;

--- a/packages/truffle-core/lib/test.js
+++ b/packages/truffle-core/lib/test.js
@@ -119,7 +119,7 @@ const Test = {
     });
 
     return new Promise(resolve => {
-      mocha.run(failures => {
+      this.mochaRunner = mocha.run(failures => {
         config.logger.warn = warn;
 
         resolve(failures);
@@ -203,12 +203,18 @@ const Test = {
     testResolver,
     runner
   }) {
-    return new Promise(function(accept) {
+    return new Promise(accept => {
       global.web3 = web3;
       global.assert = chai.assert;
       global.expect = chai.expect;
       global.artifacts = {
         require: import_path => testResolver.require(import_path)
+      };
+      global.__debug = async (...args) => {
+        // wrapped inside function so as not to load debugger on every test
+        const { CLIDebugHook } = require("./debug/mocha");
+
+        return await new CLIDebugHook(config, this.mochaRunner).debug(...args);
       };
 
       const template = function(tests) {

--- a/packages/truffle-core/lib/test.js
+++ b/packages/truffle-core/lib/test.js
@@ -228,6 +228,8 @@ const Test = {
         // wrapped inside function so as not to load debugger on every test
         const { CLIDebugHook } = require("./debug/mocha");
 
+        // note: this.mochaRunner will be available by the time debug()
+        // is invoked
         const hook = new CLIDebugHook(config, compilation, this.mochaRunner);
 
         return await hook.debug(operation);

--- a/packages/truffle-core/lib/test.js
+++ b/packages/truffle-core/lib/test.js
@@ -105,7 +105,13 @@ const Test = {
       runner
     );
 
-    await this.setJSTestGlobals(web3, accounts, testResolver, runner);
+    await this.setJSTestGlobals(
+      config,
+      web3,
+      accounts,
+      testResolver,
+      runner
+    );
 
     // Finally, run mocha.
     process.on("unhandledRejection", reason => {
@@ -190,7 +196,7 @@ const Test = {
     });
   },
 
-  setJSTestGlobals: function(web3, accounts, testResolver, runner) {
+  setJSTestGlobals: function(config, web3, accounts, testResolver, runner) {
     return new Promise(function(accept) {
       global.web3 = web3;
       global.assert = chai.assert;


### PR DESCRIPTION
#2206 #2205 

Builds on #2252 #2254. Replaces #2050.

- Add `truffle test --debug` flag, to enable in-test debugging mode
- Add `debug()` global for use in JS tests, to indicate breakpoint for Solidity debugging