### PR TITLE
Bug fix: Throw errors properly to preserve stack trace

### DIFF
--- a/packages/migrate/index.js
+++ b/packages/migrate/index.js
@@ -89,7 +89,7 @@ const Migrate = {
       return;
     } catch (error) {
       if (callbackPassed) return callback(error);
-      throw new Error(error);
+      throw error;
     }
   },
 

--- a/packages/migrate/migration.js
+++ b/packages/migrate/migration.js
@@ -121,7 +121,7 @@ class Migration {
 
       await this.emitter.emit("error", payload);
       deployer.finish();
-      throw new Error(error);
+      throw error;
     }
   }
 


### PR DESCRIPTION
Previously, useful stack traces were not showing when an error in migrations happened. This was due to the fact that when errors were caught in `migrations/index.js`, a new error was created with the caught error rather than throwing the error directly. This messed up the stack trace. This PR causes the code to throw that error directly.