### PR TITLE
Add missing return statement to fix snapshot bug

### DIFF
--- a/packages/core/lib/testing/testrunner.js
+++ b/packages/core/lib/testing/testrunner.js
@@ -53,11 +53,15 @@ TestRunner.prototype.initialize = async function() {
   );
 
   if (this.first_snapshot) {
+    debug("taking first snapshot");
     try {
       let initial_snapshot = await this.snapshot();
       this.can_snapshot = true;
       this.initial_snapshot = initial_snapshot;
-    } catch (_) {}
+    } catch (error) {
+      debug("first snapshot failed");
+      debug("Error: %O", error);
+    }
     this.first_snapshot = false;
   } else {
     await this.resetState();
@@ -91,9 +95,11 @@ TestRunner.prototype.deploy = async function() {
 
 TestRunner.prototype.resetState = async function() {
   if (this.can_snapshot) {
+    debug("reverting...");
     await this.revert(this.initial_snapshot);
     this.initial_snapshot = await this.snapshot();
   } else {
+    debug("redeploying...");
     await this.deploy();
   }
 };
@@ -221,6 +227,8 @@ TestRunner.prototype.rpc = async function(method, arg) {
   if (result.error != null) {
     throw new Error("RPC Error: " + (result.error.message || result.error));
   }
+
+  return result;
 };
 
 module.exports = TestRunner;


### PR DESCRIPTION
This PR fixes #2710... sort of.  The underlying bug that got exposed remains, of course, but this fixes the immediate cause of the problem and gets things back to how they were before.

So, what went wrong here is that I accidentally broke the test runner's use of snapshots, forcing it to rely on the buggy redeploy-based fallback.  How did I break it?  Well, uh, the test runner's `rpc` method, that performs RPC calls... I left out the `return` statement.  Oops.  With the `return` added in, snapshotting works just fine and the problem goes away.

Once this is released, I'll open an issue for the underlying redeploy bug that got exposed.  I have no idea what to do about that one.