### PR TITLE
Internal improvement: Implement GHA CI for Node 8.x, 10.x, & 12.x

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -33,6 +33,13 @@ jobs:
     - run: npm install -g yarn lerna
     - run: yarn bootstrap
     - run: ${{ matrix.env }} yarn ci
+    - uses: 8398a7/action-slack@v1
+      with:
+        type: failure
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      if: failure()
 
   slack_notification:
     needs: build
@@ -40,15 +47,8 @@ jobs:
     steps:
       - uses: 8398a7/action-slack@v1
         with:
-          type: failure
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        if: failure()
-      - uses: 8398a7/action-slack@v1
-        with:
           type: success
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        if: success()
+        if: always()

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -20,9 +20,5 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-        
-    - name: setup truffle project dependencies
-    - run: npm install -g yarn lerna
-
-    - name: bootstrap project
+      run: npm install -g yarn lerna
       run: yarn bootstrap

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest]
-        node-version: [8x, 10.x, 12.x]
+        node-version: [8.x, 10.x, 12.x]
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -33,7 +33,7 @@ jobs:
     - run: npm install -g yarn lerna
     - run: yarn bootstrap
     - run: ${{ matrix.env }} yarn ci
-    - uses: 8398a7/action-slack@v1
+    - uses: 8398a7/action-slack@v1.1.1
       with:
         type: failure
         failedMention: ""
@@ -46,7 +46,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: 8398a7/action-slack@v1
+      - uses: 8398a7/action-slack@v1.1.1
         with:
           type: success
         env:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,10 +1,20 @@
 name: Node CI
 
 on:
+  push:
+    branches:
+    # long-lived branches
+    - master
+    - develop
+    - next
+
+    # other targets
+    - truffle-db
+
   pull_request:
     branches:
-    - develop
-    
+      - "*"
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -20,5 +20,5 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-      run: npm install -g yarn lerna
-      run: yarn bootstrap
+    - run: npm install -g yarn lerna
+    - run: yarn bootstrap

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest]
         node-version: [10.x, 12.x]
-        env: [GETH=true, QUORUM=true, FABRICEVM=true, PACKAGES=true, INTEGRATION=true, COVERAGE=true]
+        env: [GETH=true, QUORUM=true, PACKAGES=true, INTEGRATION=true, COVERAGE=true]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -32,6 +32,4 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm install -g yarn lerna
     - run: yarn bootstrap
-    - run: sudo add-apt-repository ppa:ethereum/ethereum
     - run: ${{ matrix.env }} yarn ci
-    - run: npm i -g truffle

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -32,5 +32,5 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm install -g yarn lerna
     - run: yarn bootstrap
-    - run: yarn ci
+    - run: ${{ matrix.env }} yarn ci
     - run: npm i -g truffle

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -33,17 +33,22 @@ jobs:
     - run: npm install -g yarn lerna
     - run: yarn bootstrap
     - run: ${{ matrix.env }} yarn ci
-    - uses: 8398a7/action-slack@v1
-      with:
-        type: failure
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      if: failure()
-    - uses: 8398a7/action-slack@v1
-      with:
-        type: success
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      if: success()
+
+  slack_notification:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: 8398a7/action-slack@v1
+        with:
+          type: failure
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: failure()
+      - uses: 8398a7/action-slack@v1
+        with:
+          type: success
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: success()

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest]
         node-version: [10.x, 12.x]
-        env: [GETH=true, QUORUM=true]
+        env: [GETH=true, QUORUM=true, FABRICEVM=true, PACKAGES=true, INTEGRATION=true, COVERAGE=true]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -32,4 +32,6 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm install -g yarn lerna
     - run: yarn bootstrap
+    - run: truffle obtain --solc=0.5.8
+    - run: yarn ci
     - run: npm i -g truffle

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,28 @@
+name: Node CI
+
+on:
+  pull_request:
+    branches:
+    - develop
+    
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x, 12.x]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+        
+    - name: setup truffle project dependencies
+    - run: npm install -g yarn lerna
+
+    - name: bootstrap project
+      run: yarn bootstrap

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -32,6 +32,5 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm install -g yarn lerna
     - run: yarn bootstrap
-    - run: truffle obtain --solc=0.5.8
     - run: yarn ci
     - run: npm i -g truffle

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest, windows-latest
 
     strategy:
       matrix:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -19,8 +19,8 @@ jobs:
   build:
     strategy:
       matrix:
-        platform: [ubuntu-latest, windows-latest]
-        node-version: [8.x, 10.x, 12.x]
+        platform: [ubuntu-latest]
+        node-version: [10.x, 12.x]
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -20,8 +20,8 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        node-version: [10.x, 12.x]
-        env: [GETH=true, QUORUM=true, PACKAGES=true, INTEGRATION=true, COVERAGE=true]
+        node-version: [8.x, 10.x, 12.x]
+        env: [GETH=true, QUORUM=true, PACKAGES=true, INTEGRATION=true]
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -21,6 +21,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest]
         node-version: [10.x, 12.x]
+        env: [GETH=true, QUORUM=true]
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -36,6 +36,7 @@ jobs:
     - uses: 8398a7/action-slack@v1
       with:
         type: failure
+        failedMention: ""
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -22,3 +22,4 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm install -g yarn lerna
     - run: yarn bootstrap
+    - run: npm i -g truffle

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -7,12 +7,12 @@ on:
     
 jobs:
   build:
-
-    runs-on: ubuntu-latest, windows-latest
-
     strategy:
       matrix:
+        platform: [ubuntu-latest, windows-latest]
         node-version: [10.x, 12.x]
+
+    runs-on: ${{ matrix.platform }}
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -36,7 +36,7 @@ jobs:
     - uses: 8398a7/action-slack@v1.1.1
       with:
         type: failure
-        failedMention: ""
+        failedMenthon: ""
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,7 +11,6 @@ jobs:
       matrix:
         platform: [ubuntu-latest, windows-latest]
         node-version: [8x, 10.x, 12.x]
-
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -32,5 +32,6 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm install -g yarn lerna
     - run: yarn bootstrap
+    - run: sudo add-apt-repository ppa:ethereum/ethereum
     - run: ${{ matrix.env }} yarn ci
     - run: npm i -g truffle

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest]
-        node-version: [10.x, 12.x]
+        node-version: [8x, 10.x, 12.x]
 
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -33,3 +33,17 @@ jobs:
     - run: npm install -g yarn lerna
     - run: yarn bootstrap
     - run: ${{ matrix.env }} yarn ci
+    - uses: 8398a7/action-slack@v1
+      with:
+        type: failure
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      if: failure()
+    - uses: 8398a7/action-slack@v1
+      with:
+        type: success
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      if: success()

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,6 @@ branches:
     # other targets
     - truffle-db
 
-addons:
-  apt:
-    sources:
-      - sourceline: 'ppa:ethereum/ethereum'
-    packages: dpkg
-
 before_install:
   - npm list -g lerna --depth=0 || npm install -g lerna
   - npm install -g yarn
@@ -28,8 +22,6 @@ matrix:
   include:
     - node_js: 8
       env: GETH=true
-    - node_js: 8
-      env: QUORUM=true
     - node_js: 8
       env: FABRICEVM=true
     - node_js: 8

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,7 @@ matrix:
   fast_finish: true
   include:
     - node_js: 8
-      env: GETH=true
-    - node_js: 8
       env: FABRICEVM=true
-    - node_js: 8
-      env: PACKAGES=true
-    - node_js: 8
-      env: INTEGRATION=true
     - node_js: 8
       env: COVERAGE=true
   allow_failures:

--- a/packages/truffle-deployer/test/errors.js
+++ b/packages/truffle-deployer/test/errors.js
@@ -181,7 +181,7 @@ describe("Error cases", function() {
   });
 
   it("OOG (w/ estimate, hits block limit)", async function() {
-    this.timeout(20000);
+    this.timeout(30000);
 
     const migrate = function() {
       deployer.deploy(Loops);

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -84,7 +84,7 @@ elif [ "$FABRICEVM" = true ]; then
 elif [ "$PACKAGES" = true ]; then
 
   docker pull ethereum/solc:0.4.22
-  sudo add-apt-repository -y ppa:deadsnakes/ppa
+  sudo add-apt-repository -y ppa:deadsnakes/ppa ppa:ethereum/ethereum
   sudo apt update
   sudo apt install -y python3.6 python3.6-dev python3.6-venv solc
   wget https://bootstrap.pypa.io/get-pip.py
@@ -95,7 +95,7 @@ elif [ "$PACKAGES" = true ]; then
 elif [ "$COVERAGE" = true ]; then
 
   docker pull ethereum/solc:0.4.22
-  sudo add-apt-repository -y ppa:deadsnakes/ppa
+  sudo add-apt-repository -y ppa:deadsnakes/ppa ppa:ethereum/ethereum
   sudo apt update
   sudo apt install -y jq python3.6 python3.6-dev python3.6-venv solc
   wget https://bootstrap.pypa.io/get-pip.py

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -84,7 +84,8 @@ elif [ "$FABRICEVM" = true ]; then
 elif [ "$PACKAGES" = true ]; then
 
   docker pull ethereum/solc:0.4.22
-  sudo add-apt-repository -y ppa:deadsnakes/ppa ppa:ethereum/ethereum
+  sudo add-apt-repository -y ppa:deadsnakes/ppa
+  sudo add-apt-repository -y ppa:ethereum/ethereum
   sudo apt update
   sudo apt install -y python3.6 python3.6-dev python3.6-venv solc
   wget https://bootstrap.pypa.io/get-pip.py
@@ -95,7 +96,8 @@ elif [ "$PACKAGES" = true ]; then
 elif [ "$COVERAGE" = true ]; then
 
   docker pull ethereum/solc:0.4.22
-  sudo add-apt-repository -y ppa:deadsnakes/ppa ppa:ethereum/ethereum
+  sudo add-apt-repository -y ppa:deadsnakes/ppa
+  sudo add-apt-repository -y ppa:ethereum/ethereum
   sudo apt update
   sudo apt install -y jq python3.6 python3.6-dev python3.6-venv solc
   wget https://bootstrap.pypa.io/get-pip.py

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -86,7 +86,7 @@ elif [ "$PACKAGES" = true ]; then
 
   docker pull ethereum/solc:0.4.22
   sudo add-apt-repository -y ppa:deadsnakes/ppa
-  sudo add-apt-repository -y ppa:ethereum/ethereum
+#  sudo add-apt-repository -y ppa:ethereum/ethereum
   sudo apt update
   sudo apt install -y python3.6 python3.6-dev python3.6-venv solc
   wget https://bootstrap.pypa.io/get-pip.py

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -86,7 +86,7 @@ elif [ "$PACKAGES" = true ]; then
 
   docker pull ethereum/solc:0.4.22
   sudo add-apt-repository -y ppa:deadsnakes/ppa
-#  sudo add-apt-repository -y ppa:ethereum/ethereum
+  sudo add-apt-repository -y ppa:ethereum/ethereum
   sudo apt update
   sudo apt install -y python3.6 python3.6-dev python3.6-venv solc
   wget https://bootstrap.pypa.io/get-pip.py

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -37,6 +37,7 @@ elif [ "$GETH" = true ]; then
   sudo apt install -y jq
   docker pull ethereum/client-go:latest
   run_geth
+  sleep 30
   lerna run --scope truffle test --stream -- --exit
   lerna run --scope truffle-contract test --stream -- --exit
 


### PR DESCRIPTION
This PR leverages Github Actions to run CI checks against Node 8.x, 10.x, & 12.x on Ubuntu. Trims Travis' workload and keeps Travis jobs for Fabric EVM & Coveralls tests (for now).

Also adds Slack Notifications for when a workflow fails or when the build workflow job succeeds.