### PR TITLE
Backport use of Generator type to develop

### DIFF
--- a/packages/decoder/lib/decode/calldata.ts
+++ b/packages/decoder/lib/decode/calldata.ts
@@ -10,23 +10,40 @@ import { calldataSize } from "../allocate/calldata";
 import { EvmInfo } from "../types/evm";
 import { DecoderRequest } from "../types/request";
 
-export default function* decodeCalldata(definition: DecodeUtils.AstDefinition, pointer: CalldataPointer, info: EvmInfo, base: number = 0): IterableIterator<any | DecoderRequest> {
-  if(DecodeUtils.Definition.isReference(definition)) {
-    let dynamic = calldataSize(definition, info.referenceDeclarations, info.calldataAllocations)[1];
-    if(dynamic) {
-      return yield* decodeCalldataReferenceByAddress(definition, pointer, info, base);
-    }
-    else {
+export default function* decodeCalldata(
+  definition: DecodeUtils.AstDefinition,
+  pointer: CalldataPointer,
+  info: EvmInfo,
+  base: number = 0
+): Generator<DecoderRequest, any, Uint8Array> {
+  if (DecodeUtils.Definition.isReference(definition)) {
+    let dynamic = calldataSize(
+      definition,
+      info.referenceDeclarations,
+      info.calldataAllocations
+    )[1];
+    if (dynamic) {
+      return yield* decodeCalldataReferenceByAddress(
+        definition,
+        pointer,
+        info,
+        base
+      );
+    } else {
       return yield* decodeCalldataReferenceStatic(definition, pointer, info);
     }
-  }
-  else {
+  } else {
     debug("pointer %o", pointer);
     return yield* decodeValue(definition, pointer, info);
   }
 }
 
-export function* decodeCalldataReferenceByAddress(definition: DecodeUtils.AstDefinition, pointer: DataPointer, info: EvmInfo, base: number = 0): IterableIterator<any | DecoderRequest> {
+export function* decodeCalldataReferenceByAddress(
+  definition: DecodeUtils.AstDefinition,
+  pointer: DataPointer,
+  info: EvmInfo,
+  base: number = 0
+): Generator<DecoderRequest, any, Uint8Array> {
   const { state } = info;
   debug("pointer %o", pointer);
   let rawValue: Uint8Array = yield* read(pointer, state);
@@ -34,41 +51,63 @@ export function* decodeCalldataReferenceByAddress(definition: DecodeUtils.AstDef
   let startPosition = DecodeUtils.Conversion.toBN(rawValue).toNumber() + base;
   debug("startPosition %d", startPosition);
 
-  let [size, dynamic] = calldataSize(definition, info.referenceDeclarations, info.calldataAllocations);
-  if(!dynamic) { //this will only come up when called from stack.ts
+  let [size, dynamic] = calldataSize(
+    definition,
+    info.referenceDeclarations,
+    info.calldataAllocations
+  );
+  if (!dynamic) {
+    //this will only come up when called from stack.ts
     let staticPointer = {
       calldata: {
         start: startPosition,
         length: size
       }
-    }
-    return yield* decodeCalldataReferenceStatic(definition, staticPointer, info);
+    };
+    return yield* decodeCalldataReferenceStatic(
+      definition,
+      staticPointer,
+      info
+    );
   }
   let length;
   switch (DecodeUtils.Definition.typeClass(definition)) {
-
     case "bytes":
     case "string":
-      length = DecodeUtils.Conversion.toBN(yield* read({
-        calldata: { start: startPosition, length: DecodeUtils.EVM.WORD_SIZE}
-      }, state)).toNumber(); //initial word contains length
+      length = DecodeUtils.Conversion.toBN(
+        yield* read(
+          {
+            calldata: {
+              start: startPosition,
+              length: DecodeUtils.EVM.WORD_SIZE
+            }
+          },
+          state
+        )
+      ).toNumber(); //initial word contains length
 
       let childPointer: CalldataPointer = {
         calldata: { start: startPosition + DecodeUtils.EVM.WORD_SIZE, length }
-      }
+      };
 
       return yield* decodeValue(definition, childPointer, info);
 
     case "array":
-
       if (DecodeUtils.Definition.isDynamicArray(definition)) {
-        length = DecodeUtils.Conversion.toBN(yield* read({
-          calldata: { start: startPosition, length: DecodeUtils.EVM.WORD_SIZE },
-          }, state)).toNumber();  // initial word contains array length
+        length = DecodeUtils.Conversion.toBN(
+          yield* read(
+            {
+              calldata: {
+                start: startPosition,
+                length: DecodeUtils.EVM.WORD_SIZE
+              }
+            },
+            state
+          )
+        ).toNumber(); // initial word contains array length
         startPosition += DecodeUtils.EVM.WORD_SIZE; //increment startPosition to
         //next word, as first word was used for length
-      }
-      else {
+      } else {
         length = DecodeUtils.Definition.staticLength(definition);
       }
 
@@ -77,27 +116,44 @@ export function* decodeCalldataReferenceByAddress(definition: DecodeUtils.AstDef
       //then size must be EVM.WORD_SIZE
 
       let baseDefinition = definition.baseType || definition.typeName.baseType;
-        //I'm deliberately not using the DecodeUtils function for this, because
-        //we should *not* need a faked-up type here!
+      //I'm deliberately not using the DecodeUtils function for this, because
+      //we should *not* need a faked-up type here!
 
       // replace erroneous `_storage_` type identifiers with `_calldata_`
-      baseDefinition = DecodeUtils.Definition.spliceLocation(baseDefinition, "calldata");
-      let baseSize = calldataSize(baseDefinition, info.referenceDeclarations, info.calldataAllocations)[0];
+      baseDefinition = DecodeUtils.Definition.spliceLocation(
+        baseDefinition,
+        "calldata"
+      );
+      let baseSize = calldataSize(
+        baseDefinition,
+        info.referenceDeclarations,
+        info.calldataAllocations
+      )[0];
 
       let decodedChildren = [];
-      for(let index = 0; index < length; index++) {
-        decodedChildren.push(yield* decodeCalldata(
-          baseDefinition,
-          { calldata: {
-            start: startPosition + index * baseSize,
-            length: baseSize
-          }},
-          info, startPosition)); //pointer base is always start of list, never the length
+      for (let index = 0; index < length; index++) {
+        decodedChildren.push(
+          yield* decodeCalldata(
+            baseDefinition,
+            {
+              calldata: {
+                start: startPosition + index * baseSize,
+                length: baseSize
+              }
+            },
+            info,
+            startPosition
+          )
+        ); //pointer base is always start of list, never the length
       }
       return decodedChildren;
 
     case "struct":
-      return yield* decodeCalldataStructByPosition(definition, startPosition, info);
+      return yield* decodeCalldataStructByPosition(
+        definition,
+        startPosition,
+        info
+      );
 
     default:
       // debug("Unknown calldata reference type: %s", DecodeUtils.typeIdentifier(definition));
@@ -105,41 +161,63 @@ export function* decodeCalldataReferenceByAddress(definition: DecodeUtils.AstDef
   }
 }
 
-export function* decodeCalldataReferenceStatic(definition: DecodeUtils.AstDefinition, pointer: CalldataPointer, info: EvmInfo): IterableIterator<any | DecoderRequest> {
+export function* decodeCalldataReferenceStatic(
+  definition: DecodeUtils.AstDefinition,
+  pointer: CalldataPointer,
+  info: EvmInfo
+): Generator<DecoderRequest, any, Uint8Array> {
   const { state } = info;
   debug("static");
   debug("pointer %o", pointer);
 
   switch (DecodeUtils.Definition.typeClass(definition)) {
-
     case "array":
-
       //we're in the static case, so we know the array must be statically sized
       const length = DecodeUtils.Definition.staticLength(definition);
-      let size = calldataSize(definition, info.referenceDeclarations, info.calldataAllocations)[0];
+      let size = calldataSize(
+        definition,
+        info.referenceDeclarations,
+        info.calldataAllocations
+      )[0];
 
       let baseDefinition = definition.baseType || definition.typeName.baseType;
-        //I'm deliberately not using the DecodeUtils function for this, because
-        //we should *not* need a faked-up type here!
+      //I'm deliberately not using the DecodeUtils function for this, because
+      //we should *not* need a faked-up type here!
 
       // replace erroneous `_storage_` type identifiers with `_calldata_`
-      baseDefinition = DecodeUtils.Definition.spliceLocation(baseDefinition, "calldata");
-      let baseSize = calldataSize(baseDefinition, info.referenceDeclarations, info.calldataAllocations)[0];
+      baseDefinition = DecodeUtils.Definition.spliceLocation(
+        baseDefinition,
+        "calldata"
+      );
+      let baseSize = calldataSize(
+        baseDefinition,
+        info.referenceDeclarations,
+        info.calldataAllocations
+      )[0];
 
       let decodedChildren = [];
-      for(let index = 0; index < length; index++) {
-        decodedChildren.push(yield* decodeCalldata(
-          baseDefinition,
-          { calldata: {
-            start: pointer.calldata.start + index * baseSize,
-            length: baseSize
-          }},
-          info)); //static case so don't need base
+      for (let index = 0; index < length; index++) {
+        decodedChildren.push(
+          yield* decodeCalldata(
+            baseDefinition,
+            {
+              calldata: {
+                start: pointer.calldata.start + index * baseSize,
+                length: baseSize
+              }
+            },
+            info
+          )
+        ); //static case so don't need base
       }
       return decodedChildren;
 
     case "struct":
-      return yield* decodeCalldataStructByPosition(definition, pointer.calldata.start, info);
+      return yield* decodeCalldataStructByPosition(
+        definition,
+        pointer.calldata.start,
+        info
+      );
 
     default:
       // debug("Unknown calldata reference type: %s", DecodeUtils.typeIdentifier(definition));
@@ -148,7 +226,11 @@ export function* decodeCalldataReferenceStatic(definition: DecodeUtils.AstDefini
 }
 
 //note that this function takes the start position as a *number*; it does not take a calldata pointer
-function* decodeCalldataStructByPosition(definition: DecodeUtils.AstDefinition, startPosition: number, info: EvmInfo): IterableIterator<any | DecoderRequest> {
+function* decodeCalldataStructByPosition(
+  definition: DecodeUtils.AstDefinition,
+  startPosition: number,
+  info: EvmInfo
+): Generator<DecoderRequest, any, Uint8Array> {
   const { state, referenceDeclarations, calldataAllocations } = info;
 
   const referencedDeclaration = definition.typeName
@@ -156,12 +238,12 @@ function* decodeCalldataStructByPosition(definition: DecodeUtils.AstDefinition, 
     : definition.referencedDeclaration;
   const structAllocation = calldataAllocations[referencedDeclaration];
 
-  if(structAllocation == null) {
+  if (structAllocation == null) {
     return undefined; //this should never happen
   }
 
   let decodedMembers: any = {};
-  for(let memberAllocation of Object.values(structAllocation.members)) {
+  for (let memberAllocation of Object.values(structAllocation.members)) {
     const memberPointer = memberAllocation.pointer;
     const childPointer: CalldataPointer = {
       calldata: {
@@ -173,11 +255,19 @@ function* decodeCalldataStructByPosition(definition: DecodeUtils.AstDefinition, 
     let memberDefinition = memberAllocation.definition;
 
     // replace erroneous `_storage` type identifiers with `_calldata`
-    memberDefinition = DecodeUtils.Definition.spliceLocation(memberDefinition, "calldata");
+    memberDefinition = DecodeUtils.Definition.spliceLocation(
+      memberDefinition,
+      "calldata"
+    );
     //there also used to be code here to add on the "_ptr" ending when absent, but we
     //presently ignore that ending, so we'll skip that
 
-    let decoded = yield* decodeCalldata(memberDefinition, childPointer, info, startPosition);
+    let decoded = yield* decodeCalldata(
+      memberDefinition,
+      childPointer,
+      info,
+      startPosition
+    );
     //note that startPosition is only needed in the dynamic case, but we don't know which case we're in
 
     decodedMembers[memberDefinition.name] = decoded;

--- a/packages/decoder/lib/decode/constant.ts
+++ b/packages/decoder/lib/decode/constant.ts
@@ -4,13 +4,16 @@ const debug = debugModule("decoder:decode:constant");
 import * as DecodeUtils from "@truffle/decode-utils";
 import read from "../read";
 import decodeValue from "./value";
-import { ConstantDefinitionPointer} from "../types/pointer";
+import { ConstantDefinitionPointer } from "../types/pointer";
 import { EvmInfo } from "../types/evm";
 import { DecoderRequest } from "../types/request";
 import BN from "bn.js";
 
-export default function* decodeConstant(definition: DecodeUtils.AstDefinition, pointer: ConstantDefinitionPointer, info: EvmInfo): IterableIterator<any | DecoderRequest> {
-
+export default function* decodeConstant(
+  definition: DecodeUtils.AstDefinition,
+  pointer: ConstantDefinitionPointer,
+  info: EvmInfo
+): Generator<DecoderRequest, any, Uint8Array> {
   debug("definition %O", definition);
   debug("pointer %o", pointer);
 
@@ -20,9 +23,9 @@ export default function* decodeConstant(definition: DecodeUtils.AstDefinition, p
   //of the word, but readDefinition will put them at the *end* of the
   //word.  So we'll have to adjust things ourselves.
 
-  if(DecodeUtils.Definition.typeClass(definition) === "bytes") {
+  if (DecodeUtils.Definition.typeClass(definition) === "bytes") {
     let size = DecodeUtils.Definition.specifiedSize(definition);
-    if(size !== null) {
+    if (size !== null) {
       let word = yield* read(pointer, info.state);
       let bytes = word.slice(DecodeUtils.EVM.WORD_SIZE - size);
       return DecodeUtils.Conversion.toHexString(bytes);

--- a/packages/decoder/lib/decode/index.ts
+++ b/packages/decoder/lib/decode/index.ts
@@ -14,15 +14,19 @@ import * as Pointer from "../types/pointer";
 import { EvmInfo } from "../types/evm";
 import { DecoderRequest } from "../types/request";
 
-export default function* decode(definition: AstDefinition, pointer: Pointer.DataPointer, info: EvmInfo): IterableIterator<any | DecoderRequest> {
+export default function* decode(
+  definition: AstDefinition,
+  pointer: Pointer.DataPointer,
+  info: EvmInfo
+): Generator<DecoderRequest, any, Uint8Array> {
   debug("Decoding %s", definition.name);
   debug("pointer %O", pointer);
 
-  if(Pointer.isStoragePointer(pointer)) {
-    return yield* decodeStorage(definition, pointer, info)
+  if (Pointer.isStoragePointer(pointer)) {
+    return yield* decodeStorage(definition, pointer, info);
   }
 
-  if(Pointer.isStackPointer(pointer)) {
+  if (Pointer.isStackPointer(pointer)) {
     return yield* decodeStack(definition, pointer, info);
   }
 
@@ -30,24 +34,24 @@ export default function* decode(definition: AstDefinition, pointer: Pointer.Data
     return yield* decodeLiteral(definition, pointer, info);
   }
 
-  if(Pointer.isConstantDefinitionPointer(pointer)) {
+  if (Pointer.isConstantDefinitionPointer(pointer)) {
     return yield* decodeConstant(definition, pointer, info);
     //I'd like to just use decodeValue, but unfortunately there are some special
     //cases to deal with
   }
 
-  if(Pointer.isSpecialPointer(pointer)) {
+  if (Pointer.isSpecialPointer(pointer)) {
     return yield* decodeSpecial(definition, pointer, info);
   }
 
   //NOTE: the following two cases shouldn't come up but they've been left in as
   //fallback cases
 
-  if(Pointer.isMemoryPointer(pointer)) {
+  if (Pointer.isMemoryPointer(pointer)) {
     return yield* decodeMemory(definition, pointer, info);
   }
 
-  if(Pointer.isCalldataPointer(pointer)) {
+  if (Pointer.isCalldataPointer(pointer)) {
     return yield* decodeCalldata(definition, pointer, info);
   }
 }

--- a/packages/decoder/lib/decode/stack.ts
+++ b/packages/decoder/lib/decode/stack.ts
@@ -12,50 +12,68 @@ import { StackPointer, StackLiteralPointer } from "../types/pointer";
 import { EvmInfo } from "../types/evm";
 import { DecoderRequest } from "../types/request";
 
-export default function* decodeStack(definition: DecodeUtils.AstDefinition, pointer: StackPointer, info: EvmInfo): IterableIterator<any | DecoderRequest> {
+export default function* decodeStack(
+  definition: DecodeUtils.AstDefinition,
+  pointer: StackPointer,
+  info: EvmInfo
+): Generator<DecoderRequest, any, Uint8Array> {
   const rawValue: Uint8Array = yield* read(pointer, info.state);
   const literalPointer: StackLiteralPointer = { literal: rawValue };
   return yield* decodeLiteral(definition, literalPointer, info);
 }
 
-export function* decodeLiteral(definition: DecodeUtils.AstDefinition, pointer: StackLiteralPointer, info: EvmInfo): IterableIterator<any | DecoderRequest> {
-
+export function* decodeLiteral(
+  definition: DecodeUtils.AstDefinition,
+  pointer: StackLiteralPointer,
+  info: EvmInfo
+): Generator<DecoderRequest, any, Uint8Array> {
   debug("definition %O", definition);
   debug("pointer %o", pointer);
 
   //first: do we have a memory pointer? if so we can just dispatch to
   //decodeMemoryReference, which knows how to decode the pointer already
-  if(DecodeUtils.Definition.isReference(definition)
-    && DecodeUtils.Definition.referenceType(definition) === "memory") {
+  if (
+    DecodeUtils.Definition.isReference(definition) &&
+    DecodeUtils.Definition.referenceType(definition) === "memory"
+  ) {
     return yield* decodeMemoryReferenceByAddress(definition, pointer, info);
   }
 
   //next: do we have a storage pointer (which may be a mapping)? if so, we can
   //we dispatch to decodeStorageByAddress, a new function that will decode the
   //pointer and then dispatch to decodeStorageReference
-  if((DecodeUtils.Definition.isReference(definition)
-    && DecodeUtils.Definition.referenceType(definition) === "storage")
-    || DecodeUtils.Definition.isMapping(definition)) {
+  if (
+    (DecodeUtils.Definition.isReference(definition) &&
+      DecodeUtils.Definition.referenceType(definition) === "storage") ||
+    DecodeUtils.Definition.isMapping(definition)
+  ) {
     return yield* decodeStorageReferenceByAddress(definition, pointer, info);
   }
 
   //next: do we have a calldata pointer?
-  if(DecodeUtils.Definition.isReference(definition)
-    && DecodeUtils.Definition.referenceType(definition) === "calldata") {
-
+  if (
+    DecodeUtils.Definition.isReference(definition) &&
+    DecodeUtils.Definition.referenceType(definition) === "calldata"
+  ) {
     //if it's a string or bytes, we will interpret the pointer ourself and skip
     //straight to decodeValue.  this is to allow us to correctly handle the
     //case of msg.data used as a mapping key.
-    if(DecodeUtils.Definition.typeClass(definition) === "string" ||
-      DecodeUtils.Definition.typeClass(definition) === "bytes") {
-      let start = DecodeUtils.Conversion.toBN(pointer.literal.slice(0, DecodeUtils.EVM.WORD_SIZE)).toNumber();
-      let length = DecodeUtils.Conversion.toBN(pointer.literal.slice(DecodeUtils.EVM.WORD_SIZE)).toNumber();
-      let newPointer = { calldata: { start, length }};
+    if (
+      DecodeUtils.Definition.typeClass(definition) === "string" ||
+      DecodeUtils.Definition.typeClass(definition) === "bytes"
+    ) {
+      let start = DecodeUtils.Conversion.toBN(
+        pointer.literal.slice(0, DecodeUtils.EVM.WORD_SIZE)
+      ).toNumber();
+      let length = DecodeUtils.Conversion.toBN(
+        pointer.literal.slice(DecodeUtils.EVM.WORD_SIZE)
+      ).toNumber();
+      let newPointer = { calldata: { start, length } };
       return yield* decodeValue(definition, newPointer, info);
     }
 
     //otherwise, is it a dynamic array?
-    if(DecodeUtils.Definition.isDynamicArray(definition)) {
+    if (DecodeUtils.Definition.isDynamicArray(definition)) {
       //in this case, we're actually going to *throw away* the length info,
       //because it makes the logic simpler -- we'll get the length info back
       //from calldata
@@ -63,19 +81,30 @@ export function* decodeLiteral(definition: DecodeUtils.AstDefinition, pointer: S
       //HACK -- in order to read the correct location, we need to add an offset
       //of -32 (since, again, we're throwing away the length info), so we pass
       //that in as the "base" value
-      return yield* decodeCalldataReferenceByAddress(definition, {literal: locationOnly}, info, -DecodeUtils.EVM.WORD_SIZE);
-    }
-    else {
+      return yield* decodeCalldataReferenceByAddress(
+        definition,
+        { literal: locationOnly },
+        info,
+        -DecodeUtils.EVM.WORD_SIZE
+      );
+    } else {
       //multivalue case -- this case is straightforward
       //pass in 0 as the base since this is an absolute pointer
-      return yield* decodeCalldataReferenceByAddress(definition, pointer, info, 0);
+      return yield* decodeCalldataReferenceByAddress(
+        definition,
+        pointer,
+        info,
+        0
+      );
     }
   }
 
   //next: do we have an external function?  these work differently on the stack
   //than elsewhere, so we can't just pass it on to decodeValue.
-  if(DecodeUtils.Definition.typeClass(definition) === "function"
-    && DecodeUtils.Definition.visibility(definition) === "external") {
+  if (
+    DecodeUtils.Definition.typeClass(definition) === "function" &&
+    DecodeUtils.Definition.visibility(definition) === "external"
+  ) {
     let address = pointer.literal.slice(0, DecodeUtils.EVM.WORD_SIZE);
     let selector = pointer.literal.slice(-DecodeUtils.EVM.SELECTOR_SIZE);
     return yield* decodeExternalFunction(address, selector, info);

--- a/packages/decoder/lib/read/index.ts
+++ b/packages/decoder/lib/read/index.ts
@@ -6,15 +6,26 @@ import * as Pointer from "../types/pointer";
 import { EvmState } from "../types/evm";
 import { DecoderRequest } from "../types/request";
 
-export default function* read(pointer: Pointer.DataPointer, state: EvmState): IterableIterator<Uint8Array | DecoderRequest> {
+export default function* read(
+  pointer: Pointer.DataPointer,
+  state: EvmState
+): Generator<DecoderRequest, Uint8Array, Uint8Array> {
   if (Pointer.isStackPointer(pointer) && state.stack) {
     return stack.readStack(state.stack, pointer.stack.from, pointer.stack.to);
   } else if (Pointer.isStoragePointer(pointer) && state.storage) {
     return yield* storage.readRange(state.storage, pointer.storage);
   } else if (Pointer.isMemoryPointer(pointer) && state.memory) {
-    return memory.readBytes(state.memory, pointer.memory.start, pointer.memory.length);
+    return memory.readBytes(
+      state.memory,
+      pointer.memory.start,
+      pointer.memory.length
+    );
   } else if (Pointer.isCalldataPointer(pointer) && state.calldata) {
-    return memory.readBytes(state.calldata, pointer.calldata.start, pointer.calldata.length);
+    return memory.readBytes(
+      state.calldata,
+      pointer.calldata.start,
+      pointer.calldata.length
+    );
     //there is no need for a separate calldata read function; the existing memory read function
     //will do fine
   } else if (Pointer.isStackLiteralPointer(pointer)) {

--- a/packages/decoder/package.json
+++ b/packages/decoder/package.json
@@ -49,7 +49,7 @@
     "@types/utf8": "^2.1.6",
     "@types/web3": "^1.0.5",
     "json-schema-to-typescript": "^5.5.0",
-    "typescript": "^3.1.3"
+    "typescript": "^3.6.3"
   },
   "keywords": [
     "contract",


### PR DESCRIPTION
This PR backports the use of the `Generator` type from `next` to `develop`.  The intent is to fix some build issues that @eggplantzzz turned up; @eggplantzzz, you'll probably want to merge this into your build-fixing branch and see if that fixes the issues.  Otherwise I likely have more work to do!

Note: I should presumably merge `develop` into `next` as soon as this is merged, because hoo boy is it going to cause some merge conflicts (thankfully easy ones -- just take from `next` each time :P ).