### PR TITLE
Add missing defaults for shimBytecode

### DIFF
--- a/packages/truffle-compile/legacy/shims.js
+++ b/packages/truffle-compile/legacy/shims.js
@@ -47,7 +47,13 @@ function shimContract(contract) {
   };
 }
 
-function shimBytecode({ bytes, linkReferences }) {
+function shimBytecode(bytecode) {
+  if (!bytecode) {
+    return;
+  }
+
+  let { bytes, linkReferences } = bytecode;
+
   linkReferences = linkReferences || [];
 
   // inline link references - start by flattening the offsets

--- a/packages/truffle-compile/test/legacy/shims.js
+++ b/packages/truffle-compile/test/legacy/shims.js
@@ -3,6 +3,10 @@ const { assert } = require("chai");
 const { shimBytecode } = require("truffle-compile/legacy/shims");
 
 describe("shimBytecode", () => {
+  it("handles undefined", function() {
+    assert.equal(shimBytecode(undefined), undefined);
+  });
+
   it("prepends 0x", function() {
     const bytes = "ffffffff";
 


### PR DESCRIPTION
For case where trying to shim bytecodes that are undefined