### PR TITLE
Bug fix: Don't pass Ganache an empty array for "unlocked_accounts"

### DIFF
--- a/packages/environment/environment.js
+++ b/packages/environment/environment.js
@@ -38,14 +38,15 @@ const Environment = {
     const upstreamNetwork = config.network;
     const upstreamConfig = config.networks[upstreamNetwork];
     const forkedNetwork = config.network + "-fork";
+    const ganacheOptions = {
+      fork: config.provider,
+      gasLimit: block.gasLimit
+    };
+    if (accounts.length > 0) options.unlocked_accounts = accounts;
 
     config.networks[forkedNetwork] = {
       network_id: config.network_id,
-      provider: Ganache.provider({
-        fork: config.provider,
-        unlocked_accounts: accounts,
-        gasLimit: block.gasLimit
-      }),
+      provider: Ganache.provider(ganacheOptions),
       from: config.from,
       gas: upstreamConfig.gas,
       gasPrice: upstreamConfig.gasPrice


### PR DESCRIPTION
Reorganize how Ganache gets options passed to avoid passing an empty array for the `unlocked_accounts` property. This apparently is causing a bug that will be fixed on the Ganache end as well. See the discussion [here](https://github.com/trufflesuite/truffle/issues/1698) for more information.

