### PR TITLE
Switch `truffle test` to use new compile interface

### DIFF
--- a/packages/truffle-core/lib/test.js
+++ b/packages/truffle-core/lib/test.js
@@ -156,7 +156,7 @@ const Test = {
       all: config.compileAll === true,
       files: updated.concat(solidityTestFiles),
       resolver: testResolver,
-      quiet: false,
+      quiet: config.quiet,
       quietWrite: true
     });
 

--- a/packages/truffle-core/lib/test.js
+++ b/packages/truffle-core/lib/test.js
@@ -2,7 +2,6 @@ const Mocha = require("mocha");
 const chai = require("chai");
 const path = require("path");
 const Web3 = require("web3");
-const { promisify } = require("util");
 const Config = require("truffle-config");
 const Contracts = require("truffle-workflow-compile/new");
 const Resolver = require("truffle-resolver");
@@ -151,9 +150,7 @@ const Test = {
     testResolver
   ) {
     const updated =
-      (await promisify(Profiler.updated)(
-        config.with({ resolver: testResolver })
-      )) || [];
+      (await Profiler.updated(config.with({ resolver: testResolver }))) || [];
 
     const compileConfig = config.with({
       all: config.compileAll === true,

--- a/packages/truffle-core/lib/test.js
+++ b/packages/truffle-core/lib/test.js
@@ -2,8 +2,9 @@ const Mocha = require("mocha");
 const chai = require("chai");
 const path = require("path");
 const Web3 = require("web3");
+const { promisify } = require("util");
 const Config = require("truffle-config");
-const Contracts = require("truffle-workflow-compile");
+const Contracts = require("truffle-workflow-compile/new");
 const Resolver = require("truffle-resolver");
 const TestRunner = require("./testing/testrunner");
 const TestResolver = require("./testing/testresolver");
@@ -84,7 +85,7 @@ const Test = {
     );
     testResolver.cache_on = false;
 
-    const dependencyPaths = await this.compileContractsWithTestFilesIfNeeded(
+    const { compilations } = await this.compileContractsWithTestFilesIfNeeded(
       solTests,
       config,
       testResolver
@@ -101,7 +102,7 @@ const Test = {
     await this.defineSolidityTests(
       mocha,
       testContracts,
-      dependencyPaths,
+      compilations.solc.sourceIndexes,
       runner
     );
 
@@ -144,36 +145,33 @@ const Test = {
     return web3.eth.getAccounts();
   },
 
-  compileContractsWithTestFilesIfNeeded: function(
+  compileContractsWithTestFilesIfNeeded: async function(
     solidityTestFiles,
     config,
     testResolver
   ) {
-    return new Promise(function(accept, reject) {
-      Profiler.updated(config.with({ resolver: testResolver }), function(
-        err,
-        updated
-      ) {
-        if (err) return reject(err);
+    const updated =
+      (await promisify(Profiler.updated)(
+        config.with({ resolver: testResolver })
+      )) || [];
 
-        updated = updated || [];
-
-        const compileConfig = config.with({
-          all: config.compileAll === true,
-          files: updated.concat(solidityTestFiles),
-          resolver: testResolver,
-          quiet: config.quiet,
-          quietWrite: true
-        });
-        // Compile project contracts and test contracts
-        Contracts.compile(compileConfig)
-          .then(result => {
-            const paths = result.outputs.solc;
-            accept(paths);
-          })
-          .catch(reject);
-      });
+    const compileConfig = config.with({
+      all: config.compileAll === true,
+      files: updated.concat(solidityTestFiles),
+      resolver: testResolver,
+      quiet: false,
+      quietWrite: true
     });
+
+    // Compile project contracts and test contracts
+    const { contracts, compilations } = await Contracts.compile(compileConfig);
+
+    await Contracts.save(compileConfig, contracts);
+
+    return {
+      contracts,
+      compilations
+    };
   },
 
   performInitialDeploy: function(config, resolver) {


### PR DESCRIPTION
Implements #2211 
Builds on #2073 #2258 

- Use `"truffle-workflow-compile/new"` inside lib/test
- ~~Remove extraneous profiler usage (truffle-workflow-compile does this)~~ turns out this isn't so extraneous
- Capture entire compilation result instead of just dependencyPaths