### PR TITLE
Fix issue with additionalContexts

### DIFF
--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -806,9 +806,14 @@ export class ContractInstanceDecoder {
       //This way the decoder core can recognize the address as the class, without us having
       //to make serious modifications to contract decoding.  And while sure this requires
       //a little more work, I mean, it's all cached, so, no big deal.
-      let extraContext = Utils.makeContext(this.contract, this.contractNode);
-      //now override the binary
-      extraContext.binary = this.contractCode;
+      const contractWithCode = {
+        ...this.contract,
+        deployedBytecode: this.contractCode
+      };
+      const extraContext = Utils.makeContext(
+        contractWithCode,
+        this.contractNode
+      );
       this.additionalContexts = { [extraContext.context]: extraContext };
       //the following line only has any effect if we're dealing with a library,
       //since the code we pulled from the blockchain obviously does not have unresolved link references!


### PR DESCRIPTION
This PR fixes an issue I just noticed with `additionalContexts`.  (I'm realizing now that that little feature has never really been tested and uhhhh I should probably find some way of doing that before we realease it...)

Basically, `additionalContexts` didn't actually work because, in the call to `makeContext`, you'd possibly attempt to take the SHA3 hash of `undefined`, which causes an error.  And even if you avoided that, you'd still be taking the hash of the wrong thing.  And while we override the binary later, we weren't overriding the hash as well.  (Not that it should actually cause a serious problem if you hit this case, but...)

This PR fixes that by overriding the binary *before* the call to `makeContext`, so it should work fine and also produce the correct hash.

We should really probably test this, but I'm skipping adding tests for now if you don't mind.