### PR TITLE
Feature Enabled: maxGas

### DIFF
--- a/packages/truffle-contract/lib/contract/properties.js
+++ b/packages/truffle-contract/lib/contract/properties.js
@@ -49,6 +49,14 @@ module.exports = {
       this._json.autoGas = val;
     }
   },
+  maxGas: {
+    get: function() {
+      return this._json.maxGas;
+    },
+    set: function(val) {
+      this._json.maxGas = val;
+    }
+  },
   numberFormat: {
     get: function() {
       if (this._json.numberFormat === undefined) {

--- a/packages/truffle-contract/lib/execute.js
+++ b/packages/truffle-contract/lib/execute.js
@@ -35,7 +35,11 @@ var execute = {
 
           // Don't go over blockLimit
           const limit = utils.bigNumberify(blockLimit);
-          bestEstimate.gte(limit)
+          constructor.maxGas != undefined &&
+          bestEstimate.gte(constructor.maxGas) &&
+          constructor.maxGas.lte(limit)
+            ? accept(constructor.maxGas.toHexString())
+            : bestEstimate.gte(limit)
             ? accept(limit.sub(1).toHexString())
             : accept(bestEstimate.toHexString());
 

--- a/packages/truffle-contract/test/deploy.js
+++ b/packages/truffle-contract/test/deploy.js
@@ -222,6 +222,30 @@ describe("Deployments", function() {
       Example.maxGas = undefined;
     });
 
+    it("if maxGas is too big, should just use default behavior", async function() {
+      assert.isUndefined(Example.maxGas, "maxGas should be undefined here");
+      this.timeout(50000);
+      let iterations = 1000; // # of times to set a uint in a loop, consuming gas.
+
+      Example.maxGas = 200000000; //set this to be over the gas limit.
+
+      const estimate = await Example.new.estimateGas(iterations);
+      const block = await web3.eth.getBlock("latest");
+
+      assert(
+        estimate != Example.maxGas,
+        "Estimate should not be equal to maxGas"
+      );
+      assert(estimate < Example.maxGas, "Estimate should be less than maxGas");
+      assert(
+        estimate < block.gasLimit,
+        "Estimate should be less than the block limit"
+      );
+
+      //reset this so it doesn't mess with other tests.
+      Example.maxGas = undefined;
+    });
+
     it("should be possible to turn gas estimation on and off", async function() {
       Example.autoGas = false;
 

--- a/packages/truffle-contract/test/deploy.js
+++ b/packages/truffle-contract/test/deploy.js
@@ -193,6 +193,35 @@ describe("Deployments", function() {
       await Example.new(1);
     });
 
+    it("should be able to set maxGas", async function() {
+      assert.isUndefined(Example.maxGas, "maxGas should be undefined here");
+
+      Example.maxGas = 2000000;
+
+      assert.equal(Example.maxGas, 2000000, "Should be 2000000");
+
+      await Example.new(1);
+
+      //reset this so it doesn't mess with other tests.
+      Example.maxGas = undefined;
+    });
+
+    it("test that if you set the maxGas too low your contract will fail to deploy", async function() {
+      assert.isUndefined(Example.maxGas, "maxGas should be undefined here");
+
+      Example.maxGas = 1337;
+
+      try {
+        await Example.new(1);
+        assert.fail();
+      } catch (err) {
+        assert(err.message.includes("exceeds gas limit"), "Should OOG");
+      }
+
+      //reset this so it doesn't mess with other tests.
+      Example.maxGas = undefined;
+    });
+
     it("should be possible to turn gas estimation on and off", async function() {
       Example.autoGas = false;
 


### PR DESCRIPTION
#1910 Enables a maxGas property for truffle-contract.

- This value represents the maximum amount of gas the caller is willing to pay.

Comes with 3 test cases:
1. check that value is correctly set
2. check that if the value is set to be too low, the example contract will fail to deploy
3. check that if the value is set to be too big, it will revert to default behavior. 

