### PR TITLE
Internal improvement: From Web3Shim to InterfaceAdapter – Step Two: getTransactionReceipt

### DIFF
--- a/packages/contract/lib/override.js
+++ b/packages/contract/lib/override.js
@@ -78,7 +78,7 @@ const override = {
         return;
       }
 
-      constructor.web3.eth
+      constructor.interfaceAdapter
         .getTransactionReceipt(context.transactionHash)
         .then(result => {
           if (!result) return;

--- a/packages/interface-adapter/lib/ethereum-overloads.ts
+++ b/packages/interface-adapter/lib/ethereum-overloads.ts
@@ -1,6 +1,9 @@
 import BN from "bn.js";
 import { Web3Shim } from "./web3-shim";
-import { Transaction as EvmTransaction } from "web3-core";
+import {
+  Transaction as EvmTransaction,
+  TransactionReceipt as EvmTransactionReceipt
+} from "web3-core";
 import { EvmBlockType } from "./interface-adapter/types";
 
 export const EthereumDefinition = {
@@ -62,7 +65,9 @@ const overrides = {
       web3.eth.getTransactionReceipt.method.outputFormatter;
 
     // @ts-ignore
-    web3.eth.getTransactionReceipt.method.outputFormatter = receipt => {
+    web3.eth.getTransactionReceipt.method.outputFormatter = (
+      receipt: EvmTransactionReceipt
+    ) => {
       let result = _oldTransactionReceiptFormatter.call(
         // @ts-ignore
         web3.eth.getTransactionReceipt.method,

--- a/packages/interface-adapter/lib/interface-adapter.ts
+++ b/packages/interface-adapter/lib/interface-adapter.ts
@@ -7,6 +7,7 @@ import {
   Block,
   BlockType,
   Transaction,
+  TransactionReceipt,
   TxHash
 } from "./interface-adapter/types";
 import { Provider } from "@truffle/provider";
@@ -54,5 +55,9 @@ export class InterfaceAdapter {
 
   public getTransaction(tx: TxHash): Promise<Transaction> {
     return this.adapter.getTransaction(tx);
+  }
+
+  public getTransactionReceipt(tx: TxHash): Promise<TransactionReceipt> {
+    return this.adapter.getTransactionReceipt(tx);
   }
 }

--- a/packages/interface-adapter/lib/interface-adapter/types/index.d.ts
+++ b/packages/interface-adapter/lib/interface-adapter/types/index.d.ts
@@ -1,5 +1,5 @@
 import { Block as EvmBlock } from "web3-eth";
-import { Transaction as EvmTransaction } from "web3-core";
+import { Transaction as EvmTransaction, TransactionReceipt as EvmTransactionReceipt } from "web3-core";
 
 export type EvmBlockType = number | string;
 export type NetworkId = Number | String;

--- a/packages/interface-adapter/lib/interface-adapter/types/index.d.ts
+++ b/packages/interface-adapter/lib/interface-adapter/types/index.d.ts
@@ -1,9 +1,13 @@
 import { Block as EvmBlock } from "web3-eth";
-import { Transaction as EvmTransaction, TransactionReceipt as EvmTransactionReceipt } from "web3-core";
+import {
+  Transaction as EvmTransaction,
+  TransactionReceipt as EvmTransactionReceipt
+} from "web3-core";
 
 export type EvmBlockType = number | string;
 export type NetworkId = Number | String;
 export type Block = EvmBlock | any;
 export type BlockType = EvmBlockType | any;
 export type Transaction = EvmTransaction | any;
+export type TransactionReceipt = EvmTransactionReceipt | any;
 export type TxHash = string;

--- a/packages/interface-adapter/lib/web3-interface-adapter.ts
+++ b/packages/interface-adapter/lib/web3-interface-adapter.ts
@@ -25,4 +25,8 @@ export class Web3InterfaceAdapter {
   public getTransaction(tx: string) {
     return this.web3.eth.getTransaction(tx);
   }
+
+  public getTransactionReceipt(tx: string) {
+    return this.web3.eth.getTransactionReceipt(tx);
+  }
 }


### PR DESCRIPTION
Continuation of #2473 that implements Step 2 for `getTransactionReceipt` as outlined [here](https://gist.github.com/gnidan/a55bbec28800f64d487054be18730691#file-step2-ts).