### PR TITLE
Replace name with class and address

### DIFF
--- a/packages/codec/lib/format/values.ts
+++ b/packages/codec/lib/format/values.ts
@@ -35,15 +35,29 @@ export * from "./elementary";
  */
 
 //This is the overall Result type.  It may encode an actual value or an error.
-export type Result = ElementaryResult
-  | ArrayResult | MappingResult | StructResult | TupleResult | MagicResult
+export type Result =
+  | ElementaryResult
+  | ArrayResult
+  | MappingResult
+  | StructResult
+  | TupleResult
+  | MagicResult
   | EnumResult
-  | ContractResult | FunctionExternalResult | FunctionInternalResult;
+  | ContractResult
+  | FunctionExternalResult
+  | FunctionInternalResult;
 //for when you want an actual value
-export type Value = ElementaryValue
-  | ArrayValue | MappingValue | StructValue | TupleValue | MagicValue
+export type Value =
+  | ElementaryValue
+  | ArrayValue
+  | MappingValue
+  | StructValue
+  | TupleValue
+  | MagicValue
   | EnumValue
-  | ContractValue | FunctionExternalValue | FunctionInternalValue;
+  | ContractValue
+  | FunctionExternalValue
+  | FunctionInternalValue;
 
 /*
  * SECTION 2: Elementary values
@@ -54,9 +68,15 @@ export type Value = ElementaryValue
 //those (and defines the Result types)
 
 //overall groupings
-export type ElementaryResult = UintResult | IntResult | BoolResult
-  | BytesResult | AddressResult | StringResult
-  | FixedResult | UfixedResult;
+export type ElementaryResult =
+  | UintResult
+  | IntResult
+  | BoolResult
+  | BytesResult
+  | AddressResult
+  | StringResult
+  | FixedResult
+  | UfixedResult;
 export type BytesResult = BytesStaticResult | BytesDynamicResult;
 
 //integers
@@ -68,9 +88,13 @@ export type IntResult = IntValue | Errors.IntErrorResult;
 export type BoolResult = BoolValue | Errors.BoolErrorResult;
 
 //bytes (static & dynaic)
-export type BytesStaticResult = BytesStaticValue | Errors.BytesStaticErrorResult;
+export type BytesStaticResult =
+  | BytesStaticValue
+  | Errors.BytesStaticErrorResult;
 
-export type BytesDynamicResult = BytesDynamicValue | Errors.BytesDynamicErrorResult;
+export type BytesDynamicResult =
+  | BytesDynamicValue
+  | Errors.BytesDynamicErrorResult;
 
 //addresses
 export type AddressResult = AddressValue | Errors.AddressErrorResult;
@@ -162,7 +186,7 @@ export interface MagicValue {
   kind: "value";
   //a magic variable can't be circular, duh!
   value: {
-    [field: string]: Result
+    [field: string]: Result;
   };
 }
 
@@ -184,7 +208,7 @@ export interface EnumValue {
      */
     numericAsBN: BN;
   };
-};
+}
 
 /*
  * SECTION 5: CONTRACTS
@@ -204,7 +228,9 @@ export interface ContractValue {
  * There are two types -- one for contracts whose class we can identify, and one
  * for when we can't identify the class.
  */
-export type ContractValueInfo = ContractValueInfoKnown | ContractValueInfoUnknown;
+export type ContractValueInfo =
+  | ContractValueInfoKnown
+  | ContractValueInfoUnknown;
 
 /**
  * This type of ContractValueInfo is used when we can identify the class.
@@ -217,7 +243,7 @@ export interface ContractValueInfoKnown {
    */
   address: string;
   /**
-   * this is just a hexstring; no checksum (also may have padding on end)
+   * this is just a hexstring; no checksum (also may have padding beforehand)
    */
   rawAddress?: string;
   class: Types.ContractType;
@@ -235,7 +261,7 @@ export interface ContractValueInfoUnknown {
    */
   address: string;
   /**
-   * this is just a hexstring; no checksum (also may have padding on end)
+   * this is just a hexstring; no checksum (also may have padding beforehand)
    */
   rawAddress?: string;
 }
@@ -245,7 +271,9 @@ export interface ContractValueInfoUnknown {
  */
 
 //external functions
-export type FunctionExternalResult = FunctionExternalValue | Errors.FunctionExternalErrorResult;
+export type FunctionExternalResult =
+  | FunctionExternalValue
+  | Errors.FunctionExternalErrorResult;
 
 export interface FunctionExternalValue {
   type: Types.FunctionExternalType;
@@ -260,7 +288,7 @@ export interface FunctionExternalValue {
  * 3. can't determine class
  */
 export type FunctionExternalValueInfo =
-  FunctionExternalValueInfoKnown //known function of known class
+  | FunctionExternalValueInfoKnown //known function of known class
   | FunctionExternalValueInfoInvalid //known class, but can't locate function
   | FunctionExternalValueInfoUnknown; //can't determine class
 
@@ -307,7 +335,9 @@ export interface FunctionExternalValueInfoUnknown {
  */
 
 //Internal functions
-export type FunctionInternalResult = FunctionInternalValue | Errors.FunctionInternalErrorResult;
+export type FunctionInternalResult =
+  | FunctionInternalValue
+  | Errors.FunctionInternalErrorResult;
 
 export interface FunctionInternalValue {
   type: Types.FunctionInternalType;
@@ -322,7 +352,7 @@ export interface FunctionInternalValue {
  * 3. A special value to indicate that decoding internal functions isn't supported in this context.
  */
 export type FunctionInternalValueInfo =
-  FunctionInternalValueInfoKnown //actual function
+  | FunctionInternalValueInfoKnown //actual function
   | FunctionInternalValueInfoException //default value
   | FunctionInternalValueInfoUnknown; //decoding not supported in this context
 
@@ -330,7 +360,7 @@ export type FunctionInternalValueInfo =
  * This type of FunctionInternalValueInfo is used for an actual internal function.
  */
 export interface FunctionInternalValueInfoKnown {
-  kind: "function"
+  kind: "function";
   context: Types.ContractType;
   deployedProgramCounter: number;
   constructorProgramCounter: number;
@@ -347,7 +377,7 @@ export interface FunctionInternalValueInfoKnown {
  * Elsewhere they're both nonzero.
  */
 export interface FunctionInternalValueInfoException {
-  kind: "exception"
+  kind: "exception";
   context: Types.ContractType;
   deployedProgramCounter: number;
   constructorProgramCounter: number;
@@ -363,7 +393,7 @@ export interface FunctionInternalValueInfoException {
  * doesn't have the information to determine that it's an error.
  */
 export interface FunctionInternalValueInfoUnknown {
-  kind: "unknown"
+  kind: "unknown";
   context: Types.ContractType;
   deployedProgramCounter: number;
   constructorProgramCounter: number;

--- a/packages/decoder/lib/errors.ts
+++ b/packages/decoder/lib/errors.ts
@@ -9,6 +9,7 @@ export class ContractBeingDecodedHasNoNodeError extends Error {
   constructor(contractName: string) {
     const message = `Contract ${contractName} does not appear to have been compiled with Solidity (cannot locate contract node)`;
     super(message);
+    this.contractName = contractName;
     this.name = "ContractBeingDecodedHasNoNodeError";
   }
 }
@@ -27,6 +28,25 @@ export class ContractAllocationFailedError extends Error {
   public contractName: string;
   constructor(id: number, contractName: string) {
     super(`No allocation found for contract ID ${id} (${contractName})`);
+    this.id = id;
+    this.contractName = contractName;
     this.name = "ContractAllocationFailedError";
+  }
+}
+
+/**
+ * This error indicates that an invalid address was passed to
+ * [[ContractDecoder.forInstance]] or [[forContractInstance]].  Valid addresses
+ * are those that web3 accepts; i.e., either those with correct checksums, or
+ * those that are all-lowercase or all-uppercase to deliberately circumvent the
+ * checksum.
+ * @category Exception
+ */
+export class InvalidAddressError extends Error {
+  public address: string;
+  constructor(address: string) {
+    super(`Invalid address ${address}`);
+    this.address = address;
+    this.name = "InvalidAddressError";
   }
 }

--- a/packages/decoder/lib/types.ts
+++ b/packages/decoder/lib/types.ts
@@ -16,9 +16,13 @@ import { Log } from "web3/types";
  */
 export interface ContractState {
   /**
-   * The name of the contract.
+   * The contract's class, as a Format.Types.ContractType.
    */
-  name: string;
+  class: Format.Types.ContractType;
+  /**
+   * The contract's address, as a checksummed hex string.
+   */
+  address: string;
   /**
    * The contract's balance, in Wei, as a BN.
    */

--- a/packages/decoder/test/test/decoding-test.js
+++ b/packages/decoder/test/test/decoding-test.js
@@ -54,7 +54,7 @@ contract("DecodingSample", _accounts => {
     //   })
     // );
 
-    assert.equal(initialState.name, "DecodingSample");
+    assert.equal(initialState.class.typeName, "DecodingSample");
     //before we move on to the main section, we'll test the defining classes
     //of the first two variables
     assert.equal(initialVariables[0].class.typeName, "DecodingSampleParent");


### PR DESCRIPTION
This PR replaces the `name` field of `ContractState` with a `class` field, and also adds an `address` field.  The `class` field is a `ContractType` and contains the name among other info.  This is a breaking change.  Tests are updated appropriately.

(Also, `prettier` seems to have done some work here... oops? :-/ )

This PR also makes a slight change to handling of user-inputted addresses.  Before they weren't checked; Web3 would check them when used, but we didn't do the check, which is potentially troublesome.  Now they're checked on use (as in, either they should be checksummed, or else they should be all one case to circumvent the checksum), and converted to checksum form if not in that form already.

I also fixed some comments and some error constructors, which you shouldn't really do in the same commit, but oh well...

BTW, possibly crazy idea I had: What if instead of `ContractState`, we returned a `Format.Values.ContractValue`??  The other stuff in `ContractState` being added as optional fields in `ContractValue`??  I didn't do that in this PR as I'm not sure it's the right thing to do and I wanted this done quickly, but I thought it was worth raising the idea...