### PR TITLE
Internal improvement: Optimize webpack rules

### DIFF
--- a/packages/truffle/cli.webpack.config.js
+++ b/packages/truffle/cli.webpack.config.js
@@ -56,8 +56,14 @@ module.exports = {
   devtool: "source-map",
   module: {
     rules: [
-      { test: /rx\.lite\.aggregates\.js/, use: "imports-loader?define=>false" }
-      { test: /\.js$/, include: [ path.resolve(__dirname, "../core"), path.resolve(__dirname, "../environment") ], use: "shebang-loader" }
+      {
+        test: /\.js$/,
+        include: [
+          path.resolve(__dirname, "../core"),
+          path.resolve(__dirname, "../environment")
+        ],
+        use: "shebang-loader"
+      }
     ]
   },
   externals: [

--- a/packages/truffle/cli.webpack.config.js
+++ b/packages/truffle/cli.webpack.config.js
@@ -56,8 +56,8 @@ module.exports = {
   devtool: "source-map",
   module: {
     rules: [
-      { test: /\.js$/, use: "shebang-loader" },
       { test: /rx\.lite\.aggregates\.js/, use: "imports-loader?define=>false" }
+      { test: /\.js$/, include: [ path.resolve(__dirname, "../core"), path.resolve(__dirname, "../environment") ], use: "shebang-loader" }
     ]
   },
   externals: [

--- a/packages/truffle/cli.webpack.config.js
+++ b/packages/truffle/cli.webpack.config.js
@@ -56,6 +56,7 @@ module.exports = {
   devtool: "source-map",
   module: {
     rules: [
+      // ignores "#!/bin..." lines inside files
       {
         test: /\.js$/,
         include: [

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -43,7 +43,6 @@
     "ganache-core": "2.8.0",
     "glob": "^7.1.2",
     "husky": "^1.1.2",
-    "imports-loader": "^0.8.0",
     "js-scrypt": "^0.2.0",
     "meta-npm": "^0.0.22",
     "meta-pkgs": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7783,14 +7783,6 @@ import-local@^2.0.0:
     pkg-dir "^3.0.0"
     resolve-cwd "^2.0.0"
 
-imports-loader@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/imports-loader/-/imports-loader-0.8.0.tgz#030ea51b8ca05977c40a3abfd9b4088fe0be9a69"
-  integrity sha512-kXWL7Scp8KQ4552ZcdVTeaQCZSLW+e6nJfp3cwUMB673T7Hr98Xjx5JK+ql7ADlJUvj1JS5O01RLbKoutN5QDQ==
-  dependencies:
-    loader-utils "^1.0.2"
-    source-map "^0.6.1"
-
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"


### PR DESCRIPTION
Only uses `shebang-loader` where needed & removes seemingly unused `imports-loader` rule along w/ the `imports-loader` devDep.