### PR TITLE
Remove circular dependencies from Codec

### DIFF
--- a/packages/codec/lib/abi-data/allocate/types.ts
+++ b/packages/codec/lib/abi-data/allocate/types.ts
@@ -1,5 +1,5 @@
 import * as Compiler from "@truffle/codec/compiler";
-import * as Ast from "@truffle/codec/ast";
+import * as Ast from "@truffle/codec/ast/types";
 import * as AbiData from "@truffle/codec/abi-data/types";
 import * as Contexts from "@truffle/codec/contexts/types";
 import * as Pointer from "@truffle/codec/pointer";

--- a/packages/codec/lib/ast/read/index.ts
+++ b/packages/codec/lib/ast/read/index.ts
@@ -3,7 +3,7 @@ const debug = debugModule("codec:ast:read");
 
 import * as Conversion from "@truffle/codec/conversion";
 import * as Evm from "@truffle/codec/evm";
-import * as Ast from "@truffle/codec/ast";
+import * as Utils from "@truffle/codec/ast/utils";
 import * as Pointer from "@truffle/codec/pointer";
 import BN from "bn.js";
 import { DecodingError } from "@truffle/codec/errors";
@@ -14,9 +14,9 @@ export function readDefinition(
   const definition = pointer.definition;
   debug("definition %o", definition);
 
-  switch (Ast.Utils.typeClass(definition)) {
+  switch (Utils.typeClass(definition)) {
     case "rational":
-      let numericalValue: BN = Ast.Utils.rationalValue(definition);
+      let numericalValue: BN = Utils.rationalValue(definition);
       return Conversion.toBytes(numericalValue, Evm.Utils.WORD_SIZE);
     //you may be wondering, why do we not just use definition.value here,
     //like we do below? answer: because if this isn't a literal, that may not

--- a/packages/codec/lib/basic/decode/index.ts
+++ b/packages/codec/lib/basic/decode/index.ts
@@ -446,7 +446,7 @@ function* decodeContractAndContext(
         kind: "known" as const,
         address,
         rawAddress,
-        class: Format.Utils.MakeType.contextToType(context)
+        class: Contexts.Utils.contextToType(context)
       }
     };
   } else {
@@ -510,7 +510,7 @@ export function decodeInternalFunction(
 ): Format.Values.FunctionInternalResult {
   let deployedPc: number = Conversion.toBN(deployedPcBytes).toNumber();
   let constructorPc: number = Conversion.toBN(constructorPcBytes).toNumber();
-  let context: Format.Types.ContractType = Format.Utils.MakeType.contextToType(
+  let context: Format.Types.ContractType = Contexts.Utils.contextToType(
     info.currentContext
   );
   //before anything else: do we even have an internal functions table?

--- a/packages/codec/lib/contexts/utils.ts
+++ b/packages/codec/lib/contexts/utils.ts
@@ -2,6 +2,7 @@ import debugModule from "debug";
 const debug = debugModule("codec:contexts:utils");
 
 import * as Evm from "@truffle/codec/evm";
+import * as Format from "@truffle/codec/format";
 import {
   DecoderContexts,
   DecoderContext,
@@ -143,4 +144,25 @@ export function normalizeContexts(contexts: Contexts): Contexts {
 
   //finally, return this mess!
   return newContexts;
+}
+
+export function contextToType(context: Context): Format.Types.ContractType {
+  if (context.contractId !== undefined) {
+    return {
+      typeClass: "contract",
+      kind: "native",
+      id: context.contractId.toString(),
+      typeName: context.contractName,
+      contractKind: context.contractKind,
+      payable: context.payable
+    };
+  } else {
+    return {
+      typeClass: "contract",
+      kind: "foreign",
+      typeName: context.contractName,
+      contractKind: context.contractKind,
+      payable: context.payable
+    };
+  }
 }

--- a/packages/codec/lib/core.ts
+++ b/packages/codec/lib/core.ts
@@ -60,7 +60,7 @@ export function* decodeCalldata(
   }
   const compiler = context.compiler;
   const contextHash = context.context;
-  const contractType = Format.Utils.MakeType.contextToType(context);
+  const contractType = Contexts.Utils.contextToType(context);
   isConstructor = context.isConstructor;
   const allocations = info.allocations.calldata;
   let allocation: AbiData.Allocate.CalldataAllocation;
@@ -271,7 +271,7 @@ export function* decodeEvent(
     let decodingMode: DecodingMode = allocation.allocationMode; //starts out here; degrades to abi if necessary
     const contextHash = allocation.contextHash;
     const attemptContext = info.contexts[contextHash];
-    const contractType = Format.Utils.MakeType.contextToType(attemptContext);
+    const contractType = Contexts.Utils.contextToType(attemptContext);
     //you can't map with a generator, so we have to do this map manually
     let decodedArguments: AbiArgument[] = [];
     for (const argumentAllocation of allocation.arguments) {

--- a/packages/codec/lib/evm/types.ts
+++ b/packages/codec/lib/evm/types.ts
@@ -1,6 +1,6 @@
 import * as Common from "@truffle/codec/common";
 import * as Storage from "@truffle/codec/storage/types";
-import * as Ast from "@truffle/codec/ast";
+import * as Ast from "@truffle/codec/ast/types";
 import { StorageAllocations } from "@truffle/codec/storage/allocate/types";
 import { MemoryAllocations } from "@truffle/codec/memory/allocate/types";
 import {

--- a/packages/codec/lib/format/errors.ts
+++ b/packages/codec/lib/format/errors.ts
@@ -9,7 +9,7 @@ const debug = debugModule("codec:format:errors");
 
 import BN from "bn.js";
 import * as Types from "./types";
-import * as Ast from "@truffle/codec/ast";
+import * as Ast from "@truffle/codec/ast/types";
 import * as Storage from "@truffle/codec/storage/types";
 
 /*

--- a/packages/codec/lib/format/utils/exception.ts
+++ b/packages/codec/lib/format/utils/exception.ts
@@ -2,7 +2,7 @@ import debugModule from "debug";
 const debug = debugModule("codec:format:utils:exception");
 
 import * as Format from "@truffle/codec/format/common";
-import * as Ast from "@truffle/codec/ast";
+import * as AstUtils from "@truffle/codec/ast/utils";
 import * as Storage from "@truffle/codec/storage/types";
 
 //this function gives an error message
@@ -18,7 +18,7 @@ export function message(error: Format.Errors.ErrorForThrowing): string {
         error.type.id
       }`;
     case "UnsupportedConstantError":
-      return `Unsupported constant type ${Ast.Utils.typeClass(
+      return `Unsupported constant type ${AstUtils.typeClass(
         error.definition
       )}`;
     case "ReadErrorStack":

--- a/packages/codec/lib/format/utils/maketype.ts
+++ b/packages/codec/lib/format/utils/maketype.ts
@@ -4,7 +4,6 @@ const debug = debugModule("codec:format:utils:maketype");
 import BN from "bn.js";
 import * as Common from "@truffle/codec/common";
 import * as Compiler from "@truffle/codec/compiler";
-import * as Contexts from "@truffle/codec/contexts";
 import * as AbiData from "@truffle/codec/abi-data/types";
 import * as AstUtils from "@truffle/codec/ast/utils";
 import * as Ast from "@truffle/codec/ast/types";
@@ -483,28 +482,5 @@ export function abiParameterToType(
         memberTypes,
         typeHint
       };
-  }
-}
-
-export function contextToType(
-  context: Contexts.Context
-): Format.Types.ContractType {
-  if (context.contractId !== undefined) {
-    return {
-      typeClass: "contract",
-      kind: "native",
-      id: context.contractId.toString(),
-      typeName: context.contractName,
-      contractKind: context.contractKind,
-      payable: context.payable
-    };
-  } else {
-    return {
-      typeClass: "contract",
-      kind: "foreign",
-      typeName: context.contractName,
-      contractKind: context.contractKind,
-      payable: context.payable
-    };
   }
 }

--- a/packages/codec/lib/format/utils/maketype.ts
+++ b/packages/codec/lib/format/utils/maketype.ts
@@ -6,7 +6,8 @@ import * as Common from "@truffle/codec/common";
 import * as Compiler from "@truffle/codec/compiler";
 import * as Contexts from "@truffle/codec/contexts";
 import * as AbiData from "@truffle/codec/abi-data/types";
-import * as Ast from "@truffle/codec/ast";
+import * as AstUtils from "@truffle/codec/ast/utils";
+import * as Ast from "@truffle/codec/ast/types";
 import * as Format from "@truffle/codec/format/common";
 
 //NOTE: the following function will *not* work for arbitrary nodes! It will,
@@ -20,8 +21,8 @@ export function definitionToType(
   forceLocation?: Common.Location | null
 ): Format.Types.Type {
   debug("definition %O", definition);
-  let typeClass = Ast.Utils.typeClass(definition);
-  let typeHint = Ast.Utils.typeStringWithoutLocation(definition);
+  let typeClass = AstUtils.typeClass(definition);
+  let typeHint = AstUtils.typeStringWithoutLocation(definition);
   switch (typeClass) {
     case "bool":
       return {
@@ -40,14 +41,13 @@ export function definitionToType(
           return {
             typeClass,
             kind: "specific",
-            payable:
-              Ast.Utils.typeIdentifier(definition) === "t_address_payable"
+            payable: AstUtils.typeIdentifier(definition) === "t_address_payable"
           };
       }
       break; //to satisfy typescript
     }
     case "uint": {
-      let bytes = Ast.Utils.specifiedSize(definition);
+      let bytes = AstUtils.specifiedSize(definition);
       return {
         typeClass,
         bits: bytes * 8,
@@ -56,7 +56,7 @@ export function definitionToType(
     }
     case "int": {
       //typeScript won't let me group these for some reason
-      let bytes = Ast.Utils.specifiedSize(definition);
+      let bytes = AstUtils.specifiedSize(definition);
       return {
         typeClass,
         bits: bytes * 8,
@@ -65,8 +65,8 @@ export function definitionToType(
     }
     case "fixed": {
       //typeScript won't let me group these for some reason
-      let bytes = Ast.Utils.specifiedSize(definition);
-      let places = Ast.Utils.decimalPlaces(definition);
+      let bytes = AstUtils.specifiedSize(definition);
+      let places = AstUtils.decimalPlaces(definition);
       return {
         typeClass,
         bits: bytes * 8,
@@ -75,8 +75,8 @@ export function definitionToType(
       };
     }
     case "ufixed": {
-      let bytes = Ast.Utils.specifiedSize(definition);
-      let places = Ast.Utils.decimalPlaces(definition);
+      let bytes = AstUtils.specifiedSize(definition);
+      let places = AstUtils.decimalPlaces(definition);
       return {
         typeClass,
         bits: bytes * 8,
@@ -91,7 +91,7 @@ export function definitionToType(
           typeHint
         };
       }
-      let location = forceLocation || Ast.Utils.referenceType(definition);
+      let location = forceLocation || AstUtils.referenceType(definition);
       return {
         typeClass,
         location,
@@ -99,7 +99,7 @@ export function definitionToType(
       };
     }
     case "bytes": {
-      let length = Ast.Utils.specifiedSize(definition);
+      let length = AstUtils.specifiedSize(definition);
       if (length !== null) {
         return {
           typeClass,
@@ -115,7 +115,7 @@ export function definitionToType(
             typeHint
           };
         }
-        let location = forceLocation || Ast.Utils.referenceType(definition);
+        let location = forceLocation || AstUtils.referenceType(definition);
         return {
           typeClass,
           kind: "dynamic",
@@ -125,10 +125,10 @@ export function definitionToType(
       }
     }
     case "array": {
-      let baseDefinition = Ast.Utils.baseDefinition(definition);
+      let baseDefinition = AstUtils.baseDefinition(definition);
       let baseType = definitionToType(baseDefinition, compiler, forceLocation);
-      let location = forceLocation || Ast.Utils.referenceType(definition);
-      if (Ast.Utils.isDynamicArray(definition)) {
+      let location = forceLocation || AstUtils.referenceType(definition);
+      if (AstUtils.isDynamicArray(definition)) {
         if (forceLocation !== null) {
           return {
             typeClass,
@@ -146,7 +146,7 @@ export function definitionToType(
           };
         }
       } else {
-        let length = new BN(Ast.Utils.staticLengthAsString(definition));
+        let length = new BN(AstUtils.staticLengthAsString(definition));
         if (forceLocation !== null) {
           return {
             typeClass,
@@ -168,7 +168,7 @@ export function definitionToType(
       }
     }
     case "mapping": {
-      let keyDefinition = Ast.Utils.keyDefinition(definition);
+      let keyDefinition = AstUtils.keyDefinition(definition);
       //note that we can skip the scopes argument here! that's only needed when
       //a general node, rather than a declaration, is being passed in
       let keyType = <Format.Types.ElementaryType>(
@@ -200,11 +200,9 @@ export function definitionToType(
       };
     }
     case "function": {
-      let visibility = Ast.Utils.visibility(definition);
-      let mutability = Ast.Utils.mutability(definition);
-      let [inputParameters, outputParameters] = Ast.Utils.parameters(
-        definition
-      );
+      let visibility = AstUtils.visibility(definition);
+      let mutability = AstUtils.mutability(definition);
+      let [inputParameters, outputParameters] = AstUtils.parameters(definition);
       //note: don't force a location on these! use the listed location!
       let inputParameterTypes = inputParameters.map(parameter =>
         definitionToType(parameter, compiler)
@@ -234,8 +232,8 @@ export function definitionToType(
       break; //to satisfy typescript
     }
     case "struct": {
-      let id = Ast.Utils.typeId(definition).toString();
-      let qualifiedName = Ast.Utils.typeStringWithoutLocation(definition).match(
+      let id = AstUtils.typeId(definition).toString();
+      let qualifiedName = AstUtils.typeStringWithoutLocation(definition).match(
         /struct (.*)/
       )[1];
       let [definingContractName, typeName] = qualifiedName.split(".");
@@ -248,7 +246,7 @@ export function definitionToType(
           definingContractName
         };
       }
-      let location = forceLocation || Ast.Utils.referenceType(definition);
+      let location = forceLocation || AstUtils.referenceType(definition);
       return {
         typeClass,
         kind: "local",
@@ -259,8 +257,8 @@ export function definitionToType(
       };
     }
     case "enum": {
-      let id = Ast.Utils.typeId(definition).toString();
-      let qualifiedName = Ast.Utils.typeStringWithoutLocation(definition).match(
+      let id = AstUtils.typeId(definition).toString();
+      let qualifiedName = AstUtils.typeStringWithoutLocation(definition).match(
         /enum (.*)/
       )[1];
       let [definingContractName, typeName] = qualifiedName.split(".");
@@ -273,11 +271,11 @@ export function definitionToType(
       };
     }
     case "contract": {
-      let id = Ast.Utils.typeId(definition).toString();
+      let id = AstUtils.typeId(definition).toString();
       let typeName = definition.typeName
         ? definition.typeName.name
         : definition.name;
-      let contractKind = Ast.Utils.contractKind(definition);
+      let contractKind = AstUtils.contractKind(definition);
       return {
         typeClass,
         kind: "native",
@@ -287,7 +285,7 @@ export function definitionToType(
       };
     }
     case "magic": {
-      let typeIdentifier = Ast.Utils.typeIdentifier(definition);
+      let typeIdentifier = AstUtils.typeIdentifier(definition);
       let variable = <Format.Types.MagicVariableName>(
         typeIdentifier.match(/^t_magic_(.*)$/)[1]
       );
@@ -375,7 +373,7 @@ export function definitionToStoredType(
       let id = definition.id.toString();
       let typeName = definition.name;
       let contractKind = definition.contractKind;
-      let payable = Ast.Utils.isContractPayable(definition);
+      let payable = AstUtils.isContractPayable(definition);
       return {
         typeClass: "contract",
         kind: "native",

--- a/packages/codec/lib/mapping-key/encode/index.ts
+++ b/packages/codec/lib/mapping-key/encode/index.ts
@@ -4,8 +4,8 @@ const debug = debugModule("codec:mapping-key:encode");
 import * as Format from "@truffle/codec/format";
 import * as Conversion from "@truffle/codec/conversion";
 import * as Evm from "@truffle/codec/evm";
-import * as Basic from "@truffle/codec/basic";
-import * as Bytes from "@truffle/codec/bytes";
+import * as BasicEncode from "@truffle/codec/basic/encode";
+import * as BytesEncode from "@truffle/codec/bytes/encode";
 
 //UGH -- it turns out TypeScript can't handle nested tagged unions
 //see: https://github.com/microsoft/TypeScript/issues/18758
@@ -21,11 +21,11 @@ export function encodeMappingKey(
     input.type.typeClass === "string" ||
     (input.type.typeClass === "bytes" && input.type.kind === "dynamic")
   ) {
-    return Bytes.Encode.encodeBytes(<
+    return BytesEncode.encodeBytes(<
       Format.Values.StringValue | Format.Values.BytesDynamicValue
     >input);
   } else {
-    return Basic.Encode.encodeBasic(input);
+    return BasicEncode.encodeBasic(input);
   }
 }
 

--- a/packages/codec/lib/memory/allocate/types.ts
+++ b/packages/codec/lib/memory/allocate/types.ts
@@ -1,4 +1,4 @@
-import * as Ast from "@truffle/codec/ast";
+import * as Ast from "@truffle/codec/ast/types";
 import * as Pointer from "@truffle/codec/pointer";
 
 //memory works the same as abi except we don't bother keeping track of size

--- a/packages/codec/lib/pointer/types.ts
+++ b/packages/codec/lib/pointer/types.ts
@@ -1,4 +1,4 @@
-import * as Ast from "@truffle/codec/ast";
+import * as Ast from "@truffle/codec/ast/types";
 import * as Storage from "@truffle/codec/storage/types";
 
 export type DataPointer =

--- a/packages/codec/lib/read.ts
+++ b/packages/codec/lib/read.ts
@@ -1,9 +1,9 @@
-import * as Storage from "@truffle/codec/storage";
-import * as Stack from "@truffle/codec/stack";
-import * as Bytes from "@truffle/codec/bytes";
-import * as Ast from "@truffle/codec/ast";
-import * as Topic from "@truffle/codec/topic";
-import * as Special from "@truffle/codec/special";
+import * as StorageRead from "@truffle/codec/storage/read";
+import * as StackRead from "@truffle/codec/stack/read";
+import * as BytesRead from "@truffle/codec/bytes/read";
+import * as AstRead from "@truffle/codec/ast/read";
+import * as TopicRead from "@truffle/codec/topic/read";
+import * as SpecialRead from "@truffle/codec/special/read";
 import * as Pointer from "@truffle/codec/pointer";
 import { DecoderRequest } from "@truffle/codec/types";
 import * as Evm from "@truffle/codec/evm";
@@ -14,26 +14,26 @@ export default function* read(
 ): Generator<DecoderRequest, Uint8Array, Uint8Array> {
   switch (pointer.location) {
     case "stack":
-      return Stack.Read.readStack(pointer, state);
+      return StackRead.readStack(pointer, state);
 
     case "storage":
-      return yield* Storage.Read.readStorage(pointer, state);
+      return yield* StorageRead.readStorage(pointer, state);
 
     case "memory":
     case "calldata":
     case "eventdata":
-      return Bytes.Read.readBytes(pointer, state);
+      return BytesRead.readBytes(pointer, state);
 
     case "stackliteral":
-      return Stack.Read.readStackLiteral(pointer);
+      return StackRead.readStackLiteral(pointer);
 
     case "definition":
-      return Ast.Read.readDefinition(pointer);
+      return AstRead.readDefinition(pointer);
 
     case "special":
-      return Special.Read.readSpecial(pointer, state);
+      return SpecialRead.readSpecial(pointer, state);
 
     case "eventtopic":
-      return Topic.Read.readTopic(pointer, state);
+      return TopicRead.readTopic(pointer, state);
   }
 }

--- a/packages/codec/lib/storage/allocate/types.ts
+++ b/packages/codec/lib/storage/allocate/types.ts
@@ -1,5 +1,5 @@
 import * as Storage from "@truffle/codec/storage/types";
-import * as Ast from "@truffle/codec/ast";
+import * as Ast from "@truffle/codec/ast/types";
 import * as Pointer from "@truffle/codec/pointer";
 
 //holds a collection of storage allocations for structs and contracts, indexed

--- a/packages/codec/lib/topic/encode/index.ts
+++ b/packages/codec/lib/topic/encode/index.ts
@@ -4,7 +4,7 @@ const debug = debugModule("codec:topic:encode");
 import * as Format from "@truffle/codec/format";
 import * as Conversion from "@truffle/codec/conversion";
 import * as Evm from "@truffle/codec/evm";
-import * as Basic from "@truffle/codec/basic";
+import * as BasicEncode from "@truffle/codec/basic/encode";
 
 /**
  * Encodes for event topics (indexed parameters).
@@ -26,7 +26,7 @@ export function encodeTopic(
     }
   }
   //otherwise, just dispath to encodeBasic
-  return Basic.Encode.encodeBasic(input);
+  return BasicEncode.encodeBasic(input);
   //...of course, really here we should be checking
   //whether the input *is* a basic type, and if not, handling
   //that appropriately!  But so far we don't need this, so this

--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -932,7 +932,7 @@ export class ContractInstanceDecoder {
   ): Promise<DecoderTypes.ContractState> {
     let blockNumber = await this.regularizeBlock(block);
     return {
-      class: Format.Utils.MakeType.contextToType(this.context),
+      class: Contexts.Utils.contextToType(this.context),
       address: this.contractAddress,
       code: this.contractCode,
       balanceAsBN: new BN(


### PR DESCRIPTION
Branch `scatter-the-pages` currently introduces circular dependencies, mostly around trouble mostly of these kinds:

- Ast was previously not a data location and thus was safer for more things to import wholesale. Ast's new Decode module introduces circular dependencies. Consequently, this PR modifies problematic Ast imports to import specific submodules

- `types` modules seem to mostly need rely only on other types modules directly

- Read modules seem to need to import other Read modules directly

- Encode modules seem to need to import other Encode modules directly

- Decode modules seem to be able to import entire other modules wholesale

Not sure if this is worth codifying, or if it is sound inductive reasoning at all.

Ah, also: revert #2554 
