### PR TITLE
Bug fix: Filter out non-json files in build folder

### DIFF
--- a/packages/core/lib/testing/testsource.js
+++ b/packages/core/lib/testing/testsource.js
@@ -27,6 +27,10 @@ TestSource.prototype.resolve = function(importPath, callback) {
         abstractionFiles = fse.readdirSync(
           self.config.contracts_build_directory
         );
+        // Filter out non-json files
+        abstractionFiles = abstractionFiles.filter(file => {
+          return file.match(/^.*.json$/);
+        });
       } catch (error) {
         return callback(error);
       }

--- a/packages/core/lib/testing/testsource.js
+++ b/packages/core/lib/testing/testsource.js
@@ -27,10 +27,9 @@ TestSource.prototype.resolve = function(importPath, callback) {
         const buildDirFiles = (abstractionFiles = fse.readdirSync(
           self.config.contracts_build_directory
         ));
-        // Filter out non-json files
-        abstractionFiles = buildDirFiles.filter(file => {
-          return file.match(/^.*.json$/);
-        });
+        abstractionFiles = buildDirFiles.filter(file =>
+          file.match(/^.*.json$/)
+        );
       } catch (error) {
         return callback(error);
       }

--- a/packages/core/lib/testing/testsource.js
+++ b/packages/core/lib/testing/testsource.js
@@ -24,11 +24,11 @@ TestSource.prototype.resolve = function(importPath, callback) {
 
       let abstractionFiles;
       try {
-        abstractionFiles = fse.readdirSync(
+        const buildDirFiles = (abstractionFiles = fse.readdirSync(
           self.config.contracts_build_directory
-        );
+        ));
         // Filter out non-json files
-        abstractionFiles = abstractionFiles.filter(file => {
+        abstractionFiles = buildDirFiles.filter(file => {
           return file.match(/^.*.json$/);
         });
       } catch (error) {


### PR DESCRIPTION
This ignores all non-json files in the build folder when loading artifacts during testing.