### PR TITLE
Adds missing dependency.

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,7 @@
     "@truffle/debug-utils": "^1.0.19",
     "@truffle/debugger": "^5.0.35",
     "@truffle/deployer": "^3.0.40",
+    "@truffle/environment": "^0.1.19",
     "@truffle/error": "^0.0.7",
     "@truffle/expect": "^0.0.12",
     "@truffle/interface-adapter": "^0.3.2",


### PR DESCRIPTION
```
npm install @truffle/core
node node_modules/@truffle/core/build/cli.js
```
> Error: Cannot find module '@truffle/environment'
