### PR TITLE
Bug Fix: Ensure cross-chain compatibility with Provider.testConnection

### DIFF
--- a/packages/environment/environment.js
+++ b/packages/environment/environment.js
@@ -21,7 +21,7 @@ const Environment = {
       networkType: config.networks[config.network].type
     });
 
-    await Provider.testConnection(config);
+    await Provider.testConnection(web3, interfaceAdapter);
     await helpers.detectAndSetNetworkId(config, web3, interfaceAdapter);
     await helpers.setFromOnConfig(config, web3, interfaceAdapter);
   },

--- a/packages/provider/index.js
+++ b/packages/provider/index.js
@@ -1,6 +1,5 @@
 const debug = require("debug")("provider");
 const Web3 = require("web3");
-const { Web3Shim, InterfaceAdapter } = require("@truffle/interface-adapter");
 const wrapper = require("./wrapper");
 
 module.exports = {
@@ -32,10 +31,7 @@ module.exports = {
     return provider;
   },
 
-  testConnection: function(options) {
-    const provider = this.getProvider(options);
-    const interfaceAdapter = new InterfaceAdapter();
-    const web3 = new Web3Shim({ provider });
+  testConnection: function(web3, interfaceAdapter) {
     return new Promise((resolve, reject) => {
       console.log("Testing the provider...");
       console.log("=======================");

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -15,10 +15,10 @@
   },
   "dependencies": {
     "@truffle/error": "^0.0.7",
-    "@truffle/interface-adapter": "^0.3.0",
     "web3": "1.2.1"
   },
   "devDependencies": {
+    "@truffle/interface-adapter": "^0.3.0",
     "ganache-core": "2.7.0",
     "mocha": "5.2.0"
   },

--- a/packages/provider/test/create.js
+++ b/packages/provider/test/create.js
@@ -2,6 +2,7 @@ const assert = require("assert");
 const Ganache = require("ganache-core");
 const Provider = require("../index");
 const Web3 = require("web3");
+const { Web3Shim, InterfaceAdapter } = require("@truffle/interface-adapter");
 
 describe("Provider", function() {
   let server;
@@ -24,8 +25,11 @@ describe("Provider", function() {
     const provider = Provider.create({ host, port });
     assert(provider);
 
+    const interfaceAdapter = new InterfaceAdapter();
+    const web3Shim = new Web3Shim({ provider });
+
     try {
-      await Provider.testConnection({ provider });
+      await Provider.testConnection(web3Shim);
     } catch (error) {
       assert.fail(error.message);
     }
@@ -33,9 +37,11 @@ describe("Provider", function() {
 
   it("fails to connect to the wrong port", async () => {
     const provider = Provider.create({ host, port: "54321" });
+    const interfaceAdapter = new InterfaceAdapter();
+    const web3Shim = new Web3Shim({ provider });
 
     try {
-      await Provider.testConnection({ provider });
+      await Provider.testConnection(web3Shim);
       assert(false);
     } catch (error) {
       const snippet = `Could not connect to your Ethereum client`;
@@ -51,8 +57,11 @@ describe("Provider", function() {
     const provider = Provider.create({
       provider: new Ganache.provider()
     });
+    const interfaceAdapter = new InterfaceAdapter();
+    const web3Shim = new Web3Shim({ provider });
+
     try {
-      await Provider.testConnection({ provider });
+      await Provider.testConnection(web3Shim);
       assert(provider);
     } catch (error) {
       assert.fail("There was an error testing the provider.");
@@ -65,8 +74,11 @@ describe("Provider", function() {
         return new Ganache.provider();
       }
     });
+    const interfaceAdapter = new InterfaceAdapter();
+    const web3Shim = new Web3Shim({ provider });
+
     try {
-      await Provider.testConnection({ provider });
+      await Provider.testConnection(web3Shim);
       assert(provider);
     } catch (error) {
       assert.fail("There was an error testing the provider.");
@@ -77,9 +89,11 @@ describe("Provider", function() {
     const provider = Provider.create({
       provider: new Web3.providers.HttpProvider("http://127.0.0.1:9999")
     });
+    const interfaceAdapter = new InterfaceAdapter();
+    const web3Shim = new Web3Shim({ provider });
 
     try {
-      await Provider.testConnection({ provider });
+      await Provider.testConnection(web3Shim);
       assert.fail(
         "The provider was instantiated correctly. That shouldn't have happened"
       );


### PR DESCRIPTION
Slipped by in review, but currently `Provider.testConnection` is instantiating only the `ethereum`-compatible shim/adapter.

Also passes `testConnection` the already instantiated `web3/interfaceAdapter` in `Environment.detect` & removes the [redundant](https://github.com/trufflesuite/truffle/blob/develop/packages/config/src/configDefaults.ts#L197-L206) `getProvider` call.