### PR TITLE
Adjust AST processing to account for slices

### DIFF
--- a/packages/codec/lib/stack/decode/index.ts
+++ b/packages/codec/lib/stack/decode/index.ts
@@ -70,7 +70,7 @@ export function* decodeLiteral(
 
         //if it's a string or bytes, we will interpret the pointer ourself and skip
         //straight to decodeBytes.  this is to allow us to correctly handle the
-        //case of msg.data used as a mapping key.
+        //case of msg.data used as a mapping key (or, as of 0.6.0, slices)
         if (dataType.typeClass === "bytes" || dataType.typeClass === "string") {
           let startAsBN = Conversion.toBN(
             pointer.literal.slice(0, Evm.Utils.WORD_SIZE)
@@ -125,6 +125,10 @@ export function* decodeLiteral(
           //in this case, we're actually going to *throw away* the length info,
           //because it makes the logic simpler -- we'll get the length info back
           //from calldata
+          //WARNING: this approach will *not* decode slices correctly!
+          //But, there's presently no need for the debugger to decode slices of arrays
+          //(as opposed to of strings/bytestrings),
+          //so this can be addressed later perhaps?
           let locationOnly = pointer.literal.slice(0, Evm.Utils.WORD_SIZE);
           //HACK -- in order to read the correct location, we need to add an offset
           //of -32 (since, again, we're throwing away the length info), so we pass

--- a/packages/debugger/lib/data/reducers.js
+++ b/packages/debugger/lib/data/reducers.js
@@ -183,10 +183,10 @@ function mappedPaths(state = DEFAULT_PATHS, action) {
       //replacing a fairly bare-bones Slot object with one with a full path.
 
       //we do NOT want to distinguish between types with and without "_ptr" on
-      //the end here!
+      //the end here! (or _slice)
       debug("typeIdentifier %s", typeIdentifier);
-      typeIdentifier = Codec.Ast.Utils.restorePtr(typeIdentifier);
-      parentType = Codec.Ast.Utils.restorePtr(parentType);
+      typeIdentifier = Codec.Ast.Utils.regularizeTypeIdentifier(typeIdentifier);
+      parentType = Codec.Ast.Utils.regularizeTypeIdentifier(parentType);
 
       debug("slot %o", slot);
       let hexSlotAddress = Codec.Conversion.toHexString(


### PR DESCRIPTION
This PR adjusts `codec`'s AST utils to account for the addition of slice types in 0.6.0.  That's really it.

Note I *didn't* bother adding decoding support for array slices, because there's currently no need for this.  I can go back and add this later if we think it's worth it (it wouldn't be hard).

We do need decoding support for string and bytestring slices, but luckily, I added that long ago!  (Because it was necessary to get `msg.data` to work as a mapping key.)