### PR TITLE
Better handling of inherited and overridden events

### DIFF
--- a/packages/codec/docs/README.md
+++ b/packages/codec/docs/README.md
@@ -83,6 +83,10 @@ which accept decodings in either mode and always return ABI mode.
 - You can only decode storage variables in full mode. If full mode fails
   while decoding a storage variable, it will throw an exception.
 
+- If a contract `Base` declares an event `Event` and a contract `Derived`
+  inheriting from `Base` overrides `Event`, if `Derived` then emits
+  `Base.Event`, ABI mode may not be able to decode it.
+
 ---
 
 <p align="center">

--- a/packages/codec/lib/abi-data/allocate/index.ts
+++ b/packages/codec/lib/abi-data/allocate/index.ts
@@ -562,7 +562,6 @@ function allocateEvent(
   //first: determine the corresponding event node
   //search through base contracts, from most derived (right) to most base (left)
   let node: Ast.AstNode | undefined = undefined;
-  let definingContract: Ast.AstNode | undefined = undefined;
   let definedIn: Format.Types.ContractType | undefined = undefined;
   let allocationMode: DecodingMode = "full"; //degrade to abi as needed
   debug("allocating ABI: %O", abiEntry);
@@ -579,31 +578,26 @@ function allocateEvent(
         referenceDeclarations
       )
     );
-    if (node) {
-      definingContract = contractNode;
-    }
     //if we found the node, great!  If not...
-    else {
+    if (!node) {
       debug("didn't find node in base contract...");
       //let's search for the node among the base contracts.
-      //but if we find it... we might not use it!
-      ({ node, definingContract } = linearizedBaseContractsMinusSelf.reduce(
-        (
-          { node: foundNode, definingContract: foundContract },
-          baseContractId: number
-        ) => {
+      //but if we find it...
+      //[note: the following code is overcomplicated; it was used
+      //when we were trying to get the actual node, it's overcomplicated
+      //now that we're just determining its presence.  oh well]
+      node = linearizedBaseContractsMinusSelf.reduce(
+        (foundNode: Ast.AstNode, baseContractId: number) => {
           if (foundNode !== undefined) {
             return foundNode; //once we've found something, we don't need to keep looking
-            //note we check node, not definedIn, because latter can be defined even if
-            //nothing found!
           }
           let baseContractNode = referenceDeclarations[baseContractId];
           if (baseContractNode === undefined) {
-            return { node: null, definedIn: null }; //return null rather than undefined so that this will propagate through
+            return null; //return null rather than undefined so that this will propagate through
             //(i.e. by returning null here we give up the search)
             //(we don't want to continue due to possibility of grabbing the wrong override)
           }
-          let nodeFound = baseContractNode.nodes.find(
+          return baseContractNode.nodes.find(
             //may be undefined! that's OK!
             eventNode =>
               AbiDataUtils.definitionMatchesAbi(
@@ -613,31 +607,25 @@ function allocateEvent(
                 referenceDeclarations
               )
           );
-          return { node: nodeFound, definingContract: baseContractNode };
-          //baseContractNode may be defined even if no node found, but we check node, not definedIn!
         },
-        { node: undefined, definingContract: undefined } //start with nothing found
-      ));
+        undefined //start with no node found
+      );
       if (node) {
-        //...if we find the node in an ancestor, and that ancestor has a
-        //is not an interface, we deliberately *don't* allocate!  instead such
-        //cases will be handled during a later combination step
-        //NOTE: This should *really* probably be, if that ancestor does not have
-        //a deployed context.  However, we can't determine that down here, because
-        //I didn't account for this problem originally!  While I could make it work
-        //that way, I don't think it's enough of a difference to bother right now...
-        if (definingContract.contractKind !== "interface") {
-          return undefined;
-        }
+        //...if we find the node in an ancestor, we
+        //deliberately *don't* allocate!  instead such cases
+        //will be handled during a later combination step
+        debug("bailing out for later handling!");
+        debug("ABI: %O", abiEntry);
+        return undefined;
       }
     }
   }
-  //otherwise, leave node and definingContract undefined
+  //otherwise, leave node undefined
   if (node) {
     debug("found node");
     //if we found the node, let's also turn it into a type
     definedIn = <Format.Types.ContractType>(
-      Ast.Import.definitionToStoredType(definingContract, compiler)
+      Ast.Import.definitionToStoredType(node, compiler)
     ); //can skip 3rd argument here
   } else {
     //if no node, have to fall back into ABI mode

--- a/packages/codec/lib/abi-data/allocate/types.ts
+++ b/packages/codec/lib/abi-data/allocate/types.ts
@@ -92,14 +92,13 @@ export interface CalldataArgumentAllocation {
 //3. then by selector (this one is skipped for anonymou)
 //4. then by contract kind
 //5. then by (deployed) context hash
-//(and then the anonymous ones are in an array)
 
 export interface EventAllocations {
   [topics: number]: {
     bySelector: {
       [selector: string]: {
         [contractKind: string]: {
-          [contextHash: string]: EventAllocation;
+          [contextHash: string]: EventAllocation[];
         };
       };
     };
@@ -114,6 +113,7 @@ export interface EventAllocations {
 export interface EventAllocation {
   abi: AbiData.EventAbiEntry;
   contextHash: string;
+  definedIn?: Format.Types.ContractType; //is omitted if we don't know
   anonymous: boolean;
   arguments: EventArgumentAllocation[];
   allocationMode: DecodingMode;
@@ -148,9 +148,10 @@ export interface ReturndataArgumentAllocation {
 
 //NOTE: the folowing types are not for outside use!  just produced temporarily by the allocator!
 export interface EventAllocationTemporary {
-  selector?: string; //leave out for anonymous
+  selector: string; //included even for anonymous!
+  anonymous: boolean;
   topics: number;
-  allocation: EventAllocation;
+  allocation: EventAllocation | undefined;
 }
 
 export interface CalldataAllocationTemporary {

--- a/packages/codec/lib/types.ts
+++ b/packages/codec/lib/types.ts
@@ -214,6 +214,11 @@ export interface EventDecoding {
    */
   class: Format.Types.ContractType;
   /**
+   * The class of the contract that (according to this decoding) defined the event, as a Format.Types.ContractType.
+   * May be omitted if we can't determine it, as may occur in ABI mode.
+   */
+  definedIn?: Format.Types.ContractType;
+  /**
    * The list of decoded arguments to the event.
    */
   arguments: AbiArgument[];
@@ -250,6 +255,11 @@ export interface AnonymousDecoding {
    * (The address of the contract the EVM thinks emitted the event can of course be found in the original log.)
    */
   class: Format.Types.ContractType;
+  /**
+   * The class of the contract that (according to this decoding) defined the event, as a Format.Types.ContractType.
+   * May be omitted if we can't determine it, as may occur in ABI mode.
+   */
+  definedIn?: Format.Types.ContractType;
   /**
    * The list of decoded arguments to the event.
    */

--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -302,9 +302,11 @@ export class WireDecoder {
    *
    * If there are multiple possible decodings, they will always be listed in the following order:
    *
-   * 1. A non-anonymous event coming from the contract itself (there can be at most one of these)
+   * 1. Non-anonymous events coming from the contract itself (these will moreover be ordered
+   *   from most derived to most base)
    * 2. Non-anonymous events coming from libraries
-   * 3. Anonymous events coming from the contract itself
+   * 3. Anonymous events coming from the contract itself (again, ordered from most derived
+   *   to most base)
    * 4. Anonymous events coming from libraries
    *
    * You can check the kind and class.contractKind fields to distinguish between these.

--- a/packages/decoder/test/contracts/DowngradeTest.sol
+++ b/packages/decoder/test/contracts/DowngradeTest.sol
@@ -1,7 +1,11 @@
 pragma solidity ^0.5.11;
 pragma experimental ABIEncoderV2;
 
-contract DowngradeTest {
+contract DowngradeTestParent {
+  event Inherited();
+}
+
+contract DowngradeTest is DowngradeTestParent {
 
   //structs; enums; contracts; address payable; functions
 
@@ -58,6 +62,10 @@ contract DowngradeTest {
   function decoy() public { //here to make the additionalContexts test harder
     DecoyLibrary.decoy();
     emit Done();
+  }
+
+  function emitParent() public {
+    emit Inherited();
   }
 }
 

--- a/packages/decoder/test/contracts/WireTest.sol
+++ b/packages/decoder/test/contracts/WireTest.sol
@@ -10,9 +10,24 @@ contract WireTestParent {
   }
 
   //no constructor
+
+  event Overridden(uint);
 }
 
-contract WireTest is WireTestParent {
+contract WireTestAbstract {
+  event AbstractEvent();
+
+  event AbstractOverridden(uint indexed);
+
+  function danger() public;
+}
+
+contract WireTest is WireTestParent, WireTestAbstract {
+
+  function notImplemented() public {
+    emit Done();
+  } //just a dummy function, not 
+
   constructor(bool status, bytes memory info, Ternary whoknows) public {
     deepStruct["blornst"].length = 9;
     deepString.length = 9;
@@ -131,6 +146,17 @@ contract WireTest is WireTestParent {
 
   mapping(string => Triple[]) public deepStruct;
   mapping(string => string)[] public deepString;
+
+  event Overridden(uint indexed);
+  event AbstractOverridden(uint);
+
+  function interfaceAndOverrideTest() public {
+    emit AbstractEvent();
+    emit AbstractOverridden(107);
+    emit WireTestAbstract.AbstractOverridden(683);
+    emit Overridden(107);
+    emit WireTestParent.Overridden(683);
+  }
 }
 
 library WireTestLibrary {

--- a/packages/decoder/test/test/downgrade-test.js
+++ b/packages/decoder/test/test/downgrade-test.js
@@ -7,7 +7,9 @@ const Decoder = require("../..");
 const Codec = require("../../../codec");
 
 const DowngradeTestUnmodified = artifacts.require("DowngradeTest");
+const DowngradeTestParent = artifacts.require("DowngradeTestParent");
 const DecoyLibrary = artifacts.require("DecoyLibrary");
+const OtherContracts = [DowngradeTestParent, DecoyLibrary];
 
 //verify the decoding for run
 function verifyAbiDecoding(decoding, address) {
@@ -78,7 +80,7 @@ async function runTestBody(
 ) {
   let decoder = await Decoder.forProject(
     web3.currentProvider,
-    [DowngradeTest._json, DecoyLibrary] //HACK: because we've clonedeep'd DowngradeTest,
+    [DowngradeTest._json, ...OtherContracts] //HACK: because we've clonedeep'd DowngradeTest,
     //we need to pass in its _json rather than it itself (its getters have been stripped off)
   );
   let deployedContract = await DowngradeTest.new();
@@ -192,7 +194,7 @@ contract("DowngradeTest", function(accounts) {
     //...and now let's set up a decoder for our hacked-up contract artifact.
     let decoder = await Decoder.forProject(
       web3.currentProvider,
-      [DowngradeTest._json, DecoyLibrary] //HACK: see clonedeep note above
+      [DowngradeTest._json, ...OtherContracts] //HACK: see clonedeep note above
     );
 
     //the ethers encoder can't yet handle fixed-point
@@ -248,12 +250,40 @@ contract("DowngradeTest", function(accounts) {
     assert(txDecoding.arguments[0].value.value.asBig.eq(tau));
   });
 
+  it("Correctly decodes inherited events when no node", async function() {
+    //HACK
+    let DowngradeTest = clonedeep(DowngradeTestUnmodified);
+    DowngradeTest._json.ast = undefined;
+
+    //...and now let's set up a decoder for our hacked-up contract artifact.
+    let decoder = await Decoder.forProject(
+      web3.currentProvider,
+      [DowngradeTest._json, ...OtherContracts] //HACK: see clonedeep note above
+    );
+
+    let deployedContract = await DowngradeTest.new();
+
+    let result = await deployedContract.emitParent();
+    let resultLog = result.receipt.rawLogs[0];
+
+    let logDecodings = await decoder.decodeLog(resultLog);
+
+    //now let's check the results!
+    assert.lengthOf(logDecodings, 1);
+    assert.strictEqual(logDecodings[0].kind, "event");
+    assert.strictEqual(logDecodings[0].decodingMode, "abi");
+    assert.strictEqual(logDecodings[0].abi.name, "Inherited");
+    assert.strictEqual(logDecodings[0].class.typeName, "DowngradeTest");
+    assert.isUndefined(logDecodings[0].definedIn);
+    assert.isEmpty(logDecodings[0].arguments);
+  });
+
   describe("Out-of-range enums", function() {
     it("Doesn't include out-of-range enums in full mode", async function() {
       let DowngradeTest = DowngradeTestUnmodified;
       let decoder = await Decoder.forProject(
         web3.currentProvider,
-        [DowngradeTest._json, DecoyLibrary] //not strictly necessary here, but see clonedeep comment above
+        [DowngradeTest._json, ...OtherContracts] //not strictly necessary here, but see clonedeep comment above
       );
       let deployedContract = await DowngradeTest.new();
 
@@ -319,7 +349,7 @@ contract("DowngradeTest", function(accounts) {
     let address = deployedContract.address;
     let decoder = await Decoder.forContractInstance(
       deployedContract,
-      [DowngradeTest._json, DecoyLibrary] //HACK: because we've clonedeep'd DowngradeTest,
+      [DowngradeTest._json, ...OtherContracts] //HACK: because we've clonedeep'd DowngradeTest,
       //we need to pass in its _json rather than it itself (its getters have been stripped off)
     );
 
@@ -346,7 +376,7 @@ contract("DowngradeTest", function(accounts) {
 async function runEnumTestBody(DowngradeTest) {
   let decoder = await Decoder.forProject(
     web3.currentProvider,
-    [DowngradeTest._json, DecoyLibrary] //HACK: see clonedeep comment above
+    [DowngradeTest._json, ...OtherContracts] //HACK: see clonedeep comment above
   );
   let deployedContract = await DowngradeTest.new();
 


### PR DESCRIPTION
This PR takes various steps to improve the handling of inherited and overridden events in `codec`.  In order to do this it expands the format slightly, so we might want to bump the version up to 0.2.0.

So: Log decodings now contain an optional `definedIn` member.  Whereas `class` is the class that emitted the event, `definedIn` is the class that defined it.  It is optional because, in ABI mode, it is not always possible to determine.

So, let me first explain the problem this PR is trying to solve.  OK, so events can be inherited... no big deal, right?  It's not like our existing code failed to handle that.  If a contract inherits events from another, the inherited events will go in its ABI.  So all's well, right?  Sure, we didn't have `definedIn`, but that information is redundant anyway, isn't it?

Except, it's not only possible to inherit an event, but also to override it.  What's more, it's even possible for a derived class to emit those overridden events, not just the events it's overriding them with.  But what's more, if an inherited event is overridden, it *won't appear in the derived class's ABI*.  Yes, really.  Maybe the right thing to do would've been to ask Solidity to fix this and maybe we still should (although that would necessitate changes to the code in this PR, since it assumes that's not how it works!), but here's Truffle code to fix it.

So, this PR does a ton of finagling to get overridden events to work, and adds in the `definedIn` field to disambiguate (when possible -- sometimes we just can't tell).  It's written in such a way that *non*-overridden inherited events will continue to work both in full mode and in ABI mode, although as mentioned, in ABI mode, `definedIn` may sometimes be impossible to determine.

What about overridden events in ABI mode?  Well, uh, those can't be guaranteed to work, because they're not in the ABI.  For this reason I can't promise that integrating the decoder into `truffle test` -- which would throw all the ABIs together into a big pile -- will cause zero regressions.  It will not, however, regress in any case that previously worked *reliably*.  Because while under the old way overridden events may have occasionally worked, there's no way they could have ever worked reliably.  So on the whole I'd consider this an improvement.  I'm hoping nobody was emitting overridden events anyway, because... why would you do that??  (Why does Solidity *allow* that, one might ask, but...)

This PR also adds tests of the new functionality, of course.  (I ended up removing the tests of events inherited from interfaces in favor of tests of events inherited from abstract contracts, but I can say that I did also test the former, even if they're not in the final tests.)  I also updated the docs for the new fields, and also added a note to the docs about how overridden events may not always work in ABI mode.

Some other notes:
1. I ended up manually "merging" in [this commit](https://github.com/trufflesuite/truffle/pull/2646/commits/811ec76be0c9ef7c283ad6da2f82d5b7de4adb59) from PR #2646; apologies, there's probably a proper way to do this in Git but I didn't bother to determine it.  I assume this will result in some merge conflicts on that PR later.
2. I just kind of have to apologize in general for the poor code quality in this PR.  (The hack I used to handle events inherited from abstract contracts... *shudder*.)  Unfortunately, I didn't anticipate this issue while initially writing `codec`; if I had, things would likely have been written quite differently.  But I didn't, and now I'm trying to bolt this new system on top of it in a way that's a real mess.  But hey... at least it works?