### PR TITLE
Whitelist specific branches for Travis push builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,17 @@ dist: trusty
 sudo: required
 language: node_js
 
+# configure Travis to run on-push builds only on PR-recipient branches
+branches:
+  only:
+    # long-lived branches
+    - master
+    - develop
+    - next
+
+    # other targets
+    - truffle-db
+
 addons:
   apt:
     sources:


### PR DESCRIPTION
We don't really need to run two builds for every PR.

This PR should tell Travis to run only the PR build for normal PRs, running the "push build" only on branches that will be the recipient of pull requests / other merges.