### PR TITLE
Internal improvement: tidy up externals in webpack config

### DIFF
--- a/packages/truffle/cli.webpack.config.js
+++ b/packages/truffle/cli.webpack.config.js
@@ -68,24 +68,11 @@ module.exports = {
     ]
   },
   externals: [
-    // If you look at webpack's docs, `externals` doesn't need to be a function.
-    // But I never got it to work otherwise, so this is a function because "it works".
-    function(context, request, callback) {
-      // truffle-config uses the original-require module.
-      // Here, we leave it as an external, and use the original-require
-      // module that's a dependency of Truffle instead.
-      if (/^original-require$/.test(request)) {
-        return callback(null, "commonjs original-require");
-      }
-
-      // Mocha doesn't seem to bundle well either. This is a stop-gap until
-      // I can look into it further.
-      if (/^mocha$/.test(request)) {
-        return callback(null, "commonjs mocha");
-      }
-
-      callback();
-    }
+    // truffle-config uses the original-require module.
+    // Here, we leave it as an external, and use the original-require
+    // module that's a dependency of Truffle instead.
+    /^original-require$/,
+    /^mocha$/
   ],
   plugins: [
     new webpack.DefinePlugin({


### PR DESCRIPTION
Converts function in `externals` to a regex. ~Also turns out `mocha` behaves and bundles correctly (🤞) .~