### PR TITLE
Fix #2442 - add an option to compile only specific files

### DIFF
--- a/packages/compile-common/src/errors.ts
+++ b/packages/compile-common/src/errors.ts
@@ -13,3 +13,18 @@ export class CompileError extends TruffleError {
     this.message = fancy_message; //?? I don't understand this, I just found it here
   }
 }
+
+export class UnresolvedPathsError extends TruffleError {
+  public message: string;
+  constructor(unresolvedPaths: string[]) {
+    const message = `\n${colors.bold(colors.red("Error"))}: Could not find ${
+      unresolvedPaths.length === 1 ? "source" : "sources"
+    } for specified ${
+      unresolvedPaths.length === 1 ? "path" : "paths"
+    }:\n - ${unresolvedPaths.join("\n - ")}\n${colors.bold(
+      "Please check your input and try again."
+    )}\n`;
+
+    super(message);
+  }
+}

--- a/packages/compile-common/src/profiler/requiredSources.ts
+++ b/packages/compile-common/src/profiler/requiredSources.ts
@@ -72,7 +72,6 @@ export async function requiredSources({
     };
   }
 
-
   // Seed compilationTargets with known updates
   for (const update of updatedPaths) {
     if (shouldIncludePath(update)) {
@@ -101,7 +100,7 @@ export async function requiredSources({
 
       debug("currentFile: %s", currentFile);
 
-      const imports = resolved[currentFile].imports;
+      const imports = (resolved[currentFile] || {}).imports || [];
 
       debug("imports.length: %d", imports.length);
 
@@ -128,7 +127,8 @@ export async function requiredSources({
       required.push(file);
       for (const importPath of resolved[file].imports) {
         debug("importPath: %s", importPath);
-        if (!required.includes(importPath)) { //don't go into a loop!
+        if (!required.includes(importPath)) {
+          //don't go into a loop!
           filesToProcess.push(importPath);
         }
       }

--- a/packages/compile-common/src/profiler/requiredSources.ts
+++ b/packages/compile-common/src/profiler/requiredSources.ts
@@ -1,6 +1,7 @@
 import debugModule from "debug";
 const debug = debugModule("compile-common:profiler:requiredSources");
 
+import { UnresolvedPathsError } from "../errors";
 import {
   resolveAllSources,
   ResolveAllSourcesOptions
@@ -58,6 +59,13 @@ export async function requiredSources({
     shouldIncludePath,
     paths: allPaths
   });
+
+  const missing = updatedPaths.filter(
+    updatedPath => !(updatedPath in resolved)
+  );
+  if (missing.length > 0) {
+    throw new UnresolvedPathsError(missing);
+  }
 
   //exit out semi-quickly if we've been asked to compile everything
   if (listsEqual(updatedPaths, allPaths)) {

--- a/packages/core/lib/commands/compile.js
+++ b/packages/core/lib/commands/compile.js
@@ -23,8 +23,7 @@ const command = {
     }
   },
   help: {
-    usage:
-      "truffle compile [--list <filter>] [--all] [--quiet]",
+    usage: "truffle compile [<sources>..] [--list <filter>] [--all] [--quiet]",
     options: [
       {
         option: "--all",
@@ -53,6 +52,11 @@ const command = {
         description:
           "Save the raw compiler results into <output-file>, overwriting any existing content."
       },
+      {
+        option: "sources",
+        description:
+          "List of files and its dependencies to be compiled. It will be ignored if --all flag is used."
+      }
     ],
     allowedGlobalOptions: ["network", "config"]
   },
@@ -78,6 +82,33 @@ const command = {
       );
     }
 
+    if (config._ && config._.length > 0) {
+      // set paths based on command-line inputs, transforming to absolute
+      // paths where appropriate
+      config.paths = config._.map(specifiedPath => {
+        // convert relative paths to absolute paths based on whether
+        // the naive absolute path exists on disk
+        //
+        // NOTE in case of collision where the specified path refers to some
+        // non-FS source (e.g. `truffle/Assert.sol`) and where that specified
+        // path corresponds to an existing file relative to the working dir.,
+        // this selects the latter as priority over the former.
+
+        const absolutePath = path.resolve(
+          config.working_directory,
+          specifiedPath
+        );
+
+        // i.e., pass the absolutePath if it's a real file, otherwise just
+        // pass whatever was specified.
+        if (fse.existsSync(absolutePath)) {
+          return absolutePath;
+        } else {
+          return specifiedPath;
+        }
+      });
+    }
+
     const compilationOutput = await WorkflowCompile.compile(config);
     if (options.saveIntermediate) {
       // Get the filename the user provided to save the compilation results to
@@ -86,7 +117,7 @@ const command = {
       await fse.writeFile(
         compilationOutputFile,
         JSON.stringify(compilationOutput),
-        {encoding: "utf8"}
+        { encoding: "utf8" }
       );
     }
 
@@ -96,7 +127,7 @@ const command = {
   },
 
   listVersions: async function (options) {
-    const {CompilerSupplier} = require("@truffle/compile-solidity");
+    const { CompilerSupplier } = require("@truffle/compile-solidity");
     const supplier = new CompilerSupplier({
       solcConfig: options.compilers.solc,
       events: options.events

--- a/packages/core/test/lib/commands/compile.js
+++ b/packages/core/test/lib/commands/compile.js
@@ -102,6 +102,36 @@ describe("compile", function () {
     );
   });
 
+  it("compiles one specified contract after three are updated", async function () {
+    this.timeout(10000);
+
+    const reset = await updateSources([
+      "ConvertLib.sol",
+      "MetaCoin.sol",
+      "Migrations.sol"
+    ]);
+
+    try {
+      const { contracts } = await WorkflowCompile.compileAndSave(
+        config.with({
+          all: false,
+          quiet: true,
+          specificFiles: [
+            path.resolve(config.contracts_directory, "ConvertLib.sol")
+          ]
+        })
+      );
+
+      assert.equal(
+        Object.keys(contracts).length,
+        2, //ConvertLib.sol is imported by MetaCoin.sol so there should be two files.
+        "Didn't compile specified contracts."
+      );
+    } finally {
+      reset();
+    }
+  });
+
   it("compiles updated contract and its ancestors", async function () {
     this.timeout(10000);
 

--- a/packages/workflow-compile/index.js
+++ b/packages/workflow-compile/index.js
@@ -33,6 +33,12 @@ async function compile(config) {
       const compileMethod =
         config.all === true || config.compileAll === true
           ? Compile.all
+          : config.paths
+          ? options =>
+              Compile.sourcesWithDependencies({
+                paths: config.paths,
+                options
+              })
           : Compile.necessary;
 
       return await compileMethod(config);

--- a/packages/workflow-compile/legacy/index.js
+++ b/packages/workflow-compile/legacy/index.js
@@ -93,6 +93,12 @@ const WorkflowCompile = {
         const compileFunc =
           config.all === true || config.compileAll === true
             ? Compile.all
+            : config.specificFiles
+            ? config =>
+                Compile.sourcesWithDependencies({
+                  paths: config.specificFiles,
+                  options: config
+                })
             : Compile.necessary;
 
         const { compilations } = await compileFunc(config);


### PR DESCRIPTION
I created function called compile.specific both in solidity and vyper compilers. They are almost identical except there is a difference in extensions names. Would be good to do some refactoring here, but I don't know where outside of compiler-solidity and compiler-vyper I should implement this function. I can think about creating function Profiler.specific in compiler-solidity which will iterate through provided file names and return list of paths according to defined extensions. 
`Profiler.specific(files,extensions)`
Let me know if it makes sense. 

I have also added one test to core/test/lib/commands/compile.js
But it is only testing solidity compilation and skipping vyper since there are no vyper files in sandbox. 


