### PR TITLE
Remove 'gitHead' property from all package.jsons

### DIFF
--- a/packages/artifactor/package.json
+++ b/packages/artifactor/package.json
@@ -27,6 +27,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "2b5dd3fe3079aad66c1e74d0477c30e228cfae2c"
+  }
 }

--- a/packages/blockchain-utils/package.json
+++ b/packages/blockchain-utils/package.json
@@ -24,7 +24,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "2b5dd3fe3079aad66c1e74d0477c30e228cfae2c",
   "devDependencies": {
     "@types/assert": "^1.4.2",
     "@types/web3": "^1.0.19",

--- a/packages/box/package.json
+++ b/packages/box/package.json
@@ -40,6 +40,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "2b5dd3fe3079aad66c1e74d0477c30e228cfae2c"
+  }
 }

--- a/packages/code-utils/package.json
+++ b/packages/code-utils/package.json
@@ -15,7 +15,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "1ee7e21208fbff93267490729c2fac2e76bb6090",
   "devDependencies": {
     "@types/node": "^12.6.8",
     "mocha": "5.2.0",

--- a/packages/compile-solidity/package.json
+++ b/packages/compile-solidity/package.json
@@ -51,6 +51,5 @@
   "homepage": "https://github.com/trufflesuite/compile-solidity#readme",
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "2b5dd3fe3079aad66c1e74d0477c30e228cfae2c"
+  }
 }

--- a/packages/compile-vyper/package.json
+++ b/packages/compile-vyper/package.json
@@ -28,6 +28,5 @@
   ],
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "2b5dd3fe3079aad66c1e74d0477c30e228cfae2c"
+  }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -30,7 +30,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "2b5dd3fe3079aad66c1e74d0477c30e228cfae2c",
   "devDependencies": {
     "mocha": "5.2.0"
   }

--- a/packages/contract-schema/package.json
+++ b/packages/contract-schema/package.json
@@ -37,6 +37,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "2b5dd3fe3079aad66c1e74d0477c30e228cfae2c"
+  }
 }

--- a/packages/contract-sources/package.json
+++ b/packages/contract-sources/package.json
@@ -23,6 +23,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "b207efb3c1409746537293b3e0fc27350029188e"
+  }
 }

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -49,6 +49,5 @@
   ],
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "2b5dd3fe3079aad66c1e74d0477c30e228cfae2c"
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -82,6 +82,5 @@
       "url": "https://github.com/tcoulter"
     }
   ],
-  "gitHead": "2b5dd3fe3079aad66c1e74d0477c30e228cfae2c",
   "namespace": "consensys"
 }

--- a/packages/debug-utils/package.json
+++ b/packages/debug-utils/package.json
@@ -21,7 +21,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "b207efb3c1409746537293b3e0fc27350029188e",
   "devDependencies": {
     "chai": "^4.2.0",
     "mocha": "^6.1.4",

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -83,6 +83,5 @@
   ],
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "2b5dd3fe3079aad66c1e74d0477c30e228cfae2c"
+  }
 }

--- a/packages/decode-utils/package.json
+++ b/packages/decode-utils/package.json
@@ -33,6 +33,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "1ee7e21208fbff93267490729c2fac2e76bb6090"
+  }
 }

--- a/packages/decoder/package.json
+++ b/packages/decoder/package.json
@@ -56,6 +56,5 @@
     "decoder",
     "ethereum",
     "state"
-  ],
-  "gitHead": "2b5dd3fe3079aad66c1e74d0477c30e228cfae2c"
+  ]
 }

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -34,6 +34,5 @@
   ],
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "2b5dd3fe3079aad66c1e74d0477c30e228cfae2c"
+  }
 }

--- a/packages/environment/package.json
+++ b/packages/environment/package.json
@@ -23,6 +23,5 @@
   },
   "devDependencies": {
     "debug": "^4.1.0"
-  },
-  "gitHead": "2b5dd3fe3079aad66c1e74d0477c30e228cfae2c"
+  }
 }

--- a/packages/error/package.json
+++ b/packages/error/package.json
@@ -19,6 +19,5 @@
   "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/error#readme",
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "2b5dd3fe3079aad66c1e74d0477c30e228cfae2c"
+  }
 }

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -21,7 +21,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "1ee7e21208fbff93267490729c2fac2e76bb6090",
   "devDependencies": {
     "mocha": "5.2.0"
   }

--- a/packages/external-compile/package.json
+++ b/packages/external-compile/package.json
@@ -32,6 +32,5 @@
   ],
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "b207efb3c1409746537293b3e0fc27350029188e"
+  }
 }

--- a/packages/hdwallet-provider/package.json
+++ b/packages/hdwallet-provider/package.json
@@ -42,6 +42,5 @@
     "mnemonic",
     "provider",
     "wallet"
-  ],
-  "gitHead": "b207efb3c1409746537293b3e0fc27350029188e"
+  ]
 }

--- a/packages/interface-adapter/package.json
+++ b/packages/interface-adapter/package.json
@@ -32,6 +32,5 @@
     "mocha": "^6.0.2",
     "ts-node": "^8.0.3",
     "typescript": "^3.3.3333"
-  },
-  "gitHead": "1ee7e21208fbff93267490729c2fac2e76bb6090"
+  }
 }

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -30,6 +30,5 @@
   ],
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "2b5dd3fe3079aad66c1e74d0477c30e228cfae2c"
+  }
 }

--- a/packages/reporters/package.json
+++ b/packages/reporters/package.json
@@ -14,6 +14,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "1ee7e21208fbff93267490729c2fac2e76bb6090"
+  }
 }

--- a/packages/require/package.json
+++ b/packages/require/package.json
@@ -31,6 +31,5 @@
   ],
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "2b5dd3fe3079aad66c1e74d0477c30e228cfae2c"
+  }
 }

--- a/packages/solidity-loader/package.json
+++ b/packages/solidity-loader/package.json
@@ -26,6 +26,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "2b5dd3fe3079aad66c1e74d0477c30e228cfae2c"
+  }
 }

--- a/packages/solidity-utils/package.json
+++ b/packages/solidity-utils/package.json
@@ -19,6 +19,5 @@
   "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/solidity-utils#readme",
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "b207efb3c1409746537293b3e0fc27350029188e"
+  }
 }

--- a/packages/truffle-migrate/package.json
+++ b/packages/truffle-migrate/package.json
@@ -37,6 +37,5 @@
   ],
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "2b5dd3fe3079aad66c1e74d0477c30e228cfae2c"
+  }
 }

--- a/packages/truffle-resolver/package.json
+++ b/packages/truffle-resolver/package.json
@@ -35,6 +35,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "2b5dd3fe3079aad66c1e74d0477c30e228cfae2c"
+  }
 }

--- a/packages/truffle-sawtooth-seth-provider/package.json
+++ b/packages/truffle-sawtooth-seth-provider/package.json
@@ -13,6 +13,5 @@
   "dependencies": {
     "debug": "^4.1.0",
     "web3-provider-engine": "14.0.6"
-  },
-  "gitHead": "b207efb3c1409746537293b3e0fc27350029188e"
+  }
 }

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -68,6 +68,5 @@
       "url": "https://github.com/tcoulter"
     }
   ],
-  "gitHead": "2b5dd3fe3079aad66c1e74d0477c30e228cfae2c",
   "namespace": "consensys"
 }

--- a/packages/workflow-compile/package.json
+++ b/packages/workflow-compile/package.json
@@ -27,7 +27,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "2b5dd3fe3079aad66c1e74d0477c30e228cfae2c",
   "devDependencies": {
     "debug": "^4.1.1",
     "mocha": "5.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -982,17 +982,17 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
-"@types/assert@^1.4.2":
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/@types/assert/-/assert-1.4.2.tgz#e9116f5abf9cbd0c86ed22e38185b71e7f44071c"
-  integrity sha512-N5I8kX4ybqvqi4A+Y8b3coatbuRKWaa+sEPm3aCFdm9oCxsDvwY/ELNV4c/56W5MdRKJ6b8AOWRFyxhi437t7A==
-  
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"
   integrity sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==
   dependencies:
     defer-to-connect "^1.0.1"
+
+"@types/assert@^1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@types/assert/-/assert-1.4.2.tgz#e9116f5abf9cbd0c86ed22e38185b71e7f44071c"
+  integrity sha512-N5I8kX4ybqvqi4A+Y8b3coatbuRKWaa+sEPm3aCFdm9oCxsDvwY/ELNV4c/56W5MdRKJ6b8AOWRFyxhi437t7A==
 
 "@types/bn.js@*", "@types/bn.js@^4.11.2", "@types/bn.js@^4.11.4":
   version "4.11.5"
@@ -14271,6 +14271,53 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
+truffle-blockchain-utils@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/truffle-blockchain-utils/-/truffle-blockchain-utils-0.0.10.tgz#18b772673635a95a893f7083f7be6bd62227462b"
+  integrity sha512-gVvagLCvYD0QXfnkxy6I48P6O+d7TEY0smc2VFuwldl1/clLVWE+KfBO/jFMaAz+nupTQeKvPhNTeyh3JAsCeA==
+
+truffle-config@^1.0.1:
+  version "1.1.20"
+  resolved "https://registry.yarnpkg.com/truffle-config/-/truffle-config-1.1.20.tgz#9152b47c0d6f371b81c55d072b99f6dcadae91d1"
+  integrity sha512-Pam/e593+T4AY3oVgpQlOAnnFJGa+hYuhnn90DPOcTvoD7Fp1oBpnZ0sAy9bGT3YnUuB/ae7q9Phm/tYM5ffpw==
+  dependencies:
+    "@truffle/error" "^0.0.6"
+    configstore "^4.0.0"
+    find-up "^2.1.0"
+    lodash "^4.17.13"
+    original-require "1.0.1"
+    truffle-provider "^0.1.16"
+
+truffle-contract-schema@^3.0.13:
+  version "3.0.13"
+  resolved "https://registry.yarnpkg.com/truffle-contract-schema/-/truffle-contract-schema-3.0.13.tgz#8ace5734a0d57bfebc6ab3b60bf0883d46c68fdc"
+  integrity sha512-joF6oiG35xkRalc9Jeuq1NJ43jE3T0LVoWQ/8EhhGyE5E9PxYbUjNtdcj8ycOpn3BYFiomX2UUsgmt4W2U1Qtg==
+  dependencies:
+    ajv "^6.10.0"
+    crypto-js "^3.1.9-1"
+    debug "^4.1.0"
+
+truffle-contract@4.0.30:
+  version "4.0.30"
+  resolved "https://registry.yarnpkg.com/truffle-contract/-/truffle-contract-4.0.30.tgz#de0d7ac25c55dcafbe113f862f9a7fd5f83a1531"
+  integrity sha512-kQDqqhT6IPu1Vj111PzQvQ3xQiXx//cwFgMDZjaqRpBGuXGa5i80RxW+Vxfdn5pTrYk4pP0P7ZPyka9PJ248vw==
+  dependencies:
+    bignumber.js "^7.2.1"
+    ethers "^4.0.0-beta.1"
+    truffle-blockchain-utils "^0.0.10"
+    truffle-contract-schema "^3.0.13"
+    truffle-error "^0.0.5"
+    truffle-interface-adapter "^0.2.4"
+    web3 "1.2.1"
+    web3-core-promievent "1.2.1"
+    web3-eth-abi "1.2.1"
+    web3-utils "1.2.1"
+
+truffle-error@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/truffle-error/-/truffle-error-0.0.5.tgz#6b5740c9f3aac74f47b85d654fff7fe2c1fc5e0e"
+  integrity sha512-JpzPLMPSCE0vaZ3vH5NO5u42GpMj/Y1SRBkQ6b69PSw3xMSH1umApN32cEcg1nnh8q5FNYc5FnKu0m4tiBffyQ==
+
 truffle-init@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/truffle-init/-/truffle-init-1.0.7.tgz#c3de57fbddfa77ae93642ae025f41c1157de2ba7"
@@ -14282,6 +14329,25 @@ truffle-init@^1.0.7:
     rimraf "^2.5.4"
     temp "^0.8.3"
     truffle-config "^1.0.1"
+
+truffle-interface-adapter@^0.2.4, truffle-interface-adapter@^0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/truffle-interface-adapter/-/truffle-interface-adapter-0.2.5.tgz#aa0bee635517b4a8e06adcdc99eacb993e68c243"
+  integrity sha512-EL39OpP8FcZ99ne1Rno3jImfb92Nectd4iVsZzoEUCBfbwHe7sr0k+i45guoruSoP8nMUE81Mov2s8I5pi6d9Q==
+  dependencies:
+    bn.js "^4.11.8"
+    ethers "^4.0.32"
+    lodash "^4.17.13"
+    web3 "1.2.1"
+
+truffle-provider@^0.1.16:
+  version "0.1.16"
+  resolved "https://registry.yarnpkg.com/truffle-provider/-/truffle-provider-0.1.16.tgz#05db46a4bda9b7e6503f8701f2b03ccb1e6c78ba"
+  integrity sha512-3d5WqSKIzZcpgW44mdfF97s+Tgh2a/3Ly6vHJirBV9OZDUtiAzP6WVnlRNvmlDJXFCDqt6Yb9qQWoXFHbYoR6w==
+  dependencies:
+    "@truffle/error" "^0.0.6"
+    truffle-interface-adapter "^0.2.5"
+    web3 "1.2.1"
 
 tryer@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
According to [this](https://github.com/lerna/lerna/issues/1880) the `gitHead` property found in some `package.json`s are not meant to be under version control. In the interest of keeping things clean, I have removed that property in Truffle's packages.