### PR TITLE
Add working directory to config object for loader

### DIFF
--- a/packages/truffle-db/bin/server.js
+++ b/packages/truffle-db/bin/server.js
@@ -1,7 +1,7 @@
 const { ApolloServer } = require("apollo-server");
 
 const { TruffleDB } = require("truffle-db");
-const Config = require("truffle-config");
+const Config = require("@truffle/config");
 
 const port = 4444;
 
@@ -11,7 +11,8 @@ const config = Config.detect({
 
 const db = new TruffleDB({
   contracts_build_directory: config.contracts_build_directory,
-  contracts_directory: config.contracts_directory
+  contracts_directory: config.contracts_directory,
+  working_directory: config.working_directory
 });
 
 const { schema, context } = db;

--- a/packages/truffle-db/src/loaders/artifacts/index.ts
+++ b/packages/truffle-db/src/loaders/artifacts/index.ts
@@ -273,6 +273,7 @@ type CompilationConfigObject = {
   contracts_directory?: string,
   contracts_build_directory?: string,
   artifacts_directory?: string,
+  working_directory?: string,
   all?: boolean
 }
 

--- a/packages/truffle-db/src/loaders/index.ts
+++ b/packages/truffle-db/src/loaders/index.ts
@@ -24,12 +24,13 @@ const typeDefs = gql`
 const resolvers = {
   Mutation: {
     artifactsLoad: {
-      resolve: async (_, args, { artifactsDirectory, contractsDirectory, db }, info) => {
+      resolve: async (_, args, { artifactsDirectory, contractsDirectory, workingDirectory, db }, info) => {
         const tempDir = tmp.dirSync({ unsafeCleanup: true })
         const compilationConfig = {
           contracts_directory: contractsDirectory,
           contracts_build_directory: tempDir.name,
           artifacts_directory: artifactsDirectory,
+          working_directory: workingDirectory,
           all: true
         }
         const loader = new ArtifactsLoader(db, compilationConfig);


### PR DESCRIPTION
This PR adds working directory to the config passed to truffle db and also the loader, to ensure the proper working directory is accessed for all projects. 