### PR TITLE
fix: update path generation in test directory

### DIFF
--- a/packages/core/lib/commands/test/helpers.js
+++ b/packages/core/lib/commands/test/helpers.js
@@ -34,7 +34,9 @@ const determineTestFilesToRun = ({ inputFile, inputArgs = [], config }) => {
   }
 
   if (filesToRun.length === 0) {
-    const directoryContents = glob.sync(`${config.test_directory}${path.sep}*`);
+    const directoryContents = glob.sync(
+      `${config.test_directory}${path.sep}**${path.sep}*`
+    );
     filesToRun =
       directoryContents.filter(item => fs.statSync(item).isFile()) || [];
   }


### PR DESCRIPTION
When running `truffle test` it won't search recursively in the test folder for test files.

It was fixed closing #2461 and introduced again.