### PR TITLE
Fix: bump network timeout check

### DIFF
--- a/packages/provider/index.js
+++ b/packages/provider/index.js
@@ -2,7 +2,7 @@ const debug = require("debug")("provider");
 const Web3 = require("web3");
 const { createInterfaceAdapter } = require("@truffle/interface-adapter");
 const wrapper = require("./wrapper");
-const DEFAULT_NETWORK_CHECK_TIMEOUT = 5000;
+const DEFAULT_NETWORK_CHECK_TIMEOUT = 10000;
 
 module.exports = {
   wrap: function(provider, options) {


### PR DESCRIPTION
It appears the default 5 second timeout is occasionally too short for live tezos networks.
Bumping to 10 seconds has proven thus far to resolve the issue.