### PR TITLE
Bug fix: Allow extra items in migrations folder

### DIFF
--- a/packages/migrate/index.js
+++ b/packages/migrate/index.js
@@ -1,6 +1,6 @@
 const fs = require("fs");
-const dir = require("node-dir");
 const path = require("path");
+const glob = require("glob");
 const expect = require("@truffle/expect");
 const Config = require("@truffle/config");
 const Reporter = require("@truffle/reporters").migrationsV5;
@@ -35,8 +35,11 @@ const Migrate = {
       return [];
     }
 
-    const files = dir.files(config.migrations_directory, { sync: true });
-    if (!files) return [];
+    const migrationsDir = config.migrations_directory;
+    const directoryContents = glob.sync(`${migrationsDir}${path.sep}*`);
+    const files = directoryContents.filter(item => fs.statSync(item).isFile());
+
+    if (files.length === 0) return [];
 
     let migrations = files
       .filter(file => isNaN(parseInt(path.basename(file))) === false)
@@ -175,9 +178,7 @@ const Migrate = {
     try {
       Migrations = options.resolver.require("Migrations");
     } catch (error) {
-      const message = `Could not find built Migrations contract: ${
-        error.message
-      }`;
+      const message = `Could not find built Migrations contract: ${error.message}`;
       throw new Error(message);
     }
 

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -21,7 +21,7 @@
     "@truffle/reporters": "^1.0.17",
     "@truffle/require": "^2.0.28",
     "emittery": "^0.4.0",
-    "node-dir": "0.1.17",
+    "glob": "^7.1.6",
     "web3": "1.2.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7065,6 +7065,18 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.1.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, gl
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^7.1.6:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 global-modules@1.0.0, global-modules@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-1.0.0.tgz#6d770f0eb523ac78164d72b5e71a8877265cc3ea"


### PR DESCRIPTION
Remove the stupid node-dir library in favor of the almighty glob!! With glob, a slightly more sophisticated search/filter for migrations files will occur.

Previously using node-dir this was causing a problem when there was something, such as an empty folder, in the migrations folder. See #2628. #2420 was the same problem.