### PR TITLE
Sourcemap

### DIFF
--- a/packages/truffle-db/src/artifacts/json/resolvers.ts
+++ b/packages/truffle-db/src/artifacts/json/resolvers.ts
@@ -32,6 +32,9 @@ export const resolvers = {
             json: JSON.stringify(artifact.ast)
           },
           source: { contents: artifact.source, sourcePath: artifact.sourcePath },
+          sourceMap: {
+            json: JSON.stringify(artifact.sourceMap)
+          }
         };
 
         if (networkId) {

--- a/packages/truffle-db/src/artifacts/json/schema.ts
+++ b/packages/truffle-db/src/artifacts/json/schema.ts
@@ -231,6 +231,31 @@ const translations = [
     }
   }),
 
+  // override sourceMap field to be object with json property
+  ({ contractObject, ...schemas }) => ({
+    ...schemas,
+
+    contractObject: {
+      ...contractObject,
+
+      properties: {
+        ...contractObject.properties,
+
+        sourceMap: {
+          type: "object",
+          properties: {
+            json: {
+              type: "string",
+              description: "JSON-encoded sourceMap"
+            },
+          },
+
+          required: ["json"]
+        }
+      }
+    }
+  }),
+
   // find all refs and remove leading `#/definitions/`
   searchReplace(
     (key) => key === "$ref",

--- a/packages/truffle-db/src/loaders/artifacts/test/index.ts
+++ b/packages/truffle-db/src/loaders/artifacts/test/index.ts
@@ -193,6 +193,9 @@ query getWorkspaceCompilation($id: ID!) {
         contents
         sourcePath
       }
+      sourceMaps {
+        json
+      }
     }
   }
 }`;
@@ -347,12 +350,14 @@ describe("Compilation", () => {
     }));
 
     const solcCompilation = compilationsQuery[0].data.workspace.compilation;
+
     expect(solcCompilation.compiler.version).toEqual(artifacts[0].compiler.version);
     expect(solcCompilation.sources.length).toEqual(3);
     solcCompilation.sources.map((source, index)=> {
       expect(source.id).toEqual(sourceIds[index].id);
       expect(source["contents"]).toEqual(artifacts[index].source);
       expect(solcCompilation.contracts[index].name).toEqual(artifacts[index].contractName);
+      expect(solcCompilation.sourceMaps[index].json).toEqual(artifacts[index].sourceMap);
     });
 
     const vyperCompilation =  compilationsQuery[1].data.workspace.compilation

--- a/packages/truffle-db/src/schema.graphql
+++ b/packages/truffle-db/src/schema.graphql
@@ -77,7 +77,6 @@ type LinkReference {
 
 type Bytecode {
   bytes: Bytes!
-  sourceMap: String,
   instructions: [Instruction!],
   linkReferences: [LinkReference]
 }
@@ -112,10 +111,15 @@ type Source {
   ast: AST
 }
 
+type SourceMap {
+  json: String!
+}
+
 type Compilation {
   compiler: Compiler!
   sources: [Source]!
   contracts: [SourceContract]!
+  sourceMaps: [SourceMap]
 }
 
 type Compiler {

--- a/packages/truffle-db/src/workspace/pouch.ts
+++ b/packages/truffle-db/src/workspace/pouch.ts
@@ -198,7 +198,7 @@ export class Workspace {
     return {
       compilations: Promise.all(compilations.map(
         async (compilationInput) => {
-         const { compiler, contracts, sources } = compilationInput;
+         const { compiler, contracts, sources, sourceMaps } = compilationInput;
 
          const sourceIds = sources.map(source => source.id);
          const sourcesObject = Object.assign({}, sourceIds);

--- a/packages/truffle-db/src/workspace/schema.ts
+++ b/packages/truffle-db/src/workspace/schema.ts
@@ -143,10 +143,15 @@ export const schema = mergeSchemas({
       ast: CompilationSourceContractAstInput
     }
 
+    input CompilationSourceMapInput {
+      json: String!
+    }
+
     input CompilationInput {
       compiler: CompilerInput!
       contracts: [CompilationSourceContractInput!]
       sources: [CompilationSourceInput!]!
+      sourceMaps: [CompilationSourceMapInput]
     }
     input CompilationsAddInput {
       compilations: [CompilationInput!]!

--- a/packages/truffle-db/src/workspace/test/bytecode.spec.ts
+++ b/packages/truffle-db/src/workspace/test/bytecode.spec.ts
@@ -54,7 +54,6 @@ describe("Bytecode", () => {
       expect(bc).toHaveProperty("id");
       expect(bc).toHaveProperty("bytes");
       expect(bc).toHaveProperty("linkReferences");
-      expect(bc).toHaveProperty("sourceMap");
       expect(bc).toHaveProperty("instructions");
     })
 

--- a/packages/truffle-db/src/workspace/test/compilation.graphql.ts
+++ b/packages/truffle-db/src/workspace/test/compilation.graphql.ts
@@ -1,13 +1,16 @@
 import gql from "graphql-tag";
 
 export const AddCompilation = gql`
-  mutation AddCompilation($compilerName: String!, $compilerVersion: String!, $sourceId: ID!, $abi:String!) {
+  mutation AddCompilation($compilerName: String!, $compilerVersion: String!, $sourceId: ID!, $abi:String!, $sourceMap:String!) {
     compilationsAdd(input: {
       compilations: [{
         compiler: {
           name: $compilerName
           version: $compilerVersion
         }
+        sourceMaps: [{
+          json: $sourceMap
+        }]
         contracts: [
         {
           name:"testing",
@@ -32,6 +35,9 @@ export const AddCompilation = gql`
         }
         sources {
           contents
+        }
+        sourceMaps {
+          json
         }
         contracts {
           source {

--- a/packages/truffle-db/src/workspace/test/compilation.spec.ts
+++ b/packages/truffle-db/src/workspace/test/compilation.spec.ts
@@ -21,7 +21,8 @@ describe("Compilation", () => {
       compilerName: Migrations.compiler.name,
       compilerVersion: Migrations.compiler.version,
       sourceId: sourceId,
-      abi: JSON.stringify(Migrations.abi)
+      abi: JSON.stringify(Migrations.abi),
+      sourceMap: JSON.stringify(Migrations.sourceMap)
     };
     addCompilationResult = await wsClient.execute(AddCompilation, variables);
 
@@ -39,7 +40,7 @@ describe("Compilation", () => {
     for (let compilation of compilations) {
       expect(compilation).toHaveProperty("compiler");
       expect(compilation).toHaveProperty("sources");
-      const { compiler, sources, contracts } = compilation;
+      const { compiler, sources, contracts, sourceMaps } = compilation;
 
       expect(compiler).toHaveProperty("name");
 

--- a/packages/truffle-db/src/workspace/test/contract.spec.ts
+++ b/packages/truffle-db/src/workspace/test/contract.spec.ts
@@ -36,7 +36,8 @@ describe("Contract", () => {
       compilerName: Migrations.compiler.name,
       compilerVersion: Migrations.compiler.version,
       sourceId: sourceId,
-      abi: JSON.stringify(Migrations.abi)
+      abi: JSON.stringify(Migrations.abi),
+      sourceMap: JSON.stringify(Migrations.sourceMap)
     };
     const compilationResult = await wsClient.execute(AddCompilation, compilationVariables);
     compilationId = compilationResult.compilationsAdd.compilations[0].id;


### PR DESCRIPTION
This PR adds the `SourceMaps` array to the `compilation` object, in the artifacts, loader, and workspace code as well as the concomitant tests.