### PR TITLE
Add documentation for new codec

### DIFF
--- a/packages/codec/README.md
+++ b/packages/codec/README.md
@@ -1,32 +1,43 @@
 # Truffle Decoder
 
-This module provides interfaces for decoding contract state, transaction
-calldata, and events.
+This module provides an interface for decoding contract state, transaction
+calldata, and events.  It's an interface to the same low-level decoding
+functionality that Truffle Debugger uses.  However, it has additional
+functionality that the debugger does not need, and the debugger has additional
+functionality that this interface either does not need or cannot currently
+replicated.  In the future, this interface will also decode return values and
+revert strings.
 
-It's split into three classes: The wire decoder, the contract decoder, and the
-contract instance decoder.  The wire decoder is associated to the project as a
-whole and decodes transaction calldata and events.  The contract decoder is
-associated to a specific contract class.  It has all the capabilities of the
-wire decoder, but in addition it acts as a factory for contract instance
-decoders.  The contract instance decoder is associated to a specific contract
-instance; it too has all the capabilities of the wire decoder, but it can also
-decode the state variables for the specific instance.  (In addition, in the case
-that the contract does not include a `deployedBytecode` field in its artifact,
-which can hinder decoding certain things, the contract instance decoder can
-sometimes work around this where the other decoders cannot.)
+The interface is split into three classes: The wire decoder, the contract
+decoder, and the contract instance decoder.  The wire decoder is associated to
+the project as a whole and decodes transaction calldata and events.  The
+contract decoder is associated to a specific contract class.  It has all the
+capabilities of the wire decoder, but in addition it acts as a factory for
+contract instance decoders.  The contract instance decoder is associated to a
+specific contract instance; it too has all the capabilities of the wire decoder,
+but it can also decode the state variables for the specific instance.  (In
+addition, in the case that the contract does not include a `deployedBytecode`
+field in its artifact, which can hinder decoding certain things, the contract
+instance decoder can sometimes work around this where the other decoders
+cannot.)
 
 This documentation describes the current state of the decoder, but you should
 expect to see improvements soon.  Note that most of the documentation is not
-found in this README, but rather in this package's TypeDoc.  However, this
-README describes the overall approach.
+found in this README, but rather in this package's API documentation.  However,
+this README describes the overall approach.
 
 ## Usage
 
 ### Initialization
 
-Create a decoder with one of the methods `forProject`, `forContract`,
-`forContractWithDecoder`, or `forContractInstance`.  See the documentation of
-these methods for details.
+Create a decoder with one of the following functions:
+* [[forProject|`forProject`]]
+* [[forContract|`forContract`]]
+* [[forContractWithDecoder|`forContractWithDecoder`]]
+* [[forContractInstance|`forContractInstance`]]
+
+See the API documentation of these functions for details, or below for usage
+examples.
 
 ### Methods
 
@@ -39,18 +50,20 @@ mode, it decodes purely based on the information in the ABI.  In full mode, it
 uses Solidity AST information to provide a more detailed decoding.  Due to
 various technical reasons, full mode is not always reliably available.  The only
 way to guarantee the use of full mode is if all your contracts are written in
-Solidity and they were all compiled simultaneously.
+Solidity (version 0.4.9 or later) and they were all compiled simultaneously.
 
 The decoder will always run in full mode when possible, but sometimes the
 necessary information may be missing or, for technical reasons, unusable.  In
 this case, it will fall back into ABI mode.  Decodings are always marked with
 which mode produced them so you can distinguish, as the format of a result may
-differ substantially due to which mode was used.
+differ substantially due to which mode was used.  Full mode is only available
+for Solidity contracts and only for Solidity versions 0.4.9 or later; ABI mode
+works with anything using the Solidity ABI.
 
 If you want to simplify matters and to not have to deal with this distinction,
 the decoder provides methods for converting a given decoding to ABI mode.  So
 you can run the decoder in whatever mode it runs in, then run the result through
-these functions to ensure you get an ABI mode result.  As noted above, there's
+these methods to ensure you get an ABI mode result.  As noted above, there's
 no way to ensure you get a full mode result.
 
 (There are two slight differences between running the decoder in full mode and
@@ -72,38 +85,40 @@ possible.
 ### Output format: `Type`s and `Result`s
 
 This will be a brief explanation of the format of decoded variables.  For full
-detail, I recommend seeing the documentation for `Format`.
+detail, see the API documentation for [[Format|`Format`]].
 
-Each decoded value is a `Result`.  A `Result` has the following fields:
+Each decoded value is a [[Format.Values.Result|`Result`]].  A `Result` has the
+following fields:
 
-1. `type`: This is a `Type` object describing the value's type.  Each `Type`
-has a `typeClass` field describing the overall broad type, such as `"uint"` or
-`"bytes"`, together with additional information that gives the specific type.  I
-won't go into further detail about these here; I recommend simply looking at
-`Format.Types` to see how these work.
+1. `type`: This is a [[Format.Types.Type|`Type`]] object describing the value's
+type.  Each `Type` has a `typeClass` field describing the overall broad type,
+such as `"uint"` or `"bytes"`, together with additional information that gives
+the specific type.  For full detail, see `Format.Types` to see how these work.
 
-2. `kind`: This is either `"value"`, in which case the `Result` is a `Value`, or
-`"error"`, in which case the `Result` is an `ErrorResult`.  In the former case,
-there will be a `value` field containing the decoded value.  In the latter case,
-there will be an `error` field indicating what went wrong.  *Warning*: When
-decoding a complex type, such as an array, mapping, or array, getting a kind of
-`"value"` does not necessarily mean the individual elements were decoded
-successfully.  Even if the `Result` for the array (mapping, struct) as a whole
-has kind "value"`, the elements might still have kind `"error"`.
+2. `kind`: This is either `"value"`, in which case the `Result` is a
+[[Format.Values.Value|`Value`]], or `"error"`, in which case the `Result` is an
+[[Format.Errors.ErrorResult|`ErrorResult`]].  In the former case, there will be
+a `value` field containin the decoded value.  In the latter case, there will be
+an `error` field indicating what went wrong.  *Warning*: When decoding a
+complex type, such as an array, mapping, or array, getting a kind of `"value"`
+does not necessarily mean the individual elements were decoded successfully.
+Even if the `Result` for the array (mapping, struct) as a whole has kind
+`"value"`, the elements might still have kind `"error"`.
 
 3. `value`: As mentioned, this is included when `kind` is equal to `"value"`.
-It contains information about the actual decoded value.  I recommend seeing
-`Format.Values` for more information.
+It contains information about the actual decoded value.  See
+[[Format.Values|`FOrmat.Values`]] for more information.
 
 4. `error`: The alternative to `value`.  Generally includes information about
-the raw data that led to the error.  See `Format.Errors` for more
-information.
+the raw data that led to the error.  See [[Format.Errors|`Format.Errors`]] for
+more information.
 
-5. `reference`: This field is a debugger-only feature so I'll skip explaining it
-here; it won't come up when using this interface.
+5. `reference`: This field is a debugger-only feature and won't come up when
+using this interface, so it won't be documented here.
+
+#### Values vs errors
  
-Rather than explain the format in detail -- you can see the TypeDoc for that -- I'd
-instead like to take a moment to answer the question: What counts as a value,
+It's worth taking a moment here to answer the question: What counts as a value,
 and what counts as an error?
 
 In general, the answer is that anything that can be generated via Solidity
@@ -111,30 +126,29 @@ alone (i.e. no assembly), with correctly-encoded inputs, and without making use
 of compiler bugs, is a value, not an error.  That means that, for instance, the
 following things are values, not errors:
 
-1. A variable of contract type whose address does not actually hold a contract
+* A variable of contract type whose address does not actually hold a contract
 of that type;
 
-2. An external function pointer that does not correspond to a valid function;
+* An external function pointer that does not correspond to a valid function;
 
-3. A string containing invalid UTF-8;
+* A string containing invalid UTF-8;
 
 etc.
 
 By contrast, the following *are* errors:
 
-1. A `bool` which is neither `false` (0) nor `true` (1);
+* A `bool` which is neither `false` (0) nor `true` (1);
 
-2. An `enum` which is out of range;
+* An `enum` which is out of range;
 
 etc.
 
 (You may be wondering about the enum case here, because if you go sufficiently
 far back, to Solidity 0.4.4 or earlier, it *was* possible to generate
-out-of-range enums without resorting to assembly or compiler bugs.  However, the
-decoder is not intended to support Solidity older than 0.4.9 (except in ABI-only
-mode, which doesn't know about enums), so we consider it an error.  There are also
-additional technical reasons why supporting out-of-range enums as a value would be
-difficult.)
+out-of-range enums without resorting to assembly or compiler bugs.  However,
+enums are only supported in full mode, which only supports 0.4.9 and later, so
+we consider out-of-range enums an error.  There are also additional technical
+reasons why supporting out-of-range enums as a value would be difficult.)
 
 There are three special cases here that are likely worthy of note.
 
@@ -144,7 +158,8 @@ is (in a sense) our own fault that we can't decode these, so it doesn't make
 sense to report an error, which would mean that something is wrong with the
 encoded data itself.  This value that it decodes to will give the program
 counter values it corresponds to, but will not include the function name or
-defining class, as this interface is not presently capable of that.
+defining class, as this interface is not presently capable of that.  For now,
+full decoding of internal function pointers remains a debugger-only feature.
 
 (When using the debugger, an invalid internal function pointer will decode to an
 error.  However, when using this interface, we have no way of discerning whether
@@ -159,3 +174,7 @@ Finally, except when decoding events, we do not return an error if the pointers
 in an ABI-encoded array or tuple are arranged in a nonstandard way, or if
 strings or bytestrings are incorrectly padded, because it is not worth the
 trouble to detect these conditions.
+
+### Usage examples
+
+

--- a/packages/codec/README.md
+++ b/packages/codec/README.md
@@ -175,6 +175,49 @@ in an ABI-encoded array or tuple are arranged in a nonstandard way, or if
 strings or bytestrings are incorrectly padded, because it is not worth the
 trouble to detect these conditions.
 
-### Usage examples
+### Basic usage examples
 
+#### Decoding a log with the wire decoder
 
+This usage example is for a project with two contracts, `Contract1` and
+`Contract2`.
+
+```typescript
+import { forProject } from "@truffle/codec";
+const contract1 = artifacts.require("Contract1");
+const contract2 = artifacts.require("Contract2");
+const provider = web3.currentProvider;
+const decoder = await Decoder.forProject([contract1, contract2], provider);
+const decodedLog = await decoder.decodeLog(log);
+```
+
+The usage of [[WireDecoder.decodeTransaction|decodeTransaction]] is similar.
+
+For getting already-decoded logs meeting appropriate conditions, see
+[[WireDecoder.events]].
+
+#### Decoding state variables with the contract instance decoder
+
+This usage example is for decoding the state variables of a contract `Contract`
+in a project that also contains a contract `OtherContract`.
+
+```typescript
+import { forContract } from "@truffle/codec";
+const contract = artifacts.require("Contract");
+const otherContract = artifacts.require("OtherContract");
+const provider = web3.currentProvider;
+const decoder = await Decoder.forContract(contract, [otherContract], provider);
+const instanceDecoder = await decoder.forInstance();
+const variables = await instanceDecoder.variables();
+```
+
+In this example, we use the deployed version of `Contract`.  If we wanted an
+instance at a different address, we could pass the address to `forInstance`.
+
+In addition, rather than using `forContract` and then `forInstance`, we could
+also use [[forContractInstance|`forContractInstance`]] to perform both of these
+in one step.
+
+See the API documentation for more advanced decoding examples with
+[[ContractInstanceDecoder.variable|`variable`]] or
+[[ContractInstanceDecoder.watchMappingKey|`watchMappingKey`]].

--- a/packages/codec/lib/decode/errors.ts
+++ b/packages/codec/lib/decode/errors.ts
@@ -4,6 +4,9 @@ import { message } from "@truffle/codec/utils/errors";
 //For when we need to throw an error, here's a wrapper class that extends Error.
 //Apologies about the confusing name, but I wanted something that would make
 //sense should it not be caught and thus accidentally exposed to the outside.
+/**
+ * @hidden
+ */
 export class DecodingError extends Error {
   public error: Errors.ErrorForThrowing;
   constructor(error: Errors.ErrorForThrowing) {
@@ -18,6 +21,9 @@ export class DecodingError extends Error {
 //NOTE: currently we don't actually check the type of a thrown error,
 //we just rely on context.  still, I think it makes sense to be a separate
 //type.
+/**
+ * @hidden
+ */
 export class StopDecodingError extends Error {
   public error: Errors.DecoderError;
   public allowRetry: boolean; //setting this to true means that, if the error occurs

--- a/packages/codec/lib/format/elementary.ts
+++ b/packages/codec/lib/format/elementary.ts
@@ -6,8 +6,6 @@ import * as Types from "./types";
 //so let's define those types too
 export type ElementaryValue = UintValue | IntValue | BoolValue
   | BytesValue | AddressValue | StringValue | FixedValue | UfixedValue;
-//we don't include FixedValue or UfixedValue because those
-//aren't implemented yet
 export type BytesValue = BytesStaticValue | BytesDynamicValue;
 
 
@@ -45,7 +43,10 @@ export interface BytesStaticValue {
   type: Types.BytesTypeStatic;
   kind: "value";
   value: {
-    asHex: string; //should be hex-formatted, with leading "0x"
+    /**
+     * should be hex-formatted, with leading "0x"
+     */
+    asHex: string;
     rawAsHex?: string;
   };
 }
@@ -55,7 +56,10 @@ export interface BytesDynamicValue {
   type: Types.BytesTypeDynamic;
   kind: "value";
   value: {
-    asHex: string; //should be hex-formatted, with leading "0x"
+    /**
+     * should be hex-formatted, with leading "0x"
+     */
+    asHex: string;
   };
 }
 
@@ -64,7 +68,13 @@ export interface AddressValue {
   type: Types.AddressType;
   kind: "value";
   value: {
-    asAddress: string; //should have 0x and be checksum-cased
+    /**
+     * should have leading "0x" and be checksum-cased
+     */
+    asAddress: string;
+    /**
+     * just a hex string, so no checksum
+     */
     rawAsHex?: string;
   }
 }
@@ -77,18 +87,28 @@ export interface StringValue {
   value: StringValueInfo;
 }
 
-//these come in two types: valid strings and malformed strings
+
+/**
+ * these come in two types: valid strings and malformed strings
+ */
 export type StringValueInfo = StringValueInfoValid | StringValueInfoMalformed;
 
-//valid strings
+/**
+ * valid strings
+ */
 export interface StringValueInfoValid {
   kind: "valid";
   asString: string;
 }
 
-//malformed strings
+/**
+ * malformed strings
+ */
 export interface StringValueInfoMalformed {
   kind: "malformed";
+  /**
+   * should be hex-formatted, with leading "0x"
+   */
   asHex: string;
 }
 

--- a/packages/codec/lib/format/elementary.ts
+++ b/packages/codec/lib/format/elementary.ts
@@ -4,10 +4,16 @@ import * as Types from "./types";
 
 //note that we often want an elementary *value*, and not an error!
 //so let's define those types too
-export type ElementaryValue = UintValue | IntValue | BoolValue
-  | BytesValue | AddressValue | StringValue | FixedValue | UfixedValue;
+export type ElementaryValue =
+  | UintValue
+  | IntValue
+  | BoolValue
+  | BytesValue
+  | AddressValue
+  | StringValue
+  | FixedValue
+  | UfixedValue;
 export type BytesValue = BytesStaticValue | BytesDynamicValue;
-
 
 //Uints
 export interface UintValue {
@@ -44,7 +50,7 @@ export interface BytesStaticValue {
   kind: "value";
   value: {
     /**
-     * should be hex-formatted, with leading "0x"
+     * hex-formatted, with leading "0x"
      */
     asHex: string;
     rawAsHex?: string;
@@ -57,7 +63,7 @@ export interface BytesDynamicValue {
   kind: "value";
   value: {
     /**
-     * should be hex-formatted, with leading "0x"
+     * hex-formatted, with leading "0x"
      */
     asHex: string;
   };
@@ -69,14 +75,14 @@ export interface AddressValue {
   kind: "value";
   value: {
     /**
-     * should have leading "0x" and be checksum-cased
+     * has leading "0x" and is checksum-cased
      */
     asAddress: string;
     /**
      * just a hex string, so no checksum
      */
     rawAsHex?: string;
-  }
+  };
 }
 
 //strings
@@ -87,14 +93,13 @@ export interface StringValue {
   value: StringValueInfo;
 }
 
-
 /**
- * these come in two types: valid strings and malformed strings
+ * These come in two types: valid strings and malformed strings.
  */
 export type StringValueInfo = StringValueInfoValid | StringValueInfoMalformed;
 
 /**
- * valid strings
+ * This type of StringValueInfo represents a valid UTF-8 string.
  */
 export interface StringValueInfoValid {
   kind: "valid";
@@ -102,12 +107,12 @@ export interface StringValueInfoValid {
 }
 
 /**
- * malformed strings
+ * This type of StringValueInfo represents a malformed string.
  */
 export interface StringValueInfoMalformed {
   kind: "malformed";
   /**
-   * should be hex-formatted, with leading "0x"
+   * hex-formatted, with leading "0x"
    */
   asHex: string;
 }

--- a/packages/codec/lib/format/errors.ts
+++ b/packages/codec/lib/format/errors.ts
@@ -16,25 +16,53 @@ import { Range } from "@truffle/codec/types/storage";
  * SECTION 1: Generic types for values in general (including errors).
  */
 
-export type ErrorResult = ElementaryErrorResult
-  | ArrayErrorResult | MappingErrorResult | StructErrorResult | MagicErrorResult | TupleErrorResult
+export type ErrorResult =
+  | ElementaryErrorResult
+  | ArrayErrorResult
+  | MappingErrorResult
+  | StructErrorResult
+  | MagicErrorResult
+  | TupleErrorResult
   | EnumErrorResult
-  | ContractErrorResult | FunctionExternalErrorResult | FunctionInternalErrorResult;
+  | ContractErrorResult
+  | FunctionExternalErrorResult
+  | FunctionInternalErrorResult;
 
-export type DecoderError = GenericError
-  | UintError | IntError | BoolError | BytesStaticError | BytesDynamicError | AddressError
-  | StringError | FixedError | UfixedError
-  | ArrayError | MappingError | StructError | MagicError | TupleError
-  | EnumError | ContractError | FunctionExternalError | FunctionInternalError
+export type DecoderError =
+  | GenericError
+  | UintError
+  | IntError
+  | BoolError
+  | BytesStaticError
+  | BytesDynamicError
+  | AddressError
+  | StringError
+  | FixedError
+  | UfixedError
+  | ArrayError
+  | MappingError
+  | StructError
+  | MagicError
+  | TupleError
+  | EnumError
+  | ContractError
+  | FunctionExternalError
+  | FunctionInternalError
   | InternalUseError;
 
 /*
  * SECTION 2: Elementary values
  */
 
-export type ElementaryErrorResult = UintErrorResult | IntErrorResult | BoolErrorResult
-  | BytesErrorResult | AddressErrorResult | StringErrorResult
-  | FixedErrorResult | UfixedErrorResult;
+export type ElementaryErrorResult =
+  | UintErrorResult
+  | IntErrorResult
+  | BoolErrorResult
+  | BytesErrorResult
+  | AddressErrorResult
+  | StringErrorResult
+  | FixedErrorResult
+  | UfixedErrorResult;
 export type BytesErrorResult = BytesStaticErrorResult | BytesDynamicErrorResult;
 
 //Uints
@@ -277,10 +305,12 @@ export interface FunctionExternalErrorResult {
   error: GenericError | FunctionExternalError;
 }
 
-export type FunctionExternalError = FunctionExternalNonStackPaddingError | FunctionExternalStackPaddingError;
+export type FunctionExternalError =
+  | FunctionExternalNonStackPaddingError
+  | FunctionExternalStackPaddingError;
 
 /**
- * padding error for external function pointer located anywhere other than the stack
+ * This error kind represents a padding error for an external function pointer located anywhere other than the stack.
  */
 export interface FunctionExternalNonStackPaddingError {
   /**
@@ -291,15 +321,15 @@ export interface FunctionExternalNonStackPaddingError {
 }
 
 /**
- * padding error for external function pointer located on the stack
+ * This error kind represents a padding error for external function pointer located on the stack.
  */
 export interface FunctionExternalStackPaddingError {
   /**
-   * hex string (no checksum; also longer than 20 bytes)
+   * hex string (no checksum; also a full word long)
    */
   rawAddress: string;
   /**
-   * hex string (but longer than 4 bytes)
+   * hex string (but a full word long)
    */
   rawSelector: string;
   kind: "FunctionExternalStackPaddingError";
@@ -316,8 +346,11 @@ export interface FunctionInternalErrorResult {
   error: GenericError | FunctionInternalError;
 }
 
-export type FunctionInternalError = FunctionInternalPaddingError | NoSuchInternalFunctionError
-  | DeployedFunctionInConstructorError | MalformedInternalFunctionError;
+export type FunctionInternalError =
+  | FunctionInternalPaddingError
+  | NoSuchInternalFunctionError
+  | DeployedFunctionInConstructorError
+  | MalformedInternalFunctionError;
 
 export interface FunctionInternalPaddingError {
   /**
@@ -365,9 +398,18 @@ export interface MalformedInternalFunctionError {
  * SECTION 8: GENERIC ERRORS
  */
 
-export type GenericError = UserDefinedTypeNotFoundError | IndexedReferenceTypeError | ReadError;
-export type ReadError = UnsupportedConstantError | ReadErrorStack | ReadErrorBytes | ReadErrorStorage;
-export type DynamicDataImplementationError = OverlongArraysAndStringsNotImplementedError | OverlargePointersNotImplementedError;
+export type GenericError =
+  | UserDefinedTypeNotFoundError
+  | IndexedReferenceTypeError
+  | ReadError;
+export type ReadError =
+  | UnsupportedConstantError
+  | ReadErrorStack
+  | ReadErrorBytes
+  | ReadErrorStorage;
+export type DynamicDataImplementationError =
+  | OverlongArraysAndStringsNotImplementedError
+  | OverlargePointersNotImplementedError;
 
 export type ErrorForThrowing = UserDefinedTypeNotFoundError | ReadError;
 
@@ -428,7 +470,9 @@ export interface OverlargePointersNotImplementedError {
 /* you should never see these returned.
  * they are only for internal use. */
 
-export type InternalUseError = OverlongArrayOrStringStrictModeError | InternalFunctionInABIError;
+export type InternalUseError =
+  | OverlongArrayOrStringStrictModeError
+  | InternalFunctionInABIError;
 
 export interface OverlongArrayOrStringStrictModeError {
   kind: "OverlongArrayOrStringStrictModeError";
@@ -440,4 +484,3 @@ export interface OverlongArrayOrStringStrictModeError {
 export interface InternalFunctionInABIError {
   kind: "InternalFunctionInABIError";
 }
-

--- a/packages/codec/lib/format/errors.ts
+++ b/packages/codec/lib/format/errors.ts
@@ -47,7 +47,10 @@ export interface UintErrorResult {
 export type UintError = UintPaddingError;
 
 export interface UintPaddingError {
-  raw: string; //hex string
+  /**
+   * hex string
+   */
+  raw: string;
   kind: "UintPaddingError";
 }
 
@@ -61,7 +64,10 @@ export interface IntErrorResult {
 export type IntError = IntPaddingError;
 
 export interface IntPaddingError {
-  raw: string; //hex string
+  /**
+   * hex string
+   */
+  raw: string;
   kind: "IntPaddingError";
 }
 
@@ -89,7 +95,10 @@ export interface BytesStaticErrorResult {
 export type BytesStaticError = BytesPaddingError;
 
 export interface BytesPaddingError {
-  raw: string; //should be hex string
+  /**
+   * hex string
+   */
+  raw: string;
   kind: "BytesPaddingError";
 }
 
@@ -112,7 +121,10 @@ export interface AddressErrorResult {
 export type AddressError = AddressPaddingError;
 
 export interface AddressPaddingError {
-  raw: string; //should be hex string
+  /**
+   * hex string; no checksum
+   */
+  raw: string;
   kind: "AddressPaddingError";
 }
 
@@ -140,14 +152,20 @@ export interface UfixedErrorResult {
 export type FixedError = FixedPaddingError;
 
 export interface FixedPaddingError {
-  raw: string; //hex string
+  /**
+   * hex string
+   */
+  raw: string;
   kind: "FixedPaddingError";
 }
 
 export type UfixedError = UfixedPaddingError;
 
 export interface UfixedPaddingError {
-  raw: string; //hex string
+  /**
+   * hex string
+   */
+  raw: string;
   kind: "UfixedPaddingError";
 }
 
@@ -241,7 +259,10 @@ export interface ContractErrorResult {
 export type ContractError = ContractPaddingError;
 
 export interface ContractPaddingError {
-  raw: string; //should be hex string
+  /**
+   * hex string
+   */
+  raw: string;
   kind: "ContractPaddingError";
 }
 
@@ -258,13 +279,28 @@ export interface FunctionExternalErrorResult {
 
 export type FunctionExternalError = FunctionExternalNonStackPaddingError | FunctionExternalStackPaddingError;
 
+/**
+ * padding error for external function pointer located anywhere other than the stack
+ */
 export interface FunctionExternalNonStackPaddingError {
-  raw: string; //should be hex string
+  /**
+   * hex string
+   */
+  raw: string;
   kind: "FunctionExternalNonStackPaddingError";
 }
 
+/**
+ * padding error for external function pointer located on the stack
+ */
 export interface FunctionExternalStackPaddingError {
+  /**
+   * hex string (no checksum; also longer than 20 bytes)
+   */
   rawAddress: string;
+  /**
+   * hex string (but longer than 4 bytes)
+   */
   rawSelector: string;
   kind: "FunctionExternalStackPaddingError";
 }
@@ -284,10 +320,18 @@ export type FunctionInternalError = FunctionInternalPaddingError | NoSuchInterna
   | DeployedFunctionInConstructorError | MalformedInternalFunctionError;
 
 export interface FunctionInternalPaddingError {
-  raw: string; //should be hex string
+  /**
+   * hex string
+   */
+  raw: string;
   kind: "FunctionInternalPaddingError";
 }
 
+/**
+ * Indicates that the function pointer being decoded
+ * fails to point to a valid function, and also is not one of the
+ * default values
+ */
 export interface NoSuchInternalFunctionError {
   kind: "NoSuchInternalFunctionError";
   context: Types.ContractType;
@@ -295,6 +339,10 @@ export interface NoSuchInternalFunctionError {
   constructorProgramCounter: number;
 }
 
+/**
+ * Indicates that this is a deployed-style pointer,
+ * despite the fact that you're in a constructor
+ */
 export interface DeployedFunctionInConstructorError {
   kind: "DeployedFunctionInConstructorError";
   context: Types.ContractType;
@@ -302,6 +350,10 @@ export interface DeployedFunctionInConstructorError {
   constructorProgramCounter: number;
 }
 
+/**
+ * Used when the deployed PC is zero but the constructor PC
+ * is nonzero
+ */
 export interface MalformedInternalFunctionError {
   kind: "MalformedInternalFunctionError";
   context: Types.ContractType;
@@ -319,11 +371,17 @@ export type DynamicDataImplementationError = OverlongArraysAndStringsNotImplemen
 
 export type ErrorForThrowing = UserDefinedTypeNotFoundError | ReadError;
 
-//attempted to decode an indexed parameter of reference type error
+/**
+ * Used when decoding an indexed parameter of reference type.  These can't meaningfully
+ * be decoded, so instead they decode to an error, sorry.
+ */
 export interface IndexedReferenceTypeError {
   kind: "IndexedReferenceTypeError";
   type: Types.ReferenceType;
-  raw: string; //should be hex string
+  /**
+   * hex string
+   */
+  raw: string;
 }
 
 //type-location error

--- a/packages/codec/lib/format/index.ts
+++ b/packages/codec/lib/format/index.ts
@@ -2,4 +2,16 @@ import * as Types from "./types";
 import * as Values from "./values";
 import * as Errors from "./errors";
 
+/**
+ * Here's the decoder output format.
+ * Most of this doesn't have explanatory documentation
+ * because it's largely self-explanatory, but particularly
+ * non-obvious parts have been documented for clarity.
+ *
+ * A note on optional fields: A number of types or values
+ * have optional fields.  These contain helpful
+ * but non-essential information, or information which
+ * for technical reasons we can't guarantee we can determine.
+ */
+
 export { Types, Values, Errors };

--- a/packages/codec/lib/format/types.ts
+++ b/packages/codec/lib/format/types.ts
@@ -151,6 +151,10 @@ export interface FunctionExternalTypeGeneral {
 export type ContractDefinedType = StructTypeLocal | EnumTypeLocal;
 export type UserDefinedType = ContractDefinedType | ContractTypeNative | StructTypeGlobal | EnumTypeGlobal;
 
+/**
+ * Structs may be local (defined in a contract) or global (defined outside of any contract);
+ * the latter will be introduced in Solidity 0.6.x
+ */
 export type StructType = StructTypeLocal | StructTypeGlobal;
 
 export interface NameTypePair {
@@ -161,20 +165,32 @@ export interface NameTypePair {
 export interface StructTypeLocal {
   typeClass: "struct";
   kind: "local";
+  /**
+   * Internal ID.  Format may change in future.
+   */
   id: string;
   typeName: string;
   definingContractName: string;
   definingContract?: ContractTypeNative;
-  memberTypes?: NameTypePair[]; //these should be in order
+  /**
+   * these should be in order
+   */
+  memberTypes?: NameTypePair[];
   location?: Ast.Location;
 }
 
 export interface StructTypeGlobal {
   typeClass: "struct";
   kind: "global";
+  /**
+   * Internal ID.  Format may change in future.
+   */
   id: string;
   typeName: string;
-  memberTypes?: NameTypePair[]; //these should be in order
+  /**
+   * these should be in order
+   */
+  memberTypes?: NameTypePair[];
   location?: Ast.Location;
 }
 
@@ -189,34 +205,59 @@ export interface TupleType {
   typeHint?: string;
 }
 
+/**
+ * Enums may be local (defined in a contract) or global (defined outside of any contract);
+ * the latter will be introduced in Solidity 0.6.x
+ */
 export type EnumType = EnumTypeLocal | EnumTypeGlobal;
 
 export interface EnumTypeLocal {
   typeClass: "enum";
   kind: "local";
+  /**
+   * Internal ID.  Format may change in future.
+   */
   id: string;
   typeName: string;
   definingContractName: string;
   definingContract?: ContractTypeNative;
-  options?: string[]; //these should be in order
+  /**
+   * these should be in order
+   */
+  options?: string[];
 }
 
 export interface EnumTypeGlobal {
   typeClass: "enum";
   kind: "global";
+  /**
+   * Internal ID.  Format may change in future.
+   */
   id: string;
   typeName: string;
-  options?: string[]; //these should be in order
+  /**
+   * these should be in order
+   */
+  options?: string[];
 }
 
+/**
+ * Contract types may be native (has Solidity info) or foreign (lacking Solidity info).
+ */
 export type ContractType = ContractTypeNative | ContractTypeForeign;
 
 export interface ContractTypeNative {
   typeClass: "contract";
   kind: "native";
+  /**
+   * Internal ID.  Format may change in future.
+   */
   id: string;
   typeName: string;
   contractKind?: Ast.ContractKind;
+  /**
+   * Indicates whether contract has payable fallback function
+   */
   payable?: boolean; //will be useful in the future
   //may have more optional members defined later, but I'll leave these out for
   //now
@@ -227,6 +268,9 @@ export interface ContractTypeForeign {
   kind: "foreign";
   typeName: string;
   contractKind?: Ast.ContractKind;
+  /**
+   * Indicates whether contract has payable fallback function
+   */
   payable?: boolean; //will be useful in the future
   //may have more optional members defined later, but I'll leave these out for
   //now
@@ -251,4 +295,3 @@ export type ReferenceType = ArrayType | MappingType | StructType | StringType | 
 export interface TypesById {
   [id: string]: UserDefinedType;
 };
-

--- a/packages/codec/lib/format/values.ts
+++ b/packages/codec/lib/format/values.ts
@@ -39,15 +39,29 @@ export * from "./elementary";
  */
 
 //This is the overall Result type.  It may encode an actual value or an error.
-export type Result = ElementaryResult
-  | ArrayResult | MappingResult | StructResult | TupleResult | MagicResult
+export type Result =
+  | ElementaryResult
+  | ArrayResult
+  | MappingResult
+  | StructResult
+  | TupleResult
+  | MagicResult
   | EnumResult
-  | ContractResult | FunctionExternalResult | FunctionInternalResult;
+  | ContractResult
+  | FunctionExternalResult
+  | FunctionInternalResult;
 //for when you want an actual value
-export type Value = ElementaryValue
-  | ArrayValue | MappingValue | StructValue | TupleValue | MagicValue
+export type Value =
+  | ElementaryValue
+  | ArrayValue
+  | MappingValue
+  | StructValue
+  | TupleValue
+  | MagicValue
   | EnumValue
-  | ContractValue | FunctionExternalValue | FunctionInternalValue;
+  | ContractValue
+  | FunctionExternalValue
+  | FunctionInternalValue;
 
 /*
  * SECTION 2: Elementary values
@@ -58,9 +72,15 @@ export type Value = ElementaryValue
 //those (and defines the Result types)
 
 //overall groupings
-export type ElementaryResult = UintResult | IntResult | BoolResult
-  | BytesResult | AddressResult | StringResult
-  | FixedResult | UfixedResult;
+export type ElementaryResult =
+  | UintResult
+  | IntResult
+  | BoolResult
+  | BytesResult
+  | AddressResult
+  | StringResult
+  | FixedResult
+  | UfixedResult;
 export type BytesResult = BytesStaticResult | BytesDynamicResult;
 
 //integers
@@ -72,9 +92,13 @@ export type IntResult = IntValue | Errors.IntErrorResult;
 export type BoolResult = BoolValue | Errors.BoolErrorResult;
 
 //bytes (static & dynaic)
-export type BytesStaticResult = BytesStaticValue | Errors.BytesStaticErrorResult;
+export type BytesStaticResult =
+  | BytesStaticValue
+  | Errors.BytesStaticErrorResult;
 
-export type BytesDynamicResult = BytesDynamicValue | Errors.BytesDynamicErrorResult;
+export type BytesDynamicResult =
+  | BytesDynamicValue
+  | Errors.BytesDynamicErrorResult;
 
 //addresses
 export type AddressResult = AddressValue | Errors.AddressErrorResult;
@@ -134,7 +158,7 @@ export interface StructValue {
    */
   reference?: number;
   /**
-   * these should be stored in order!
+   * these must be stored in order!
    */
   value: NameValuePair[];
 }
@@ -166,7 +190,7 @@ export interface MagicValue {
   kind: "value";
   //a magic variable can't be circular, duh!
   value: {
-    [field: string]: Result
+    [field: string]: Result;
   };
 }
 
@@ -188,7 +212,7 @@ export interface EnumValue {
      */
     numericAsBN: BN;
   };
-};
+}
 
 /*
  * SECTION 5: CONTRACTS
@@ -208,20 +232,22 @@ export interface ContractValue {
  * There are two types -- one for contracts whose class we can identify, and one
  * for when we can't identify the class.
  */
-export type ContractValueInfo = ContractValueInfoKnown | ContractValueInfoUnknown;
+export type ContractValueInfo =
+  | ContractValueInfoKnown
+  | ContractValueInfoUnknown;
 
 /**
- * when we can identify the class
+ * This type of ContractValueInfo is used when we can identify the class.
  */
 export interface ContractValueInfoKnown {
   kind: "known";
   /**
-   * should be formatted as address (leading "0x", checksum-cased);
+   * formatted as address (leading "0x", checksum-cased);
    * note that this is not an AddressResult!
    */
   address: string;
   /**
-   * this is just a hexstring; no checksum (also longer than 20 bytes)
+   * this is just a hexstring; no checksum (also may have padding on end)
    */
   rawAddress?: string;
   class: Types.ContractType;
@@ -229,17 +255,17 @@ export interface ContractValueInfoKnown {
 }
 
 /**
- * when we can't identify the class
+ * This type of ContractValueInfo is used when we can't identify the class.
  */
 export interface ContractValueInfoUnknown {
   kind: "unknown";
   /**
-   * should be formatted as address (leading "0x", checksum-cased);
+   * formatted as address (leading "0x", checksum-cased);
    * note that this is not an AddressResult!
    */
   address: string;
   /**
-   * this is just a hexstring; no checksum (also longer than 20 bytes)
+   * this is just a hexstring; no checksum (also may have padding on end)
    */
   rawAddress?: string;
 }
@@ -249,7 +275,9 @@ export interface ContractValueInfoUnknown {
  */
 
 //external functions
-export type FunctionExternalResult = FunctionExternalValue | Errors.FunctionExternalErrorResult;
+export type FunctionExternalResult =
+  | FunctionExternalValue
+  | Errors.FunctionExternalErrorResult;
 
 export interface FunctionExternalValue {
   type: Types.FunctionExternalType;
@@ -264,12 +292,12 @@ export interface FunctionExternalValue {
  * 3. can't determine class
  */
 export type FunctionExternalValueInfo =
-  FunctionExternalValueInfoKnown //known function of known class
+  | FunctionExternalValueInfoKnown //known function of known class
   | FunctionExternalValueInfoInvalid //known class, but can't locate function
   | FunctionExternalValueInfoUnknown; //can't determine class
 
 /**
- * known function of known class
+ * This type of FunctionExternalValueInfo is used for a known function of a known class.
  */
 export interface FunctionExternalValueInfoKnown {
   kind: "known";
@@ -283,7 +311,7 @@ export interface FunctionExternalValueInfoKnown {
 }
 
 /**
- * known class but can't locate function
+ * This type of FunctionExternalValueInfo is used when we can identify the class but can't locate the function.
  */
 export interface FunctionExternalValueInfoInvalid {
   kind: "invalid";
@@ -295,7 +323,7 @@ export interface FunctionExternalValueInfoInvalid {
 }
 
 /**
- * can't even locate class
+ * This type of FunctionExternalValueInfo is used when we can't even locate the class.
  */
 export interface FunctionExternalValueInfoUnknown {
   kind: "unknown";
@@ -311,7 +339,9 @@ export interface FunctionExternalValueInfoUnknown {
  */
 
 //Internal functions
-export type FunctionInternalResult = FunctionInternalValue | Errors.FunctionInternalErrorResult;
+export type FunctionInternalResult =
+  | FunctionInternalValue
+  | Errors.FunctionInternalErrorResult;
 
 export interface FunctionInternalValue {
   type: Types.FunctionInternalType;
@@ -326,15 +356,15 @@ export interface FunctionInternalValue {
  * 3. A special value to indicate that decoding internal functions isn't supported in this context.
  */
 export type FunctionInternalValueInfo =
-  FunctionInternalValueInfoKnown //actual function
+  | FunctionInternalValueInfoKnown //actual function
   | FunctionInternalValueInfoException //default value
   | FunctionInternalValueInfoUnknown; //decoding not supported in this context
 
 /**
- * An actual internal function
+ * This type of FunctionInternalValueInfo is used for an actual internal function.
  */
 export interface FunctionInternalValueInfoKnown {
-  kind: "function"
+  kind: "function";
   context: Types.ContractType;
   deployedProgramCounter: number;
   constructorProgramCounter: number;
@@ -351,7 +381,7 @@ export interface FunctionInternalValueInfoKnown {
  * Elsewhere they're both nonzero.
  */
 export interface FunctionInternalValueInfoException {
-  kind: "exception"
+  kind: "exception";
   context: Types.ContractType;
   deployedProgramCounter: number;
   constructorProgramCounter: number;
@@ -364,10 +394,10 @@ export interface FunctionInternalValueInfoException {
  * detailed information in the debugger!)  You'll still get the program counter
  * values, but further information will be absent.  Note you'll get this even
  * if really it should decode to an error, because the decoding interface
- * doesn't have the information to determine that it's an error.  
+ * doesn't have the information to determine that it's an error.
  */
 export interface FunctionInternalValueInfoUnknown {
-  kind: "unknown"
+  kind: "unknown";
   context: Types.ContractType;
   deployedProgramCounter: number;
   constructorProgramCounter: number;

--- a/packages/codec/lib/index-typedoc.ts
+++ b/packages/codec/lib/index-typedoc.ts
@@ -6,18 +6,24 @@
  * ```
  *
  * @module @truffle/codec
- *//** */
+ */ /** */
 
 import * as Format from "@truffle/codec/format";
 export { Format };
 
 export * from "./interface";
 export {
-  ContractState, DecodedVariable, DecodedTransaction, DecodedLog, EventOptions
+  ContractState,
+  DecodedVariable,
+  DecodedTransaction,
+  DecodedLog,
+  EventOptions
 } from "./types/interface";
 
 export {
   AbiArgument,
+  CalldataDecoding,
+  LogDecoding,
   AnonymousDecoding,
   ConstructorDecoding,
   EventDecoding,

--- a/packages/codec/lib/interface/decoders/contract.ts
+++ b/packages/codec/lib/interface/decoders/contract.ts
@@ -2,7 +2,13 @@ import debugModule from "debug";
 const debug = debugModule("codec:interface:decoders:contract");
 
 import * as CodecUtils from "@truffle/codec/utils";
-import { wrapElementaryViaDefinition, Definition as DefinitionUtils, AbiUtils, EVM, ContextUtils } from "@truffle/codec/utils";
+import {
+  wrapElementaryViaDefinition,
+  Definition as DefinitionUtils,
+  AbiUtils,
+  EVM,
+  ContextUtils
+} from "@truffle/codec/utils";
 import { DecoderContext, DecoderContexts } from "@truffle/codec/types/contexts";
 import * as Utils from "@truffle/codec/utils/interface";
 import { AstDefinition, AstReferences } from "@truffle/codec/types/ast";
@@ -17,20 +23,25 @@ import { Provider } from "web3/providers";
 import * as DecoderTypes from "@truffle/codec/types/interface";
 import { EvmInfo, AllocationInfo } from "@truffle/codec/types/evm";
 import { StorageMemberAllocation } from "@truffle/codec/types/allocation";
-import { getStorageAllocations, storageSize } from "@truffle/codec/allocate/storage";
+import {
+  getStorageAllocations,
+  storageSize
+} from "@truffle/codec/allocate/storage";
 import { CalldataDecoding, LogDecoding } from "@truffle/codec/types/decoding";
 import { decodeVariable } from "@truffle/codec/core/decoding";
 import { Slot } from "@truffle/codec/types/storage";
 import { isWordsLength, equalSlots } from "@truffle/codec/utils/storage";
 import { StoragePointer } from "@truffle/codec/types/pointer";
-import { ContractBeingDecodedHasNoNodeError, ContractAllocationFailedError } from "@truffle/codec/interface/errors";
+import {
+  ContractBeingDecodedHasNoNodeError,
+  ContractAllocationFailedError
+} from "@truffle/codec/interface/errors";
 
 /**
- * The ContractDecoder class.  Spawns the ContractInstanceDecoder class.
+ * The ContractDecoder class.  Spawns the [[ContractInstanceDecoder]] class.
  * Also, decodes transactions and logs.  See below for a method listing.
  */
 export default class ContractDecoder {
-
   private web3: Web3;
 
   private contexts: DecoderContexts; //note: this is deployed contexts only!
@@ -48,8 +59,11 @@ export default class ContractDecoder {
   /**
    * @private
    */
-  constructor(contract: ContractObject, wireDecoder: WireDecoder, address?: string) {
-
+  constructor(
+    contract: ContractObject,
+    wireDecoder: WireDecoder,
+    address?: string
+  ) {
     this.contract = contract;
     this.wireDecoder = wireDecoder;
     this.web3 = wireDecoder.getWeb3();
@@ -58,24 +72,32 @@ export default class ContractDecoder {
 
     this.contractNode = Utils.getContractNode(this.contract);
 
-    if(this.contract.deployedBytecode && this.contract.deployedBytecode !== "0x") {
-      const unnormalizedContext = Utils.makeContext(this.contract, this.contractNode);
+    if (
+      this.contract.deployedBytecode &&
+      this.contract.deployedBytecode !== "0x"
+    ) {
+      const unnormalizedContext = Utils.makeContext(
+        this.contract,
+        this.contractNode
+      );
       this.contextHash = unnormalizedContext.context;
       //we now throw away the unnormalized context, instead fetching the correct one from
       //this.contexts (which is normalized) via the context getter below
     }
 
     this.allocations = this.wireDecoder.getAllocations();
-    if(this.contractNode) {
+    if (this.contractNode) {
       this.allocations.storage = getStorageAllocations(
         this.wireDecoder.getReferenceDeclarations(), //redundant stuff will be skipped so this is fine
-        {[this.contractNode.id]: this.contractNode},
+        { [this.contractNode.id]: this.contractNode },
         this.allocations.storage //existing allocations from wire decoder
       );
 
       debug("done with allocation");
-      if(this.allocations.storage[this.contractNode.id]) {
-        this.stateVariableReferences = this.allocations.storage[this.contractNode.id].members;
+      if (this.allocations.storage[this.contractNode.id]) {
+        this.stateVariableReferences = this.allocations.storage[
+          this.contractNode.id
+        ].members;
       }
       //if it doesn't exist, we will leave it undefined, and then throw an exception when
       //we attempt to decode
@@ -101,19 +123,17 @@ export default class ContractDecoder {
   }
 
   /**
-   * Takes a Web3 Transaction object and returns a copy of that object but with
-   * an additional decoding field.  This field holds a CalldataDecoding; see the
-   * documentation on DecodedTransaction for more.
+   * See [[WireDecoder.decodeTransaction]].
    * @param transaction The transaction to be decoded.
    */
-  public async decodeTransaction(transaction: Transaction): Promise<DecoderTypes.DecodedTransaction> {
+  public async decodeTransaction(
+    transaction: Transaction
+  ): Promise<DecoderTypes.DecodedTransaction> {
     return await this.wireDecoder.decodeTransaction(transaction);
   }
 
   /**
-   * Takes a Web3 Log object and returns a copy of that object but with
-   * an additional decodings field.  This field holds an array of LogDecodings;
-   * see the documentation on DecodedLog for more.
+   * See [[WireDecoder.decodeLog]].
    * @param log The log to be decoded.
    */
   public async decodeLog(log: Log): Promise<DecoderTypes.DecodedLog> {
@@ -121,7 +141,7 @@ export default class ContractDecoder {
   }
 
   /**
-   * Similar to decodeLog, but operates on an array of logs and decodes them all.
+   * See [[WireDecoder.decodeLogs]].
    * @param logs The logs to be decoded.
    */
   public async decodeLogs(logs: Log[]): Promise<DecoderTypes.DecodedLog[]> {
@@ -129,24 +149,24 @@ export default class ContractDecoder {
   }
 
   /**
-   * Gets all events meeting certain conditions and decodes them.
-   * This function is fairly rudimentary at the moment but more functionality
-   * will be added in the future.
+   * See [[WireDecoder.events]].
    * @param options Used to determine what events to fetch; see the documentation on the EventOptions type for more.
    */
-  public async events(options: DecoderTypes.EventOptions = {}): Promise<DecoderTypes.DecodedLog[]> {
+  public async events(
+    options: DecoderTypes.EventOptions = {}
+  ): Promise<DecoderTypes.DecodedLog[]> {
     return await this.wireDecoder.events(options);
   }
 
   /**
-   * See WireDecoder.abifyCallDataDecoding
+   * See [[WireDecoder.abifyCalldataDecoding]].
    */
   public abifyCalldataDecoding(decoding: CalldataDecoding): CalldataDecoding {
     return this.wireDecoder.abifyCalldataDecoding(decoding);
   }
 
   /**
-   * See WireDecoder.abifyLogDecoding
+   * See [[WireDecoder.abifyLogDecoding]].
    */
   public abifyLogDecoding(decoding: LogDecoding): LogDecoding {
     return this.wireDecoder.abifyLogDecoding(decoding);
@@ -183,8 +203,8 @@ export default class ContractDecoder {
       contract: this.contract,
       contractNode: this.contractNode,
       contractNetwork: this.contractNetwork,
-      contextHash: this.contextHash,
-    }
+      contextHash: this.contextHash
+    };
   }
 }
 
@@ -240,9 +260,8 @@ export class ContractInstanceDecoder {
    * @private
    */
   constructor(contractDecoder: ContractDecoder, address?: string) {
-
     this.contractDecoder = contractDecoder;
-    if(address !== undefined) {
+    if (address !== undefined) {
       this.contractAddress = address;
     }
     this.wireDecoder = this.contractDecoder.getWireDecoder();
@@ -255,14 +274,16 @@ export class ContractInstanceDecoder {
       contract: this.contract,
       contractNode: this.contractNode,
       contractNetwork: this.contractNetwork,
-      contextHash: this.contextHash,
+      contextHash: this.contextHash
     } = this.contractDecoder.getContractInfo());
 
     this.allocations = this.contractDecoder.getAllocations();
     this.stateVariableReferences = this.contractDecoder.getStateVariableReferences();
 
-    if(this.contractAddress === undefined) {
-      this.contractAddress = this.contract.networks[this.contractNetwork].address;
+    if (this.contractAddress === undefined) {
+      this.contractAddress = this.contract.networks[
+        this.contractNetwork
+      ].address;
     }
   }
 
@@ -271,10 +292,16 @@ export class ContractInstanceDecoder {
    */
   public async init(): Promise<void> {
     this.contractCode = CodecUtils.Conversion.toHexString(
-      await this.getCode(this.contractAddress, await this.web3.eth.getBlockNumber())
+      await this.getCode(
+        this.contractAddress,
+        await this.web3.eth.getBlockNumber()
+      )
     );
 
-    if(!this.contract.deployedBytecode || this.contract.deployedBytecode === "0x") {
+    if (
+      !this.contract.deployedBytecode ||
+      this.contract.deployedBytecode === "0x"
+    ) {
       //if this contract does *not* have the deployedBytecode field, then the decoder core
       //has no way of knowing that contracts or function pointers with its address
       //are of its class; this is an especial problem for function pointers, as it
@@ -287,14 +314,16 @@ export class ContractInstanceDecoder {
       let extraContext = Utils.makeContext(this.contract, this.contractNode);
       //now override the binary
       extraContext.binary = this.contractCode;
-      this.additionalContexts = {[extraContext.context]: extraContext};
+      this.additionalContexts = { [extraContext.context]: extraContext };
       //the following line only has any effect if we're dealing with a library,
       //since the code we pulled from the blockchain obviously does not have unresolved link references!
       //(it's not strictly necessary even then, but, hey, why not?)
-      this.additionalContexts = <DecoderContexts>ContextUtils.normalizeContexts(this.additionalContexts);
+      this.additionalContexts = <DecoderContexts>(
+        ContextUtils.normalizeContexts(this.additionalContexts)
+      );
       //again, since the code did not have unresolved link references, it is safe to just
       //mash these together like I'm about to
-      this.contexts = {...this.contexts, ...this.additionalContexts};
+      this.contexts = { ...this.contexts, ...this.additionalContexts };
     }
   }
 
@@ -303,18 +332,24 @@ export class ContractInstanceDecoder {
   }
 
   private checkAllocationSuccess(): void {
-    if(!this.contractNode) {
+    if (!this.contractNode) {
       throw new ContractBeingDecodedHasNoNodeError(this.contract.contractName);
     }
-    if(!this.stateVariableReferences) {
-      throw new ContractAllocationFailedError(this.contractNode.id, this.contract.contractName);
+    if (!this.stateVariableReferences) {
+      throw new ContractAllocationFailedError(
+        this.contractNode.id,
+        this.contract.contractName
+      );
     }
   }
 
-  private async decodeVariable(variable: StorageMemberAllocation, block: number): Promise<DecoderTypes.DecodedVariable> {
+  private async decodeVariable(
+    variable: StorageMemberAllocation,
+    block: number
+  ): Promise<DecoderTypes.DecodedVariable> {
     const info: EvmInfo = {
       state: {
-        storage: {},
+        storage: {}
       },
       mappingKeys: this.mappingKeys,
       userDefinedTypes: this.userDefinedTypes,
@@ -326,12 +361,16 @@ export class ContractInstanceDecoder {
     const decoder = decodeVariable(variable.definition, variable.pointer, info);
 
     let result = decoder.next();
-    while(result.done === false) {
+    while (result.done === false) {
       let request = result.value;
       let response: Uint8Array;
-      switch(request.type) {
+      switch (request.type) {
         case "storage":
-          response = await this.getStorage(this.contractAddress, request.slot, block);
+          response = await this.getStorage(
+            this.contractAddress,
+            request.slot,
+            block
+          );
           break;
         case "code":
           response = await this.getCode(request.address, block);
@@ -343,50 +382,59 @@ export class ContractInstanceDecoder {
 
     return {
       name: variable.definition.name,
-      class: <Types.ContractType> this.userDefinedTypes[variable.definedIn.id],
-      value: result.value,
+      class: <Types.ContractType>this.userDefinedTypes[variable.definedIn.id],
+      value: result.value
     };
   }
 
   /**
    * Returns information about the state of the contract, but does not include
    * information about the storage or decoded variables.  See the documentation
-   * for the ContractState type for more.
+   * for the [[ContractState]] type for more.
    * @param block The block to inspect the contract's state at.  Defaults to latest.
    */
-  public async state(block: BlockType = "latest"): Promise<DecoderTypes.ContractState> {
+  public async state(
+    block: BlockType = "latest"
+  ): Promise<DecoderTypes.ContractState> {
     return {
       name: this.contract.contractName,
       code: this.contractCode,
-      balanceAsBN: new BN(await this.web3.eth.getBalance(this.contractAddress, block)),
-      nonceAsBN: new BN(await this.web3.eth.getTransactionCount(this.contractAddress, block)),
+      balanceAsBN: new BN(
+        await this.web3.eth.getBalance(this.contractAddress, block)
+      ),
+      nonceAsBN: new BN(
+        await this.web3.eth.getTransactionCount(this.contractAddress, block)
+      )
     };
   }
 
   /**
    * Decodes the contract's variables; returns an array of these decoded variables.
-   * See the documentation of the DecodedVariable type for more.
+   * See the documentation of the [[DecodedVariable]] type for more.
    * Note that variable decoding can only operate in full mode; if the decoder wasn't able to
    * start up in full mode, this method will throw an exception.
    * Note that decoding mappings requires first watching mapping keys in order to get any results;
-   * see the documentation for watchMappingKey.
+   * see the documentation for [[watchMappingKey]].
    * Additional methods to make mapping decoding a less manual affair are planned for the future.
    * Also, due to a technical limitation, it is not currently possible to
-   * usefully decode internal function pointers.  See the FunctionInternalValue
+   * usefully decode internal function pointers.  See the
+   * [[Format.Values.FunctionInternalValue|FunctionInternalValue]]
    * documentation and the README for more on how these are handled.
    * @param block The block to inspect the contract's variables at.  Defaults to latest.
    */
-  public async variables(block: BlockType = "latest"): Promise<DecoderTypes.DecodedVariable[]> {
+  public async variables(
+    block: BlockType = "latest"
+  ): Promise<DecoderTypes.DecodedVariable[]> {
     this.checkAllocationSuccess();
 
-    let blockNumber = typeof block === "number"
-      ? block
-      : (await this.web3.eth.getBlock(block)).number;
+    let blockNumber =
+      typeof block === "number"
+        ? block
+        : (await this.web3.eth.getBlock(block)).number;
 
     let result: DecoderTypes.DecodedVariable[] = [];
 
-    for(const variable of this.stateVariableReferences) {
-
+    for (const variable of this.stateVariableReferences) {
       debug("about to decode %s", variable.definition.name);
       const decodedVariable = await this.decodeVariable(variable, blockNumber);
       debug("decoded");
@@ -398,75 +446,86 @@ export class ContractInstanceDecoder {
   }
 
   /**
-   * Decodes an individual contract variable; returns its value as a Result.
-   * See the documentation for variables() for various caveats that also apply here.
+   * Decodes an individual contract variable; returns its value as a [[Format.Values.Result|Result]].
+   * See the documentation for [[variables|variables()]] for various caveats that also apply here.
    * If the variable can't be located, returns undefined.  In the future this will probably throw an exception instead.
    * @param nameOrId The name (or numeric ID, if you know that) of the variable.  Can be given as a qualified name, allowing one to get at shadowed variables from base contracts.  If given by ID, can be given as a number or numeric string.
    * @param block The block to inspect the contract's variables at.  Defaults to latest.
    */
-  public async variable(nameOrId: string | number, block: BlockType = "latest"): Promise<Values.Result | undefined> {
+  public async variable(
+    nameOrId: string | number,
+    block: BlockType = "latest"
+  ): Promise<Values.Result | undefined> {
     this.checkAllocationSuccess();
 
-    let blockNumber = typeof block === "number"
-      ? block
-      : (await this.web3.eth.getBlock(block)).number;
+    let blockNumber =
+      typeof block === "number"
+        ? block
+        : (await this.web3.eth.getBlock(block)).number;
 
     let variable = this.findVariableByNameOrId(nameOrId);
 
-    if(variable === undefined) { //if user put in a bad name
+    if (variable === undefined) {
+      //if user put in a bad name
       return undefined;
     }
 
     return (await this.decodeVariable(variable, blockNumber)).value;
   }
 
-  private findVariableByNameOrId(nameOrId: string | number): StorageMemberAllocation | undefined {
+  private findVariableByNameOrId(
+    nameOrId: string | number
+  ): StorageMemberAllocation | undefined {
     //case 1: an ID was input
-    if(typeof nameOrId === "number" || nameOrId.match(/[0-9]+/)) {
+    if (typeof nameOrId === "number" || nameOrId.match(/[0-9]+/)) {
       let id: number = Number(nameOrId);
       return this.stateVariableReferences.find(
-        ({definition}) => definition.id === nameOrId
+        ({ definition }) => definition.id === nameOrId
       );
       //there should be exactly one; returns undefined if none
     }
     //case 2: a name was input
-    else if(!nameOrId.includes(".")) {
+    else if (!nameOrId.includes(".")) {
       //we want to search *backwards*, to get most derived version;
       //we use slice().reverse() to clone before reversing since reverse modifies
-      return this.stateVariableReferences.slice().reverse().find(
-        ({definition}) => definition.name === nameOrId
-      );
+      return this.stateVariableReferences
+        .slice()
+        .reverse()
+        .find(({ definition }) => definition.name === nameOrId);
     }
     //case 3: a qualified name was input
     else {
       let [className, variableName] = nameOrId.split(".");
       //again, we'll search backwards, although, uhhh...?
-      return this.stateVariableReferences.slice().reverse().find(
-        ({definition, definedIn}) =>
-          definition.name === variableName && definedIn.name === className
-      );
+      return this.stateVariableReferences
+        .slice()
+        .reverse()
+        .find(
+          ({ definition, definedIn }) =>
+            definition.name === variableName && definedIn.name === className
+        );
     }
   }
 
-  private async getStorage(address: string, slot: BN, block: number): Promise<Uint8Array> {
+  private async getStorage(
+    address: string,
+    slot: BN,
+    block: number
+  ): Promise<Uint8Array> {
     //first, set up any preliminary layers as needed
-    if(this.storageCache[block] === undefined) {
+    if (this.storageCache[block] === undefined) {
       this.storageCache[block] = {};
     }
-    if(this.storageCache[block][address] === undefined) {
+    if (this.storageCache[block][address] === undefined) {
       this.storageCache[block][address] = {};
     }
     //now, if we have it cached, just return it
-    if(this.storageCache[block][address][slot.toString()] !== undefined) {
+    if (this.storageCache[block][address][slot.toString()] !== undefined) {
       return this.storageCache[block][address][slot.toString()];
     }
     //otherwise, get it, cache it, and return it
     let word = CodecUtils.Conversion.toBytes(
-      await this.web3.eth.getStorageAt(
-        address,
-        slot,
-        block
-      ),
+      await this.web3.eth.getStorageAt(address, slot, block),
       CodecUtils.EVM.WORD_SIZE
     );
     this.storageCache[block][address][slot.toString()] = word;
@@ -479,7 +538,7 @@ export class ContractInstanceDecoder {
 
   /**
    * Watches a mapping key; adds it to the decoder's list of watched mapping keys.
-   * This affects the results of both variables() and variable().
+   * This affects the results of both [[variables|variables()]] and [[variable|variable()]].
    * When a mapping is decoded, only the values at its watched keys will be included in its value.
    * Note that it is possible to watch mappings that are inside structs, arrays, other mappings, etc;
    * see below for more on how to do this.
@@ -489,7 +548,7 @@ export class ContractInstanceDecoder {
    * unpredictable results.  This will be remedied in the future (by having it throw exceptions on
    * bad input), but right now essentially no checking is implemented.
    * Also, there may be slight changes to the format of indices in the future.
-   * @param variable The variable that the mapping lives under; this works like the nameOrId argument to variable().  If the mapping is a top-level state variable, put the mapping itself here.  Otherwise, put the top-level state variable it lives under.
+   * @param variable The variable that the mapping lives under; this works like the nameOrId argument to [[variable|variable()]].  If the mapping is a top-level state variable, put the mapping itself here.  Otherwise, put the top-level state variable it lives under.
    * @param indices Further arguments to watchMappingKey, if given, will be interpreted as indices into or members of the variable identified by the variable argument.  Thus, if we have a struct type MapStruct with a mapping(string => string) called "map", and we have a variable arr of type MapStruct[], then one could watch arr[3].map["hello"] by calling watchMappingKey("arr", 3, "map", "hello").  Array indices and mapping keys are specified by value; struct members are specified by name or (if you know it) numeric ID.  Numeric values can be given as number, BN, or numeric string.  Bytestring values are given as hex strings.  Boolean values are given as booleans, or as the strings "true" or "false".  Address values are given as hex strings; they are currently not required to be in checksum case, but this will likely change in the future, so don't rely on that.  Note that if the path to a given mapping key includes mapping keys above it, any ancestors will also be watched automatically.  E.g., if m is of type mapping(uint => mapping(uint => uint)), then watching m[3][5] will also automatically watch m[3]; otherwise, watching m[3][5] wouldn't do much of anything.
    */
   public watchMappingKey(variable: number | string, ...indices: any[]): void {
@@ -497,22 +556,25 @@ export class ContractInstanceDecoder {
     let slot: Slot | undefined = this.constructSlot(variable, ...indices)[0];
     //add mapping key and all ancestors
     debug("slot: %O", slot);
-    while(slot !== undefined &&
-      this.mappingKeys.every(existingSlot =>
-      !equalSlots(existingSlot,slot)
+    while (
+      slot !== undefined &&
+      this.mappingKeys.every(
+        existingSlot => !equalSlots(existingSlot, slot)
         //we put the newness requirement in the while condition rather than a
         //separate if because if we hit one ancestor that's not new, the futher
         //ones won't be either
-    )) {
-      if(slot.key !== undefined) { //only add mapping keys
-          this.mappingKeys = [...this.mappingKeys, slot];
+      )
+    ) {
+      if (slot.key !== undefined) {
+        //only add mapping keys
+        this.mappingKeys = [...this.mappingKeys, slot];
       }
       slot = slot.path;
     }
   }
 
   /**
-   * Opposite of watchMappingKey; unwatches the specified mapping key.  See watchMappingKey
+   * Opposite of [[watchMappingKey]]; unwatches the specified mapping key.  See watchMappingKey
    * for more on how watching mapping keys works, and on how the parameters work.
    * Note that unwatching a mapping key will also unwatch all its descendants.
    * E.g., if m is of type mapping(uint => mapping(uint => uint)), then unwatching
@@ -522,13 +584,13 @@ export class ContractInstanceDecoder {
   public unwatchMappingKey(variable: number | string, ...indices: any[]): void {
     this.checkAllocationSuccess();
     let slot: Slot | undefined = this.constructSlot(variable, ...indices)[0];
-    if(slot === undefined) {
+    if (slot === undefined) {
       return; //not strictly necessary, but may as well
     }
     //remove mapping key and all descendants
-    this.mappingKeys = this.mappingKeys.filter( existingSlot => {
-      while(existingSlot !== undefined) {
-        if(equalSlots(existingSlot, slot)) {
+    this.mappingKeys = this.mappingKeys.filter(existingSlot => {
+      while (existingSlot !== undefined) {
+        if (equalSlots(existingSlot, slot)) {
           return false; //if it matches, remove it
         }
         existingSlot = existingSlot.path;
@@ -541,51 +603,59 @@ export class ContractInstanceDecoder {
   //than a while
 
   /**
-   * See ContractDecoder.decodeTransaction
+   * See [[WireDecoder.decodeTransaction]].
    */
-  public async decodeTransaction(transaction: Transaction): Promise<DecoderTypes.DecodedTransaction> {
-    return await this.wireDecoder.decodeTransaction(transaction, this.additionalContexts);
+  public async decodeTransaction(
+    transaction: Transaction
+  ): Promise<DecoderTypes.DecodedTransaction> {
+    return await this.wireDecoder.decodeTransaction(
+      transaction,
+      this.additionalContexts
+    );
   }
 
   /**
-   * See ContractDecoder.decodeLog
+   * See [[WireDecoder.decodeLog]].
    */
   public async decodeLog(log: Log): Promise<DecoderTypes.DecodedLog> {
     return await this.wireDecoder.decodeLog(log, {}, this.additionalContexts);
   }
 
   /**
-   * See ContractDecoder.decodeLogs
+   * See [[WireDecoder.decodeLogs]].
    */
   public async decodeLogs(logs: Log[]): Promise<DecoderTypes.DecodedLog[]> {
     return await this.wireDecoder.decodeLogs(logs, {}, this.additionalContexts);
   }
 
   /**
-   * See WireDecoder.abifyCallDataDecoding
+   * See [[WireDecoder.abifyCalldataDecoding]].
    */
   public abifyCalldataDecoding(decoding: CalldataDecoding): CalldataDecoding {
     return this.wireDecoder.abifyCalldataDecoding(decoding);
   }
 
   /**
-   * See WireDecoder.abifyLogDecoding
+   * See [[WireDecoder.abifyLogDecoding]].
    */
   public abifyLogDecoding(decoding: LogDecoding): LogDecoding {
     return this.wireDecoder.abifyLogDecoding(decoding);
   }
 
   /**
-   * Gets all events meeting certain conditions and decodes them.
-   * This function is fairly rudimentary at the moment but more functionality
-   * will be added in the future.
-   * Note that unlike other variants of this function, this one, by default, restricts to events originating from this instance's address.
+   * This mostly behaves as [[WireDecoder.events]].
+   * However, unlike other variants of this function, this one, by default, restricts to events originating from this instance's address.
    * If you don't want to restrict like that, you can explicitly set address = undefined in the options to disable this.
    * (You can also of course set a different address to restrict to that.)
-   * @param options Used to determine what events to fetch; see the documentation on the EventOptions type for more.
+   * @param options Used to determine what events to fetch; see the documentation on the [[EventOptions]] type for more.
    */
-  public async events(options: DecoderTypes.EventOptions = {}): Promise<DecoderTypes.DecodedLog[]> {
-    return await this.wireDecoder.events({address: this.contractAddress, ...options}, this.additionalContexts);
+  public async events(
+    options: DecoderTypes.EventOptions = {}
+  ): Promise<DecoderTypes.DecodedLog[]> {
+    return await this.wireDecoder.events(
+      { address: this.contractAddress, ...options },
+      this.additionalContexts
+    );
   }
 
   //in addition to returning the slot we want, it also returns a definition
@@ -598,14 +668,18 @@ export class ContractInstanceDecoder {
   //bytes mapping keys should be given as hex strings beginning with "0x"
   //address mapping keys are like bytes; checksum case is not required
   //boolean mapping keys may be given either as booleans, or as string "true" or "false"
-  private constructSlot(variable: number | string, ...indices: any[]): [Slot | undefined , AstDefinition | undefined] {
+  private constructSlot(
+    variable: number | string,
+    ...indices: any[]
+  ): [Slot | undefined, AstDefinition | undefined] {
     //base case: we need to locate the variable and its definition
-    if(indices.length === 0) {
+    if (indices.length === 0) {
       let allocation = this.findVariableByNameOrId(variable);
 
       let definition = allocation.definition;
       let pointer = allocation.pointer;
-      if(pointer.location !== "storage") { //i.e., if it's a constant
+      if (pointer.location !== "storage") {
+        //i.e., if it's a constant
         return [undefined, undefined];
       }
       return [pointer.range.from.slot, definition];
@@ -613,8 +687,11 @@ export class ContractInstanceDecoder {
 
     //main case
     let parentIndices = indices.slice(0, -1); //remove last index
-    let [parentSlot, parentDefinition] = this.constructSlot(variable, ...parentIndices);
-    if(parentSlot === undefined) {
+    let [parentSlot, parentDefinition] = this.constructSlot(
+      variable,
+      ...parentIndices
+    );
+    if (parentSlot === undefined) {
       return [undefined, undefined];
     }
     let rawIndex = indices[indices.length - 1];
@@ -622,59 +699,70 @@ export class ContractInstanceDecoder {
     let key: Values.ElementaryValue;
     let slot: Slot;
     let definition: AstDefinition;
-    switch(DefinitionUtils.typeClass(parentDefinition)) {
+    switch (DefinitionUtils.typeClass(parentDefinition)) {
       case "array":
-        if(rawIndex instanceof BN) {
+        if (rawIndex instanceof BN) {
           index = rawIndex.clone();
-        }
-        else {
+        } else {
           index = new BN(rawIndex);
         }
-        definition = parentDefinition.baseType || parentDefinition.typeName.baseType;
-        let size = storageSize(definition, this.referenceDeclarations, this.allocations.storage);
-        if(!isWordsLength(size)) {
+        definition =
+          parentDefinition.baseType || parentDefinition.typeName.baseType;
+        let size = storageSize(
+          definition,
+          this.referenceDeclarations,
+          this.allocations.storage
+        );
+        if (!isWordsLength(size)) {
           return [undefined, undefined];
         }
         slot = {
           path: parentSlot,
           offset: index.muln(size.words),
           hashPath: DefinitionUtils.isDynamicArray(parentDefinition)
-        }
+        };
         break;
       case "mapping":
-        let keyDefinition = parentDefinition.keyType || parentDefinition.typeName.keyType;
-        key = wrapElementaryViaDefinition(rawIndex, keyDefinition, this.contract.compiler);
-        definition = parentDefinition.valueType || parentDefinition.typeName.valueType;
+        let keyDefinition =
+          parentDefinition.keyType || parentDefinition.typeName.keyType;
+        key = wrapElementaryViaDefinition(
+          rawIndex,
+          keyDefinition,
+          this.contract.compiler
+        );
+        definition =
+          parentDefinition.valueType || parentDefinition.typeName.valueType;
         slot = {
           path: parentSlot,
           key,
           offset: new BN(0)
-        }
+        };
         break;
       case "struct":
         let parentId = DefinitionUtils.typeId(parentDefinition);
         let allocation: StorageMemberAllocation;
-        if(typeof rawIndex === "number") {
+        if (typeof rawIndex === "number") {
           index = rawIndex;
           allocation = this.allocations.storage[parentId].members[index];
           definition = allocation.definition;
-        }
-        else {
-          allocation = Object.values(this.allocations.storage[parentId].members)
-          .find(({definition}) => definition.name === rawIndex); //there should be exactly one
+        } else {
+          allocation = Object.values(
+            this.allocations.storage[parentId].members
+          ).find(({ definition }) => definition.name === rawIndex); //there should be exactly one
           definition = allocation.definition;
           index = definition.id; //not really necessary, but may as well
         }
         slot = {
           path: parentSlot,
           //need type coercion here -- we know structs don't contain constants but the compiler doesn't
-          offset: (<StoragePointer>allocation.pointer).range.from.slot.offset.clone()
-        }
+          offset: (<StoragePointer>(
+            allocation.pointer
+          )).range.from.slot.offset.clone()
+        };
         break;
       default:
         return [undefined, undefined];
     }
     return [slot, definition];
   }
-
 }

--- a/packages/codec/lib/interface/decoders/contract.ts
+++ b/packages/codec/lib/interface/decoders/contract.ts
@@ -392,6 +392,8 @@ export class ContractInstanceDecoder {
    * information about the storage or decoded variables.  See the documentation
    * for the [[ContractState]] type for more.
    * @param block The block to inspect the contract's state at.  Defaults to latest.
+   *   See [the web3 docs](https://web3js.readthedocs.io/en/v1.2.1/web3-eth.html#id14)
+   *   for legal values.
    */
   public async state(
     block: BlockType = "latest"
@@ -424,6 +426,8 @@ export class ContractInstanceDecoder {
    * [[Format.Values.FunctionInternalValue|FunctionInternalValue]]
    * documentation and the README for more on how these are handled.
    * @param block The block to inspect the contract's variables at.  Defaults to latest.
+   *   See [the web3 docs](https://web3js.readthedocs.io/en/v1.2.1/web3-eth.html#id14)
+   *   for legal values.
    */
   public async variables(
     block: BlockType = "latest"
@@ -461,6 +465,8 @@ export class ContractInstanceDecoder {
    *   number or numeric string.
    * @param block The block to inspect the contract's variables at.  Defaults
    *   to latest.
+   *   See [the web3 docs](https://web3js.readthedocs.io/en/v1.2.1/web3-eth.html#id14)
+   *   for legal values.
    * @example Consider a contract `Derived` inheriting from a contract `Base`.
    *   Suppose `Derived` has a variable `x` and `Base` has variables `x` and
    *   `y`.  One can access `Derived.x` as `variable("x")` or

--- a/packages/codec/lib/interface/decoders/contract.ts
+++ b/packages/codec/lib/interface/decoders/contract.ts
@@ -446,11 +446,22 @@ export class ContractInstanceDecoder {
   }
 
   /**
-   * Decodes an individual contract variable; returns its value as a [[Format.Values.Result|Result]].
-   * See the documentation for [[variables|variables()]] for various caveats that also apply here.
-   * If the variable can't be located, returns undefined.  In the future this will probably throw an exception instead.
-   * @param nameOrId The name (or numeric ID, if you know that) of the variable.  Can be given as a qualified name, allowing one to get at shadowed variables from base contracts.  If given by ID, can be given as a number or numeric string.
-   * @param block The block to inspect the contract's variables at.  Defaults to latest.
+   * Decodes an individual contract variable; returns its value as a
+   * [[Format.Values.Result|Result]].  See the documentation for
+   * [[variables|variables()]] for various caveats that also apply here.  If
+   * the variable can't be located, returns undefined.  In the future this will
+   * probably throw an exception instead.
+   * @param nameOrId The name (or numeric ID, if you know that) of the
+   *   variable.  Can be given as a qualified name, allowing one to get at
+   *   shadowed variables from base contracts.  If given by ID, can be given as a
+   *   number or numeric string.
+   * @param block The block to inspect the contract's variables at.  Defaults
+   *   to latest.
+   * @example Consider a contract `Derived` inheriting from a contract `Base`.
+   *   Suppose `Derived` has a variable `x` and `Base` has variables `x` and
+   *   `y`.  One can access `Derived.x` as `variable("x")` or
+   *   `variable("Derived.x")`, can access `Base.x` as `variable("Base.x")`,
+   *   and can access `Base.y` as `variable("y")` or `variable("Base.y")`.
    */
   public async variable(
     nameOrId: string | number,
@@ -537,19 +548,47 @@ export class ContractInstanceDecoder {
   }
 
   /**
-   * Watches a mapping key; adds it to the decoder's list of watched mapping keys.
-   * This affects the results of both [[variables|variables()]] and [[variable|variable()]].
-   * When a mapping is decoded, only the values at its watched keys will be included in its value.
-   * Note that it is possible to watch mappings that are inside structs, arrays, other mappings, etc;
-   * see below for more on how to do this.
-   * Note that watching mapping keys is only possible in full mode; if the decoder wasn't able to
-   * start up in full mode, this method will throw an exception.
-   * Warning: At the moment, this function does very little to check its input.  Bad input may have
-   * unpredictable results.  This will be remedied in the future (by having it throw exceptions on
-   * bad input), but right now essentially no checking is implemented.
-   * Also, there may be slight changes to the format of indices in the future.
-   * @param variable The variable that the mapping lives under; this works like the nameOrId argument to [[variable|variable()]].  If the mapping is a top-level state variable, put the mapping itself here.  Otherwise, put the top-level state variable it lives under.
-   * @param indices Further arguments to watchMappingKey, if given, will be interpreted as indices into or members of the variable identified by the variable argument.  Thus, if we have a struct type MapStruct with a mapping(string => string) called "map", and we have a variable arr of type MapStruct[], then one could watch arr[3].map["hello"] by calling watchMappingKey("arr", 3, "map", "hello").  Array indices and mapping keys are specified by value; struct members are specified by name or (if you know it) numeric ID.  Numeric values can be given as number, BN, or numeric string.  Bytestring values are given as hex strings.  Boolean values are given as booleans, or as the strings "true" or "false".  Address values are given as hex strings; they are currently not required to be in checksum case, but this will likely change in the future, so don't rely on that.  Note that if the path to a given mapping key includes mapping keys above it, any ancestors will also be watched automatically.  E.g., if m is of type mapping(uint => mapping(uint => uint)), then watching m[3][5] will also automatically watch m[3]; otherwise, watching m[3][5] wouldn't do much of anything.
+   * Watches a mapping key; adds it to the decoder's list of watched mapping
+   * keys.  This affects the results of both [[variables|variables()]] and
+   * [[variable|variable()]].  When a mapping is decoded, only the values at
+   * its watched keys will be included in its value.  Note that it is possible
+   * to watch mappings that are inside structs, arrays, other mappings, etc;
+   * see below for more on how to do this.  Note that watching mapping keys is
+   * only possible in full mode; if the decoder wasn't able to start up in full
+   * mode, this method will throw an exception.  Warning: At the moment, this
+   * function does very little to check its input.  Bad input may have
+   * unpredictable results.  This will be remedied in the future (by having it
+   * throw exceptions on bad input), but right now essentially no checking is
+   * implemented.  Also, there may be slight changes to the format of indices
+   * in the future.
+   * @param variable The variable that the mapping lives under; this works like
+   *   the nameOrId argument to [[variable|variable()]].  If the mapping is a
+   *   top-level state variable, put the mapping itself here.  Otherwise, put the
+   *   top-level state variable it lives under.
+   * @param indices Further arguments to watchMappingKey, if given, will be
+   *   interpreted as indices into or members of the variable identified by the
+   *   variable argument; see the example.  Array indices and mapping
+   *   keys are specified by value; struct members are specified by name or (if
+   *   you know it) numeric ID.  Numeric values can be given as number, BN, or
+   *   numeric string.  Bytestring values are given as hex strings.  Boolean
+   *   values are given as booleans, or as the strings "true" or "false".
+   *   Address values are given as hex strings; they are currently not required
+   *   to be in checksum case, but this will likely change in the future, so
+   *   don't rely on that.  Note that if the path to a given mapping key
+   *   includes mapping keys above it, any ancestors will also be watched
+   *   automatically.
+   * @example First, a simple example.  Say we have a mapping `m` of type
+   *   `mapping(uint => uint)`.  You could call `watchMappingKey("m", 0)` to
+   *   watch `m[0]`.
+   * @example Now for a slightly more complicated example.  Say `m` is of type
+   *   `mapping(uint => mapping(uint => uint))`, then to watch `m[3][5]`, you
+   *   can call `watchMappingKey("m", 3, 5)`.  This will also automatically
+   *   watch `m[3]`; otherwise, watching `m[3][5]` wouldn't do much of
+   *   anything.
+   * @example Now for a well more complicated example.  Say we have a struct
+   *   type `MapStruct` with a member called `map` which is a `mapping(string => string)`,
+   *   and say we have a variable `arr` of type `MapStruct[]`, then one could
+   *   watch `arr[3].map["hello"]` by calling `watchMappingKey("arr", 3, "map", "hello")`.
    */
   public watchMappingKey(variable: number | string, ...indices: any[]): void {
     this.checkAllocationSuccess();
@@ -574,12 +613,13 @@ export class ContractInstanceDecoder {
   }
 
   /**
-   * Opposite of [[watchMappingKey]]; unwatches the specified mapping key.  See watchMappingKey
-   * for more on how watching mapping keys works, and on how the parameters work.
-   * Note that unwatching a mapping key will also unwatch all its descendants.
-   * E.g., if m is of type mapping(uint => mapping(uint => uint)), then unwatching
-   * m[0] will also unwatch m[0][0], m[0][1], etc, if these are currently watched.
-   * This function has the same caveats as watchMappingKey.
+   * Opposite of [[watchMappingKey]]; unwatches the specified mapping key.  See
+   * watchMappingKey for more on how watching mapping keys works, and on how
+   * the parameters work.  Note that unwatching a mapping key will also unwatch
+   * all its descendants.  E.g., if `m` is of type `mapping(uint =>
+   * mapping(uint => uint))`, then unwatching `m[0]` will also unwatch
+   * `m[0][0]`, `m[0][1]`, etc, if these are currently watched.  This function
+   * has the same caveats as watchMappingKey.
    */
   public unwatchMappingKey(variable: number | string, ...indices: any[]): void {
     this.checkAllocationSuccess();
@@ -645,7 +685,7 @@ export class ContractInstanceDecoder {
   /**
    * This mostly behaves as [[WireDecoder.events]].
    * However, unlike other variants of this function, this one, by default, restricts to events originating from this instance's address.
-   * If you don't want to restrict like that, you can explicitly set address = undefined in the options to disable this.
+   * If you don't want to restrict like that, you can explicitly use `address: undefined` in the options to disable this.
    * (You can also of course set a different address to restrict to that.)
    * @param options Used to determine what events to fetch; see the documentation on the [[EventOptions]] type for more.
    */

--- a/packages/codec/lib/interface/decoders/contract.ts
+++ b/packages/codec/lib/interface/decoders/contract.ts
@@ -411,11 +411,14 @@ export class ContractInstanceDecoder {
   /**
    * Decodes the contract's variables; returns an array of these decoded variables.
    * See the documentation of the [[DecodedVariable]] type for more.
+   *
    * Note that variable decoding can only operate in full mode; if the decoder wasn't able to
    * start up in full mode, this method will throw an exception.
+   *
    * Note that decoding mappings requires first watching mapping keys in order to get any results;
    * see the documentation for [[watchMappingKey]].
    * Additional methods to make mapping decoding a less manual affair are planned for the future.
+   *
    * Also, due to a technical limitation, it is not currently possible to
    * usefully decode internal function pointers.  See the
    * [[Format.Values.FunctionInternalValue|FunctionInternalValue]]
@@ -448,9 +451,10 @@ export class ContractInstanceDecoder {
   /**
    * Decodes an individual contract variable; returns its value as a
    * [[Format.Values.Result|Result]].  See the documentation for
-   * [[variables|variables()]] for various caveats that also apply here.  If
-   * the variable can't be located, returns undefined.  In the future this will
-   * probably throw an exception instead.
+   * [[variables|variables()]] for various caveats that also apply here.
+   *
+   * If the variable can't be located, returns undefined.  In the future this
+   * will probably throw an exception instead.
    * @param nameOrId The name (or numeric ID, if you know that) of the
    *   variable.  Can be given as a qualified name, allowing one to get at
    *   shadowed variables from base contracts.  If given by ID, can be given as a
@@ -551,11 +555,17 @@ export class ContractInstanceDecoder {
    * Watches a mapping key; adds it to the decoder's list of watched mapping
    * keys.  This affects the results of both [[variables|variables()]] and
    * [[variable|variable()]].  When a mapping is decoded, only the values at
-   * its watched keys will be included in its value.  Note that it is possible
+   * its watched keys will be included in its value.
+   *
+   * Note that it is possible
    * to watch mappings that are inside structs, arrays, other mappings, etc;
-   * see below for more on how to do this.  Note that watching mapping keys is
+   * see below for more on how to do this.
+   *
+   * Note that watching mapping keys is
    * only possible in full mode; if the decoder wasn't able to start up in full
-   * mode, this method will throw an exception.  Warning: At the moment, this
+   * mode, this method will throw an exception.
+   *
+   * Warning: At the moment, this
    * function does very little to check its input.  Bad input may have
    * unpredictable results.  This will be remedied in the future (by having it
    * throw exceptions on bad input), but right now essentially no checking is
@@ -569,12 +579,16 @@ export class ContractInstanceDecoder {
    *   interpreted as indices into or members of the variable identified by the
    *   variable argument; see the example.  Array indices and mapping
    *   keys are specified by value; struct members are specified by name or (if
-   *   you know it) numeric ID.  Numeric values can be given as number, BN, or
+   *   you know it) numeric ID.
+   *
+   *   Numeric values can be given as number, BN, or
    *   numeric string.  Bytestring values are given as hex strings.  Boolean
    *   values are given as booleans, or as the strings "true" or "false".
    *   Address values are given as hex strings; they are currently not required
    *   to be in checksum case, but this will likely change in the future, so
-   *   don't rely on that.  Note that if the path to a given mapping key
+   *   don't rely on that.
+   *
+   *   Note that if the path to a given mapping key
    *   includes mapping keys above it, any ancestors will also be watched
    *   automatically.
    * @example First, a simple example.  Say we have a mapping `m` of type
@@ -615,11 +629,14 @@ export class ContractInstanceDecoder {
   /**
    * Opposite of [[watchMappingKey]]; unwatches the specified mapping key.  See
    * watchMappingKey for more on how watching mapping keys works, and on how
-   * the parameters work.  Note that unwatching a mapping key will also unwatch
-   * all its descendants.  E.g., if `m` is of type `mapping(uint =>
-   * mapping(uint => uint))`, then unwatching `m[0]` will also unwatch
-   * `m[0][0]`, `m[0][1]`, etc, if these are currently watched.  This function
-   * has the same caveats as watchMappingKey.
+   * the parameters work.
+   *
+   * Note that unwatching a mapping key will also unwatch all its descendants.
+   * E.g., if `m` is of type `mapping(uint => mapping(uint => uint))`, then
+   * unwatching `m[0]` will also unwatch `m[0][0]`, `m[0][1]`, etc, if these
+   * are currently watched.
+   *
+   * This function has the same caveats as watchMappingKey.
    */
   public unwatchMappingKey(variable: number | string, ...indices: any[]): void {
     this.checkAllocationSuccess();

--- a/packages/codec/lib/interface/decoders/wire.ts
+++ b/packages/codec/lib/interface/decoders/wire.ts
@@ -337,8 +337,11 @@ export default class WireDecoder {
    * Gets all events meeting certain conditions and decodes them.
    * This function is fairly rudimentary at the moment but more functionality
    * will be added in the future.
-   * @param options Used to determine what events to fetch; see the documentation on the [[EventOptions]] type for more.
+   * @param options Used to determine what events to fetch; see the documentation
+   *   on the [[EventOptions]] type for more.
    * @param additionalContexts For internal use only; please don't use this.
+   * @example `events({name: "TestEvent"})` -- get events named "TestEvent"
+   *   from the most recent block
    */
   public async events(
     options: DecoderTypes.EventOptions = {},

--- a/packages/codec/lib/interface/decoders/wire.ts
+++ b/packages/codec/lib/interface/decoders/wire.ts
@@ -213,9 +213,11 @@ export default class WireDecoder {
    * [Transaction](https://web3js.readthedocs.io/en/v1.2.1/web3-eth.html#eth-gettransaction-return)
    * object and returns a copy of that object but with an additional decoding
    * field.  This field holds a [[CalldataDecoding]]; see the documentation on
-   * [[DecodedTransaction]] for more.  Note that decoding of transactions sent
-   * to libraries is presently not supported and may have unreliable results.
-   * Limited support for this is planned for future versions.
+   * [[DecodedTransaction]] for more.
+   *
+   * Note that decoding of transactions sent to libraries is presently not
+   * supported and may have unreliable results.  Limited support for this is
+   * planned for future versions.
    * @param transaction The transaction to be decoded.
    * @param additionalContexts For internal use only; please don't use this.
    */
@@ -371,6 +373,7 @@ export default class WireDecoder {
   /**
    * Takes a [[CalldataDecoding]], which may have been produced in full mode or ABI mode,
    * and converts it to its ABI mode equivalent.  See the README for more information.
+   *
    * Please only use on decodings produced by this same decoder instance; use
    * on decodings produced by other instances may not work consistently.
    * @param decoding The decoding to abify
@@ -382,6 +385,7 @@ export default class WireDecoder {
   /**
    * Takes a [[LogDecoding]], which may have been produced in full mode or ABI mode,
    * and converts it to its ABI mode equivalent.  See the README for more information.
+   *
    * Please only use on decodings produced by this same decoder instance; use
    * on decodings produced by other instances may not work consistently.
    * @param decoding The decoding to abify

--- a/packages/codec/lib/interface/decoders/wire.ts
+++ b/packages/codec/lib/interface/decoders/wire.ts
@@ -21,6 +21,9 @@ import { getStorageAllocations } from "@truffle/codec/allocate/storage";
 import { decodeCalldata, decodeEvent } from "@truffle/codec/core/decoding";
 import { CalldataDecoding, LogDecoding } from "@truffle/codec/types/decoding";
 
+/**
+ * The WireDecoder class.  Decodes transactions and logs.  See below for a method listing.
+ */
 export default class WireDecoder {
   private web3: Web3;
 
@@ -124,7 +127,10 @@ export default class WireDecoder {
     return {definitions: references, types};
   }
 
-  //for internal use
+  /**
+   * @hidden
+   * for internal use
+   */
   public async getCode(address: string, block: number): Promise<Uint8Array> {
     //first, set up any preliminary layers as needed
     if(this.codeCache[block] === undefined) {
@@ -145,7 +151,13 @@ export default class WireDecoder {
     return code;
   }
 
-  //NOTE: additionalContexts parameter is for internal use only.
+  /**
+   * Takes a Web3 Transaction object and returns a copy of that object but with
+   * an additional decoding field.  This field holds a CalldataDecoding; see the
+   * documentation on DecodedTransaction for more.
+   * @param transaction The transaction to be decoded.
+   * @param additionalContexts For internal use only; please don't use this.
+   */
   public async decodeTransaction(transaction: Transaction, additionalContexts: Contexts.DecoderContexts = {}): Promise<DecoderTypes.DecodedTransaction> {
     debug("transaction: %O", transaction);
     const block = transaction.blockNumber;
@@ -185,8 +197,14 @@ export default class WireDecoder {
     };
   }
 
-  //NOTE: options is meant for internal use; do not rely on it
-  //NOTE: additionalContexts parameter is for internal use only.
+  /**
+   * Takes a Web3 Log object and returns a copy of that object but with
+   * an additional decodings field.  This field holds an array of LogDecodings;
+   * see the documentation on DecodedLog for more.
+   * @param log The log to be decoded.
+   * @param options Meant for internal use; please don't use this.
+   * @param additionalContexts For internal use only; please don't use this.
+   */
   public async decodeLog(log: Log, options: DecoderTypes.EventOptions = {}, additionalContexts: Contexts.DecoderContexts = {}): Promise<DecoderTypes.DecodedLog> {
     const block = log.blockNumber;
     const data = CodecUtils.Conversion.toBytes(log.data);
@@ -224,13 +242,23 @@ export default class WireDecoder {
     };
   }
 
-  //NOTE: options is meant for internal use; do not rely on it
-  //NOTE: additionalContexts parameter is for internal use only.
+  /**
+   * Similar to decodeLog, but operates on an array of logs and decodes them all.
+   * @param logs The logs to be decoded.
+   * @param options Meant for internal use; please don't use this.
+   * @param additionalContexts For internal use only; please don't use this.
+   */
   public async decodeLogs(logs: Log[], options: DecoderTypes.EventOptions = {}, additionalContexts: Contexts.DecoderContexts = {}): Promise<DecoderTypes.DecodedLog[]> {
     return await Promise.all(logs.map(log => this.decodeLog(log, options, additionalContexts)));
   }
 
-  //NOTE: additionalContexts parameter is for internal use only.
+  /**
+   * Gets all events meeting certain conditions and decodes them.
+   * This function is fairly rudimentary at the moment but more functionality
+   * will be added in the future.
+   * @param options Used to determine what events to fetch; see the documentation on the EventOptions type for more.
+   * @param additionalContexts For internal use only; please don't use this.
+   */
   public async events(options: DecoderTypes.EventOptions = {}, additionalContexts: Contexts.DecoderContexts = {}): Promise<DecoderTypes.DecodedLog[]> {
     let { address, name, fromBlock, toBlock } = options;
 
@@ -255,10 +283,24 @@ export default class WireDecoder {
     return events;
   }
 
+  /**
+   * Takes a CalldataDecoding, which may have been produced in full mode or ABI mode,
+   * and converts it to its ABI mode equivalent.  See the README for more information.
+   * Please only use on decodings produced by this same decoder instance; use
+   * on decodings produced by other instances may not work consistently.
+   * @param decoding The decoding to abify
+   */
   public abifyCalldataDecoding(decoding: CalldataDecoding): CalldataDecoding {
     return abifyCalldataDecoding(decoding, this.userDefinedTypes);
   }
 
+  /**
+   * Takes a LogDecoding, which may have been produced in full mode or ABI mode,
+   * and converts it to its ABI mode equivalent.  See the README for more information.
+   * Please only use on decodings produced by this same decoder instance; use
+   * on decodings produced by other instances may not work consistently.
+   * @param decoding The decoding to abify
+   */
   public abifyLogDecoding(decoding: LogDecoding): LogDecoding {
     return abifyLogDecoding(decoding, this.userDefinedTypes);
   }
@@ -283,14 +325,24 @@ export default class WireDecoder {
   }
 
   //the following functions are intended for internal use only
+
+  /**
+   * @hidden
+   */
   public getReferenceDeclarations(): AstReferences {
     return this.referenceDeclarations;
   }
 
+  /**
+   * @hidden
+   */
   public getUserDefinedTypes(): Types.TypesById {
     return this.userDefinedTypes;
   }
 
+  /**
+   * @hidden
+   */
   public getAllocations(): AllocationInfo {
     return {
       abi: this.allocations.abi,
@@ -298,10 +350,16 @@ export default class WireDecoder {
     };
   }
 
+  /**
+   * @hidden
+   */
   public getWeb3(): Web3 {
     return this.web3;
   }
 
+  /**
+   * @hidden
+   */
   public getDeployedContexts(): Contexts.DecoderContexts {
     return this.deployedContexts;
   }

--- a/packages/codec/lib/interface/decoders/wire.ts
+++ b/packages/codec/lib/interface/decoders/wire.ts
@@ -2,7 +2,15 @@ import debugModule from "debug";
 const debug = debugModule("codec:interface:decoders:wire");
 
 import * as CodecUtils from "@truffle/codec/utils";
-import { Definition as DefinitionUtils, AbiUtils, EVM, ContextUtils, abifyCalldataDecoding, abifyLogDecoding, MakeType } from "@truffle/codec/utils";
+import {
+  Definition as DefinitionUtils,
+  AbiUtils,
+  EVM,
+  ContextUtils,
+  abifyCalldataDecoding,
+  abifyLogDecoding,
+  MakeType
+} from "@truffle/codec/utils";
 import * as Utils from "@truffle/codec/utils/interface";
 import * as Contexts from "@truffle/codec/types/contexts";
 import { AstDefinition, AstReferences } from "@truffle/codec/types/ast";
@@ -15,8 +23,15 @@ import { Log } from "web3/types";
 import { Provider } from "web3/providers";
 import * as DecoderTypes from "@truffle/codec/types/interface";
 import { EvmInfo, AllocationInfo } from "@truffle/codec/types/evm";
-import { AbiAllocations, ContractAllocationInfo } from "@truffle/codec/types/allocation";
-import { getAbiAllocations, getCalldataAllocations, getEventAllocations } from "@truffle/codec/allocate/abi";
+import {
+  AbiAllocations,
+  ContractAllocationInfo
+} from "@truffle/codec/types/allocation";
+import {
+  getAbiAllocations,
+  getCalldataAllocations,
+  getEventAllocations
+} from "@truffle/codec/allocate/abi";
 import { getStorageAllocations } from "@truffle/codec/allocate/storage";
 import { decodeCalldata, decodeEvent } from "@truffle/codec/core/decoding";
 import { CalldataDecoding, LogDecoding } from "@truffle/codec/types/decoding";
@@ -44,50 +59,72 @@ export default class WireDecoder {
    * @private
    */
   constructor(contracts: ContractObject[], provider: Provider) {
-
     this.web3 = new Web3(provider);
 
     let contractsAndContexts: DecoderTypes.ContractAndContexts[] = [];
 
-    for(let contract of contracts) {
+    for (let contract of contracts) {
       let node: AstDefinition = Utils.getContractNode(contract);
       let deployedContext: Contexts.DecoderContext | undefined = undefined;
       let constructorContext: Contexts.DecoderContext | undefined = undefined;
-      if(node !== undefined) {
+      if (node !== undefined) {
         this.contracts[node.id] = contract;
         this.contractNodes[node.id] = node;
       }
-      if(contract.deployedBytecode && contract.deployedBytecode !== "0x") {
+      if (contract.deployedBytecode && contract.deployedBytecode !== "0x") {
         deployedContext = Utils.makeContext(contract, node);
         this.contexts[deployedContext.context] = deployedContext;
         //note that we don't set up deployedContexts until after normalization!
       }
-      if(contract.bytecode && contract.bytecode !== "0x") {
+      if (contract.bytecode && contract.bytecode !== "0x") {
         constructorContext = Utils.makeContext(contract, node, true);
         this.contexts[constructorContext.context] = constructorContext;
       }
-      contractsAndContexts.push({contract, node, deployedContext, constructorContext});
+      contractsAndContexts.push({
+        contract,
+        node,
+        deployedContext,
+        constructorContext
+      });
     }
 
-    this.contexts = <Contexts.DecoderContexts>ContextUtils.normalizeContexts(this.contexts);
-    this.deployedContexts = Object.assign({}, ...Object.values(this.contexts).map(
-      context => !context.isConstructor ? {[context.context]: context} : {}
-    ));
+    this.contexts = <Contexts.DecoderContexts>(
+      ContextUtils.normalizeContexts(this.contexts)
+    );
+    this.deployedContexts = Object.assign(
+      {},
+      ...Object.values(this.contexts).map(
+        context =>
+          !context.isConstructor ? { [context.context]: context } : {}
+      )
+    );
 
-    for(let contractAndContexts of contractsAndContexts) {
+    for (let contractAndContexts of contractsAndContexts) {
       //change everythign to normalized version
-      if(contractAndContexts.deployedContext) {
-        contractAndContexts.deployedContext = this.contexts[contractAndContexts.deployedContext.context]; //get normalized version
+      if (contractAndContexts.deployedContext) {
+        contractAndContexts.deployedContext = this.contexts[
+          contractAndContexts.deployedContext.context
+        ]; //get normalized version
       }
-      if(contractAndContexts.constructorContext) {
-        contractAndContexts.constructorContext = this.contexts[contractAndContexts.constructorContext.context]; //get normalized version
+      if (contractAndContexts.constructorContext) {
+        contractAndContexts.constructorContext = this.contexts[
+          contractAndContexts.constructorContext.context
+        ]; //get normalized version
       }
     }
 
-    ({definitions: this.referenceDeclarations, types: this.userDefinedTypes} = this.collectUserDefinedTypes());
+    ({
+      definitions: this.referenceDeclarations,
+      types: this.userDefinedTypes
+    } = this.collectUserDefinedTypes());
 
     let allocationInfo: ContractAllocationInfo[] = contractsAndContexts.map(
-      ({contract: { abi, compiler }, node, deployedContext, constructorContext}) => ({
+      ({
+        contract: { abi, compiler },
+        node,
+        deployedContext,
+        constructorContext
+      }) => ({
         abi: AbiUtils.schemaAbiToAbi(abi),
         compiler,
         contractNode: node,
@@ -99,32 +136,55 @@ export default class WireDecoder {
 
     this.allocations = {};
     this.allocations.abi = getAbiAllocations(this.userDefinedTypes);
-    this.allocations.storage = getStorageAllocations(this.referenceDeclarations, {}); //not used by wire decoder itself, but used by contract decoder
-    this.allocations.calldata = getCalldataAllocations(allocationInfo, this.referenceDeclarations, this.userDefinedTypes, this.allocations.abi);
-    this.allocations.event = getEventAllocations(allocationInfo, this.referenceDeclarations, this.userDefinedTypes, this.allocations.abi);
+    this.allocations.storage = getStorageAllocations(
+      this.referenceDeclarations,
+      {}
+    ); //not used by wire decoder itself, but used by contract decoder
+    this.allocations.calldata = getCalldataAllocations(
+      allocationInfo,
+      this.referenceDeclarations,
+      this.userDefinedTypes,
+      this.allocations.abi
+    );
+    this.allocations.event = getEventAllocations(
+      allocationInfo,
+      this.referenceDeclarations,
+      this.userDefinedTypes,
+      this.allocations.abi
+    );
     debug("done with allocation");
   }
 
-  private collectUserDefinedTypes(): {definitions: AstReferences, types: Types.TypesById} {
+  private collectUserDefinedTypes(): {
+    definitions: AstReferences;
+    types: Types.TypesById;
+  } {
     let references: AstReferences = {};
     let types: Types.TypesById = {};
-    for(const id in this.contracts) {
+    for (const id in this.contracts) {
       const compiler = this.contracts[id].compiler;
       //first, add the contract itself
       const contractNode = this.contractNodes[id];
       references[id] = contractNode;
       types[id] = MakeType.definitionToStoredType(contractNode, compiler);
       //now, add its struct and enum definitions
-      for(const node of contractNode.nodes) {
-        if(node.nodeType === "StructDefinition" || node.nodeType === "EnumDefinition") {
+      for (const node of contractNode.nodes) {
+        if (
+          node.nodeType === "StructDefinition" ||
+          node.nodeType === "EnumDefinition"
+        ) {
           references[node.id] = node;
           //HACK even though we don't have all the references, we only need one:
           //the reference to the contract itself, which we just added, so we're good
-          types[node.id] = MakeType.definitionToStoredType(node, compiler, references);
+          types[node.id] = MakeType.definitionToStoredType(
+            node,
+            compiler,
+            references
+          );
         }
       }
     }
-    return {definitions: references, types};
+    return { definitions: references, types };
   }
 
   /**
@@ -133,58 +193,67 @@ export default class WireDecoder {
    */
   public async getCode(address: string, block: number): Promise<Uint8Array> {
     //first, set up any preliminary layers as needed
-    if(this.codeCache[block] === undefined) {
+    if (this.codeCache[block] === undefined) {
       this.codeCache[block] = {};
     }
     //now, if we have it cached, just return it
-    if(this.codeCache[block][address] !== undefined) {
+    if (this.codeCache[block][address] !== undefined) {
       return this.codeCache[block][address];
     }
     //otherwise, get it, cache it, and return it
     let code = CodecUtils.Conversion.toBytes(
-      await this.web3.eth.getCode(
-        address,
-        block
-      )
+      await this.web3.eth.getCode(address, block)
     );
     this.codeCache[block][address] = code;
     return code;
   }
 
   /**
-   * Takes a Web3 Transaction object and returns a copy of that object but with
-   * an additional decoding field.  This field holds a CalldataDecoding; see the
-   * documentation on DecodedTransaction for more.
+   * Takes a Web3
+   * [Transaction](https://web3js.readthedocs.io/en/v1.2.1/web3-eth.html#eth-gettransaction-return)
+   * object and returns a copy of that object but with an additional decoding
+   * field.  This field holds a [[CalldataDecoding]]; see the documentation on
+   * [[DecodedTransaction]] for more.  Note that decoding of transactions sent
+   * to libraries is presently not supported and may have unreliable results.
+   * Limited support for this is planned for future versions.
    * @param transaction The transaction to be decoded.
    * @param additionalContexts For internal use only; please don't use this.
    */
-  public async decodeTransaction(transaction: Transaction, additionalContexts: Contexts.DecoderContexts = {}): Promise<DecoderTypes.DecodedTransaction> {
+  public async decodeTransaction(
+    transaction: Transaction,
+    additionalContexts: Contexts.DecoderContexts = {}
+  ): Promise<DecoderTypes.DecodedTransaction> {
     debug("transaction: %O", transaction);
     const block = transaction.blockNumber;
-    const context = await this.getContextByAddress(transaction.to, block, transaction.input, additionalContexts);
+    const context = await this.getContextByAddress(
+      transaction.to,
+      block,
+      transaction.input,
+      additionalContexts
+    );
 
     const data = CodecUtils.Conversion.toBytes(transaction.input);
     const info: EvmInfo = {
       state: {
         storage: {},
-        calldata: data,
+        calldata: data
       },
       userDefinedTypes: this.userDefinedTypes,
       allocations: this.allocations,
-      contexts: {...this.deployedContexts, ...additionalContexts},
+      contexts: { ...this.deployedContexts, ...additionalContexts },
       currentContext: context
     };
     const decoder = decodeCalldata(info);
 
     let result = decoder.next();
-    while(result.done === false) {
+    while (result.done === false) {
       let request = result.value;
       let response: Uint8Array;
-      switch(request.type) {
-	case "code":
+      switch (request.type) {
+        case "code":
           response = await this.getCode(request.address, block);
-	  break;
-	//not writing a storage case as it shouldn't occur here!
+          break;
+        //not writing a storage case as it shouldn't occur here!
       }
       result = decoder.next(response);
     }
@@ -198,14 +267,20 @@ export default class WireDecoder {
   }
 
   /**
-   * Takes a Web3 Log object and returns a copy of that object but with
-   * an additional decodings field.  This field holds an array of LogDecodings;
-   * see the documentation on DecodedLog for more.
+   * Takes a Web3
+   * [Log](https://web3js.readthedocs.io/en/v1.2.1/web3-eth.html#eth-getpastlogs-return)
+   * object and returns a copy of that object but with an additional decodings
+   * field.  This field holds an array of [[LogDecoding|LogDecodings]]; see the
+   * documentation on [[DecodedLog]] for more.
    * @param log The log to be decoded.
    * @param options Meant for internal use; please don't use this.
    * @param additionalContexts For internal use only; please don't use this.
    */
-  public async decodeLog(log: Log, options: DecoderTypes.EventOptions = {}, additionalContexts: Contexts.DecoderContexts = {}): Promise<DecoderTypes.DecodedLog> {
+  public async decodeLog(
+    log: Log,
+    options: DecoderTypes.EventOptions = {},
+    additionalContexts: Contexts.DecoderContexts = {}
+  ): Promise<DecoderTypes.DecodedLog> {
     const block = log.blockNumber;
     const data = CodecUtils.Conversion.toBytes(log.data);
     const topics = log.topics.map(CodecUtils.Conversion.toBytes);
@@ -217,19 +292,19 @@ export default class WireDecoder {
       },
       userDefinedTypes: this.userDefinedTypes,
       allocations: this.allocations,
-      contexts: {...this.deployedContexts, ...additionalContexts}
+      contexts: { ...this.deployedContexts, ...additionalContexts }
     };
     const decoder = decodeEvent(info, log.address, options.name);
 
     let result = decoder.next();
-    while(result.done === false) {
+    while (result.done === false) {
       let request = result.value;
       let response: Uint8Array;
-      switch(request.type) {
-	case "code":
+      switch (request.type) {
+        case "code":
           response = await this.getCode(request.address, block);
-	  break;
-	//not writing a storage case as it shouldn't occur here!
+          break;
+        //not writing a storage case as it shouldn't occur here!
       }
       result = decoder.next(response);
     }
@@ -243,29 +318,38 @@ export default class WireDecoder {
   }
 
   /**
-   * Similar to decodeLog, but operates on an array of logs and decodes them all.
+   * Similar to [[decodeLog]], but operates on an array of logs and decodes them all.
    * @param logs The logs to be decoded.
    * @param options Meant for internal use; please don't use this.
    * @param additionalContexts For internal use only; please don't use this.
    */
-  public async decodeLogs(logs: Log[], options: DecoderTypes.EventOptions = {}, additionalContexts: Contexts.DecoderContexts = {}): Promise<DecoderTypes.DecodedLog[]> {
-    return await Promise.all(logs.map(log => this.decodeLog(log, options, additionalContexts)));
+  public async decodeLogs(
+    logs: Log[],
+    options: DecoderTypes.EventOptions = {},
+    additionalContexts: Contexts.DecoderContexts = {}
+  ): Promise<DecoderTypes.DecodedLog[]> {
+    return await Promise.all(
+      logs.map(log => this.decodeLog(log, options, additionalContexts))
+    );
   }
 
   /**
    * Gets all events meeting certain conditions and decodes them.
    * This function is fairly rudimentary at the moment but more functionality
    * will be added in the future.
-   * @param options Used to determine what events to fetch; see the documentation on the EventOptions type for more.
+   * @param options Used to determine what events to fetch; see the documentation on the [[EventOptions]] type for more.
    * @param additionalContexts For internal use only; please don't use this.
    */
-  public async events(options: DecoderTypes.EventOptions = {}, additionalContexts: Contexts.DecoderContexts = {}): Promise<DecoderTypes.DecodedLog[]> {
+  public async events(
+    options: DecoderTypes.EventOptions = {},
+    additionalContexts: Contexts.DecoderContexts = {}
+  ): Promise<DecoderTypes.DecodedLog[]> {
     let { address, name, fromBlock, toBlock } = options;
 
     const logs = await this.web3.eth.getPastLogs({
       address,
       fromBlock,
-      toBlock,
+      toBlock
     });
 
     let events = await this.decodeLogs(logs, options, additionalContexts);
@@ -274,17 +358,15 @@ export default class WireDecoder {
     //if a target name was specified, we'll restrict to events that decoded
     //to something with that name.  (note that only decodings with that name
     //will have been returned from decodeLogs in the first place)
-    if(name !== undefined) {
-      events = events.filter(
-        event => event.decodings.length > 0
-      );
+    if (name !== undefined) {
+      events = events.filter(event => event.decodings.length > 0);
     }
 
     return events;
   }
 
   /**
-   * Takes a CalldataDecoding, which may have been produced in full mode or ABI mode,
+   * Takes a [[CalldataDecoding]], which may have been produced in full mode or ABI mode,
    * and converts it to its ABI mode equivalent.  See the README for more information.
    * Please only use on decodings produced by this same decoder instance; use
    * on decodings produced by other instances may not work consistently.
@@ -295,7 +377,7 @@ export default class WireDecoder {
   }
 
   /**
-   * Takes a LogDecoding, which may have been produced in full mode or ABI mode,
+   * Takes a [[LogDecoding]], which may have been produced in full mode or ABI mode,
    * and converts it to its ABI mode equivalent.  See the README for more information.
    * Please only use on decodings produced by this same decoder instance; use
    * on decodings produced by other instances may not work consistently.
@@ -309,18 +391,22 @@ export default class WireDecoder {
   //and checks this against the known contexts to determine the contract type
   //however, if this fails and constructorBinary is passed in, it will then also
   //attempt to determine it from that
-  private async getContextByAddress(address: string, block: number, constructorBinary?: string, additionalContexts: Contexts.DecoderContexts = {}): Promise<Contexts.DecoderContext | null> {
+  private async getContextByAddress(
+    address: string,
+    block: number,
+    constructorBinary?: string,
+    additionalContexts: Contexts.DecoderContexts = {}
+  ): Promise<Contexts.DecoderContext | null> {
     let code: string;
-    if(address !== null) {
+    if (address !== null) {
       code = CodecUtils.Conversion.toHexString(
         await this.getCode(address, block)
       );
-    }
-    else if(constructorBinary) {
+    } else if (constructorBinary) {
       code = constructorBinary;
     }
     //if neither of these hold... we have a problem
-    let contexts = {...this.contexts, ...additionalContexts};
+    let contexts = { ...this.contexts, ...additionalContexts };
     return ContextUtils.findDecoderContext(contexts, code);
   }
 

--- a/packages/codec/lib/interface/errors.ts
+++ b/packages/codec/lib/interface/errors.ts
@@ -1,3 +1,8 @@
+/**
+ * This error indicates that the contract you are attempting to decode does not have AST
+ * information associated with it, or that the decoder cannot find it.  This error will
+ * be thrown if you attempt to use functions that require AST information with such a contract.
+ */
 export class ContractBeingDecodedHasNoNodeError extends Error {
   public contractName: string;
   constructor(contractName: string) {
@@ -7,6 +12,14 @@ export class ContractBeingDecodedHasNoNodeError extends Error {
   }
 }
 
+/**
+ * This error indicates that something went wrong while attempting to determine the location
+ * of this contract's state variables.  This error will be thrown if you attempt to use
+ * decoding functions after something went wrong during setup.  Unfortunately, we can't
+ * always avoid this at the moment; we're hoping to make this more robust in the future
+ * with Truffle DB.  In the meantime, it is at least worth noting that you should not encounter
+ * this error if your entire project was written in Solidity and all compiled at once.  Sorry.
+ */
 export class ContractAllocationFailedError extends Error {
   public id: number;
   public contractName: string;

--- a/packages/codec/lib/interface/index.ts
+++ b/packages/codec/lib/interface/index.ts
@@ -11,12 +11,29 @@ export { Errors };
 import { Provider } from "web3/providers";
 import { ContractObject } from "@truffle/contract-schema/spec";
 
+/**
+ * Constructs a contract instance decoder for a given contract instance.
+ * @param contract The contract constructor object corresponding to the type of the contract.
+ * @param relevantContracts A list of contract constructor objects for other contracts in the project that may be relevant
+ * (e.g., providing needed struct or enum definitions, or appearing as a contract type).
+ * Including the contract itself here is fine; so is excluding it.
+ * @param provider The Web3 provider object to use.
+ * @param address The address of the contract instance to decode.  If left out, it will be autodetected on startup.
+ */
 export async function forContractInstance(contract: ContractObject, relevantContracts: ContractObject[], provider: Provider, address?: string): Promise<Decoders.ContractInstanceDecoder> {
   let contractDecoder = await forContract(contract, relevantContracts, provider);
   let instanceDecoder = await contractDecoder.forInstance(address);
   return instanceDecoder;
 }
 
+/**
+ * Constructs a contract instance decoder for a given contract instance.
+ * @param contract The contract constructor object corresponding to the type of the contract.
+ * @param relevantContracts A list of contract constructor objects for other contracts in the project that may be relevant
+ * (e.g., providing needed struct or enum definitions, or appearing as a contract type).
+ * Including the contract itself here is fine; so is excluding it.
+ * @param provider The Web3 provider object to use.
+ */
 export async function forContract(contract: ContractObject, relevantContracts: ContractObject[], provider: Provider): Promise<Decoders.ContractDecoder> {
   let contracts = relevantContracts.includes(contract)
     ? relevantContracts
@@ -27,10 +44,20 @@ export async function forContract(contract: ContractObject, relevantContracts: C
   return contractDecoder;
 }
 
+/**
+ * Constructs a wire decoder for the project.
+ * @param contracts A list of contract constructor objects for contracts in the project.
+ * @param provider The Web3 provider object to use.
+ */
 export async function forProject(contracts: ContractObject[], provider: Provider): Promise<Decoders.WireDecoder> {
   return new Decoders.WireDecoder(contracts, provider);
 }
 
+/**
+ * Constructs a contract decoder given an existing wire decoder for the project.
+ * @param contract The contract constructor object corresponding to the type of the contract.
+ * @param decoder An existing wire decoder for the project.
+ */
 export async function forContractWithDecoder(contract: ContractObject, decoder: Decoders.WireDecoder): Promise<Decoders.ContractDecoder> {
   let contractDecoder = new Decoders.ContractDecoder(contract, decoder);
   await contractDecoder.init();

--- a/packages/codec/lib/types/decoding.ts
+++ b/packages/codec/lib/types/decoding.ts
@@ -100,9 +100,6 @@ export interface ConstructorDecoding {
  * This type represents a decoding for a call to a known class that does not appear
  * to be a function call, i.e., one that will result in the fallback function being invoked
  * if there is one.
- *
- * NOTE: Because libraries do not expose their functions in their ABI, all
- * calls to known libraries will decode to this.
  */
 export interface MessageDecoding {
   /**

--- a/packages/codec/lib/types/decoding.ts
+++ b/packages/codec/lib/types/decoding.ts
@@ -2,67 +2,236 @@ import { DecoderContext } from "./contexts";
 import * as AbiTypes from "./abi";
 import { Types, Values } from "@truffle/codec/format";
 
+/**
+ * A type representing a transaction (calldata) decoding.  As you can see, these come in four types,
+ * each of which is documented separately.
+ */
 export type CalldataDecoding = FunctionDecoding | ConstructorDecoding | MessageDecoding | UnknownDecoding;
+
+/**
+ * A type representing a log (event) decoding.  As you can see, these come in two types, each of which
+ * is documented separately.
+ */
 export type LogDecoding = EventDecoding | AnonymousDecoding;
 
+/**
+ * This is a type for recording what decoding mode a given decoding was produced in.  There are two
+ * decoding modes, full mode and ABI mode.  In ABI mode, decoding is done purely based on the ABI JSON.
+ * Full mode, by contrast, additionally uses AST information to produce a more informative decoding.
+ * For more on full mode and ABI mode, see the README.
+ */
 export type DecodingMode = "full" | "abi";
 
+/**
+ * This type represents a transaction decoding for an ordinary function call to a known class;
+ * not a constructor call, not a fallback call.
+ */
 export interface FunctionDecoding {
+  /**
+   * The kind of decoding; indicates that this is a FunctionDecoding.
+   */
   kind: "function";
+  /**
+   * The class of contract that was called, as a Types.ContractType.
+   */
   class: Types.ContractType;
+  /**
+   * The list of decoded arguments to the function.
+   */
   arguments: AbiArgument[];
+  /**
+   * The ABI entry for the function that was called.  You can use this
+   * to extract the name, for instance.
+   */
   abi: AbiTypes.FunctionAbiEntry;
+  /**
+   * The selector for the function that was called, as a hexadecimal string.
+   */
   selector: string;
+  /**
+   * The decoding mode that was used; see the README for more on these.
+   */
   decodingMode: DecodingMode;
 }
 
+/**
+ * This type represents a transaction decoding for a constructor call.
+ * It's even possible to decode a library constructor call with this.
+ *
+ * NOTE: In the future, this type will also contain information about
+ * any linked libraries the contract being constructed uses.  However,
+ * this is not implemented at present.
+ */
 export interface ConstructorDecoding {
+  /**
+   * The kind of decoding; indicates that this is a ConstructorDecoding.
+   */
   kind: "constructor";
+  /**
+   * The class of contract being constructed, as a Types.ContractType.
+   */
   class: Types.ContractType;
+  /**
+   * The list of decoded arguments to the constructor.  This will be empty for a
+   * default constructor.
+   */
   arguments: AbiArgument[];
+  /**
+   * The ABI entry for the constructor that was called.  Note that although
+   * default constructors don't actually get an ABI entry, we still return an
+   * ABI entry regardless in that case.
+   */
   abi: AbiTypes.ConstructorAbiEntry;
+  /**
+   * The bytecode of the constructor that was called.
+   */
   bytecode: string;
+  /**
+   * The decoding mode that was used; see the README for more on these.
+   */
   decodingMode: DecodingMode;
 }
 
+/**
+ * This type represents a decoding for a call to a known class that does not appear
+ * to be a function call, i.e., one that will result in the fallback function being invoked
+ * if there is one.
+ *
+ * NOTE: Because libraries do not expose their functions in their ABI, all
+ * calls to known libraries will decode to this.
+ */
 export interface MessageDecoding {
+  /**
+   * The kind of decoding; indicates that this is a MessageDecoding.
+   */
   kind: "message";
+  /**
+   * The class of contract that was called, as a Types.ContractType.
+   */
   class: Types.ContractType;
+  /**
+   * The ABI entry for the contract's fallback function; will be null if
+   * there is none.
+   */
   abi: AbiTypes.FallbackAbiEntry | null; //null indicates no fallback ABI
+  /**
+   * The data that was sent to the contract.
+   */
   data: string;
+  /**
+   * The decoding mode that was used; see the README for more on these.
+   */
   decodingMode: DecodingMode;
 }
 
+/**
+ * This type represents a function call to an unknown class, or a constructor
+ * call constructing an unknown class.  In this case, it's simply not possible
+ * to return much information.
+ */
 export interface UnknownDecoding {
+  /**
+   * The kind of decoding; indicates that this is an UnknownDecoding.
+   */
   kind: "unknown";
+  /**
+   * The decoding mode that was used; see the README for more on these.
+   */
   decodingMode: DecodingMode;
+  /**
+   * The data that was sent to the contract, or the bytecode of the constructor.
+   */
   data: string;
 }
 
+/**
+ * This type represents a decoding of a log as a non-anonymous event.
+ */
 export interface EventDecoding {
+  /**
+   * The kind of decoding; indicates that this is an EventDecoding.
+   */
   kind: "event";
+  /**
+   * The class of the contract that (according to this decoding) emitted the event, as a Types.ContractType.
+   * This may be a library!  When a library emits an event, the EVM records it as the calling contract
+   * having emitted the event, but we decode it as if the library emitted the event, for clarity.
+   * (The address of the contract the EVM thinks emitted the event can of course be found in the original log.)
+   */
   class: Types.ContractType;
+  /**
+   * The list of decoded arguments to the event.
+   */
   arguments: AbiArgument[];
+  /**
+   * The ABI entry for the event.  You can use this to extract the name, for
+   * instance.
+   */
   abi: AbiTypes.EventAbiEntry; //should be non-anonymous
+  /**
+   * The selector for the event, as a hexadecimal string.
+   */
   selector: string;
+  /**
+   * The decoding mode that was used; see the README for more on these.
+   */
   decodingMode: DecodingMode;
 }
 
+/**
+ * This type represents a decoding of a log as an anonymous event.
+ */
 export interface AnonymousDecoding {
+  /**
+   * The kind of decoding; indicates that this is an AnonymousDecoding.
+   */
   kind: "anonymous";
+  /**
+   * The class of the contract that (according to this decoding) emitted the event, as a Types.ContractType.
+   * This may be a library!  When a library emits an event, the EVM records it as the calling contract
+   * having emitted the event, but we decode it as if the library emitted the event, for clarity.
+   * (The address of the contract the EVM thinks emitted the event can of course be found in the original log.)
+   */
   class: Types.ContractType;
+  /**
+   * The list of decoded arguments to the event.
+   */
   arguments: AbiArgument[];
+  /**
+   * The ABI entry for the event.  You can use this to extract the name, for
+   * instance.
+   */
   abi: AbiTypes.EventAbiEntry; //should be anonymous
+  /**
+   * The decoding mode that was used; see the README for more on these.
+   */
   decodingMode: DecodingMode;
 }
 
+/**
+ * This type represents a decoded argument passed to a transaction or event.
+ */
 export interface AbiArgument {
+  /**
+   * The name of the parameter.  Excluded if the parameter is nameless.
+   */
   name?: string; //included if parameter is named
+  /**
+   * Whether this is an indexed paramter.  Only included for event parameters.
+   */
   indexed?: boolean; //included for event parameters
+  /**
+   * The decoded value of the argument.  Note that this is a Values.Result, so it
+   * may contain errors (although event decodings should typically not contain errors;
+   * see the DecodedLog documentation for why).
+   */
   value: Values.Result;
 }
 
 //the following types are intended for internal use only
+/**
+ * @hidden
+ */
 export interface ContractInfoAndContext {
   contractInfo: Values.ContractValueInfo;
   context?: DecoderContext;

--- a/packages/codec/lib/types/decoding.ts
+++ b/packages/codec/lib/types/decoding.ts
@@ -6,7 +6,11 @@ import { Types, Values } from "@truffle/codec/format";
  * A type representing a transaction (calldata) decoding.  As you can see, these come in four types,
  * each of which is documented separately.
  */
-export type CalldataDecoding = FunctionDecoding | ConstructorDecoding | MessageDecoding | UnknownDecoding;
+export type CalldataDecoding =
+  | FunctionDecoding
+  | ConstructorDecoding
+  | MessageDecoding
+  | UnknownDecoding;
 
 /**
  * A type representing a log (event) decoding.  As you can see, these come in two types, each of which
@@ -221,9 +225,9 @@ export interface AbiArgument {
    */
   indexed?: boolean; //included for event parameters
   /**
-   * The decoded value of the argument.  Note that this is a Values.Result, so it
+   * The decoded value of the argument.  Note that this is a [[Format.Values.Result|Values.Result]], so it
    * may contain errors (although event decodings should typically not contain errors;
-   * see the DecodedLog documentation for why).
+   * see the [[DecodedLog]] documentation for why).
    */
   value: Values.Result;
 }

--- a/packages/codec/lib/types/errors.ts
+++ b/packages/codec/lib/types/errors.ts
@@ -1,3 +1,11 @@
+/**
+ * This error indicates that the decoder was unable to locate a user-defined
+ * type (struct, enum, or contract type) via its ID.  Unfortunately, we can't
+ * always avoid this at the moment; we're hoping to make this more robust in
+ * the future with Truffle DB.  In the meantime, it is at least worth noting that
+ * you should not encounter this error if your entire project was written in
+ * Solidity and all compiled at once.  Sorry.
+ */
 export class UnknownUserDefinedTypeError extends Error {
   public typeString: string;
   public id: string;

--- a/packages/codec/lib/types/interface.ts
+++ b/packages/codec/lib/types/interface.ts
@@ -7,24 +7,87 @@ import { CalldataDecoding, LogDecoding } from "./decoding";
 import { Transaction, BlockType } from "web3/eth/types";
 import { Log } from "web3/types";
 
+/**
+ * This type represents the state of a contract aside from its storage.
+ */
 export interface ContractState {
+  /**
+   * The name of the contract.
+   */
   name: string;
+  /**
+   * The contract's balance, in Wei, as a BN.
+   */
   balanceAsBN: BN;
+  /**
+   * The contract's nonce, as a BN.
+   */
   nonceAsBN: BN;
+  /**
+   * The contract's code, as a hexidecimal string.
+   */
   code: string;
 }
 
+/**
+ * This type represents one of the decoded contract's state variables.
+ */
 export interface DecodedVariable {
+  /**
+   * The name of the variable.  Note that due to inheritance, this may not be unique.
+   */
   name: string;
+  /**
+   * The class of the contract that defined the variable, as a Types.ContractType.
+   * Note that this class may differ from that of the contract being decoded, due
+   * to inheritance.
+   */
   class: Types.ContractType;
+  /**
+   * The decoded value of the variable.  Note this is a Values.Result, so it may be an error.
+   */
   value: Values.Result;
 }
 
+/**
+ * This type represents a web3 Transaction object that has been decoded.
+ * Note that it extends the Transaction type and just adds an additional field
+ * with the decoding.
+ */
 export interface DecodedTransaction extends Transaction {
+  /**
+   * The decoding of the transaction.  Note that transactions are not decoded in strict mode,
+   * so there will always be a decoding, although it may contain errors.
+   */
   decoding: CalldataDecoding;
 }
 
+/**
+ * This type represents a web3 Log object that has been decoded.
+ * Note that it extends the Log type and just adds an additional field
+ * with the decoding.
+ */
 export interface DecodedLog extends Log {
+  /**
+   * An array of possible decodings of the given log -- it's an array because logs can be ambiguous.
+   * Note that logs are decoded in strict mode, so (with one exception) none of the decodings should
+   * contain errors; if a decoding would contain an error, instead it is simply excluded from the
+   * list of possible decodings.  The one exception to this is that indexed parameters of reference
+   * type cannot meaningfully be decoded, so those will decode to an error.
+   *
+   * If there are multiple possible decodings, they will always be listed in the following order:
+   *
+   * 1. A non-anonymous event coming from the contract itself (there can be at most one of these)
+   * 2. Non-anonymous events coming from libraries
+   * 3. Anonymous events coming from the contract itself
+   * 4. Anonymous events coming from libraries
+   *
+   * You can check the kind and class.contractKind fields to distinguish between these.
+   *
+   * If no possible decodings are found, the list of decodings will be empty.
+   *
+   * Note that different decodings may use different decoding modes.
+   */
   decodings: LogDecoding[];
 }
 
@@ -53,9 +116,30 @@ export interface ContractAndContexts {
   constructorContext?: DecoderContext;
 }
 
+/**
+ * The type of the options parameter to events().  This type will be expanded in the future
+ * as more filtering options are added.
+ */
 export interface EventOptions {
+  /**
+   * If included, the name parameter will restrict to events with the given name.
+   */
   name?: string;
+  /**
+   * The earliest block to include events from.  Defaults to "latest".
+   */
   fromBlock?: BlockType;
+  /**
+   * The latest block to include events from.  Defaults to "latest".
+   */
   toBlock?: BlockType;
-  address?: string; //ignored by contract decoder!
+  /**
+   * If included, will restrict to events emitted by the given address.
+   *
+   * NOTE: In the contract instance decoder, if omitted, defaults to the
+   * address of the contract instance being decoded, rather than not filtering
+   * by address.  However, this behavior can be turned off by explicitly specifying
+   * address as undefined.
+   */
+  address?: string;
 }

--- a/packages/codec/lib/types/interface.ts
+++ b/packages/codec/lib/types/interface.ts
@@ -93,7 +93,7 @@ export interface DecodedLog extends Log {
 
 export interface ContractMapping {
   [nodeId: number]: ContractObject;
-};
+}
 
 export interface StorageCache {
   [block: number]: {
@@ -127,10 +127,14 @@ export interface EventOptions {
   name?: string;
   /**
    * The earliest block to include events from.  Defaults to "latest".
+   * See [the web3 docs](https://web3js.readthedocs.io/en/v1.2.1/web3-eth.html#id14)
+   * for legal values.
    */
   fromBlock?: BlockType;
   /**
    * The latest block to include events from.  Defaults to "latest".
+   * See [the web3 docs](https://web3js.readthedocs.io/en/v1.2.1/web3-eth.html#id14)
+   * for legal values.
    */
   toBlock?: BlockType;
   /**


### PR DESCRIPTION
This PR adds a bunch of documentation for the new codec, mostly in the form of TypeDoc comments, but also there's a README.  Hooray...

Note that `Format` has been mostly left alone as self-explanatory, with just occasional comments where I thought it necessary.  The rest though has plenty of comments...