### PR TITLE
Add test & comment re: circular types

### DIFF
--- a/packages/codec/lib/ast/utils.ts
+++ b/packages/codec/lib/ast/utils.ts
@@ -564,6 +564,13 @@ function parametersToAbi(
   );
 }
 
+//NOTE: This function is only for types that could potentially go in the ABI!
+//(otherwise it could, say, loop infinitely)
+//currently it will only ever be called on those because it's only called from
+//definitionToAbi, which filters out any definitions that are not for
+//this that *actually* go in the ABI
+//if you want to expand it to handle those (by throwing an exception, say),
+//you'll need to give it a way to detect circularities
 function parameterToAbi(
   node: AstNode,
   referenceDeclarations: AstNodes,

--- a/packages/decoder/test/contracts/WireTest.sol
+++ b/packages/decoder/test/contracts/WireTest.sol
@@ -27,6 +27,16 @@ contract WireTest is WireTestParent {
     bytes z;
   }
 
+  //the point of including this is to test that it doesn't send
+  //the allocator into an infinite loop
+  struct RedHerring {
+    RedHerring[] redHerring;
+  }
+
+  //similarly
+  function redHerring(RedHerring memory) internal pure {
+  }
+
   enum Ternary {
     Yes, No, MaybeSo
   }


### PR DESCRIPTION
This PR *was* going to fix a bug that I thought existed regarding circular types in the allocator.  It turns out that this bug doesn't exist though.  So instead I added a comment explaining why it doesn't exist (so I don't make this mistake again) and a test of its nonexistence (just in case somene accidentally causes it to exist someday).