### PR TITLE
Enhancement: Feature truffle init

### DIFF
--- a/packages/core/lib/commands/init.js
+++ b/packages/core/lib/commands/init.js
@@ -15,30 +15,17 @@ var command = {
     ]
   },
   run: function(options, done) {
-    var Config = require("@truffle/config");
-    var OS = require("os");
-    var UnboxCommand = require("./unbox");
-
-    var config = Config.default().with({
-      logger: console
-    });
+    const UnboxCommand = require("./unbox");
+    const fse = require("fs-extra");
 
     if (options._ && options._.length > 0) {
-      config.logger.log(
-        "Error: `truffle init` no longer accepts a project template name as an argument."
-      );
-      config.logger.log();
-      config.logger.log(
-        " - For an empty project, use `truffle init` with no arguments" +
-          OS.EOL +
-          " - Or, browse the Truffle Boxes at <http://truffleframework.com/boxes>!"
-      );
-      process.exit(1);
+      const inputPath = options._[0];
+      if (!fse.existsSync(inputPath)) fse.ensureDirSync(inputPath);
     }
 
     // defer to `truffle unbox` command with "bare" box as arg
-    var url = "https://github.com/truffle-box/bare-box.git";
-    options._ = [url];
+    const url = "https://github.com/truffle-box/bare-box.git";
+    options._ = [url, inputPath];
 
     UnboxCommand.run(options, done);
   }

--- a/packages/core/lib/commands/init.js
+++ b/packages/core/lib/commands/init.js
@@ -17,9 +17,9 @@ var command = {
   run: function(options, done) {
     const UnboxCommand = require("./unbox");
     const fse = require("fs-extra");
-
+    let inputPath;
     if (options._ && options._.length > 0) {
-      const inputPath = options._[0];
+      inputPath = options._[0];
       if (!fse.existsSync(inputPath)) fse.ensureDirSync(inputPath);
     }
 

--- a/packages/core/lib/commands/unbox.js
+++ b/packages/core/lib/commands/unbox.js
@@ -125,7 +125,7 @@ const command = {
 
     const config = Config.default().with({ logger: console });
 
-    ({ url, destination } = normalizeInput(options._));
+    let { url, destination } = normalizeInput(options._);
     url = normalizeURL(url);
 
     const normalizedDestination = normalizeDestination(

--- a/packages/truffle/test/scenarios/commands/init.js
+++ b/packages/truffle/test/scenarios/commands/init.js
@@ -2,7 +2,7 @@ const assert = require("assert");
 const CommandRunner = require("../commandrunner");
 const path = require("path");
 const tmp = require("tmp");
-const fs = require("fs");
+const fse = require("fs-extra");
 
 describe("truffle init [ @standalone ]", () => {
   let tempDir, config;
@@ -20,6 +20,7 @@ describe("truffle init [ @standalone ]", () => {
 
   it("does not error", done => {
     CommandRunner.run("init", config, error => {
+      if (error) done(error);
       assert(typeof error === "undefined");
       done();
     });
@@ -27,8 +28,29 @@ describe("truffle init [ @standalone ]", () => {
 
   it("unboxes a project with a truffle config", done => {
     CommandRunner.run("init", config, () => {
-      assert(fs.existsSync(path.join(tempDir.name, "truffle-config.js")));
+      assert(fse.existsSync(path.join(tempDir.name, "truffle-config.js")));
       done();
     });
   }).timeout(20000);
+
+  describe("when a path is provided", () => {
+    it("initializes with a relative path", done => {
+      const myPath = "./my/favorite/folder/structure";
+      CommandRunner.run(`init ${myPath}`, config, error => {
+        if (error) done(error);
+        assert(
+          fse.existsSync(path.join(tempDir.name, myPath, "truffle-config.js"))
+        );
+        done();
+      });
+    }).timeout(20000);
+    it("initializes with an absolute path", done => {
+      const myPath = path.join(tempDir.name, "somethingElse");
+      CommandRunner.run(`init ${myPath}`, config, error => {
+        if (error) done(error);
+        assert(fse.existsSync(path.join(myPath, "truffle-config.js")));
+        done();
+      });
+    }).timeout(20000);
+  });
 });

--- a/packages/truffle/test/scenarios/commands/unbox.js
+++ b/packages/truffle/test/scenarios/commands/unbox.js
@@ -1,7 +1,7 @@
 const assert = require("assert");
 const CommandRunner = require("../commandrunner");
 const MemoryLogger = require("../memorylogger");
-const fs = require("fs-extra");
+const fse = require("fs-extra");
 const tmp = require("tmp");
 const path = require("path");
 
@@ -23,19 +23,19 @@ describe("truffle unbox [ @standalone ]", () => {
     it("unboxes truffle-init-default", done => {
       CommandRunner.run("unbox --force", config, () => {
         assert(
-          fs.pathExistsSync(
+          fse.pathExistsSync(
             path.join(tempDir.name, "contracts", "ConvertLib.sol")
           ),
           "ConvertLib.sol does not exist"
         );
         assert(
-          fs.pathExistsSync(
+          fse.pathExistsSync(
             path.join(tempDir.name, "contracts", "Migrations.sol")
           ),
           "Migrations.sol does not exist"
         );
         assert(
-          fs.pathExistsSync(
+          fse.pathExistsSync(
             path.join(tempDir.name, "contracts", "MetaCoin.sol")
           ),
           "MetaCoin.sol does not exist"
@@ -221,6 +221,25 @@ describe("truffle unbox [ @standalone ]", () => {
             () => {
               const output = logger.contents();
               assert(output.includes("Unbox successful."));
+              done();
+            }
+          );
+        }).timeout(20000);
+      });
+
+      describe("when run with a path", () => {
+        it("unboxes successfully to the specified path", done => {
+          const myPath = "./candy/cane/lane";
+          CommandRunner.run(
+            `unbox truffle-box/bare-box ${myPath}`,
+            config,
+            error => {
+              if (error) done(error);
+              assert(
+                fse.pathExistsSync(
+                  path.join(tempDir.name, myPath, "truffle-config.js")
+                )
+              );
               done();
             }
           );


### PR DESCRIPTION
This incredible PR enables the passing of a path (as a command line argument) to the init command. For example, one could execute `truffle init ./myPath` to initialize a shiny, brand new project in the `myPath` folder!

As a consequence of this cutting-edge feature, the unbox command has also been enhanced! Now you can also pass a path to the command as an argument as follows: `truffle unbox metacoin /Users/Agatha/secretStuff/myMetacoinProject`. The metacoin box will then be unboxed in the `myMetacoinProject` directory.

**NOTE:** Previously you could provide a path at the end of the URL a la `http://something:my/path`. If you provide your own path as an argument, it overrides this suffix path.

**ANOTHER NOTE:** The nightmare of a method that is known as `normalizeInput` in `packages/core/lib/commands/unbox.js` should probably be rewritten at some point in the future as it is a mess to untangle and make sense of. Liberté, egalité, fraternité!