### PR TITLE
Update codec & decoder for 0.6.0 receive functions

### DIFF
--- a/packages/codec/lib/abi-data/types.ts
+++ b/packages/codec/lib/abi-data/types.ts
@@ -6,6 +6,7 @@ export type AbiEntry =
   | FunctionAbiEntry
   | ConstructorAbiEntry
   | FallbackAbiEntry
+  | ReceiveAbiEntry
   | EventAbiEntry;
 
 export interface FunctionAbiEntry {
@@ -29,6 +30,14 @@ export interface FallbackAbiEntry {
   type: "fallback";
   stateMutability?: "payable" | "nonpayable"; //only in newer ones
   payable?: boolean; //only in older ones
+}
+
+export interface ReceiveAbiEntry {
+  type: "receive";
+  stateMutability?: "payable";
+  payable?: boolean; //will never actually be present -- receive was
+  //introduced in 0.6.0, after this field was removed -- but included
+  //to keep typings simpler elsewhere
 }
 
 export interface EventAbiEntry {

--- a/packages/codec/lib/contexts/types.ts
+++ b/packages/codec/lib/contexts/types.ts
@@ -25,7 +25,11 @@ export interface DecoderContext {
   contractKind?: Common.ContractKind; //note: should never be "interface"
   abi?: AbiData.FunctionAbiBySelectors;
   payable?: boolean;
-  hasFallback?: boolean; //used just by the calldata decoder...
+  fallbackAbi?: {
+    //used only by the calldata decoder
+    fallback: AbiData.FallbackAbiEntry | null; //set to null if none
+    receive: AbiData.ReceiveAbiEntry | null; //set to null if none
+  };
   compiler?: Compiler.CompilerVersion;
 }
 

--- a/packages/codec/lib/core.ts
+++ b/packages/codec/lib/core.ts
@@ -88,12 +88,20 @@ export function* decodeCalldata(
     allocation = allocations.functionAllocations[contextHash][selector].input;
   }
   if (allocation === undefined) {
+    let abiEntry:
+      | AbiData.FallbackAbiEntry
+      | AbiData.ReceiveAbiEntry
+      | null = null;
+    if (info.state.calldata.length === 0) {
+      //to hell with reads, let's just be direct
+      abiEntry = context.fallbackAbi.receive || context.fallbackAbi.fallback;
+    } else {
+      abiEntry = context.fallbackAbi.fallback;
+    }
     return {
       kind: "message" as const,
       class: contractType,
-      abi: context.hasFallback
-        ? AbiData.Utils.fallbackAbiForPayability(context.payable)
-        : null,
+      abi: abiEntry,
       data: Conversion.toHexString(info.state.calldata),
       decodingMode: "full" as const
     };

--- a/packages/codec/lib/types.ts
+++ b/packages/codec/lib/types.ts
@@ -137,10 +137,10 @@ export interface MessageDecoding {
    */
   class: Format.Types.ContractType;
   /**
-   * The ABI entry for the contract's fallback function; will be null if
-   * there is none.
+   * The ABI entry for the contract's fallback or receive function that would
+   * handle this message; will be null if there is none.
    */
-  abi: AbiData.FallbackAbiEntry | null; //null indicates no fallback ABI
+  abi: AbiData.FallbackAbiEntry | AbiData.ReceiveAbiEntry | null;
   /**
    * The data that was sent to the contract.
    */

--- a/packages/decoder/lib/utils.ts
+++ b/packages/decoder/lib/utils.ts
@@ -46,6 +46,14 @@ export function makeContext(
       value: binary
     })
   );
+  const fallback =
+    <Codec.AbiData.FallbackAbiEntry>(
+      abi.find(abiEntry => abiEntry.type === "fallback")
+    ) || null; //TS is failing at inference here
+  const receive =
+    <Codec.AbiData.ReceiveAbiEntry>(
+      abi.find(abiEntry => abiEntry.type === "receive")
+    ) || null; //and here
   return {
     context: hash,
     contractName: contract.contractName,
@@ -55,7 +63,7 @@ export function makeContext(
     isConstructor,
     abi: Codec.AbiData.Utils.computeSelectors(abi),
     payable: Codec.AbiData.Utils.abiHasPayableFallback(abi),
-    hasFallback: Codec.AbiData.Utils.abiHasFallback(abi),
+    fallbackAbi: { fallback, receive },
     compiler: contract.compiler
   };
 }


### PR DESCRIPTION
This PR updates the codec & decoder for the addition of receive functions in 0.6.0.  It also adjusts doc comments appropriately.

Now, when doing a `decodeCalldata`, if the decoding is of type `"message"`, the `abi` field will contain the `receive` ABI rather than the `fallback` ABI if applicable (i.e., a `receive` ABI exists and the transaction had no data).  In order to make this work I decided to just store both these ABIs in the context object rather than do the circuitous thing I had before where I would reconstruct them.

Note: This PR really should have tests.  It doesn't though because upgrading the tests to 0.6.0 is something I'm intending to do separately later and not something I want to deal with right now.