### PR TITLE
Mute unsupported options warning for plugins

### DIFF
--- a/packages/core/lib/command.js
+++ b/packages/core/lib/command.js
@@ -125,7 +125,8 @@ class Command {
         opt => !validOptions.includes(opt)
       );
 
-      if (invalidOptions.length > 0) {
+      // TODO: Remove exception for 'truffle run' when plugin options support added.
+      if (invalidOptions.length > 0 && result.name !== "run") {
         if (options.logger) {
           const log = options.logger.log || options.logger.debug;
           log(

--- a/packages/truffle/test/scenarios/commands/run.js
+++ b/packages/truffle/test/scenarios/commands/run.js
@@ -127,6 +127,14 @@ describe("truffle run [ @standalone ]", () => {
             done();
           });
         }).timeout(20000);
+
+        it("does not warn about unsupported options", done => {
+          CommandRunner.run("run mock --option value", config, () => {
+            const output = logger.contents();
+            assert(!output.includes("Warning:"));
+            done();
+          });
+        }).timeout(20000);
       });
     });
   }).timeout(10000);


### PR DESCRIPTION
(Change discussed in #2381)

This is a stop-gap to prevent... 
```
$ truffle run race --km 5
> > Warning: possible unsupported (undocumented in help) command line option: --km
```

(Love the plugin tests)
[EDIT - CI is [failing](https://github.com/trufflesuite/truffle/pull/2402/checks?check_run_id=232125668#step:6:629) on a truffle/compile-solidity test, believe it's unrelated to this PR]