### PR TITLE
Makes `config` available in the migration context.

### DIFF
--- a/packages/migrate/index.js
+++ b/packages/migrate/index.js
@@ -31,20 +31,18 @@ const Migrate = {
     const config = Config.detect(options);
 
     if (
-      fs.existsSync(options.migrations_directory) &&
-      fs.readdirSync(options.migrations_directory).length > 0
+      fs.existsSync(config.migrations_directory) &&
+      fs.readdirSync(config.migrations_directory).length > 0
     ) {
-      const files = dir.files(options.migrations_directory, { sync: true });
+      const files = dir.files(config.migrations_directory, { sync: true });
       if (!files) return [];
-
-      options.allowed_extensions = config.migrations_file_extension_regexp;
 
       let migrations = files
         .filter(file => isNaN(parseInt(path.basename(file))) === false)
         .filter(
-          file => path.extname(file).match(options.allowed_extensions) != null
+          file => path.extname(file).match(config.migrations_file_extension_regexp) != null
         )
-        .map(file => new Migration(file, Migrate.reporter, options));
+        .map(file => new Migration(file, Migrate.reporter, config));
 
       // Make sure to sort the prefixes as numbers and not strings.
       migrations = migrations.sort((a, b) => {

--- a/packages/migrate/migration.js
+++ b/packages/migrate/migration.js
@@ -7,16 +7,16 @@ const { Web3Shim, InterfaceAdapter } = require("@truffle/interface-adapter");
 const ResolverIntercept = require("./resolverintercept");
 
 class Migration {
-  constructor(file, reporter, options) {
+  constructor(file, reporter, config) {
     this.file = path.resolve(file);
     this.reporter = reporter;
     this.number = parseInt(path.basename(file));
     this.emitter = new Emittery();
     this.isFirst = false;
     this.isLast = false;
-    this.dryRun = options.dryRun;
-    this.interactive = options.interactive;
-    this.options = options || {};
+    this.dryRun = config.dryRun;
+    this.interactive = config.interactive;
+    this.config = config || {};
   }
 
   // ------------------------------------- Private -------------------------------------------------
@@ -109,8 +109,8 @@ class Migration {
         // Exiting w provider-engine appears to be hopeless. This hack on
         // our fork just swallows errors from eth-block-tracking
         // as we unwind the handlers downstream from here.
-        if (this.options.provider && this.options.provider.engine) {
-          this.options.provider.engine.silent = true;
+        if (this.config.provider && this.config.provider.engine) {
+          this.config.provider.engine.silent = true;
         }
       }
     } catch (error) {
@@ -178,7 +178,7 @@ class Migration {
     const resolver = new ResolverIntercept(options.resolver);
 
     // Initial context.
-    const context = { web3, interfaceAdapter };
+    const context = { web3, interfaceAdapter, config: this.config };
 
     const deployer = new Deployer({
       logger,


### PR DESCRIPTION
This will allow a migration to be able to interact with any of the Truffle packages using the same configuration that the migration is using to run.  One example use case (mine) is to compile dynamic contracts based on the result of migration (e.g., hard-code an address in a contract as a gas optimization rather than passing it as a constructor).

Along the way I also cleaned up options vs config a little bit, once `config` is resolved it should be used rather than `options` since it may have different property values once full config resolution is complete.