### PR TITLE
Enhancement: add `--ignore-networks` flag to `truffle test`

### DIFF
--- a/packages/truffle-core/lib/commands/test.js
+++ b/packages/truffle-core/lib/commands/test.js
@@ -6,6 +6,11 @@ const command = {
       describe: "Show all test logs",
       type: "boolean",
       default: false
+    },
+    "ignore-networks": {
+      describe: "Ignore networks defined in truffle-config.js",
+      type: "boolean",
+      default: false
     }
   },
   help: {

--- a/packages/truffle-core/lib/commands/test.js
+++ b/packages/truffle-core/lib/commands/test.js
@@ -55,6 +55,10 @@ const command = {
 
     const config = Config.detect(options);
 
+    if (options.ignoreNetworks) {
+      config.networks = {};
+    }
+
     // if "development" exists, default to using that for testing
     if (!config.network && config.networks.development) {
       config.network = "development";

--- a/packages/truffle-core/lib/commands/test.js
+++ b/packages/truffle-core/lib/commands/test.js
@@ -10,7 +10,8 @@ const command = {
   },
   help: {
     usage:
-      "truffle test [<test_file>] [--compile-all] [--network <name>] [--verbose-rpc] [--show-events]",
+      "truffle test [<test_file>] [--compile-all] [--network <name>]" +
+      "\n\t\t\t     [--verbose-rpc] [--show-events] [--ignore-networks]",
     options: [
       {
         option: "<test_file>",

--- a/packages/truffle-core/lib/commands/test.js
+++ b/packages/truffle-core/lib/commands/test.js
@@ -51,7 +51,7 @@ const command = {
       }
     ]
   },
-  run: function(options, done) {
+  run(options, done) {
     const OS = require("os");
     const dir = require("node-dir");
     const temp = require("temp").track();
@@ -97,9 +97,9 @@ const command = {
       return done(error);
     }
 
-    files = files.filter(function(file) {
-      return file.match(config.test_file_extension_regexp) != null;
-    });
+    files = files.filter(
+      file => file.match(config.test_file_extension_regexp) != null
+    );
 
     let temporaryDirectory;
     try {
@@ -109,7 +109,7 @@ const command = {
     }
 
     function runCallback() {
-      var args = arguments;
+      const args = arguments;
       // Ensure directory cleanup.
       done.apply(null, args);
       if (ipcDisconnect) ipcDisconnect();
@@ -129,7 +129,7 @@ const command = {
         .catch(runCallback);
     }
 
-    const environmentCallback = function() {
+    const environmentCallback = () => {
       // Copy all the built files over to a temporary directory, because we
       // don't want to save any tests artifacts. Only do this if the build directory
       // exists.
@@ -141,7 +141,7 @@ const command = {
 
       promisifiedCopy(config.contracts_build_directory, temporaryDirectory)
         .then(() => {
-          config.logger.log("Using network '" + config.network + "'." + OS.EOL);
+          config.logger.log(`Using network '${config.network}'.${OS.EOL}`);
 
           run();
         })

--- a/packages/truffle-core/lib/commands/test.js
+++ b/packages/truffle-core/lib/commands/test.js
@@ -38,6 +38,10 @@ const command = {
       {
         option: "--show-events",
         description: "Log all contract events."
+      },
+      {
+        option: "--ignore-networks",
+        description: "Ignore networks defined in truffle-config.js."
       }
     ]
   },


### PR DESCRIPTION
This PR adds an `--ignore-networks` flag to `truffle test`, allowing users to completely ignore `networks` loaded from their given `truffle-config.js` file.

Useful for situations where you don't want to repeatedly comment/uncomment network values during development _or_ when using `truffle test` in a CI/CD environment 😉 .

