### PR TITLE
Fix BigNumber encoding

### DIFF
--- a/packages/contract/lib/utils.js
+++ b/packages/contract/lib/utils.js
@@ -209,7 +209,10 @@ const Utils = {
 
         // Convert Web3 BN / BigNumber
       } else if (Utils.is_big_number(item)) {
-        const ethersBN = bigNumberify(item.toString());
+        const stringValue = web3Utils.isBigNumber(item)
+          ? item.toFixed() //prevents use of scientific notation
+          : item.toString();
+        const ethersBN = bigNumberify(stringValue);
         converted.push(ethersBN);
       } else {
         converted.push(item);


### PR DESCRIPTION
This PR fixes #2373.  The problem was that `BN`'s and `BigNumber`'s alike were both being converted to ethers big numbers by means of `toString()`.  However with `BigNumber` you have to use `toFixed()` to prevent the use of scientific notation.  This PR fixes that.

Side note: Given that ethers's big number class is just a wrapper around `BN`, it's disappointing that ethers doesn't provide (AFAICT) any more straightforward way to convert a `BN` to one... (I suppose converting to a hex string rather than a base 10 string might technically save some computation, but that isn't actually worth worrying about...)