### PR TITLE
Bug fix: Provide reason for calls

### DIFF
--- a/packages/truffle-contract/lib/override.js
+++ b/packages/truffle-contract/lib/override.js
@@ -43,20 +43,20 @@ const override = {
    * @param  {Object} err     error
    */
   start: async function(context, web3Error) {
-    var constructor = this;
-    var currentBlock = override.defaultMaxBlocks;
-    var maxBlocks = constructor.timeoutBlocks;
+    const constructor = this;
+    let currentBlock = override.defaultMaxBlocks;
+    const maxBlocks = constructor.timeoutBlocks;
 
-    var timedOut =
+    const timedOut =
       web3Error.message && web3Error.message.includes(override.timeoutMessage);
-    var shouldWait = maxBlocks > currentBlock;
+    const shouldWait = maxBlocks > currentBlock;
 
     // Reject after attempting to get reason string if we shouldn't be waiting.
     if (!timedOut || !shouldWait) {
       // We might have been routed here in web3 >= beta.34 by their own status check
       // error. We want to extract the receipt, emit a receipt event
       // and reject it ourselves.
-      var receipt = override.extractReceipt(web3Error.message);
+      const receipt = override.extractReceipt(web3Error.message);
       if (receipt) {
         await handlers.receipt(context, receipt);
         return;
@@ -75,7 +75,7 @@ const override = {
     }
 
     // This will run every block from now until contract.timeoutBlocks
-    var listener = function(pollID) {
+    const listener = function(pollID) {
       currentBlock++;
 
       if (currentBlock > constructor.timeoutBlocks) {

--- a/packages/truffle-contract/test/revertReasons.js
+++ b/packages/truffle-contract/test/revertReasons.js
@@ -1,0 +1,35 @@
+const { assert } = require("chai");
+const util = require("./util");
+
+describe("revert reasons", function() {
+  let RevertingContract;
+  const providerOptions = { vmErrorsOnRPCResponse: true }; // <--- TRUE
+
+  before(async function() {
+    this.timeout(10000);
+
+    RevertingContract = await util.createRevertingContract();
+
+    await util.setUpProvider(RevertingContract, providerOptions);
+  });
+
+  it("provides a reason when a function reverts", async () => {
+    try {
+      let instance = await RevertingContract.new();
+      await instance.revertingFunction();
+      assert.fail();
+    } catch (error) {
+      assert(error.reason, "Too reverty of a function");
+    }
+  });
+
+  it("provides a reason when a view function (call) reverts", async () => {
+    try {
+      let instance = await RevertingContract.new();
+      await instance.revertingView();
+      assert.fail();
+    } catch (error) {
+      assert(error.reason, "Too reverty of a view");
+    }
+  });
+});

--- a/packages/truffle-contract/test/sources/RevertingContract.sol
+++ b/packages/truffle-contract/test/sources/RevertingContract.sol
@@ -1,0 +1,17 @@
+pragma solidity ^0.5.0;
+
+contract RevertingContract {
+  uint256 public value;
+
+  constructor() public {
+    value = 0;
+  }
+
+  function revertingView() public view {
+    require(value > 0, "Too reverty of a view");
+  }
+
+  function revertingFunction() public {
+    require(value > 0, "Too reverty of a function");
+  }
+}

--- a/packages/truffle-contract/test/util.js
+++ b/packages/truffle-contract/test/util.js
@@ -35,6 +35,13 @@ var util = {
     );
   },
 
+  createRevertingContract: async function() {
+    return await util._createContractInstance(
+      path.join(__dirname, "sources", "RevertingContract.sol"),
+      "RevertingContract"
+    );
+  },
+
   _createContractInstance: async function(sourcePath, contractName) {
     var contractObj;
     const sources = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5775,7 +5775,7 @@ ethjs-util@0.1.6, ethjs-util@^0.1.3, ethjs-util@^0.1.6:
     is-hex-prefixed "1.0.0"
     strip-hex-prefix "1.0.0"
 
-ethpm-registry@^0.1.0-next.3:
+ethpm-registry@0.1.0-next.3:
   version "0.1.0-next.3"
   resolved "https://registry.yarnpkg.com/ethpm-registry/-/ethpm-registry-0.1.0-next.3.tgz#e335e7f57cda3c1cead388db6833903121773e9c"
   integrity sha512-PZZ1wo7lf2J3xWfvdEHzG6gJzh2wJiw8jzBcLgqOicLQoxVzgzCCcF6GZKakIeDZfMilrP/0fm7uu5PviZzECg==


### PR DESCRIPTION
Fixes #2321 

Previously, reasons for reverts were provided only when a "send" was reverted. This PR extracts a method that parses out a revert reason and uses it when "call"s revert as well.