### PR TITLE
Implement return data decoding in codec

### DIFF
--- a/packages/codec/lib/abi-data/allocate/index.ts
+++ b/packages/codec/lib/abi-data/allocate/index.ts
@@ -438,8 +438,8 @@ function allocateCalldata(
         id,
         outputTypes,
         userDefinedTypes,
-        abiAllocations,
-        offset
+        abiAllocations
+        //note the lack of an offset!
       )[id];
     } catch {
       //if something goes wrong, switch to ABI mdoe
@@ -477,8 +477,8 @@ function allocateCalldata(
       id,
       outputTypes,
       userDefinedTypes,
-      abiAllocations,
-      offset
+      abiAllocations
+      //note the lack of an offset!
     )[id];
   }
   //finally: transform the allocation appropriately

--- a/packages/codec/lib/abi-data/allocate/index.ts
+++ b/packages/codec/lib/abi-data/allocate/index.ts
@@ -514,7 +514,7 @@ function allocateCalldata(
       };
       break;
     case "constructor":
-      outputsAllocation = CONSTRUCTOR_OUTPUT_ALLOCATION;
+      outputsAllocation = constructorOutputAllocation;
       break;
   }
   return { input: inputsAllocation, output: outputsAllocation };
@@ -729,11 +729,11 @@ function defaultConstructorAllocation(
     arguments: [] as CalldataArgumentAllocation[],
     allocationMode: "full" as const
   };
-  let output = CONSTRUCTOR_OUTPUT_ALLOCATION;
+  let output = constructorOutputAllocation;
   return { input, output };
 }
 
-const CONSTRUCTOR_OUTPUT_ALLOCATION: ReturndataAllocation = {
+const constructorOutputAllocation: ReturndataAllocation = {
   selector: new Uint8Array(), //empty by default
   allocationMode: "full" as const,
   kind: "bytecode" as const,

--- a/packages/codec/lib/abi-data/allocate/types.ts
+++ b/packages/codec/lib/abi-data/allocate/types.ts
@@ -126,7 +126,12 @@ export interface EventArgumentAllocation {
 }
 
 //now let's go back ands fill in returndata
-type ReturndataKind = "return" | "revert" | "failure" | "empty" | "bytecode";
+type ReturndataKind =
+  | "return"
+  | "revert"
+  | "failure"
+  | "selfdestruct"
+  | "bytecode";
 
 export interface ReturndataAllocation {
   selector: Uint8Array;

--- a/packages/codec/lib/abi-data/allocate/types.ts
+++ b/packages/codec/lib/abi-data/allocate/types.ts
@@ -57,13 +57,18 @@ export interface CalldataAllocations {
 }
 
 export interface CalldataConstructorAllocations {
-  [contextHash: string]: CalldataAllocation;
+  [contextHash: string]: CalldataAndReturndataAllocation;
 }
 
 export interface CalldataFunctionAllocations {
   [contextHash: string]: {
-    [selector: string]: CalldataAllocation;
+    [selector: string]: CalldataAndReturndataAllocation;
   };
+}
+
+export interface CalldataAndReturndataAllocation {
+  input: CalldataAllocation;
+  output: ReturndataAllocation; //return data will be discussed below
 }
 
 export interface CalldataAllocation {
@@ -120,6 +125,40 @@ export interface EventArgumentAllocation {
   pointer: Pointer.EventDataPointer | Pointer.EventTopicPointer;
 }
 
+//now let's go back ands fill in returndata
+type ReturndataKind =
+  | "return"
+  | "revert"
+  | "empty"
+  | "selfdestruct"
+  | "bytecode";
+
+export interface ReturndataAllocation {
+  abi: AbiData.FunctionAbiEntry | AbiData.ConstructorAbiEntry;
+  offset: number; //measured in bytes
+  arguments: ReturndataArgumentAllocation[];
+  allocationMode: DecodingMode;
+  status: boolean;
+  kind: ReturndataKind;
+}
+
+export type ReturndataArgumentAllocation =
+  | ReturndataArgumentAllocationAbi
+  | ReturndataArgumentAllocationRaw;
+
+export interface ReturndataArgumentAllocationAbi {
+  kind: "abi";
+  name: string;
+  type: Format.Types.Type;
+  pointer: Pointer.ReturndataPointer;
+}
+
+export interface ReturndataArgumentAllocationRaw {
+  kind: "raw";
+  name: string;
+  pointer: Pointer.ReturndataPointer;
+}
+
 //NOTE: the folowing types are not for outside use!  just produced temporarily by the allocator!
 export interface EventAllocationTemporary {
   selector?: string; //leave out for anonymous
@@ -128,8 +167,8 @@ export interface EventAllocationTemporary {
 }
 
 export interface CalldataAllocationTemporary {
-  constructorAllocation?: CalldataAllocation;
+  constructorAllocation?: CalldataAndReturndataAllocation;
   functionAllocations: {
-    [selector: string]: CalldataAllocation;
+    [selector: string]: CalldataAndReturndataAllocation;
   };
 }

--- a/packages/codec/lib/abi-data/allocate/types.ts
+++ b/packages/codec/lib/abi-data/allocate/types.ts
@@ -126,19 +126,12 @@ export interface EventArgumentAllocation {
 }
 
 //now let's go back ands fill in returndata
-type ReturndataKind =
-  | "return"
-  | "revert"
-  | "empty"
-  | "selfdestruct"
-  | "bytecode";
+type ReturndataKind = "return" | "revert" | "failure" | "empty" | "bytecode";
 
 export interface ReturndataAllocation {
-  abi: AbiData.FunctionAbiEntry | AbiData.ConstructorAbiEntry;
-  offset: number; //measured in bytes
+  selector: Uint8Array;
   arguments: ReturndataArgumentAllocation[];
   allocationMode: DecodingMode;
-  status: boolean;
   kind: ReturndataKind;
 }
 
@@ -156,6 +149,7 @@ export interface ReturndataArgumentAllocationAbi {
 export interface ReturndataArgumentAllocationRaw {
   kind: "raw";
   name: string;
+  type: Format.Types.BytesTypeDynamic; //only allowed type for raw!
   pointer: Pointer.ReturndataPointer;
 }
 

--- a/packages/codec/lib/abi-data/allocate/types.ts
+++ b/packages/codec/lib/abi-data/allocate/types.ts
@@ -130,26 +130,14 @@ type ReturndataKind = "return" | "revert" | "failure" | "empty" | "bytecode";
 
 export interface ReturndataAllocation {
   selector: Uint8Array;
-  arguments: ReturndataArgumentAllocation[];
+  arguments: ReturndataArgumentAllocation[]; //ignored if kind="bytecode"
   allocationMode: DecodingMode;
   kind: ReturndataKind;
 }
 
-export type ReturndataArgumentAllocation =
-  | ReturndataArgumentAllocationAbi
-  | ReturndataArgumentAllocationRaw;
-
-export interface ReturndataArgumentAllocationAbi {
-  kind: "abi";
+export interface ReturndataArgumentAllocation {
   name: string;
   type: Format.Types.Type;
-  pointer: Pointer.ReturndataPointer;
-}
-
-export interface ReturndataArgumentAllocationRaw {
-  kind: "raw";
-  name: string;
-  type: Format.Types.BytesTypeDynamic; //only allowed type for raw!
   pointer: Pointer.ReturndataPointer;
 }
 

--- a/packages/codec/lib/abi-data/decode/index.ts
+++ b/packages/codec/lib/abi-data/decode/index.ts
@@ -80,6 +80,7 @@ export function* decodeAbiReferenceByAddress(
   let rawValue: Uint8Array;
   try {
     rawValue = yield* read(pointer, state);
+    debug("state: %O", state);
   } catch (error) {
     if (strict) {
       throw new StopDecodingError((<DecodingError>error).error);
@@ -93,6 +94,8 @@ export function* decodeAbiReferenceByAddress(
   }
 
   let rawValueAsBN = Conversion.toBN(rawValue);
+  debug("rawValue: %O", rawValue);
+  debug("rawValueAsBN: %O", rawValueAsBN);
   let rawValueAsNumber: number;
   try {
     rawValueAsNumber = rawValueAsBN.toNumber();

--- a/packages/codec/lib/abify.ts
+++ b/packages/codec/lib/abify.ts
@@ -3,7 +3,11 @@ const debug = debugModule("codec:abify");
 
 import * as Format from "@truffle/codec/format";
 import * as Common from "@truffle/codec/common";
-import { CalldataDecoding, LogDecoding } from "@truffle/codec/types";
+import {
+  CalldataDecoding,
+  LogDecoding,
+  ReturndataDecoding
+} from "@truffle/codec/types";
 import BN from "bn.js";
 import * as Conversion from "@truffle/codec/conversion";
 
@@ -292,9 +296,9 @@ export function abifyCalldataDecoding(
       return {
         ...decoding,
         decodingMode: "abi",
-        arguments: decoding.arguments.map(({ name, value }) => ({
-          name,
-          value: abifyResult(value, userDefinedTypes)
+        arguments: decoding.arguments.map(argument => ({
+          ...argument,
+          value: abifyResult(argument.value, userDefinedTypes)
         }))
       };
     default:
@@ -316,9 +320,36 @@ export function abifyLogDecoding(
   return {
     ...decoding,
     decodingMode: "abi",
-    arguments: decoding.arguments.map(({ name, value }) => ({
-      name,
-      value: abifyResult(value, userDefinedTypes)
+    arguments: decoding.arguments.map(argument => ({
+      ...argument,
+      value: abifyResult(argument.value, userDefinedTypes)
     }))
   };
+}
+
+/** @category ABIfication */
+export function abifyReturndataDecoding(
+  decoding: ReturndataDecoding,
+  userDefinedTypes: Format.Types.TypesById
+): ReturndataDecoding {
+  if (decoding.decodingMode === "abi") {
+    return decoding;
+  }
+  switch (decoding.kind) {
+    case "return":
+    case "revert":
+      return {
+        ...decoding,
+        decodingMode: "abi",
+        arguments: decoding.arguments.map(argument => ({
+          ...argument,
+          value: abifyResult(argument.value, userDefinedTypes)
+        }))
+      };
+    default:
+      return {
+        ...decoding,
+        decodingMode: "abi"
+      };
+  }
 }

--- a/packages/codec/lib/ast/utils.ts
+++ b/packages/codec/lib/ast/utils.ts
@@ -696,31 +696,7 @@ function getterDefinitionToAbi(
 //important note: inner structs within a struct are just returned, not
 //partially destructured like the outermost struct!  Yes, this is confusing.
 
-//here's a simplified function that just does the inputs. it's for use by the
-//allocator. I'm keeping it separate because it doesn't require a
-//referenceDeclarations argument.
-export function getterInputs(node: AstNode): AstNode[] {
-  node = node.typeName || node;
-  let inputs: AstNode[] = [];
-  while (typeClass(node) === "array" || typeClass(node) === "mapping") {
-    let keyNode = keyDefinition(node); //note: if node is an array, this spoofs up a uint256 definition
-    inputs.push({ ...keyNode, name: "" }); //getter input params have no name
-    switch (typeClass(node)) {
-      case "array":
-        node = node.baseType;
-        break;
-      case "mapping":
-        node = node.valueType;
-        break;
-    }
-  }
-  return inputs;
-}
-
-//again, despite the duplication, this function is kept separate from the
-//more straightforward getterInputs function because, since it has to handle
-//outputs too, it requires referenceDeclarations
-function getterParameters(
+export function getterParameters(
   node: AstNode,
   referenceDeclarations: AstNodes
 ): { inputs: AstNode[]; outputs: AstNode[] } {

--- a/packages/codec/lib/core.ts
+++ b/packages/codec/lib/core.ts
@@ -67,7 +67,7 @@ export function* decodeCalldata(
   let selector: string;
   //first: is this a creation call?
   if (isConstructor) {
-    allocation = allocations.constructorAllocations[contextHash];
+    allocation = allocations.constructorAllocations[contextHash].input;
   } else {
     //skipping any error-handling on this read, as a calldata read can't throw anyway
     let rawSelector = yield* read(
@@ -79,7 +79,7 @@ export function* decodeCalldata(
       info.state
     );
     selector = Conversion.toHexString(rawSelector);
-    allocation = allocations.functionAllocations[contextHash][selector];
+    allocation = allocations.functionAllocations[contextHash][selector].input;
   }
   if (allocation === undefined) {
     return {
@@ -394,3 +394,7 @@ export function* decodeEvent(
   }
   return decodings;
 }
+
+/**
+ * @Category Decoding
+ */

--- a/packages/codec/lib/core.ts
+++ b/packages/codec/lib/core.ts
@@ -443,7 +443,7 @@ const DEFAULT_RETURN_ALLOCATIONS: AbiData.Allocate.ReturndataAllocation[] = [
 
 /**
  * If there are multiple possibilities, they're always returned in
- * the order: return, revert, failure, empty, bytecode.
+ * the order: return, revert, failure, empty, bytecode, unknownbytecode
  * @Category Decoding
  */
 export function* decodeReturndata(
@@ -506,6 +506,15 @@ export function* decodeReturndata(
         info.contexts,
         bytecode
       );
+      if (!context) {
+        decodings.push({
+          kind: "unknownbytecode" as const,
+          status: true as const,
+          decodingMode,
+          bytecode
+        });
+        continue; //skip the rest of the code in the allocation loop!
+      }
       const contractType = Contexts.Import.contextToType(context);
       let decoding: BytecodeDecoding = {
         kind: "bytecode" as const,

--- a/packages/codec/lib/core.ts
+++ b/packages/codec/lib/core.ts
@@ -526,7 +526,7 @@ export function* decodeReturndata(
           "0x" + pushAddressInstruction + "..".repeat(Evm.Utils.ADDRESS_SIZE);
         if (context.binary.startsWith(delegateCallGuardString)) {
           decoding.address = Web3Utils.toChecksumAddress(
-            bytecode.slice(2, 2 + 2 * Evm.Utils.ADDRESS_SIZE)
+            bytecode.slice(4, 4 + 2 * Evm.Utils.ADDRESS_SIZE) //4 = "0x73".length
           );
         }
       }

--- a/packages/codec/lib/core.ts
+++ b/packages/codec/lib/core.ts
@@ -400,24 +400,24 @@ export function* decodeEvent(
   return decodings;
 }
 
-const ERROR_SELECTOR: Uint8Array = Conversion.toBytes(
+const errorSelector: Uint8Array = Conversion.toBytes(
   Web3Utils.soliditySha3({
     type: "string",
     value: "Error(string)"
   })
 ).subarray(0, Evm.Utils.SELECTOR_SIZE);
 
-const DEFAULT_RETURN_ALLOCATIONS: AbiData.Allocate.ReturndataAllocation[] = [
+const defaultReturnAllocations: AbiData.Allocate.ReturndataAllocation[] = [
   {
     kind: "revert" as const,
     allocationMode: "full" as const,
-    selector: ERROR_SELECTOR,
+    selector: errorSelector,
     arguments: [
       {
         name: "",
         pointer: {
           location: "returndata" as const,
-          start: ERROR_SELECTOR.length,
+          start: errorSelector.length,
           length: Evm.Utils.WORD_SIZE
         },
         type: {
@@ -453,24 +453,16 @@ export function* decodeReturndata(
 ): Generator<DecoderRequest, ReturndataDecoding[], Uint8Array> {
   let possibleAllocations: AbiData.Allocate.ReturndataAllocation[];
   if (successAllocation === null) {
-    possibleAllocations = DEFAULT_RETURN_ALLOCATIONS;
+    possibleAllocations = defaultReturnAllocations;
   } else {
     switch (successAllocation.kind) {
       case "return":
-        possibleAllocations = [
-          successAllocation,
-          ...DEFAULT_RETURN_ALLOCATIONS
-        ];
+        possibleAllocations = [successAllocation, ...defaultReturnAllocations];
         break;
       case "bytecode":
-        possibleAllocations = [
-          ...DEFAULT_RETURN_ALLOCATIONS,
-          successAllocation
-        ];
+        possibleAllocations = [...defaultReturnAllocations, successAllocation];
         break;
-      default:
-        //this shouldn't happen
-        possibleAllocations = DEFAULT_RETURN_ALLOCATIONS; //I guess??
+      //Other cases shouldn't happen so I'm leaving them to cause errors!
     }
   }
   let decodings: ReturndataDecoding[] = [];

--- a/packages/codec/lib/core.ts
+++ b/packages/codec/lib/core.ts
@@ -434,7 +434,7 @@ const DEFAULT_RETURN_ALLOCATIONS: AbiData.Allocate.ReturndataAllocation[] = [
     arguments: []
   },
   {
-    kind: "empty" as const,
+    kind: "selfdestruct" as const,
     allocationMode: "full" as const,
     selector: new Uint8Array(), //empty by default
     arguments: []
@@ -485,7 +485,7 @@ export function* decodeReturndata(
     encodedData = encodedData.subarray(allocation.selector.length); //slice off the selector for later
     //also we check, does the status match?
     if (status !== undefined) {
-      const successKinds = ["return", "empty", "bytecode"];
+      const successKinds = ["return", "selfdestruct", "bytecode"];
       const failKinds = ["failure", "revert"];
       if (status) {
         if (!successKinds.includes(allocation.kind)) {
@@ -645,7 +645,7 @@ export function* decodeReturndata(
           decodingMode
         };
         break;
-      case "empty":
+      case "selfdestruct":
         decoding = {
           kind,
           status: true as const,

--- a/packages/codec/lib/decode.ts
+++ b/packages/codec/lib/decode.ts
@@ -42,6 +42,7 @@ export default function* decode(
 
     case "calldata":
     case "eventdata":
+    case "returndata":
       return yield* AbiData.Decode.decodeAbi(dataType, pointer, info, options);
 
     case "eventtopic":

--- a/packages/codec/lib/evm/types.ts
+++ b/packages/codec/lib/evm/types.ts
@@ -21,6 +21,7 @@ export interface EvmState {
   };
   eventdata?: Uint8Array;
   eventtopics?: Uint8Array[];
+  returndata?: Uint8Array;
 }
 
 export interface WordMapping {

--- a/packages/codec/lib/format/errors.ts
+++ b/packages/codec/lib/format/errors.ts
@@ -751,7 +751,7 @@ export interface ReadErrorStack {
 /**
  * A byte-based location
  */
-export type BytesLocation = "memory" | "calldata" | "eventdata";
+export type BytesLocation = "memory" | "calldata" | "eventdata" | "returndata";
 
 /**
  * Read error in a byte-based location (memory, calldata, etc)

--- a/packages/codec/lib/index.ts
+++ b/packages/codec/lib/index.ts
@@ -45,9 +45,10 @@
  * (Note that circularity detection for memory structures has yet to be
  * implemented, but is coming soon.)
  *
- * There is also some rudimentary encoding functionality, although currently
- * that's just used internally.  A better interface for the encoding
- * functionality is intended for the future.
+ * There is also functionality for decoding return values and revert messages
+ * (currently mostly unused, intended to be hooked up later) as well as some
+ * rudimentary encoding functionality, although currently that's just used
+ * internally.  A better interface for these things is intended for the future.
  *
  * ## How to use
  *

--- a/packages/codec/lib/index.ts
+++ b/packages/codec/lib/index.ts
@@ -242,7 +242,13 @@ for technical reasons we can't guarantee we can determine.
 
 //now... various low-level stuff we want to export!
 //the actual decoding functions and related errors
-export { decodeVariable, decodeEvent, decodeCalldata } from "./core";
+export {
+  decodeVariable,
+  decodeEvent,
+  decodeCalldata,
+  decodeReturndata,
+  decodeRevert
+} from "./core";
 export { DecodingError, StopDecodingError } from "./errors";
 
 //now: what types should we export? (other than the ones from ./format)

--- a/packages/codec/lib/pointer/types.ts
+++ b/packages/codec/lib/pointer/types.ts
@@ -2,16 +2,13 @@ import * as Ast from "@truffle/codec/ast";
 import * as Storage from "@truffle/codec/storage/types";
 
 export type DataPointer =
-  | StackPointer
+  | StackFormPointer
   | MemoryPointer
   | StoragePointer
-  | CalldataPointer
-  | StackLiteralPointer
+  | AbiDataPointer
   | ConstantDefinitionPointer
   | SpecialPointer
-  | EventDataPointer
-  | EventTopicPointer
-  | ReturndataPointer;
+  | EventTopicPointer;
 
 export type StackFormPointer = StackPointer | StackLiteralPointer;
 export type AbiPointer = AbiDataPointer | GenericAbiPointer;
@@ -19,7 +16,7 @@ export type AbiDataPointer =
   | CalldataPointer
   | ReturndataPointer
   | EventDataPointer;
-export type BytesPointer = MemoryPointer | CalldataPointer | EventDataPointer;
+export type BytesPointer = MemoryPointer | AbiDataPointer;
 
 export interface StackPointer {
   location: "stack";

--- a/packages/codec/lib/pointer/types.ts
+++ b/packages/codec/lib/pointer/types.ts
@@ -10,10 +10,15 @@ export type DataPointer =
   | ConstantDefinitionPointer
   | SpecialPointer
   | EventDataPointer
-  | EventTopicPointer;
+  | EventTopicPointer
+  | ReturndataPointer;
 
-export type AbiPointer = CalldataPointer | EventDataPointer | GenericAbiPointer;
-export type AbiDataPointer = CalldataPointer | EventDataPointer;
+export type StackFormPointer = StackPointer | StackLiteralPointer;
+export type AbiPointer = AbiDataPointer | GenericAbiPointer;
+export type AbiDataPointer =
+  | CalldataPointer
+  | ReturndataPointer
+  | EventDataPointer;
 export type BytesPointer = MemoryPointer | CalldataPointer | EventDataPointer;
 
 export interface StackPointer {
@@ -30,6 +35,12 @@ export interface MemoryPointer {
 
 export interface CalldataPointer {
   location: "calldata";
+  start: number;
+  length: number;
+}
+
+export interface ReturndataPointer {
+  location: "returndata";
   start: number;
   length: number;
 }

--- a/packages/codec/lib/read.ts
+++ b/packages/codec/lib/read.ts
@@ -22,6 +22,7 @@ export default function* read(
     case "memory":
     case "calldata":
     case "eventdata":
+    case "returndata":
       return BytesRead.readBytes(pointer, state);
 
     case "stackliteral":

--- a/packages/codec/lib/types.ts
+++ b/packages/codec/lib/types.ts
@@ -72,7 +72,8 @@ export interface FunctionDecoding {
    */
   selector: string;
   /**
-   * The decoding mode that was used; see the README for more on these.
+   * The decoding mode that was used; [see the README](../#decoding-modes) for
+   * more on these.
    */
   decodingMode: DecodingMode;
 }
@@ -112,7 +113,8 @@ export interface ConstructorDecoding {
    */
   bytecode: string;
   /**
-   * The decoding mode that was used; see the README for more on these.
+   * The decoding mode that was used; [see the README](../#decoding-modes) for
+   * more on these.
    */
   decodingMode: DecodingMode;
 }
@@ -143,7 +145,8 @@ export interface MessageDecoding {
    */
   data: string;
   /**
-   * The decoding mode that was used; see the README for more on these.
+   * The decoding mode that was used; [see the README](../#decoding-modes) for
+   * more on these.
    */
   decodingMode: DecodingMode;
 }
@@ -160,11 +163,12 @@ export interface UnknownCallDecoding {
    */
   kind: "unknown";
   /**
-   * The decoding mode that was used; see the README for more on these.
+   * The decoding mode that was used; [see the README](../#decoding-modes) for
+   * more on these.
    */
   decodingMode: DecodingMode;
   /**
-   * The data that was sent to the contract
+   * The data that was sent to the contract.
    */
   data: string;
 }
@@ -181,11 +185,12 @@ export interface UnknownCreationDecoding {
    */
   kind: "create";
   /**
-   * The decoding mode that was used; see the README for more on these.
+   * The decoding mode that was used; [see the README](../#decoding-modes) for
+   * more on these.
    */
   decodingMode: DecodingMode;
   /**
-   * The bytecode of the contract creation
+   * The bytecode of the contract creation.
    */
   bytecode: string;
 }
@@ -221,7 +226,8 @@ export interface EventDecoding {
    */
   selector: string;
   /**
-   * The decoding mode that was used; see the README for more on these.
+   * The decoding mode that was used; [see the README](../#decoding-modes) for
+   * more on these.
    */
   decodingMode: DecodingMode;
 }
@@ -253,7 +259,8 @@ export interface AnonymousDecoding {
    */
   abi: AbiData.EventAbiEntry; //should be anonymous
   /**
-   * The decoding mode that was used; see the README for more on these.
+   * The decoding mode that was used; [see the README](../#decoding-modes) for
+   * more on these.
    */
   decodingMode: DecodingMode;
 }
@@ -277,7 +284,8 @@ export interface ReturnDecoding {
    */
   arguments: AbiArgument[];
   /**
-   * The decoding mode that was used; see the README for more on these.
+   * The decoding mode that was used; [see the README](../#decoding-modes) for
+   * more on these.
    */
   decodingMode: DecodingMode;
 }
@@ -297,7 +305,8 @@ export interface UnexpectedEmptyDecoding {
    */
   status: true;
   /**
-   * The decoding mode that was used; see the README for more on these.
+   * The decoding mode that was used; [see the README](../#decoding-modes) for
+   * more on these.
    */
   decodingMode: DecodingMode;
 }
@@ -317,7 +326,8 @@ export interface EmptyFailureDecoding {
    */
   status: false;
   /**
-   * The decoding mode that was used; see the README for more on these.
+   * The decoding mode that was used; [see the README](../#decoding-modes) for
+   * more on these.
    */
   decodingMode: DecodingMode;
 }
@@ -343,7 +353,8 @@ export interface RevertMessageDecoding {
    */
   arguments: AbiArgument[];
   /**
-   * The decoding mode that was used; see the README for more on these.
+   * The decoding mode that was used; [see the README](../#decoding-modes) for
+   * more on these.
    */
   decodingMode: DecodingMode;
 }
@@ -368,7 +379,8 @@ export interface BytecodeDecoding {
    */
   status: true;
   /**
-   * The decoding mode that was used; see the README for more on these.
+   * The decoding mode that was used; [see the README](../#decoding-modes) for
+   * more on these.
    */
   decodingMode: DecodingMode;
   /**

--- a/packages/codec/lib/types.ts
+++ b/packages/codec/lib/types.ts
@@ -23,6 +23,19 @@ export type CalldataDecoding =
 export type LogDecoding = EventDecoding | AnonymousDecoding;
 
 /**
+ * A type representing a returndata (return value or revert message) decoding.
+ * As you can see, these come in five types, each of which is documented
+ * separately.
+ * @Category Output
+ */
+export type ReturndataDecoding =
+  | ReturnDecoding
+  | BytecodeDecoding
+  | EmptySuccessDecoding
+  | RevertMessageDecoding
+  | EmptyFailureDecoding;
+
+/**
  * This is a type for recording what decoding mode a given decoding was produced in.  There are two
  * decoding modes, full mode and ABI mode.  In ABI mode, decoding is done purely based on the ABI JSON.
  * Full mode, by contrast, additionally uses AST information to produce a more informative decoding.
@@ -246,7 +259,132 @@ export interface AnonymousDecoding {
 }
 
 /**
- * This type represents a decoded argument passed to a transaction or event.
+ * This type represents a decoding of the return data as a collection of
+ * return values from a successful call.
+ * @Category Output
+ */
+export interface ReturnDecoding {
+  /**
+   * The kind of decoding; indicates that this is a ReturnDecoding.
+   */
+  kind: "return";
+  /**
+   * Indicates that this kind of decoding indicates a successful return.
+   */
+  status: true;
+  /**
+   * The list of decoded return values from the function.
+   */
+  arguments: AbiArgument[];
+  /**
+   * The decoding mode that was used; see the README for more on these.
+   */
+  decodingMode: DecodingMode;
+}
+
+/**
+ * This type represents a decoding of empty return data from a successful
+ * call.  This can occur even when the call is supposed to return a value if,
+ * say, the contract self-destructs instead.
+ * @Category Output
+ */
+export interface EmptySuccessDecoding {
+  /**
+   * The kind of decoding; indicates that this is an EmptySuccessDecoding.
+   */
+  kind: "empty";
+  /**
+   * Indicates that this kind of decoding indicates a successful return.
+   */
+  status: true;
+  /**
+   * The decoding mode that was used; see the README for more on these.
+   */
+  decodingMode: DecodingMode;
+}
+
+/**
+ * This type represents a decoding of empty return data from an unsuccessful
+ * call, a reversion with no message.
+ * @Category Output
+ */
+export interface EmptyFailureDecoding {
+  /**
+   * The kind of decoding; indicates that this is an EmptyFailureDecoding.
+   */
+  kind: "failure";
+  /**
+   * Indicates that this kind of decoding indicates an unsuccessful return.
+   */
+  status: false;
+  /**
+   * The decoding mode that was used; see the README for more on these.
+   */
+  decodingMode: DecodingMode;
+}
+
+/**
+ * This type represents a decoding of the return data as a revert message.
+ * For forward-compatibility, we do not assume that the revert message is
+ * a string.
+ * @Category Output
+ */
+export interface RevertMessageDecoding {
+  /**
+   * The kind of decoding; indicates that this is a RevertMessageDecoding.
+   */
+  kind: "revert";
+  /**
+   * Indicates that this kind of decoding indicates an unsuccessful return.
+   */
+  status: false;
+  /**
+   * The list of decoded arguments passed to revert(); currently, this will
+   * always contain just a single string.
+   */
+  arguments: AbiArgument[];
+  /**
+   * The decoding mode that was used; see the README for more on these.
+   */
+  decodingMode: DecodingMode;
+}
+
+/**
+ * This type represents a decoding of the return data as bytecode
+ * returned from a constructor.
+ *
+ * NOTE: In the future, this type will also contain information about
+ * any linked libraries the contract being constructed uses.  However,
+ * this is not implemented at present.
+ *
+ * @Category Output
+ */
+export interface BytecodeDecoding {
+  /**
+   * The kind of decoding; indicates that this is a BytecodeDecoding.
+   */
+  kind: "bytecode";
+  /**
+   * Indicates that this kind of decoding indicates a successful return.
+   */
+  status: true;
+  /**
+   * The decoding mode that was used; see the README for more on these.
+   */
+  decodingMode: DecodingMode;
+  /**
+   * The class of contract being constructed, as a Format.Types.ContractType.
+   */
+  class: Format.Types.ContractType;
+  /**
+   * The bytecode of the contract that was created.
+   */
+  bytecode: string;
+}
+
+/**
+ * This type represents a decoded argument passed to a transaction or event,
+ * or returned from a call.
  *
  * @Category Output
  */

--- a/packages/codec/lib/types.ts
+++ b/packages/codec/lib/types.ts
@@ -31,7 +31,7 @@ export type LogDecoding = EventDecoding | AnonymousDecoding;
 export type ReturndataDecoding =
   | ReturnDecoding
   | BytecodeDecoding
-  | EmptySuccessDecoding
+  | UnexpectedEmptyDecoding
   | RevertMessageDecoding
   | EmptyFailureDecoding;
 
@@ -283,14 +283,13 @@ export interface ReturnDecoding {
 }
 
 /**
- * This type represents a decoding of empty return data from a successful
- * call.  This can occur even when the call is supposed to return a value if,
- * say, the contract self-destructs instead.
+ * This type represents a decoding of unexpectedly empty return data from a
+ * successful call.  This can occur if, say, the contract self-destructs.
  * @Category Output
  */
-export interface EmptySuccessDecoding {
+export interface UnexpectedEmptyDecoding {
   /**
-   * The kind of decoding; indicates that this is an EmptySuccessDecoding.
+   * The kind of decoding; indicates that this is an UnexpectedEmptyDecoding.
    */
   kind: "empty";
   /**

--- a/packages/codec/lib/types.ts
+++ b/packages/codec/lib/types.ts
@@ -32,7 +32,7 @@ export type ReturndataDecoding =
   | ReturnDecoding
   | BytecodeDecoding
   | UnknownBytecodeDecoding
-  | UnexpectedEmptyDecoding
+  | SelfDestructDecoding
   | RevertMessageDecoding
   | EmptyFailureDecoding;
 
@@ -293,14 +293,14 @@ export interface ReturnDecoding {
 
 /**
  * This type represents a decoding of unexpectedly empty return data from a
- * successful call.  This can occur if, say, the contract self-destructs.
+ * successful call, indicating that the contract self-destructed.
  * @Category Output
  */
-export interface UnexpectedEmptyDecoding {
+export interface SelfDestructDecoding {
   /**
-   * The kind of decoding; indicates that this is an UnexpectedEmptyDecoding.
+   * The kind of decoding; indicates that this is an SelfDestructDecoding.
    */
-  kind: "empty";
+  kind: "selfdestruct";
   /**
    * Indicates that this kind of decoding indicates a successful return.
    */

--- a/packages/codec/lib/types.ts
+++ b/packages/codec/lib/types.ts
@@ -24,13 +24,14 @@ export type LogDecoding = EventDecoding | AnonymousDecoding;
 
 /**
  * A type representing a returndata (return value or revert message) decoding.
- * As you can see, these come in five types, each of which is documented
+ * As you can see, these come in six types, each of which is documented
  * separately.
  * @Category Output
  */
 export type ReturndataDecoding =
   | ReturnDecoding
   | BytecodeDecoding
+  | UnknownBytecodeDecoding
   | UnexpectedEmptyDecoding
   | RevertMessageDecoding
   | EmptyFailureDecoding;
@@ -360,8 +361,8 @@ export interface RevertMessageDecoding {
 }
 
 /**
- * This type represents a decoding of the return data as bytecode
- * returned from a constructor.
+ * This type represents a decoding of the return data as bytecode for a known
+ * class returned from a constructor.
  *
  * NOTE: In the future, this type will also contain information about
  * any linked libraries the contract being constructed uses.  However,
@@ -398,6 +399,36 @@ export interface BytecodeDecoding {
    * otherwise!
    */
   address?: string;
+}
+
+/**
+ * This type represents a decoding of the return data as bytecode for an
+ * unknown class returned from a constructor.
+ *
+ * NOTE: In the future, this type will also contain information about
+ * any linked libraries the contract being constructed uses.  However,
+ * this is not implemented at present.
+ *
+ * @Category Output
+ */
+export interface UnknownBytecodeDecoding {
+  /**
+   * The kind of decoding; indicates that this is an UnknownBytecodeDecoding.
+   */
+  kind: "unknownbytecode";
+  /**
+   * Indicates that this kind of decoding indicates a successful return.
+   */
+  status: true;
+  /**
+   * The decoding mode that was used; [see the README](../#decoding-modes) for
+   * more on these.
+   */
+  decodingMode: DecodingMode;
+  /**
+   * The bytecode of the contract that was created.
+   */
+  bytecode: string;
 }
 
 /**

--- a/packages/codec/lib/types.ts
+++ b/packages/codec/lib/types.ts
@@ -380,6 +380,13 @@ export interface BytecodeDecoding {
    * The bytecode of the contract that was created.
    */
   bytecode: string;
+  /**
+   * If the contract created was a library, and was compiled with Solidity
+   * 0.4.20 or later, this field will be included, which gives the address of
+   * the created contract (checksummed).  This field will not be included
+   * otherwise!
+   */
+  address?: string;
 }
 
 /**


### PR DESCRIPTION
This PR implements return data decoding in `codec`.  It does *not* put an interface for it in `decoder`, partly because it's not yet clear how such an interface should work.  It does, however, add a function `decodeRevertMessage` to `codec` that can be used as something of an interface for revert string decoding.

By the way, here have been some changes to the internals of allocation objects to support this new feature; but as the internal structure of allocation objects (rather than their use) have never really been public-facing, I wouldn't really consider this a breaking change.  There's also a new data location, `returndata`, with corresponding pointer type.  Strictly speaking that wasn't necessary, but I figured it was the right way to do this.  (Also, while making changes to pointer types, I decided to add the type `StackFormPointer` as the union of `StackPointer` and `StackLiteralPointer` for convenience.  Not big on the name; feel free to suggest a better one.)

So, what's actually new?

First we have `decodeReturndata`.  This is a generator function (as you might expect) and takes three arguments.  The first, of course, is the `EvmInfo`.  The second is called `successAllocation`.  The thing about return value decoding is that it's simply not possible unless you already know what sort of thing you're decoding, so the allocation is passed in here as one of the arguments.  You can also pass `null` here if you only want the default possibilities.  Finally, you can optionally pass a boolean `status`; if you do, only decodings with the given status will be returned.

Return values are something of a mess, so unsurprisingly the return type is `ReturndataDecoding[]`.  So, yes, that's a new type of decoding (with a corresponding new abify function), and this one has a whopping *six* possibilities.  Let's go over them.

(Actually, sidenote: I made a slight modification to the existing abify functions so that they don't accidentally add a `name` field to things that did not already have one.  I also turned some things in the docs into links that weren't previously.)

Every `ReturndataDecoding`, regardless of its kind, has the fields `kind` (of course), `decodingMode` (of course), and `status`, which represents what the return status of the transaction/call must have been if this is the correct decoding.  Technically `status` is redundant with `kind`, but it's convenient to have.

Anyway, the kinds are:

1. `ReturnDecoding` -- The transaction successfully returned, and you can find the returned values in `arguments`, much like in the other sorts of decodings we already produce.
2. `RevertMessageDecoding` -- The transaction failed, and we've decoded the revert message.  For forward compatibility, the decoding of the message itself is the sole (nameless) entry in an `arguments` array, which works like it always does.
3. `EmptyFailureDecoding` -- The transaction failed, but there was no revert message.  There is no `arguments` field.
4. `SelfDestructDecoding` -- The transaction succeeded... but there was no return value, indicating that the contract self-destructed.  There is no `arguments` field.
5. `BytecodeDecoding` -- The transaction was a constructor, and we got back the bytecode (and it corresponds to a class we know).  Instead of `arguments`, there's `bytecode` (with the bytecode), `class` (with what class it is), and sometimes -- for libraries with a delegate call guard -- `address`.  Generally I've avoided optional fields in favor of making more kinds, but in this case I didn't think it made sense to make a distinction.  As with transaction decoding, I'm hoping to eventually include linked library addresses here too, but I'd prefer to wait until Truffle DB is ready.
6. `UnknownBytecodeDecoding` -- As above, except we don't know the class, so there's no `class` (and definitely no `address`).

If there are multiple interpretations of multiple types, they'll always be returned in the order I just listed.

It's probably not obvious from this just how much of a mess return values are, though, so let's consider some examples:

1. A function with a return value returns successfully.  We decode it.  There's only one possibility: It's  a return value.  Yay!
2. A function reverts with a revert message.  Again, only one possibility.  Still simple.
3. We call a function with a return value... but we get back no data.  If we only have the return value and not the status, we now have *two* possibilities: We'll get both an `EmptyFailureDecoding` *and* a `SelfDestructDecoding`, since without the status these look identical.  Of course, if we know the status, we can pass that, and only the appropriate one will be returned.
4. We call a function with *no* return value and we get back no data.  Uh-oh, now we have three possibilities: `ReturnDecoding` (maybe it returned successfully), `EmptyFailureDecoding` (maybe it reverted), and `SelfDestructDecoding` (maybe it self-destructed!).  Passing a status will help disambiguate here, but if you pass `true` you'll still have two possibilities; you still don't know whether the "successful" return was a normal return or a self-destruct.
5. A constructor returns successfully.  OK, this one should be unambiguous.  Phew.
6. A constructor reverts with a revert message.  Uh-oh.  Maybe what we have is a revert message... or maybe what we have is the bytecode for a mysterious, unknown (and not very functional) contract!  So, there's two possibilities.  Of course one of them is highly unlikely to be correct, and status will disambiguate.
7. We call a constructor and get no data back.  Three possibilities again!  Could be a revert with no message.  Could be a self-destruct.  Or, as in the previous case, could be the bytecode for a contract with no code?  Yeah...

(How do fallback functions fit into this exactly?  Well, uh, I haven't figured that out yet, because what I've written so far hasn't forced me to, but I'm thinking the answer should be it works just like (4).)

Thankfully the messier possibilities are also the less *useful* possibilities, and you're not actually very likely to try to decode the return from a function that isn't supposed to return anything, or from a constructor.

Question: Wondering if (7) should really have three possibilities, seeing as self-destructing and "successfully" deploying empty code are effectively the same.  Blargh.  I'm wary of making this more complicated than it already is, so I think this is getting left alone.

So yeah, it's a mess!

Anyway, I've also `decodeRevertMessage`, which basically acts as an interface on top of `decodeReturndata` for the specific case of just decoding revert messages.  It's *not* a generator function, just an ordinary pure function.  Since it's part of `codec`, it takes its input as a `Uint8Array`.  It just calls `decodeReturndata` with `successAllocation = null` and `status = false`.  But wait, how does it handle requests?  Well, no requests should occur in this case, so it just takes the first value returned and assumes it's a value, not a request, because that assumption is correct!

I didn't add any tests of this, I just did manual testing.  Testing `decodeReturndata` is kind of a pain given that it's not really hooked up to anything at the moment.  Honestly even testing `decodeRevertMessage` is a bit of a pain because it requires obtaining actual revert messages, which web3 does not make so easy!  You'd have to go around it and do the RPC yourself.

Btw, you may notice that `decodeReturndata` has a lot of copypasted code.  Yeah, uh, I don't really know how to factor that sort of thing... oh well?

Also you may notice that `bytecode` decoding and allocation works totally different from the other types.  Yeah... I originally had it more unified and parallel, but I had to keep adding more and more special cases and crudding things up until I decided it was simpler to just keep it separate after all.