### PR TITLE
Split UnknownDecoding type in two

### DIFF
--- a/packages/codec/lib/core.ts
+++ b/packages/codec/lib/core.ts
@@ -33,21 +33,30 @@ export function* decodeVariable(
 }
 
 export function* decodeCalldata(
-  info: Evm.EvmInfo
+  info: Evm.EvmInfo,
+  isConstructor?: boolean //ignored if context! trust context instead if have
 ): Generator<DecoderRequest, CalldataDecoding, Uint8Array> {
   const context = info.currentContext;
   if (context === null) {
     //if we don't know the contract ID, we can't decode
-    return {
-      kind: "unknown" as const,
-      decodingMode: "full" as const,
-      data: Conversion.toHexString(info.state.calldata)
-    };
+    if (isConstructor) {
+      return {
+        kind: "create" as const,
+        decodingMode: "full" as const,
+        bytecode: Conversion.toHexString(info.state.calldata)
+      };
+    } else {
+      return {
+        kind: "unknown" as const,
+        decodingMode: "full" as const,
+        data: Conversion.toHexString(info.state.calldata)
+      };
+    }
   }
   const compiler = context.compiler;
   const contextHash = context.context;
   const contractType = Contexts.Utils.contextToType(context);
-  const isConstructor: boolean = context.isConstructor;
+  isConstructor = context.isConstructor;
   const allocations = info.allocations.calldata;
   let allocation: Allocation.CalldataAllocation;
   let selector: string;

--- a/packages/codec/lib/types.ts
+++ b/packages/codec/lib/types.ts
@@ -4,10 +4,15 @@ import * as Abi from "@truffle/codec/abi/types";
 import * as Format from "@truffle/codec/format";
 
 /**
- * A type representing a transaction (calldata) decoding.  As you can see, these come in four types,
+ * A type representing a transaction (calldata) decoding.  As you can see, these come in five types,
  * each of which is documented separately.
  */
-export type CalldataDecoding = FunctionDecoding | ConstructorDecoding | MessageDecoding | UnknownDecoding;
+export type CalldataDecoding =
+  | FunctionDecoding
+  | ConstructorDecoding
+  | MessageDecoding
+  | UnknownCallDecoding
+  | UnknownCreationDecoding;
 
 /**
  * A type representing a log (event) decoding.  As you can see, these come in two types, each of which
@@ -123,11 +128,10 @@ export interface MessageDecoding {
 }
 
 /**
- * This type represents a function call to an unknown class, or a constructor
- * call constructing an unknown class.  In this case, it's simply not possible
- * to return much information.
+ * This type represents a function call to an unknown class.  In this case,
+ * it's simply not possible to return much information.
  */
-export interface UnknownDecoding {
+export interface UnknownCallDecoding {
   /**
    * The kind of decoding; indicates that this is an UnknownDecoding.
    */
@@ -137,9 +141,28 @@ export interface UnknownDecoding {
    */
   decodingMode: DecodingMode;
   /**
-   * The data that was sent to the contract, or the bytecode of the constructor.
+   * The data that was sent to the contract
    */
   data: string;
+}
+
+/**
+ * This type represents a contract creation for an unknown class. In this case,
+ * it's simply not possible to return much information.
+ */
+export interface UnknownCreationDecoding {
+  /**
+   * The kind of decoding; indicates that this is an UnknownCreationDecoding.
+   */
+  kind: "create";
+  /**
+   * The decoding mode that was used; see the README for more on these.
+   */
+  decodingMode: DecodingMode;
+  /**
+   * The bytecode of the contract creation
+   */
+  bytecode: string;
 }
 
 /**

--- a/packages/decoder/lib/decoders/wire.ts
+++ b/packages/decoder/lib/decoders/wire.ts
@@ -82,8 +82,9 @@ export default class WireDecoder {
     );
     this.deployedContexts = Object.assign(
       {},
-      ...Object.values(this.contexts).map(context =>
-        !context.isConstructor ? { [context.context]: context } : {}
+      ...Object.values(this.contexts).map(
+        context =>
+          !context.isConstructor ? { [context.context]: context } : {}
       )
     );
 
@@ -218,6 +219,7 @@ export default class WireDecoder {
   ): Promise<DecoderTypes.DecodedTransaction> {
     debug("transaction: %O", transaction);
     const block = transaction.blockNumber;
+    const isConstructor = transaction.to === null;
     const context = await this.getContextByAddress(
       transaction.to,
       block,
@@ -236,7 +238,7 @@ export default class WireDecoder {
       contexts: { ...this.deployedContexts, ...additionalContexts },
       currentContext: context
     };
-    const decoder = decodeCalldata(info);
+    const decoder = decodeCalldata(info, isConstructor);
 
     let result = decoder.next();
     while (result.done === false) {


### PR DESCRIPTION
This PR splits the `UnknownDecoding` type into `UnknownCallDecoding` and `UnknownCreationDecoding`.  This is a breaking change.

The two types are basically the same except that `UnknownCreationDecoding` has a `bytecode` field instead of a `data` field.  But that's it.

The tag for `UnknownCallDecoding` remains as `"unknown"`; the tag for `UnknownCreationDecoding` is `"create"`.

Note that in order to do this I had to add an extra argument to `decodeCalldata`, one specifying whether you're looking a constructor or not.  I made it optional.  Note that this argument is ignored if we have an actual context, since that context will include the information about whether it's a constructor or not.  The function will trust the context as long as one was passed in in the `info`.  If none was passed in, however, it needs to use this new argument to determine whether to return an `UnknownCallDecoding` or an `UnknownCreationDecoding`.

You may notice that `abify.ts` was not changed.  That's because both of these fall under the `default` case there, which works fine for both, so there's no need to change anything.