### PR TITLE
Use modifier depth to solve double-modifier problem

### DIFF
--- a/packages/debugger/lib/data/selectors/index.js
+++ b/packages/debugger/lib/data/selectors/index.js
@@ -923,30 +923,17 @@ const data = createSelectorTree({
                     id = matchIds[0]; //there should only be one!
                   }
 
-                  //if not contract, it's local, so find the innermost
-                  //(but not beyond current depth)
+                  //if not contract, it's local, so identify by stackframe
                   if (id === undefined) {
-                    let matchFrames = (assignments.byAstId[astId] || [])
-                      .map(id => assignments.byId[id].stackframe)
-                      .filter(stackframe => stackframe !== undefined);
-
-                    if (matchFrames.length > 0) {
-                      //this check isn't *really*
-                      //necessary, but may as well prevent stupid stuff
-                      let maxMatch = Math.min(
-                        currentDepth,
-                        Math.max(...matchFrames)
-                      );
-                      //if we're in a modifier, include modifierDepth
-                      if (inModifier) {
-                        id = stableKeccak256({
-                          astId,
-                          stackframe: maxMatch,
-                          modifierDepth
-                        });
-                      } else {
-                        id = stableKeccak256({ astId, stackframe: maxMatch });
-                      }
+                    //if we're in a modifier, include modifierDepth
+                    if (inModifier) {
+                      id = stableKeccak256({
+                        astId,
+                        stackframe: currentDepth,
+                        modifierDepth
+                      });
+                    } else {
+                      id = stableKeccak256({ astId, stackframe: currentDepth });
                     }
                   }
                 } else {

--- a/packages/debugger/lib/solidity/selectors/index.js
+++ b/packages/debugger/lib/solidity/selectors/index.js
@@ -53,6 +53,14 @@ function createMultistepSelectors(stepSelector) {
     ),
 
     /**
+     * .modifierDepth
+     */
+    modifierDepth: createLeaf(
+      ["./instruction"],
+      instruction => instruction.modifierDepth
+    ),
+
+    /**
      * .source
      */
     source: createLeaf(
@@ -78,8 +86,10 @@ function createMultistepSelectors(stepSelector) {
     /**
      * .node
      */
-    node: createLeaf(["./source", "./pointer"], ({ ast }, pointer) =>
-      pointer ? jsonpointer.get(ast, pointer) : jsonpointer.get(ast, "")
+    node: createLeaf(
+      ["./source", "./pointer"],
+      ({ ast }, pointer) =>
+        pointer ? jsonpointer.get(ast, pointer) : jsonpointer.get(ast, "")
     )
   };
 }
@@ -129,19 +139,10 @@ let solidity = createSelectorTree({
     /**
      * solidity.current.humanReadableSourceMap
      */
-    humanReadableSourceMap: createLeaf(["./sourceMap"], sourceMap =>
-      sourceMap ? SolidityUtils.getHumanReadableSourceMap(sourceMap) : null
-    ),
-
-    /**
-     * solidity.current.isModifierDepthAvailable
-     */
-    isModifierDepthAvailable: createLeaf(
-      ["./humanReadableSourceMap"],
+    humanReadableSourceMap: createLeaf(
+      ["./sourceMap"],
       sourceMap =>
-        sourceMap && sourceMap[0]
-          ? sourceMap[0].modifierDepth !== undefined
-          : null
+        sourceMap ? SolidityUtils.getHumanReadableSourceMap(sourceMap) : null
     ),
 
     /**

--- a/packages/solidity-utils/index.js
+++ b/packages/solidity-utils/index.js
@@ -65,7 +65,18 @@ var SolidityUtils = {
         processedInstruction.modifierDepth = parseInt(splitInstruction[4]);
       }
 
-      processedSourceMap.push({ ...processedInstruction }); //need to clone so they won't all be copies!
+      //we need to clone before pushing so that the array won't contain a
+      //bunch of copies of the same thing.  unfortunately, we don't have
+      //babel here, so we need to clone a bit manually.
+      let clonedProcessedInstruction = {
+        start: processedInstruction.start,
+        length: processedInstruction.length,
+        file: processedInstruction.file,
+        jump: processedInstruction.jump,
+        modifierDepth: processedInstruction.modifierDepth
+      };
+
+      processedSourceMap.push(clonedProcessedInstruction);
     }
 
     return processedSourceMap;

--- a/packages/solidity-utils/package.json
+++ b/packages/solidity-utils/package.json
@@ -19,5 +19,8 @@
   "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/solidity-utils#readme",
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "debug": "^4.1.1"
   }
 }


### PR DESCRIPTION
This PR does a few things.

First of all, it rewrites the `getHumanReadableSourceMap` function in `solidity-utils` to be a bit more readable, while also expanding it to cover the new modifier depth field included in the source maps as of 0.6.0.

Secondly, it updates the `solidity.current.instructions` selector to include this information as well.

Thirdly, it now puts the modifier depth in the variable ID for modifier variables.  I only did this for modifiers proper, not for base constructors.  Note that you *don't* want to do this for variables not from a modifier, as the base function may have *multiple* modifier depths (the parameters will have modifier depth 0 but the other local variables may be higher).

While I was at it, I removed the overcomplicated logic in `data.current.identifiers.refs` used for selecting a stackframe.  When I wrote that, I didn't understand that the debugger only shows variables currently in scope.  Since it does, there's no need for such complex logic; we can just use the current stackframe, not attempt to use multiple different ones depending on the variable.

The effect of this is that now, if a function has the same modifier twice, the debugger will no longer get the variables from the two instances of the modifier mixed up with each other (as long as the contract was compiled with 0.6.0 or higher).

I'm adding this without a test as adding a test would require upgrading the tests to 0.6.0, which I haven't done yet.  Hope that's OK for now.

Note that this PR only solves the double-modifier problem.  It does *not* solve the problem of, what if the debugger can't locate the modifier parameters in the first place?  (Which can happen in a few edge cases, as you may recall.)  It may be possible to use the new modifier depth information to clean up many of those edge cases, although unfortunately, due to a quirk of how modifier depth works, it definitely still won't be able to solve *all* of them without further support from Solidity.  In any case, figuring out to what extent that is possible will require more study and I decided to save it for a separate PR.  For now, anyway, the double-modifier problem at least is solved.

**NOTE** @truffle/solidity-utils will need a minor release for this