### PR TITLE
Internal improvement: add ens-related conditional to provisioner

### DIFF
--- a/packages/provisioner/index.js
+++ b/packages/provisioner/index.js
@@ -13,7 +13,9 @@ var provision = function(abstraction, options) {
     abstraction.setNetworkType(options.networks[options.network].type);
   }
 
-  abstraction.ens = options.ens;
+  if (options.ens) {
+    abstraction.ens = options.ens;
+  }
 
   ["from", "gas", "gasPrice"].forEach(function(key) {
     if (options[key]) {


### PR DESCRIPTION
There should probably be a `TruffleContract` method that handles this (`abstraction.setEns`) & errors appropriately if something bad gets passed, but this seems like a good start.