### PR TITLE
Fix: incorrect key in `@truffle/contract`

### DIFF
--- a/packages/contract/lib/contract/constructorMethods.js
+++ b/packages/contract/lib/contract/constructorMethods.js
@@ -216,7 +216,7 @@ module.exports = Contract => ({
     bootstrap(temp);
 
     temp.web3 = new Web3Shim({
-      type: temp.networkType
+      networkType: temp.networkType
     });
     temp.class_defaults = temp.prototype.defaults || {};
 


### PR DESCRIPTION
This PR fixes an incorrect key (`type`) being passed to `Web3Shim` in `@truffle/contract`.

🐞 