### PR TITLE
Add missing break in data saga switch!

### DIFF
--- a/packages/debugger/lib/data/sagas/index.js
+++ b/packages/debugger/lib/data/sagas/index.js
@@ -460,6 +460,7 @@ function* variablesAndMappingsSaga() {
           Codec.Ast.Utils.typeIdentifier(baseExpression)
         )
       );
+      break;
 
     default:
       if (node.typeDescriptions == undefined) {


### PR DESCRIPTION
The giant switch in the data saga was missing a `break`!  Quick PR to add it in.

Have to wonder whether this might happen to be the cause of #2673.  Doubt it, don't see how it would cause that, but it's not totally implausible?