### PR TITLE
Rework interface for getting variables in the contract decoder

### DIFF
--- a/packages/codec/lib/allocate/storage.ts
+++ b/packages/codec/lib/allocate/storage.ts
@@ -24,8 +24,8 @@ interface DefinitionPair {
 
 //contracts contains only the contracts to be allocated; any base classes not
 //being allocated should just be in referenceDeclarations
-export function getStorageAllocations(referenceDeclarations: AstReferences, contracts: AstReferences): StorageAllocations {
-  let allocations: StorageAllocations = {};
+export function getStorageAllocations(referenceDeclarations: AstReferences, contracts: AstReferences, existingAllocations: StorageAllocations = {}): StorageAllocations {
+  let allocations = existingAllocations;
   for(const node of Object.values(referenceDeclarations)) {
     if(node.nodeType === "StructDefinition") {
       try {

--- a/packages/codec/lib/allocate/storage.ts
+++ b/packages/codec/lib/allocate/storage.ts
@@ -28,11 +28,25 @@ export function getStorageAllocations(referenceDeclarations: AstReferences, cont
   let allocations: StorageAllocations = {};
   for(const node of Object.values(referenceDeclarations)) {
     if(node.nodeType === "StructDefinition") {
-      allocations = allocateStruct(node, referenceDeclarations, allocations);
+      try {
+        allocations = allocateStruct(node, referenceDeclarations, allocations);
+      }
+      catch(_) {
+        //if allocation fails... oh well, allocation fails, we do nothing and just move on :P
+        //note: a better way of handling this would probably be to *mark* it
+        //as failed rather than throwing an exception as that would lead to less
+        //recomputation, but this is simpler and I don't think the recomputation
+        //should really be a problem
+      }
     }
   }
   for(const contract of Object.values(contracts)) {
-    allocations = allocateContract(contract, referenceDeclarations, allocations);
+    try {
+      allocations = allocateContract(contract, referenceDeclarations, allocations);
+    }
+    catch(_) {
+      //similarly, we'll allow failure here too, and catch the problem elsewhere
+    }
   }
   return allocations;
 }

--- a/packages/codec/lib/interface/contract.ts
+++ b/packages/codec/lib/interface/contract.ts
@@ -60,12 +60,12 @@ export default class TruffleContractDecoder extends AsyncEventEmitter {
       //this.contexts (which is normalized) via the context getter below
     }
 
-    this.allocations = {};
-    this.allocations.abi = this.wireDecoder.getAbiAllocations();
+    this.allocations = this.wireDecoder.getAllocations();
     if(this.contractNode) {
       this.allocations.storage = getStorageAllocations(
-        this.wireDecoder.getReferenceDeclarations(),
-        {[this.contractNode.id]: this.contractNode}
+        this.wireDecoder.getReferenceDeclarations(), //redundant stuff will be skipped so this is fine
+        {[this.contractNode.id]: this.contractNode},
+        this.allocations.storage //existing allocations from wire decoder
       );
 
       debug("done with allocation");

--- a/packages/codec/lib/interface/wire.ts
+++ b/packages/codec/lib/interface/wire.ts
@@ -18,6 +18,7 @@ import * as DecoderTypes from "../types/interface";
 import { EvmInfo, AllocationInfo } from "../types/evm";
 import { AbiAllocations, ContractAllocationInfo } from "../types/allocation";
 import { getAbiAllocations, getCalldataAllocations, getEventAllocations } from "../allocate/abi";
+import { getStorageAllocations } from "../allocate/storage";
 import { decodeCalldata, decodeEvent } from "../core/decoding";
 import { CalldataDecoding, LogDecoding } from "../types/decoding";
 
@@ -94,6 +95,7 @@ export default class TruffleWireDecoder extends AsyncEventEmitter {
 
     this.allocations = {};
     this.allocations.abi = getAbiAllocations(this.userDefinedTypes);
+    this.allocations.storage = getStorageAllocations(this.referenceDeclarations, {}); //not used by wire decoder itself, but used by contract decoder
     this.allocations.calldata = getCalldataAllocations(allocationInfo, this.referenceDeclarations, this.userDefinedTypes, this.allocations.abi);
     this.allocations.event = getEventAllocations(allocationInfo, this.referenceDeclarations, this.userDefinedTypes, this.allocations.abi);
     debug("done with allocation");
@@ -295,8 +297,11 @@ export default class TruffleWireDecoder extends AsyncEventEmitter {
     return this.userDefinedTypes;
   }
 
-  public getAbiAllocations(): AbiAllocations {
-    return this.allocations.abi;
+  public getAllocations(): AllocationInfo {
+    return {
+      abi: this.allocations.abi,
+      storage: this.allocations.storage
+    };
   }
 
   public getWeb3(): Web3 {

--- a/packages/codec/lib/types/errors.ts
+++ b/packages/codec/lib/types/errors.ts
@@ -46,3 +46,21 @@ export class UnknownUserDefinedTypeError extends Error {
     this.typeString = typeString;
   }
 }
+
+export class ContractBeingDecodedHasNoNodeError extends Error {
+  public contractName: string;
+  constructor(contractName: string) {
+    const message = `Contract ${contractName} does not appear to have been compiled with Solidity (cannot locate contract node)`;
+    super(message);
+    this.name = "ContractBeingDecodedHasNoNodeError";
+  }
+}
+
+export class ContractAllocationFailedError extends Error {
+  public id: number;
+  public contractName: string;
+  constructor(id: number, contractName: string) {
+    super(`No allocation found for contract ID ${id} (${contractName})`);
+    this.name = "ContractAllocationFailedError";
+  }
+}

--- a/packages/codec/lib/types/interface.ts
+++ b/packages/codec/lib/types/interface.ts
@@ -12,7 +12,6 @@ export interface ContractState {
   balanceAsBN: BN;
   nonceAsBN: BN;
   code: string;
-  variables: DecodedVariable[];
 }
 
 export interface DecodedVariable {
@@ -59,24 +58,4 @@ export interface EventOptions {
   fromBlock?: BlockType;
   toBlock?: BlockType;
   address?: string; //ignored by contract decoder!
-}
-
-export class ContractBeingDecodedHasNoNodeError extends Error {
-  constructor() {
-    const message = "Contract does not appear to have been compiled with Solidity (cannot locate contract node)";
-    super(message);
-    this.name = "ContractBeingDecodedHasNoNodeError";
-  }
-}
-
-export class EventOrTransactionIsNotForThisContractError extends Error {
-  thisAddress: string;
-  decoderAddress: string;
-  constructor(thisAddress: string, decoderAddress: string) {
-    const message = "This event or transaction's address does not match that of the contract decoder";
-    super(message);
-    this.name = "EventOrTransactionIsNotForThisContractError";
-    this.thisAddress = thisAddress;
-    this.decoderAddress = decoderAddress;
-  }
 }

--- a/packages/codec/lib/utils/interface.ts
+++ b/packages/codec/lib/utils/interface.ts
@@ -14,7 +14,7 @@ export function getContractNode(contract: ContractObject): AstDefinition {
   );
 }
 
-export function makeContext(contract: ContractObject, node: AstDefinition, isConstructor = false): DecoderContext {
+export function makeContext(contract: ContractObject, node: AstDefinition | undefined, isConstructor = false): DecoderContext {
   const abi = AbiUtils.schemaAbiToAbi(contract.abi);
   const binary = isConstructor ? contract.bytecode : contract.deployedBytecode;
   const hash = ConversionUtils.toHexString(

--- a/packages/codec/test/test/decoding-test.js
+++ b/packages/codec/test/test/decoding-test.js
@@ -41,6 +41,7 @@ contract("DecodingSample", _accounts => {
     decoder.watchMappingKey("varMapping", 3);
 
     const initialState = await decoder.state();
+    const initialVariables = await decoder.variables();
 
     // used for debugging test results
     // console.log(
@@ -54,14 +55,11 @@ contract("DecodingSample", _accounts => {
     assert.equal(initialState.name, "DecodingSample");
     //before we move on to the main section, we'll test the defining classes
     //of the first two variables
-    assert.equal(
-      initialState.variables[0].class.typeName,
-      "DecodingSampleParent"
-    );
-    assert.equal(initialState.variables[1].class.typeName, "DecodingSample");
+    assert.equal(initialVariables[0].class.typeName, "DecodingSampleParent");
+    assert.equal(initialVariables[1].class.typeName, "DecodingSample");
 
     const variables = TruffleCodec.Utils.Conversion.nativizeDecoderVariables(
-      initialState.variables
+      initialVariables
     );
 
     assert.notStrictEqual(typeof variables.varUint, "undefined");


### PR DESCRIPTION
That's right, @davidmurdoch, @adrianmcli, it's another breaking change to the decoder!  But it's getting bundled with all the others.  Hoping to write up docs for all this soon.

Anyway.  This PR does several things:

1. The `state` function in the decoder no longer includes the variables.  If you want the variables, that's now a separate `variables` function.

2. The decoder should no longer throw exceptions on startup!  I mean, I can't rule it out entirely, but, if it happens, that means I messed up.  It's no longer expected behavior, no longer something you should have to be prepared for.

3. However, the new `variables` function -- as well as the existing `variable`, `watchMappingKey`, and `unwatchMappingKey` function -- now all begin by checking to see whether allocation succeeded, and, if not, they throw an exception.  Note that `state` is not listed here; since it doesn't involve the variables anymore, it shouldn't throw exceptions.

4. Internal change: The wire decoder now performs storage struct allocations -- it doesn't need these, of course, but this way any contract decoders made with it don't have to redo this work.  In order to allow this, the `getStorageAllocations` function now has an optional third argument, where you can pass in any existing storage allocations you already know about.  Note that it's OK if some of the stuff you pass in to be allocated in the first two arguments is already there, since the allocator just skips over things that are already allocated.

Anyway, point is, you should no longer have to `try`/`catch` everything involving the decoder!  Only things that actually involve decoding variables.