### PR TITLE
Test additional contexts feature in contract instance decoder

### DIFF
--- a/packages/decoder/test/contracts/DecodingSample.sol
+++ b/packages/decoder/test/contracts/DecodingSample.sol
@@ -63,7 +63,7 @@ contract DecodingSample is DecodingSampleParent {
   //S[2]       fixedArrayStructS;
   // S[]       dynamicArrayStructS;
 
-  function() external functionExternal;
+  function() external functionExternal = this.example;
 
   function example() public {
     functionExternal = this.example;
@@ -155,7 +155,5 @@ contract DecodingSample is DecodingSampleParent {
     varMapping[2] = 41;
     varMapping[3] = 107;
     varAddressMapping[address(this)] = 683;
-
-    functionExternal = this.example;
   }
 }

--- a/packages/decoder/test/contracts/DowngradeTest.sol
+++ b/packages/decoder/test/contracts/DowngradeTest.sol
@@ -26,6 +26,8 @@ contract DowngradeTest {
   function() external payable {
   }
 
+  function() external doYouSeeMe = this.causeTrouble;
+
   function run(AsymmetricTriple memory at, Ternary t, DowngradeTest dt, address payable ap) public {
     emit TheWorks(at, t, dt, ap);
   }
@@ -52,9 +54,17 @@ contract DowngradeTest {
 
   event EnumSilliness1(uint8 indexed, uint8 indexed, Ternary, PositionOnHill);
   event EnumSilliness2(uint8, uint8, Ternary indexed, PositionOnHill indexed);
+
+  function decoy() public { //here to make the additionalContexts test harder
+    DecoyLibrary.decoy();
+    emit Done();
+  }
 }
 
 library DecoyLibrary {
   event EnumSilliness1(uint8, uint8, DowngradeTest.Ternary indexed, DowngradeTest.PositionOnHill indexed);
   event EnumSilliness2(uint8 indexed, uint8 indexed, DowngradeTest.Ternary, DowngradeTest.PositionOnHill);
+
+  function decoy() external pure {
+  }
 }

--- a/packages/decoder/test/migrations/2_deploy_contracts.js
+++ b/packages/decoder/test/migrations/2_deploy_contracts.js
@@ -1,8 +1,12 @@
+const DecoyLibrary = artifacts.require("DecoyLibrary");
+const DowngradeTest = artifacts.require("DowngradeTest");
 const DecodingSample = artifacts.require("DecodingSample");
 const WireTest = artifacts.require("WireTest");
 const WireTestLibrary = artifacts.require("WireTestLibrary");
 
 module.exports = function(deployer) {
+  deployer.deploy(DecoyLibrary);
+  deployer.link(DecoyLibrary, DowngradeTest);
   deployer.deploy(DecodingSample);
   deployer.deploy(WireTestLibrary);
   deployer.link(WireTestLibrary, WireTest);


### PR DESCRIPTION
This PR adds a test for the contract instance decoder's "additional contexts" feature.  It adds a state variable, `doYouSeeMe`, of type `function() external`, and initializes it to `this.causeTrouble`.  Then, it attempts to decode this variable but with a mangled artifact that is missing the deployed bytecode.  Because of the additional contexts feature, the decoding succeeds (with full information) regardless.

It also adds a link to `DecoyLibrary` from `DowngradeTest` just to make the test a little harder to pass. :)  (OK, I guess this doesn't *really* make it harder, but like, it notionally could?  IDK.)