### PR TITLE
Enhancement: Allow --config flag

### DIFF
--- a/packages/config/index.js
+++ b/packages/config/index.js
@@ -132,12 +132,19 @@ Config.search = (options = {}, filename) => {
 };
 
 Config.detect = (options = {}, filename) => {
-  const configFile = Config.search(options, filename);
+  const { configPath } = options;
+  let configFile;
+  if (configPath) {
+    configFile = path.isAbsolute(configPath)
+      ? configPath
+      : path.resolve(configPath);
+  } else {
+    configFile = Config.search(options, filename);
+  }
 
   if (!configFile) {
     throw new TruffleError("Could not find suitable configuration file.");
   }
-
   return Config.load(configFile, options);
 };
 

--- a/packages/config/index.js
+++ b/packages/config/index.js
@@ -151,7 +151,11 @@ Config.detect = (options = {}, filename) => {
 Config.load = (file, options) => {
   const config = new Config();
 
-  config.working_directory = process.cwd();
+  if (options.config) {
+    config.working_directory = process.cwd();
+  } else {
+    config.working_directory = path.dirname(path.resolve(file));
+  }
 
   // The require-nocache module used to do this for us, but
   // it doesn't bundle very well. So we've pulled it out ourselves.

--- a/packages/config/index.js
+++ b/packages/config/index.js
@@ -132,8 +132,8 @@ Config.search = (options = {}, filename) => {
 };
 
 Config.detect = (options = {}, filename) => {
-  const { configPath } = options;
   let configFile;
+  const configPath = options.config;
   if (configPath) {
     configFile = path.isAbsolute(configPath)
       ? configPath
@@ -151,7 +151,7 @@ Config.detect = (options = {}, filename) => {
 Config.load = (file, options) => {
   const config = new Config();
 
-  config.working_directory = path.dirname(path.resolve(file));
+  config.working_directory = process.cwd();
 
   // The require-nocache module used to do this for us, but
   // it doesn't bundle very well. So we've pulled it out ourselves.

--- a/packages/config/test/methods.js
+++ b/packages/config/test/methods.js
@@ -9,7 +9,7 @@ describe("TruffleConfig.detect", () => {
   describe("when a config path is provided", () => {
     beforeEach(() => {
       sinon.stub(TruffleConfig, "load");
-      options = { configPath: "/my/favorite/config.js" };
+      options = { config: "/my/favorite/config.js" };
       expectedPath = "/my/favorite/config.js";
     });
     afterEach(() => {
@@ -21,7 +21,7 @@ describe("TruffleConfig.detect", () => {
       assert(TruffleConfig.load.calledWith(expectedPath));
     });
     it("loads a config even with a relative path", () => {
-      options.configPath = "../../config.js";
+      options.config = "../../config.js";
       TruffleConfig.detect(options);
       assert(
         TruffleConfig.load.calledWith(
@@ -31,10 +31,19 @@ describe("TruffleConfig.detect", () => {
     });
   });
 
-  it("throws if a truffle config isn't detected", () => {
-    assert.throws(() => {
-      TruffleConfig.detect();
-    }, "should have thrown!");
+  describe("when it can't find a config file", () => {
+    beforeEach(() => {
+      sinon.stub(TruffleConfig, "search").returns(undefined);
+    });
+    afterEach(() => {
+      TruffleConfig.search.restore();
+    });
+
+    it("throws if a truffle config isn't detected", () => {
+      assert.throws(() => {
+        TruffleConfig.detect();
+      }, "should have thrown!");
+    });
   });
 });
 

--- a/packages/config/test/methods.js
+++ b/packages/config/test/methods.js
@@ -1,8 +1,36 @@
 const assert = require("assert");
 const fs = require("fs");
 const TruffleConfig = require("../");
+const sinon = require("sinon");
+const path = require("path");
+let expectedPath, options;
 
 describe("TruffleConfig.detect", () => {
+  describe("when a config path is provided", () => {
+    beforeEach(() => {
+      sinon.stub(TruffleConfig, "load");
+      options = { configPath: "/my/favorite/config.js" };
+      expectedPath = "/my/favorite/config.js";
+    });
+    afterEach(() => {
+      TruffleConfig.load.restore();
+    });
+
+    it("loads a config from the options if available", () => {
+      TruffleConfig.detect(options);
+      assert(TruffleConfig.load.calledWith(expectedPath));
+    });
+    it("loads a config even with a relative path", () => {
+      options.configPath = "../../config.js";
+      TruffleConfig.detect(options);
+      assert(
+        TruffleConfig.load.calledWith(
+          path.resolve(process.cwd(), "../../config.js")
+        )
+      );
+    });
+  });
+
   it("throws if a truffle config isn't detected", () => {
     assert.throws(() => {
       TruffleConfig.detect();


### PR DESCRIPTION
Allow an option `--config` whereby a user can provide a relative or absolute path to a config file of their choice. Truffle will attempt to load the file and use it during the command flow they specified.

This also adds 2 unit tests for `Config.detect`.