### PR TITLE
Internal improvement: From Web3Shim to InterfaceAdapter – Step Two: getCode

### DIFF
--- a/packages/contract/lib/contract/constructorMethods.js
+++ b/packages/contract/lib/contract/constructorMethods.js
@@ -67,7 +67,7 @@ module.exports = Contract => ({
 
     try {
       await this.detectNetwork();
-      const onChainCode = await this.web3.eth.getCode(address);
+      const onChainCode = await this.interfaceAdapter.getCode(address);
       await utils.checkCode(onChainCode, this.contractName, address);
       return new this(address);
     } catch (error) {

--- a/packages/interface-adapter/lib/adapter/types.ts
+++ b/packages/interface-adapter/lib/adapter/types.ts
@@ -18,4 +18,5 @@ export interface InterfaceAdapter {
   getTransaction(tx: TxHash): Promise<Transaction>;
   getTransactionReceipt(tx: TxHash): Promise<TransactionReceipt>;
   getBalance(address: string): Promise<string>;
+  getCode(address: string): Promise<string>;
 }

--- a/packages/interface-adapter/lib/adapter/web3/index.ts
+++ b/packages/interface-adapter/lib/adapter/web3/index.ts
@@ -33,4 +33,8 @@ export class Web3InterfaceAdapter implements InterfaceAdapter {
   public getBalance(address: string) {
     return this.web3.eth.getBalance(address);
   }
+
+  public getCode(address: string) {
+    return this.web3.eth.getCode(address);
+  }
 }

--- a/packages/migrate/index.js
+++ b/packages/migrate/index.js
@@ -183,10 +183,9 @@ const Migrate = {
 
     if (Migrations.isDeployed() === false) return 0;
 
-    const migrationsOnChain = async (migrationsAddress, callback) => {
+    const migrationsOnChain = async migrationsAddress => {
       return (
-        (await Migrations.web3.eth.getCode(migrationsAddress, callback)) !==
-        "0x"
+        (await Migrations.interfaceAdapter.getCode(migrationsAddress)) !== "0x"
       );
     };
 


### PR DESCRIPTION
Continuation of #2473 that implements Step 2 for `getCode` as outlined [here](https://gist.github.com/gnidan/a55bbec28800f64d487054be18730691#file-step2-ts).