### PR TITLE
Switch typedoc to our custom theme

### DIFF
--- a/packages/codec/docs/typedoc.json
+++ b/packages/codec/docs/typedoc.json
@@ -2,7 +2,7 @@
   "name": "Truffle Decoding and Encoding",
   "mode": "modules",
   "module": "commonjs",
-  "theme": "default",
+  "theme": "../../../node_modules/@trufflesuite/typedoc-default-themes/bin/default/",
   "includeDeclarations": false,
   "ignoreCompilerErrors": true,
   "preserveConstEnums": true,

--- a/packages/codec/package.json
+++ b/packages/codec/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@gnd/typedoc": "^0.15.0-0",
     "@truffle/contract-schema": "^3.0.18-next.1",
+    "@trufflesuite/typedoc-default-themes": "^0.6.1",
     "@types/big.js": "^4.0.5",
     "@types/bn.js": "^4.11.2",
     "@types/debug": "^0.0.31",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1072,6 +1072,16 @@
     strip-indent "^2.0.0"
     super-split "^1.1.0"
 
+"@trufflesuite/typedoc-default-themes@^0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@trufflesuite/typedoc-default-themes/-/typedoc-default-themes-0.6.1.tgz#6b733ee896519476f6721d0db3effa2ca3bff7ce"
+  integrity sha512-/wt3Jp+fD/DsxArEMixt94hDjHlB6R82Xa2ffjoCzlXrF8OSidzmzYkMvuxi53t1PaQvobNY5wMTXUqGnt/HXA==
+  dependencies:
+    backbone "^1.4.0"
+    jquery "^3.4.1"
+    lunr "^2.3.6"
+    underscore "^1.9.1"
+
 "@types/assert@^1.4.2":
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/@types/assert/-/assert-1.4.3.tgz#c3b68c062a2375647d1b9efc41e57f8286bb30fe"


### PR DESCRIPTION
(Part of #2505)

This PR sets typedoc to use our custom theme which lives in the `@trufflesuite/typedoc-default-themes` repo.  Most of the work of course was in making that theme, but that's done, and this PR sets us to use it.

A note: When I `yarn add`ed the theme, it ended up in the top-level `node_modules` directory, not `codec`'s one.  So, uh, hopefully that happens consistently?  Because I don't know of any way to make it work regardless of which one it ends up (although it might not be impossible to hack something together, but that would probably be a task for someone else).