### PR TITLE
Update ABI utilities to account for internalType

### DIFF
--- a/packages/truffle-codec-utils/src/abi.ts
+++ b/packages/truffle-codec-utils/src/abi.ts
@@ -53,6 +53,7 @@ export namespace AbiUtils {
     type: string;
     indexed?: boolean; //only present for inputs
     components?: AbiParameter[]; //only preset for tuples (structs)
+    internalType?: string;
   }
 
   export interface FunctionAbiBySelectors {

--- a/packages/truffle-codec-utils/src/definition.ts
+++ b/packages/truffle-codec-utils/src/definition.ts
@@ -20,7 +20,7 @@ export namespace Definition {
   }
 
   //returns the type string, but with location (if any) stripped off the end
-  export function typeStringNoLocation(definition: AstDefinition): string {
+  export function typeStringWithoutLocation(definition: AstDefinition): string {
     return typeString(definition).replace(/ (storage|memory|calldata)$/, "");
   }
 

--- a/packages/truffle-codec-utils/src/definition.ts
+++ b/packages/truffle-codec-utils/src/definition.ts
@@ -292,7 +292,7 @@ export namespace Definition {
         }
 
         let keyString = typeString(definition)
-          .match(/mapping\((.*?) => .*\)( storage)?/)[1];
+          .match(/mapping\((.*?) => .*\)( storage)?$/)[1];
           //use *non*-greedy match; note that if the key type could include
           //"=>", this could cause a problem, but mappings are not allowed as key
           //types, so this can't come up

--- a/packages/truffle-codec-utils/src/definition.ts
+++ b/packages/truffle-codec-utils/src/definition.ts
@@ -248,7 +248,7 @@ export namespace Definition {
 
     // another HACK - we get away with it because we're only using that one property
     let result: AstDefinition = cloneDeep(definition);
-    result.typeDescriptions = definition.typeDescriptions;
+    result.typeDescriptions.typeIdentifier = baseIdentifier;
     return result;
 
     //WARNING -- these hacks do *not* correctly handle all cases!
@@ -291,9 +291,18 @@ export namespace Definition {
           keyIdentifier = `${keyIdentifier}_ptr`;
         }
 
+        let keyString = typeString(definition)
+          .match(/mapping\((.*?) => .*\)( storage)?/)[1];
+          //use *non*-greedy match; note that if the key type could include
+          //"=>", this could cause a problem, but mappings are not allowed as key
+          //types, so this can't come up
+
         // another HACK - we get away with it because we're only using that one property
         result = cloneDeep(definition);
-        result.typeDescriptions = definition.typeDescriptions;
+        result.typeDescriptions = {
+          typeIdentifier: keyIdentifier,
+          typeString: keyString
+        };
         return result;
 
       case "array":

--- a/packages/truffle-codec-utils/src/definition2abi.ts
+++ b/packages/truffle-codec-utils/src/definition2abi.ts
@@ -94,7 +94,7 @@ function parameterToAbi(node: AstDefinition, referenceDeclarations: AstReference
   if(checkIndexed) {
     indexed = node.indexed; //note: may be undefined for a base type
   }
-  let internalType: string = Definition.typeStringNoLocation(node);
+  let internalType: string = Definition.typeStringWithoutLocation(node);
   //is this an array? if so use separate logic
   if(Definition.typeClass(node) === "array") {
     let baseType = node.typeName ? node.typeName.baseType : node.baseType;

--- a/packages/truffle-codec-utils/src/definition2abi.ts
+++ b/packages/truffle-codec-utils/src/definition2abi.ts
@@ -94,6 +94,7 @@ function parameterToAbi(node: AstDefinition, referenceDeclarations: AstReference
   if(checkIndexed) {
     indexed = node.indexed; //note: may be undefined for a base type
   }
+  let internalType: string = Definition.typeStringNoLocation(node);
   //is this an array? if so use separate logic
   if(Definition.typeClass(node) === "array") {
     let baseType = node.typeName ? node.typeName.baseType : node.baseType;
@@ -105,7 +106,8 @@ function parameterToAbi(node: AstDefinition, referenceDeclarations: AstReference
       name,
       type: baseAbi.type + arraySuffix,
       indexed,
-      components: baseAbi.components
+      components: baseAbi.components,
+      internalType
     };
   }
   let abiTypeString = toAbiType(node, referenceDeclarations);
@@ -123,7 +125,8 @@ function parameterToAbi(node: AstDefinition, referenceDeclarations: AstReference
     name, //may be empty string but should only be undefined in recursive calls
     type: abiTypeString,
     indexed, //undefined if !checkedIndex
-    components //undefined if not a struct or (multidim) array of structs
+    components, //undefined if not a struct or (multidim) array of structs
+    internalType
   };
 }
 


### PR DESCRIPTION
This PR updates `abi.ts` by adding `internalType` to the ABI type; and it updates `definition2abi.ts` to generate this.  To find the `internalType` from the definition, it simply takes the `typeString` and then strips off any location that may be included at the end.

Since we're now making more use of type strings, I updated the hacky case of the `keyDefinition` function in `definition.ts` to spoof the full `typeDescriptions` rather than just the `typeIdentifier`.  (I left the `baseDefinition` function alone, since it's irrelevant here.)  I also made it so that `keyDefinition` will just, well, take the key definition if there is one -- the function was originally written to be used with expressions, rather than with actual variable definitions, which is why that case was missing.