### PR TITLE
Bug fix: Edit compile subscriber output

### DIFF
--- a/packages/events/defaultSubscribers/compile.js
+++ b/packages/events/defaultSubscribers/compile.js
@@ -43,9 +43,7 @@ module.exports = {
     "compile:warnings": [
       function({ warnings }) {
         this.logger.log("> Compilation warnings encountered:");
-        this.logger.log(
-          warnings.map(warning => warning.formattedMessage).join()
-        );
+        this.logger.log(`${OS.EOL}    ${warnings.join()}`);
       }
     ],
     "compile:nothingToCompile": [


### PR DESCRIPTION
#2722 

Adjust subscriber output to correctly display warning output.

Previously it looks like the raw warning output from the Solidity compiler was getting passed to the subscriber. Currently only the formatted message is and so the handler function was not adjusted to accept this.