### PR TITLE
Workarounds for test event errors

### DIFF
--- a/packages/contract/lib/utils.js
+++ b/packages/contract/lib/utils.js
@@ -66,10 +66,14 @@ const Utils = {
         let logArgs;
         try {
           logArgs = abi.decodeLog(logABI.inputs, copy.data, copy.topics);
+          copy.args = reformat.numbers.call(
+            constructor,
+            logArgs,
+            logABI.inputs
+          );
         } catch (_) {
           return null;
         }
-        copy.args = reformat.numbers.call(constructor, logArgs, logABI.inputs);
 
         delete copy.data;
         delete copy.topics;

--- a/packages/core/lib/testing/testrunner.js
+++ b/packages/core/lib/testing/testrunner.js
@@ -206,6 +206,10 @@ TestRunner.prototype.endTest = function(mocha, callback) {
         } catch (_) {
           //temporary HACK until we're using the new decoder
           self.logger.log(`    Warning: event decoding failed`);
+          self.logger.log(
+            `    (This may be due to multiple events with same signature`
+          );
+          self.logger.log(`    or due to unsupported data types)`);
           return;
         }
 

--- a/packages/core/lib/testing/testrunner.js
+++ b/packages/core/lib/testing/testrunner.js
@@ -196,11 +196,18 @@ TestRunner.prototype.endTest = function(mocha, callback) {
           return input.type;
         });
 
-        var values = abi.decodeLog(
-          event.abi_entry.inputs,
-          log.data,
-          log.topics.slice(1) // skip topic[0] for non-anonymous event
-        );
+        var values;
+        try {
+          values = abi.decodeLog(
+            event.abi_entry.inputs,
+            log.data,
+            log.topics.slice(1) // skip topic[0] for non-anonymous event
+          );
+        } catch (_) {
+          //temporary HACK until we're using the new decoder
+          self.logger.log(`    Warning: event decoding failed`);
+          return;
+        }
 
         var eventName = event.abi_entry.name;
         var eventArgs = event.abi_entry.inputs


### PR DESCRIPTION
This PR provides some temporary workarounds for #2449 until the new decoder is ready.

In the test runner, this consists of putting a try/catch around event decoding and just printing a warning if it fails.

In `contract`, this consists of moving the number formatting call into the try/catch I earlier put around event decoding (thanks @eggplantzzz for figuring out this problem).