### PR TITLE
Fix bug with `deploying` cases with describe-json flag on migrate

### DIFF
--- a/packages/reporters/reporters/migrations-V5/messages.js
+++ b/packages/reporters/reporters/migrations-V5/messages.js
@@ -289,7 +289,7 @@ class MigrationsMessages {
             data: Object.assign({}, data, {
               contract: {
                 contractName: data.contract.contractName,
-                address: data.contract.address
+                address: data.receipt.contractAddress
               },
               instance: undefined,
               receipt: {

--- a/packages/truffle/test/scenarios/migrations/describe-json.js
+++ b/packages/truffle/test/scenarios/migrations/describe-json.js
@@ -5,6 +5,83 @@ const sandbox = require("../sandbox");
 const path = require("path");
 const MemoryLogger = require("../memorylogger");
 
+function verifyMigrationStatuses(statuses, deployingStatusString) {
+  let cost = 0;
+
+  it("includes all statuses", done => {
+    assert.equal(statuses.length, 7);
+    done();
+  });
+
+  it("includes preAllMigrations status", done => {
+    const status = statuses[0];
+    assert.equal(status.status, "preAllMigrations");
+    assert.equal(status.data.dryRun, false);
+    assert.equal(status.data.migrations.length, 1);
+    done();
+  });
+
+  it("includes preMigrate status", done => {
+    const status = statuses[1];
+    assert.equal(status.status, "preMigrate");
+    assert.equal(status.data.file, "1_initial_migration.js");
+    assert.equal(status.data.number, 1);
+    assert.equal(status.data.isFirst, true);
+    assert.equal(status.data.network, "development");
+    done();
+  });
+
+  it(`includes ${deployingStatusString} status`, done => {
+    const status = statuses[2];
+    assert.equal(status.status, deployingStatusString);
+    assert.equal(status.data.contractName, "Migrations");
+
+    if (deployingStatusString === "replacing") {
+      assert.equal(typeof status.data.priorAddress, "string");
+      assert.equal(status.data.priorAddress.slice(0, 2), "0x");
+      assert.equal(status.data.priorAddress.length, 42);
+    }
+
+    done();
+  });
+
+  it("includes deployed status", done => {
+    const status = statuses[3];
+    assert.equal(status.status, "deployed");
+    assert.equal(status.data.contract.contractName, "Migrations");
+    assert.equal(typeof status.data.contract.address, "string");
+    assert.equal(status.data.contract.address.slice(0, 2), "0x");
+    assert.equal(status.data.contract.address.length, 42);
+    assert.equal(status.data.deployed, true);
+    cost = parseFloat(status.data.cost);
+    assert(cost > 0);
+    done();
+  });
+
+  it("includes postMigrate status", done => {
+    const status = statuses[4];
+    assert.equal(status.status, "postMigrate");
+    assert.equal(status.data.number, 1);
+    assert.equal(parseFloat(status.data.cost), cost);
+    done();
+  });
+
+  it("includes lastMigrate status", done => {
+    const status = statuses[5];
+    assert.equal(status.status, "lastMigrate");
+    assert.equal(parseFloat(status.data.finalCost), cost);
+    done();
+  });
+
+  it("includes postAllMigrations status", done => {
+    const status = statuses[6];
+    assert.equal(status.status, "postAllMigrations");
+    assert.equal(status.data.dryRun, false);
+    assert.equal(status.data.error, null);
+    done();
+  });
+}
+
 describe("truffle migrate --describe-json", () => {
   let config, projectPath;
   let logger = new MemoryLogger();
@@ -41,96 +118,60 @@ describe("truffle migrate --describe-json", () => {
   });
 
   describe("when run on the most basic truffle project with --describe-json", () => {
-    let statuses = [];
-    let cost = 0;
+    describe("with existing migration", () => {
+      let statuses = [];
 
-    it("runs the migration without throwing", done => {
-      CommandRunner.run("migrate --reset --describe-json", config, error => {
-        assert(error === undefined, "error should be undefined here");
+      it("runs the migration without throwing", done => {
+        CommandRunner.run("migrate --reset --describe-json", config, error => {
+          assert(error === undefined, "error should be undefined here");
 
-        const contents = logger.contents();
-        statuses = contents
-          .split("\n")
-          .filter(line => line.includes("MIGRATION_STATUS"))
-          .map(line => JSON.parse(line.replace("MIGRATION_STATUS:", "")));
+          const contents = logger.contents();
+          statuses.push(
+            ...contents
+              .split("\n")
+              .filter(line => line.includes("MIGRATION_STATUS"))
+              .map(line => JSON.parse(line.replace("MIGRATION_STATUS:", "")))
+          );
 
-        done();
+          done();
+        });
+      }).timeout(20000);
+
+      verifyMigrationStatuses(statuses, "replacing");
+    });
+
+    describe("without existing migration (i.e. clean slate)", () => {
+      let statuses = [];
+
+      before("before all setup", done => {
+        projectPath = path.join(__dirname, "../../sources/migrations/init");
+        sandbox
+          .create(projectPath)
+          .then(conf => {
+            config = conf;
+            config.network = "development";
+            config.logger = logger;
+          })
+          .then(done);
       });
-    }).timeout(20000);
 
-    it("includes all statuses", done => {
-      assert.equal(statuses.length, 7);
-      done();
-    });
+      it("runs the migration without throwing", done => {
+        CommandRunner.run("migrate --describe-json", config, error => {
+          assert(error === undefined, "error should be undefined here");
 
-    it("includes preAllMigrations status", done => {
-      const status = statuses[0];
-      assert.equal(status.status, "preAllMigrations");
-      assert.equal(status.data.dryRun, false);
-      assert.equal(status.data.migrations.length, 1);
-      done();
-    });
+          const contents = logger.contents();
+          statuses.push(
+            ...contents
+              .split("\n")
+              .filter(line => line.includes("MIGRATION_STATUS"))
+              .map(line => JSON.parse(line.replace("MIGRATION_STATUS:", "")))
+          );
 
-    it("includes preMigrate status", done => {
-      const status = statuses[1];
-      assert.equal(status.status, "preMigrate");
-      assert.equal(status.data.file, "1_initial_migration.js");
-      assert.equal(status.data.number, 1);
-      assert.equal(status.data.isFirst, true);
-      assert.equal(status.data.network, "development");
-      done();
-    });
+          done();
+        });
+      }).timeout(20000);
 
-    it("includes replacing (aka deploying on fresh migrations) status", done => {
-      const status = statuses[2];
-      assert.equal(status.status, "replacing");
-      assert.equal(status.data.contractName, "Migrations");
-      assert.equal(typeof status.data.priorAddress, "string");
-      assert.equal(status.data.priorAddress.slice(0, 2), "0x");
-      assert.equal(status.data.priorAddress.length, 42);
-      done();
-    });
-
-    it("includes deployed status", done => {
-      const status = statuses[3];
-      assert.equal(status.status, "deployed");
-      assert.equal(status.data.contract.contractName, "Migrations");
-      assert.equal(typeof status.data.contract.address, "string");
-      assert.equal(status.data.contract.address.slice(0, 2), "0x");
-      assert.equal(status.data.contract.address.length, 42);
-      assert.equal(status.data.deployed, true);
-      cost = parseFloat(status.data.cost);
-      assert(cost > 0);
-      done();
-    });
-
-    it("includes postMigrate status", done => {
-      const status = statuses[4];
-      assert.equal(status.status, "postMigrate");
-      assert.equal(status.data.number, 1);
-      assert.equal(parseFloat(status.data.cost), cost);
-      done();
-    });
-
-    it("includes lastMigrate status", done => {
-      const status = statuses[5];
-      assert.equal(status.status, "lastMigrate");
-      assert.equal(parseFloat(status.data.finalCost), cost);
-      done();
-    });
-
-    it("includes postAllMigrations status", done => {
-      const status = statuses[6];
-      assert.equal(status.status, "postAllMigrations");
-      assert.equal(status.data.dryRun, false);
-      assert.equal(status.data.error, null);
-      done();
-    });
-
-    after(done => {
-      logger = new MemoryLogger();
-      config.logger = logger;
-      done();
+      verifyMigrationStatuses(statuses, "deploying");
     });
   });
 });


### PR DESCRIPTION
(Builds on #2344)

There is a bug with the `migrate --describe-json` flag which throws when migrating a project that hasn't been migrated before. I guess I didn't capture this because I was always using the `--reset` flag that existing addresses, and the test case only tested the `--reset` case.

This PR fixes the bug and adds a test which creates a fresh sandbox to make sure we test both `deploying` and `replacing` cases.