### PR TITLE
Replace Truffle DB's Contract.constructor with bytecode fields

### DIFF
--- a/packages/truffle-db/src/artifacts/schema.ts
+++ b/packages/truffle-db/src/artifacts/schema.ts
@@ -141,23 +141,17 @@ export const schema = mergeSchemas({
           return sourceContract;
         }
       },
-      constructor: {
+      createBytecode: {
         fragment: `... on ContractObject {
-            bytecode { bytes, linkReferences { offsets, name, length } }
-          }`,
-        resolve: obj => {
-          const { bytecode } = obj;
-          const contractConstructor = {
-            createBytecode: {
-              bytecode: {
-                bytes: bytecode.bytes,
-                linkReferences: bytecode.linkReferences
-              },
-              linkValues: []
-            }
-          };
-          return contractConstructor;
-        }
+          bytecode { bytes, linkReferences { offsets, name, length } }
+        }`,
+        resolve: ({ bytecode: createBytecode }) => createBytecode
+      },
+      callBytecode: {
+        fragment: `... on ContractObject {
+          deployedBytecode { bytes, linkReferences { offsets, name, length } }
+        }`,
+        resolve: ({ deployedBytecode: callBytecode }) => callBytecode
       }
     }
   }

--- a/packages/truffle-db/src/loaders/artifacts/index.ts
+++ b/packages/truffle-db/src/loaders/artifacts/index.ts
@@ -134,14 +134,8 @@ export class ArtifactsLoader {
         network => network.contract == contract["contractName"]
       );
 
-      if (network.length > 0) {
-        createBytecodeLinkValues = this.getNetworkLinks(
-          network[0],
-          bytecodes.bytecodes[index]
-        );
-      } else {
-        createBytecodeLinkValues = [];
-      }
+      const createBytecode = bytecodes.bytecodes[index];
+      const callBytecode = bytecodes.callBytecodes[index];
 
       let contractObject = {
         name: contract["contractName"],
@@ -154,11 +148,11 @@ export class ArtifactsLoader {
         sourceContract: {
           index: index
         },
-        constructor: {
-          createBytecode: {
-            bytecode: { id: bytecodes.bytecodes[index].id },
-            linkValues: createBytecodeLinkValues
-          }
+        createBytecode: {
+          id: createBytecode.id
+        },
+        callBytecode: {
+          id: callBytecode.id
         }
       };
 

--- a/packages/truffle-db/src/loaders/queries/contracts.ts
+++ b/packages/truffle-db/src/loaders/queries/contracts.ts
@@ -14,7 +14,7 @@ export const AddContracts = gql`
     index: FileIndex
   }
 
-  input ContractConstructorBytecodeInput {
+  input ContractBytecodeInput {
     id: ID!
   }
 
@@ -23,26 +23,13 @@ export const AddContracts = gql`
     index: FileIndex
   }
 
-  input ContractConstructorLinkValueInput {
-    value: Address!
-    LinkReference: LinkReferenceInput
-  }
-
-  input ContractConstructorLinkedBytecodeInput {
-    bytecode: ContractConstructorBytecodeInput!
-    linkValues: [ContractContructorLinkValueInput]
-  }
-
-  input ContractConstructorInput {
-    createBytecode: ContractConstructorLinkedBytecodeInput!
-  }
-
   input ContractInput {
     name: String
     abi: AbiInput
     compilation: ContractCompilationInput
     sourceContract: ContractSourceContractInput
-    constructor: ContractConstructorInput
+    createBytecode: ContractBytecodeInput
+    callBytecode: ContractBytecodeInput
   }
 
   mutation AddContracts($contracts: [ContractInput!]!) {
@@ -84,16 +71,20 @@ export const AddContracts = gql`
               sourcePath
             }
           }
-          constructor {
-            createBytecode {
-              bytecode {
-                bytes
-                linkReferences {
-                  offsets
-                  name
-                  length
-                }
-              }
+          createBytecode {
+            bytes
+            linkReferences {
+              offsets
+              name
+              length
+            }
+          }
+          callBytecode {
+            bytes
+            linkReferences {
+              offsets
+              name
+              length
             }
           }
         }

--- a/packages/truffle-db/src/schema.graphql
+++ b/packages/truffle-db/src/schema.graphql
@@ -31,7 +31,8 @@ type Contract {
   abi: ABI
   compilation: Compilation
   sourceContract: SourceContract
-  constructor: Constructor
+  createBytecode: Bytecode
+  callBytecode: Bytecode
 }
 
 type ABI {

--- a/packages/truffle-db/src/workspace/pouch.ts
+++ b/packages/truffle-db/src/workspace/pouch.ts
@@ -178,7 +178,8 @@ export class Workspace {
             abi,
             compilation,
             sourceContract,
-            constructor: contractConstructor
+            createBytecode,
+            callBytecode
           } = contractInput;
           const id = soliditySha3(
             jsonStableStringify({
@@ -204,7 +205,8 @@ export class Workspace {
               abi,
               compilation,
               sourceContract,
-              constructor: contractConstructor,
+              createBytecode,
+              callBytecode,
               id
             };
           }

--- a/packages/truffle-db/src/workspace/schema.ts
+++ b/packages/truffle-db/src/workspace/schema.ts
@@ -100,17 +100,8 @@ export const schema = mergeSchemas({
       index: FileIndex
     }
 
-    input ContractConstructorBytecodeInput {
+    input ContractBytecodeInput {
       id: ID!
-    }
-
-    input ContractConstructorLinkedBytecodeInput {
-      bytecode: ContractConstructorBytecodeInput!
-      linkValues: [ContractConstructorLinkValueInput]
-    }
-
-    input ContractConstructorInput {
-      createBytecode: ContractConstructorLinkedBytecodeInput!
     }
 
     input ContractInput {
@@ -118,7 +109,8 @@ export const schema = mergeSchemas({
       abi: AbiInput
       compilation: ContractCompilationInput
       sourceContract: ContractSourceContractInput
-      constructor: ContractConstructorInput
+      createBytecode: ContractBytecodeInput
+      callBytecode: ContractBytecodeInput
     }
 
     input ContractsAddInput {
@@ -181,11 +173,6 @@ export const schema = mergeSchemas({
     }
 
     input ContractInstanceCreationConstructorLinkValueInput {
-      value: Address!
-      linkReference: LinkReferenceInput!
-    }
-
-    input ContractConstructorLinkValueInput {
       value: Address!
       linkReference: LinkReferenceInput!
     }
@@ -364,26 +351,13 @@ export const schema = mergeSchemas({
           return sourceContracts[sourceContract.index];
         }
       },
-      constructor: {
-        resolve: async ({ constructor }, _, { workspace }) => {
-          let bytecode = await workspace.bytecode(
-            constructor.createBytecode.bytecode
-          );
-          let linkValues = constructor.createBytecode.linkValues.map(
-            ({ value, linkReference }) => {
-              return {
-                value: value,
-                linkReference: bytecode.linkReferences[linkReference.index]
-              };
-            }
-          );
-          return {
-            createBytecode: {
-              bytecode: bytecode,
-              linkValues: linkValues
-            }
-          };
-        }
+      createBytecode: {
+        resolve: ({ createBytecode }, _, { workspace }) =>
+          workspace.bytecode(createBytecode)
+      },
+      callBytecode: {
+        resolve: ({ callBytecode }, _, { workspace }) =>
+          workspace.bytecode(callBytecode)
       }
     },
     ContractInstance: {


### PR DESCRIPTION
Currently, the Contract object defines a `constructor` that was the same as ContractInstance's `creation.constructor`, which specified linked binary. Since ContractInstances have a network, this linked binary is available in that context (we can determine link values given a network), and so that's fine.

But, in the context of #2720, which tries to add contracts during compilation, when networks are not available, this proves impossible. We can't get link values, so we can't save linked bytecodes. This PR posits that Contract should just have unlinked bytecode fields (`createBytecode` and `callBytecode`) instead of a Constructor data object.

Changes:
- Remove all notion of contracts having a constructor
- Add createBytecode and callBytecode fields to contract (as regular,
  unlinked bytecode objects)
- Update schemas for artifacts, workspace, loaders, and the root schema
- Update mutations and queries and such
- Update tests that check contract constructor to check bytecodes instead