### PR TITLE
Add note about overlarge lengths & pointers

### DIFF
--- a/packages/codec/lib/index.ts
+++ b/packages/codec/lib/index.ts
@@ -149,6 +149,12 @@ export {
    * of reference type.  Thus, these decode to an error
    * (`IndexedReferenceTypeError`, which see) rather than to a value.
    *
+   * Thirdly, objects with encoded length fields larger than what fits in a
+   * JavaScript safe integer, or pointed to by pointers with values larger than
+   * what fits in a JavaScript safe integer, will decode to errors, even if they
+   * may technically be legal.  Such cases are impractical to handle and should
+   * never come up in real use so we decode them to errors.
+   *
    * Finally, except when decoding events, we do not return an error if the pointers
    * in an ABI-encoded array or tuple are arranged in a nonstandard way, or if
    * strings or bytestrings are incorrectly padded, because it is not worth the


### PR DESCRIPTION
This PR adds a note to the format documentation about overlarge lengths and pointers, and how these are considered errors even though by our stated criteria they likely shouldn't be.