### PR TITLE
Fix accidental breaking change to resolver

### DIFF
--- a/packages/contract/index.js
+++ b/packages/contract/index.js
@@ -2,10 +2,8 @@ const Schema = require("@truffle/contract-schema");
 const Contract = require("./lib/contract");
 const truffleContractVersion = require("./package.json").version;
 
-const contract = (json = {}, networkType = "ethereum") => {
-  const normalizedArtifactObject = Object.assign({}, Schema.normalize(json), {
-    networkType
-  });
+const contract = (json = {}) => {
+  const normalizedArtifactObject = Schema.normalize(json);
 
   // Note we don't use `new` here at all. This will cause the class to
   // "mutate" instead of instantiate an instance.

--- a/packages/contract/test/cloning.js
+++ b/packages/contract/test/cloning.js
@@ -17,6 +17,8 @@ describe("Cloning", function() {
     this.timeout(10000);
 
     ExampleOne = await util.createExample();
+    await util.setUpProvider(ExampleOne);
+
     debug("ExampleOne %o", ExampleOne);
     ExampleTwo = ExampleOne.clone();
   });
@@ -26,5 +28,9 @@ describe("Cloning", function() {
     assert(Object.keys(ExampleTwo._json).length > 0);
     assert.notEqual(ExampleTwo._json, ExampleOne._json);
     assert.deepEqual(ExampleTwo._json, ExampleOne._json);
+  });
+
+  it("reuses the provider", function() {
+    assert.equal(ExampleTwo.currentProvider, ExampleOne.currentProvider);
   });
 });

--- a/packages/contract/test/contract/constructorMethods.js
+++ b/packages/contract/test/contract/constructorMethods.js
@@ -171,7 +171,6 @@ describe("TruffleContract.setNetworkType()", () => {
   it("sets network_type on Web3Shim", () => {
     const freshTruffleContract = TruffleContract();
     // default Web3Shim networkType
-    assert.strictEqual(freshTruffleContract.web3.networkType, "ethereum");
     freshTruffleContract.setNetworkType("quorum");
     assert.strictEqual(freshTruffleContract.web3.networkType, "quorum");
   });
@@ -181,7 +180,6 @@ describe("TruffleContract.setWallet()", () => {
   it("sets wallet on Web3Shim", () => {
     const freshTruffleContract = TruffleContract();
     const mockWalletObj = {};
-    assert(freshTruffleContract.web3.eth.accounts.wallet);
     freshTruffleContract.setWallet(mockWalletObj);
     assert.deepStrictEqual(
       freshTruffleContract.web3.eth.accounts.wallet,

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -119,10 +119,7 @@ class Console extends EventEmitter {
     });
 
     const abstractions = jsonBlobs.map(json => {
-      const abstraction = contract(
-        json,
-        this.options.networks[this.options.network].type
-      );
+      const abstraction = contract(json);
       provision(abstraction, this.options);
       return abstraction;
     });

--- a/packages/core/lib/testing/testrunner.js
+++ b/packages/core/lib/testing/testrunner.js
@@ -77,11 +77,7 @@ TestRunner.prototype.initialize = function(callback) {
         function(err, data) {
           if (err) return callback(err);
 
-          var contracts = data
-            .map(JSON.parse)
-            .map(json =>
-              contract(json, self.config.networks[self.config.network].type)
-            );
+          var contracts = data.map(JSON.parse).map(json => contract(json));
           var abis = _.flatMap(contracts, "abi");
 
           abis.map(function(abi) {

--- a/packages/resolver/index.js
+++ b/packages/resolver/index.js
@@ -26,10 +26,7 @@ Resolver.prototype.require = function(import_path, search_path) {
   this.sources.forEach(source => {
     const result = source.require(import_path, search_path);
     if (result) {
-      abstraction = contract(
-        result,
-        this.options.networks[this.options.network].type
-      );
+      abstraction = contract(result);
       provision(abstraction, this.options);
     }
   });


### PR DESCRIPTION
Surfaced from [Gitter conversation](https://gitter.im/ConsenSys/truffle?at=5dcb38ba4adf071a841b760d), this PR fixes a recent breakage caused by the introduction of a networkType argument to the root @truffle/contract factory.

Since @truffle/contract is documented to work via a separate "provision" step, this PR removes the recently-added pre-provision network configuration and aligns it with the more mature provider configuration, since they are effectively related.

This consolidates `setNetworkType` / `setProvider` inside @truffle/contract to be simple facades to a new `configureNetwork` method, and implements the newly-required `setNetworkType` method to the InterfaceAdapter (necessary for the parallelism).
 