### PR TITLE
Internal improvement: From Web3Shim to InterfaceAdapter – Step Two: getBlockNumber

### DIFF
--- a/packages/contract/lib/override.js
+++ b/packages/contract/lib/override.js
@@ -97,10 +97,10 @@ const override = {
     };
 
     // Start polling
-    let currentPollingBlock = await constructor.web3.eth.getBlockNumber();
+    let currentPollingBlock = await constructor.interfaceAdapter.getBlockNumber();
 
     const pollID = setInterval(async () => {
-      const newBlock = await constructor.web3.eth.getBlockNumber();
+      const newBlock = await constructor.interfaceAdapter.getBlockNumber();
 
       if (newBlock > currentPollingBlock) {
         currentPollingBlock = newBlock;

--- a/packages/core/lib/testing/testrunner.js
+++ b/packages/core/lib/testing/testrunner.js
@@ -147,15 +147,14 @@ TestRunner.prototype.resetState = function(callback) {
 };
 
 TestRunner.prototype.startTest = function(mocha, callback) {
-  var self = this;
   this.interfaceAdapter
     .getBlockNumber()
     .then(result => {
-      var one = self.web3.utils.toBN(1);
-      result = self.web3.utils.toBN(result);
+      const one = this.web3.utils.toBN(1);
+      const resultBN = this.web3.utils.toBN(result);
 
       // Add one in base 10
-      self.currentTestStartBlock = result.add(one);
+      this.currentTestStartBlock = resultBN.add(one);
 
       callback();
     })

--- a/packages/core/lib/testing/testrunner.js
+++ b/packages/core/lib/testing/testrunner.js
@@ -148,7 +148,7 @@ TestRunner.prototype.resetState = function(callback) {
 
 TestRunner.prototype.startTest = function(mocha, callback) {
   var self = this;
-  this.web3.eth
+  this.interfaceAdapter
     .getBlockNumber()
     .then(result => {
       var one = self.web3.utils.toBN(1);

--- a/packages/deployer/src/deployment.js
+++ b/packages/deployer/src/deployment.js
@@ -82,10 +82,10 @@ class Deployment {
 
     let secondsWaited = 0;
     let blocksWaited = 0;
-    let currentBlock = await web3.eth.getBlockNumber();
+    let currentBlock = await interfaceAdapter.getBlockNumber();
 
     self.blockPoll = setInterval(async () => {
-      const newBlock = await web3.eth.getBlockNumber();
+      const newBlock = await interfaceAdapter.getBlockNumber();
 
       blocksWaited = newBlock - currentBlock + blocksWaited;
       currentBlock = newBlock;
@@ -121,13 +121,13 @@ class Deployment {
    */
   async _waitBlocks(blocksToWait, state, web3, interfaceAdapter) {
     const self = this;
-    let currentBlock = await web3.eth.getBlockNumber();
+    let currentBlock = await interfaceAdapter.getBlockNumber();
 
     return new Promise(accept => {
       let blocksHeard = 0;
 
       const poll = setInterval(async () => {
-        const newBlock = await web3.eth.getBlockNumber();
+        const newBlock = await interfaceAdapter.getBlockNumber();
 
         if (newBlock > currentBlock) {
           blocksHeard = newBlock - currentBlock + blocksHeard;

--- a/packages/deployer/src/deployment.js
+++ b/packages/deployer/src/deployment.js
@@ -76,7 +76,7 @@ class Deployment {
    * @param  {Object}    web3
    * @param  {Object}    interfaceAdapter
    */
-  async _startBlockPolling(web3, interfaceAdapter) {
+  async _startBlockPolling(interfaceAdapter) {
     const self = this;
     const startTime = new Date().getTime();
 
@@ -119,7 +119,7 @@ class Deployment {
    * @param  {Object} interfaceAdapter
    * @return {Promise}             Resolves after `blockToWait` blocks
    */
-  async _waitBlocks(blocksToWait, state, web3, interfaceAdapter) {
+  async _waitBlocks(blocksToWait, state, interfaceAdapter) {
     const self = this;
     let currentBlock = await interfaceAdapter.getBlockNumber();
 
@@ -343,7 +343,7 @@ class Deployment {
           .on("transactionHash", self._hashCb.bind(promiEvent, self, state))
           .on("receipt", self._receiptCb.bind(promiEvent, self, state));
 
-        await self._startBlockPolling(contract.web3, contract.interfaceAdapter);
+        await self._startBlockPolling(contract.interfaceAdapter);
 
         // Get instance (or error)
         try {
@@ -386,7 +386,6 @@ class Deployment {
         await self._waitBlocks(
           self.confirmations,
           state,
-          contract.web3,
           contract.interfaceAdapter
         );
       }

--- a/packages/deployer/test/deployer.js
+++ b/packages/deployer/test/deployer.js
@@ -1,5 +1,6 @@
 const ganache = require("ganache-core");
 const Web3 = require("web3");
+const { createInterfaceAdapter } = require("@truffle/interface-adapter");
 const assert = require("assert");
 const Reporter = require("@truffle/reporters").migrationsV5;
 const EventEmitter = require("events");
@@ -261,11 +262,13 @@ describe("Deployer (sync)", function() {
 
     utils.startAutoMine(web3, 4000);
 
+    const interfaceAdapter = createInterfaceAdapter({ provider });
+
     const migrate = function() {
       deployer.then(async function() {
-        await deployer._startBlockPolling(web3);
+        await deployer._startBlockPolling(interfaceAdapter);
         await utils.waitMS(9000);
-        await deployer._startBlockPolling(web3);
+        await deployer._startBlockPolling(interfaceAdapter);
       });
     };
 

--- a/packages/interface-adapter/lib/adapter/types.ts
+++ b/packages/interface-adapter/lib/adapter/types.ts
@@ -17,6 +17,7 @@ export type TxHash = string;
 export interface InterfaceAdapter {
   getNetworkId(): Promise<NetworkId>;
   getBlock(block: BlockType): Promise<Block>;
+  getBlockNumber(): Promise<number>;
   getTransaction(tx: TxHash): Promise<Transaction>;
   getTransactionReceipt(tx: TxHash): Promise<TransactionReceipt>;
   getBalance(address: string): Promise<string>;

--- a/packages/interface-adapter/lib/adapter/web3/index.ts
+++ b/packages/interface-adapter/lib/adapter/web3/index.ts
@@ -46,4 +46,8 @@ export class Web3InterfaceAdapter implements InterfaceAdapter {
   public estimateGas(transactionConfig: EvmTransactionConfig) {
     return this.web3.eth.estimateGas(transactionConfig);
   }
+
+  public getBlockNumber() {
+    return this.web3.eth.getBlockNumber();
+  }
 }

--- a/packages/provider/index.js
+++ b/packages/provider/index.js
@@ -1,9 +1,6 @@
 const debug = require("debug")("provider");
 const Web3 = require("web3");
-const {
-  Web3Shim,
-  createInterfaceAdapter
-} = require("@truffle/interface-adapter");
+const { createInterfaceAdapter } = require("@truffle/interface-adapter");
 const wrapper = require("./wrapper");
 const DEFAULT_NETWORK_CHECK_TIMEOUT = 5000;
 
@@ -47,7 +44,6 @@ module.exports = {
       networkCheckTimeout = DEFAULT_NETWORK_CHECK_TIMEOUT;
     }
     const provider = this.getProvider(options);
-    const web3 = new Web3Shim({ provider, networkType });
     const interfaceAdapter = createInterfaceAdapter({ provider, networkType });
     return new Promise((resolve, reject) => {
       const noResponseFromNetworkCall = setTimeout(() => {

--- a/packages/provider/index.js
+++ b/packages/provider/index.js
@@ -59,7 +59,7 @@ module.exports = {
           "networks[networkName].networkCheckTimeout property to do this.";
         throw new Error(errorMessage);
       }, networkCheckTimeout);
-      web3.eth
+      interfaceAdapter
         .getBlockNumber()
         .then(() => {
           clearTimeout(noResponseFromNetworkCall);


### PR DESCRIPTION
Continuation of #2473 that implements Step 2 for `getBlockNumber` as outlined [here](https://gist.github.com/gnidan/a55bbec28800f64d487054be18730691#file-step2-ts).