### PR TITLE
Update contract schema with internalType for Solidity 0.5.11

### DIFF
--- a/packages/truffle-contract-schema/spec/abi.spec.json
+++ b/packages/truffle-contract-schema/spec/abi.spec.json
@@ -133,7 +133,8 @@
         "components": {
           "type": "array",
           "items": { "type": "object" }
-        }
+        },
+	"internalType": "string"
       },
       "if": {
         "properties": {

--- a/packages/truffle-contract-schema/spec/abi.spec.json
+++ b/packages/truffle-contract-schema/spec/abi.spec.json
@@ -134,7 +134,7 @@
           "type": "array",
           "items": { "type": "object" }
         },
-	"internalType": "string"
+	"internalType": { "type": "string" }
       },
       "if": {
         "properties": {
@@ -154,7 +154,8 @@
       "properties": {
         "name": { "$ref": "#/definitions/Name" },
         "type": { "$ref": "#/definitions/Type" },
-        "indexed": { "type": "boolean" }
+        "indexed": { "type": "boolean" },
+	"internalType": { "type": "string" }
       },
       "required": ["name", "type", "indexed"]
     }


### PR DESCRIPTION
Solidity 0.5.11 is out and it adds to the ABI JSON the possibility for parameters (input or output) to be tagged with an additional `internalType` field.  I've added this to the schema, for both `Parameter` and `EventParameter`.  Note that I've deliberately left it not required.