### PR TITLE
@truffle/hdwallet-provider: debug removed (browser support added)

### DIFF
--- a/packages/hdwallet-provider/package.json
+++ b/packages/hdwallet-provider/package.json
@@ -20,7 +20,6 @@
     "any-promise": "^1.3.0",
     "bindings": "^1.5.0",
     "bip39": "^2.4.2",
-    "debug": "^4.1.1",
     "ethereum-protocol": "^1.0.1",
     "ethereumjs-tx": "^2.1.1",
     "ethereumjs-util": "^6.1.0",

--- a/packages/hdwallet-provider/src/index.ts
+++ b/packages/hdwallet-provider/src/index.ts
@@ -2,7 +2,6 @@ import * as bip39 from 'bip39';
 import * as EthUtil from 'ethereumjs-util';
 import ethJSWallet from 'ethereumjs-wallet';
 import EthereumHDKey from 'ethereumjs-wallet/hdkey';
-import debugModule from 'debug';
 import { Transaction } from 'ethereumjs-tx';
 import ProviderEngine from 'web3-provider-engine';
 import FiltersSubprovider from 'web3-provider-engine/subproviders/filters';
@@ -16,7 +15,7 @@ import {
   JSONRPCResponsePayload
 } from 'ethereum-protocol';
 
-const debug = debugModule('@truffle/hdwallet-provider');
+// Important: do not use debug module. Reason: https://github.com/trufflesuite/truffle/issues/2374#issuecomment-536109086
 
 // This line shares nonce state across multiple provider instances. Necessary
 // because within truffle the wallet is repeatedly newed if it's declared in the config within a
@@ -187,8 +186,6 @@ class HDWalletProvider {
   }
 
   public getAddress(idx?: number): string {
-    debug('getting addresses', this.addresses[0], idx);
-
     if (!idx) {
       return this.addresses[0];
     } else {


### PR DESCRIPTION
After an investigation, I noticed that after building `webpack`, I get a broken bundle, the reason for this is the `debug` module, which cannot work with the browser.

Therefore, I decided to remove this module and add support for browsers.

Related with #2374 issue