### PR TITLE
Release script enhancements

### DIFF
--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -5,6 +5,8 @@ set -ex
 
 LAST_PUBLISHED_TAG=$(awk -F\" '/"version":/ {print $4}' ./packages/truffle/package.json)
 
+git checkout master
+git pull origin master
 git checkout develop
 git pull origin develop
 yarn bootstrap

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -5,10 +5,15 @@ set -ex
 
 LAST_PUBLISHED_TAG=$(awk -F\" '/"version":/ {print $4}' ./packages/truffle/package.json)
 
+## Get the latest branch states
 git checkout master
 git pull origin master
 git checkout develop
 git pull origin develop
+
+## Build
 yarn bootstrap
+
+## Get output of changes for release notes
 prs-merged-since --repo trufflesuite/truffle --tag v$LAST_PUBLISHED_TAG --format markdown
 lerna changed

--- a/scripts/publish-dist-tag.sh
+++ b/scripts/publish-dist-tag.sh
@@ -13,7 +13,13 @@ if [ "${distTag}" == "" ];
 fi
 
 echo "Publishing \"truffle@${distTag}\" from \"${currentGitBranch}\" branch."
-npm login
+
+npm whoami
+if [ "$?" != "0" ];
+  then
+    npm login
+fi
+
 node ./scripts/npm-access.js
 lerna version --no-git-tag-version --preid $distTag
 git add .

--- a/scripts/publish-dist-tag.sh
+++ b/scripts/publish-dist-tag.sh
@@ -4,6 +4,13 @@
 set -ex
 
 distTag=$1 # first arg after yarn publish-dist-tag
+
+# Optional `lerna version` 'bump' command
+# must be an explicit version string _or_ one of:
+#   'major', 'minor', 'patch', 'premajor', 'preminor', 'prepatch', or 'prerelease'.
+# Omitting will prompt the user
+lernaVersionCommand=$2
+
 currentGitBranch=$(git rev-parse --abbrev-ref HEAD)
 
 if [ "${distTag}" == "" ];
@@ -23,7 +30,7 @@ fi
 node ./scripts/npm-access.js
 
 ## Bump package versions and commit
-lerna version --no-git-tag-version --preid $distTag
+lerna version --no-git-tag-version --preid $distTag $lernaVersionCommand
 git add packages/*/package.json
 git commit -m "Publish truffle@${distTag}"
 

--- a/scripts/publish-dist-tag.sh
+++ b/scripts/publish-dist-tag.sh
@@ -22,7 +22,7 @@ fi
 
 node ./scripts/npm-access.js
 lerna version --no-git-tag-version --preid $distTag
-git add .
+git add packages/*/package.json
 git commit -m "Publish truffle@${distTag}"
 lerna publish from-package --dist-tag ${distTag}
 git push origin $currentGitBranch

--- a/scripts/publish-dist-tag.sh
+++ b/scripts/publish-dist-tag.sh
@@ -14,18 +14,27 @@ fi
 
 echo "Publishing \"truffle@${distTag}\" from \"${currentGitBranch}\" branch."
 
+## Obtain/check npm access
 npm whoami
 if [ "$?" != "0" ];
   then
     npm login
 fi
-
 node ./scripts/npm-access.js
+
+## Bump package versions and commit
 lerna version --no-git-tag-version --preid $distTag
 git add packages/*/package.json
 git commit -m "Publish truffle@${distTag}"
+
+## Publish packages to npm
 lerna publish from-package --dist-tag ${distTag}
+
+## Update git branch
 git push origin $currentGitBranch
+
+## Reinstall using published version
 npm un -g truffle
 npm i -g truffle@${distTag}
+
 echo -e "\\n\\nWoo!"

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -3,7 +3,12 @@
 # The below tells bash to stop the script if any of the commands fail
 set -ex
 
-npm login
+npm whoami
+if [ "$?" != "0" ];
+  then
+    npm login
+fi
+
 node ./scripts/npm-access.js
 lerna publish -- --access=public
 git checkout master

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -3,19 +3,26 @@
 # The below tells bash to stop the script if any of the commands fail
 set -ex
 
+## Obtain/check npm access
 npm whoami
 if [ "$?" != "0" ];
   then
     npm login
 fi
-
 node ./scripts/npm-access.js
+
+## Publish packages to npm
 lerna publish -- --access=public
+
+## Update git branches
 git checkout master
 git merge develop
 git push origin master
 git checkout develop
 git pull origin master
+
+## Reinstall using published version
 npm un -g truffle
 npm i -g truffle
+
 echo -e "\\n\\nWoo!"


### PR DESCRIPTION
I made some changes/enhancements when I was doing a dist-tag release, and @gnidan [showed interest in a PR](https://trufflesuite.slack.com/archives/CB276HKKJ/p1567815458430200).

This PR does the following:
- Only runs `npm login` if you're not logged in currently (for dist-tag releasing, I could release multiple times a day. this just prevents me from entering all of my info each time)
- The `publish-dist-tag.sh` used to do `git add .`. While `lerna publish` requires you to have no unstaged changes, I don't want this script to bundle temporary changes (i.e. to the scripts themselves) in the commit. Both @gnidan and I [agreed that it makes more sense for the error and for the user to explicitly fix it rather than just commit it](https://trufflesuite.slack.com/archives/CB276HKKJ/p1567815597432600)
- Adds a checkout/pull of `master` in the `prepare-release.sh` script
- Adds some whitespace/comments for readability
- Adds an optional parameter to `yarn publish-dist-tag <pre-id>` to make it `yarn publish-dist-tag <pre-id> [<lerna-version-bump-command>]` which can allow me to specify the `lerna version` command to skip all of the prompts. Leaving it blank will still prompt the user