### PR TITLE
Bump highlightjs-solidity version

### DIFF
--- a/packages/debug-utils/package.json
+++ b/packages/debug-utils/package.json
@@ -9,7 +9,7 @@
     "chalk": "^2.4.2",
     "debug": "^4.1.0",
     "highlight.js": "^9.15.8",
-    "highlightjs-solidity": "^1.0.7",
+    "highlightjs-solidity": "^1.0.8",
     "node-dir": "0.1.17"
   },
   "main": "index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7715,10 +7715,10 @@ highlight.js@^9.12.0, highlight.js@^9.15.8:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.15.8.tgz#f344fda123f36f1a65490e932cf90569e4999971"
   integrity sha512-RrapkKQWwE+wKdF73VsOa2RQdIoO3mxwJ4P8mhbI6KYJUraUHRKM5w5zQQKXNk0xNL4UVRdulV9SBJcmzJNzVA==
 
-highlightjs-solidity@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/highlightjs-solidity/-/highlightjs-solidity-1.0.7.tgz#a5389519a144bf88a1c700a8513695ddcc174c2e"
-  integrity sha512-2C2bXI2L1GPqExuvkjIpGpBfmzQAtnBV9jMMhWcsAfXjKhHBcvULn9Nm/4PN2RSElIrxfgIZVRbGBcmXKtl1oA==
+highlightjs-solidity@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/highlightjs-solidity/-/highlightjs-solidity-1.0.8.tgz#9fa7fa022cff7b66c23f982d0641dd14ae03c6fb"
+  integrity sha512-rc5/5lwmQE+3WiN7uUlyKE8UCMy3ZA3c6M+uh0UdARVxCU1b97+bf41hG4HzHtKSTXPUhkJDXhrm8fSBAX/o6Q==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
This PR bumps the version of highlightjs-solidity used for the syntax highlighting in the debugger, now that 1.0.8 is out.