### PR TITLE
Abstract the config command to read project-level parameters

### DIFF
--- a/packages/core/lib/commands/config.js
+++ b/packages/core/lib/commands/config.js
@@ -203,8 +203,8 @@ const command = {
             options.logger.log(config[command.key]);
           }
         })
-        .catch(options.logger.logs)
-        .finally(done);
+        .then(done)
+        .catch(options.logger.logs);
     }
   }
 };

--- a/packages/core/lib/commands/config.js
+++ b/packages/core/lib/commands/config.js
@@ -1,107 +1,3 @@
-const parse = function(args) {
-  if (args.length === 0) {
-    return null;
-  }
-
-  let command = args[0];
-
-  if (typeof command !== "string") {
-    // invalid command
-    throw new Error(`Invalid config option "${command}"`);
-  }
-  command = command.toLowerCase();
-
-  let set = false;
-  let key = args[1];
-  let value = args[2];
-
-  switch (command) {
-    case "enable": {
-      set = true;
-      value = true;
-      break;
-    }
-    case "disable": {
-      set = true;
-      value = false;
-      break;
-    }
-    case "get":
-    case "read": {
-      set = false;
-      if (typeof key === "undefined" || key === null || key === "") {
-        // invalid key
-        throw new Error("Must provide a <key>");
-      }
-
-      break;
-    }
-    case "set":
-    case "write": {
-      set = true;
-      if (typeof key === "undefined" || key === null || key === "") {
-        // invalid key
-        throw new Error("Must provide a <key>");
-      }
-
-      if (typeof value !== "string" || value === "") {
-        // invalid value
-        throw new Error("Must provide a <value-for-set>");
-      }
-
-      switch (value.toLowerCase()) {
-        case "null": {
-          value = null;
-          break;
-        }
-        case "undefined": {
-          value = undefined;
-          break;
-        }
-        case "true": {
-          value = true;
-          break;
-        }
-        case "false": {
-          value = false;
-          break;
-        }
-        default: {
-          // check if number, otherwise leave as string
-          const float = parseFloat(value);
-          if (!isNaN(float) && value === float.toString()) {
-            value = float;
-          }
-          break;
-        }
-      }
-
-      break;
-    }
-    default: {
-      if (
-        command !== "--enable-analytics" &&
-        command !== "--disable-analytics" &&
-        command !== ""
-      ) {
-        // TODO: Deprecate the --(en|dis)able-analytics flag in favor for `enable analytics`
-        // invalid command!
-        throw new Error(`Invalid config option "${command}"`);
-      } else {
-        // we should not have gotten here
-        return null;
-      }
-    }
-  }
-
-  return {
-    set,
-    userLevel: module.exports.userLevelSettings.includes(key),
-    key,
-    value
-  };
-};
-
 const command = {
   command: "config",
   description: "Set user-level configuration options",
@@ -190,7 +86,7 @@ const command = {
       done();
     } else {
       Promise.resolve()
-        .then(async () => {
+        .then(() => {
           const config = Config.detect(options);
 
           if (command.set) {
@@ -204,9 +100,113 @@ const command = {
           }
         })
         .then(done)
-        .catch(options.logger.logs);
+        .catch(options.logger.log);
     }
   }
+};
+
+const parse = function(args) {
+  if (args.length === 0) {
+    return null;
+  }
+
+  let option = args[0];
+
+  if (typeof option !== "string") {
+    // invalid option
+    throw new Error(`Invalid config option "${option}"`);
+  }
+  option = option.toLowerCase();
+
+  let set = false;
+  let key = args[1];
+  let value = args[2];
+
+  switch (option) {
+    case "enable": {
+      set = true;
+      value = true;
+      break;
+    }
+    case "disable": {
+      set = true;
+      value = false;
+      break;
+    }
+    case "get":
+    case "read": {
+      set = false;
+      if (typeof key === "undefined" || key === null || key === "") {
+        // invalid key
+        throw new Error("Must provide a <key>");
+      }
+
+      break;
+    }
+    case "set":
+    case "write": {
+      set = true;
+      if (typeof key === "undefined" || key === null || key === "") {
+        // invalid key
+        throw new Error("Must provide a <key>");
+      }
+
+      if (typeof value !== "string" || value === "") {
+        // invalid value
+        throw new Error("Must provide a <value-for-set>");
+      }
+
+      switch (value.toLowerCase()) {
+        case "null": {
+          value = null;
+          break;
+        }
+        case "undefined": {
+          value = undefined;
+          break;
+        }
+        case "true": {
+          value = true;
+          break;
+        }
+        case "false": {
+          value = false;
+          break;
+        }
+        default: {
+          // check if number, otherwise leave as string
+          const float = parseFloat(value);
+          if (!isNaN(float) && value === float.toString()) {
+            value = float;
+          }
+          break;
+        }
+      }
+
+      break;
+    }
+    default: {
+      if (
+        option !== "--enable-analytics" &&
+        option !== "--disable-analytics" &&
+        option !== ""
+      ) {
+        // TODO: Deprecate the --(en|dis)able-analytics flag in favor for `enable analytics`
+        // invalid command!
+        throw new Error(`Invalid config option "${option}"`);
+      } else {
+        // we should not have gotten here
+        return null;
+      }
+    }
+  }
+
+  return {
+    set,
+    userLevel: command.userLevelSettings.includes(key),
+    key,
+    value
+  };
 };
 
 module.exports = command;

--- a/packages/core/lib/commands/config.js
+++ b/packages/core/lib/commands/config.js
@@ -1,8 +1,113 @@
+const parse = function(args) {
+  if (args.length === 0) {
+    return null;
+  }
+
+  let command = args[0];
+
+  if (typeof command !== "string") {
+    // invalid command
+    throw new Error(`Invalid config option "${command}"`);
+  }
+  command = command.toLowerCase();
+
+  let set = false;
+  let key = args[1];
+  let value = args[2];
+
+  switch (command) {
+    case "enable": {
+      set = true;
+      value = true;
+      break;
+    }
+    case "disable": {
+      set = true;
+      value = false;
+      break;
+    }
+    case "get":
+    case "read": {
+      set = false;
+      if (typeof key === "undefined" || key === null || key === "") {
+        // invalid key
+        throw new Error("Must provide a <key>");
+      }
+
+      break;
+    }
+    case "set":
+    case "write": {
+      set = true;
+      if (typeof key === "undefined" || key === null || key === "") {
+        // invalid key
+        throw new Error("Must provide a <key>");
+      }
+
+      if (typeof value !== "string" || value === "") {
+        // invalid value
+        throw new Error("Must provide a <value-for-set>");
+      }
+
+      switch (value.toLowerCase()) {
+        case "null": {
+          value = null;
+          break;
+        }
+        case "undefined": {
+          value = undefined;
+          break;
+        }
+        case "true": {
+          value = true;
+          break;
+        }
+        case "false": {
+          value = false;
+          break;
+        }
+        default: {
+          // check if number, otherwise leave as string
+          const float = parseFloat(value);
+          if (!isNaN(float) && value === float.toString()) {
+            value = float;
+          }
+          break;
+        }
+      }
+
+      break;
+    }
+    default: {
+      if (
+        command !== "--enable-analytics" &&
+        command !== "--disable-analytics" &&
+        command !== ""
+      ) {
+        // TODO: Deprecate the --(en|dis)able-analytics flag in favor for `enable analytics`
+        // invalid command!
+        throw new Error(`Invalid config option "${command}"`);
+      } else {
+        // we should not have gotten here
+        return null;
+      }
+    }
+  }
+
+  return {
+    set,
+    userLevel: module.exports.userLevelSettings.includes(key),
+    key,
+    value
+  };
+};
+
 const command = {
   command: "config",
   description: "Set user-level configuration options",
   help: {
-    usage: "truffle config <option>",
+    usage:
+      "truffle config <enable|disable|get|read|set|write> <key> [<value-for-set>]",
     options: [
       {
         option: "--enable-analytics",
@@ -12,27 +117,94 @@ const command = {
         option: "--disable-analytics",
         description:
           "Disable Truffle's ability to send usage data to Google Analytics"
+      },
+      {
+        option: "enable",
+        discription: "Enable a Truffle Attribute"
+      },
+      {
+        option: "disable",
+        discription: "Disable a Truffle Attribute"
+      },
+      {
+        option: "get",
+        discription: "Get a Truffle Attribute"
+      },
+      {
+        option: "read",
+        discription: "Get a Truffle Attribute"
+      },
+      {
+        option: "set",
+        discription: "Set a Truffle Attribute"
+      },
+      {
+        option: "write",
+        discription: "Set a Truffle Attribute"
       }
     ]
   },
-  builder: {},
+  userLevelSettings: ["analytics"],
+  builder: {
+    _: {
+      type: "string"
+    }
+  },
   /**
-   * run config commands to set user-level config settings
+   * run config commands to get/set project/user-level config settings
    * @param {Object} options
    * @param {Func} callback
    */
   run: function(options, done) {
     const googleAnalytics = require("../services/analytics/google.js");
-    let setAnalytics;
-    if (options.enableAnalytics) {
-      setAnalytics = googleAnalytics.setAnalytics(true);
-      done();
-    } else if (options.disableAnalytics) {
-      setAnalytics = googleAnalytics.setAnalytics(false);
+    const Config = require("truffle-config");
+
+    let command;
+    if (options.enableAnalytics || options.disableAnalytics) {
+      // TODO: Deprecate the --(en|dis)able-analytics flag in favor for `enable analytics`
+      command = {
+        set: true,
+        userLevel: true,
+        key: "analytics",
+        value: options.enableAnalytics || false
+      };
+    } else {
+      command = parse(options._);
+    }
+
+    if (command === null) {
+      const setAnalytics = googleAnalytics.setUserConfigViaPrompt();
+      setAnalytics.then(() => done()).catch(err => err);
+    } else if (command.userLevel) {
+      switch (command.key) {
+        case "analytics": {
+          if (command.set) {
+            googleAnalytics.setAnalytics(command.value);
+          } else {
+            options.logger.log(googleAnalytics.getAnalytics());
+          }
+          break;
+        }
+      }
+
       done();
     } else {
-      setAnalytics = googleAnalytics.setUserConfigViaPrompt();
-      setAnalytics.then(() => done()).catch(err => err);
+      Promise.resolve()
+        .then(async () => {
+          const config = Config.detect(options);
+
+          if (command.set) {
+            options.logger.log(
+              "Setting project-level parameters is not supported yet."
+            );
+            // TODO: add support for writing project-level settings to the truffle config file
+            // config[command.key] = command.value;
+          } else {
+            options.logger.log(config[command.key]);
+          }
+        })
+        .catch(options.logger.logs)
+        .finally(done);
     }
   }
 };

--- a/packages/core/lib/commands/config.js
+++ b/packages/core/lib/commands/config.js
@@ -38,6 +38,7 @@ const command = {
   run: function(options, done) {
     const googleAnalytics = require("../services/analytics/google.js");
     const Config = require("truffle-config");
+    const OS = require("os");
 
     let command;
     if (options.enableAnalytics || options.disableAnalytics) {
@@ -48,6 +49,11 @@ const command = {
         key: "analytics",
         value: options.enableAnalytics || false
       };
+      const message =
+        `> WARNING: The --enable-analytics and ` +
+        `--disable-analytics flags have been deprecated.${OS.EOL}> Please ` +
+        `use 'truffle config set analytics <boolean>'.`;
+      console.warn(OS.EOL + message + OS.EOL);
     } else {
       command = parse(options._);
     }

--- a/packages/core/lib/commands/config.js
+++ b/packages/core/lib/commands/config.js
@@ -7,12 +7,12 @@ const command = {
     options: [
       {
         option: "--enable-analytics",
-        description: "Enable Truffle to send usage data to Google Analytics"
+        description: "Enable Truffle to send usage data to Google Analytics."
       },
       {
         option: "--disable-analytics",
         description:
-          "Disable Truffle's ability to send usage data to Google Analytics"
+          "Disable Truffle's ability to send usage data to Google Analytics."
       },
       {
         option: "get",

--- a/packages/core/lib/commands/config.js
+++ b/packages/core/lib/commands/config.js
@@ -3,7 +3,7 @@ const command = {
   description: "Set user-level configuration options",
   help: {
     usage:
-      "truffle config <enable|disable|get|read|set|write> <key> [<value-for-set>]",
+      "truffle config [--enable-analytics|--disable-analytics] [[<get|set> <key>] [<value-for-set>]]",
     options: [
       {
         option: "--enable-analytics",
@@ -15,28 +15,12 @@ const command = {
           "Disable Truffle's ability to send usage data to Google Analytics"
       },
       {
-        option: "enable",
-        discription: "Enable a Truffle Attribute"
-      },
-      {
-        option: "disable",
-        discription: "Disable a Truffle Attribute"
-      },
-      {
         option: "get",
-        discription: "Get a Truffle Attribute"
-      },
-      {
-        option: "read",
-        discription: "Get a Truffle Attribute"
+        discription: "Get a Truffle config option value."
       },
       {
         option: "set",
-        discription: "Set a Truffle Attribute"
-      },
-      {
-        option: "write",
-        discription: "Set a Truffle Attribute"
+        discription: "Set a Truffle config option value."
       }
     ]
   },
@@ -47,7 +31,7 @@ const command = {
     }
   },
   /**
-   * run config commands to get/set project/user-level config settings
+   * run config commands to get/set Truffle config options
    * @param {Object} options
    * @param {Func} callback
    */
@@ -57,7 +41,7 @@ const command = {
 
     let command;
     if (options.enableAnalytics || options.disableAnalytics) {
-      // TODO: Deprecate the --(en|dis)able-analytics flag in favor for `enable analytics`
+      // TODO: Deprecate the --(en|dis)able-analytics flag in favor of `set analytics true`
       command = {
         set: true,
         userLevel: true,
@@ -123,18 +107,7 @@ const parse = function(args) {
   let value = args[2];
 
   switch (option) {
-    case "enable": {
-      set = true;
-      value = true;
-      break;
-    }
-    case "disable": {
-      set = true;
-      value = false;
-      break;
-    }
-    case "get":
-    case "read": {
+    case "get": {
       set = false;
       if (typeof key === "undefined" || key === null || key === "") {
         // invalid key
@@ -143,8 +116,7 @@ const parse = function(args) {
 
       break;
     }
-    case "set":
-    case "write": {
+    case "set": {
       set = true;
       if (typeof key === "undefined" || key === null || key === "") {
         // invalid key

--- a/packages/core/lib/services/analytics/google.js
+++ b/packages/core/lib/services/analytics/google.js
@@ -76,12 +76,18 @@ const googleAnalytics = {
         analyticsSet: true,
         analyticsMessageDateTime: Date.now()
       });
-    } else {
+    } else if (analyticsBool === false) {
       userConfig.set({
         enableAnalytics: false,
         analyticsSet: true,
         analyticsMessageDateTime: Date.now()
       });
+    } else {
+      const message =
+        `Error setting config option.` +
+        `\n> You must set the 'analytics' option to either 'true' ` +
+        `or 'false'. \n> The value you provided was ${analyticsBool}.`;
+      throw new Error(message);
     }
     return true;
   },

--- a/packages/core/lib/services/analytics/google.js
+++ b/packages/core/lib/services/analytics/google.js
@@ -56,6 +56,14 @@ const googleAnalytics = {
     }
   },
   /**
+   * get user-level options for analytics
+   * @param {Object} userConfig
+   * @returns {bool}
+   */
+  getAnalytics: function() {
+    return userConfig.get("enableAnalytics");
+  },
+  /**
    * set user-level options for analytics
    * @param {bool} analyticsBool
    * @param {Object} userConfig

--- a/packages/core/test/lib/commands/config.js
+++ b/packages/core/test/lib/commands/config.js
@@ -1,13 +1,13 @@
-var assert = require("chai").assert;
-var Box = require("truffle-box");
-var Artifactor = require("truffle-artifactor");
-var Resolver = require("truffle-resolver");
-var MemoryStream = require("memorystream");
-var command = require("../../../lib/commands/config");
-var path = require("path");
-var fs = require("fs-extra");
-var glob = require("glob");
-var Config = require("truffle-config");
+const assert = require("chai").assert;
+const Box = require("@truffle/box");
+const Artifactor = require("@truffle/artifactor");
+const Resolver = require("@truffle/resolver");
+const MemoryStream = require("memorystream");
+const command = require("../../../lib/commands/config");
+const path = require("path");
+const fs = require("fs-extra");
+const glob = require("glob");
+const Config = require("@truffle/config");
 
 describe("config", function() {
   var config;

--- a/packages/core/test/user-config.js
+++ b/packages/core/test/user-config.js
@@ -25,7 +25,7 @@ describe("config", function() {
       sinon.assert.calledOnce(analytics.setAnalytics);
     });
     it("calls analytics.setuserConfigViaPrompt() if not provided with options", function() {
-      configCommand.run({});
+      configCommand.run({ _: [] });
       sinon.assert.calledOnce(analytics.setUserConfigViaPrompt);
     });
   });

--- a/packages/truffle-core/test/lib/commands/config.js
+++ b/packages/truffle-core/test/lib/commands/config.js
@@ -1,0 +1,94 @@
+var assert = require("chai").assert;
+var Box = require("truffle-box");
+var Artifactor = require("truffle-artifactor");
+var Resolver = require("truffle-resolver");
+var MemoryStream = require("memorystream");
+var command = require("../../../lib/commands/config");
+var path = require("path");
+var fs = require("fs-extra");
+var glob = require("glob");
+var Config = require("truffle-config");
+
+describe("config", function() {
+  var config;
+  var output = "";
+  var memStream;
+
+  before("Create a sandbox", async () => {
+    config = await Box.sandbox("default");
+    config.resolver = new Resolver(config);
+    config.artifactor = new Artifactor(config.contracts_build_directory);
+    config.networks = {
+      default: {
+        network_id: "1"
+      },
+      secondary: {
+        network_id: "12345"
+      }
+    };
+    config.network = "default";
+    config.logger = { log: val => val && memStream.write(val) };
+  });
+
+  beforeEach(() => {
+    memStream = new MemoryStream();
+    memStream.on("data", function(data) {
+      output += data.toString();
+    });
+  });
+
+  after("Cleanup tmp files", function(done) {
+    glob("tmp-*", (err, files) => {
+      if (err) done(err);
+      files.forEach(file => fs.removeSync(file));
+      done();
+    });
+  });
+
+  afterEach("Clear MemoryStream", () => {
+    memStream.end("");
+    output = "";
+  });
+
+  it("retrieves the default migrations directory", function(done) {
+    command.run(
+      {
+        working_directory: config.working_directory,
+        _: ["get", "migrations_directory"],
+        logger: config.logger
+      },
+      () => {
+        const expected = path.join(config.working_directory, "./migrations");
+        assert.equal(output, expected);
+        done();
+      }
+    );
+  });
+
+  it("retrieves an adjusted migrations directory", function(done) {
+    const configFile = Config.search({
+      working_directory: config.working_directory
+    });
+    fs.writeFileSync(
+      configFile,
+      "module.exports = { migrations_directory: './a-different-dir' };",
+      { encoding: "utf8" }
+    );
+
+    command.run(
+      {
+        working_directory: config.working_directory,
+        _: ["get", "migrations_directory"],
+        logger: config.logger
+      },
+      () => {
+        const expected = path.join(
+          config.working_directory,
+          "./a-different-dir"
+        );
+        assert.equal(output, expected);
+        done();
+      }
+    );
+  });
+});


### PR DESCRIPTION
This PR modifies the `truffle config` command behavior to be similar to other config-getting/setting CLIs.

This PR maintains the previous behavior to prevent a breaking change:
- `truffle config` will prompt the user if they'd like to enable/disable analytics
- `truffle config --(en|dis)able-analytics` will enable/disable user-level analytics

The second flags are now deprecated in favor of the new functionality (i.e. `truffle config set analytics <true|false>`). A message to the user has been added to tell them to use the new syntax.

This PR changes the `Help Usage` to be `truffle config <get|set> <key> [<value-for-set>]`. Here is a run down of each of the different commands:
~- `enable` is an alias for `set` with an implied `value-for-set` to be `true`~
~- `disable` is an alias for `set` with an implied `value-for-set` to be `false`~
- `get` retrieves the value of a user-level setting (which is denoted in `userLevelSettings` in `commands/config.js`) or project-level setting after `truffle-config` loads the project. It logs the value to `options.logger`
~- `read` is an alias for `get`~
- `set` sets the value for a user-level setting. Project-level setting cannot be easily done with the current infrastructure (and outside the scope of this PR) to modify the `truffle(-config)?.js` file appropriately
~- `write` is an alias for `set`~

This enables you to do things like `truffle config get migrations_directory` in the truffle project's directory.