### PR TITLE
Stop wrapping the provider for migrations

### DIFF
--- a/packages/migrate/index.js
+++ b/packages/migrate/index.js
@@ -130,7 +130,6 @@ const Migrate = {
       clone.logger = { log: function() {} };
     }
 
-    clone.provider = this.wrapProvider(options.provider, clone.logger);
     clone.resolver = this.wrapResolver(options.resolver, clone.provider);
 
     // Make migrations aware of their position in sequence
@@ -174,16 +173,6 @@ const Migrate = {
         }
       );
     });
-  },
-
-  wrapProvider: function(provider) {
-    return {
-      send: function(payload, callback) {
-        provider.send(payload, function(err, result) {
-          err ? callback(err) : callback(err, result);
-        });
-      }
-    };
   },
 
   wrapResolver: function(resolver, provider) {

--- a/packages/migrate/test/index.js
+++ b/packages/migrate/test/index.js
@@ -66,7 +66,6 @@ describe("Migrate", () => {
 
   describe("runMigrations(migrations, options)", () => {
     beforeEach(() => {
-      sinon.stub(Migrate, "wrapProvider").returns("fake wrapped providerzzz");
       sinon.stub(Migrate, "wrapResolver");
       migrations = [
         {
@@ -77,28 +76,14 @@ describe("Migrate", () => {
       ];
     });
     afterEach(() => {
-      Migrate.wrapProvider.restore();
       Migrate.wrapResolver.restore();
     });
 
-    it("calls wrapProvider with the provider and logger", done => {
-      Migrate.runMigrations(migrations, options)
-        .then(() => {
-          assert(
-            Migrate.wrapProvider.calledWith(options.provider, options.logger)
-          );
-          done();
-        })
-        .catch(done);
-    });
     it("calls wrapResolver with the resolver and the wrapped provider", done => {
       Migrate.runMigrations(migrations, options)
         .then(() => {
           assert(
-            Migrate.wrapResolver.calledWith(
-              options.resolver,
-              "fake wrapped providerzzz"
-            )
+            Migrate.wrapResolver.calledWith(options.resolver, options.provider)
           );
           done();
         })


### PR DESCRIPTION
Looks like the provider wrapper doesn't actually do anything!

It [used to](https://github.com/trufflesuite/truffle/blob/28dca63366004258e8abf1329fbbd1be1ca9948f/packages/truffle-migrate/index.js#L206-L233), but now the wrapper is basically a no-op with restrictions.

This should remove the need for #1307 and solve other problems (@CruzMolina said something about the provider-engine fork, but not sure of specifics.)