### PR TITLE
Internal improvement: pin geth to latest stable version

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -10,7 +10,7 @@ run_geth() {
     -p 8545:8545 \
     -p 8546:8546 \
     -p 30303:30303 \
-    ethereum/client-go:latest \
+    ethereum/client-go:v1.9.3 \
     --rpc \
     --rpcaddr '0.0.0.0' \
     --rpcport 8545 \
@@ -35,7 +35,7 @@ if [ "$INTEGRATION" = true ]; then
 elif [ "$GETH" = true ]; then
 
   sudo apt install -y jq
-  docker pull ethereum/client-go:latest
+  docker pull ethereum/client-go:v1.9.3
   run_geth
   sleep 30
   lerna run --scope truffle test --stream -- --exit


### PR DESCRIPTION
geth latest isn't playing nice with Truffle (or at least our CI).

One of these recently merged PRs appears to have caused the issue: ethereum/go-ethereum#20075, ethereum/go-ethereum#19953, ethereum/go-ethereum#20054.