### PR TITLE
Fix: ensure truffle-resolver/fs only parses json artifacts

### DIFF
--- a/packages/truffle-resolver/fs.js
+++ b/packages/truffle-resolver/fs.js
@@ -31,8 +31,11 @@ class FS {
   }
 
   getContractName(sourcePath, searchPath = this.contractsBuildDirectory) {
-    let filenames = fs.readdirSync(searchPath);
-    filenames = filenames.filter(file => file.match(".json") != null);
+    const contractsBuildDirFiles = fs.readdirSync(searchPath);
+    const filteredBuildArtifacts = contractsBuildDirFiles.filter(
+      file => file.match(".json") != null
+    );
+
     for (let i = 0; i < filenames.length; i++) {
       const filename = filenames[i];
 

--- a/packages/truffle-resolver/fs.js
+++ b/packages/truffle-resolver/fs.js
@@ -9,7 +9,7 @@ class FS {
   }
 
   require(importPath, searchPath = this.contractsBuildDirectory) {
-    const normalizedImportPath = path.normalize(normalizedImportPath);
+    const normalizedImportPath = path.normalize(importPath);
     const contractName = this.getContractName(normalizedImportPath, searchPath);
 
     // If we have an absoulte path, only check the file if it's a child of the workingDirectory.
@@ -36,17 +36,15 @@ class FS {
       file => file.match(".json") != null
     );
 
-    for (let i = 0; i < filenames.length; i++) {
-      const filename = filenames[i];
-
+    filteredBuildArtifacts.forEach(buildArtifact => {
       const artifact = JSON.parse(
-        fs.readFileSync(path.resolve(searchPath, filename))
+        fs.readFileSync(path.resolve(searchPath, buildArtifact))
       );
 
       if (artifact.sourcePath === sourcePath) {
         return artifact.contractName;
       }
-    }
+    });
 
     // fallback
     return path.basename(sourcePath, ".sol");

--- a/packages/truffle-resolver/fs.js
+++ b/packages/truffle-resolver/fs.js
@@ -1,103 +1,99 @@
-var path = require("path");
-var fs = require("fs");
-var eachSeries = require("async/eachSeries");
+const path = require("path");
+const fs = require("fs");
+const eachSeries = require("async/eachSeries");
 
-function FS(working_directory, contracts_build_directory) {
-  this.working_directory = working_directory;
-  this.contracts_build_directory = contracts_build_directory;
-}
+class FS {
+  constructor(working_directory, contracts_build_directory) {
+    this.working_directory = working_directory;
+    this.contracts_build_directory = contracts_build_directory;
+  }
 
-FS.prototype.require = function(import_path, search_path) {
-  search_path = search_path || this.contracts_build_directory;
+  require(import_path, search_path = this.contracts_build_directory) {
+    // For Windows: Allow import paths to be either path separator ('\' or '/')
+    // by converting all '/' to the default (path.sep);
+    import_path = import_path.replace(/\//g, path.sep);
 
-  // For Windows: Allow import paths to be either path separator ('\' or '/')
-  // by converting all '/' to the default (path.sep);
-  import_path = import_path.replace(/\//g, path.sep);
+    const contract_name = this.getContractName(import_path, search_path);
 
-  var contract_name = this.getContractName(import_path, search_path);
+    // If we have an absoulte path, only check the file if it's a child of the working_directory.
+    if (path.isAbsolute(import_path)) {
+      if (import_path.indexOf(this.working_directory) !== 0) {
+        return null;
+      }
+      import_path = `./${import_path.replace(this.working_directory)}`;
+    }
 
-  // If we have an absoulte path, only check the file if it's a child of the working_directory.
-  if (path.isAbsolute(import_path)) {
-    if (import_path.indexOf(this.working_directory) !== 0) {
+    try {
+      const result = fs.readFileSync(
+        path.join(search_path, `${contract_name}.json`),
+        "utf8"
+      );
+      return JSON.parse(result);
+    } catch (e) {
       return null;
     }
-    import_path = "./" + import_path.replace(this.working_directory);
   }
 
-  try {
-    var result = fs.readFileSync(
-      path.join(search_path, contract_name + ".json"),
-      "utf8"
-    );
-    return JSON.parse(result);
-  } catch (e) {
-    return null;
-  }
-};
+  getContractName(sourcePath, searchPath = this.contracts_build_directory) {
+    let filenames = fs.readdirSync(searchPath);
+    filenames = filenames.filter(file => file.match(".json") != null);
+    for (let i = 0; i < filenames.length; i++) {
+      const filename = filenames[i];
 
-FS.prototype.getContractName = function(sourcePath, searchPath) {
-  searchPath = searchPath || this.contracts_build_directory;
+      const artifact = JSON.parse(
+        fs.readFileSync(path.resolve(searchPath, filename))
+      );
 
-  var filenames = fs.readdirSync(searchPath);
-  filenames = filenames.filter(file => file.match(".json") != null);
-  for (var i = 0; i < filenames.length; i++) {
-    var filename = filenames[i];
-
-    var artifact = JSON.parse(
-      fs.readFileSync(path.resolve(searchPath, filename))
-    );
-
-    if (artifact.sourcePath === sourcePath) {
-      return artifact.contractName;
-    }
-  }
-
-  // fallback
-  return path.basename(sourcePath, ".sol");
-};
-
-FS.prototype.resolve = function(import_path, imported_from, callback) {
-  imported_from = imported_from || "";
-
-  var possible_paths = [
-    import_path,
-    path.join(path.dirname(imported_from), import_path)
-  ];
-
-  var resolved_body = null;
-  var resolved_path = null;
-
-  eachSeries(
-    possible_paths,
-    function(possible_path, finished) {
-      if (resolved_body != null) {
-        return finished();
+      if (artifact.sourcePath === sourcePath) {
+        return artifact.contractName;
       }
+    }
 
-      // Check the expected path.
-      fs.readFile(possible_path, { encoding: "utf8" }, function(err, body) {
-        // If there's an error, that means we can't read the source even if
-        // it exists. Treat it as if it doesn't by ignoring any errors.
-        // body will be undefined if error.
-        if (body) {
-          resolved_body = body;
-          resolved_path = possible_path;
+    // fallback
+    return path.basename(sourcePath, ".sol");
+  }
+
+  resolve(import_path, imported_from = "", callback) {
+    const possible_paths = [
+      import_path,
+      path.join(path.dirname(imported_from), import_path)
+    ];
+
+    let resolved_body = null;
+    let resolved_path = null;
+
+    eachSeries(
+      possible_paths,
+      (possible_path, finished) => {
+        if (resolved_body != null) {
+          return finished();
         }
 
-        return finished();
-      });
-    },
-    function(err) {
-      if (err) return callback(err);
-      callback(null, resolved_body, resolved_path);
-    }
-  );
-};
+        // Check the expected path.
+        fs.readFile(possible_path, { encoding: "utf8" }, (err, body) => {
+          // If there's an error, that means we can't read the source even if
+          // it exists. Treat it as if it doesn't by ignoring any errors.
+          // body will be undefined if error.
+          if (body) {
+            resolved_body = body;
+            resolved_path = possible_path;
+          }
 
-// Here we're resolving from local files to local files, all absolute.
-FS.prototype.resolve_dependency_path = function(import_path, dependency_path) {
-  var dirname = path.dirname(import_path);
-  return path.resolve(path.join(dirname, dependency_path));
-};
+          return finished();
+        });
+      },
+      err => {
+        if (err) return callback(err);
+        callback(null, resolved_body, resolved_path);
+      }
+    );
+  }
+
+  // Here we're resolving from local files to local files, all absolute.
+  resolve_dependency_path(import_path, dependency_path) {
+    const dirname = path.dirname(import_path);
+    return path.resolve(path.join(dirname, dependency_path));
+  }
+}
 
 module.exports = FS;

--- a/packages/truffle-resolver/fs.js
+++ b/packages/truffle-resolver/fs.js
@@ -12,7 +12,7 @@ class FS {
     const normalizedImportPath = path.normalize(importPath);
     const contractName = this.getContractName(normalizedImportPath, searchPath);
 
-    // If we have an absoulte path, only check the file if it's a child of the workingDirectory.
+    // If we have an absolute path, only check the file if it's a child of the workingDirectory.
     if (path.isAbsolute(normalizedImportPath)) {
       if (normalizedImportPath.indexOf(this.workingDirectory) !== 0) {
         return null;

--- a/packages/truffle-resolver/fs.js
+++ b/packages/truffle-resolver/fs.js
@@ -17,7 +17,6 @@ class FS {
       if (normalizedImportPath.indexOf(this.workingDirectory) !== 0) {
         return null;
       }
-      importPath = `./${importPath.replace(this.workingDirectory)}`;
     }
 
     try {

--- a/packages/truffle-resolver/fs.js
+++ b/packages/truffle-resolver/fs.js
@@ -9,15 +9,12 @@ class FS {
   }
 
   require(importPath, searchPath = this.contractsBuildDirectory) {
-    // For Windows: Allow import paths to be either path separator ('\' or '/')
-    // by converting all '/' to the default (path.sep);
-    importPath = importPath.replace(/\//g, path.sep);
-
-    const contractName = this.getContractName(importPath, searchPath);
+    const normalizedImportPath = path.normalize(normalizedImportPath);
+    const contractName = this.getContractName(normalizedImportPath, searchPath);
 
     // If we have an absoulte path, only check the file if it's a child of the workingDirectory.
-    if (path.isAbsolute(importPath)) {
-      if (importPath.indexOf(this.workingDirectory) !== 0) {
+    if (path.isAbsolute(normalizedImportPath)) {
+      if (normalizedImportPath.indexOf(this.workingDirectory) !== 0) {
         return null;
       }
       importPath = `./${importPath.replace(this.workingDirectory)}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1044,6 +1044,11 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.133.tgz#430721c96da22dd1694443e68e6cec7ba1c1003d"
   integrity sha512-/3JqnvPnY58GLzG3Y7fpphOhATV1DDZ/Ak3DQufjlRK5E4u+s0CfClfNFtAGBabw+jDGtRFbOZe+Z02ZMWCBNQ==
 
+"@types/lodash@^4.14.136":
+  version "4.14.136"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.136.tgz#413e85089046b865d960c9ff1d400e04c31ab60f"
+  integrity sha512-0GJhzBdvsW2RUccNHOBkabI8HZVdOXmXbXhuKlDEd5Vv12P7oAVGfomGp3Ne21o5D/qu1WmthlNKFaoZJJeErA==
+
 "@types/minimist@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"


### PR DESCRIPTION
This PR attempts to resolve #2134 by ensuring `getContractName` filters out non-json files before attempting to parse them.

Also ES6's `truffle-resolver/fs.js` and cleans up some of the code.