### PR TITLE
Dependency Update: web3-provider-engine@14.1.0

### DIFF
--- a/packages/hdwallet-provider/package.json
+++ b/packages/hdwallet-provider/package.json
@@ -26,7 +26,7 @@
     "ethereumjs-util": "^6.1.0",
     "ethereumjs-wallet": "^0.6.3",
     "web3": "1.2.2",
-    "web3-provider-engine": "https://github.com/trufflesuite/provider-engine#web3-one"
+    "web3-provider-engine": "14.1.0"
   },
   "devDependencies": {
     "@types/bip39": "^2.4.2",

--- a/packages/hdwallet-provider/src/index.ts
+++ b/packages/hdwallet-provider/src/index.ts
@@ -177,7 +177,7 @@ class HDWalletProvider {
     payload: JSONRPCRequestPayload,
     callback: JSONRPCErrorCallback | Callback<JsonRpcResponse>
   ): void {
-    return this.engine.send.call(this.engine, payload, callback);
+    return this.engine.sendAsync.call(this.engine, payload, callback);
   }
 
   public sendAsync(

--- a/packages/hdwallet-provider/src/index.ts
+++ b/packages/hdwallet-provider/src/index.ts
@@ -163,7 +163,6 @@ class HDWalletProvider {
         Web3.providers.HttpProvider.prototype.send;
       this.engine.addProvider(
         new ProviderSubprovider(
-          // @ts-ignore
           new Web3.providers.HttpProvider(provider, { keepAlive: false })
         )
       );

--- a/packages/hdwallet-provider/src/index.ts
+++ b/packages/hdwallet-provider/src/index.ts
@@ -158,9 +158,9 @@ class HDWalletProvider {
 
     this.engine.addProvider(new FiltersSubprovider());
     if (typeof provider === "string") {
-      // shim Web3 to give it expected sendAsync method. Needed if web3-engine-provider upgraded!
-      // Web3.providers.HttpProvider.prototype.sendAsync =
-      // Web3.providers.HttpProvider.prototype.send;
+      // shim Web3 to give it expected sendAsync method
+      Web3.providers.HttpProvider.prototype.sendAsync =
+        Web3.providers.HttpProvider.prototype.send;
       this.engine.addProvider(
         new ProviderSubprovider(
           // @ts-ignore

--- a/yarn.lock
+++ b/yarn.lock
@@ -15672,10 +15672,10 @@ web3-net@1.2.2:
     web3-core-method "1.2.2"
     web3-utils "1.2.2"
 
-web3-provider-engine@14.2.1:
-  version "14.2.1"
-  resolved "https://registry.yarnpkg.com/web3-provider-engine/-/web3-provider-engine-14.2.1.tgz#ef351578797bf170e08d529cb5b02f8751329b95"
-  integrity sha512-iSv31h2qXkr9vrL6UZDm4leZMc32SjWJFGOp/D92JXfcEboCqraZyuExDkpxKw8ziTufXieNM7LSXNHzszYdJw==
+web3-provider-engine@14.1.0:
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/web3-provider-engine/-/web3-provider-engine-14.1.0.tgz#91590020f8b8c1b65846321310cbfdb039090fc6"
+  integrity sha512-vGZtqhSUzGTiMGhJXNnB/aRDlrPZLhLnBZ2NPArkZtr8XSrwg9m08tw4+PuWg5za0TJuoE/vuPQc501HddZZWw==
   dependencies:
     async "^2.5.0"
     backoff "^2.5.0"
@@ -15698,9 +15698,10 @@ web3-provider-engine@14.2.1:
     xhr "^2.2.0"
     xtend "^4.0.1"
 
-"web3-provider-engine@https://github.com/trufflesuite/provider-engine#web3-one":
-  version "14.0.6"
-  resolved "https://github.com/trufflesuite/provider-engine#3538c60bc4836b73ccae1ac3f64c8fed8ef19c1a"
+web3-provider-engine@14.2.1:
+  version "14.2.1"
+  resolved "https://registry.yarnpkg.com/web3-provider-engine/-/web3-provider-engine-14.2.1.tgz#ef351578797bf170e08d529cb5b02f8751329b95"
+  integrity sha512-iSv31h2qXkr9vrL6UZDm4leZMc32SjWJFGOp/D92JXfcEboCqraZyuExDkpxKw8ziTufXieNM7LSXNHzszYdJw==
   dependencies:
     async "^2.5.0"
     backoff "^2.5.0"


### PR DESCRIPTION
Take `@truffle/hdwallet-provider` off the `trufflesuite` hacky fork of `web3-provider-engine@~14.0.6` and onto `web3-provider-engine@14.1.0`.

Also unleashes a necessary shim to get `Web3` working with `web3-provider-engine`.
`web3-provider-engine` no longer supports synchronous requests, so we shim Web3 & also tweak `HdWalletProvider.send` to use `engine.sendAsync`.

QA/Smoke tested locally.