### PR TITLE
Internal improvement: Update migrations

### DIFF
--- a/packages/migrate/index.js
+++ b/packages/migrate/index.js
@@ -141,7 +141,7 @@ const Migrate = {
     });
 
     try {
-      for (let migration of migrations) {
+      for (const migration of migrations) {
         await migration.run(clone);
       }
       await this.emitter.emit("postAllMigrations", {

--- a/packages/migrate/index.js
+++ b/packages/migrate/index.js
@@ -29,33 +29,31 @@ const Migrate = {
 
   assemble: function(options) {
     const config = Config.detect(options);
-
     if (
-      fs.existsSync(config.migrations_directory) &&
-      fs.readdirSync(config.migrations_directory).length > 0
-    ) {
-      const files = dir.files(config.migrations_directory, { sync: true });
-      if (!files) return [];
-
-      let migrations = files
-        .filter(file => isNaN(parseInt(path.basename(file))) === false)
-        .filter(
-          file =>
-            path.extname(file).match(config.migrations_file_extension_regexp) !=
-            null
-        )
-        .map(file => new Migration(file, Migrate.reporter, config));
-
-      // Make sure to sort the prefixes as numbers and not strings.
-      migrations = migrations.sort((a, b) => {
-        if (a.number > b.number) return 1;
-        if (a.number < b.number) return -1;
-        return 0;
-      });
-      return migrations;
-    } else {
+      !fs.existsSync(config.migrations_directory) ||
+      !fs.readdirSync(config.migrations_directory).length > 0
+    )
       return [];
-    }
+
+    const files = dir.files(config.migrations_directory, { sync: true });
+    if (!files) return [];
+
+    let migrations = files
+      .filter(file => isNaN(parseInt(path.basename(file))) === false)
+      .filter(
+        file =>
+          path.extname(file).match(config.migrations_file_extension_regexp) !=
+          null
+      )
+      .map(file => new Migration(file, Migrate.reporter, config));
+
+    // Make sure to sort the prefixes as numbers and not strings.
+    migrations = migrations.sort((a, b) => {
+      if (a.number > b.number) return 1;
+      if (a.number < b.number) return -1;
+      return 0;
+    });
+    return migrations;
   },
 
   run: async function(options, callback) {

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -20,7 +20,6 @@
     "@truffle/interface-adapter": "^0.3.3",
     "@truffle/reporters": "^1.0.17",
     "@truffle/require": "^2.0.28",
-    "async": "2.6.1",
     "emittery": "^0.4.0",
     "node-dir": "0.1.17",
     "web3": "1.2.2"


### PR DESCRIPTION
This PR removes the `async` library from `@truffle/migrate`. It, in my opinion, also cleans up the code a bit and makes it easier to read.