### PR TITLE
Prune various things from exports/docs

### DIFF
--- a/packages/codec/lib/abi/index.ts
+++ b/packages/codec/lib/abi/index.ts
@@ -4,9 +4,6 @@ export { Allocate };
 import * as Encode from "@truffle/codec/encode/abi";
 export { Encode };
 
-import * as Decode from "@truffle/codec/decode/abi";
-export { Decode };
-
 export * from "./types";
 
 import * as Utils from "./utils";

--- a/packages/codec/lib/allocate/abi.ts
+++ b/packages/codec/lib/allocate/abi.ts
@@ -276,6 +276,9 @@ function abiSizeAndAllocate(
 }
 
 //assumes you've already done allocation! don't use if you haven't!
+/**
+ * @protected
+ */
 export function abiSizeInfo(
   dataType: Format.Types.Type,
   allocations?: Allocation.AbiAllocations

--- a/packages/codec/lib/encode/abi.ts
+++ b/packages/codec/lib/encode/abi.ts
@@ -166,6 +166,10 @@ export function encodeAbi(
   }
 }
 
+/**
+ * @protected
+ * @Category Encoding (low-level)
+ */
 export function stringToBytes(input: string): Uint8Array {
   input = utf8.encode(input);
   let bytes = new Uint8Array(input.length);
@@ -177,6 +181,9 @@ export function stringToBytes(input: string): Uint8Array {
   //but, well, it shouldn't contain that...
 }
 
+/**
+ * @Category Encoding (low-level)
+ */
 function padAndPrependLength(bytes: Uint8Array): Uint8Array {
   let length = bytes.length;
   let paddedLength =

--- a/packages/codec/lib/format/utils/index.ts
+++ b/packages/codec/lib/format/utils/index.ts
@@ -1,5 +1,10 @@
 import * as Exception from "./exception";
-export { Exception };
+export {
+  /**
+   * @protected
+   */
+  Exception
+};
 
 import * as Inspect from "./inspect";
 export { Inspect };

--- a/packages/codec/lib/format/utils/inspect.ts
+++ b/packages/codec/lib/format/utils/inspect.ts
@@ -7,7 +7,7 @@ import * as Exception from "./exception";
 
 //we'll need to write a typing for the options type ourself, it seems; just
 //going to include the relevant properties here
-export interface InspectOptions {
+interface InspectOptions {
   stylize?: (toMaybeColor: string, style?: string) => string;
   colors: boolean;
   breakLength: number;

--- a/packages/codec/lib/index.ts
+++ b/packages/codec/lib/index.ts
@@ -47,10 +47,25 @@ export { encodeMappingKey } from "./encode/key";
 
 //now: what types should we export? (other than the ones from ./format)
 //public-facing types for the interface
-export * from "./types";
+export {
+  DecodingMode,
+  CalldataDecoding,
+  LogDecoding,
+  FunctionDecoding,
+  ConstructorDecoding,
+  MessageDecoding,
+  UnknownCallDecoding,
+  UnknownCreationDecoding,
+  EventDecoding,
+  AnonymousDecoding,
+  AbiArgument,
+  DecoderRequest,
+  StorageRequest,
+  CodeRequest
+} from "./types";
 export * from "./common";
 
-export * from "./abify";
+export { abifyCalldataDecoding, abifyLogDecoding } from "./abify";
 
 //for those who want more low-level stuff...
 import * as Abi from "./abi";


### PR DESCRIPTION
This PR prunes various things from the codec exports (or just the docs).  Specifically:

* `DecoderOptions` is no longer exported
* `abifyResult` and `abifyType` are no longer exported
* `Abi` no longer has an exported `Decode` submodule
* Since there was no way I could find to avoid exporting it, `abiSizeInfo` is now marked `@protected`
* Similarly with `stringToBytes` (this and `padAndPrependLength` also got a category applied to them to avoid causing an empty "other functions" section)
* Since there was no way to avoid exporting it, the `Exception` module in `Format` is now marked `@protected`