### PR TITLE
Move contextToType to MakeType

### DIFF
--- a/packages/codec/lib/basic/decode/index.ts
+++ b/packages/codec/lib/basic/decode/index.ts
@@ -488,7 +488,7 @@ function* decodeContractAndContext(
         kind: "known" as const,
         address,
         rawAddress,
-        class: Contexts.Utils.contextToType(context)
+        class: Format.Utils.MakeType.contextToType(context)
       }
     };
   } else {
@@ -552,7 +552,7 @@ export function decodeInternalFunction(
 ): Format.Values.FunctionInternalResult {
   let deployedPc: number = Conversion.toBN(deployedPcBytes).toNumber();
   let constructorPc: number = Conversion.toBN(constructorPcBytes).toNumber();
-  let context: Format.Types.ContractType = Contexts.Utils.contextToType(
+  let context: Format.Types.ContractType = Format.Utils.MakeType.contextToType(
     info.currentContext
   );
   //before anything else: do we even have an internal functions table?

--- a/packages/codec/lib/contexts/utils.ts
+++ b/packages/codec/lib/contexts/utils.ts
@@ -2,7 +2,6 @@ import debugModule from "debug";
 const debug = debugModule("codec:contexts:utils");
 
 import * as Evm from "@truffle/codec/evm";
-import * as Format from "@truffle/codec/format";
 import {
   DecoderContexts,
   DecoderContext,
@@ -144,25 +143,4 @@ export function normalizeContexts(contexts: Contexts): Contexts {
 
   //finally, return this mess!
   return newContexts;
-}
-
-export function contextToType(context: Context): Format.Types.ContractType {
-  if (context.contractId !== undefined) {
-    return {
-      typeClass: "contract",
-      kind: "native",
-      id: context.contractId.toString(),
-      typeName: context.contractName,
-      contractKind: context.contractKind,
-      payable: context.payable
-    };
-  } else {
-    return {
-      typeClass: "contract",
-      kind: "foreign",
-      typeName: context.contractName,
-      contractKind: context.contractKind,
-      payable: context.payable
-    };
-  }
 }

--- a/packages/codec/lib/core.ts
+++ b/packages/codec/lib/core.ts
@@ -59,7 +59,7 @@ export function* decodeCalldata(
   }
   const compiler = context.compiler;
   const contextHash = context.context;
-  const contractType = Contexts.Utils.contextToType(context);
+  const contractType = Format.Utils.MakeType.contextToType(context);
   isConstructor = context.isConstructor;
   const allocations = info.allocations.calldata;
   let allocation: AbiData.Allocate.CalldataAllocation;
@@ -270,7 +270,7 @@ export function* decodeEvent(
     let decodingMode: DecodingMode = allocation.allocationMode; //starts out here; degrades to abi if necessary
     const contextHash = allocation.contextHash;
     const attemptContext = info.contexts[contextHash];
-    const contractType = Contexts.Utils.contextToType(attemptContext);
+    const contractType = Format.Utils.MakeType.contextToType(attemptContext);
     //you can't map with a generator, so we have to do this map manually
     let decodedArguments: AbiArgument[] = [];
     for (const argumentAllocation of allocation.arguments) {

--- a/packages/codec/lib/format/utils/maketype.ts
+++ b/packages/codec/lib/format/utils/maketype.ts
@@ -4,6 +4,7 @@ const debug = debugModule("codec:format:utils:maketype");
 import BN from "bn.js";
 import * as Common from "@truffle/codec/common";
 import * as Compiler from "@truffle/codec/compiler";
+import * as Contexts from "@truffle/codec/contexts";
 import * as AbiData from "@truffle/codec/abi-data/types";
 import * as Ast from "@truffle/codec/ast";
 import * as Format from "@truffle/codec/format/common";
@@ -484,5 +485,28 @@ export function abiParameterToType(
         memberTypes,
         typeHint
       };
+  }
+}
+
+export function contextToType(
+  context: Contexts.Context
+): Format.Types.ContractType {
+  if (context.contractId !== undefined) {
+    return {
+      typeClass: "contract",
+      kind: "native",
+      id: context.contractId.toString(),
+      typeName: context.contractName,
+      contractKind: context.contractKind,
+      payable: context.payable
+    };
+  } else {
+    return {
+      typeClass: "contract",
+      kind: "foreign",
+      typeName: context.contractName,
+      contractKind: context.contractKind,
+      payable: context.payable
+    };
   }
 }

--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -932,7 +932,7 @@ export class ContractInstanceDecoder {
   ): Promise<DecoderTypes.ContractState> {
     let blockNumber = await this.regularizeBlock(block);
     return {
-      class: Contexts.Utils.contextToType(this.context),
+      class: Format.Utils.MakeType.contextToType(this.context),
       address: this.contractAddress,
       code: this.contractCode,
       balanceAsBN: new BN(


### PR DESCRIPTION
This PR moves the `contextToType` function from `Contexts` into the `MakeType` module for consistency, and adjusts appropriately everywhere that calls it.