### PR TITLE
support command-line args as `--option=value` #2173

### DIFF
--- a/packages/core/cli.js
+++ b/packages/core/cli.js
@@ -10,6 +10,8 @@ const version = require("./lib/version");
 const versionInfo = version.info();
 const XRegExp = require("xregexp");
 
+const { reformatArguments } = require("./utils");
+
 // pre-flight check: Node version compatibility
 const minimumNodeVersion = "8.9.4";
 if (!semver.satisfies(process.version, ">=" + minimumNodeVersion)) {
@@ -49,6 +51,9 @@ if (userWantsGeneralHelp) {
   command.displayGeneralHelp();
   process.exit(0);
 }
+
+// Reformat the arguments to allow --option=value
+reformatArguments(inputArguments);
 
 command.run(inputArguments, options, function(err) {
   if (err) {

--- a/packages/core/cli.js
+++ b/packages/core/cli.js
@@ -10,7 +10,7 @@ const version = require("./lib/version");
 const versionInfo = version.info();
 const XRegExp = require("xregexp");
 
-const { reformatArguments } = require("./utils");
+const { reformatArguments } = require("./utils"); // to reformat arguments of type --option=value
 
 // pre-flight check: Node version compatibility
 const minimumNodeVersion = "8.9.4";

--- a/packages/core/utils.js
+++ b/packages/core/utils.js
@@ -1,0 +1,25 @@
+// Regex for checking --option=value
+const argTester = /--[a-zA-Z0-9]+[-]*[a-z0-9A-Z]*=[a-zA-Z0-9.-:]+/;
+
+// Reformats the arguments --option=value to  --option value
+const reformatArguments = inputArguments => {
+  inputArguments.map((arg, i) => {
+    // If arg is in form --option=value
+    if (argTester.test(arg)) {
+      if (arg.replace(argTester, "").length === 0) {
+        let splittedArgs = arg.split("=");
+        // Check if value=true then don't include the value  in inputArguments
+        if (splittedArgs[1] === "true") {
+          inputArguments.splice(i, 1, splittedArgs[0]);
+        } else if (splittedArgs[1] === "false") {
+          // if value is  false then remove that inputArguments
+          inputArguments.splice(i, 1);
+        } else {
+          inputArguments.splice(i, 1, ...splittedArgs); // push down the splittedArgs
+        }
+      }
+    }
+  });
+};
+
+module.exports.reformatArguments = reformatArguments;


### PR DESCRIPTION
This PR is for #2173
Supports command line arguments also as `--option=value` (not just  `--option value`)
If argument is provided as `--option=true` then only `--option` is passed down as argument
A separate file **packages/core/utils.js** consists the code for this