### PR TITLE
Internal improvement: Update from Trusty to Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: required
 language: node_js
 

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -29,12 +29,12 @@ run_geth() {
 
 if [ "$INTEGRATION" = true ]; then
 
-  sudo apt-get install -y jq
+  sudo apt install -y jq
   lerna run --scope truffle test --stream
 
 elif [ "$GETH" = true ]; then
 
-  sudo apt-get install -y jq
+  sudo apt install -y jq
   docker pull ethereum/client-go:latest
   run_geth
   lerna run --scope truffle test --stream -- --exit
@@ -56,8 +56,8 @@ elif [ "$PACKAGES" = true ]; then
 
   docker pull ethereum/solc:0.4.22
   sudo add-apt-repository -y ppa:deadsnakes/ppa
-  sudo apt-get update
-  sudo apt-get install -y python3.6 python3.6-dev python3.6-venv solc
+  sudo apt update
+  sudo apt install -y python3.6 python3.6-dev python3.6-venv solc
   wget https://bootstrap.pypa.io/get-pip.py
   sudo python3.6 get-pip.py
   sudo pip3 install vyper
@@ -67,8 +67,8 @@ elif [ "$COVERAGE" = true ]; then
 
   docker pull ethereum/solc:0.4.22
   sudo add-apt-repository -y ppa:deadsnakes/ppa
-  sudo apt-get update
-  sudo apt-get install -y jq python3.6 python3.6-dev python3.6-venv solc
+  sudo apt update
+  sudo apt install -y jq python3.6 python3.6-dev python3.6-venv solc
   wget https://bootstrap.pypa.io/get-pip.py
   sudo python3.6 get-pip.py
   sudo pip3 install vyper


### PR DESCRIPTION
Ubuntu Trusty 14.04 is now EOL by Canonical (https://help.ubuntu.com/community/EOL) and Travis has begun defaulting to Xenial (https://docs.travis-ci.com/user/trusty-to-xenial-migration-guide).

This PR bumps the distro and updates a few commands to use `apt` instead of `apt-get`.