### PR TITLE
Mark things protected, add warning to nativize

### DIFF
--- a/packages/codec/lib/format/utils/inspect.ts
+++ b/packages/codec/lib/format/utils/inspect.ts
@@ -380,7 +380,7 @@ export function nativizeVariables(variables: {
  * probably have a better option than using this in real code!
  *
  * (For instance, if you just want to nicely print individual values, without
- * attempting to first operate them via Javascript expressions, we have the
+ * attempting to first operate on them via Javascript expressions, we have the
  * [[ResultInspector]] class, which can be used with Node's
  * [util.inspect()](https://nodejs.org/api/util.html#util_util_inspect_object_options)
  * to do exactly that.)

--- a/packages/codec/lib/format/utils/inspect.ts
+++ b/packages/codec/lib/format/utils/inspect.ts
@@ -375,14 +375,20 @@ export function nativizeVariables(variables: {
  * ever written to support our hacked-together watch expression system, and
  * later repurposed to make testing easier.
  *
- * If you are not doing something as horrible as our hacked-together watch
- * expression system, then you probably have a better option than using this in
- * real code!
+ * If you are not doing something as horrible as evaluating user-inputted
+ * Javascript expressions meant to operate upon Solidity variables, then you
+ * probably have a better option than using this in real code!
+ *
+ * (For instance, if you just want to nicely print individual values, without
+ * attempting to first operate them via Javascript expressions, we have the
+ * [[ResultInspector]] class, which can be used with Node's
+ * [util.inspect()](https://nodejs.org/api/util.html#util_util_inspect_object_options)
+ * to do exactly that.)
  *
  * Remember, the decoder output format was made to be machine-readable.  It
  * shouldn't be too hard for you to process.  If it comes to it, copy-paste
- * this code and dehackify it for your use case, which hopefully is saner than
- * the one that caused us to write this.
+ * this code and dehackify it for your use case, which hopefully is more
+ * manageable than the one that caused us to write this.
  */
 export function nativize(result: Format.Values.Result): any {
   if (result.kind === "error") {

--- a/packages/codec/lib/format/utils/inspect.ts
+++ b/packages/codec/lib/format/utils/inspect.ts
@@ -17,8 +17,8 @@ export interface InspectOptions {
 function cleanStylize(options: InspectOptions) {
   return Object.assign(
     {},
-    ...Object.entries(options).map(([key, value]) =>
-      key === "stylize" ? {} : { [key]: value }
+    ...Object.entries(options).map(
+      ([key, value]) => (key === "stylize" ? {} : { [key]: value })
     )
   );
 }
@@ -159,7 +159,9 @@ export class ResultInspector {
                     break;
                   case "invalid":
                   case "unknown":
-                    firstLine = `[Function: Unknown selector ${coercedResult.value.selector} of`;
+                    firstLine = `[Function: Unknown selector ${
+                      coercedResult.value.selector
+                    } of`;
                     break;
                 }
                 let secondLine = `${contractString}]`;
@@ -178,7 +180,9 @@ export class ResultInspector {
                 switch (coercedResult.value.kind) {
                   case "function":
                     return options.stylize(
-                      `[Function: ${coercedResult.value.definedIn.typeName}.${coercedResult.value.name}]`,
+                      `[Function: ${coercedResult.value.definedIn.typeName}.${
+                        coercedResult.value.name
+                      }]`,
                       "special"
                     );
                   case "exception":
@@ -187,7 +191,11 @@ export class ResultInspector {
                       : options.stylize(`[Function: assert(false)]`, "special");
                   case "unknown":
                     let firstLine = `[Function: decoding not supported (raw info:`;
-                    let secondLine = `deployed PC=${coercedResult.value.deployedProgramCounter}, constructor PC=${coercedResult.value.constructorProgramCounter})]`;
+                    let secondLine = `deployed PC=${
+                      coercedResult.value.deployedProgramCounter
+                    }, constructor PC=${
+                      coercedResult.value.constructorProgramCounter
+                    })]`;
                     let breakingSpace =
                       firstLine.length >= options.breakLength ? "\n" : " ";
                     //now, put it together
@@ -204,19 +212,31 @@ export class ResultInspector {
         let errorResult = <Format.Errors.ErrorResult>this.result; //the hell?? why couldn't it make this inference??
         switch (errorResult.error.kind) {
           case "UintPaddingError":
-            return `Uint has extra leading bytes (padding error) (raw value ${errorResult.error.raw})`;
+            return `Uint has extra leading bytes (padding error) (raw value ${
+              errorResult.error.raw
+            })`;
           case "IntPaddingError":
-            return `Int out of range (padding error) (raw value ${errorResult.error.raw})`;
+            return `Int out of range (padding error) (raw value ${
+              errorResult.error.raw
+            })`;
           case "UintPaddingError":
-            return `Ufixed has extra leading bytes (padding error) (raw value ${errorResult.error.raw})`;
+            return `Ufixed has extra leading bytes (padding error) (raw value ${
+              errorResult.error.raw
+            })`;
           case "FixedPaddingError":
-            return `Fixed out of range (padding error) (raw value ${errorResult.error.raw})`;
+            return `Fixed out of range (padding error) (raw value ${
+              errorResult.error.raw
+            })`;
           case "BoolOutOfRangeError":
             return `Invalid boolean (numeric value ${errorResult.error.rawAsBN.toString()})`;
           case "BytesPaddingError":
-            return `Bytestring has extra trailing bytes (padding error) (raw value ${errorResult.error.raw})`;
+            return `Bytestring has extra trailing bytes (padding error) (raw value ${
+              errorResult.error.raw
+            })`;
           case "AddressPaddingError":
-            return `Address has extra leading bytes (padding error) (raw value ${errorResult.error.raw})`;
+            return `Address has extra leading bytes (padding error) (raw value ${
+              errorResult.error.raw
+            })`;
           case "EnumOutOfRangeError":
             return `Invalid ${enumTypeName(
               errorResult.error.type
@@ -228,21 +248,39 @@ export class ResultInspector {
               errorResult.error.type.id
             } (numeric value ${errorResult.error.rawAsBN.toString()})`;
           case "ContractPaddingError":
-            return `Contract address has extra leading bytes (padding error) (raw value ${errorResult.error.raw})`;
+            return `Contract address has extra leading bytes (padding error) (raw value ${
+              errorResult.error.raw
+            })`;
           case "FunctionExternalNonStackPaddingError":
-            return `External function has extra trailing bytes (padding error) (raw value ${errorResult.error.raw})`;
+            return `External function has extra trailing bytes (padding error) (raw value ${
+              errorResult.error.raw
+            })`;
           case "FunctionExternalStackPaddingError":
-            return `External function address or selector has extra leading bytes (padding error) (raw address ${errorResult.error.rawAddress}, raw selector ${errorResult.error.rawSelector})`;
+            return `External function address or selector has extra leading bytes (padding error) (raw address ${
+              errorResult.error.rawAddress
+            }, raw selector ${errorResult.error.rawSelector})`;
           case "FunctionInternalPaddingError":
-            return `Internal function has extra leading bytes (padding error) (raw value ${errorResult.error.raw})`;
+            return `Internal function has extra leading bytes (padding error) (raw value ${
+              errorResult.error.raw
+            })`;
           case "NoSuchInternalFunctionError":
-            return `Invalid function (Deployed PC=${errorResult.error.deployedProgramCounter}, constructor PC=${errorResult.error.constructorProgramCounter}) of contract ${errorResult.error.context.typeName}`;
+            return `Invalid function (Deployed PC=${
+              errorResult.error.deployedProgramCounter
+            }, constructor PC=${
+              errorResult.error.constructorProgramCounter
+            }) of contract ${errorResult.error.context.typeName}`;
           case "DeployedFunctionInConstructorError":
-            return `Deployed-style function (PC=${errorResult.error.deployedProgramCounter}) in constructor`;
+            return `Deployed-style function (PC=${
+              errorResult.error.deployedProgramCounter
+            }) in constructor`;
           case "MalformedInternalFunctionError":
-            return `Malformed internal function w/constructor PC only (value: ${errorResult.error.constructorProgramCounter})`;
+            return `Malformed internal function w/constructor PC only (value: ${
+              errorResult.error.constructorProgramCounter
+            })`;
           case "IndexedReferenceTypeError":
-            return `Cannot decode indexed parameter of reference type ${errorResult.error.type.typeClass} (raw value ${errorResult.error.raw})`;
+            return `Cannot decode indexed parameter of reference type ${
+              errorResult.error.type.typeClass
+            } (raw value ${errorResult.error.raw})`;
           case "OverlongArraysAndStringsNotImplementedError":
             return `Array or string is too long (length ${errorResult.error.lengthAsBN.toString()}); decoding is not supported`;
           case "OverlargePointersNotImplementedError":
@@ -300,14 +338,20 @@ function formatCircular(loopLength: number, options: InspectOptions): string {
 function enumFullName(value: Format.Values.EnumValue): string {
   switch (value.type.kind) {
     case "local":
-      return `${value.type.definingContractName}.${value.type.typeName}.${value.value.name}`;
+      return `${value.type.definingContractName}.${value.type.typeName}.${
+        value.value.name
+      }`;
     case "global":
       return `${value.type.typeName}.${value.value.name}`;
   }
 }
 
-//NOTE: Definitely do not use this in real code!  For tests only!
-//for convenience: invokes the nativize method on all the given variables
+/**
+ * WARNING! Do NOT use this function in real code unless you
+ * absolutely have to!  Using it in controlled tests is fine,
+ * but do NOT use it in real code if you have any better option!
+ * See [[nativize]] for why!
+ */
 export function nativizeVariables(variables: {
   [name: string]: Format.Values.Result;
 }): { [name: string]: any } {
@@ -319,9 +363,27 @@ export function nativizeVariables(variables: {
   );
 }
 
-//HACK! Avoid using! Only use this if:
-//1. you absolutely have to, or
-//2. it's just testing, not real code
+//HACK! Avoid using!
+/**
+ * WARNING! Do NOT use this function in real code unless you absolutely have
+ * to!  Using it in controlled tests is fine, but do NOT use it in real code if
+ * you have any better option!
+ *
+ * This function is a giant hack.  It will throw exceptions on numbers that
+ * don't fit in a Javascript number.  It will go into an infinite loop on
+ * circular structures (although that might be fixed eventually).  It was only
+ * ever written to support our hacked-together watch expression system, and
+ * later repurposed to make testing easier.
+ *
+ * If you are not doing something as horrible as our hacked-together watch
+ * expression system, then you probably have a better option than using this in
+ * real code!
+ *
+ * Remember, the decoder output format was made to be machine-readable.  It
+ * shouldn't be too hard for you to process.  If it comes to it, copy-paste
+ * this code and dehackify it for your use case, which hopefully is saner than
+ * the one that caused us to write this.
+ */
 export function nativize(result: Format.Values.Result): any {
   if (result.kind === "error") {
     return undefined;
@@ -395,7 +457,9 @@ export function nativize(result: Format.Values.Result): any {
       let coercedResult = <Format.Values.ContractValue>result;
       switch (coercedResult.value.kind) {
         case "known":
-          return `${coercedResult.value.class.typeName}(${coercedResult.value.address})`;
+          return `${coercedResult.value.class.typeName}(${
+            coercedResult.value.address
+          })`;
         case "unknown":
           return coercedResult.value.address;
       }
@@ -407,18 +471,26 @@ export function nativize(result: Format.Values.Result): any {
           let coercedResult = <Format.Values.FunctionExternalValue>result;
           switch (coercedResult.value.kind) {
             case "known":
-              return `${coercedResult.value.contract.class.typeName}(${coercedResult.value.contract.address}).${coercedResult.value.abi.name}`;
+              return `${coercedResult.value.contract.class.typeName}(${
+                coercedResult.value.contract.address
+              }).${coercedResult.value.abi.name}`;
             case "invalid":
-              return `${coercedResult.value.contract.class.typeName}(${coercedResult.value.contract.address}).call(${coercedResult.value.selector}...)`;
+              return `${coercedResult.value.contract.class.typeName}(${
+                coercedResult.value.contract.address
+              }).call(${coercedResult.value.selector}...)`;
             case "unknown":
-              return `${coercedResult.value.contract.address}.call(${coercedResult.value.selector}...)`;
+              return `${coercedResult.value.contract.address}.call(${
+                coercedResult.value.selector
+              }...)`;
           }
         }
         case "internal": {
           let coercedResult = <Format.Values.FunctionInternalValue>result;
           switch (coercedResult.value.kind) {
             case "function":
-              return `${coercedResult.value.definedIn.typeName}.${coercedResult.value.name}`;
+              return `${coercedResult.value.definedIn.typeName}.${
+                coercedResult.value.name
+              }`;
             case "exception":
               return coercedResult.value.deployedProgramCounter === 0
                 ? `<zero>`

--- a/packages/decoder/lib/decoders/contract.ts
+++ b/packages/decoder/lib/decoders/contract.ts
@@ -51,7 +51,7 @@ export default class ContractDecoder {
   private wireDecoder: WireDecoder;
 
   /**
-   * @private
+   * @protected
    */
   constructor(
     contract: ContractObject,
@@ -100,7 +100,7 @@ export default class ContractDecoder {
   }
 
   /**
-   * @hidden
+   * @protected
    */
   public async init(): Promise<void> {
     this.contractNetwork = (await this.web3.eth.net.getId()).toString();
@@ -170,28 +170,28 @@ export default class ContractDecoder {
   //the following functions are for internal use
 
   /**
-   * @hidden
+   * @protected
    */
   public getAllocations() {
     return this.allocations;
   }
 
   /**
-   * @hidden
+   * @protected
    */
   public getStateVariableReferences() {
     return this.stateVariableReferences;
   }
 
   /**
-   * @hidden
+   * @protected
    */
   public getWireDecoder() {
     return this.wireDecoder;
   }
 
   /**
-   * @hidden
+   * @protected
    */
   public getContractInfo(): ContractInfo {
     return {
@@ -253,7 +253,7 @@ export class ContractInstanceDecoder {
   private wireDecoder: WireDecoder;
 
   /**
-   * @private
+   * @protected
    */
   constructor(contractDecoder: ContractDecoder, address?: string) {
     this.contractDecoder = contractDecoder;
@@ -287,7 +287,7 @@ export class ContractInstanceDecoder {
   }
 
   /**
-   * @hidden
+   * @protected
    */
   public async init(): Promise<void> {
     this.contractCode = Conversion.toHexString(

--- a/packages/decoder/lib/decoders/wire.ts
+++ b/packages/decoder/lib/decoders/wire.ts
@@ -45,7 +45,7 @@ export default class WireDecoder {
   private codeCache: DecoderTypes.CodeCache = {};
 
   /**
-   * @private
+   * @protected
    */
   constructor(contracts: ContractObject[], provider: Provider) {
     this.web3 = new Web3(provider);
@@ -182,7 +182,7 @@ export default class WireDecoder {
   }
 
   /**
-   * @hidden
+   * @protected
    * for internal use
    */
   public async getCode(address: string, block: number): Promise<Uint8Array> {
@@ -411,21 +411,21 @@ export default class WireDecoder {
   //the following functions are intended for internal use only
 
   /**
-   * @hidden
+   * @protected
    */
   public getReferenceDeclarations(): Ast.AstNodes {
     return this.referenceDeclarations;
   }
 
   /**
-   * @hidden
+   * @protected
    */
   public getUserDefinedTypes(): Format.Types.TypesById {
     return this.userDefinedTypes;
   }
 
   /**
-   * @hidden
+   * @protected
    */
   public getAllocations(): Evm.AllocationInfo {
     return {
@@ -435,14 +435,14 @@ export default class WireDecoder {
   }
 
   /**
-   * @hidden
+   * @protected
    */
   public getWeb3(): Web3 {
     return this.web3;
   }
 
   /**
-   * @hidden
+   * @protected
    */
   public getDeployedContexts(): Contexts.DecoderContexts {
     return this.deployedContexts;


### PR DESCRIPTION
This PR does two things.  First, it replaces `@hidden` and `@private` with `@protected`.  Second, it puts giant warnings on the nativize function to make clear you shouldn't actually use it in real code.

(Partial addressing of #2505 )