### PR TITLE
Unbreak support for ethers.js BigNumber

### DIFF
--- a/packages/contract/lib/utils.js
+++ b/packages/contract/lib/utils.js
@@ -13,6 +13,10 @@ const Utils = {
   is_big_number(val) {
     if (typeof val !== "object") return false;
 
+    //NOTE: For some reason, contrary to the docs,
+    //web3Utils.isBigNumber returns true not only for
+    //bignumber.js BigNumbers, but also for ethers BigNumbers,
+    //even though these are totally different things.
     return web3Utils.isBN(val) || web3Utils.isBigNumber(val);
   },
 
@@ -209,7 +213,10 @@ const Utils = {
 
         // Convert Web3 BN / BigNumber
       } else if (Utils.is_big_number(item)) {
-        const stringValue = web3Utils.isBigNumber(item)
+        //HACK: Since we can't rely on web3Utils.isBigNumber to tell
+        //whether we have a bignumber.js BigNumber, we'll just check
+        //whether it has the toFixed method
+        const stringValue = item.toFixed
           ? item.toFixed() //prevents use of scientific notation
           : item.toString();
         const ethersBN = bigNumberify(stringValue);


### PR DESCRIPTION
This PR fixes an issue reported by @area on Gitter; it turns out that my earlier PR #2401 broke encoding of ethers.js `BigNumber`s.

The reason it broke encoding of these is that I didn't realize we supported them!  Honestly I'm not sure the support was even intentional, but it exists and @area was relying on it, so we'd better not break it.  Our code detects whether a given object is a big number of any sort by using `Web3.utils.isBN` and `Web3.utils.isBigNumber`.  The documentation claims that the latter detects the `BigNumber` class from bignumber.js.  In fact, however, it also detects the `BigNumber` class from ethers.js, despite this being a totally different class!

That's pretty crazy, but I think we have to live with it for now -- or at least, we can worry about it later; first let's just unbreak things, right?

Anyway, since it turns out we can't actually rely on `Web3.utils.isBigNumber` to determine whether we have a bignumber.js `BigNumber`, I changed it so that (once we know we have a big number of *some* sort) we just check if the given object has the `toFixed` method.  If it does, we use that to convert to string, and if not, we use `toString`.

This works for `BN`s and ethers.js `BigNumber`s, which do not have `toFixed`, and whose `toString` method never uses scientific notation; and it works for bignumber.js `BigNumber`s, which do have the `toFixed` method and for which you'd better use that method or else we get the problem that #2401 was originally fixing.

So, it's kind of a hack, but it works.  I tested it with all *three* classes this time to be sure!