### PR TITLE
Rename ContractObject to Artifact for clarity

### DIFF
--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -19,7 +19,7 @@ import {
 import * as Utils from "./utils";
 import * as DecoderTypes from "./types";
 import Web3 from "web3";
-import { ContractObject } from "@truffle/contract-schema/spec";
+import { ContractObject as Artifact } from "@truffle/contract-schema/spec";
 import BN from "bn.js";
 import { Provider } from "web3/providers";
 import {
@@ -52,7 +52,7 @@ export class WireDecoder {
   /**
    * @protected
    */
-  constructor(contracts: ContractObject[], provider: Provider) {
+  constructor(contracts: Artifact[], provider: Provider) {
     this.web3 = new Web3(provider);
 
     let contractsAndContexts: DecoderTypes.ContractAndContexts[] = [];
@@ -478,7 +478,7 @@ export class WireDecoder {
    *   Note: The artifact must be one of the ones used to initialize the wire
    *   decoder; otherwise you will have problems.
    */
-  public async forArtifact(artifact: ContractObject): Promise<ContractDecoder> {
+  public async forArtifact(artifact: Artifact): Promise<ContractDecoder> {
     let contractDecoder = new ContractDecoder(artifact, this);
     await contractDecoder.init();
     return contractDecoder;
@@ -500,7 +500,7 @@ export class WireDecoder {
    *   If an invalid address is provided, this method will throw an exception.
    */
   public async forInstance(
-    artifact: ContractObject,
+    artifact: Artifact,
     address?: string
   ): Promise<ContractInstanceDecoder> {
     let contractDecoder = await this.forArtifact(artifact);
@@ -558,7 +558,7 @@ export class ContractDecoder {
 
   private contexts: Contexts.DecoderContexts; //note: this is deployed contexts only!
 
-  private contract: ContractObject;
+  private contract: Artifact;
   private contractNode: Ast.AstNode;
   private contractNetwork: string;
   private contextHash: string;
@@ -571,11 +571,7 @@ export class ContractDecoder {
   /**
    * @protected
    */
-  constructor(
-    contract: ContractObject,
-    wireDecoder: WireDecoder,
-    address?: string
-  ) {
+  constructor(contract: Artifact, wireDecoder: WireDecoder, address?: string) {
     this.contract = contract;
     this.wireDecoder = wireDecoder;
     this.web3 = wireDecoder.getWeb3();
@@ -722,7 +718,7 @@ export class ContractDecoder {
 }
 
 interface ContractInfo {
-  contract: ContractObject;
+  contract: Artifact;
   contractNode: Ast.AstNode;
   contractNetwork: string;
   contextHash: string;
@@ -747,7 +743,7 @@ interface ContractInfo {
 export class ContractInstanceDecoder {
   private web3: Web3;
 
-  private contract: ContractObject;
+  private contract: Artifact;
   private contractNode: Ast.AstNode;
   private contractNetwork: string;
   private contractAddress: string;

--- a/packages/decoder/lib/index.ts
+++ b/packages/decoder/lib/index.ts
@@ -43,7 +43,7 @@ For a contract instance decoder, use one of the following:
 * [[forDeployedContract|`forDeployedContract`]]
 * [[forArtifactAt|`forArtifactAt`]]
 * [[forContractAt|`forContractAt`]]
-* [[forContractAbstraction|`forContractAbstraction`]]
+* [[forContractInstance|`forContractInstance`]]
 
 See the API documentation of these functions for details, or below for usage
 examples.
@@ -114,11 +114,11 @@ in one step.  If we wanted to do this with a specified address, we could use
 
 Yet another way would be:
 ```typescript
-import { forContractAbstraction } from "@truffle/decoder";
+import { forContractInstance } from "@truffle/decoder";
 const contract = artifacts.require("Contract");
 const otherContract = artifacts.require("OtherContract");
 const deployedContract = await contract.deployed();
-const instanceDecoder = await Decoder.forContractAbstraction(deployedContract, [otherContract]);
+const instanceDecoder = await Decoder.forContractInstance(deployedContract, [otherContract]);
 const variables = await instanceDecoder.variables();
 ```
 

--- a/packages/decoder/lib/index.ts
+++ b/packages/decoder/lib/index.ts
@@ -154,7 +154,7 @@ export {
 } from "./types";
 
 import { Provider } from "web3/providers";
-import { ContractObject } from "@truffle/contract-schema/spec";
+import { ContractObject as Artifact } from "@truffle/contract-schema/spec";
 import { ContractConstructorObject, ContractInstanceObject } from "./types";
 
 /**
@@ -172,7 +172,7 @@ import { ContractConstructorObject, ContractInstanceObject } from "./types";
  */
 export async function forProject(
   provider: Provider,
-  artifacts: ContractObject[]
+  artifacts: Artifact[]
 ): Promise<WireDecoder> {
   return new WireDecoder(artifacts, provider);
 }
@@ -198,9 +198,9 @@ export async function forProject(
  * @category Provider-based Constructor
  */
 export async function forArtifact(
-  artifact: ContractObject,
+  artifact: Artifact,
   provider: Provider,
-  artifacts: ContractObject[]
+  artifacts: Artifact[]
 ): Promise<ContractDecoder> {
   artifacts = artifacts.includes(artifact)
     ? artifacts
@@ -226,7 +226,7 @@ export async function forArtifact(
  */
 export async function forContract(
   contract: ContractConstructorObject,
-  artifacts: ContractObject[]
+  artifacts: Artifact[]
 ): Promise<ContractDecoder> {
   return await forArtifact(contract, contract.web3.currentProvider, artifacts);
 }
@@ -249,9 +249,9 @@ export async function forContract(
  * @category Provider-based Constructor
  */
 export async function forDeployedArtifact(
-  artifact: ContractObject,
+  artifact: Artifact,
   provider: Provider,
-  artifacts: ContractObject[]
+  artifacts: Artifact[]
 ): Promise<ContractInstanceDecoder> {
   let contractDecoder = await forArtifact(artifact, provider, artifacts);
   let instanceDecoder = await contractDecoder.forInstance();
@@ -273,7 +273,7 @@ export async function forDeployedArtifact(
  */
 export async function forDeployedContract(
   contract: ContractConstructorObject,
-  artifacts: ContractObject[]
+  artifacts: Artifact[]
 ): Promise<ContractInstanceDecoder> {
   let contractDecoder = await forContract(contract, artifacts);
   let instanceDecoder = await contractDecoder.forInstance();
@@ -302,10 +302,10 @@ export async function forDeployedContract(
  * @category Provider-based Constructor
  */
 export async function forArtifactAt(
-  artifact: ContractObject,
+  artifact: Artifact,
   provider: Provider,
   address: string,
-  artifacts: ContractObject[]
+  artifacts: Artifact[]
 ): Promise<ContractInstanceDecoder> {
   let contractDecoder = await forArtifact(artifact, provider, artifacts);
   let instanceDecoder = await contractDecoder.forInstance(address);
@@ -332,7 +332,7 @@ export async function forArtifactAt(
 export async function forContractAt(
   contract: ContractConstructorObject,
   address: string,
-  artifacts: ContractObject[]
+  artifacts: Artifact[]
 ): Promise<ContractInstanceDecoder> {
   let contractDecoder = await forContract(contract, artifacts);
   let instanceDecoder = await contractDecoder.forInstance(address);
@@ -354,7 +354,7 @@ export async function forContractAt(
  */
 export async function forContractInstance(
   contract: ContractInstanceObject,
-  artifacts: ContractObject[]
+  artifacts: Artifact[]
 ): Promise<ContractInstanceDecoder> {
   return await forContractAt(contract.constructor, contract.address, artifacts);
 }

--- a/packages/decoder/lib/types.ts
+++ b/packages/decoder/lib/types.ts
@@ -1,5 +1,5 @@
 import BN from "bn.js";
-import { ContractObject } from "@truffle/contract-schema/spec";
+import { ContractObject as Artifact } from "@truffle/contract-schema/spec";
 import {
   Format,
   Ast,
@@ -74,7 +74,7 @@ export interface DecodedLog extends Log {
 }
 
 export interface ContractMapping {
-  [nodeId: number]: ContractObject;
+  [nodeId: number]: Artifact;
 }
 
 export interface StorageCache {
@@ -92,7 +92,7 @@ export interface CodeCache {
 }
 
 export interface ContractAndContexts {
-  contract: ContractObject;
+  contract: Artifact;
   node: Ast.AstNode;
   deployedContext?: Contexts.DecoderContext;
   constructorContext?: Contexts.DecoderContext;
@@ -250,8 +250,8 @@ export type BlockSpecifier = number | "genesis" | "latest" | "pending";
 export type RegularizedBlockSpecifier = number | "pending";
 
 //HACK
-export interface ContractConstructorObject extends ContractObject {
-  _json: ContractObject;
+export interface ContractConstructorObject extends Artifact {
+  _json: Artifact;
   web3: Web3;
 }
 

--- a/packages/decoder/lib/utils.ts
+++ b/packages/decoder/lib/utils.ts
@@ -1,4 +1,4 @@
-import { ContractObject } from "@truffle/contract-schema/spec";
+import { ContractObject as Artifact } from "@truffle/contract-schema/spec";
 import Web3 from "web3";
 import BN from "bn.js";
 
@@ -24,7 +24,7 @@ export function nativizeDecoderVariables(
   //Again, don't use this in real code!
 }
 
-export function getContractNode(contract: ContractObject): Codec.Ast.AstNode {
+export function getContractNode(contract: Artifact): Codec.Ast.AstNode {
   return (contract.ast || { nodes: [] }).nodes.find(
     (contractNode: Codec.Ast.AstNode) =>
       contractNode.nodeType === "ContractDefinition" &&
@@ -34,7 +34,7 @@ export function getContractNode(contract: ContractObject): Codec.Ast.AstNode {
 }
 
 export function makeContext(
-  contract: ContractObject,
+  contract: Artifact,
   node: Codec.Ast.AstNode | undefined,
   isConstructor = false
 ): Codec.Contexts.DecoderContext {
@@ -62,7 +62,7 @@ export function makeContext(
 
 //attempts to determine if the given contract is a library or not
 function contractKind(
-  contract: ContractObject,
+  contract: Artifact,
   node?: Codec.Ast.AstNode
 ): Codec.ContractKind {
   //first: if we have a node, use its listed contract kind


### PR DESCRIPTION
(Part of #2505)

This PR renames `ContractObject` to `Artifact` on import for clarity.

Also, while I was at it, I fixed the outdated function name `forContractAbstraction` in the decoder docs.