### PR TITLE
Direct function call + more sensible naming

### DIFF
--- a/packages/contract/lib/utils/index.js
+++ b/packages/contract/lib/utils/index.js
@@ -81,7 +81,7 @@ const Utils = {
   },
 
   consoleLog(receiptLogs) {
-    const TruffleLogEvents = receiptLogs.filter(x => x.event === "__Log");
+    const TruffleLogEvents = receiptLogs.filter(x => x.event === "_TruffleLog");
     TruffleLogEvents.forEach(event => {
       const result = event.args;
 

--- a/packages/core/lib/logging/TruffleLogger.sol
+++ b/packages/core/lib/logging/TruffleLogger.sol
@@ -8,27 +8,27 @@ contract TruffleLogger {
   event _TruffleLog(bytes32 b32);
   event _TruffleLog(address addr);
 
-  function Log(bool x) public {
+  function log(bool x) public {
     emit _TruffleLog(x);
   }
 
-  function Log(int x) public {
+  function log(int x) public {
     emit _TruffleLog(x);
   }
 
-  function Log(uint x) public {
+  function log(uint x) public {
     emit _TruffleLog(x);
   }
 
-  function Log(string memory x) public {
+  function log(string memory x) public {
     emit _TruffleLog(x);
   }
 
-  function Log(bytes32 x) public {
+  function log(bytes32 x) public {
     emit _TruffleLog(x);
   }
 
-  function Log(address x) public {
+  function log(address x) public {
     emit _TruffleLog(x);
   }
 }

--- a/packages/core/lib/logging/TruffleLogger.sol
+++ b/packages/core/lib/logging/TruffleLogger.sol
@@ -7,4 +7,28 @@ contract TruffleLogger {
   event __Log(string str);
   event __Log(bytes32 b32);
   event __Log(address addr);
+
+  function Log(bool x) public {
+    emit __Log(x);
+  }
+
+  function Log(int x) public {
+    emit __Log(x);
+  }
+
+  function Log(uint x) public {
+    emit __Log(x);
+  }
+
+  function Log(string memory x) public {
+    emit __Log(x);
+  }
+
+  function Log(bytes32 x) public {
+    emit __Log(x);
+  }
+
+  function Log(address x) public {
+    emit __Log(x);
+  }
 }

--- a/packages/core/lib/logging/TruffleLogger.sol
+++ b/packages/core/lib/logging/TruffleLogger.sol
@@ -1,34 +1,34 @@
 pragma solidity >=0.4.21 <0.6.0;
 
 contract TruffleLogger {
-  event __Log(bool boolean);
-  event __Log(int num);
-  event __Log(uint num);
-  event __Log(string str);
-  event __Log(bytes32 b32);
-  event __Log(address addr);
+  event _TruffleLog(bool boolean);
+  event _TruffleLog(int num);
+  event _TruffleLog(uint num);
+  event _TruffleLog(string str);
+  event _TruffleLog(bytes32 b32);
+  event _TruffleLog(address addr);
 
   function Log(bool x) public {
-    emit __Log(x);
+    emit _TruffleLog(x);
   }
 
   function Log(int x) public {
-    emit __Log(x);
+    emit _TruffleLog(x);
   }
 
   function Log(uint x) public {
-    emit __Log(x);
+    emit _TruffleLog(x);
   }
 
   function Log(string memory x) public {
-    emit __Log(x);
+    emit _TruffleLog(x);
   }
 
   function Log(bytes32 x) public {
-    emit __Log(x);
+    emit _TruffleLog(x);
   }
 
   function Log(address x) public {
-    emit __Log(x);
+    emit _TruffleLog(x);
   }
 }


### PR DESCRIPTION
@CruzMolina I've made a couple minor improvements for the logger, but not sure how to publish onto the NPM tag.

This small PR changes:

- The logger event to watch is now `_TruffleLog` instead of `__Log`
  - **Rationale:** Better namespacing

- Users who want to log can now call `TruffleLogger.log` instead of `emit TruffleLogger.__Log`
  - **Rationale:** Better developer experience, more similar to `console.log`