### PR TITLE
Add some minimal typing to fix processSchema()

### DIFF
--- a/packages/truffle-db/src/artifacts/json/schema.ts
+++ b/packages/truffle-db/src/artifacts/json/schema.ts
@@ -63,7 +63,13 @@ function convertToArray(schema, keyName = "key", valueName = "value") {
   }
 }
 
-function processSchema(name, schema) {
+interface SchemaDefinitions {
+  [name: string]: {
+    [k: string]: any;
+  }
+}
+
+function processSchema(name, schema: { definitions: SchemaDefinitions }) {
   const definitions = [
     ...Object.entries(schema.definitions)
       .map( ([ id, definition ]) => ({


### PR DESCRIPTION
Since TypeScript fails to recognize Object.entries() pair type