### PR TITLE
Allow absence of whitespace in import statement

### DIFF
--- a/packages/truffle-compile/parser.js
+++ b/packages/truffle-compile/parser.js
@@ -51,7 +51,7 @@ module.exports = {
       .filter(({ message }) => !message.includes(failingImportFileName))
       .map(({ formattedMessage }) => {
         const matches = formattedMessage.match(
-          /import[^'"]+("|')([^'"]+)("|')/
+          /import\s*("|')([^'"]+)("|')/
         );
 
         // Return the item between the quotes.


### PR DESCRIPTION
Solc can compile either of the below import lines (notice the lack of white space in the second one):
`import "Example.sol;`
`import"Example.sol;`

But the regex currently fails on the second one.  This update allows either to pass.