### PR TITLE
Fix: ensure config.with returns a Config object

### DIFF
--- a/packages/truffle-config/index.js
+++ b/packages/truffle-config/index.js
@@ -310,7 +310,7 @@ class Config {
     const normalized = this.normalize(obj);
     const current = this.normalize(this);
 
-    return _.extend({}, current, normalized);
+    return _.extend(Object.create(Config.prototype), current, normalized);
   }
 
   merge(obj) {


### PR DESCRIPTION
This PR fixes a bug where `config.with` was returning a non-`TruffleConfig` object (missing `TruffleConfig` key/values).