### PR TITLE
Add sqlite adapter for Truffle DB

### DIFF
--- a/packages/truffle-db/bin/server.js
+++ b/packages/truffle-db/bin/server.js
@@ -9,11 +9,7 @@ const config = Config.detect({
   workingDirectory: process.argv[2] || process.cwd()
 });
 
-const db = new TruffleDB({
-  contracts_build_directory: config.contracts_build_directory,
-  contracts_directory: config.contracts_directory,
-  working_directory: config.working_directory
-});
+const db = new TruffleDB(config);
 
 const { schema, context } = db;
 

--- a/packages/truffle-db/package.json
+++ b/packages/truffle-db/package.json
@@ -68,6 +68,7 @@
     "pascal-case": "^2.0.1",
     "pouchdb": "7.1.1",
     "pouchdb-adapter-memory": "^7.1.1",
+    "pouchdb-adapter-node-websql": "^7.0.0",
     "pouchdb-debug": "^7.1.1",
     "pouchdb-find": "^7.0.0",
     "source-map-support": "^0.5.9",

--- a/packages/truffle-db/src/db.ts
+++ b/packages/truffle-db/src/db.ts
@@ -8,6 +8,12 @@ interface IConfig {
   contracts_build_directory: string;
   contracts_directory: string;
   working_directory?: string;
+  db?: {
+    adapter?: {
+      name: string;
+      settings?: any;
+    };
+  };
 }
 
 interface IContext {
@@ -41,7 +47,8 @@ export class TruffleDB {
   createContext(config: IConfig): IContext {
     return {
       workspace: new Workspace({
-        workingDirectory: config.working_directory
+        workingDirectory: config.working_directory,
+        adapter: (config.db || {}).adapter
       }),
       artifactsDirectory: config.contracts_build_directory,
       workingDirectory: config.working_directory || process.cwd(),

--- a/packages/truffle-db/src/workspace/index.ts
+++ b/packages/truffle-db/src/workspace/index.ts
@@ -13,11 +13,8 @@ export interface WorkspaceConfig {
   };
 }
 
-const getDefaultAdapter = workingDirectory => ({
-  name: "fs",
-  settings: {
-    directory: path.join(workingDirectory, ".db", "json")
-  }
+const getDefaultFSAdapterSettings = workingDirectory => ({
+  directory: path.join(workingDirectory, ".db", "json")
 });
 
 export class Workspace {
@@ -25,11 +22,14 @@ export class Workspace {
 
   constructor({
     workingDirectory,
-    adapter: { name, settings } = getDefaultAdapter(workingDirectory)
+    adapter: { name, settings } = { name: "fs" }
   }: WorkspaceConfig) {
     switch (name) {
       case "fs": {
-        this.databases = new FSDatabases({ definitions, settings });
+        this.databases = new FSDatabases({
+          definitions,
+          settings: settings || getDefaultFSAdapterSettings(workingDirectory)
+        });
         break;
       }
       case "memory": {

--- a/packages/truffle-db/src/workspace/index.ts
+++ b/packages/truffle-db/src/workspace/index.ts
@@ -1,7 +1,7 @@
 import path from "path";
 
 export { schema } from "./schema";
-import { FSDatabases, MemoryDatabases } from "./pouch";
+import { FSDatabases, MemoryDatabases, SqliteDatabases } from "./pouch";
 import { WorkspaceDatabases } from "./types";
 import { definitions } from "./definitions";
 
@@ -17,6 +17,10 @@ const getDefaultFSAdapterSettings = workingDirectory => ({
   directory: path.join(workingDirectory, ".db", "json")
 });
 
+const getDefaultSqliteAdapterSettings = workingDirectory => ({
+  directory: path.join(workingDirectory, ".db", "sqlite")
+});
+
 export class Workspace {
   public databases: WorkspaceDatabases;
 
@@ -29,6 +33,14 @@ export class Workspace {
         this.databases = new FSDatabases({
           definitions,
           settings: settings || getDefaultFSAdapterSettings(workingDirectory)
+        });
+        break;
+      }
+      case "sqlite": {
+        this.databases = new SqliteDatabases({
+          definitions,
+          settings:
+            settings || getDefaultSqliteAdapterSettings(workingDirectory)
         });
         break;
       }

--- a/packages/truffle-db/src/workspace/pouch/index.ts
+++ b/packages/truffle-db/src/workspace/pouch/index.ts
@@ -1,3 +1,4 @@
 export * from "./types";
 export * from "./fs";
 export * from "./memory";
+export * from "./sqlite";

--- a/packages/truffle-db/src/workspace/pouch/sqlite.ts
+++ b/packages/truffle-db/src/workspace/pouch/sqlite.ts
@@ -1,0 +1,33 @@
+import path from "path";
+import fse from "fs-extra";
+import PouchDB from "pouchdb";
+import PouchDBNodeWebSQLAdapter from "pouchdb-adapter-node-websql";
+
+import {
+  Databases,
+  MutationMapping,
+  ResourceMapping,
+  WorkspaceDatabasesOptions
+} from "./types";
+
+export class SqliteDatabases<
+  R,
+  C,
+  M,
+  CR extends ResourceMapping<R, C>,
+  CM extends MutationMapping<C, M>
+> extends Databases<R, C, M, CR, CM> {
+  private directory: string;
+
+  setup(options) {
+    this.directory = options.settings.directory;
+    fse.ensureDir(this.directory);
+
+    PouchDB.plugin(PouchDBNodeWebSQLAdapter);
+  }
+
+  createDatabase(resource) {
+    const savePath = path.resolve(this.directory, resource);
+    return new PouchDB(savePath, { adapter: "websql" });
+  }
+}

--- a/packages/truffle-db/src/workspace/test/persistence.spec.ts
+++ b/packages/truffle-db/src/workspace/test/persistence.spec.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import { Workspace } from "..";
 import { generateId, Migrations } from "./utils";
 
@@ -18,7 +19,14 @@ const memoryAdapter = {
 const fsAdapter = {
   name: "fs",
   settings: {
-    directory: tempDir.name
+    directory: path.join(tempDir.name, "json")
+  }
+};
+
+const sqliteAdapter = {
+  name: "sqlite",
+  settings: {
+    directory: path.join(tempDir.name, "sqlite")
   }
 };
 
@@ -58,6 +66,27 @@ describe("FS-based Workspace", () => {
 
     // create a second workspace and don't add anything
     const workspace2 = new Workspace({ adapter: fsAdapter });
+
+    // but DO get data out
+    expect(await workspace2.bytecode({ id })).toBeDefined();
+  });
+});
+
+describe("SQLite-based Workspace", () => {
+  it("does persist data", async () => {
+    // create first workspace and add to it
+    const workspace1 = new Workspace({ adapter: sqliteAdapter });
+    await workspace1.bytecodesAdd({
+      input: {
+        bytecodes: [bytecode]
+      }
+    });
+
+    // make sure we can get data out of that workspace
+    expect(await workspace1.bytecode({ id })).toBeDefined();
+
+    // create a second workspace and don't add anything
+    const workspace2 = new Workspace({ adapter: sqliteAdapter });
 
     // but DO get data out
     expect(await workspace2.bytecode({ id })).toBeDefined();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2455,7 +2455,7 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-argsarray@0.0.1:
+argsarray@0.0.1, argsarray@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/argsarray/-/argsarray-0.0.1.tgz#6e7207b4ecdb39b0af88303fa5ae22bda8df61cb"
   integrity sha1-bnIHtOzbObCviDA/pa4ivajfYcs=
@@ -8961,7 +8961,7 @@ immediate@3.0.6:
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
   integrity sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=
 
-immediate@^3.2.3, immediate@~3.2.3:
+immediate@^3.2.2, immediate@^3.2.3, immediate@~3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.2.3.tgz#d140fa8f614659bd6541233097ddaac25cdd991c"
   integrity sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=
@@ -12691,6 +12691,11 @@ nodent-runtime@^3.0.3:
   resolved "https://registry.yarnpkg.com/nodent-runtime/-/nodent-runtime-3.2.1.tgz#9e2755d85e39f764288f0d4752ebcfe3e541e00e"
   integrity sha512-7Ws63oC+215smeKJQCxzrK21VFVlCFBkwl0MOObt0HOpVQXs3u483sAmtkF33nNqZ5rSOQjB76fgyPBmAUrtCA==
 
+noop-fn@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/noop-fn/-/noop-fn-1.0.0.tgz#5f33d47f13d2150df93e0cb036699e982f78ffbf"
+  integrity sha1-XzPUfxPSFQ35PgywNmmemC94/78=
+
 nopt@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
@@ -13721,6 +13726,27 @@ pouchdb-adapter-memory@^7.1.1:
     pouchdb-adapter-leveldb-core "7.1.1"
     pouchdb-utils "7.1.1"
 
+pouchdb-adapter-node-websql@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pouchdb-adapter-node-websql/-/pouchdb-adapter-node-websql-7.0.0.tgz#64ad88dd45b23578e454bf3032a3a79f9d1e4008"
+  integrity sha512-fNaOMO8bvMrRTSfmH4RSLSpgnKahRcCA7Z0jg732PwRbGvvMdGbreZwvKPPD1fg2tm2ZwwiXWK2G3+oXyoqZYw==
+  dependencies:
+    pouchdb-adapter-websql-core "7.0.0"
+    pouchdb-utils "7.0.0"
+    websql "1.0.0"
+
+pouchdb-adapter-utils@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pouchdb-adapter-utils/-/pouchdb-adapter-utils-7.0.0.tgz#1ac8d34481911e0e9a9bf51024610a2e7351dc80"
+  integrity sha512-UWKPC6jkz6mHUzZefrU7P5X8ZGvBC8LSNZ7BIp0hWvJE6c20cnpDwedTVDpZORcCbVJpDmFOHBYnOqEIblPtbA==
+  dependencies:
+    pouchdb-binary-utils "7.0.0"
+    pouchdb-collections "7.0.0"
+    pouchdb-errors "7.0.0"
+    pouchdb-md5 "7.0.0"
+    pouchdb-merge "7.0.0"
+    pouchdb-utils "7.0.0"
+
 pouchdb-adapter-utils@7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/pouchdb-adapter-utils/-/pouchdb-adapter-utils-7.1.1.tgz#565e63e06ed69cbdc36bac358b0eef6ebbf9eb31"
@@ -13732,6 +13758,19 @@ pouchdb-adapter-utils@7.1.1:
     pouchdb-md5 "7.1.1"
     pouchdb-merge "7.1.1"
     pouchdb-utils "7.1.1"
+
+pouchdb-adapter-websql-core@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pouchdb-adapter-websql-core/-/pouchdb-adapter-websql-core-7.0.0.tgz#27b3e404159538e515b2567baa7869f90caac16c"
+  integrity sha512-NyMaH0bl20SdJdOCzd+fwXo8JZ15a48/MAwMcIbXzsRHE4DjFNlRcWAcjUP6uN4Ezc+Gx+r2tkBBMf71mIz1Aw==
+  dependencies:
+    pouchdb-adapter-utils "7.0.0"
+    pouchdb-binary-utils "7.0.0"
+    pouchdb-collections "7.0.0"
+    pouchdb-errors "7.0.0"
+    pouchdb-json "7.0.0"
+    pouchdb-merge "7.0.0"
+    pouchdb-utils "7.0.0"
 
 pouchdb-binary-utils@7.0.0:
   version "7.0.0"
@@ -13804,6 +13843,13 @@ pouchdb-find@^7.0.0:
     pouchdb-selector-core "7.0.0"
     pouchdb-utils "7.0.0"
 
+pouchdb-json@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pouchdb-json/-/pouchdb-json-7.0.0.tgz#d9860f66f27a359ac6e4b24da4f89b6909f37530"
+  integrity sha512-w0bNRu/7VmmCrFWMYAm62n30wvJJUT2SokyzeTyj3hRohj4GFwTRg1mSZ+iAmxgRKOFE8nzZstLG/WAB4Ymjew==
+  dependencies:
+    vuvuzela "1.0.3"
+
 pouchdb-json@7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/pouchdb-json/-/pouchdb-json-7.1.1.tgz#e248b7ee7cc8c30b121184bb64b477a9c67d2378"
@@ -13836,6 +13882,11 @@ pouchdb-md5@7.1.1:
   dependencies:
     pouchdb-binary-utils "7.1.1"
     spark-md5 "3.0.0"
+
+pouchdb-merge@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pouchdb-merge/-/pouchdb-merge-7.0.0.tgz#9f476ce7e32aae56904ad770ae8a1dfe14b57547"
+  integrity sha512-tci5u6NpznQhGcPv4ho1h0miky9rs+ds/T9zQ9meQeDZbUojXNaX1Jxsb0uYEQQ+HMqdcQs3Akdl0/u0mgwPGg==
 
 pouchdb-merge@7.1.1:
   version "7.1.1"
@@ -16043,7 +16094,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-sqlite3@^4.0.4:
+sqlite3@^4.0.0, sqlite3@^4.0.4:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-4.1.1.tgz#539a42e476640796578e22d589b3283c28055242"
   integrity sha512-CvT5XY+MWnn0HkbwVKJAyWEMfzpAPwnTiB3TobA5Mri44SrTovmmh499NPQP+gatkeOipqPlBLel7rn4E/PCQg==
@@ -16809,6 +16860,11 @@ timers-ext@^0.1.5:
   dependencies:
     es5-ext "~0.10.46"
     next-tick "1"
+
+tiny-queue@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/tiny-queue/-/tiny-queue-0.2.1.tgz#25a67f2c6e253b2ca941977b5ef7442ef97a6046"
+  integrity sha1-JaZ/LG4lOyypQZd7XvdELvl6YEY=
 
 title-case@^2.1.0:
   version "2.1.1"
@@ -18856,6 +18912,17 @@ websocket@1.0.29:
     nan "^2.14.0"
     typedarray-to-buffer "^3.1.5"
     yaeti "^0.0.6"
+
+websql@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/websql/-/websql-1.0.0.tgz#1bd00b27392893134715d5dd6941fd89e730bab5"
+  integrity sha512-7iZ+u28Ljw5hCnMiq0BCOeSYf0vCFQe/ORY0HgscTiKjQed8WqugpBUggJ2NTnB9fahn1kEnPRX2jf8Px5PhJw==
+  dependencies:
+    argsarray "^0.0.1"
+    immediate "^3.2.2"
+    noop-fn "^1.0.0"
+    sqlite3 "^4.0.0"
+    tiny-queue "^0.2.1"
 
 wget-improved@^1.4.0:
   version "1.5.0"


### PR DESCRIPTION
Add another backend storage adapter for Truffle DB, to use pouchdb-adapter-node-websql to write to local sqlite3 databases.