### PR TITLE
Implement circularity detection in codec & debugger

### DIFF
--- a/packages/codec/lib/decode.ts
+++ b/packages/codec/lib/decode.ts
@@ -21,6 +21,17 @@ export default function* decode(
   info: Evm.EvmInfo,
   options: DecoderOptions = {}
 ): Generator<DecoderRequest, Format.Values.Result, Uint8Array> {
+  return Format.Utils.Circularity.tie(
+    yield* decodeDispatch(dataType, pointer, info, options)
+  );
+}
+
+function* decodeDispatch(
+  dataType: Format.Types.Type,
+  pointer: Pointer.DataPointer,
+  info: Evm.EvmInfo,
+  options: DecoderOptions = {}
+): Generator<DecoderRequest, Format.Values.Result, Uint8Array> {
   debug("type %O", dataType);
   debug("pointer %O", pointer);
 
@@ -50,6 +61,11 @@ export default function* decode(
     case "memory":
       //NOTE: this case should never actually occur, but I'm including it
       //anyway as a fallback
-      return yield* Memory.Decode.decodeMemory(dataType, pointer, info);
+      return yield* Memory.Decode.decodeMemory(
+        dataType,
+        pointer,
+        info,
+        options
+      );
   }
 }

--- a/packages/codec/lib/format/utils/circularity.ts
+++ b/packages/codec/lib/format/utils/circularity.ts
@@ -1,0 +1,83 @@
+import debugModule from "debug";
+const debug = debugModule("codec:format:utils:circularity");
+
+import * as Format from "@truffle/codec/format/common";
+
+export function tie(untied: Format.Values.Result): Format.Values.Result {
+  return tieWithTable(untied, []);
+}
+
+function tieWithTable(
+  untied: Format.Values.Result,
+  seenSoFar: (Format.Values.ArrayValue | Format.Values.StructValue)[]
+): Format.Values.Result {
+  if (untied.kind === "error") {
+    return untied;
+  }
+  let reference: number;
+  switch (untied.type.typeClass) {
+    case "array":
+      let untiedAsArray = <Format.Values.ArrayValue>untied; //dammit TS
+      reference = untiedAsArray.reference;
+      if (reference === undefined) {
+        //we need to do some pointer stuff here, so let's first create our new
+        //object we'll be pointing to
+        //[we don't want to alter the original accidentally so let's clone a bit]
+        let tied = { ...untiedAsArray, value: [...untiedAsArray.value] };
+        //now, we can't use a map here, or we'll screw things up!
+        //we want to *mutate* value, not replace it with a new object
+        for (let index in tied.value) {
+          tied.value[index] = tieWithTable(tied.value[index], [
+            tied,
+            ...seenSoFar
+          ]);
+        }
+        return tied;
+      } else {
+        return { ...seenSoFar[reference - 1], reference };
+      }
+    case "struct":
+      let untiedAsStruct = <Format.Values.StructValue>untied; //dammit TS
+      reference = untiedAsStruct.reference;
+      if (reference === undefined) {
+        //we need to do some pointer stuff here, so let's first create our new
+        //object we'll be pointing to
+        //[we don't want to alter the original accidentally so let's clone a bit]
+        let tied = {
+          ...untiedAsStruct,
+          value: untiedAsStruct.value.map(component => ({ ...component }))
+        };
+        //now, we can't use a map here, or we'll screw things up!
+        //we want to *mutate* value, not replace it with a new object
+        for (let index in tied.value) {
+          tied.value[index] = {
+            ...tied.value[index],
+            value: tieWithTable(tied.value[index].value, [tied, ...seenSoFar])
+          };
+        }
+        return tied;
+      } else {
+        return { ...seenSoFar[reference - 1], reference };
+      }
+    case "tuple": //currently there are no memory tuples, but may as well
+      //can't be circular, just recurse
+      //note we can just recurse with a straight tie here; don't need tieWithTable
+      let untiedAsTuple = <Format.Values.TupleValue>untied; //dammit TS
+      //we need to do some pointer stuff here, so let's first create our new
+      //object we'll be pointing to
+      let tied = { ...untiedAsTuple };
+      tied.value = tied.value.map(component => ({
+        ...component,
+        value: tie(component.value)
+      }));
+      return tied;
+    default:
+      //other types either:
+      //1. aren't containers and so need no recursion
+      //2. are containers but can't go in or contain memory things
+      //and so still need no recursion
+      //(or, in the case of mappings, can't contain *nontrivial* memory
+      //things)
+      return untied;
+  }
+}

--- a/packages/codec/lib/format/utils/index.ts
+++ b/packages/codec/lib/format/utils/index.ts
@@ -8,3 +8,6 @@ export {
 
 import * as Inspect from "./inspect";
 export { Inspect };
+
+import * as Circularity from "./circularity";
+export { Circularity };

--- a/packages/codec/lib/types.ts
+++ b/packages/codec/lib/types.ts
@@ -296,6 +296,6 @@ export interface DecoderOptions {
   permissivePadding?: boolean; //allows incorrect padding on certain data types
   strictAbiMode?: boolean; //throw errors instead of returning; check array & string lengths (crudely)
   allowRetry?: boolean; //turns on error-throwing for retry-allowed errors only
-  abiPointerBase?: number;
-  memoryVisited?: number[]; //for the future
+  abiPointerBase?: number; //what relative pointers should be considered relative to
+  memoryVisited?: number[]; //for circularity detection
 }

--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -461,22 +461,25 @@ var DebugUtils = {
   },
 
   //HACK
-  cleanConstructors: function(object) {
+  //note that this is written in terms of mutating things
+  //rather than just using map() due to the need to handle
+  //circular objects
+  cleanConstructors: function(object, seenSoFar = new Map()) {
     debug("object %o", object);
-
-    if (object && typeof object.map === "function") {
-      //array case
-      return object.map(DebugUtils.cleanConstructors);
+    if (seenSoFar.has(object)) {
+      return seenSoFar.get(object);
     }
 
-    if (object && object instanceof Map) {
-      //map case
-      return new Map(
-        Array.from(object.entries()).map(([key, value]) => [
-          key,
-          DebugUtils.cleanConstructors(value)
-        ])
-      );
+    if (Array.isArray(object)) {
+      //array case
+      let output = object.slice(); //clone
+      //set up new seenSoFar
+      let seenNow = new Map(seenSoFar);
+      seenNow.set(object, output);
+      for (let index in output) {
+        output[index] = DebugUtils.cleanConstructors(output[index], seenNow);
+      }
+      return output;
     }
 
     //HACK -- due to safeEval altering things, it's possible for isBN() to
@@ -493,16 +496,23 @@ var DebugUtils = {
 
     if (object && typeof object === "object") {
       //generic object case
-      return Object.assign(
+      let output = Object.assign(
         {},
         ...Object.entries(object)
           .filter(
             ([key, value]) => key !== "constructor" || value !== undefined
           )
           .map(([key, value]) => ({
-            [key]: DebugUtils.cleanConstructors(value)
+            [key]: value //don't clean yet!
           }))
       );
+      //set up new seenSoFar
+      let seenNow = new Map(seenSoFar);
+      seenNow.set(object, output);
+      for (let field in output) {
+        output[field] = DebugUtils.cleanConstructors(output[field], seenNow);
+      }
+      return output;
     }
 
     //for strings, numbers, etc

--- a/packages/debug-utils/test/index.js
+++ b/packages/debug-utils/test/index.js
@@ -16,13 +16,6 @@ describe("Utils", function() {
       //now we'll check that it was removed
       assert(!cleanedResult.hasOwnProperty("constructor"));
     });
-    it("Leaves maps recognizable", function() {
-      let context = { a: new Map([["value", 107]]) };
-      let expr = "a";
-      let result = safeEval(expr, context);
-      let cleanedResult = DebugUtils.cleanConstructors(result);
-      assert.instanceOf(cleanedResult, Map);
-    });
     it("Leaves BNs recognizable", function() {
       let context = { a: new BN(107) };
       let expr = "a";
@@ -36,6 +29,15 @@ describe("Utils", function() {
       let result = safeEval(expr, context);
       let cleanedResult = DebugUtils.cleanConstructors(result);
       assert.isArray(cleanedResult);
+    });
+    it("Doesn't choke on circular objects", function() {
+      let circular = { x: 107, children: [] };
+      circular.children.push(circular);
+      let context = { circular };
+      let expr = "circular";
+      let result = safeEval(expr, context);
+      DebugUtils.cleanConstructors(result);
+      //no need for an assert, if we finish without crashing we're good
     });
   });
 });


### PR DESCRIPTION
This PR implements circularity detection in `codec` (with one change to `debug-utils` as well).  Note that this only really affects the debugger, as only memory structures can be circular in Solidity; storage structures may have circular *types* but are not allowed to take on circular *values*, while ABI-encoded structures aren't even allowed to have circular types.

It's worth noting that the decoded version of a circular structure may not be isomorphic to the original.  It will, however, be bisimilar.  I think that's OK.  At the very least, it's the best we can do at the moment; if we wanted isomorphism, we'd have to rework both the decoder itself and the output format.  As it is I think it's fine.  I mean, you don't expect the decoder to detect aliasing in *non*-circular structures, do you?  Then it should be OK if there's some, uh, de-aliasing in circular structures too, right? :)

In order to make this work, the `decodeMemory` function now accepts an option, `memoryVisited`, which keeps track of the memory addresses visited on the way to the particular structure being decoded.  If, when decoding an array or struct, we find that its memory address is in the list of addresses already visited, we don't populate the `value` field like normal -- we leave that as an empty array -- but instead populate the `reference` field to indicate how far back up the tree we last saw this adress.

But while `decodeMemory` leaves the `value` array empty, `decode` itself does not.  There's now an additional step at the end of decoding: We run the decoded value through a new function called `tie` which ties up any references to create a circular object.  Admittedly, I could have done it the other way, but this way we now have the `tie` function which can be used later for deserialization.  (I didn't bother writing `sever` (or I guess `untie` would be the more systematic name), since we don't need it yet, and anyway that one is easy!)

Of course, it's not enough to just create circular values; we have to be able to process them, too!  This meant `nativize` had to be updated to handle circular values, and so did `cleanConstructors`.  With `ResultInspector` actually I had already written the code for handling circular values, but it turned out to have an error, so I fixed that.

I also added a simple test.

Writing code for creating circular values turned out to be a bit of a pain, btw, because you have to mutate things to do it, rather than just using maps and object literals like you might be used to.  So, that's now in a bunch of places.  I'm pretty sure I successfully kept each function pure though in that none of them should mutate their inputs.

Also, yeah, using the `for ... in` syntax with arrays is not recommended since it could iterate over the array in any order, but in this particular case the order doesn't actually matter, so I just used it anyway because it looks nicer than `array.forEach` or doing a C-style loop.