### PR TITLE
Correct what's printed by the ; command

### DIFF
--- a/packages/core/lib/debug/interpreter.js
+++ b/packages/core/lib/debug/interpreter.js
@@ -350,6 +350,7 @@ class DebugInterpreter {
         case "u":
         case "n":
         case "c":
+        case ";":
           //are we "finished" because we've reached the end, or because
           //nothing is loaded?
           if (this.session.view(selectors.session.status.loaded)) {
@@ -451,9 +452,18 @@ class DebugInterpreter {
       case "B":
         await this.setOrClearBreakpoint(splitArgs, false);
         break;
-      case ";":
       case "p":
         if (this.session.view(selectors.session.status.loaded)) {
+          this.printer.printFile();
+          this.printer.printInstruction();
+          this.printer.printState();
+        }
+        await this.printer.printWatchExpressionsResults(
+          this.enabledExpressions
+        );
+        break;
+      case ";":
+        if (!this.session.view(trace.finishedOrUnloaded)) {
           this.printer.printFile();
           this.printer.printInstruction();
           this.printer.printState();


### PR DESCRIPTION
This quick PR fixes what's printed by the `;` command.  I noticed it wasn't behaving properly when the transaction halted or had already halted; turned out it wasn't checking that condition and was treated identically to the `p` command.  Now it behaves like `n` and the other advancing commands when the trace finishes.