### PR TITLE
Normalize the source paths so they match when reading artifact files.

### DIFF
--- a/packages/compile-solidity/profiler/index.js
+++ b/packages/compile-solidity/profiler/index.js
@@ -34,7 +34,9 @@ module.exports = {
     let sourceFilesArtifactsUpdatedTimes = {};
 
     try {
-      const sourceFiles = await getFiles();
+      const sourceFiles = (await getFiles())
+        .map(x => x.replace(/\//g, '\\'))
+        .map(x => /^[a-zA-Z]:\\.*/.test(x) ? `${x.slice(0,1).toUpperCase()}${x.slice(1)}` : x);
       sourceFilesArtifacts = readAndParseArtifactFiles(
         sourceFiles,
         contracts_build_directory

--- a/packages/compile-solidity/profiler/readAndParseArtifactFiles.js
+++ b/packages/compile-solidity/profiler/readAndParseArtifactFiles.js
@@ -35,11 +35,14 @@ const readAndParseArtifactFiles = (sourceFiles, contracts_build_directory) => {
       const data = JSON.parse(jsonData[i].body);
 
       // In case there are artifacts from other source locations.
-      if (sourceFilesArtifacts[data.sourcePath] == null) {
-        sourceFilesArtifacts[data.sourcePath] = [];
+      const sourcePath = const sourcePath = data.sourcePath
+        ? path.normalize(data.sourcePath).replace(/\//g, '\\').replace(/^([a-z]):\\/, x => x.toUpperCase())
+        : data.sourcePath;
+      if (sourceFilesArtifacts[sourcePath] == null) {
+        sourceFilesArtifacts[sourcePath] = [];
       }
 
-      sourceFilesArtifacts[data.sourcePath].push(data);
+      sourceFilesArtifacts[sourcePath].push(data);
     } catch (error) {
       // JSON.parse throws SyntaxError objects
       if (e instanceof SyntaxError) {

--- a/packages/compile-solidity/profiler/readAndParseArtifactFiles.js
+++ b/packages/compile-solidity/profiler/readAndParseArtifactFiles.js
@@ -35,7 +35,7 @@ const readAndParseArtifactFiles = (sourceFiles, contracts_build_directory) => {
       const data = JSON.parse(jsonData[i].body);
 
       // In case there are artifacts from other source locations.
-      const sourcePath = const sourcePath = data.sourcePath
+      const sourcePath = data.sourcePath
         ? path.normalize(data.sourcePath).replace(/\//g, '\\').replace(/^([a-z]):\\/, x => x.toUpperCase())
         : data.sourcePath;
       if (sourceFilesArtifacts[sourcePath] == null) {


### PR DESCRIPTION
This is a bandaid solution that "works for me".  The problem is that the path written to the build.json files is not internally consistent on Windows (sometimes I get `/C/Path/to/file.sol` and sometimes I get `C:\Path\to\file.sol` and it is also not consistent with what `glob` returns (`c:/Path/to/file.sol`).

This is a terrible bandaid fix that addresses my specific instance of this problem, but I'm sure doesn't work for all scenarios.