### PR TITLE
Bug fix: Correct packages/box/tsconfig.json

### DIFF
--- a/packages/box/tsconfig.json
+++ b/packages/box/tsconfig.json
@@ -19,11 +19,11 @@
     "typeRoots": [
       "./typings",
       "node_modules/@types",
-      "../../**/node_modules/@types/mocha",
-      "../../**/node_modules/@types/fs-extra",
-      "../../**/node_modules/@types/inquirer",
-      "../../**/node_modules/@types/request-promise-native",
-      "../../**/node_modules/@types/tmp"
+      "../../node_modules/@types/mocha",
+      "../../node_modules/@types/fs-extra",
+      "../../node_modules/@types/inquirer",
+      "../../node_modules/@types/request-promise-native",
+      "../../node_modules/@types/tmp"
     ]
   },
   "include": [


### PR DESCRIPTION
Edit paths in packages/box/tsconfig.json to point to the root-level node_modules folder instead of the one for packages/box as they are not installed there.

`./packages/box` has the types dependencies listed in the package.json but they end up being installed at the project root level instead of in `packages/box`.