### PR TITLE
Internal improvement: Start removing the use of the async library

### DIFF
--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -34,7 +34,6 @@
   },
   "devDependencies": {
     "@truffle/compile-solidity": "^4.2.12",
-    "async": "2.6.1",
     "browserify": "^14.0.0",
     "chai": "4.2.0",
     "debug": "^4.1.0",

--- a/packages/debug-utils/package.json
+++ b/packages/debug-utils/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "@truffle/codec": "^0.1.0",
     "@trufflesuite/chromafi": "^2.1.2",
-    "async": "2.6.1",
     "chalk": "^2.4.2",
     "debug": "^4.1.0",
     "highlight.js": "^9.15.8",

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -44,7 +44,6 @@
     "@truffle/migrate": "^3.1.0",
     "@truffle/resolver": "^5.0.21",
     "@truffle/workflow-compile": "^2.1.13",
-    "async": "2.6.1",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",

--- a/packages/resolver/package.json
+++ b/packages/resolver/package.json
@@ -23,7 +23,6 @@
     "@truffle/contract": "^4.1.0",
     "@truffle/expect": "^0.0.13",
     "@truffle/provisioner": "^0.2.0",
-    "async": "2.6.1",
     "detect-installed": "^2.0.4",
     "get-installed-path": "^4.0.8"
   },


### PR DESCRIPTION
This PR is an initial effort at getting rid of the use of the `async` library.  No, not the `async` keyword, the `async` library.  Yes, it exists.  Yes, we use it.  Yes, that's confusing.

It's an old library for writing callback-style code, which unfortunately we still have a lot of.  I wanted to get rid of it, but quickly found that rewriting a bunch of callback-style code with `async` (the keyword, that is!) and `await` wasn't really an easy thing to do when it wasn't code I knew at all and some of it used callbacks with multiple success parameters.

So, I'm PRing this partial effort.  I uninstalled `async` from several packages that had it listed but weren't actually using it, and removed its use from `debug-utils`.

It can still be found in `compile-vyper` (one use), and in `core` (a bunch of uses; I'm planning to address some of these soon, but not all of them).

Note that the only functions we use from `async` are `async.map`, `async.each`, `async.parallel`, `async.series`.  If you put in the effort to rewrite things in terms of promises -- which I'll admit is a substantial "if" -- all of these are easily replaced by standard functions.  Both `async.map` and `async.each` can basically be replaced by a combination of `map` (the array function) and `Promise.all`, while `async.parallel` basically just is `Promise.all`, and `async.series` is basically just a `for ... of` loop.

Anyway yeah.  I'll do a little bit more of this soon, but I'm not expecting to be the one to finish this...