### PR TITLE
Bug fix/Internal improvement: Update migrations

### DIFF
--- a/packages/migrate/index.js
+++ b/packages/migrate/index.js
@@ -85,7 +85,7 @@ const Migrate = {
       return;
     } catch (error) {
       if (callbackPassed) return callback(error);
-      throw new Error(error);
+      throw error;
     }
   },
 

--- a/packages/migrate/index.js
+++ b/packages/migrate/index.js
@@ -28,33 +28,31 @@ const Migrate = {
 
   assemble: function(options) {
     const config = Config.detect(options);
-
     if (
-      fs.existsSync(config.migrations_directory) &&
-      fs.readdirSync(config.migrations_directory).length > 0
-    ) {
-      const files = dir.files(config.migrations_directory, { sync: true });
-      if (!files) return [];
-
-      let migrations = files
-        .filter(file => isNaN(parseInt(path.basename(file))) === false)
-        .filter(
-          file =>
-            path.extname(file).match(config.migrations_file_extension_regexp) !=
-            null
-        )
-        .map(file => new Migration(file, Migrate.reporter, config));
-
-      // Make sure to sort the prefixes as numbers and not strings.
-      migrations = migrations.sort((a, b) => {
-        if (a.number > b.number) return 1;
-        if (a.number < b.number) return -1;
-        return 0;
-      });
-      return migrations;
-    } else {
+      !fs.existsSync(config.migrations_directory) ||
+      !fs.readdirSync(config.migrations_directory).length > 0
+    )
       return [];
-    }
+
+    const files = dir.files(config.migrations_directory, { sync: true });
+    if (!files) return [];
+
+    let migrations = files
+      .filter(file => isNaN(parseInt(path.basename(file))) === false)
+      .filter(
+        file =>
+          path.extname(file).match(config.migrations_file_extension_regexp) !=
+          null
+      )
+      .map(file => new Migration(file, Migrate.reporter, config));
+
+    // Make sure to sort the prefixes as numbers and not strings.
+    migrations = migrations.sort((a, b) => {
+      if (a.number > b.number) return 1;
+      if (a.number < b.number) return -1;
+      return 0;
+    });
+    return migrations;
   },
 
   run: async function(options, callback) {

--- a/packages/migrate/index.js
+++ b/packages/migrate/index.js
@@ -1,7 +1,6 @@
 const fs = require("fs");
 const dir = require("node-dir");
 const path = require("path");
-const async = require("async");
 const expect = require("@truffle/expect");
 const Config = require("@truffle/config");
 const Reporter = require("@truffle/reporters").migrationsV5;
@@ -81,7 +80,6 @@ const Migrate = {
       }
 
       const lastMigration = await this.lastCompletedMigration(options);
-
       // Don't rerun the last completed migration.
       await this.runFrom(lastMigration + 1, options);
 
@@ -144,30 +142,20 @@ const Migrate = {
       migrations
     });
 
-    return new Promise((resolve, reject) => {
-      return async.eachSeries(
-        migrations,
-        (migration, finished) => {
-          migration
-            .run(clone)
-            .then(() => {
-              finished();
-            })
-            .catch(error => {
-              finished(error);
-            });
-        },
-        async error => {
-          await this.emitter.emit("postAllMigrations", {
-            dryRun: options.dryRun,
-            error: error ? error.toString() : null
-          });
-
-          if (error) return reject(error);
-          return resolve();
-        }
-      );
-    });
+    try {
+      await Promise.all(migrations.map(migration => migration.run(clone)));
+      await this.emitter.emit("postAllMigrations", {
+        dryRun: options.dryRun,
+        error: null
+      });
+      return;
+    } catch (error) {
+      await this.emitter.emit("postAllMigrations", {
+        dryRun: options.dryRun,
+        error: error.toString()
+      });
+      throw error;
+    }
   },
 
   wrapResolver: function(resolver, provider) {

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -20,7 +20,6 @@
     "@truffle/interface-adapter": "^0.3.3",
     "@truffle/reporters": "^1.0.17",
     "@truffle/require": "^2.0.28",
-    "async": "2.6.1",
     "emittery": "^0.4.0",
     "node-dir": "0.1.17",
     "web3": "1.2.2"


### PR DESCRIPTION
Previously, useful stack traces were not showing when an error in migrations happened. This was due to the fact that when errors were caught in `migrations/index.js`, a new error was created with the caught error rather than throwing the error directly. This messed up the stack trace. This PR causes the code to throw that error directly.

This PR also removes the `async` library from `@truffle/migrate` and uses Promises in the place where that library was utilized for the migrations. The logic should remain the same.