### PR TITLE
Enhancement: Add flag `truffle test --runner-output-only`

### DIFF
--- a/packages/core/lib/commands/test.js
+++ b/packages/core/lib/commands/test.js
@@ -38,6 +38,10 @@ const command = {
       {
         option: "--show-events",
         description: "Log all contract events."
+      },
+      {
+        option: "--quiet",
+        description: "Suppress all output except for the test report."
       }
     ]
   },
@@ -132,7 +136,9 @@ const command = {
 
       promisifiedCopy(config.contracts_build_directory, temporaryDirectory)
         .then(() => {
-          config.logger.log("Using network '" + config.network + "'." + OS.EOL);
+          if (config.quiet !== true) {
+            config.logger.log(`Using network '${config.network}'.${OS.EOL}`);
+          }
 
           run();
         })

--- a/packages/core/lib/commands/test.js
+++ b/packages/core/lib/commands/test.js
@@ -6,6 +6,11 @@ const command = {
       describe: "Show all test logs",
       type: "boolean",
       default: false
+    },
+    "mocha-output-only": {
+      describe: "Suppress all logging except for mocha output.",
+      type: "boolean",
+      default: false
     }
   },
   help: {
@@ -40,8 +45,8 @@ const command = {
         description: "Log all contract events."
       },
       {
-        option: "--quiet",
-        description: "Suppress all output except for the test report."
+        option: "--mocha-output-only",
+        description: "Suppress all output except for mocha output."
       }
     ]
   },
@@ -136,10 +141,9 @@ const command = {
 
       promisifiedCopy(config.contracts_build_directory, temporaryDirectory)
         .then(() => {
-          if (config.quiet !== true) {
+          if (config.mochaOutputOnly !== true) {
             config.logger.log(`Using network '${config.network}'.${OS.EOL}`);
           }
-
           run();
         })
         .catch(done);

--- a/packages/core/lib/commands/test.js
+++ b/packages/core/lib/commands/test.js
@@ -7,8 +7,8 @@ const command = {
       type: "boolean",
       default: false
     },
-    "mocha-output-only": {
-      describe: "Suppress all logging except for mocha output.",
+    "runner-output-only": {
+      describe: "Suppress all output except for test runner output.",
       type: "boolean",
       default: false
     }
@@ -45,8 +45,8 @@ const command = {
         description: "Log all contract events."
       },
       {
-        option: "--mocha-output-only",
-        description: "Suppress all output except for mocha output."
+        option: "--runner-output-only",
+        description: "Suppress all output except for test runner output."
       }
     ]
   },
@@ -141,7 +141,7 @@ const command = {
 
       promisifiedCopy(config.contracts_build_directory, temporaryDirectory)
         .then(() => {
-          if (config.mochaOutputOnly !== true) {
+          if (config.runnerOutputOnly !== true) {
             config.logger.log(`Using network '${config.network}'.${OS.EOL}`);
           }
           run();


### PR DESCRIPTION
Add flag for truffle test to suppress all output save for the output from the test runner itself.

Inspired by https://github.com/trufflesuite/truffle/issues/2457