### PR TITLE
Increase minimum Solidity version required for full mode

### DIFF
--- a/packages/codec/docs/README.md
+++ b/packages/codec/docs/README.md
@@ -59,7 +59,7 @@ not be reliable. If decoding fails in full mode, it **falls back to ABI mode.**
 Returned decodings (i.e. [[CalldataDecoding]] and [[LogDecoding]]) indicate
 which mode was used via the `"decodingMode"` field.
 
-To ensure full mode works, use Solidity v0.4.9 or higher and compile all your
+To ensure full mode works, use Solidity v0.4.12 or higher and compile all your
 contracts at the same time.
 
 If you can't use full mode or don't want to deal with the distinction,

--- a/packages/codec/lib/index.ts
+++ b/packages/codec/lib/index.ts
@@ -180,7 +180,7 @@ far back, to Solidity 0.4.4 or earlier, it *was* possible to generate
 out-of-range enums without resorting to assembly or compiler bugs.  However,
 enums are only supported in full mode (see
 [Notes on decoding modes](../#decoding-modes)),
-which only supports 0.4.9 and later, so
+which only supports 0.4.12 and later, so
 we consider out-of-range enums an error.  There are also additional technical
 reasons why supporting out-of-range enums as a value would be difficult.)
 


### PR DESCRIPTION
This PR (part of #2505 I guess though I didn't bother adding it there) increases the documented minimum version of Solidity required for full mode from 0.4.9 to 0.4.12, just to be a little safer. :)