### PR TITLE
Regularize behavior of block inputs; fix "pending"

### DIFF
--- a/packages/decoder/lib/types.ts
+++ b/packages/decoder/lib/types.ts
@@ -237,9 +237,17 @@ export interface Log {
  *
  * Intended to work like Web3's
  * [BlockType](https://web3js.readthedocs.io/en/v1.2.1/web3-eth.html#id14).
+ *
+ * *Warning*: Using "pending", while allowed, is not advised, as it may lead
+ * to internally inconsistent results.  Use of "latest" is safe and will not
+ * lead to inconsistent results from a single decoder call due to the decoder's
+ * caching system, but pending blocks cannot be cached under this system, which
+ * may cause inconsistencies.
  * @category Inputs
  */
 export type BlockSpecifier = number | "genesis" | "latest" | "pending";
+
+export type RegularizedBlockSpecifier = number | "pending";
 
 //HACK
 export interface ContractConstructorObject extends ContractObject {


### PR DESCRIPTION
This PR fixes some wonky behavior of `decoder` regarding `BlockType` inputs (or, as I've renamed it, `BlockSpecifier`).  I was originally going to do this on develop but decided it was too much trouble, so, well, it's a PR against `next`.

There are basically two problems here in need of fixing:
1. If a user enters `"pending"` as the block they want, it won't work properly because our caching system relies on blocks having numbers.
2. If a user enters `"genesis"` as either bounding block in a call to `events`, it won't work properly because it turns out that Web3 doesn't allow using `"genesis"` as a bound in `getPastLogs()`.

To solve these problems, all user-entered blocks are now run through a new method I call `regularizeBlock`.  This returns a type I'm calling `RegularizedBlockSpecifier`, which is defined as just `number | "pending"`.  What `regularizeBlock` does is just, if the input was a number or `"pending"`, leaves it alone; otherwise it fetches the block number from the blockchain based on the input.

We were already doing this manually in some locations (minus the special case for `"pending"`), but now we do it everywhere.  Even in those places that don't use the caching system, I still put it in to prevent one call returning internally-inconsistent results.

Of course, there's still the problem of `"pending"` not working with the caching system.  (Pending blocks don't have hashes or numbers, so there's no persistent identifier to cache by.)  So, now, the `getCode` and `getStorage` functions, if passed `"pending"` for the block, will simply bypass the cache.

Note that this PR was originally going to do more, expanding the `BlockSpecifier` type to handle more general input.  However, the problem is that, while web3 does allow more general ways of specifying blocks, its Typescript typings don't know this!  So, I deemed including that to be more trouble than it's worth for now.  We can always add that in later, I suppose, if we find a nice way to do it, or decide we really want to.

(Actually, thinking it over now, it probably wouldn't be so bad -- we should only need one coercion -- but, eh, still not gonna put it in this PR.)

(FWIW: With the exception of `getPastLogs`, as best I can tell every `web3` function that takes a block allows it to be specified by any of:
1. A block number, given as `number`, numeric string, `BN`, or `BigNumber`;
2. A block hash (as hex string);
3. The special strings `"genesis"`, `"pending"`, or `"latest"`.

The `getPastLogs()` function is an exception, in that it doesn't allow block hashes and doesn't allow `"genesis"`, but it does seem to still allow everything else.)