### PR TITLE
Enhancement: Make HDWalletProvider's default number of accounts unlocked align with ganache

### DIFF
--- a/packages/hdwallet-provider/src/index.ts
+++ b/packages/hdwallet-provider/src/index.ts
@@ -34,7 +34,7 @@ class HDWalletProvider {
     mnemonic: string | string[],
     provider: string | any,
     addressIndex: number = 0,
-    numAddresses: number = 1,
+    numAddresses: number = 10,
     shareNonce: boolean = true,
     walletHdpath: string = `m/44'/60'/0'/0/`
   ) {
@@ -87,7 +87,7 @@ class HDWalletProvider {
     // private helper leveraging ethUtils to populate wallets/addresses
     const ethUtilValidation = (privateKeys: string[]) => {
       // crank the addresses out
-      for (let i = addressIndex; i < addressIndex + numAddresses; i++) {
+      for (let i = addressIndex; i < privateKeys.length; i++) {
         const privateKey = Buffer.from(privateKeys[i].replace("0x", ""), "hex");
         if (EthUtil.isValidPrivate(privateKey)) {
           const wallet = ethJSWallet.fromPrivateKey(privateKey);

--- a/packages/hdwallet-provider/test/provider.test.ts
+++ b/packages/hdwallet-provider/test/provider.test.ts
@@ -42,7 +42,7 @@ describe("HD Wallet Provider", function() {
 
     const mnemonic =
       "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat";
-    provider = new WalletProvider(mnemonic, `http://localhost:${port}`, 0, 10);
+    provider = new WalletProvider(mnemonic, `http://localhost:${port}`);
 
     assert.deepEqual(provider.getAddresses(), truffleDevAccounts);
     web3.setProvider(provider);
@@ -57,9 +57,7 @@ describe("HD Wallet Provider", function() {
     try {
       provider = new WalletProvider(
         "takoyaki is delicious",
-        "http://localhost:8545",
-        0,
-        1
+        "http://localhost:8545"
       );
       assert.fail("Should throw on invalid mnemonic");
     } catch (e) {
@@ -99,12 +97,7 @@ describe("HD Wallet Provider", function() {
         "9549f39decea7b7504e15572b2c6a72766df0281cea22bd1a3bc87166b1ca290"
     };
 
-    provider = new WalletProvider(
-      privateKeys,
-      `http://localhost:${port}`,
-      0,
-      privateKeys.length
-    ); //pass in num_addresses to load full array
+    provider = new WalletProvider(privateKeys, `http://localhost:${port}`);
     web3.setProvider(provider);
 
     const addresses = provider.getAddresses();


### PR DESCRIPTION
Change default numAddresses from 1 to 10:
- Aligns HDWalletProvider behavior with Ganache's default

Change privateKey for loop logic:
- Ensures only the array length of privateKeys passed are
attempted to be unlocked as accounts

Valid mnemonic's will unlock 10 accounts by default. Only the number of private keys passed will be unlocked.