### PR TITLE
Manually mark various functions as async in docstring

### DIFF
--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -209,6 +209,8 @@ export class WireDecoder {
   }
 
   /**
+   * **This method is asynchronous.**
+   *
    * Takes a Web3
    * [Transaction](https://web3js.readthedocs.io/en/v1.2.1/web3-eth.html#eth-gettransaction-return)
    * object and returns a copy of that object but with an additional decoding
@@ -270,6 +272,8 @@ export class WireDecoder {
   }
 
   /**
+   * **This method is asynchronous.**
+   *
    * Takes a Web3
    * [Log](https://web3js.readthedocs.io/en/v1.2.1/web3-eth.html#eth-getpastlogs-return)
    * object and returns a copy of that object but with an additional decodings
@@ -326,6 +330,8 @@ export class WireDecoder {
   }
 
   /**
+   * **This method is asynchronous.**
+   *
    * Similar to [[decodeLog]], but operates on an array of logs and decodes them all.
    * @param logs The logs to be decoded.
    */
@@ -349,6 +355,8 @@ export class WireDecoder {
   }
 
   /**
+   * **This method is asynchronous.**
+   *
    * Gets all events meeting certain conditions and decodes them.
    * This function is fairly rudimentary at the moment but more functionality
    * will be added in the future.
@@ -441,6 +449,8 @@ export class WireDecoder {
   //finally: the spawners!
 
   /**
+   * **This method is asynchronous.**
+   *
    * Constructs a contract decoder for a given contract artifact.
    * @param artifact The artifact for the contract.
    *
@@ -457,6 +467,8 @@ export class WireDecoder {
   }
 
   /**
+   * **This method is asynchronous.**
+   *
    * Constructs a contract instance decoder for a given instance of a contract in this
    * project.
    * @param artifact The artifact for the contract.
@@ -595,6 +607,8 @@ export class ContractDecoder {
   }
 
   /**
+   * **This method is asynchronous.**
+   *
    * Constructs a contract instance decoder for a given instance of this contract.
    * @param address The address of the contract instance decode.  If left out, it will be autodetected.
    *   If an invalid address is provided, this method will throw an exception.
@@ -606,6 +620,8 @@ export class ContractDecoder {
   }
 
   /**
+   * **This method is asynchronous.**
+   *
    * See [[WireDecoder.decodeTransaction]].
    * @param transaction The transaction to be decoded.
    */
@@ -616,6 +632,8 @@ export class ContractDecoder {
   }
 
   /**
+   * **This method is asynchronous.**
+   *
    * See [[WireDecoder.decodeLog]].
    * @param log The log to be decoded.
    */
@@ -624,6 +642,8 @@ export class ContractDecoder {
   }
 
   /**
+   * **This method is asynchronous.**
+   *
    * See [[WireDecoder.decodeLogs]].
    * @param logs The logs to be decoded.
    */
@@ -632,6 +652,8 @@ export class ContractDecoder {
   }
 
   /**
+   * **This method is asynchronous.**
+   *
    * See [[WireDecoder.events]].
    * @param options Used to determine what events to fetch; see the documentation on the EventOptions type for more.
    */
@@ -881,6 +903,8 @@ export class ContractInstanceDecoder {
   }
 
   /**
+   * **This method is asynchronous.**
+   *
    * Returns information about the state of the contract, but does not include
    * information about the storage or decoded variables.  See the documentation
    * for the [[ContractState]] type for more.
@@ -905,6 +929,8 @@ export class ContractInstanceDecoder {
   }
 
   /**
+   * **This method is asynchronous.**
+   *
    * Decodes the contract's variables; returns an array of these decoded variables.
    * See the documentation of the [[DecodedVariable]] type for more.
    *
@@ -947,6 +973,8 @@ export class ContractInstanceDecoder {
   }
 
   /**
+   * **This method is asynchronous.**
+   *
    * Decodes an individual contract variable; returns its value as a
    * [[Format.Values.Result|Result]].  See the documentation for
    * [[variables|variables()]] for various caveats that also apply here.
@@ -1051,6 +1079,8 @@ export class ContractInstanceDecoder {
   }
 
   /**
+   * **This method is asynchronous.**
+   *
    * Watches a mapping key; adds it to the decoder's list of watched mapping
    * keys.  This affects the results of both [[variables|variables()]] and
    * [[variable|variable()]].  When a mapping is decoded, only the values at
@@ -1133,6 +1163,8 @@ export class ContractInstanceDecoder {
   }
 
   /**
+   * **This method is asynchronous.**
+   *
    * Opposite of [[watchMappingKey]]; unwatches the specified mapping key.  See
    * watchMappingKey for more on how watching mapping keys works, and on how
    * the parameters work.
@@ -1172,6 +1204,8 @@ export class ContractInstanceDecoder {
   //than a while
 
   /**
+   * **This method is asynchronous.**
+   *
    * See [[WireDecoder.decodeTransaction]].
    */
   public async decodeTransaction(
@@ -1184,6 +1218,8 @@ export class ContractInstanceDecoder {
   }
 
   /**
+   * **This method is asynchronous.**
+   *
    * See [[WireDecoder.decodeLog]].
    */
   public async decodeLog(log: Log): Promise<DecoderTypes.DecodedLog> {
@@ -1195,6 +1231,8 @@ export class ContractInstanceDecoder {
   }
 
   /**
+   * **This method is asynchronous.**
+   *
    * See [[WireDecoder.decodeLogs]].
    */
   public async decodeLogs(logs: Log[]): Promise<DecoderTypes.DecodedLog[]> {
@@ -1220,6 +1258,8 @@ export class ContractInstanceDecoder {
   }
 
   /**
+   * **This method is asynchronous.**
+   *
    * This mostly behaves as [[WireDecoder.events]].
    * However, unlike other variants of this function, this one, by default, restricts to events originating from this instance's address.
    * If you don't want to restrict like that, you can explicitly use `address: undefined` in the options to disable this.

--- a/packages/decoder/lib/index.ts
+++ b/packages/decoder/lib/index.ts
@@ -33,6 +33,8 @@ import { ContractObject } from "@truffle/contract-schema/spec";
 import { ContractConstructorObject, ContractInstanceObject } from "./types";
 
 /**
+ * **This function is asynchronous.**
+ *
  * Constructs a wire decoder for the project.
  * @param provider The Web3 provider object to use.
  * @param artifacts A list of contract artifacts for contracts in the project.
@@ -51,6 +53,8 @@ export async function forProject(
 }
 
 /**
+ * **This function is asynchronous.**
+ *
  * Constructs a contract decoder for a given contract artifact.
  * @param artifact The artifact for the contract.
  *
@@ -83,6 +87,8 @@ export async function forArtifact(
 }
 
 /**
+ * **This function is asynchronous.**
+ *
  * Constructs a contract decoder for a given contract.
  * @param contract The contract constructor object corresponding to the type of the contract.
  * @param artifacts A list of artifacts for other contracts in the project that may be relevant
@@ -101,6 +107,8 @@ export async function forContract(
 }
 
 /**
+ * **This function is asynchronous.**
+ *
  * Constructs a contract instance decoder for a deployed contract instance.
  * @param artifact The artifact corresponding to the type of the contract.
  *
@@ -126,6 +134,8 @@ export async function forDeployedArtifact(
 }
 
 /**
+ * **This function is asynchronous.**
+ *
  * Constructs a contract instance decoder for a deployed contract instance.
  * @param contract The contract constructor object corresponding to the type of the contract.
  * @param artifacts A list of artifacts for other contracts in the project that may be relevant
@@ -146,6 +156,8 @@ export async function forDeployedContract(
 }
 
 /**
+ * **This function is asynchronous.**
+ *
  * Constructs a contract instance decoder for a contract instance at a given address.
  * @param artifact The artifact corresponding to the type of the contract.
  *
@@ -176,6 +188,8 @@ export async function forArtifactAt(
 }
 
 /**
+ * **This function is asynchronous.**
+ *
  * Constructs a contract instance decoder for a contract instance at a given address.
  * @param contract The contract constructor object corresponding to the type of the contract.
  * @param address The address of the contract instance to decode.
@@ -201,6 +215,8 @@ export async function forContractAt(
 }
 
 /**
+ * **This function is asynchronous.**
+ *
  * Constructs a contract instance decoder for a given contract instance.
  * @param contract The contract abstraction object corresponding to the contract instance.
  * @param artifacts A list of artifacts for other contracts in the project that may be relevant


### PR DESCRIPTION
(Related to #2505)

Because we can't get TypeDoc to display `async` on async functions, this PR manually marks async functions as such with bold warnings in their docstrings.