### PR TITLE
Correctly disable VM errors for `truffle test`'s ganache-core

### DIFF
--- a/packages/core/lib/commands/test/index.js
+++ b/packages/core/lib/commands/test/index.js
@@ -132,7 +132,7 @@ const command = {
         mnemonic:
           "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat",
         gasLimit: config.gas,
-        noVMErrorsOnRPCResponse: true,
+        vmErrorsOnRPCResponse: false,
         time: config.genesis_time
       };
       Develop.connectOrStart(


### PR DESCRIPTION
Previously, looks like lib/commands/test was trying to turn off Ganache VM errors (i.e., operate in standard mode)... but it was using the field name `noVMErrorsOnRPCResponse` instead of the correct `vmErrorsOnRPCResponse`.