### PR TITLE
Internal Improvement: From Web3Shim to InterfaceAdapter – Step Two: setProvider

### DIFF
--- a/packages/interface-adapter/lib/interface-adapter.ts
+++ b/packages/interface-adapter/lib/interface-adapter.ts
@@ -4,6 +4,7 @@ import {
 } from "./web3-interface-adapter";
 import { Block as EvmBlock } from "web3/eth/types";
 import { BlockType as EvmBlockType } from "web3/eth/types";
+import { Provider } from "web3/providers";
 
 export interface InterfaceAdapterOptions extends Web3InterfaceAdapterOptions {}
 export type NetworkId = Number | String;
@@ -43,5 +44,9 @@ export class InterfaceAdapter {
 
   public getBlock(block: BlockType): Promise<Block> {
     return this.adapter.getBlock(block);
+  }
+
+  public setProvider(provider: Provider) {
+    return this.adapter.setProvider(provider);
   }
 }

--- a/packages/interface-adapter/lib/web3-interface-adapter.ts
+++ b/packages/interface-adapter/lib/web3-interface-adapter.ts
@@ -1,5 +1,6 @@
 import { Web3Shim, Web3ShimOptions } from "./web3-shim";
 import { BlockType } from "web3/eth/types";
+import { Provider } from "web3/providers";
 
 export interface Web3InterfaceAdapterOptions extends Web3ShimOptions {}
 
@@ -16,5 +17,8 @@ export class Web3InterfaceAdapter {
   public getBlock(block: BlockType) {
     return this.web3.eth.getBlock(block);
   }
+
+  public setProvider(provider: Provider) {
+    return this.web3.setProvider(provider);
   }
 }

--- a/packages/interface-adapter/lib/web3-interface-adapter.ts
+++ b/packages/interface-adapter/lib/web3-interface-adapter.ts
@@ -3,16 +3,18 @@ import { BlockType } from "web3/eth/types";
 
 export interface Web3InterfaceAdapterOptions extends Web3ShimOptions {}
 
-export class Web3InterfaceAdapter extends Web3Shim {
+export class Web3InterfaceAdapter {
+  public web3: Web3Shim;
   constructor(options?: Web3InterfaceAdapterOptions) {
-    super(options);
+    this.web3 = new Web3Shim(options);
   }
 
   public getNetworkId() {
-    return this.eth.net.getId();
+    return this.web3.eth.net.getId();
   }
 
   public getBlock(block: BlockType) {
-    return this.eth.getBlock(block);
+    return this.web3.eth.getBlock(block);
+  }
   }
 }

--- a/packages/workflow-compile/test/index.js
+++ b/packages/workflow-compile/test/index.js
@@ -56,6 +56,6 @@ describe("Contracts.compile", () => {
             `${process.cwd()}/${config.contracts_directory}/${contractName}.sol`
           )
       );
-    }).timeout(3000);
+    }).timeout(4000);
   });
 });


### PR DESCRIPTION
Continuation of #2480 & #2532 that implements Step 2 for `setProvider` as outlined [here](https://gist.github.com/gnidan/a55bbec28800f64d487054be18730691#file-step2-ts).