### PR TITLE
Redo @truffle/decoder constructor functions

### DIFF
--- a/packages/decoder/README.md
+++ b/packages/decoder/README.md
@@ -30,14 +30,26 @@ this README describes the overall approach.
 
 ### Initialization
 
-Create a decoder with one of the following functions:
-* [[forProject|`forProject`]]
-* [[forContract|`forContract`]]
-* [[forContractWithDecoder|`forContractWithDecoder`]]
-* [[forContractInstance|`forContractInstance`]]
+Create a decoder with one of the various constructor functions.
+
+For a wire decoder, use the [[forProject|`forProject`]] function.
+
+For a contract decoder, use the [[forArtifact|`forArtifact`]] or
+[[forContract|`forContract`]] function.
+
+For a contract instance decoder, use one of the following:
+* [[forDeployedArtifact|`forDeployedArtifact`]]
+* [[forDeployedContract|`forDeployedContract`]]
+* [[forArtifactAt|`forArtifactAt`]]
+* [[forContractAt|`forContractAt`]]
+* [[forContractAbstraction|`forContractAbstraction`]]
 
 See the API documentation of these functions for details, or below for usage
 examples.
+
+All of these functions presently require a final argument containing all
+artifacts that could potentially be relevant.  It's intended that this argument
+will be optional in the future.
 
 ### Methods
 
@@ -183,11 +195,11 @@ This usage example is for a project with two contracts, `Contract1` and
 `Contract2`.
 
 ```typescript
-import { forProject } from "@truffle/codec";
+import { forProject } from "@truffle/decoder";
 const contract1 = artifacts.require("Contract1");
 const contract2 = artifacts.require("Contract2");
 const provider = web3.currentProvider;
-const decoder = await Decoder.forProject([contract1, contract2], provider);
+const decoder = await Decoder.forProject(provider, [contract1, contract2]);
 const decodedLog = await decoder.decodeLog(log);
 ```
 
@@ -202,11 +214,10 @@ This usage example is for decoding the state variables of a contract `Contract`
 in a project that also contains a contract `OtherContract`.
 
 ```typescript
-import { forContract } from "@truffle/codec";
+import { forContract } from "@truffle/decoder";
 const contract = artifacts.require("Contract");
 const otherContract = artifacts.require("OtherContract");
-const provider = web3.currentProvider;
-const decoder = await Decoder.forContract(contract, [otherContract], provider);
+const decoder = await Decoder.forContract(contract, [otherContract]);
 const instanceDecoder = await decoder.forInstance();
 const variables = await instanceDecoder.variables();
 ```
@@ -215,8 +226,21 @@ In this example, we use the deployed version of `Contract`.  If we wanted an
 instance at a different address, we could pass the address to `forInstance`.
 
 In addition, rather than using `forContract` and then `forInstance`, we could
-also use [[forContractInstance|`forContractInstance`]] to perform both of these
-in one step.
+also use [[forDeployedContract|`forContractInstance`]] to perform both of these
+in one step.  If we wanted to do this with a specified address, we could use
+[[forContractAt|`forContractAt`]].
+
+Yet another way would be:
+```typescript
+import { forContractAbstraction } from "@truffle/decoder";
+const contract = artifacts.require("Contract");
+const otherContract = artifacts.require("OtherContract");
+const deployedContract = await contract.deployed();
+const instanceDecoder = await Decoder.forContractAbstraction(deployedContract, [otherContract]);
+const variables = await instanceDecoder.variables();
+```
+
+These examples are not exhaustive.
 
 See the API documentation for more advanced decoding examples with
 [[ContractInstanceDecoder.variable|`variable`]] or

--- a/packages/decoder/lib/index.ts
+++ b/packages/decoder/lib/index.ts
@@ -35,7 +35,7 @@ import { ContractConstructorObject, ContractInstanceObject } from "./types";
 /**
  * Constructs a wire decoder for the project.
  * @param provider The Web3 provider object to use.
- * @param contracts A list of contract artifacts for contracts in the project.
+ * @param artifacts A list of contract artifacts for contracts in the project.
  *
  *   Contract constructor objects may be substituted for artifacts, so if
  *   you're not sure which you're dealing with, it's OK.
@@ -44,19 +44,19 @@ import { ContractConstructorObject, ContractInstanceObject } from "./types";
  */
 export async function forProject(
   provider: Provider,
-  contracts: ContractObject[]
+  artifacts: ContractObject[]
 ): Promise<WireDecoder> {
-  return new WireDecoder(contracts, provider);
+  return new WireDecoder(artifacts, provider);
 }
 
 /**
- * Constructs a contract instance decoder for a given contract instance.
- * @param contract The artifact for the contract.
+ * Constructs a contract decoder for a given contract artifact.
+ * @param artifact The artifact for the contract.
  *
  *   A contract constructor object may be substituted for the artifact, so if
  *   you're not sure which you're dealing with, it's OK.
  * @param provider The Web3 provider object to use.
- * @param relevantContracts A list of artifacts for other contracts in the project that may be relevant
+ * @param artifacts A list of artifacts for other contracts in the project that may be relevant
  *   (e.g., providing needed struct or enum definitions, or appearing as a contract type).
  *
  *   Contract constructor objects may be substituted for artifacts, so if
@@ -67,82 +67,73 @@ export async function forProject(
  *   This parameter is intended to be made optional in the future.
  */
 export async function forArtifact(
-  contract: ContractObject,
+  artifact: ContractObject,
   provider: Provider,
-  relevantContracts: ContractObject[]
+  artifacts: ContractObject[]
 ): Promise<ContractDecoder> {
-  let contracts = relevantContracts.includes(contract)
-    ? relevantContracts
-    : [contract, ...relevantContracts];
-  let wireDecoder = await forProject(provider, contracts);
-  let contractDecoder = new ContractDecoder(contract, wireDecoder);
+  artifacts = artifacts.includes(artifact)
+    ? artifacts
+    : [artifact, ...artifacts];
+  let wireDecoder = await forProject(provider, artifacts);
+  let contractDecoder = new ContractDecoder(artifact, wireDecoder);
   await contractDecoder.init();
   return contractDecoder;
 }
 
 /**
- * Constructs a contract instance decoder for a given contract instance.
+ * Constructs a contract decoder for a given contract.
  * @param contract The contract constructor object corresponding to the type of the contract.
- * @param provider The Web3 provider object to use.
- * @param relevantContracts A list of artifacts for other contracts in the project that may be relevant
+ * @param artifacts A list of artifacts for other contracts in the project that may be relevant
  *   (e.g., providing needed struct or enum definitions, or appearing as a contract type).
  *
- *   See the relevantContracts parameter documentation on [[forArtifact]] for more detail.
+ *   See the artifacts parameter documentation on [[forArtifact]] for more detail.
  *
  *   This parameter is intended to be made optional in the future.
  */
 export async function forContract(
   contract: ContractConstructorObject,
-  relevantContracts: ContractObject[]
+  artifacts: ContractObject[]
 ): Promise<ContractDecoder> {
-  return await forArtifact(
-    contract,
-    contract.web3.currentProvider,
-    relevantContracts
-  );
+  return await forArtifact(contract, contract.web3.currentProvider, artifacts);
 }
 
 /**
  * Constructs a contract decoder given an existing wire decoder for the project.
- * @param contract The artifact corresponding to the type of the contract.
+ * @param artifact The artifact corresponding to the type of the contract.
  *
  *   A contract constructor object may be substituted for the artifact, so if
  *   you're not sure which you're dealing with, it's OK.
  * @param decoder An existing wire decoder for the project.
  */
 export async function forArtifactWithDecoder(
-  contract: ContractObject,
+  artifact: ContractObject,
   decoder: WireDecoder
 ): Promise<ContractDecoder> {
-  let contractDecoder = new ContractDecoder(contract, decoder);
+  let contractDecoder = new ContractDecoder(artifact, decoder);
   await contractDecoder.init();
   return contractDecoder;
 }
 
 /**
  * Constructs a contract instance decoder for a deployed contract instance.
- * @param contract The artifact corresponding to the type of the contract.
+ * @param artifact The artifact corresponding to the type of the contract.
  *
  *   A contract constructor object may be substituted for the artifact, so if
  *   you're not sure which you're dealing with, it's OK.
  * @param provider The Web3 provider object to use.
- * @param relevantContracts A list of artifacts for other contracts in the project that may be relevant
+ * @param artifacts A list of artifacts for other contracts in the project that may be relevant
  *   (e.g., providing needed struct or enum definitions, or appearing as a contract type).
  *
- *   See the relevantContracts parameter documentation on [[forArtifact]] for more detail.
+ *   See the artifacts parameter documentation on [[forArtifact]] for more detail.
  *
  *   This parameter is intended to be made optional in the future.
  */
 export async function forDeployedArtifact(
-  contract: ContractObject,
+  artifact: ContractObject,
   provider: Provider,
-  relevantContracts: ContractObject[]
+  artifacts: ContractObject[]
 ): Promise<ContractInstanceDecoder> {
-  let contractDecoder = await forArtifact(
-    contract,
-    provider,
-    relevantContracts
-  );
+  let contractDecoder = await forArtifact(artifact, provider, artifacts);
   let instanceDecoder = await contractDecoder.forInstance();
   return instanceDecoder;
 }
@@ -150,25 +141,25 @@ export async function forDeployedArtifact(
 /**
  * Constructs a contract instance decoder for a deployed contract instance.
  * @param contract The contract constructor object corresponding to the type of the contract.
- * @param relevantContracts A list of artifacts for other contracts in the project that may be relevant
+ * @param artifacts A list of artifacts for other contracts in the project that may be relevant
  *   (e.g., providing needed struct or enum definitions, or appearing as a contract type).
  *
- *   See the relevantContracts parameter documentation on [[forArtifact]] for more detail.
+ *   See the artifacts parameter documentation on [[forArtifact]] for more detail.
  *
  *   This parameter is intended to be made optional in the future.
  */
 export async function forDeployedContract(
   contract: ContractConstructorObject,
-  relevantContracts: ContractObject[]
+  artifacts: ContractObject[]
 ): Promise<ContractInstanceDecoder> {
-  let contractDecoder = await forContract(contract, relevantContracts);
+  let contractDecoder = await forContract(contract, artifacts);
   let instanceDecoder = await contractDecoder.forInstance();
   return instanceDecoder;
 }
 
 /**
  * Constructs a contract instance decoder for a contract instance at a given address.
- * @param contract The artifact corresponding to the type of the contract.
+ * @param artifact The artifact corresponding to the type of the contract.
  *
  *   A contract constructor object may be substituted for the artifact, so if
  *   you're not sure which you're dealing with, it's OK.
@@ -177,24 +168,20 @@ export async function forDeployedContract(
  *
  *   Address must either be checksummed, or in all one case to circumvent the checksum.
  *   Mixed-case with bad checksum will cause this function to throw an exception.
- * @param relevantContracts A list of artifacts for other contracts in the project that may be relevant
+ * @param artifacts A list of artifacts for other contracts in the project that may be relevant
  *   (e.g., providing needed struct or enum definitions, or appearing as a contract type).
  *
- *   See the relevantContracts parameter documentation on [[forArtifact]] for more detail.
+ *   See the artifacts parameter documentation on [[forArtifact]] for more detail.
  *
  *   This parameter is intended to be made optional in the future.
  */
 export async function forArtifactAt(
-  contract: ContractObject,
+  artifact: ContractObject,
   provider: Provider,
   address: string,
-  relevantContracts: ContractObject[]
+  artifacts: ContractObject[]
 ): Promise<ContractInstanceDecoder> {
-  let contractDecoder = await forArtifact(
-    contract,
-    provider,
-    relevantContracts
-  );
+  let contractDecoder = await forArtifact(artifact, provider, artifacts);
   let instanceDecoder = await contractDecoder.forInstance(address);
   return instanceDecoder;
 }
@@ -206,19 +193,19 @@ export async function forArtifactAt(
  *
  *   Address must either be checksummed, or in all one case to circumvent the checksum.
  *   Mixed-case with bad checksum will cause this function to throw an exception.
- * @param relevantContracts A list of artifacts for other contracts in the project that may be relevant
+ * @param artifacts A list of artifacts for other contracts in the project that may be relevant
  *   (e.g., providing needed struct or enum definitions, or appearing as a contract type).
  *
- *   See the relevantContracts parameter documentation on [[forArtifact]] for more detail.
+ *   See the artifacts parameter documentation on [[forArtifact]] for more detail.
  *
  *   This parameter is intended to be made optional in the future.
  */
 export async function forContractAt(
   contract: ContractConstructorObject,
   address: string,
-  relevantContracts: ContractObject[]
+  artifacts: ContractObject[]
 ): Promise<ContractInstanceDecoder> {
-  let contractDecoder = await forContract(contract, relevantContracts);
+  let contractDecoder = await forContract(contract, artifacts);
   let instanceDecoder = await contractDecoder.forInstance(address);
   return instanceDecoder;
 }
@@ -226,20 +213,16 @@ export async function forContractAt(
 /**
  * Constructs a contract instance decoder for a given contract instance.
  * @param contract The contract abstraction object corresponding to the contract instance.
- * @param relevantContracts A list of artifacts for other contracts in the project that may be relevant
+ * @param artifacts A list of artifacts for other contracts in the project that may be relevant
  *   (e.g., providing needed struct or enum definitions, or appearing as a contract type).
  *
- *   See the relevantContracts parameter documentation on [[forArtifact]] for more detail.
+ *   See the artifacts parameter documentation on [[forArtifact]] for more detail.
  *
  *   This parameter is intended to be made optional in the future.
  */
 export async function forContractAbstraction(
   contract: ContractInstanceObject,
-  relevantContracts: ContractObject[]
+  artifacts: ContractObject[]
 ): Promise<ContractInstanceDecoder> {
-  return await forContractAt(
-    contract.constructor,
-    contract.address,
-    relevantContracts
-  );
+  return await forContractAt(contract.constructor, contract.address, artifacts);
 }

--- a/packages/decoder/lib/index.ts
+++ b/packages/decoder/lib/index.ts
@@ -30,76 +30,216 @@ export {
 
 import { Provider } from "web3/providers";
 import { ContractObject } from "@truffle/contract-schema/spec";
+import { ContractConstructorObject, ContractInstanceObject } from "./types";
 
 /**
- * Constructs a contract instance decoder for a given contract instance.
- * @param contract The contract constructor object corresponding to the type of the contract.
- * @param relevantContracts A list of contract constructor objects for other contracts in the project that may be relevant
- * (e.g., providing needed struct or enum definitions, or appearing as a contract type).
- * Including the contract itself here is fine; so is excluding it.
+ * Constructs a wire decoder for the project.
  * @param provider The Web3 provider object to use.
- * @param address The address of the contract instance to decode.  If left out, it will be autodetected on startup.
- *   If an invalid address is provided, this function will throw an exception.
+ * @param contracts A list of contract artifacts for contracts in the project.
+ *
+ *   Contract constructor objects may be substituted for artifacts, so if
+ *   you're not sure which you're dealing with, it's OK.
+ *
+ *   This parameter is intended to be made optional in the future.
  */
-export async function forContractInstance(
-  contract: ContractObject,
-  relevantContracts: ContractObject[],
+export async function forProject(
   provider: Provider,
-  address?: string
-): Promise<ContractInstanceDecoder> {
-  let contractDecoder = await forContract(
-    contract,
-    relevantContracts,
-    provider
-  );
-  let instanceDecoder = await contractDecoder.forInstance(address);
-  return instanceDecoder;
+  contracts: ContractObject[]
+): Promise<WireDecoder> {
+  return new WireDecoder(contracts, provider);
 }
 
 /**
  * Constructs a contract instance decoder for a given contract instance.
- * @param contract The contract constructor object corresponding to the type of the contract.
- * @param relevantContracts A list of contract constructor objects for other contracts in the project that may be relevant
- * (e.g., providing needed struct or enum definitions, or appearing as a contract type).
- * Including the contract itself here is fine; so is excluding it.
+ * @param contract The artifact for the contract.
+ *
+ *   A contract constructor object may be substituted for the artifact, so if
+ *   you're not sure which you're dealing with, it's OK.
  * @param provider The Web3 provider object to use.
+ * @param relevantContracts A list of artifacts for other contracts in the project that may be relevant
+ *   (e.g., providing needed struct or enum definitions, or appearing as a contract type).
+ *
+ *   Contract constructor objects may be substituted for artifacts, so if
+ *   you're not sure which you're dealing with, it's OK.
+ *
+ *   Including the contract itself here is fine; so is excluding it.
+ *
+ *   This parameter is intended to be made optional in the future.
  */
-export async function forContract(
+export async function forArtifact(
   contract: ContractObject,
-  relevantContracts: ContractObject[],
-  provider: Provider
+  provider: Provider,
+  relevantContracts: ContractObject[]
 ): Promise<ContractDecoder> {
   let contracts = relevantContracts.includes(contract)
     ? relevantContracts
     : [contract, ...relevantContracts];
-  let wireDecoder = await forProject(contracts, provider);
+  let wireDecoder = await forProject(provider, contracts);
   let contractDecoder = new ContractDecoder(contract, wireDecoder);
   await contractDecoder.init();
   return contractDecoder;
 }
 
 /**
- * Constructs a wire decoder for the project.
- * @param contracts A list of contract constructor objects for contracts in the project.
+ * Constructs a contract instance decoder for a given contract instance.
+ * @param contract The contract constructor object corresponding to the type of the contract.
  * @param provider The Web3 provider object to use.
+ * @param relevantContracts A list of artifacts for other contracts in the project that may be relevant
+ *   (e.g., providing needed struct or enum definitions, or appearing as a contract type).
+ *
+ *   See the relevantContracts parameter documentation on [[forArtifact]] for more detail.
+ *
+ *   This parameter is intended to be made optional in the future.
  */
-export async function forProject(
-  contracts: ContractObject[],
-  provider: Provider
-): Promise<WireDecoder> {
-  return new WireDecoder(contracts, provider);
+export async function forContract(
+  contract: ContractConstructorObject,
+  relevantContracts: ContractObject[]
+): Promise<ContractDecoder> {
+  return await forArtifact(
+    contract,
+    contract.web3.currentProvider,
+    relevantContracts
+  );
 }
 
 /**
  * Constructs a contract decoder given an existing wire decoder for the project.
- * @param contract The contract constructor object corresponding to the type of the contract.
+ * @param contract The artifact corresponding to the type of the contract.
+ *
+ *   A contract constructor object may be substituted for the artifact, so if
+ *   you're not sure which you're dealing with, it's OK.
  * @param decoder An existing wire decoder for the project.
  */
-export async function forContractWithDecoder(
+export async function forArtifactWithDecoder(
   contract: ContractObject,
   decoder: WireDecoder
 ): Promise<ContractDecoder> {
   let contractDecoder = new ContractDecoder(contract, decoder);
   await contractDecoder.init();
   return contractDecoder;
+}
+
+/**
+ * Constructs a contract instance decoder for a deployed contract instance.
+ * @param contract The artifact corresponding to the type of the contract.
+ *
+ *   A contract constructor object may be substituted for the artifact, so if
+ *   you're not sure which you're dealing with, it's OK.
+ * @param provider The Web3 provider object to use.
+ * @param relevantContracts A list of artifacts for other contracts in the project that may be relevant
+ *   (e.g., providing needed struct or enum definitions, or appearing as a contract type).
+ *
+ *   See the relevantContracts parameter documentation on [[forArtifact]] for more detail.
+ *
+ *   This parameter is intended to be made optional in the future.
+ */
+export async function forDeployedArtifact(
+  contract: ContractObject,
+  provider: Provider,
+  relevantContracts: ContractObject[]
+): Promise<ContractInstanceDecoder> {
+  let contractDecoder = await forArtifact(
+    contract,
+    provider,
+    relevantContracts
+  );
+  let instanceDecoder = await contractDecoder.forInstance();
+  return instanceDecoder;
+}
+
+/**
+ * Constructs a contract instance decoder for a deployed contract instance.
+ * @param contract The contract constructor object corresponding to the type of the contract.
+ * @param relevantContracts A list of artifacts for other contracts in the project that may be relevant
+ *   (e.g., providing needed struct or enum definitions, or appearing as a contract type).
+ *
+ *   See the relevantContracts parameter documentation on [[forArtifact]] for more detail.
+ *
+ *   This parameter is intended to be made optional in the future.
+ */
+export async function forDeployedContract(
+  contract: ContractConstructorObject,
+  relevantContracts: ContractObject[]
+): Promise<ContractInstanceDecoder> {
+  let contractDecoder = await forContract(contract, relevantContracts);
+  let instanceDecoder = await contractDecoder.forInstance();
+  return instanceDecoder;
+}
+
+/**
+ * Constructs a contract instance decoder for a contract instance at a given address.
+ * @param contract The artifact corresponding to the type of the contract.
+ *
+ *   A contract constructor object may be substituted for the artifact, so if
+ *   you're not sure which you're dealing with, it's OK.
+ * @param provider The Web3 provider object to use.
+ * @param address The address of the contract instance to decode.
+ *
+ *   Address must either be checksummed, or in all one case to circumvent the checksum.
+ *   Mixed-case with bad checksum will cause this function to throw an exception.
+ * @param relevantContracts A list of artifacts for other contracts in the project that may be relevant
+ *   (e.g., providing needed struct or enum definitions, or appearing as a contract type).
+ *
+ *   See the relevantContracts parameter documentation on [[forArtifact]] for more detail.
+ *
+ *   This parameter is intended to be made optional in the future.
+ */
+export async function forArtifactAt(
+  contract: ContractObject,
+  provider: Provider,
+  address: string,
+  relevantContracts: ContractObject[]
+): Promise<ContractInstanceDecoder> {
+  let contractDecoder = await forArtifact(
+    contract,
+    provider,
+    relevantContracts
+  );
+  let instanceDecoder = await contractDecoder.forInstance(address);
+  return instanceDecoder;
+}
+
+/**
+ * Constructs a contract instance decoder for a contract instance at a given address.
+ * @param contract The contract constructor object corresponding to the type of the contract.
+ * @param address The address of the contract instance to decode.
+ *
+ *   Address must either be checksummed, or in all one case to circumvent the checksum.
+ *   Mixed-case with bad checksum will cause this function to throw an exception.
+ * @param relevantContracts A list of artifacts for other contracts in the project that may be relevant
+ *   (e.g., providing needed struct or enum definitions, or appearing as a contract type).
+ *
+ *   See the relevantContracts parameter documentation on [[forArtifact]] for more detail.
+ *
+ *   This parameter is intended to be made optional in the future.
+ */
+export async function forContractAt(
+  contract: ContractConstructorObject,
+  address: string,
+  relevantContracts: ContractObject[]
+): Promise<ContractInstanceDecoder> {
+  let contractDecoder = await forContract(contract, relevantContracts);
+  let instanceDecoder = await contractDecoder.forInstance(address);
+  return instanceDecoder;
+}
+
+/**
+ * Constructs a contract instance decoder for a given contract instance.
+ * @param contract The contract abstraction object corresponding to the contract instance.
+ * @param relevantContracts A list of artifacts for other contracts in the project that may be relevant
+ *   (e.g., providing needed struct or enum definitions, or appearing as a contract type).
+ *
+ *   See the relevantContracts parameter documentation on [[forArtifact]] for more detail.
+ *
+ *   This parameter is intended to be made optional in the future.
+ */
+export async function forContractAbstraction(
+  contract: ContractInstanceObject,
+  relevantContracts: ContractObject[]
+): Promise<ContractInstanceDecoder> {
+  return await forContractAt(
+    contract.constructor,
+    contract.address,
+    relevantContracts
+  );
 }

--- a/packages/decoder/lib/types.ts
+++ b/packages/decoder/lib/types.ts
@@ -9,6 +9,7 @@ import {
 } from "@truffle/codec";
 import { Transaction, BlockType } from "web3/eth/types";
 import { Log } from "web3/types";
+import Web3 from "web3";
 
 /**
  * This type represents the state of a contract aside from its storage.
@@ -158,4 +159,16 @@ export interface EventOptions {
    * address as undefined.
    */
   address?: string;
+}
+
+//HACK
+export interface ContractConstructorObject extends ContractObject {
+  _json: ContractObject;
+  web3: Web3;
+}
+
+//HACK
+export interface ContractInstanceObject {
+  constructor: ContractConstructorObject;
+  address: string;
 }

--- a/packages/decoder/test/test/decoding-test.js
+++ b/packages/decoder/test/test/decoding-test.js
@@ -32,11 +32,9 @@ contract("DecodingSample", _accounts => {
   it("should get the initial state properly", async function() {
     let deployedContract = await DecodingSample.deployed();
     let address = deployedContract.address;
-    const decoder = await Decoder.forContractInstance(
-      DecodingSample,
-      [DecodingSampleParent],
-      web3.currentProvider
-    );
+    const decoder = await Decoder.forContractAbstraction(deployedContract, [
+      DecodingSampleParent
+    ]);
 
     await decoder.watchMappingKey("varMapping", 2);
     await decoder.watchMappingKey("varMapping", 3);

--- a/packages/decoder/test/test/downgrade-test.js
+++ b/packages/decoder/test/test/downgrade-test.js
@@ -79,9 +79,9 @@ async function runTestBody(
   fullMode = false
 ) {
   let decoder = await Decoder.forProject(
-    [DowngradeTest._json, DecoyLibrary], //HACK: because we've clonedeep'd DowngradeTest,
+    web3.currentProvider,
+    [DowngradeTest._json, DecoyLibrary] //HACK: because we've clonedeep'd DowngradeTest,
     //we need to pass in its _json rather than it itself (its getters have been stripped off)
-    web3.currentProvider
   );
   let deployedContract = await DowngradeTest.new();
   let address = deployedContract.address;
@@ -193,8 +193,8 @@ contract("DowngradeTest", function(accounts) {
 
     //...and now let's set up a decoder for our hacked-up contract artifact.
     let decoder = await Decoder.forProject(
-      [DowngradeTest._json, DecoyLibrary], //HACK: see clonedeep note above
-      web3.currentProvider
+      web3.currentProvider,
+      [DowngradeTest._json, DecoyLibrary] //HACK: see clonedeep note above
     );
 
     //the ethers encoder can't yet handle fixed-point
@@ -254,8 +254,8 @@ contract("DowngradeTest", function(accounts) {
     it("Doesn't include out-of-range enums in full mode", async function() {
       let DowngradeTest = DowngradeTestUnmodified;
       let decoder = await Decoder.forProject(
-        [DowngradeTest._json, DecoyLibrary], //not strictly necessary here, but see clonedeep comment above
-        web3.currentProvider
+        web3.currentProvider,
+        [DowngradeTest._json, DecoyLibrary] //not strictly necessary here, but see clonedeep comment above
       );
       let deployedContract = await DowngradeTest.new();
 
@@ -316,8 +316,8 @@ contract("DowngradeTest", function(accounts) {
 
 async function runEnumTestBody(DowngradeTest) {
   let decoder = await Decoder.forProject(
-    [DowngradeTest._json, DecoyLibrary], //HACK: see clonedeep comment above
-    web3.currentProvider
+    web3.currentProvider,
+    [DowngradeTest._json, DecoyLibrary] //HACK: see clonedeep comment above
   );
   let deployedContract = await DowngradeTest.new();
 

--- a/packages/decoder/test/test/wire-test.js
+++ b/packages/decoder/test/test/wire-test.js
@@ -15,10 +15,11 @@ contract("WireTest", _accounts => {
     let address = deployedContract.address;
     let constructorHash = deployedContract.transactionHash;
 
-    const decoder = await Decoder.forProject(
-      [WireTest, WireTestParent, WireTestLibrary],
-      web3.currentProvider
-    );
+    const decoder = await Decoder.forProject(web3.currentProvider, [
+      WireTest,
+      WireTestParent,
+      WireTestLibrary
+    ]);
 
     let deployedContractNoConstructor = await WireTestParent.new();
     let defaultConstructorHash = deployedContractNoConstructor.transactionHash;
@@ -423,10 +424,11 @@ contract("WireTest", _accounts => {
   it("disambiguates events when possible and not when impossible", async function() {
     let deployedContract = await WireTest.deployed();
 
-    const decoder = await Decoder.forProject(
-      [WireTest, WireTestParent, WireTestLibrary],
-      web3.currentProvider
-    );
+    const decoder = await Decoder.forProject(web3.currentProvider, [
+      WireTest,
+      WireTestParent,
+      WireTestLibrary
+    ]);
 
     //HACK HACK -- we're going to repeatedly apply the hack from above
     //because ethers also can't handle ambiguous events
@@ -566,10 +568,11 @@ contract("WireTest", _accounts => {
   it("Handles anonymous events", async function() {
     let deployedContract = await WireTest.deployed();
 
-    const decoder = await Decoder.forProject(
-      [WireTest, WireTestParent, WireTestLibrary],
-      web3.currentProvider
-    );
+    const decoder = await Decoder.forProject(web3.currentProvider, [
+      WireTest,
+      WireTestParent,
+      WireTestLibrary
+    ]);
 
     //thankfully, ethers ignores anonymous events,
     //so we don't need to use that hack here


### PR DESCRIPTION
This PR redoes the `@truffle/decoder` constructor functions.  It also adjusts the documentation and tests to match.

Because of all the added documentation, I'm skipping a long writeup of how the new functions work and why they're organized as they are; you can just see the documentation.  (Which, uh, hopefully I haven't messed up.)  Also @gnidan you will be familiar with it from our earlier discussion. :P

This PR does contain one nasty hack (which is why I've tagged you, @CruzMolina :P ); since there don't currently exist proper types for contract constructor or abstraction objects, I've just declared them myself, containing just the parts that we need.  The intent is to get rid of this later once proper types exist.  (...or maybe not, if that leads to circular dependencies; but the intent is also to eventually get rid of the contract decoder and just move all that functionality into `contract`, so whatever.)

Note I didn't add tests of all the functions, just `forContractAbstraction` -- which calls `forContractAt`, which calls `forContract`, which calls `forArtifact`; I'm hoping leaving the others without specific tests due to how analogous they are is OK.