### PR TITLE
Internal improvement: Fix fabric-evm job

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -59,6 +59,7 @@ elif [ "$FABRICEVM" = true ]; then
   sudo add-apt-repository -y ppa:rmescandon/yq
   sudo apt update
   sudo apt install -y yq
+  eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=1.12 bash)"
   cd $GOPATH
   mkdir -p src/github.com/hyperledger
   cd src/github.com/hyperledger


### PR DESCRIPTION
Updates Golang to 1.12 on the `fabric-evm` job.

Resolves #2636 .