### PR TITLE
Add readme files for codec and decoder repos

### DIFF
--- a/packages/codec/README.md
+++ b/packages/codec/README.md
@@ -1,15 +1,36 @@
-# Truffle Decoder Core
-This module provides interfaces for decoding Solidity variables.  This is a
-fairly low-level interface meant to be used by e.g. a debugger; for a
-higher-level interface, see the `truffle-contract-decoder` package instead.
+# Truffle Codec
 
-## Usage
+This module, `@truffle/codec`, provides an interface for decoding Solidity
+smart contract state as well as information sent to or from smart contracts
+using the Solidity ABI.  It produces output in a machine-readable form that
+avoids losing any information.  It also has some rudimentary encoding
+functionality, that will be expanded in the future.  This module is also
+what Truffle Debugger uses for its decoding.
+
+This is a low-level module, and it's probable that you should use the
+higher-level interface [Truffle
+Decoder](https://github.com/trufflesuite/truffle/tree/master/packages/decoder)
+instead.  That said, if for whatever reason Truffle Decoder will not suffice
+for your use case, it's possible that you may need to use this.
+
+## Install
+
 ```
-import { forEvmState } from 'truffle-decoder-core';
-
-const decoder = forEvmState(definition, pointer, info);
+$ npm install @truffle/codec
 ```
 
-The variable `decoder` will then contain a generator you can use to decode your
-variable.  It may make requests for storage or for code; responses should be in
-the form of a `Uint8Array`.
+This module does not provide a CLI; it is entirely meant to be used as part
+of a larger JavaScript or TypeScript program.
+
+## Usage and Documentation
+
+This module has some [API
+documentation](https://www.trufflesuite.com/docs/truffle/codec/index.html),
+which you should see for further usage information.  Note that as this is a
+low-level module mostly intended for internal Truffle use, its documentation is
+sparse at the moment.
+
+## License
+
+As part of the larger [Truffle Suite](https://github.com/trufflesuite/truffle/),
+this module is MIT-licensed.

--- a/packages/codec/README.md
+++ b/packages/codec/README.md
@@ -8,15 +8,14 @@ functionality, that will be expanded in the future.  This module is also
 what Truffle Debugger uses for its decoding.
 
 This is a low-level module, and it's probable that you should use the
-higher-level interface [Truffle
-Decoder](https://github.com/trufflesuite/truffle/tree/master/packages/decoder)
-instead.  That said, if for whatever reason Truffle Decoder will not suffice
-for your use case, it's possible that you may need to use this.
+higher-level interface [Truffle Decoder](../decoder/) instead.  That said, if
+for whatever reason Truffle Decoder will not suffice for your use case, it's
+possible that you may need to use this.
 
 ## Install
 
 ```
-$ npm install @truffle/codec
+$ npm install --save @truffle/codec
 ```
 
 This module does not provide a CLI; it is entirely meant to be used as part

--- a/packages/decoder/README.md
+++ b/packages/decoder/README.md
@@ -1,0 +1,29 @@
+# Truffle Decoder
+
+This module, `@truffle/decoder`, provides an interface for decoding Solidity
+smart contract state as well as information sent to or from smart contracts
+using the Solidity ABI.  It produces output in a machine-readable form that
+avoids losing any information.
+
+For detailed instructions on how to use this module, please see the [API
+documentation](https://www.trufflesuite.com/docs/truffle/codec/index.html).
+
+## Install
+
+```
+$ npm install @truffle/decoder
+```
+
+This module does not provide a CLI; it is entirely meant to be used as part
+of a larger JavaScript or TypeScript program.
+
+## Usage and Documentation
+
+Please see the [API
+documentation](https://www.trufflesuite.com/docs/truffle/codec/index.html) for
+detailed usage instructions.
+
+## License
+
+As part of the larger [Truffle Suite](https://github.com/trufflesuite/truffle/),
+this module is MIT-licensed.

--- a/packages/decoder/README.md
+++ b/packages/decoder/README.md
@@ -11,7 +11,7 @@ documentation](https://www.trufflesuite.com/docs/truffle/codec/index.html).
 ## Install
 
 ```
-$ npm install @truffle/decoder
+$ npm install --save @truffle/decoder
 ```
 
 This module does not provide a CLI; it is entirely meant to be used as part

--- a/packages/decoder/lib/index.ts
+++ b/packages/decoder/lib/index.ts
@@ -6,7 +6,7 @@ calldata, and events.  It's an interface to the same low-level decoding
 functionality that Truffle Debugger uses.  However, it has additional
 functionality that the debugger does not need, and the debugger has additional
 functionality that this interface either does not need or cannot currently
-replicated.  In the future, this interface will also decode return values and
+replicate.  In the future, this interface will also decode return values and
 revert strings.
 
 The interface is split into three classes: The wire decoder, the contract


### PR DESCRIPTION
(Part of #2505)

This PR adds brief repository readmes for codec and decoder.  They are short as their main function is to link to the API documentation.

I also fixed an unrelated typo.