### PR TITLE
Stop running Slack notifier for forks

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -54,4 +54,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        if: always()
+        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork


### PR DESCRIPTION
To prevent build failure when the lack of `secrets` causes the action to break