### PR TITLE
Fix nested array conversion

### DIFF
--- a/packages/contract/lib/reformat.js
+++ b/packages/contract/lib/reformat.js
@@ -31,8 +31,10 @@ const _convertNumber = function(val, format) {
  * @param  {String}   format    name of format to convert to
  * @return {Object[]|String[]}  array of converted values
  */
-const _convertNumberArray = function(arr, format) {
-  return arr.map(item => _convertNumber(item, format));
+const _convertNumberArray = function(arr, format, depth = 0) {
+  if (depth == 0) return arr.map(item => _convertNumber(item, format));
+  // arr is nested
+  return arr.map(item => _convertNumberArray(item, format, depth - 1));
 };
 
 /**
@@ -53,9 +55,12 @@ const numbers = function(result, abiSegment) {
     if (output.type.includes("int")) {
       // output is an array type
       if (output.type.includes("[")) {
+        // larger than zero if nested array
+        let depth = output.type.split("[").length - 2;
+
         // result is array
         if (Array.isArray(result)) {
-          result = _convertNumberArray(result, format);
+          result = _convertNumberArray(result, format, depth);
 
           // result is object
         } else {
@@ -63,11 +68,12 @@ const numbers = function(result, abiSegment) {
           if (output.name.length) {
             result[output.name] = _convertNumberArray(
               result[output.name],
-              format
+              format,
+              depth
             );
           }
           // output will always have an index key
-          result[i] = _convertNumberArray(result[i], format);
+          result[i] = _convertNumberArray(result[i], format, depth);
         }
         //
       } else if (typeof result === "object") {

--- a/packages/contract/test/methods.js
+++ b/packages/contract/test/methods.js
@@ -217,6 +217,26 @@ describe("Methods", function() {
       assert(web3.utils.isBN(value[1]));
     });
 
+    it("should output nested uint array values as BN by default (call)", async function() {
+      let value;
+      const example = await Example.new(1);
+
+      value = await example.returnsNamedStaticNestedArray();
+      assert(Array.isArray(value));
+      assert(web3.utils.isBN(value[0][0]));
+      assert(web3.utils.isBN(value[0][1]));
+      assert(web3.utils.isBN(value[1][0]));
+      assert(web3.utils.isBN(value[1][1]));
+
+      value = await example.returnsUnnamedStaticNestedArray();
+
+      assert(Array.isArray(value));
+      assert(web3.utils.isBN(value[0][0]));
+      assert(web3.utils.isBN(value[0][1]));
+      assert(web3.utils.isBN(value[1][0]));
+      assert(web3.utils.isBN(value[1][1]));
+    });
+
     it("should output int values as BN by default (call)", async function() {
       let value;
       const example = await Example.new(1);

--- a/packages/contract/test/methods.js
+++ b/packages/contract/test/methods.js
@@ -223,6 +223,8 @@ describe("Methods", function() {
 
       value = await example.returnsNamedStaticNestedArray();
       assert(Array.isArray(value));
+      assert(Array.isArray(value[0]));
+      assert(Array.isArray(value[1]));
       assert(web3.utils.isBN(value[0][0]));
       assert(web3.utils.isBN(value[0][1]));
       assert(web3.utils.isBN(value[1][0]));
@@ -231,6 +233,8 @@ describe("Methods", function() {
       value = await example.returnsUnnamedStaticNestedArray();
 
       assert(Array.isArray(value));
+      assert(Array.isArray(value[0]));
+      assert(Array.isArray(value[1]));
       assert(web3.utils.isBN(value[0][0]));
       assert(web3.utils.isBN(value[0][1]));
       assert(web3.utils.isBN(value[1][0]));

--- a/packages/contract/test/sources/Example.sol
+++ b/packages/contract/test/sources/Example.sol
@@ -177,6 +177,28 @@ contract Example {
     return arr;
   }
 
+  function returnsNamedStaticNestedArray()
+    public
+    view
+    returns (uint[2][] memory named)
+  {
+    uint[2][] memory arr = new uint[2][](2);
+    arr[0] = [uint(5), 5];
+    arr[1] = [uint(7), 7];
+    return arr;
+  }
+
+  function returnsUnnamedStaticNestedArray()
+    public
+    view
+    returns (uint[2][] memory)
+  {
+    uint[2][] memory arr = new uint[2][](2);
+    arr[0] = [uint(5), 5];
+    arr[1] = [uint(7), 7];
+    return arr;
+  }
+
   function() external payable {
     fallbackTriggered = true;
   }


### PR DESCRIPTION
- Using `_convertNumberArray()` recursively to finally `_convertNumber()`
- Also added one test case for both named and unnamed return values

Fixes #1723 