### PR TITLE
Update TypeScript to 3.6 and make use of Generator types

### DIFF
--- a/packages/truffle-codec-utils/package.json
+++ b/packages/truffle-codec-utils/package.json
@@ -36,7 +36,7 @@
     "@types/web3": "^1.0.19",
     "truffle-contract-schema": "^3.0.11",
     "json-schema-to-typescript": "^6.1.3",
-    "typescript": "^3.5.1"
+    "typescript": "^3.6.2"
   },
   "gitHead": "b207efb3c1409746537293b3e0fc27350029188e"
 }

--- a/packages/truffle-codec/lib/decode/constant.ts
+++ b/packages/truffle-codec/lib/decode/constant.ts
@@ -2,15 +2,15 @@ import debugModule from "debug";
 const debug = debugModule("codec:decode:constant");
 
 import * as CodecUtils from "truffle-codec-utils";
-import { Types, Values } from "truffle-codec-utils";
+import { Types, Values, Errors } from "truffle-codec-utils";
 import read from "../read";
 import decodeValue from "./value";
 import { ConstantDefinitionPointer} from "../types/pointer";
 import { EvmInfo } from "../types/evm";
-import { DecoderRequest, GeneratorJunk } from "../types/request";
+import { DecoderRequest } from "../types/request";
 import BN from "bn.js";
 
-export default function* decodeConstant(dataType: Types.Type, pointer: ConstantDefinitionPointer, info: EvmInfo): IterableIterator<Values.Result | DecoderRequest | GeneratorJunk> {
+export default function* decodeConstant(dataType: Types.Type, pointer: ConstantDefinitionPointer, info: EvmInfo): Generator<DecoderRequest, Values.Result, Uint8Array> {
 
   debug("pointer %o", pointer);
 
@@ -26,18 +26,18 @@ export default function* decodeConstant(dataType: Types.Type, pointer: ConstantD
     try {
       word = yield* read(pointer, info.state);
     }
-    catch(error) { //error: Errors.DecodingError
+    catch(error) {
       return {
         type: dataType,
-        kind: "error",
-        error: error.error
+        kind: "error" as const,
+        error: (<Errors.DecodingError>error).error
       };
     }
     //not bothering to check padding; shouldn't be necessary
     let bytes = word.slice(CodecUtils.EVM.WORD_SIZE - size);
     return {
       type: dataType,
-      kind: "value",
+      kind: "value" as const,
       value: {
         asHex: CodecUtils.Conversion.toHexString(bytes)
       }

--- a/packages/truffle-codec/lib/decode/event.ts
+++ b/packages/truffle-codec/lib/decode/event.ts
@@ -3,24 +3,24 @@ const debug = debugModule("codec:decode:event");
 
 import decodeValue from "./value";
 import read from "../read";
-import { Types, Values, Conversion as ConversionUtils } from "truffle-codec-utils";
+import { Types, Values, Errors, Conversion as ConversionUtils } from "truffle-codec-utils";
 import { EventTopicPointer } from "../types/pointer";
 import { EvmInfo } from "../types/evm";
 import { DecoderOptions } from "../types/options";
-import { DecoderRequest, GeneratorJunk } from "../types/request";
+import { DecoderRequest } from "../types/request";
 import { StopDecodingError } from "../types/errors";
 
-export default function* decodeTopic(dataType: Types.Type, pointer: EventTopicPointer, info: EvmInfo, options: DecoderOptions = {}): IterableIterator<Values.Result | DecoderRequest | GeneratorJunk> {
+export default function* decodeTopic(dataType: Types.Type, pointer: EventTopicPointer, info: EvmInfo, options: DecoderOptions = {}): Generator<DecoderRequest, Values.Result, Uint8Array> {
   if(Types.isReferenceType(dataType)) {
     //we cannot decode reference types "stored" in topics; we have to just return an error
     let bytes: Uint8Array = yield* read(pointer, info.state);
     let raw: string = ConversionUtils.toHexString(bytes);
     //NOTE: even in strict mode we want to just return this, not throw an error here
-    return {
+    return <Errors.ErrorResult> { //dunno why TS is failing here
       type: dataType,
-      kind: "error",
+      kind: "error" as const,
       error: {
-	kind: "IndexedReferenceTypeError",
+	kind: "IndexedReferenceTypeError" as const,
         type: dataType,
         raw
       }

--- a/packages/truffle-codec/lib/decode/index.ts
+++ b/packages/truffle-codec/lib/decode/index.ts
@@ -14,9 +14,9 @@ import { Types, Values } from "truffle-codec-utils";
 import * as Pointer from "../types/pointer";
 import { EvmInfo } from "../types/evm";
 import { DecoderOptions } from "../types/options";
-import { DecoderRequest, GeneratorJunk } from "../types/request";
+import { DecoderRequest } from "../types/request";
 
-export default function* decode(dataType: Types.Type, pointer: Pointer.DataPointer, info: EvmInfo, options: DecoderOptions = {}): IterableIterator<Values.Result | DecoderRequest | GeneratorJunk> {
+export default function* decode(dataType: Types.Type, pointer: Pointer.DataPointer, info: EvmInfo, options: DecoderOptions = {}): Generator<DecoderRequest, Values.Result, Uint8Array> {
   debug("type %O", dataType);
   debug("pointer %O", pointer);
 

--- a/packages/truffle-codec/lib/interface/index.ts
+++ b/packages/truffle-codec/lib/interface/index.ts
@@ -6,7 +6,7 @@ export { slotAddress } from "../read/storage";
 export { StoragePointer } from "../types/pointer";
 export { ContractAllocationInfo, StorageAllocations, StorageMemberAllocation, AbiAllocations, CalldataAllocations, EventAllocations } from "../types/allocation";
 export { Slot, isWordsLength, equalSlots } from "../types/storage";
-export { DecoderRequest, isStorageRequest, isCodeRequest } from "../types/request";
+export { DecoderRequest } from "../types/request";
 export { EvmInfo, AllocationInfo } from "../types/evm";
 export { CalldataDecoding, LogDecoding } from "../types/decoding";
 

--- a/packages/truffle-codec/lib/read/index.ts
+++ b/packages/truffle-codec/lib/read/index.ts
@@ -7,7 +7,7 @@ import { EvmState } from "../types/evm";
 import { DecoderRequest } from "../types/request";
 import { Errors } from "truffle-codec-utils";
 
-export default function* read(pointer: Pointer.DataPointer, state: EvmState): IterableIterator<Uint8Array | DecoderRequest> {
+export default function* read(pointer: Pointer.DataPointer, state: EvmState): Generator<DecoderRequest, Uint8Array, Uint8Array> {
   switch(pointer.location) {
 
     case "stack":

--- a/packages/truffle-codec/lib/read/storage.ts
+++ b/packages/truffle-codec/lib/read/storage.ts
@@ -54,7 +54,7 @@ export function slotAddressPrintout(slot: Slot): string {
  * @param slot - see slotAddress() code to understand how these work
  * @param offset - for array, offset from the keccak determined location
  */
-export function* read(storage: WordMapping, slot: Slot): IterableIterator<Uint8Array | DecoderRequest> {
+export function* read(storage: WordMapping, slot: Slot): Generator<DecoderRequest, Uint8Array, Uint8Array> {
   debug("Slot printout: %s", slotAddressPrintout(slot));
   const address: BN = slotAddress(slot);
 
@@ -92,7 +92,7 @@ export function* read(storage: WordMapping, slot: Slot): IterableIterator<Uint8A
  * @param to - location (see ^). inclusive.
  * @param length - instead of `to`, number of bytes after `from`
  */
-export function* readRange(storage: WordMapping, range: Range): IterableIterator<Uint8Array | DecoderRequest> {
+export function* readRange(storage: WordMapping, range: Range): Generator<DecoderRequest, Uint8Array, Uint8Array> {
   debug("readRange %o", range);
 
   let { from, to, length } = range;

--- a/packages/truffle-codec/lib/types/request.ts
+++ b/packages/truffle-codec/lib/types/request.ts
@@ -12,14 +12,3 @@ export interface CodeRequest {
   type: "code";
   address: string;
 }
-
-export function isStorageRequest(request: DecoderRequest): request is StorageRequest {
-  return request.type === "storage";
-}
-
-export function isCodeRequest(request: DecoderRequest): request is CodeRequest {
-  return request.type === "code";
-}
-
-//HACK -- to help mitigate the generator problem
-export type GeneratorJunk = Uint8Array | Values.ContractValueInfo | Values.FunctionExternalValueInfo;

--- a/packages/truffle-codec/package.json
+++ b/packages/truffle-codec/package.json
@@ -32,7 +32,7 @@
     "@types/lodash.partition": "^4.6.6",
     "@types/lodash.sum": "^4.0.6",
     "@types/utf8": "^2.1.6",
-    "typescript": "^3.1.3"
+    "typescript": "^3.6.2"
   },
   "dependencies": {
     "bn.js": "^4.11.8",

--- a/packages/truffle-decoder/lib/wire.ts
+++ b/packages/truffle-decoder/lib/wire.ts
@@ -156,17 +156,19 @@ export default class TruffleWireDecoder extends AsyncEventEmitter {
     const decoder = Codec.decodeCalldata(info);
 
     let result = decoder.next();
-    while(!result.done) {
-      let request = <Codec.DecoderRequest>(result.value);
+    while(result.done === false) {
+      let request = result.value;
       let response: Uint8Array;
-      //only code requests should occur here
-      if(Codec.isCodeRequest(request)) {
-        response = await this.getCode(request.address, block);
+      switch(request.type) {
+	case "code":
+          response = await this.getCode(request.address, block);
+	  break;
+	//not writing a storage case as it shouldn't occur here!
       }
       result = decoder.next(response);
     }
     //at this point, result.value holds the final value
-    const decoding = <Codec.CalldataDecoding>result.value;
+    const decoding = result.value;
     
     return {
       ...transaction,
@@ -193,17 +195,19 @@ export default class TruffleWireDecoder extends AsyncEventEmitter {
     const decoder = Codec.decodeEvent(info, log.address, options.name);
 
     let result = decoder.next();
-    while(!result.done) {
-      let request = <Codec.DecoderRequest>(result.value);
+    while(result.done === false) {
+      let request = result.value;
       let response: Uint8Array;
-      //only code requests should occur here
-      if(Codec.isCodeRequest(request)) {
-        response = await this.getCode(request.address, block);
+      switch(request.type) {
+	case "code":
+          response = await this.getCode(request.address, block);
+	  break;
+	//not writing a storage case as it shouldn't occur here!
       }
       result = decoder.next(response);
     }
     //at this point, result.value holds the final value
-    const decodings = <Codec.LogDecoding[]>result.value;
+    const decodings = result.value;
     
     return {
       ...log,

--- a/packages/truffle-decoder/package.json
+++ b/packages/truffle-decoder/package.json
@@ -31,10 +31,8 @@
     "async-eventemitter": "^0.2.4",
     "bn.js": "^4.11.8",
     "debug": "^4.1.1",
-    "json-schema-to-typescript": "^6.1.3",
     "truffle-codec": "^3.0.8",
     "truffle-codec-utils": "^1.0.16",
-    "truffle-contract-schema": "^3.0.9",
     "web3": "^1.2.1"
   },
   "devDependencies": {
@@ -44,7 +42,7 @@
     "chai": "^4.2.0",
     "json-schema-to-typescript": "^6.1.3",
     "@truffle/contract-schema": "^3.0.13",
-    "typescript": "^3.5.1",
+    "typescript": "^3.6.2",
     "web3-core": "1.0.0-beta.37"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14358,7 +14358,7 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
-truffle-contract-schema@^3.0.11, truffle-contract-schema@^3.0.9:
+truffle-contract-schema@^3.0.11:
   version "3.0.13"
   resolved "https://registry.yarnpkg.com/truffle-contract-schema/-/truffle-contract-schema-3.0.13.tgz#8ace5734a0d57bfebc6ab3b60bf0883d46c68fdc"
   integrity sha512-joF6oiG35xkRalc9Jeuq1NJ43jE3T0LVoWQ/8EhhGyE5E9PxYbUjNtdcj8ycOpn3BYFiomX2UUsgmt4W2U1Qtg==
@@ -14529,15 +14529,15 @@ typescript-tuple@^2.1.0:
   dependencies:
     typescript-compare "^0.0.2"
 
-typescript@^3.1.3, typescript@^3.3.3333:
+typescript@^3.3.3333:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.1.tgz#ba72a6a600b2158139c5dd8850f700e231464202"
   integrity sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==
 
-typescript@^3.5.1:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
-  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
+typescript@^3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.2.tgz#105b0f1934119dde543ac8eb71af3a91009efe54"
+  integrity sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==
 
 typewise-core@^1.2, typewise-core@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
This PR updates the TypeScript version to 3.6 and makes use of its new `Generator` types to improve the typing on the decoder.  No longer do the decoder return types contain a bunch of irrelevant junk; now TypeScript can actually distinguish between a `return`ed value and a `yield`ed request.  I've removed the coercions from the places that use these functions' return values since they're no longer necessary.  And, of course, the `GeneratorJunk` type is gone entirely.

While I was at it, I also removed some unnecessary type predicates that I had put in when I didn't know about discriminated unions.  I also removed some lines from `package.json` that shouldn't have been there, which I assume ended up there mistakenly during a merge.

Unfortunately TypeScript had a bunch of trouble handling some of the typings related to errors, and I ended having to just put coercions on to convince it it's OK.  Probably I should file an issue about this... (or since it's TypeScript, more likely, comment on an existing issue).