### PR TITLE
Hide private state variables when out of scope

### DIFF
--- a/packages/debugger/lib/data/reducers.js
+++ b/packages/debugger/lib/data/reducers.js
@@ -16,7 +16,6 @@ const DEFAULT_SCOPES = {
 function scopes(state = DEFAULT_SCOPES, action) {
   var scope;
   var variables;
-  var visibles;
 
   switch (action.type) {
     case actions.SCOPE:
@@ -40,10 +39,6 @@ function scopes(state = DEFAULT_SCOPES, action) {
     case actions.DECLARE:
       scope = state.byId[action.node.scope] || {};
       variables = scope.variables || [];
-      visibles = scope.visibles || [];
-
-      let visible = action.node.visibility !== "private";
-      //so, public and internal are both visible
 
       return {
         byId: {
@@ -54,12 +49,9 @@ function scopes(state = DEFAULT_SCOPES, action) {
 
             variables: [
               ...variables,
-              { name: action.node.name, id: action.node.id }
-            ],
 
-            visibles: visible
-              ? [...visibles, { name: action.node.name, id: action.node.id }]
-              : visibles
+              { name: action.node.name, id: action.node.id }
+            ]
           }
         }
       };

--- a/packages/debugger/lib/data/reducers.js
+++ b/packages/debugger/lib/data/reducers.js
@@ -16,6 +16,7 @@ const DEFAULT_SCOPES = {
 function scopes(state = DEFAULT_SCOPES, action) {
   var scope;
   var variables;
+  var visibles;
 
   switch (action.type) {
     case actions.SCOPE:
@@ -39,6 +40,10 @@ function scopes(state = DEFAULT_SCOPES, action) {
     case actions.DECLARE:
       scope = state.byId[action.node.scope] || {};
       variables = scope.variables || [];
+      visibles = scope.visibles || [];
+
+      let visible = action.node.visibility !== "private";
+      //so, public and internal are both visible
 
       return {
         byId: {
@@ -49,9 +54,12 @@ function scopes(state = DEFAULT_SCOPES, action) {
 
             variables: [
               ...variables,
-
               { name: action.node.name, id: action.node.id }
-            ]
+            ],
+
+            visibles: visible
+              ? [...visibles, { name: action.node.name, id: action.node.id }]
+              : visibles
           }
         }
       };

--- a/packages/debugger/lib/data/selectors/index.js
+++ b/packages/debugger/lib/data/selectors/index.js
@@ -263,14 +263,21 @@ const data = createSelectorTree({
             let linearizedBaseContractsFromBase = definition.linearizedBaseContracts
               .slice()
               .reverse();
+            //...but wait, we want to treat the last one specially, so let's pop that
+            //off
+            linearizedBaseContractsFromBase.pop();
             //now, we put it all together
             newScope.variables = []
               .concat(
                 ...linearizedBaseContractsFromBase.map(
-                  contractId => scopes[contractId].variables || []
+                  contractId => scopes[contractId].visibles || []
                   //we need the || [] because contracts with no state variables
                   //have variables undefined rather than empty like you'd expect
                 )
+              )
+              .concat(
+                scopes[id].variables || []
+                //for the last one we use all variables, not just visibles
               )
               .filter(variable => {
                 //...except, HACK, let's filter out those constants we don't know
@@ -283,6 +290,8 @@ const data = createSelectorTree({
                 );
               });
 
+            //NOTE: we don't bother altering newScope.visibles -- you shouldn't
+            //be using that from this point out :P
             return { [id]: newScope };
           })
         )

--- a/packages/debugger/lib/data/selectors/index.js
+++ b/packages/debugger/lib/data/selectors/index.js
@@ -263,21 +263,14 @@ const data = createSelectorTree({
             let linearizedBaseContractsFromBase = definition.linearizedBaseContracts
               .slice()
               .reverse();
-            //...but wait, we want to treat the last one specially, so let's pop that
-            //off
-            linearizedBaseContractsFromBase.pop();
             //now, we put it all together
             newScope.variables = []
               .concat(
                 ...linearizedBaseContractsFromBase.map(
-                  contractId => scopes[contractId].visibles || []
+                  contractId => scopes[contractId].variables || []
                   //we need the || [] because contracts with no state variables
                   //have variables undefined rather than empty like you'd expect
                 )
-              )
-              .concat(
-                scopes[id].variables || []
-                //for the last one we use all variables, not just visibles
               )
               .filter(variable => {
                 //...except, HACK, let's filter out those constants we don't know
@@ -290,8 +283,6 @@ const data = createSelectorTree({
                 );
               });
 
-            //NOTE: we don't bother altering newScope.visibles -- you shouldn't
-            //be using that from this point out :P
             return { [id]: newScope };
           })
         )


### PR DESCRIPTION
This PR hides out-of-scope private state variables in the debugger.  So, if you have a base class `Base` with a private state variable `x`, and are currently stepping through a function in a derived class `Derived`, the variable `x` will not appear when you press the `v` command, nor will it be accessible in watch expressions.

~~To accomplish this, I've slightly modified the `DECLARE` system.  Now, each scope maintains both `variables` and `visibles`; when a variable is declared; it's added to `variables`, but only added to `visibiles` if its visibility is not equal to `private` (i.e., is equal to `public` or `internal`).~~

~~Then, when variables from base classes are added in during computation of `data.info.scopes`, only the `visibles` from these base classes are pulled in.  Note that the last entry in the list of base classes, i.e. the class under consideration itself, now has to be treated specially, as we want all of its variables, even the `private` ones.~~

Edit: I've redone this without modifying any reducers.  Now all filtering is done in the selector, because we can use a variable's ID to look up its visibility, without needing to store it.

All this has no effect on allocation, as the allocator handles inheritance itself; so we're not screwing up the allocation by filtering some variables out in the debugger.

~~Note: I didn't bother altering the value of `scope.visibles` in `data.info.scopes`, because, well, that's not used for anything, and it'd just be way more trouble to change it.  So that's still there with its old value that doesn't account for inheritance, same as in `data.info.scopes.raw`, it just doesn't mean anything.  Hope that's OK.~~

Also note: I branched this off develop, but it's possible we might want to save this for `next`, because it kind of goes along with the other base variable stuff, which I was planning on only doing on `next`?  Probably it makes more sense to do this on develop like I did in fact do it, but just thought I'd throw that out there.