### PR TITLE
Account for instantly-returning creates

### DIFF
--- a/packages/debugger/lib/evm/sagas/index.js
+++ b/packages/debugger/lib/evm/sagas/index.js
@@ -82,15 +82,15 @@ export function* callstackAndCodexSaga() {
     debug("exceptional halt!");
 
     yield put(actions.fail());
+  } else if (yield select(evm.current.step.isInstantCallOrCreate)) {
+    // if there is no binary (e.g. for precompiles or externally owned
+    // accounts), or if the call fails instantly (callstack overflow or not
+    // enough ether), there will be no trace steps for the called code, and so
+    // we shouldn't tell the debugger that we're entering another execution
+    // context
+    // (so we do nothing)
   } else if (yield select(evm.current.step.isCall)) {
     debug("got call");
-    // if there is no binary (e.g. in the case of precompiled contracts or
-    // externally owned accounts), then there will be no trace steps for the
-    // called code, and so we shouldn't tell the debugger that we're entering
-    // another execution context
-    if (yield select(evm.current.step.callsPrecompileOrExternal)) {
-      return;
-    }
 
     let address = yield select(evm.current.step.callAddress);
     let data = yield select(evm.current.step.callData);

--- a/packages/debugger/lib/evm/selectors/index.js
+++ b/packages/debugger/lib/evm/selectors/index.js
@@ -451,14 +451,19 @@ const evm = createSelectorTree({
       ),
 
       /**
-       * evm.current.step.callsPrecompileOrExternal
+       * evm.current.step.isInstantCallOrReturn
        *
-       * are we calling a precompiled contract or an externally-owned account,
-       * rather than a contract account that isn't precompiled?
+       * are we doing a call or create for which there are no trace steps?
+       * This can happen if:
+       * 1. we call a precompile
+       * 2. we call an externally-owned account
+       * 3. we do a call or create but the call stack is exhausted
+       * 4. we attempt to transfer more ether than we have
        */
-      callsPrecompileOrExternal: createLeaf(
-        ["./isCall", "/current/state/depth", "/next/state/depth"],
-        (calls, currentDepth, nextDepth) => calls && currentDepth === nextDepth
+      isInstantCallOrCreate: createLeaf(
+        ["./isCall", "./isCreate", "/current/state/depth", "/next/state/depth"],
+        (calls, creates, currentDepth, nextDepth) =>
+          (calls || creates) && currentDepth === nextDepth
       ),
 
       /**

--- a/packages/debugger/lib/solidity/sagas/index.js
+++ b/packages/debugger/lib/solidity/sagas/index.js
@@ -27,16 +27,17 @@ function* functionDepthSaga() {
     //we do this case first so we can be sure we're not failing in any of the
     //other cases below!
     yield put(actions.externalReturn());
+  } else if (
+    yield select(solidity.current.willCallOrCreateButInstantlyReturn)
+  ) {
+    //do nothing
+    //again, we put this second so we can be sure the other cases are not this
   } else if (yield select(solidity.current.willJump)) {
     let jumpDirection = yield select(solidity.current.jumpDirection);
     yield put(actions.jump(jumpDirection));
   } else if (yield select(solidity.current.willCall)) {
     debug("about to call");
-    if (yield select(solidity.current.callsPrecompileOrExternal)) {
-      //call to precompile or externally-owned account; do nothing
-    } else {
-      yield put(actions.externalCall());
-    }
+    yield put(actions.externalCall());
   } else if (yield select(solidity.current.willCreate)) {
     yield put(actions.externalCall());
   } else if (yield select(solidity.current.willReturn)) {

--- a/packages/debugger/lib/solidity/selectors/index.js
+++ b/packages/debugger/lib/solidity/selectors/index.js
@@ -365,10 +365,10 @@ let solidity = createSelectorTree({
     willCreate: createLeaf([evm.current.step.isCreate], x => x),
 
     /**
-     * solidity.current.callsPrecompileOrExternal
+     * solidity.current.willCallOrCreateButInstantlyReturn
      */
-    callsPrecompileOrExternal: createLeaf(
-      [evm.current.step.callsPrecompileOrExternal],
+    willCallOrCreateButInstantlyReturn: createLeaf(
+      [evm.current.step.isInstantCallOrCreate],
       x => x
     ),
 


### PR DESCRIPTION
The debugger currently has code to account for the possibility that a call instantly returns, with no trace steps generated for the called account.  This situation comes up when calling a precompiled contract or externally-owned account.  However, I recently learned that there's another situation where it comes up: When the call instantly fails due to attempting to transfer more ether than you have, or when it instantly fails due to overflowing the call stack.  These last two possibilities can also come up with contract creations, not just message calls; however, we were only accounting for it in the case of calls.  This PR modifies the relevant code so that it applies to contract creations as well.

I also added a test of this.