### PR TITLE
Add rudimentary code for TypeType, TypeValue, etc

### DIFF
--- a/packages/codec/lib/abi-data/encode/index.ts
+++ b/packages/codec/lib/abi-data/encode/index.ts
@@ -34,7 +34,8 @@ export function encodeAbi(
   switch (input.type.typeClass) {
     case "mapping":
     case "magic":
-      //neither of these can go in the ABI
+    case "type":
+      //none of these can go in the ABI
       return undefined;
     case "bytes":
       switch (input.type.kind) {

--- a/packages/codec/lib/format/errors.ts
+++ b/packages/codec/lib/format/errors.ts
@@ -447,7 +447,7 @@ export interface TypeErrorResult {
  *
  * @Category Special container types (debugger-only)
  */
-export type TypeErrorResult = never;
+export type TypeErrorUnion = never;
 
 /*
  * SECTION 4: ENUMS

--- a/packages/codec/lib/format/errors.ts
+++ b/packages/codec/lib/format/errors.ts
@@ -27,6 +27,7 @@ export type ErrorResult =
   | MappingErrorResult
   | StructErrorResult
   | MagicErrorResult
+  | TypeErrorResult
   | TupleErrorResult
   | EnumErrorResult
   | ContractErrorResult
@@ -53,6 +54,7 @@ export type DecoderError =
   | MappingError
   | StructError
   | MagicError
+  | TypeErrorUnion
   | TupleError
   | EnumError
   | ContractError
@@ -427,6 +429,25 @@ export interface MagicErrorResult {
  * @Category Special container types (debugger-only)
  */
 export type MagicError = never;
+
+/**
+ * An error result for a type
+ *
+ * @Category Special container types (debugger-only)
+ */
+export interface TypeErrorResult {
+  type: Types.TypeType;
+  kind: "error";
+  error: GenericError | TypeErrorUnion;
+}
+
+/**
+ * An error specific to type values (there are none);
+ * this isn't called TypeError because that's not legal
+ *
+ * @Category Special container types (debugger-only)
+ */
+export type TypeErrorResult = never;
 
 /*
  * SECTION 4: ENUMS

--- a/packages/codec/lib/format/types.ts
+++ b/packages/codec/lib/format/types.ts
@@ -39,6 +39,7 @@ export type Type =
   | EnumType
   | ContractType
   | MagicType
+  | TypeType
   | TupleType;
 
 /**
@@ -335,7 +336,7 @@ export interface StructTypeLocal {
   definingContractName: string;
   definingContract?: ContractTypeNative;
   /**
-   * these should be in order
+   * these must be in order
    */
   memberTypes?: NameTypePair[];
   location?: Location;
@@ -355,7 +356,7 @@ export interface StructTypeGlobal {
   id: string;
   typeName: string;
   /**
-   * these should be in order
+   * these must be in order
    */
   memberTypes?: NameTypePair[];
   location?: Location;
@@ -403,7 +404,7 @@ export interface EnumTypeLocal {
   definingContractName: string;
   definingContract?: ContractTypeNative;
   /**
-   * these should be in order
+   * these must be in order
    */
   options?: string[];
 }
@@ -422,7 +423,7 @@ export interface EnumTypeGlobal {
   id: string;
   typeName: string;
   /**
-   * these should be in order
+   * these must be in order
    */
   options?: string[];
 }
@@ -494,6 +495,21 @@ export interface MagicType {
     [field: string]: Type;
   };
   //may have more optional fields defined in the future
+}
+
+/**
+ * Type of a type!  This is currently only used for contract types, but
+ * may expand in the future.
+ * @Category Special container types (debugger-only)
+ */
+export interface TypeType {
+  typeClass: "type";
+  type: ContractTypeNative;
+  /**
+   * these must be in order, and must only include
+   * **non-inherited** state variables
+   */
+  stateVariableTypes?: NameTypePair[];
 }
 
 /**

--- a/packages/codec/lib/format/utils/inspect.ts
+++ b/packages/codec/lib/format/utils/inspect.ts
@@ -150,6 +150,19 @@ export class ResultInspector {
               options
             );
           }
+          case "type": {
+            //same as struct case but w/o circularity check
+            let coercedResult = <Format.Values.TypeValue>this.result;
+            return util.inspect(
+              Object.assign(
+                {},
+                ...coercedResult.value.map(({ name, value }) => ({
+                  [name]: new ResultInspector(value)
+                }))
+              ),
+              options
+            );
+          }
           case "magic":
             return util.inspect(
               Object.assign(
@@ -472,6 +485,14 @@ export function nativize(result: Format.Values.Result): any {
       return Object.assign(
         {},
         ...(<Format.Values.StructValue>result).value.map(({ name, value }) => ({
+          [name]: nativize(value)
+        }))
+      );
+    case "type": //keeping this separate from struct as struct will likely get
+      //some modifications later
+      return Object.assign(
+        {},
+        ...(<Format.Values.TypeValue>result).value.map(({ name, value }) => ({
           [name]: nativize(value)
         }))
       );

--- a/packages/codec/lib/format/values.ts
+++ b/packages/codec/lib/format/values.ts
@@ -46,6 +46,7 @@ export type Result =
   | StructResult
   | TupleResult
   | MagicResult
+  | TypeResult
   | EnumResult
   | ContractResult
   | FunctionExternalResult
@@ -62,6 +63,7 @@ export type Value =
   | StructValue
   | TupleValue
   | MagicValue
+  | TypeValue
   | EnumValue
   | ContractValue
   | FunctionExternalValue
@@ -291,6 +293,29 @@ export interface MagicValue {
   value: {
     [field: string]: Result;
   };
+}
+
+/**
+ * A type's value (or error)
+ *
+ * @Category Special container types (debugger-only)
+ */
+export type TypeResult = TypeValue | Errors.TypeErrorResult;
+
+/**
+ * A type's value -- for now, we consider the value of a contract type to
+ * consist of the values of its non-inherited state variables in the current
+ * context.  May contain errors.
+ *
+ * @Category Special container types (debugger-only)
+ */
+export interface TypeValue {
+  type: Types.TypeType;
+  kind: "value";
+  /**
+   * these must be stored in order!
+   */
+  value: NameValuePair[];
 }
 
 /*


### PR DESCRIPTION
This PR adds typeclass `type` to the type system, so that we don't break things by adding it later.  (Hopefully we don't have to add anything else for quite a while!)  It doesn't actually add anything that produces these, but it does add some rudimentary handling for them.

Note: I added `stateVariableTypes` as an optional property of `TypeType` rather than `ContractType` (or rather `ContractTypeNative`).  I only realized now that seems kind of off.  But, I think it's fine -- `TypeType` is really just meant for internal use; so even if this seems a bit wrong, this better matches how I intend the code to actually work.

Also, the type that would be called `TypeError` is instead called `TypeErrorUnion`, because, uh, yeah, that name's already taken. :P

I also changed a bunch of "should"s to "must"s that were missed earlier.