### PR TITLE
Fix bug with watching address keys in decoder

### DIFF
--- a/packages/codec/lib/interface/contract.ts
+++ b/packages/codec/lib/interface/contract.ts
@@ -470,7 +470,7 @@ export class TruffleContractInstanceDecoder extends AsyncEventEmitter {
         break;
       case "mapping":
         let keyDefinition = parentDefinition.keyType || parentDefinition.typeName.keyType;
-        key = wrapElementaryViaDefinition(rawIndex, keyDefinition);
+        key = wrapElementaryViaDefinition(rawIndex, keyDefinition, this.contract.compiler);
         definition = parentDefinition.valueType || parentDefinition.typeName.valueType;
         slot = {
           path: parentSlot,

--- a/packages/codec/lib/utils/wrap.ts
+++ b/packages/codec/lib/utils/wrap.ts
@@ -3,6 +3,7 @@ const debug = debugModule("codec:utils:wrap");
 
 import Web3 from "web3";
 import BN from "bn.js";
+import { CompilerVersion } from "../types/compiler";
 import { AstDefinition } from "../types/ast";
 import { Types } from "../format/types";
 import { MakeType } from "./maketype";
@@ -20,11 +21,8 @@ import { Values } from "../format/values";
 //1. check its inputs,
 //2. take a slightly different input format,
 //3. also be named differently and... it'll be different :P ]
-export function wrapElementaryViaDefinition(value: any, definition: AstDefinition): Values.ElementaryValue {
-  //force location to undefined, force address to nonpayable
-  //(we force address to nonpayable since address payable can't be declared
-  //as a mapping key type)
-  let dataType = MakeType.definitionToType(definition, null, null);
+export function wrapElementaryViaDefinition(value: any, definition: AstDefinition, compiler: CompilerVersion): Values.ElementaryValue {
+  let dataType = MakeType.definitionToType(definition, compiler, null); //force location to undefined
   return wrapElementaryValue(value, dataType);
 }
 

--- a/packages/codec/test/contracts/DecodingSample.sol
+++ b/packages/codec/test/contracts/DecodingSample.sol
@@ -38,6 +38,7 @@ contract DecodingSample {
   S       varStructS;
 
   mapping(uint => uint) varMapping;
+  mapping(address => uint) varAddressMapping;
 
   uint[2]    fixedArrayUint;
   string[2]  fixedArrayString;
@@ -149,6 +150,7 @@ contract DecodingSample {
 
     varMapping[2] = 41;
     varMapping[3] = 107;
+    varAddressMapping[address(this)] = 683;
 
     functionExternal = this.example;
   }

--- a/packages/codec/test/test/decoding-test.js
+++ b/packages/codec/test/test/decoding-test.js
@@ -38,6 +38,7 @@ contract("DecodingSample", _accounts => {
 
     decoder.watchMappingKey("varMapping", 2);
     decoder.watchMappingKey("varMapping", 3);
+    decoder.watchMappingKey("varAddressMapping", address);
 
     const initialState = await decoder.state();
 
@@ -130,6 +131,7 @@ contract("DecodingSample", _accounts => {
 
     assert.equal(variables.varMapping[2], 41);
     assert.equal(variables.varMapping[3], 107);
+    assert.equal(variables.varAddressMapping[address], 683);
 
     assert.equal(
       variables.functionExternal,


### PR DESCRIPTION
This PR fixes a bug regarding watching address keys in the contract decoder.  In PR #2379, I got rid of the `compiler = null` hack when converting definitions to types.  However, I forgot about one other place I used this hack, in the `wrapElementaryViaDefinition` function.  This PR gets rid of that and has the actual compiler version passed in.  I also added a test of address keys to the contract decoder test.  (Note: The contract decoder is still very much under-tested, but I'll worry about that some other time.)

Note I'm planning to basically replace these `wrap` functions with better versions in the future.  But that's a ways out still...