### PR TITLE
Dependency Update: use v5.2.1 mocha fork for node 12/LTS support

### DIFF
--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "app-module-path": "^2.2.0",
-    "mocha": "5.2.0",
+    "mocha": "https://github.com/trufflesuite/mocha.git#v5.2.1",
     "original-require": "1.0.1"
   },
   "devDependencies": {

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -7,7 +7,7 @@
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"
   },
-  "version": "5.1.8",
+  "version": "5.1.9-nodeLTS.0",
   "main": "./build/library.bundled.js",
   "bin": {
     "truffle": "./build/cli.bundled.js"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10582,6 +10582,22 @@ mocha@^6.0.2, mocha@^6.1.4:
     yargs-parser "13.1.1"
     yargs-unparser "1.6.0"
 
+"mocha@https://github.com/trufflesuite/mocha.git#v5.2.1":
+  version "5.2.0"
+  resolved "https://github.com/trufflesuite/mocha.git#c20611d9fd80529ed9455554b24a10d0798c1952"
+  dependencies:
+    browser-stdout "1.3.1"
+    commander "2.15.1"
+    debug "3.1.0"
+    diff "3.5.0"
+    escape-string-regexp "1.0.5"
+    glob "7.1.2"
+    growl "1.10.5"
+    he "1.1.1"
+    minimatch "3.0.4"
+    mkdirp "0.5.1"
+    supports-color "5.4.0"
+
 mock-fs@^4.1.0:
   version "4.10.4"
   resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-4.10.4.tgz#4eaa3d6f7da2f44e1f3dd6b462cbbcb7b082e3d4"


### PR DESCRIPTION
Aims to resolve #2070.