### PR TITLE
Bug fix: Update glob pattern for test file search

### DIFF
--- a/packages/core/lib/commands/test.js
+++ b/packages/core/lib/commands/test.js
@@ -79,7 +79,7 @@ const command = {
     try {
       if (files.length === 0) {
         const directoryContents = glob.sync(
-          `${config.test_directory}${path.sep}*`
+          `${config.test_directory}${path.sep}**${path.sep}*`
         );
         files =
           directoryContents.filter(item => fs.statSync(item).isFile()) || [];


### PR DESCRIPTION
There is a bug in 5.0.40 where when running `truffle test` it won't search recursively in the test folder for test files. This updates the glob pattern search to do this.