### PR TITLE
Rename TruffleLogger to Console

### DIFF
--- a/packages/contract/lib/handlers.js
+++ b/packages/contract/lib/handlers.js
@@ -101,7 +101,7 @@ const handlers = {
       return context.promiEvent.reject(error);
     }
 
-    // Check logs for TruffleLogger usage & log if necessary
+    // Check logs for Console.log usage & log if necessary
     Utils.consoleLog(receipt.logs);
 
     // Emit receipt

--- a/packages/core/lib/logging/Console.sol
+++ b/packages/core/lib/logging/Console.sol
@@ -1,6 +1,6 @@
-pragma solidity >=0.4.21 <0.6.0;
+pragma solidity >=0.4.21 <0.7.0;
 
-library TruffleLogger {
+library Console {
   event _TruffleLog(bool boolean);
   event _TruffleLog(int num);
   event _TruffleLog(uint num);

--- a/packages/core/lib/testing/testsource.js
+++ b/packages/core/lib/testing/testsource.js
@@ -115,7 +115,7 @@ TestSource.prototype.resolve = function(importPath, callback) {
       );
   }
 
-  const loggingLibraries = ["TruffleLogger"];
+  const loggingLibraries = ["Console"];
 
   for (const lib of loggingLibraries) {
     const actualImportPath =

--- a/packages/migrate/migration.js
+++ b/packages/migrate/migration.js
@@ -203,14 +203,14 @@ class Migration {
 
   async deployAndLinkLogger(options, resolver) {
     const { networks, network, network_id, provider } = options;
-    let TruffleLogger;
+    let Console;
     try {
-      TruffleLogger = resolver.require("TruffleLogger");
+      Console = resolver.require("Console");
     } catch (error) {
       return;
     }
 
-    if (!TruffleLogger.isDeployed()) {
+    if (!Console.isDeployed()) {
       const loggerDeployer = new Deployer({
         networks,
         network,
@@ -218,7 +218,7 @@ class Migration {
         provider
       });
       await loggerDeployer.start();
-      await loggerDeployer.deploy(TruffleLogger);
+      await loggerDeployer.deploy(Console);
 
       // Gather all available contract artifacts
       const files = await dir.promiseFiles(options.contracts_build_directory);
@@ -235,7 +235,7 @@ class Migration {
         });
 
       for (const contract of contracts) {
-        await loggerDeployer.link(TruffleLogger, contract);
+        await loggerDeployer.link(Console, contract);
       }
       await loggerDeployer.finish();
     }

--- a/packages/migrate/migration.js
+++ b/packages/migrate/migration.js
@@ -210,35 +210,27 @@ class Migration {
       return;
     }
 
-    if (!Console.isDeployed()) {
-      const loggerDeployer = new Deployer({
-        networks,
-        network,
-        network_id,
-        provider
-      });
-      await loggerDeployer.start();
-      await loggerDeployer.deploy(Console);
+    const loggerDeployer = new Deployer({
+      networks,
+      network,
+      network_id,
+      provider
+    });
+    await loggerDeployer.start();
+    await loggerDeployer.deploy(Console);
 
-      // Gather all available contract artifacts
-      const files = await dir.promiseFiles(options.contracts_build_directory);
+    // Gather all available contract artifacts
+    const files = await dir.promiseFiles(options.contracts_build_directory);
 
-      const contracts = files
-        .filter(filePath => {
-          return path.extname(filePath) === ".json";
-        })
-        .map(filePath => {
-          return path.basename(filePath, ".json");
-        })
-        .map(contractName => {
-          return resolver.require(contractName);
-        });
+    const contracts = files
+      .filter(filePath => path.extname(filePath) === ".json")
+      .map(filePath => path.basename(filePath, ".json"))
+      .map(contractName => resolver.require(contractName));
 
-      for (const contract of contracts) {
-        await loggerDeployer.link(Console, contract);
-      }
-      await loggerDeployer.finish();
+    for (const contract of contracts) {
+      await loggerDeployer.link(Console, contract);
     }
+    await loggerDeployer.finish();
   }
 
   /**

--- a/packages/resolver/fs.js
+++ b/packages/resolver/fs.js
@@ -56,7 +56,7 @@ class FS {
       path.join(path.dirname(importedFrom), importPath)
     ];
 
-    if (importPath === "truffle/TruffleLogger.sol") {
+    if (importPath === "truffle/Console.sol") {
       const actualImportPath =
         typeof BUNDLE_VERSION !== "undefined"
           ? path.resolve(__dirname, path.basename(importPath))

--- a/packages/truffle/cli.webpack.config.js
+++ b/packages/truffle/cli.webpack.config.js
@@ -283,7 +283,7 @@ module.exports = {
           "@truffle/core",
           "lib",
           "logging",
-          "TruffleLogger.sol"
+          "Console.sol"
         )
       }
     ]),


### PR DESCRIPTION
I hope I didn't miss any re-namings here, but basically this makes it so that usage requires `Truffle.log` rather than `TruffleLogger.log`.