### PR TITLE
Adds dependency that was missing.

### DIFF
--- a/packages/resolver/package.json
+++ b/packages/resolver/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@truffle/expect": "^0.0.12",
     "@truffle/provisioner": "^0.1.6",
+    "@truffle/contract": "^4.0.38",
     "async": "2.6.1",
     "detect-installed": "^2.0.4",
     "get-installed-path": "^4.0.8"


### PR DESCRIPTION
`resolver/index.js` references `@truffle/contract` yet the project doesn't have a dependency on it.  This means if someone tries to use this package standalone, or as a transitive dependency of some other package, they'll get a runtime failure.