### PR TITLE
Internal improvement: web3-utils as independent pkg

### DIFF
--- a/packages/contract/lib/utils/ens.js
+++ b/packages/contract/lib/utils/ens.js
@@ -1,4 +1,5 @@
 const ENSJS = require("ethereum-ens");
+const { isAddress } = require("web3-utils");
 
 module.exports = {
   convertENSNames: async function({
@@ -38,7 +39,6 @@ module.exports = {
 
   convertENSArgsNames: function(inputArgs, methodABI, web3, registryAddress) {
     if (methodABI.inputs.length === 0) return inputArgs;
-    const { isAddress } = web3.utils;
     const ensjs = this.getNewENSJS({
       provider: web3.currentProvider,
       registryAddress
@@ -60,7 +60,6 @@ module.exports = {
   },
 
   convertENSParamsNames: async function(params, web3, registryAddress) {
-    const { isAddress } = web3.utils;
     if (params.from && !isAddress(params.from)) {
       const ensjs = this.getNewENSJS({
         provider: web3.currentProvider,

--- a/packages/core/lib/assertions.js
+++ b/packages/core/lib/assertions.js
@@ -1,5 +1,4 @@
-var Web3 = require("web3");
-var web3 = new Web3();
+const web3Utils = require("web3-utils");
 
 module.exports = function(chai, _utils) {
   var assert = chai.assert;
@@ -14,7 +13,7 @@ module.exports = function(chai, _utils) {
     // Controversial: Technically there is that edge case where
     // all zeroes could be a valid address. But: This catches all
     // those cases where Ethereum returns 0x0000... if something fails.
-    var number = web3.utils.toBN(this._obj);
+    const number = web3Utils.toBN(this._obj);
     this.assert(
       number.equals(0) === false,
       "expected address #{this} to not be zero",

--- a/packages/core/lib/testing/deployed.js
+++ b/packages/core/lib/testing/deployed.js
@@ -1,5 +1,4 @@
-// Using web3 for its sha function...
-var Web3 = require("web3");
+const web3Utils = require("web3-utils");
 const semver = require("semver");
 const Native = require("@truffle/compile-solidity/compilerSupplier/loadingStrategies/Native");
 
@@ -47,9 +46,8 @@ var Deployed = {
 
   // Pulled from ethereumjs-util, but I don't want all its dependencies at the moment.
   toChecksumAddress: function(address) {
-    var web3 = new Web3();
     address = address.toLowerCase().replace("0x", "");
-    var hash = web3.utils.sha3(address).replace("0x", "");
+    const hash = web3Utils.sha3(address).replace("0x", "");
     var ret = "0x";
 
     for (var i = 0; i < address.length; i++) {

--- a/packages/core/lib/testing/testrunner.js
+++ b/packages/core/lib/testing/testrunner.js
@@ -2,6 +2,7 @@ const {
   Web3Shim,
   createInterfaceAdapter
 } = require("@truffle/interface-adapter");
+const web3Utils = require("web3-utils");
 var Config = require("@truffle/config");
 var Migrate = require("@truffle/migrate");
 var TestResolver = require("./testresolver");
@@ -87,7 +88,7 @@ TestRunner.prototype.initialize = function(callback) {
             if (abi.type === "event") {
               var signature =
                 abi.name + "(" + _.map(abi.inputs, "type").join(",") + ")";
-              self.known_events[self.web3.utils.sha3(signature)] = {
+              self.known_events[web3Utils.sha3(signature)] = {
                 signature: signature,
                 abi_entry: abi
               };
@@ -151,11 +152,11 @@ TestRunner.prototype.startTest = function(mocha, callback) {
   this.web3.eth
     .getBlockNumber()
     .then(result => {
-      var one = self.web3.utils.toBN(1);
-      result = self.web3.utils.toBN(result);
+      const one = web3Utils.toBN(1);
+      const resultBN = web3Utils.toBN(result);
 
       // Add one in base 10
-      self.currentTestStartBlock = result.add(one);
+      self.currentTestStartBlock = resultBN.add(one);
 
       callback();
     })

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -65,6 +65,7 @@
     "temp": "^0.8.3",
     "universal-analytics": "^0.4.17",
     "web3": "1.2.2",
+    "web3-utils": "1.2.2",
     "xregexp": "^4.2.4",
     "yargs": "^8.0.2"
   },

--- a/packages/deployer/ens.js
+++ b/packages/deployer/ens.js
@@ -1,6 +1,6 @@
 const ENSJS = require("ethereum-ens");
 const contract = require("@truffle/contract");
-const sha3 = require("web3").utils.sha3;
+const { sha3 } = require("web3-utils");
 const { hash } = require("eth-ens-namehash");
 
 class ENS {

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -20,7 +20,8 @@
     "@truffle/expect": "^0.0.13",
     "emittery": "^0.4.0",
     "eth-ens-namehash": "^2.0.8",
-    "ethereum-ens": "^0.7.7"
+    "ethereum-ens": "^0.7.7",
+    "web3-utils": "1.2.2"
   },
   "devDependencies": {
     "@truffle/reporters": "^1.0.17",

--- a/packages/deployer/src/deployment.js
+++ b/packages/deployer/src/deployment.js
@@ -73,7 +73,6 @@ class Deployment {
    * meant to be cancelled immediately on resolution of the
    * contract instance or on error. (See stopBlockPolling)
    * @private
-   * @param  {Object}    web3
    * @param  {Object}    interfaceAdapter
    */
   async _startBlockPolling(web3, interfaceAdapter) {
@@ -115,7 +114,6 @@ class Deployment {
    * @private
    * @param  {Number} blocksToWait
    * @param  {Object} receipt
-   * @param  {Object} web3
    * @param  {Object} interfaceAdapter
    * @return {Promise}             Resolves after `blockToWait` blocks
    */
@@ -357,9 +355,7 @@ class Deployment {
           // Reporter might not be enabled (via Migrate.launchReporter) so
           // message is a (potentially empty) array of results from the emitter
           if (!message.length) {
-            message = `while migrating ${contract.contractName}: ${
-              eventArgs.error.message
-            }`;
+            message = `while migrating ${contract.contractName}: ${eventArgs.error.message}`;
           }
 
           self.close();

--- a/packages/external-compile/index.js
+++ b/packages/external-compile/index.js
@@ -8,8 +8,7 @@ const glob = promisify(require("glob"));
 const fs = require("fs");
 const expect = require("@truffle/expect");
 const Schema = require("@truffle/contract-schema");
-const web3 = {};
-web3.utils = require("web3-utils");
+const web3Utils = require("web3-utils");
 
 const DEFAULT_ABI = [
   {
@@ -144,7 +143,7 @@ function decodeContents(contents) {
   }
 
   // raw binary
-  return web3.utils.bytesToHex(contents);
+  return web3Utils.bytesToHex(contents);
 }
 
 async function processTargets(targets, cwd, logger) {


### PR DESCRIPTION
This PR makes all web3 utility functions use `web3-utils` directly rather than `web3`.