### PR TITLE
Simplify wire decoder return types; internalize Web3 types

### DIFF
--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -22,8 +22,6 @@ import * as DecoderTypes from "./types";
 import Web3 from "web3";
 import { ContractObject } from "@truffle/contract-schema/spec";
 import BN from "bn.js";
-import { BlockType, Transaction } from "web3/eth/types";
-import { Log } from "web3/types";
 import { Provider } from "web3/providers";
 import {
   ContractBeingDecodedHasNoNodeError,
@@ -211,10 +209,8 @@ export class WireDecoder {
   /**
    * **This method is asynchronous.**
    *
-   * Takes a Web3
-   * [Transaction](https://web3js.readthedocs.io/en/v1.2.1/web3-eth.html#eth-gettransaction-return)
-   * object and decodes it.  The result is a [[CalldataDecoding]]; see the documentation on
-   * that interface for more.
+   * Takes a [[Transaction]] object and decodes it.  The result is a
+   * [[CalldataDecoding]]; see the documentation on that interface for more.
    *
    * Note that decoding of transactions sent to libraries is presently not
    * supported and may have unreliable results.  Limited support for this is
@@ -222,7 +218,7 @@ export class WireDecoder {
    * @param transaction The transaction to be decoded.
    */
   public async decodeTransaction(
-    transaction: Transaction
+    transaction: DecoderTypes.Transaction
   ): Promise<CalldataDecoding> {
     return await this.decodeTransactionWithAdditionalContexts(transaction);
   }
@@ -231,7 +227,7 @@ export class WireDecoder {
    * @protected
    */
   public async decodeTransactionWithAdditionalContexts(
-    transaction: Transaction,
+    transaction: DecoderTypes.Transaction,
     additionalContexts: Contexts.DecoderContexts = {}
   ): Promise<CalldataDecoding> {
     debug("transaction: %O", transaction);
@@ -276,10 +272,8 @@ export class WireDecoder {
   /**
    * **This method is asynchronous.**
    *
-   * Takes a Web3
-   * [Log](https://web3js.readthedocs.io/en/v1.2.1/web3-eth.html#eth-getpastlogs-return)
-   * object and decodes it.  Logs can be ambiguous, so this so this function
-   * returns an array of [[LogDecoding|LogDecodings]].
+   * Takes a [[Log]] object and decodes it.  Logs can be ambiguous, so this so
+   * this function returns an array of [[LogDecoding|LogDecodings]].
    *
    * Note that logs are decoded in strict mode, so (with one exception) none of the decodings should
    * contain errors; if a decoding would contain an error, instead it is simply excluded from the
@@ -301,7 +295,7 @@ export class WireDecoder {
    *
    * @param log The log to be decoded.
    */
-  public async decodeLog(log: Log): Promise<LogDecoding[]> {
+  public async decodeLog(log: DecoderTypes.Log): Promise<LogDecoding[]> {
     return await this.decodeLogWithAdditionalOptions(log);
   }
 
@@ -309,7 +303,7 @@ export class WireDecoder {
    * @protected
    */
   public async decodeLogWithAdditionalOptions(
-    log: Log,
+    log: DecoderTypes.Log,
     options: DecoderTypes.EventOptions = {},
     additionalContexts: Contexts.DecoderContexts = {}
   ): Promise<LogDecoding[]> {
@@ -627,7 +621,7 @@ export class ContractDecoder {
    * @param transaction The transaction to be decoded.
    */
   public async decodeTransaction(
-    transaction: Transaction
+    transaction: DecoderTypes.Transaction
   ): Promise<CalldataDecoding> {
     return await this.wireDecoder.decodeTransaction(transaction);
   }
@@ -638,7 +632,7 @@ export class ContractDecoder {
    * See [[WireDecoder.decodeLog]].
    * @param log The log to be decoded.
    */
-  public async decodeLog(log: Log): Promise<LogDecoding[]> {
+  public async decodeLog(log: DecoderTypes.Log): Promise<LogDecoding[]> {
     return await this.wireDecoder.decodeLog(log);
   }
 
@@ -905,11 +899,10 @@ export class ContractInstanceDecoder {
    * information about the storage or decoded variables.  See the documentation
    * for the [[ContractState]] type for more.
    * @param block The block to inspect the contract's state at.  Defaults to latest.
-   *   See [the web3 docs](https://web3js.readthedocs.io/en/v1.2.1/web3-eth.html#id14)
-   *   for legal values.
+   *   See [[BlockSpecifier]] for legal values.
    */
   public async state(
-    block: BlockType = "latest"
+    block: DecoderTypes.BlockSpecifier = "latest"
   ): Promise<DecoderTypes.ContractState> {
     return {
       class: Contexts.Utils.contextToType(this.context),
@@ -941,12 +934,11 @@ export class ContractInstanceDecoder {
    * usefully decode internal function pointers.  See the
    * [[Format.Values.FunctionInternalValue|FunctionInternalValue]]
    * documentation and the README for more on how these are handled.
-   * @param block The block to inspect the contract's variables at.  Defaults to latest.
-   *   See [the web3 docs](https://web3js.readthedocs.io/en/v1.2.1/web3-eth.html#id14)
-   *   for legal values.
+   * @param block The block to inspect the contract's state at.  Defaults to latest.
+   *   See [[BlockSpecifier]] for legal values.
    */
   public async variables(
-    block: BlockType = "latest"
+    block: DecoderTypes.BlockSpecifier = "latest"
   ): Promise<DecoderTypes.StateVariable[]> {
     this.checkAllocationSuccess();
 
@@ -980,10 +972,8 @@ export class ContractInstanceDecoder {
    *   variable.  Can be given as a qualified name, allowing one to get at
    *   shadowed variables from base contracts.  If given by ID, can be given as a
    *   number or numeric string.
-   * @param block The block to inspect the contract's variables at.  Defaults
-   *   to latest.
-   *   See [the web3 docs](https://web3js.readthedocs.io/en/v1.2.1/web3-eth.html#id14)
-   *   for legal values.
+   * @param block The block to inspect the contract's state at.  Defaults to latest.
+   *   See [[BlockSpecifier]] for legal values.
    * @example Consider a contract `Derived` inheriting from a contract `Base`.
    *   Suppose `Derived` has a variable `x` and `Base` has variables `x` and
    *   `y`.  One can access `Derived.x` as `variable("x")` or
@@ -992,7 +982,7 @@ export class ContractInstanceDecoder {
    */
   public async variable(
     nameOrId: string | number,
-    block: BlockType = "latest"
+    block: DecoderTypes.BlockSpecifier = "latest"
   ): Promise<Format.Values.Result | undefined> {
     this.checkAllocationSuccess();
 
@@ -1205,7 +1195,7 @@ export class ContractInstanceDecoder {
    * See [[WireDecoder.decodeTransaction]].
    */
   public async decodeTransaction(
-    transaction: Transaction
+    transaction: DecoderTypes.Transaction
   ): Promise<CalldataDecoding> {
     return await this.wireDecoder.decodeTransactionWithAdditionalContexts(
       transaction,
@@ -1218,7 +1208,7 @@ export class ContractInstanceDecoder {
    *
    * See [[WireDecoder.decodeLog]].
    */
-  public async decodeLog(log: Log): Promise<LogDecoding[]> {
+  public async decodeLog(log: DecoderTypes.Log): Promise<LogDecoding[]> {
     return await this.wireDecoder.decodeLogWithAdditionalOptions(
       log,
       {},

--- a/packages/decoder/lib/index.ts
+++ b/packages/decoder/lib/index.ts
@@ -23,7 +23,6 @@ export {
 export {
   ContractState,
   StateVariable,
-  DecodedTransaction,
   DecodedLog,
   EventOptions
 } from "./types";

--- a/packages/decoder/lib/index.ts
+++ b/packages/decoder/lib/index.ts
@@ -24,7 +24,10 @@ export {
   ContractState,
   StateVariable,
   DecodedLog,
-  EventOptions
+  EventOptions,
+  Transaction,
+  Log,
+  BlockSpecifier
 } from "./types";
 
 import { Provider } from "web3/providers";

--- a/packages/decoder/lib/types.ts
+++ b/packages/decoder/lib/types.ts
@@ -7,8 +7,6 @@ import {
   CalldataDecoding,
   LogDecoding
 } from "@truffle/codec";
-import { Transaction, BlockType } from "web3/eth/types";
-import { Log } from "web3/types";
 import Web3 from "web3";
 
 /**
@@ -103,7 +101,7 @@ export interface ContractAndContexts {
 /**
  * The type of the options parameter to events().  This type will be expanded in the future
  * as more filtering options are added.
- * @category Configurations
+ * @category Inputs
  */
 export interface EventOptions {
   /**
@@ -115,13 +113,13 @@ export interface EventOptions {
    * See [the web3 docs](https://web3js.readthedocs.io/en/v1.2.1/web3-eth.html#id14)
    * for legal values.
    */
-  fromBlock?: BlockType;
+  fromBlock?: BlockSpecifier;
   /**
    * The latest block to include events from.  Defaults to "latest".
    * See [the web3 docs](https://web3js.readthedocs.io/en/v1.2.1/web3-eth.html#id14)
    * for legal values.
    */
-  toBlock?: BlockType;
+  toBlock?: BlockSpecifier;
   /**
    * If included, will restrict to events emitted by the given address.
    *
@@ -132,6 +130,120 @@ export interface EventOptions {
    */
   address?: string;
 }
+
+/**
+ * Contains information about a transaction.  Most of the fields have
+ * been made optional; only those needed by the decoder have been made
+ * mandatory.
+ *
+ * Intended to be identical to Web3's
+ * [Transaction](https://web3js.readthedocs.io/en/v1.2.1/web3-eth.html#eth-gettransaction-return)
+ * type.
+ * @category Inputs
+ */
+export interface Transaction {
+  /**
+   * The transaction hash as hex string.
+   */
+  hash?: string;
+  /**
+   * The nonce of the sender before this transaction was sent.
+   */
+  nonce?: number;
+  /**
+   * Hash of this transaction's block as hex string; null if pending.
+   */
+  blockHash?: string | null;
+  /**
+   * This transaction's block number; null if pending.
+   */
+  blockNumber: number | null;
+  /**
+   * Index of transaction in block; null if block is pending.
+   */
+  transactionIndex?: number | null;
+  /**
+   * Address of the sender (as checksummed hex string).
+   */
+  from?: string;
+  /**
+   * Address of the recipient (as checksummed hex string), or null for a
+   * contract creation.
+   */
+  to: string | null;
+  /**
+   * Wei sent with this transaction, as numeric string.
+   */
+  value?: string;
+  /**
+   * Gas price for this transaction, as numeric string.
+   */
+  gasPrice?: string;
+  /**
+   * Gas provided by the sender, as numeric string.
+   */
+  gas?: string;
+  /**
+   * Data sent with the transaction, as hex string.
+   */
+  input: string;
+}
+
+/**
+ * Contains information about a transaction.  Most of the fields have
+ * been made optional; only those needed by the decoder have been made
+ * mandatory.
+ *
+ * Intended to be identical to Web3's
+ * [Log](https://web3js.readthedocs.io/en/v1.2.1/web3-eth.html#eth-getpastlogs-return)
+ * type.
+ * @category Inputs
+ */
+export interface Log {
+  /**
+   * Address of the emitter (as checksummed hex string).
+   */
+  address: string;
+  /**
+   * The log's data section (as hex string).
+   */
+  data: string;
+  /**
+   * The log's topics; each is a hex string representing 32 bytes.
+   */
+  topics: string[];
+  /**
+   * Index of the log within the block.
+   */
+  logIndex?: number;
+  /**
+   * Index within the block of the emitting transaction; null if
+   * block is pending.
+   */
+  transactionIndex?: number | null;
+  /**
+   * The emitting transaction's hash (as hex string).
+   */
+  transactionHash?: string;
+  /**
+   * The block hash (as hex string).  Null if pending.
+   */
+  blockHash?: string | null;
+  /**
+   * The block number.  Null if pending.
+   */
+  blockNumber: number | null;
+}
+
+/**
+ * Specifies a block.  Can be given by number, or can be given via the
+ * special strings "genesis", "latest", or "pending".
+ *
+ * Intended to work the same as Web3's
+ * [BlockType](https://web3js.readthedocs.io/en/v1.2.1/web3-eth.html#id14).
+ * @category Inputs
+ */
+export type BlockSpecifier = number | "genesis" | "latest" | "pending";
 
 //HACK
 export interface ContractConstructorObject extends ContractObject {

--- a/packages/decoder/lib/types.ts
+++ b/packages/decoder/lib/types.ts
@@ -60,20 +60,6 @@ export interface StateVariable {
 }
 
 /**
- * This type represents a web3 Transaction object that has been decoded.
- * Note that it extends the Transaction type and just adds an additional field
- * with the decoding.
- * @category Results
- */
-export interface DecodedTransaction extends Transaction {
-  /**
-   * The decoding of the transaction.  Note that transactions are not decoded in strict mode,
-   * so there will always be a decoding, although it may contain errors.
-   */
-  decoding: CalldataDecoding;
-}
-
-/**
  * This type represents a web3 Log object that has been decoded.
  * Note that it extends the Log type and just adds an additional field
  * with the decoding.
@@ -82,23 +68,9 @@ export interface DecodedTransaction extends Transaction {
 export interface DecodedLog extends Log {
   /**
    * An array of possible decodings of the given log -- it's an array because logs can be ambiguous.
-   * Note that logs are decoded in strict mode, so (with one exception) none of the decodings should
-   * contain errors; if a decoding would contain an error, instead it is simply excluded from the
-   * list of possible decodings.  The one exception to this is that indexed parameters of reference
-   * type cannot meaningfully be decoded, so those will decode to an error.
    *
-   * If there are multiple possible decodings, they will always be listed in the following order:
-   *
-   * 1. A non-anonymous event coming from the contract itself (there can be at most one of these)
-   * 2. Non-anonymous events coming from libraries
-   * 3. Anonymous events coming from the contract itself
-   * 4. Anonymous events coming from libraries
-   *
-   * You can check the kind and class.contractKind fields to distinguish between these.
-   *
-   * If no possible decodings are found, the list of decodings will be empty.
-   *
-   * Note that different decodings may use different decoding modes.
+   * This field works just like the output of [[WireDecoder.decodeLog]], so see that for more
+   * information.
    */
   decodings: LogDecoding[];
 }

--- a/packages/decoder/lib/types.ts
+++ b/packages/decoder/lib/types.ts
@@ -110,14 +110,10 @@ export interface EventOptions {
   name?: string;
   /**
    * The earliest block to include events from.  Defaults to "latest".
-   * See [the web3 docs](https://web3js.readthedocs.io/en/v1.2.1/web3-eth.html#id14)
-   * for legal values.
    */
   fromBlock?: BlockSpecifier;
   /**
    * The latest block to include events from.  Defaults to "latest".
-   * See [the web3 docs](https://web3js.readthedocs.io/en/v1.2.1/web3-eth.html#id14)
-   * for legal values.
    */
   toBlock?: BlockSpecifier;
   /**
@@ -136,7 +132,7 @@ export interface EventOptions {
  * been made optional; only those needed by the decoder have been made
  * mandatory.
  *
- * Intended to be identical to Web3's
+ * Intended to work like Web3's
  * [Transaction](https://web3js.readthedocs.io/en/v1.2.1/web3-eth.html#eth-gettransaction-return)
  * type.
  * @category Inputs
@@ -194,7 +190,7 @@ export interface Transaction {
  * been made optional; only those needed by the decoder have been made
  * mandatory.
  *
- * Intended to be identical to Web3's
+ * Intended to work like Web3's
  * [Log](https://web3js.readthedocs.io/en/v1.2.1/web3-eth.html#eth-getpastlogs-return)
  * type.
  * @category Inputs
@@ -239,7 +235,7 @@ export interface Log {
  * Specifies a block.  Can be given by number, or can be given via the
  * special strings "genesis", "latest", or "pending".
  *
- * Intended to work the same as Web3's
+ * Intended to work like Web3's
  * [BlockType](https://web3js.readthedocs.io/en/v1.2.1/web3-eth.html#id14).
  * @category Inputs
  */

--- a/packages/decoder/test/test/downgrade-test.js
+++ b/packages/decoder/test/test/downgrade-test.js
@@ -91,8 +91,8 @@ async function runTestBody(
   let resultTx = await web3.eth.getTransaction(resultHash);
   let resultLog = result.receipt.rawLogs[0];
 
-  let txDecoding = (await decoder.decodeTransaction(resultTx)).decoding;
-  let logDecodings = (await decoder.decodeLog(resultLog)).decodings;
+  let txDecoding = await decoder.decodeTransaction(resultTx);
+  let logDecodings = await decoder.decodeLog(resultLog);
 
   if (fullMode) {
     assert.strictEqual(txDecoding.decodingMode, "full");
@@ -233,7 +233,7 @@ contract("DowngradeTest", function(accounts) {
     let decimalTx = await web3.eth.getTransaction(decimalHash);
 
     //now, let's do the decoding
-    let txDecoding = (await decoder.decodeTransaction(decimalTx)).decoding;
+    let txDecoding = await decoder.decodeTransaction(decimalTx);
 
     //now let's check the results!
     debug("txDecoding: %O", txDecoding);
@@ -266,9 +266,8 @@ contract("DowngradeTest", function(accounts) {
       let indexedLog = result.receipt.rawLogs[1];
       //(these are the order they went in)
 
-      let nonIndexedLogDecodings = (await decoder.decodeLog(nonIndexedLog))
-        .decodings;
-      let indexedLogDecodings = (await decoder.decodeLog(indexedLog)).decodings;
+      let nonIndexedLogDecodings = await decoder.decodeLog(nonIndexedLog);
+      let indexedLogDecodings = await decoder.decodeLog(indexedLog);
 
       assert.lengthOf(nonIndexedLogDecodings, 1); //because we're in full mode, the decoy decoding should be filtered out
       assert.strictEqual(nonIndexedLogDecodings[0].decodingMode, "full");
@@ -335,9 +334,8 @@ async function runEnumTestBody(DowngradeTest) {
   let indexedLog = result.receipt.rawLogs[1];
   //(these are the order they went in)
 
-  let nonIndexedLogDecodings = (await decoder.decodeLog(nonIndexedLog))
-    .decodings;
-  let indexedLogDecodings = (await decoder.decodeLog(indexedLog)).decodings;
+  let nonIndexedLogDecodings = await decoder.decodeLog(nonIndexedLog);
+  let indexedLogDecodings = await decoder.decodeLog(indexedLog);
 
   assert.lengthOf(nonIndexedLogDecodings, 2); //we're in ABI mode, so should have correct decoding and decoy decoding
   let decoyDecoding1 = nonIndexedLogDecodings[1]; //decoy decoding should be second (library)

--- a/packages/decoder/test/test/wire-test.js
+++ b/packages/decoder/test/test/wire-test.js
@@ -79,19 +79,15 @@ contract("WireTest", _accounts => {
       defaultConstructorHash
     );
 
-    let constructorDecoding = (await decoder.decodeTransaction(constructorTx))
-      .decoding;
-    let emitStuffDecoding = (await decoder.decodeTransaction(emitStuffTx))
-      .decoding;
-    let moreStuffDecoding = (await decoder.decodeTransaction(moreStuffTx))
-      .decoding;
-    let inheritedDecoding = (await decoder.decodeTransaction(inheritedTx))
-      .decoding;
-    let getterDecoding1 = (await decoder.decodeTransaction(getterTx1)).decoding;
-    let getterDecoding2 = (await decoder.decodeTransaction(getterTx2)).decoding;
-    let defaultConstructorDecoding = (await decoder.decodeTransaction(
+    let constructorDecoding = await decoder.decodeTransaction(constructorTx);
+    let emitStuffDecoding = await decoder.decodeTransaction(emitStuffTx);
+    let moreStuffDecoding = await decoder.decodeTransaction(moreStuffTx);
+    let inheritedDecoding = await decoder.decodeTransaction(inheritedTx);
+    let getterDecoding1 = await decoder.decodeTransaction(getterTx1);
+    let getterDecoding2 = await decoder.decodeTransaction(getterTx2);
+    let defaultConstructorDecoding = await decoder.decodeTransaction(
       defaultConstructorTx
-    )).decoding;
+    );
 
     assert.strictEqual(constructorDecoding.kind, "constructor");
     assert.strictEqual(constructorDecoding.class.typeName, "WireTest");


### PR DESCRIPTION
(Part of #2505)

This PR simplifies the return types of `decodeTransaction` and `decodeLog` by having them simply return the decoding (or array of decodings) without the additional complication of `DecodedTransaction` or `DecodedLog`.  The `DecodedLog` type is still present so it can be returned by `events`, though.  Also, the `decodeLogs` function has been removed entirely.  Tests have been updated appropriately.

In addition, the `Transaction`, `Log`, and `BlockType` types from Web3 have been replaced by equivalent types we define.  Note that I renamed `BlockType` to `BlockSpecifier` for clarity.

In writing this I noticed that there may be some slight problems in how block specifiers are currently handled.  I'll fix those in a separate PR.  (Or possibly two PRs, since some of this I'd like to fix on `develop` as well.)