### PR TITLE
Fix missing underscore dependency

### DIFF
--- a/packages/truffle-interface-adapter/lib/quorum-overloads.ts
+++ b/packages/truffle-interface-adapter/lib/quorum-overloads.ts
@@ -1,7 +1,7 @@
 import BN from "bn.js";
 import { Web3Shim } from "./web3-shim";
 import {AbiCoder as EthersAbi} from 'ethers/utils/abi-coder';
-import _ from "underscore";
+import _ from "lodash";
 
 export const QuorumDefinition = {
   async initNetworkType (web3: Web3Shim) {
@@ -143,7 +143,9 @@ const overrides = {
 
       returnValue[i] = decodedValue;
 
+      // @ts-ignore object not having name key
       if (_.isObject(output) && output.name) {
+        // @ts-ignore object not having name key
         returnValue[output.name] = decodedValue;
       }
 

--- a/packages/truffle-interface-adapter/package.json
+++ b/packages/truffle-interface-adapter/package.json
@@ -20,10 +20,12 @@
   "dependencies": {
     "bn.js": "^4.11.8",
     "ethers": "^4.0.32",
+    "lodash": "^4.17.13",
     "web3": "^1.2.0"
   },
   "devDependencies": {
     "@types/bn.js": "^4.11.4",
+    "@types/lodash": "^4.14.136",
     "@types/mocha": "^5.2.6",
     "@types/web3": "^1.0.18",
     "ganache-core": "2.5.7",


### PR DESCRIPTION
File `quorum-overloads` from `interface-adapter` imported the underscore library, even though it was not declared on the package.json as a dependency. This caused a `require` of the package (or any other package that depended on it) to fail.

Instead of installing underscore, since other truffle packages already use lodash, this commit changes underscore to lodash, and declares it as a dependency on the package.json.