### PR TITLE
Remove network fork references

### DIFF
--- a/packages/truffle-db/src/loaders/artifacts/index.ts
+++ b/packages/truffle-db/src/loaders/artifacts/index.ts
@@ -230,15 +230,10 @@ const AddNetworks = gql`
     hash: String!
   }
 
-  input NetworkIdInput {
-    id: ID!
-  }
-
   input NetworkInput {
     name: String
     networkId: NetworkId!
     historicBlock: HistoricBlockInput!
-    fork: NetworkIdInput
   }
 
   mutation AddNetworks($networks: [NetworkInput!]!) {
@@ -253,7 +248,6 @@ const AddNetworks = gql`
             height
             hash
           }
-          fork
         }
       }
     }

--- a/packages/truffle-db/src/schema.graphql
+++ b/packages/truffle-db/src/schema.graphql
@@ -58,7 +58,6 @@ type Network {
   name: String
   networkId: NetworkId!
   historicBlock: HistoricBlock!
-  fork: Network
 }
 
 type HistoricBlock {

--- a/packages/truffle-db/src/workspace/schema.ts
+++ b/packages/truffle-db/src/workspace/schema.ts
@@ -199,7 +199,6 @@ export const schema = mergeSchemas({
       name: String
       networkId: NetworkId!
       historicBlock: HistoricBlockInput!
-      fork: NetworkInput
     }
 
     input NetworksAddInput {


### PR DESCRIPTION
This PR removes the references to network fork, because we will be treating network forks as a separate resource in order to maintain the immutability of resources. A new resource called "parent" will be developed and will allow us to assess the the correct network that each contract instance is on. 