### PR TITLE
Change return type of state() to allow multiple variables with same name

### DIFF
--- a/packages/codec/lib/allocate/storage.ts
+++ b/packages/codec/lib/allocate/storage.ts
@@ -19,7 +19,7 @@ interface StorageAllocationInfo {
 
 interface DefinitionPair {
   definition: AstDefinition;
-  definedIn?: Format.Types.ContractType;
+  definedIn?: AstDefinition;
 }
 
 //contracts contains only the contracts to be allocated; any base classes not
@@ -192,14 +192,10 @@ function allocateContract(contract: AstDefinition, referenceDeclarations: AstRef
     if(baseNode === undefined) {
       throw new UnknownBaseContractIdError(contract.id, contract.name, contract.contractKind, id);
     }
-    let classObject = CodecUtils.MakeType.definitionToStoredType(baseNode, null, referenceDeclarations); //HACK
-    //for technical reasons, when this is called from the debugger, it's not always possible to know the compiler
-    //(due to how information is organized there)
-    //so... we just don't pass one in!  We pass null.  We get away with it because the compiler doesn't actually matter here!
     return getStateVariables(baseNode).map(
       definition => ({
         definition,
-        definedIn: classObject
+        definedIn: baseNode
       })
     );
   }));

--- a/packages/codec/lib/interface/contract.ts
+++ b/packages/codec/lib/interface/contract.ts
@@ -257,7 +257,7 @@ export class TruffleContractInstanceDecoder extends AsyncEventEmitter {
 
     return {
       name: variable.definition.name,
-      class: variable.definedIn,
+      class: <Types.ContractType> this.userDefinedTypes[variable.definedIn.id],
       value: result.value,
     };
   }
@@ -327,7 +327,7 @@ export class TruffleContractInstanceDecoder extends AsyncEventEmitter {
       //again, we'll search backwards, although, uhhh...?
       return this.stateVariableReferences.slice().reverse().find(
         ({definition, definedIn}) =>
-          definition.name === variableName && definedIn.typeName === className
+          definition.name === variableName && definedIn.name === className
       );
     }
   }

--- a/packages/codec/lib/types/allocation.ts
+++ b/packages/codec/lib/types/allocation.ts
@@ -41,7 +41,9 @@ export interface StorageAllocation {
 //of a contract
 export interface StorageMemberAllocation {
   definition: AstDefinition;
-  pointer: Pointer.StoragePointer | Pointer.ConstantDefinitionPointer;
+  definedIn?: Types.ContractType; //used only for variables of contracts, not structs
+  pointer: Pointer.StoragePointer | Pointer.ConstantDefinitionPointer; //latter case will only happen
+  //for variables of contracts, not structs
 }
 
 //abi types below work similar to storage types above; note these are only

--- a/packages/codec/lib/types/allocation.ts
+++ b/packages/codec/lib/types/allocation.ts
@@ -41,7 +41,7 @@ export interface StorageAllocation {
 //of a contract
 export interface StorageMemberAllocation {
   definition: AstDefinition;
-  definedIn?: Types.ContractType; //used only for variables of contracts, not structs
+  definedIn?: AstDefinition; //used only for variables of contracts, not structs
   pointer: Pointer.StoragePointer | Pointer.ConstantDefinitionPointer; //latter case will only happen
   //for variables of contracts, not structs
 }

--- a/packages/codec/lib/types/interface.ts
+++ b/packages/codec/lib/types/interface.ts
@@ -2,7 +2,7 @@ import BN from "bn.js";
 import { ContractObject } from "@truffle/contract-schema/spec";
 import { DecoderContext } from "./contexts";
 import { AstDefinition } from "./ast";
-import { Values } from "../format/values";
+import { Types, Values } from "../format";
 import { CalldataDecoding, LogDecoding } from "./decoding";
 import { Transaction, BlockType } from "web3/eth/types";
 import { Log } from "web3/types";
@@ -12,10 +12,14 @@ export interface ContractState {
   balanceAsBN: BN;
   nonceAsBN: BN;
   code: string;
-  variables: {
-    [name: string]: Values.Result
-  };
-};
+  variables: DecodedVariable[];
+}
+
+export interface DecodedVariable {
+  name: string;
+  class: Types.ContractType;
+  value: Values.Result;
+}
 
 export interface DecodedTransaction extends Transaction {
   decoding: CalldataDecoding;

--- a/packages/codec/lib/utils/conversion.ts
+++ b/packages/codec/lib/utils/conversion.ts
@@ -8,6 +8,7 @@ import { Constants } from "./constants";
 import { Types } from "../format/types";
 import { Values } from "../format/values";
 import { enumFullName } from "./inspect";
+import { DecodedVariable } from "../types/interface";
 
 export namespace Conversion {
 
@@ -196,11 +197,25 @@ export namespace Conversion {
     return Math.max(0, value.c.length - value.e - 1);
   }
 
+  //NOTE: Definitely do not use this in real code!  For tests only!
   //for convenience: invokes the nativize method on all the given variables
   export function nativizeVariables(variables: {[name: string]: Values.Result}): {[name: string]: any} {
     return Object.assign({}, ...Object.entries(variables).map(
       ([name, value]) => ({[name]: nativize(value)})
     ));
+  }
+  
+  //NOTE: Definitely do not use this in real code!  For tests only!
+  //for convenience: invokes the nativize method on all the given variables, and changes them to
+  //the old format
+  export function nativizeDecoderVariables(variables: DecodedVariable[]): {[name: string]: any} {
+    return Object.assign({}, ...variables.map(
+      ({name, value}) => ({[name]: nativize(value)})
+    ));
+    //note that the assignments are processed in order, so if multiple have same name, later
+    //(i.e. more derived) will overwrite earlier (i.e. baser)... be aware!  I mean, this is the
+    //right way to do overwriting, but it's still overwriting so still dangerous.
+    //Again, don't use this in real code!
   }
 
   //converts out of range booleans to true; something of a HACK

--- a/packages/codec/test/contracts/DecodingSample.sol
+++ b/packages/codec/test/contracts/DecodingSample.sol
@@ -1,6 +1,10 @@
 pragma solidity ^0.5.10;
 
-contract DecodingSample {
+contract DecodingSampleParent {
+  uint definedInParent;
+}
+
+contract DecodingSample is DecodingSampleParent {
   enum E {
     EnumValZero,
     EnumValOne,

--- a/packages/codec/test/test/decoding-test.js
+++ b/packages/codec/test/test/decoding-test.js
@@ -51,7 +51,7 @@ contract("DecodingSample", _accounts => {
     // );
 
     assert.equal(initialState.name, "DecodingSample");
-    const variables = TruffleCodec.Utils.Conversion.nativizeVariables(
+    const variables = TruffleCodec.Utils.Conversion.nativizeDecoderVariables(
       initialState.variables
     );
 

--- a/packages/codec/test/test/decoding-test.js
+++ b/packages/codec/test/test/decoding-test.js
@@ -4,6 +4,7 @@ const util = require("util"); // eslint-disable-line no-unused-vars
 const TruffleCodec = require("../../../codec");
 
 const DecodingSample = artifacts.require("DecodingSample");
+const DecodingSampleParent = artifacts.require("DecodingSampleParent");
 
 function validateStructS(struct, values) {
   assert.equal(typeof struct, "object");
@@ -32,7 +33,7 @@ contract("DecodingSample", _accounts => {
     let address = deployedContract.address;
     const decoder = await TruffleCodec.forContractInstance(
       DecodingSample,
-      [],
+      [DecodingSampleParent],
       web3.currentProvider
     );
 
@@ -51,6 +52,14 @@ contract("DecodingSample", _accounts => {
     // );
 
     assert.equal(initialState.name, "DecodingSample");
+    //before we move on to the main section, we'll test the defining classes
+    //of the first two variables
+    assert.equal(
+      initialState.variables[0].class.typeName,
+      "DecodingSampleParent"
+    );
+    assert.equal(initialState.variables[1].class.typeName, "DecodingSample");
+
     const variables = TruffleCodec.Utils.Conversion.nativizeDecoderVariables(
       initialState.variables
     );

--- a/packages/debugger/lib/data/selectors/index.js
+++ b/packages/debugger/lib/data/selectors/index.js
@@ -701,6 +701,10 @@ const data = createSelectorTree({
                   .filter(v => variables[v.name] == undefined)
                   .map(v => ({ [v.name]: { astId: v.id } }))
               );
+              //NOTE: because these assignments are processed in order, that means
+              //that if a base class and derived class have variables with the same
+              //name, the derived version will be processed later and therefore overwrite --
+              //which is exactly what we want, so yay
 
               cur = scopes[cur].parentId;
             } while (cur != null);


### PR DESCRIPTION
This PR changes the format of the output returned by the contract decoder's `state` function in order to make sure that all state variables are included even when a base contract and derived contract contain state variables of the same name.

Specifically, instead of state variables being indexed by name and containing just a `Result`, they're now in an array, each containing a name, a `Result`, and a `ContractType` object for the contract they were defined in.  This allows different variables with the same name to be distinguished.

This required some extra information being both passed in to and stored in the output of the main storage allocation function so that these defining contracts can be determined later.  Note that it stores the definition, not the type object; the type object is looked up from the definition upon decoding.  This is in keeping with how storage allocation currently works in that it's definition-based rather than type-based; I've opted to leave this alone for now, it can be reworked later.

Note that the debugger currently ignores this extra information in the allocation; and it doesn't use the contract decoder, so the changed output format of that is irrelevant to the debugger.  Showing these shadowed base variables in the debugger will come later.  (It's lucky that the debugger's existing behavior was to show the most derived version; I've added a comment explaining why this is true.)

I also added functionality to `variable` and the mapping key watch/unwatch functions so that variables can now be looked up by qualified name (e.g. `"Base.x"`).  They've also been fixed so that using the unqualified name gets the most derived version -- previously they would have gotten the most *base* version!  All this ended up involving factoring out variable lookup into a separate function whereas previously it had been done manually each time.

Also I added a test of this functionality.