### PR TITLE
Update debug namespaces for codec reorg

### DIFF
--- a/packages/codec/lib/abi/utils.ts
+++ b/packages/codec/lib/abi/utils.ts
@@ -1,5 +1,5 @@
 import debugModule from "debug";
-const debug = debugModule("codec:utils:abi");
+const debug = debugModule("codec:abi:utils");
 
 // untyped import since no @types/web3-utils exists
 const Web3Utils = require("web3-utils");

--- a/packages/codec/lib/abify.ts
+++ b/packages/codec/lib/abify.ts
@@ -1,5 +1,5 @@
 import debugModule from "debug";
-const debug = debugModule("codec:format:abify");
+const debug = debugModule("codec:abify");
 
 import * as Format from "@truffle/codec/format";
 import * as Common from "@truffle/codec/common";

--- a/packages/codec/lib/compiler/utils.ts
+++ b/packages/codec/lib/compiler/utils.ts
@@ -1,5 +1,5 @@
 import debugModule from "debug";
-const debug = debugModule("codec:utils:compiler");
+const debug = debugModule("codec:compiler:utils");
 
 import semver from "semver";
 import { CompilerVersion, SolidityFamily } from "./types";

--- a/packages/codec/lib/contexts/utils.ts
+++ b/packages/codec/lib/contexts/utils.ts
@@ -1,9 +1,15 @@
 import debugModule from "debug";
-const debug = debugModule("codec:utils:contexts");
+const debug = debugModule("codec:contexts:utils");
 
 import * as Evm from "@truffle/codec/evm";
 import * as Format from "@truffle/codec/format";
-import { DecoderContexts, DecoderContext, Context, Contexts, DebuggerContexts } from "./types";
+import {
+  DecoderContexts,
+  DecoderContext,
+  Context,
+  Contexts,
+  DebuggerContexts
+} from "./types";
 import escapeRegExp from "lodash.escaperegexp";
 
 //I split these next two apart because the type system was giving me trouble
@@ -31,10 +37,7 @@ export function findDebuggerContext(
   return context !== undefined ? context.context : null;
 }
 
-export function matchContext(
-  context: Context,
-  givenBinary: string
-): boolean {
+export function matchContext(context: Context, givenBinary: string): boolean {
   let { binary, isConstructor } = context;
   let lengthDifference = givenBinary.length - binary.length;
   //first: if it's not a constructor, they'd better be equal in length.
@@ -63,9 +66,7 @@ export function matchContext(
   return true;
 }
 
-export function normalizeContexts(
-  contexts: Contexts
-): Contexts {
+export function normalizeContexts(contexts: Contexts): Contexts {
   //unfortunately, due to our current link references format, we can't
   //really use the binary from the artifact directly -- neither for purposes
   //of matching, nor for purposes of decoding internal functions.  So, we
@@ -145,9 +146,7 @@ export function normalizeContexts(
   return newContexts;
 }
 
-export function contextToType(
-  context: Context
-): Format.Types.ContractType {
+export function contextToType(context: Context): Format.Types.ContractType {
   if (context.contractId !== undefined) {
     return {
       typeClass: "contract",

--- a/packages/codec/lib/core.ts
+++ b/packages/codec/lib/core.ts
@@ -1,5 +1,5 @@
 import debugModule from "debug";
-const debug = debugModule("codec:core:decoding");
+const debug = debugModule("codec:core");
 
 import * as Ast from "@truffle/codec/ast";
 import * as Abi from "@truffle/codec/abi";

--- a/packages/codec/lib/evm/utils.ts
+++ b/packages/codec/lib/evm/utils.ts
@@ -1,5 +1,5 @@
 import debugModule from "debug";
-const debug = debugModule("codec:utils:evm");
+const debug = debugModule("codec:evm:utils");
 
 import BN from "bn.js";
 // untyped import since no @types/web3-utils exists

--- a/packages/codec/lib/format/utils/exception.ts
+++ b/packages/codec/lib/format/utils/exception.ts
@@ -1,5 +1,5 @@
 import debugModule from "debug";
-const debug = debugModule("codec:utils:errors");
+const debug = debugModule("codec:format:utils:exception");
 
 import * as Format from "@truffle/codec/format/common";
 import * as Ast from "@truffle/codec/ast";
@@ -14,7 +14,9 @@ export function message(error: Format.Errors.ErrorForThrowing): string {
       let typeName = Format.Types.isContractDefinedType(error.type)
         ? error.type.definingContractName + "." + error.type.typeName
         : error.type.typeName;
-      return `Unknown ${error.type.typeClass} type ${typeName} of id ${error.type.id}`;
+      return `Unknown ${error.type.typeClass} type ${typeName} of id ${
+        error.type.id
+      }`;
     case "UnsupportedConstantError":
       return `Unsupported constant type ${Ast.Utils.typeClass(
         error.definition
@@ -22,7 +24,9 @@ export function message(error: Format.Errors.ErrorForThrowing): string {
     case "ReadErrorStack":
       return `Can't read stack from position ${error.from} to ${error.to}`;
     case "ReadErrorBytes":
-      return `Can't read ${error.length} bytes from input starting at ${error.start}`;
+      return `Can't read ${error.length} bytes from input starting at ${
+        error.start
+      }`;
     case "ReadErrorStorage":
       if (error.range.length) {
         return `Can't read ${

--- a/packages/codec/lib/format/utils/inspect.ts
+++ b/packages/codec/lib/format/utils/inspect.ts
@@ -1,5 +1,5 @@
 import debugModule from "debug";
-const debug = debugModule("codec:format:inspect");
+const debug = debugModule("codec:format:utils:inspect");
 
 import util from "util";
 import * as Format from "@truffle/codec/format/common";

--- a/packages/codec/lib/format/utils/maketype.ts
+++ b/packages/codec/lib/format/utils/maketype.ts
@@ -1,5 +1,5 @@
 import debugModule from "debug";
-const debug = debugModule("codec:format:maketype");
+const debug = debugModule("codec:format:utils:maketype");
 
 import BN from "bn.js";
 import * as Common from "@truffle/codec/common";


### PR DESCRIPTION
This PR just updates the `debug` namespaces as per @gnidan's codec reorganization.

(`prettier` seems to have done some work as well...)