### PR TITLE
Internal improvement: Update tests to use the InterfaceAdapter

### DIFF
--- a/packages/artifactor/package.json
+++ b/packages/artifactor/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@truffle/contract": "^4.0.38",
+    "@truffle/interface-adapter": "^0.3.1",
     "@types/fs-extra": "^8.0.0",
     "@types/node": "^12.6.2",
     "chai": "4.2.0",
@@ -28,8 +29,7 @@
     "require-nocache": "^1.0.0",
     "temp": "^0.8.3",
     "ts-node": "^8.3.0",
-    "typescript": "^3.6.3",
-    "web3": "1.2.1"
+    "typescript": "^3.6.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/artifactor/test/contracts.js
+++ b/packages/artifactor/test/contracts.js
@@ -8,7 +8,7 @@ const fs = require("fs");
 const requireNoCache = require("require-nocache")(module);
 const Compile = require("@truffle/compile-solidity/legacy");
 const Ganache = require("ganache-core");
-const Web3 = require("web3");
+const { InterfaceAdapter } = require("@truffle/interface-adapter");
 const { promisify } = require("util");
 
 describe("artifactor + require", () => {
@@ -19,10 +19,9 @@ describe("artifactor + require", () => {
   let networkID;
   let artifactor;
   const provider = Ganache.provider();
-  const web3 = new Web3();
-  web3.setProvider(provider);
+  const interfaceAdapter = new InterfaceAdapter({ provider });
 
-  before(() => web3.eth.net.getId().then(id => (networkID = id)));
+  before(() => interfaceAdapter.getNetworkId().then(id => (networkID = id)));
 
   before(async function() {
     this.timeout(20000);
@@ -96,7 +95,7 @@ describe("artifactor + require", () => {
   });
 
   before(() =>
-    web3.eth.getAccounts().then(_accounts => {
+    interfaceAdapter.eth.getAccounts().then(_accounts => {
       accounts = _accounts;
 
       Example.defaults({
@@ -230,20 +229,20 @@ describe("artifactor + require", () => {
           "Fallback should not have been triggered yet"
         );
         return example.sendTransaction({
-          value: web3.utils.toWei("1", "ether")
+          value: interfaceAdapter.utils.toWei("1", "ether")
         });
       })
       .then(
         () =>
           new Promise((accept, reject) =>
-            web3.eth.getBalance(example.address, (err, balance) => {
+            interfaceAdapter.eth.getBalance(example.address, (err, balance) => {
               if (err) return reject(err);
               accept(balance);
             })
           )
       )
       .then(balance => {
-        assert(balance === web3.utils.toWei("1", "ether"));
+        assert(balance === interfaceAdapter.utils.toWei("1", "ether"));
       });
   });
 
@@ -259,19 +258,19 @@ describe("artifactor + require", () => {
           triggered === false,
           "Fallback should not have been triggered yet"
         );
-        return example.send(web3.utils.toWei("1", "ether"));
+        return example.send(interfaceAdapter.utils.toWei("1", "ether"));
       })
       .then(
         () =>
           new Promise((accept, reject) =>
-            web3.eth.getBalance(example.address, (err, balance) => {
+            interfaceAdapter.eth.getBalance(example.address, (err, balance) => {
               if (err) return reject(err);
               accept(balance);
             })
           )
       )
       .then(balance => {
-        assert(balance === web3.utils.toWei("1", "ether"));
+        assert(balance === interfaceAdapter.utils.toWei("1", "ether"));
       });
   });
 
@@ -341,7 +340,7 @@ describe("artifactor + require", () => {
 
     MyContract.setNetwork(5);
 
-    const expectedEventTopic = web3.utils.sha3(
+    const expectedEventTopic = interfaceAdapter.utils.sha3(
       "PackageRelease(bytes32,bytes32)"
     );
 

--- a/packages/contract/test/linking.js
+++ b/packages/contract/test/linking.js
@@ -2,7 +2,7 @@
 var assert = require("chai").assert;
 var temp = require("temp").track();
 var contract = require("../");
-var Web3 = require("web3");
+const { InterfaceAdapter } = require("@truffle/interface-adapter");
 var debug = require("debug")("ganache-core");
 var Ganache = require("ganache-core");
 var path = require("path");
@@ -25,13 +25,10 @@ describe("Library linking", function() {
   var LibraryExample;
   var provider = Ganache.provider({ logger: log });
   var network_id;
-  var web3 = new Web3();
-  web3.setProvider(provider);
+  const interfaceAdapter = new InterfaceAdapter({ provider });
 
   before(function() {
-    return web3.eth.net.getId().then(function(id) {
-      network_id = id;
-    });
+    return interfaceAdapter.getNetworkId().then(id => (network_id = id));
   });
 
   before(function() {
@@ -107,14 +104,12 @@ describe("Library linking with contract objects", function() {
   var ExampleLibrary;
   var ExampleLibraryConsumer;
   var accounts;
-  var web3;
   var network_id;
   var provider = Ganache.provider({ logger: log });
-  web3 = new Web3();
-  web3.setProvider(provider);
+  const interfaceAdapter = new InterfaceAdapter({ provider });
 
   before(function() {
-    return web3.eth.net.getId().then(function(id) {
+    return interfaceAdapter.getNetworkId().then(function(id) {
       network_id = id;
     });
   });
@@ -186,7 +181,7 @@ describe("Library linking with contract objects", function() {
   });
 
   before(function(done) {
-    web3.eth.getAccounts(function(err, accs) {
+    interfaceAdapter.eth.getAccounts(function(err, accs) {
       accounts = accs;
 
       ExampleLibrary.defaults({

--- a/packages/core/test/migrate.js
+++ b/packages/core/test/migrate.js
@@ -9,7 +9,7 @@ var glob = require("glob");
 var Ganache = require("ganache-core");
 var Resolver = require("@truffle/resolver");
 var Artifactor = require("@truffle/artifactor");
-var Web3 = require("web3");
+const { InterfaceAdapter } = require("@truffle/interface-adapter");
 
 describe("migrate", function() {
   var config;
@@ -23,9 +23,9 @@ describe("migrate", function() {
 
   function createProviderAndSetNetworkConfig(network) {
     var provider = Ganache.provider({ seed: network, gasLimit: config.gas });
-    var web3 = new Web3(provider);
-    return web3.eth.getAccounts().then(accs => {
-      return web3.eth.net.getId().then(network_id => {
+    const interfaceAdapter = new InterfaceAdapter({ provider });
+    return interfaceAdapter.eth.getAccounts().then(accs => {
+      return interfaceAdapter.getNetworkId().then(network_id => {
         config.networks[network] = {
           provider: provider,
           network_id: network_id + "",

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -19,11 +19,11 @@
     "emittery": "^0.4.0"
   },
   "devDependencies": {
+    "@truffle/interface-adapter": "^0.3.1",
     "@truffle/reporters": "^1.0.15",
     "@truffle/workflow-compile": "^2.1.11",
     "ganache-core": "2.7.0",
-    "mocha": "5.2.0",
-    "web3": "1.2.1"
+    "mocha": "5.2.0"
   },
   "keywords": [
     "contracts",

--- a/packages/deployer/test/await.js
+++ b/packages/deployer/test/await.js
@@ -1,5 +1,5 @@
 const ganache = require("ganache-core");
-const Web3 = require("web3");
+const { InterfaceAdapter } = require("@truffle/interface-adapter");
 const assert = require("assert");
 
 const Deployer = require("../index");
@@ -10,12 +10,12 @@ describe("Deployer (async / await)", function() {
   let options;
   let networkId;
   const provider = ganache.provider();
-  const web3 = new Web3(provider);
+  const interfaceAdapter = new InterfaceAdapter({ provider });
 
   beforeEach(async function() {
     this.timeout(20000);
-    networkId = await web3.eth.net.getId();
-    const accounts = await web3.eth.getAccounts();
+    networkId = await interfaceAdapter.getNetworkId();
+    const accounts = await interfaceAdapter.eth.getAccounts();
 
     owner = accounts[0];
     options = {

--- a/packages/deployer/test/deployer.js
+++ b/packages/deployer/test/deployer.js
@@ -1,5 +1,5 @@
 const ganache = require("ganache-core");
-const Web3 = require("web3");
+const { InterfaceAdapter } = require("@truffle/interface-adapter");
 const assert = require("assert");
 const Reporter = require("@truffle/reporters").migrationsV5;
 const EventEmitter = require("events");
@@ -27,11 +27,11 @@ describe("Deployer (sync)", function() {
     emitter: new EventEmitter()
   };
 
-  const web3 = new Web3(provider);
+  const interfaceAdapter = new InterfaceAdapter({ provider });
 
   beforeEach(async function() {
-    networkId = await web3.eth.net.getId();
-    const accounts = await web3.eth.getAccounts();
+    networkId = await interfaceAdapter.getNetworkId();
+    const accounts = await interfaceAdapter.eth.getAccounts();
 
     owner = accounts[0];
     await utils.compile();
@@ -225,9 +225,9 @@ describe("Deployer (sync)", function() {
 
   it("waits for confirmations", async function() {
     this.timeout(15000);
-    const startBlock = await web3.eth.getBlockNumber();
+    const startBlock = await interfaceAdapter.eth.getBlockNumber();
 
-    utils.startAutoMine(web3, 1500);
+    utils.startAutoMine(interfaceAdapter, 1500);
 
     const migrate = function() {
       deployer.deploy(IsLibrary);
@@ -241,10 +241,10 @@ describe("Deployer (sync)", function() {
 
     utils.stopAutoMine();
 
-    const libReceipt = await web3.eth.getTransactionReceipt(
+    const libReceipt = await interfaceAdapter.eth.getTransactionReceipt(
       IsLibrary.transactionHash
     );
-    const exampleReceipt = await web3.eth.getTransactionReceipt(
+    const exampleReceipt = await interfaceAdapter.eth.getTransactionReceipt(
       Example.transactionHash
     );
 
@@ -259,13 +259,13 @@ describe("Deployer (sync)", function() {
   it("emits block events while waiting for a tx to mine", async function() {
     this.timeout(15000);
 
-    utils.startAutoMine(web3, 4000);
+    utils.startAutoMine(interfaceAdapter, 4000);
 
     const migrate = function() {
       deployer.then(async function() {
-        await deployer._startBlockPolling(web3);
+        await deployer._startBlockPolling(interfaceAdapter);
         await utils.waitMS(9000);
-        await deployer._startBlockPolling(web3);
+        await deployer._startBlockPolling(interfaceAdapter);
       });
     };
 

--- a/packages/deployer/test/errors.js
+++ b/packages/deployer/test/errors.js
@@ -1,5 +1,5 @@
 const ganache = require("ganache-core");
-const Web3 = require("web3");
+const { InterfaceAdapter } = require("@truffle/interface-adapter");
 const assert = require("assert");
 const Reporter = require("@truffle/reporters").migrationsV5;
 const EventEmitter = require("events");
@@ -27,11 +27,11 @@ describe("Error cases", function() {
     emitter: new EventEmitter()
   };
 
-  const web3 = new Web3(provider);
+  const interfaceAdapter = new InterfaceAdapter({ provider });
 
   beforeEach(async function() {
-    networkId = await web3.eth.net.getId();
-    accounts = await web3.eth.getAccounts();
+    networkId = await interfaceAdapter.getNetworkId();
+    accounts = await interfaceAdapter.eth.getAccounts();
 
     owner = accounts[0];
     await utils.compile();
@@ -253,7 +253,7 @@ describe("Error cases", function() {
   });
 
   it("exceeds block limit", async function() {
-    const block = await web3.eth.getBlock("latest");
+    const block = await interfaceAdapter.getBlock("latest");
     const gas = block.gasLimit + 1000;
 
     migrate = function() {
@@ -275,15 +275,15 @@ describe("Error cases", function() {
 
   it("insufficient funds", async function() {
     const emptyAccount = accounts[7];
-    let balance = await web3.eth.getBalance(emptyAccount);
-    await web3.eth.sendTransaction({
+    let balance = await interfaceAdapter.eth.getBalance(emptyAccount);
+    await interfaceAdapter.eth.sendTransaction({
       to: accounts[0],
       from: emptyAccount,
       value: balance,
       gasPrice: 0
     });
 
-    balance = await web3.eth.getBalance(emptyAccount);
+    balance = await interfaceAdapter.eth.getBalance(emptyAccount);
     assert(parseInt(balance) === 0);
 
     migrate = function() {

--- a/packages/deployer/test/helpers/utils.js
+++ b/packages/deployer/test/helpers/utils.js
@@ -24,9 +24,9 @@ const utils = {
     });
   },
 
-  evm_mine: function(web3) {
+  evm_mine: function(interfaceAdapter) {
     return new Promise(function(accept, reject) {
-      web3.currentProvider.send(
+      interfaceAdapter.currentProvider.send(
         {
           jsonrpc: "2.0",
           method: "evm_mine",
@@ -39,9 +39,9 @@ const utils = {
     });
   },
 
-  startAutoMine: function(web3, interval) {
+  startAutoMine: function(interfaceAdapter, interval) {
     utils.miningId = setInterval(async () => {
-      await utils.evm_mine(web3);
+      await utils.evm_mine(interfaceAdapter);
     }, interval);
   },
 

--- a/packages/truffle/test/scenarios/migrations/dryrun.js
+++ b/packages/truffle/test/scenarios/migrations/dryrun.js
@@ -6,6 +6,7 @@ const Server = require("../server");
 const Reporter = require("../reporter");
 const sandbox = require("../sandbox");
 const Web3 = require("web3");
+const { InterfaceAdapter } = require("@truffle/interface-adapter");
 
 const log = console.log;
 
@@ -18,7 +19,6 @@ function processErr(err, output) {
 
 describe("migrate (dry-run)", function() {
   let config;
-  let web3;
   const project = path.join(__dirname, "../../sources/migrations/success");
   const logger = new MemoryLogger();
 
@@ -37,8 +37,8 @@ describe("migrate (dry-run)", function() {
     const provider = new Web3.providers.HttpProvider("http://localhost:8545", {
       keepAlive: false
     });
-    web3 = new Web3(provider);
-    networkId = await web3.eth.net.getId();
+    const interfaceAdapter = new InterfaceAdapter({ provider });
+    networkId = await interfaceAdapter.getNetworkId();
   });
 
   it("uses the dry-run option", function(done) {

--- a/packages/truffle/test/scenarios/migrations/errors.js
+++ b/packages/truffle/test/scenarios/migrations/errors.js
@@ -6,10 +6,10 @@ const Server = require("../server");
 const Reporter = require("../reporter");
 const sandbox = require("../sandbox");
 const Web3 = require("web3");
+const { InterfaceAdapter } = require("@truffle/interface-adapter");
 
 describe("migration errors", function() {
   let config;
-  let web3;
   let networkId;
   const project = path.join(__dirname, "../../sources/migrations/error");
   const logger = new MemoryLogger();
@@ -29,8 +29,8 @@ describe("migration errors", function() {
     const provider = new Web3.providers.HttpProvider("http://localhost:8545", {
       keepAlive: false
     });
-    web3 = new Web3(provider);
-    networkId = await web3.eth.net.getId();
+    const interfaceAdapter = new InterfaceAdapter({ provider });
+    networkId = await interfaceAdapter.getNetworkId();
   });
 
   it("should error and stop", function(done) {

--- a/packages/truffle/test/scenarios/migrations/init.js
+++ b/packages/truffle/test/scenarios/migrations/init.js
@@ -6,6 +6,7 @@ const Server = require("../server");
 const Reporter = require("../reporter");
 const sandbox = require("../sandbox");
 const Web3 = require("web3");
+const { InterfaceAdapter } = require("@truffle/interface-adapter");
 
 const log = console.log;
 
@@ -18,7 +19,6 @@ function processErr(err, output) {
 
 describe("solo migration", function() {
   let config;
-  let web3;
   let networkId;
   const project = path.join(__dirname, "../../sources/migrations/init");
   const logger = new MemoryLogger();
@@ -38,8 +38,8 @@ describe("solo migration", function() {
     const provider = new Web3.providers.HttpProvider("http://localhost:8545", {
       keepAlive: false
     });
-    web3 = new Web3(provider);
-    networkId = await web3.eth.net.getId();
+    const interfaceAdapter = new InterfaceAdapter({ provider });
+    networkId = await interfaceAdapter.getNetworkId();
   });
 
   it("runs a migration with just Migrations.sol ", function(done) {

--- a/packages/truffle/test/scenarios/migrations/migrate.js
+++ b/packages/truffle/test/scenarios/migrations/migrate.js
@@ -6,6 +6,7 @@ const Server = require("../server");
 const Reporter = require("../reporter");
 const sandbox = require("../sandbox");
 const Web3 = require("web3");
+const { InterfaceAdapter } = require("@truffle/interface-adapter");
 
 const log = console.log;
 
@@ -18,7 +19,6 @@ function processErr(err, output) {
 
 describe("migrate (success)", function() {
   let config;
-  let web3;
   let networkId;
   const project = path.join(__dirname, "../../sources/migrations/success");
   const logger = new MemoryLogger();
@@ -38,8 +38,8 @@ describe("migrate (success)", function() {
     const provider = new Web3.providers.HttpProvider("http://localhost:8545", {
       keepAlive: false
     });
-    web3 = new Web3(provider);
-    networkId = await web3.eth.net.getId();
+    const interfaceAdapter = new InterfaceAdapter({ provider });
+    networkId = await interfaceAdapter.getNetworkId();
   });
 
   it("runs migrations (sync & async/await)", function(done) {

--- a/packages/truffle/test/scenarios/migrations/production.js
+++ b/packages/truffle/test/scenarios/migrations/production.js
@@ -5,6 +5,7 @@ const assert = require("assert");
 const Reporter = require("../reporter");
 const sandbox = require("../sandbox");
 const Web3 = require("web3");
+const { InterfaceAdapter } = require("@truffle/interface-adapter");
 
 const log = console.log;
 
@@ -20,7 +21,6 @@ describe("production", function() {
     if (!process.env.GETH) return;
 
     let config;
-    let web3;
     let networkId;
     const project = path.join(__dirname, "../../sources/migrations/production");
     const logger = new MemoryLogger();
@@ -38,8 +38,8 @@ describe("production", function() {
         "http://localhost:8545",
         { keepAlive: false }
       );
-      web3 = new Web3(provider);
-      networkId = await web3.eth.net.getId();
+      const interfaceAdapter = new InterfaceAdapter({ provider });
+      networkId = await interfaceAdapter.getNetworkId();
     });
 
     it("auto dry-runs and honors confirmations option", function(done) {
@@ -82,7 +82,6 @@ describe("production", function() {
     if (!process.env.GETH) return;
 
     let config;
-    let web3;
     let networkId;
     const project = path.join(__dirname, "../../sources/migrations/production");
     const logger = new MemoryLogger();
@@ -100,8 +99,8 @@ describe("production", function() {
         "http://localhost:8545",
         { keepAlive: false }
       );
-      web3 = new Web3(provider);
-      networkId = await web3.eth.net.getId();
+      const interfaceAdapter = new InterfaceAdapter({ provider });
+      networkId = await interfaceAdapter.getNetworkId();
     });
 
     it("migrates without dry-run", function(done) {

--- a/packages/truffle/test/scenarios/migrations/quorum.js
+++ b/packages/truffle/test/scenarios/migrations/quorum.js
@@ -6,11 +6,11 @@ const assert = require("assert");
 const Reporter = require("../reporter");
 const sandbox = require("../sandbox");
 const Web3 = require("web3");
+const { InterfaceAdapter } = require("@truffle/interface-adapter");
 
 describe("migrate with [ @quorum ] interface", () => {
   if (!process.env.QUORUM) return;
   let config;
-  let web3;
   let networkId;
   const project = path.join(__dirname, "../../sources/migrations/quorum");
   const logger = new MemoryLogger();
@@ -26,8 +26,11 @@ describe("migrate with [ @quorum ] interface", () => {
     const provider = new Web3.providers.HttpProvider("http://localhost:22000", {
       keepAlive: false
     });
-    web3 = new Web3(provider);
-    networkId = await web3.eth.net.getId();
+    const interfaceAdapter = new InterfaceAdapter({
+      provider,
+      networkType: "quorum"
+    });
+    networkId = await interfaceAdapter.getNetworkId();
   });
 
   it("runs migrations (sync & async/await)", async () => {


### PR DESCRIPTION
This PR swaps out using `Web3` in scenario & integration tests to properly test the `InterfaceAdapter` instead.