### PR TITLE
Prevent exception from decoding failure in truffle-contract

### DIFF
--- a/packages/truffle-contract/lib/utils.js
+++ b/packages/truffle-contract/lib/utils.js
@@ -59,7 +59,12 @@ const Utils = {
           copy.data = "";
         }
 
-        const logArgs = abi.decodeLog(logABI.inputs, copy.data, copy.topics);
+        let logArgs;
+        try {
+          logArgs = abi.decodeLog(logABI.inputs, copy.data, copy.topics);
+        } catch (_) {
+          return null;
+        }
         copy.args = reformat.numbers.call(constructor, logArgs, logABI.inputs);
 
         delete copy.data;


### PR DESCRIPTION
I'd been getting annoyed with the fact that `sendTransaction` would throw an exception if for some reason something went wrong during event decoding (e.g., if the event contained an external function among its parameters, or if it was ambiguous in a way that web3 couldn't handle).  So, I put a try/catch around it, and had it return `null` on failure.  In context, that means such events will simply be skipped.  Not ideal, but a decent workaround for the time being that's definitely better than throwing an exception.

This PR does not do any of the following:
1. Make an analogous change to the decoding in truffle test.  I've simply never encountered any analogous problem with the decoding there, so I left it alone.  I mean, I'm sure *something* goes wrong in these cases there, but nothing that's caused any sort of catastrophic problem for me, so I left it alone.
2. Do anything about decoding return values of calls.  I'm pretty sure that's `web3` that does that, not us, so that would require a PR to `web3` to change.

Also note: This PR shouldn't cause problems for my `wire-decoder` tests when merged into `next`.  My tests there do wrap certain calls to `sendTransaction` in a try/catch, because they presently throw exceptions; however, the tests do not *rely* on these calls throwing an exception (the catch blocks contain nothing substantial and the needed information is extracted by other means), so this should not affect them.

Since this is a PR on develop, and `wire-decoder` isn't even merged into `next` yet, obviously this PR doesn't change those tests, but again, it doesn't need to, and I can go back and change them to be written less hackily later, I figure.