### PR TITLE
Internal improvement: From Web3Shim to InterfaceAdapter – Step Two: estimateGas

### DIFF
--- a/packages/contract/lib/execute.js
+++ b/packages/contract/lib/execute.js
@@ -19,14 +19,13 @@ const execute = {
   getGasEstimate: function(params, blockLimit) {
     const constructor = this;
     const interfaceAdapter = this.interfaceAdapter;
-    const web3 = this.web3;
 
     return new Promise(function(accept) {
       // Always prefer specified gas - this includes gas set by class_defaults
       if (params.gas) return accept(params.gas);
       if (!constructor.autoGas) return accept();
 
-      web3.eth
+      interfaceAdapter
         .estimateGas(params)
         .then(gas => {
           const bestEstimate = utils.multiplyBigNumberByDecimal(

--- a/packages/interface-adapter/lib/adapter/types.ts
+++ b/packages/interface-adapter/lib/adapter/types.ts
@@ -1,7 +1,8 @@
 import { Block as EvmBlock } from "web3-eth";
 import {
   Transaction as EvmTransaction,
-  TransactionReceipt as EvmTransactionReceipt
+  TransactionReceipt as EvmTransactionReceipt,
+  TransactionConfig as EvmTransactionConfig
 } from "web3-core";
 
 export type EvmBlockType = number | string;
@@ -10,6 +11,7 @@ export type Block = EvmBlock | any;
 export type BlockType = EvmBlockType | any;
 export type Transaction = EvmTransaction | any;
 export type TransactionReceipt = EvmTransactionReceipt | any;
+export type TransactionConfig = EvmTransactionConfig | any;
 export type TxHash = string;
 
 export interface InterfaceAdapter {

--- a/packages/interface-adapter/lib/adapter/types.ts
+++ b/packages/interface-adapter/lib/adapter/types.ts
@@ -22,4 +22,5 @@ export interface InterfaceAdapter {
   getBalance(address: string): Promise<string>;
   getCode(address: string): Promise<string>;
   getAccounts(): Promise<string[]>;
+  estimateGas(transactionConfig: TransactionConfig): Promise<number>;
 }

--- a/packages/interface-adapter/lib/adapter/web3/index.ts
+++ b/packages/interface-adapter/lib/adapter/web3/index.ts
@@ -1,4 +1,5 @@
 import { Web3Shim } from "../../shim";
+import { TransactionConfig as EvmTransactionConfig } from "web3-core";
 import { InterfaceAdapter, EvmBlockType } from "../types";
 import { Provider } from "@truffle/provider";
 
@@ -40,5 +41,9 @@ export class Web3InterfaceAdapter implements InterfaceAdapter {
 
   public getAccounts() {
     return this.web3.eth.getAccounts();
+  }
+
+  public estimateGas(transactionConfig: EvmTransactionConfig) {
+    return this.web3.eth.estimateGas(transactionConfig);
   }
 }


### PR DESCRIPTION
Continuation of #2473 that implements Step 2 for `estimateGas` as outlined [here](https://gist.github.com/gnidan/a55bbec28800f64d487054be18730691#file-step2-ts).