### PR TITLE
Have debugger CLI print revert string on failing halt

### DIFF
--- a/packages/core/lib/debug/interpreter.js
+++ b/packages/core/lib/debug/interpreter.js
@@ -412,8 +412,7 @@ class DebugInterpreter {
       this.printer.print("");
       //check if transaction failed
       if (!this.session.view(evm.transaction.status)) {
-        let rawRevertMessage = this.session.view(evm.current.step.returnValue);
-        this.printer.printRevertMessage(rawRevertMessage);
+        this.printer.printRevertMessage();
       } else {
         //case if transaction succeeded
         this.printer.print("Transaction completed successfully.");

--- a/packages/core/lib/debug/interpreter.js
+++ b/packages/core/lib/debug/interpreter.js
@@ -412,11 +412,8 @@ class DebugInterpreter {
       this.printer.print("");
       //check if transaction failed
       if (!this.session.view(evm.transaction.status)) {
-        this.printer.print("Transaction halted with a RUNTIME ERROR.");
-        this.printer.print("");
-        this.printer.print(
-          "This is likely due to an intentional halting expression, like assert(), require() or revert(). It can also be due to out-of-gas exceptions. Please inspect your transaction parameters and contract code to determine the meaning of this error."
-        );
+        let rawRevertMessage = this.session.view(evm.current.step.returnValue);
+        this.printer.printRevertMessage(rawRevertMessage);
       } else {
         //case if transaction succeeded
         this.printer.print("Transaction completed successfully.");

--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -8,7 +8,7 @@ const DebugUtils = require("@truffle/debug-utils");
 const Codec = require("@truffle/codec");
 
 const selectors = require("@truffle/debugger").selectors;
-const { session, solidity, trace, controller } = selectors;
+const { session, solidity, trace, controller, evm } = selectors;
 
 class DebugPrinter {
   constructor(config, session) {
@@ -197,9 +197,10 @@ class DebugPrinter {
     }
   }
 
-  printRevertMessage(rawRevertMessage) {
+  printRevertMessage() {
     this.config.logger.log("Transaction halted with a RUNTIME ERROR.");
     this.config.logger.log("");
+    let rawRevertMessage = this.session.view(evm.current.step.returnValue);
     let revertDecodings = Codec.decodeRevert(
       Codec.Conversion.toBytes(rawRevertMessage)
     );

--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -197,6 +197,62 @@ class DebugPrinter {
     }
   }
 
+  printRevertMessage(rawRevertMessage) {
+    this.config.logger.log("Transaction halted with a RUNTIME ERROR.");
+    this.config.logger.log("");
+    let revertDecodings = Codec.decodeRevert(
+      Codec.Conversion.toBytes(rawRevertMessage)
+    );
+    switch (revertDecodings.length) {
+      case 0:
+        this.config.logger.log(
+          "There was a revert message, but it could not be decoded."
+        );
+        break;
+      case 1:
+        let revertDecoding = revertDecodings[0];
+        switch (revertDecoding.kind) {
+          case "failure":
+            this.config.logger.log(
+              "There was no revert message.  This may be due to an in intentional halting expression, such as assert(), revert(), or require(), or could be due to an unintentional exception such as out-of-gas exceptions."
+            );
+            break;
+          case "revert":
+            let revertStringInfo = revertDecoding.arguments[0].value.value;
+            let revertString;
+            switch (revertStringInfo.kind) {
+              case "valid":
+                revertString = revertStringInfo.asString;
+                this.config.logger.log(`Revert message: ${revertString}`);
+                break;
+              case "malformed":
+                //turn into a JS string while smoothing over invalid UTF-8
+                //slice 2 to remove 0x prefix
+                revertString = Buffer.from(
+                  revertStringInfo.asHex.slice(2),
+                  "hex"
+                ).toString();
+                this.config.logger.log(`Revert message: ${revertString}`);
+                this.config.logger.log(
+                  "Warning: This message contained invalid UTF-8."
+                );
+                break;
+            }
+            break;
+        }
+        break;
+      default:
+        //Note: This shouldn't happen
+        this.config.logger.log(
+          "There was a revert message, but it could not be unambiguously decoded."
+        );
+        break;
+    }
+    this.config.logger.log(
+      "Please inspect your transaction parameters and contract code to determine the meaning of this error."
+    );
+  }
+
   async printWatchExpressionsResults(expressions) {
     debug("expressions %o", expressions);
     for (let expression of expressions) {

--- a/packages/debugger/lib/evm/selectors/index.js
+++ b/packages/debugger/lib/evm/selectors/index.js
@@ -260,20 +260,17 @@ function createStepSelectors(step, state = null) {
       /*
        * .returnValue
        *
-       * for a RETURN instruction, the value returned
+       * for a RETURN or REVERT instruction, the value returned;
        * we DO prepend "0x"
-       * (will also return "0x" for STOP or SELFDESTRUCT but
-       * null otherwise)
+       * for everything else, just returns "0x" (which is what the
+       * return value would be if the instruction were to fail)
+       * (or succeed in the case of STOP or SELFDESTRUCT)
        */
       returnValue: createLeaf(
-        ["./trace", "./isHalting", state],
+        ["./trace", state],
 
-        (step, isHalting, { stack, memory }) => {
-          if (!isHalting) {
-            return null;
-          }
-          if (step.op !== "RETURN") {
-            //STOP and SELFDESTRUCT return empty value
+        (step, { stack, memory }) => {
+          if (step.op !== "RETURN" && step.op !== "REVERT") {
             return "0x";
           }
           // Get the data from memory.

--- a/packages/debugger/lib/evm/selectors/index.js
+++ b/packages/debugger/lib/evm/selectors/index.js
@@ -255,31 +255,6 @@ function createStepSelectors(step, state = null) {
 
           return stack[stack.length - 1];
         }
-      ),
-
-      /*
-       * .returnValue
-       *
-       * for a RETURN or REVERT instruction, the value returned;
-       * we DO prepend "0x"
-       * for everything else, just returns "0x" (which is what the
-       * return value would be if the instruction were to fail)
-       * (or succeed in the case of STOP or SELFDESTRUCT)
-       */
-      returnValue: createLeaf(
-        ["./trace", state],
-
-        (step, { stack, memory }) => {
-          if (step.op !== "RETURN" && step.op !== "REVERT") {
-            return "0x";
-          }
-          // Get the data from memory.
-          // Note we multiply by 2 because these offsets are in bytes.
-          const offset = parseInt(stack[stack.length - 1], 16) * 2;
-          const length = parseInt(stack[stack.length - 2], 16) * 2;
-
-          return "0x" + memory.join("").substring(offset, offset + length);
-        }
       )
     });
   }
@@ -513,6 +488,36 @@ const evm = createSelectorTree({
             const ZERO_WORD = "00".repeat(Codec.Evm.Utils.WORD_SIZE);
             return stack[stack.length - 1] !== ZERO_WORD;
           }
+        }
+      ),
+
+      /*
+       * evm.current.step.returnValue
+       *
+       * for a [successful] RETURN or REVERT instruction, the value returned;
+       * we DO prepend "0x"
+       * for everything else, including unsuccessful RETURN, just returns "0x"
+       * (which is what the return value would be if the instruction were to
+       * fail) (or succeed in the case of STOP or SELFDESTRUCT)
+       * NOTE: technically this will be wrong if a REVERT fails, but that case
+       * is hard to detect and it barely matters
+       */
+      returnValue: createLeaf(
+        ["./trace", "./isExceptionalHalting", "../state"],
+
+        (step, isExceptionalHalting, { stack, memory }) => {
+          if (step.op !== "RETURN" && step.op !== "REVERT") {
+            return "0x";
+          }
+          if (isExceptionalHalting && step.op !== "REVERT") {
+            return "0x";
+          }
+          // Get the data from memory.
+          // Note we multiply by 2 because these offsets are in bytes.
+          const offset = parseInt(stack[stack.length - 1], 16) * 2;
+          const length = parseInt(stack[stack.length - 2], 16) * 2;
+
+          return "0x" + memory.join("").substring(offset, offset + length);
         }
       )
     },


### PR DESCRIPTION
This PR addresses issue #2551.  It has the debugger CLI print the revert message (decoded via Truffle Codec) at the end of a failing transaction.

In order to make this work there is also one change to the debugger library itself.  Previously, the `evm.current.step.returnValue` selector would return `null` if the current instruction wasn't a normal halting instruction, including if it were `REVERT`.  Now, it gets the return value on either `RETURN` or `REVERT`, and simply returns `"0x"` otherwise; it no longer ever returns `null`.

Strictly speaking, this does lead to two crazy corner cases:
1. If the transaction ends with a `REVERT`, but the revert *fails* (by running out of gas), we'll display the revert message even though no revert message technically occurred.  This seems fine.
2. ~~If the transaction ends with a `RETURN` that fails (again, due to running out of gas), we'll end up displaying a message saying there was a revert message, but it was indecipherable.  Maybe I should tweak that message to explicitly say, the contract may have run out of gas just as it was about to return?~~

Anyway yeah the first of these seems fine, and the second could maybe use a message tweak but overall, eh, whatever.  Both these are pretty unlikely.  And while I could eliminate the second of these with a little more effort, eliminating the first would be pretty difficult.

(Edit: OK, I went back and eliminated the second of these.)

I thought about generalizing this further by also having the CLI print the return *values* at the end of a successful transaction, but, that seems more involved and less necessary, and can be saved for a future improvement.