### PR TITLE
Add (partial) support for globally-declared structs & enums

### DIFF
--- a/packages/codec/docs/README.md
+++ b/packages/codec/docs/README.md
@@ -59,8 +59,13 @@ not be reliable. If decoding fails in full mode, it **falls back to ABI mode.**
 Returned decodings (i.e. [[CalldataDecoding]] and [[LogDecoding]]) indicate
 which mode was used via the `"decodingMode"` field.
 
-To ensure full mode works, use Solidity v0.4.12 or higher and compile all your
-contracts at the same time.
+To ensure full mode works:
+  * Use Solidity v0.4.12 or higher;
+  * Compile all your contracts at the same time;
+  * Ensure all custom data types are declared in a file with at least one contract.
+
+(Our apologies for these technical limitations, but we are working to address
+these last two problems.)
 
 If you can't use full mode or don't want to deal with the distinction,
 the decoder provides

--- a/packages/codec/lib/format/types.ts
+++ b/packages/codec/lib/format/types.ts
@@ -671,7 +671,7 @@ export function typeStringWithoutLocation(dataType: Type): string {
           return `${dataType.typeClass} ${dataType.definingContractName}.${
             dataType.typeName
           }`;
-        case "global": //WARNING, SPECULATIVE
+        case "global":
           return `${dataType.typeClass} ${dataType.typeName}`;
       }
     case "tuple":

--- a/packages/codec/lib/format/types.ts
+++ b/packages/codec/lib/format/types.ts
@@ -307,8 +307,7 @@ export type UserDefinedType =
 /**
  * Type of a struct
  *
- * Structs may be local (defined in a contract) or global (defined outside of any contract);
- * the latter will be introduced in Solidity 0.6.x
+ * Structs may be local (defined in a contract) or global (defined outside of any contract)
  *
  * @Category Container types
  */
@@ -342,7 +341,7 @@ export interface StructTypeLocal {
 }
 
 /**
- * Global structs (coming in 0.6.x)
+ * Global structs
  *
  * @Category Container types
  */
@@ -380,8 +379,7 @@ export interface TupleType {
 /**
  * Type of an enum
  *
- * Enums may be local (defined in a contract) or global (defined outside of any contract);
- * the latter will be introduced in Solidity 0.6.x
+ * Enums may be local (defined in a contract) or global (defined outside of any contract)
  *
  * @Category Other user-defined types
  */
@@ -409,7 +407,7 @@ export interface EnumTypeLocal {
 }
 
 /**
- * Global enum (coming in 0.6.x)
+ * Global enum
  *
  * @Category Other user-defined types
  */

--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -163,20 +163,23 @@ export class WireDecoder {
       const contractNode = this.contractNodes[id];
       references[id] = contractNode;
       types[id] = Ast.Import.definitionToStoredType(contractNode, compiler);
-      //now, add its struct and enum definitions
-      for (const node of contractNode.nodes) {
+      //now, add its struct and enum definitions, as well as any globals in its file
+      const globalNode = this.contracts[id].ast;
+      for (const node of [...contractNode.nodes, ...globalNode.nodes]) {
         if (
           node.nodeType === "StructDefinition" ||
           node.nodeType === "EnumDefinition"
         ) {
-          references[node.id] = node;
-          //HACK even though we don't have all the references, we only need one:
-          //the reference to the contract itself, which we just added, so we're good
-          types[node.id] = Ast.Import.definitionToStoredType(
-            node,
-            compiler,
-            references
-          );
+          if (!references[node.id]) {
+            references[node.id] = node;
+            //HACK even though we don't have all the references, we only need one:
+            //the reference to the contract itself, which we just added, so we're good
+            types[node.id] = Ast.Import.definitionToStoredType(
+              node,
+              compiler,
+              references
+            );
+          }
         }
       }
     }


### PR DESCRIPTION
This PR adds (partial) support for Solidity 0.6.0's globally-declared structs and enums.  For the most part this is pretty simple -- some of this support was actually already there.  The import functions needed to be written (simple enough), and `decoder`'s function to locate user defined types needed to check the nodes directly under the root node as well as those inside a contract.  (The debugger's function to locate these didn't need modification, as it already crawls the whole AST.)

So why is the support partial?  Well, a limitation of our artifact-based system is that we can only get sources that contain at least one contract.  So, if you have a file that only declares data types and no contracts, it's going to get missed, and we're not going to find that data type.  I've updated the documentation to mention this limitation.  I'm hopeful that we'll be able to fix this once Truffle DB is ready, or at least some version of Truffle DB (I gather this is probably not going to be in the initial version -- @fainashalts?).

In the decoder, if you hit this problem, this can mean that decoding state variables can fail, or, if you're decoding ABI stuff, that it can end up falling back into ABI mode (thankfully that part of the system is pretty robust).  In the debugger, if you hit this problem, uh... yeah... it's probably going to cause some nasty error messages.  I included nothing in this PR to mitigate that.  There's not a lot we can do to be honest; for now I'm hoping people just won't run into this that often?  We'll see when people start complaining, I guess...

Again, I'm PRing this without tests, even though this really ought to have tests, for the same reason as my last 0.6.0 compatibility PR.  Intending to go back and add tests later.