### PR TITLE
Emit deploy method information in truffle-contract lifecycle

### DIFF
--- a/packages/truffle-contract/lib/contract/constructorMethods.js
+++ b/packages/truffle-contract/lib/contract/constructorMethods.js
@@ -1,4 +1,3 @@
-const Web3PromiEvent = require("web3-core-promievent");
 const Web3Shim = require("truffle-interface-adapter").Web3Shim;
 const utils = require("../utils");
 const execute = require("../execute");
@@ -17,8 +16,6 @@ module.exports = Contract => ({
   },
 
   new() {
-    const promiEvent = new Web3PromiEvent();
-
     utils.checkProvider(this);
 
     if (!this.bytecode || this.bytecode === "0x") {
@@ -31,23 +28,9 @@ module.exports = Contract => ({
       );
     }
 
-    const args = Array.prototype.slice.call(arguments);
+    var constructorABI = this.abi.filter(i => i.type === "constructor")[0];
 
-    // Promievent and flag that allows instance to resolve (rather than just receipt)
-    const context = {
-      contract: this,
-      promiEvent,
-      onlyEmitReceipt: true
-    };
-
-    this.detectNetwork()
-      .then(({ blockLimit }) => {
-        utils.checkLibraries.apply(this);
-        return execute.deploy.call(this, args, context, blockLimit);
-      })
-      .catch(promiEvent.reject);
-
-    return promiEvent.eventEmitter;
+    return execute.deploy.call(this, constructorABI)(...arguments);
   },
 
   async at(address) {

--- a/packages/truffle-contract/lib/execute.js
+++ b/packages/truffle-contract/lib/execute.js
@@ -240,6 +240,12 @@ var execute = {
 
           context.params = params;
 
+          promiEvent.eventEmitter.emit("execute:deploy:method", {
+            args,
+            abi: constructorABI,
+            contract: constructor
+          });
+
           deferred = web3.eth.sendTransaction(params);
           handlers.setup(deferred, context);
 


### PR DESCRIPTION
Required for #2205 
Continues along same reasoning as #2251 

In addition to the existing `execute:send:method` and `execute:call:method`, this adds a new event `execute:deploy:method`.

The purpose here is to allow #2252 and #2253 to also offer the behavior of debugging contract deployments in tests.

**Note** Future work might involve changing the names of these events, perhaps before they end up getting used externally too much.