### PR TITLE
Dependency update/Internal improvement: Bump default Solidity version to 0.5.12

### DIFF
--- a/packages/compile-solidity/compilerSupplier/index.js
+++ b/packages/compile-solidity/compilerSupplier/index.js
@@ -7,7 +7,7 @@ const { Docker, Local, Native, VersionRange } = require("./loadingStrategies");
 class CompilerSupplier {
   constructor(_config) {
     _config = _config || {};
-    const defaultConfig = { version: "0.5.8" };
+    const defaultConfig = { version: "0.5.12" };
     this.config = Object.assign({}, defaultConfig, _config);
     this.strategyOptions = { version: this.config.version };
   }

--- a/packages/contract-schema/package.json
+++ b/packages/contract-schema/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "json-schema-to-typescript": "^5.5.0",
     "mocha": "5.2.0",
-    "solc": "0.5.0"
+    "solc": "0.5.12"
   },
   "directories": {
     "spec": "./spec"


### PR DESCRIPTION
Bump the default Solidity version to 0.5.12 in CompilerSupplier