### PR TITLE
Enhancement: Ignore keyword truffle in console input

### DIFF
--- a/packages/truffle-core/lib/repl.js
+++ b/packages/truffle-core/lib/repl.js
@@ -113,9 +113,25 @@ ReplManager.prototype.stop = function(callback) {
   }
 };
 
-ReplManager.prototype.interpret = function(cmd, context, filename, callback) {
-  var currentContext = this.contexts[this.contexts.length - 1];
-  currentContext.interpreter(cmd, context, filename, callback);
+ReplManager.prototype.interpret = function(
+  replInput,
+  context,
+  filename,
+  callback
+) {
+  const processedReplInput = processReplInput(replInput);
+  const currentContext = this.contexts[this.contexts.length - 1];
+  currentContext.interpreter(processedReplInput, context, filename, callback);
+};
+
+const processReplInput = input => {
+  const inputComponents = input.split(" ");
+  if (inputComponents.length === 0) return input;
+
+  if (inputComponents[0] === "truffle") {
+    return inputComponents.slice(1).join(" ");
+  }
+  return input;
 };
 
 module.exports = ReplManager;


### PR DESCRIPTION
Add processReplInput method which filters out the word truffle when it is the first keyword in console input. This work was inspired by https://github.com/trufflesuite/truffle/issues/2318