### PR TITLE
Bug fix: Do not process contracts when none are found in compiler output

### DIFF
--- a/packages/compile-solidity/run.js
+++ b/packages/compile-solidity/run.js
@@ -331,6 +331,7 @@ function processContracts({
   originalSourcePaths,
   solcVersion
 }) {
+  if (!compilerOutput.contracts) return [];
   return (
     Object.entries(compilerOutput.contracts)
       // map to [[{ source, contractName, contract }]]


### PR DESCRIPTION
If no contracts were found in compiled files, do not attempt to process the contract output.

This fixes a bug regarding the case where there is a source that does not have a contract declared in it. In that case, the compiler output will not have a `contracts` property. When it attempts to process the contracts, an error will occur. This PR checks to see if the `contracts` property is undefined and if it is, returns an empty array.

The one slightly "off" thing about this PR is that the output will be something like the following:
<img width="607" alt="Screen Shot 2019-10-17 at 5 44 49 PM" src="https://user-images.githubusercontent.com/14827965/67046011-c6908000-f105-11e9-85a6-480d5dd5fa84.png">

You will notice that it says "Compiling ./contracts/Imports.sol" and later on it says "Everything is up to date, there is nothing to compile". That is because it prints the first message before actually compiling. Once it determines there were no contracts compiled, then it prints the second message.

Perhaps we should change the first message to something like "Preparing to compile ./contracts/Imports.sol". That way it would be slightly less awkward of a message for the user. Thoughts?
