### PR TITLE
Fix debugger crash from regression in codex system

### DIFF
--- a/packages/debugger/lib/evm/reducers.js
+++ b/packages/debugger/lib/evm/reducers.js
@@ -198,14 +198,17 @@ function codex(state = DEFAULT_CODEX, action) {
     accounts: {
       ...frame.accounts,
       [address]: {
-        ...frame.accounts[address],
+        code: "0x", //this will get overridden if it already exists!
+        context: null, //similarly!
+        ...frame.accounts[address], //may be undefined
         storage: {
-          ...frame.accounts[address].storage,
+          ...(frame.accounts[address] || {}).storage, //may be undefined
           [slot]: value
         }
       }
     }
   });
+  //(note that {...undefined} just expands to {} and is OK)
 
   const updateFrameCode = (frame, address, code, context) => {
     let existingPage = frame.accounts[address] || { storage: {} };
@@ -241,6 +244,7 @@ function codex(state = DEFAULT_CODEX, action) {
       return [...state, state[state.length - 1]];
 
     case actions.CREATE:
+      debug("create action");
       //on a create, make a new stackframe, then add a new pages to the
       //codex if necessary; don't add a zero page though (or pages that already
       //exist)
@@ -272,6 +276,7 @@ function codex(state = DEFAULT_CODEX, action) {
       return newState;
 
     case actions.STORE: {
+      debug("store action");
       //on a store, the relevant page should already exist, so we can just
       //add or update the needed slot
       const { address, slot, value } = action;
@@ -291,6 +296,7 @@ function codex(state = DEFAULT_CODEX, action) {
     }
 
     case actions.LOAD: {
+      debug("load action");
       //loads are a little more complicated -- usually we do nothing, but if
       //it's an external load (there was nothing already there), then we want
       //to update *every* stackframe
@@ -318,12 +324,14 @@ function codex(state = DEFAULT_CODEX, action) {
     }
 
     case actions.RETURN_CALL:
+      debug("return from call");
       //we want to pop the top while making the new top a copy of the old top;
       //that is to say, we want to drop just the element *second* from the top
       //NOTE: we don't ever go down to 1 element!
       return safeSave(state);
 
     case actions.RETURN_CREATE: {
+      debug("return from create");
       //we're going to do the same things in this case as in the usual return
       //case, but first we need to record the code that was returned
       const { address, code, context } = action;
@@ -341,14 +349,17 @@ function codex(state = DEFAULT_CODEX, action) {
     }
 
     case actions.FAIL:
+      debug("fail action");
       //pop the stack
       //NOTE: we don't ever go down to 1 element!
       return safePop(state);
 
     case actions.RESET:
+      debug("reset action");
       return [state[0]]; //leave the -1 frame on the stack
 
     case actions.UNLOAD_TRANSACTION:
+      debug("unload action");
       return DEFAULT_CODEX;
 
     case actions.ADD_INSTANCE: {


### PR DESCRIPTION
This PR fixes a debugger crash resulting from a regression in the codex system.  I think what happened is this:

Originally, when I made the codex system, I made it so that, at debugger startup, it created an account for every contract that got called or created.  However, later we made it so that this didn't include creations.  I forget why, but I assume we had a good reason. :P  This then caused a problem when the `updateFrameStorage` function just assumed that the accounts it was updating already existed, and they might not, potentially crashing the debugger.

So, this PR fixes that; now, if `updateFrameStorage` finds that no account exists, it will create one.  Note that it *does* still rely on the assumption that this will only happen with contracts we create rather than contracts we call into -- when it creates a new account, it creates it with no code.  This is only valid because, as I said, this case should only arise with contracts created during the transaction, which therefore must have necessarily started the transaction with no code.

It's possible that really we should revisit the question of which contracts should have accounts created on startup, but, well, this seemed easier, and as far as I can tell is entirely correct (again, assuming we do fetch the code at startup for all contracts we don't create, which currently we do).