### PR TITLE
Internal improvement: Set CI env

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -33,6 +33,8 @@ jobs:
     - run: npm install -g yarn lerna
     - run: yarn bootstrap
     - run: ${{ matrix.env }} yarn ci
+      env:
+        CI: true
     - uses: 8398a7/action-slack@v1.1.1
       with:
         type: failure


### PR DESCRIPTION
Since Github Actions supports any number of custom workflows, it doesn't pass `CI=true` by default (which Travis does).

Makes sure docker/native solc tests (along with any other tests relying on the env) run in Actions CI.