### PR TITLE
Fix: Filter console reading of contracts_build_directory for json

### DIFF
--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -87,7 +87,10 @@ class Console extends EventEmitter {
   provision() {
     let files;
     try {
-      files = fse.readdirSync(this.options.contracts_build_directory);
+      const unfilteredFiles = fse.readdirSync(
+        this.options.contracts_build_directory
+      );
+      files = unfilteredFiles.filter(file => file.match(".json") !== null);
     } catch (error) {
       // Error reading the build directory? Must mean it doesn't exist or we don't have access to it.
       // Couldn't provision the contracts if we wanted. It's possible we're hiding very rare FS


### PR DESCRIPTION
`truffle develop` and `truffle console` currently die silently if using the `contracts_build_directory` config option with a directory that has a system file, e.g., `.DS_Store`.

Filtering for json files only fixes the issue.