### PR TITLE
Add tests of Solidity 0.6.0 debugging/decoding features... and fix a bug

### DIFF
--- a/packages/codec/lib/core.ts
+++ b/packages/codec/lib/core.ts
@@ -85,7 +85,11 @@ export function* decodeCalldata(
       info.state
     );
     selector = Conversion.toHexString(rawSelector);
-    allocation = allocations.functionAllocations[contextHash][selector].input;
+    allocation = (
+      allocations.functionAllocations[contextHash][selector] || {
+        input: undefined
+      }
+    ).input;
   }
   if (allocation === undefined) {
     let abiEntry:

--- a/packages/debugger/test/data/ids.js
+++ b/packages/debugger/test/data/ids.js
@@ -25,7 +25,7 @@ contract FactorialTest {
     uint prevFac;
     nbang = n;
     prev = n - 1; //break here #1 (12)
-    if(n>0)
+    if(n > 0)
     {
       prevFac = factorial(n - 1);
       nbang = n * prevFac;
@@ -136,12 +136,32 @@ library InterveningLib {
 }
 `;
 
+const __MODIFIERS = `
+pragma solidity ^0.6.1;
+
+contract ModifierTest {
+
+  event Echo(uint);
+
+  modifier modifiedBy(uint x) {
+    uint temp = x + 1;
+    emit Echo(temp); //BREAK HERE #1
+    _;
+    emit Echo(temp); //BREAK HERE #2
+  }
+
+  function run() public modifiedBy(3) modifiedBy(5) {
+  }
+}
+`;
+
 const __MIGRATION = `
 let Intervening = artifacts.require("Intervening");
 let Inner = artifacts.require("Inner");
 let AddressTest = artifacts.require("AddressTest");
 let FactorialTest = artifacts.require("FactorialTest");
 let InterveningLib = artifacts.require("InterveningLib");
+let ModifierTest = artifacts.require("ModifierTest");
 
 module.exports = async function(deployer) {
   await deployer.deploy(InterveningLib);
@@ -151,6 +171,7 @@ module.exports = async function(deployer) {
   await deployer.deploy(Intervening, inner.address);
   await deployer.deploy(AddressTest);
   await deployer.deploy(FactorialTest);
+  await deployer.deploy(ModifierTest);
 };
 `;
 
@@ -158,7 +179,8 @@ let sources = {
   "FactorialTest.sol": __FACTORIAL,
   "AddressTest.sol": __ADDRESS,
   "Intervening.sol": __INTERVENING,
-  "InterveningLib.sol": __INTERVENINGLIB
+  "InterveningLib.sol": __INTERVENINGLIB,
+  "ModifierTest.sol": __MODIFIERS
 };
 
 let migrations = {
@@ -222,6 +244,50 @@ describe("Variable IDs", function() {
     }
 
     assert.deepEqual(values, [3, 2, 1, 0, 1, 1, 2, 6]);
+  });
+
+  it("Distinguishes between modifier invocations", async function() {
+    this.timeout(8000);
+    let instance = await abstractions.ModifierTest.deployed();
+    let receipt = await instance.run();
+    let txHash = receipt.tx;
+
+    let bugger = await Debugger.forTx(txHash, {
+      provider,
+      files,
+      contracts: artifacts
+    });
+
+    let session = bugger.connect();
+    debug("sourceId %d", session.view(solidity.current.source).id);
+
+    let sourceId = session.view(solidity.current.source).id;
+    let source = session.view(solidity.current.source).source;
+    await session.addBreakpoint({
+      sourceId,
+      line: lineOf("BREAK HERE #1", source)
+    });
+    await session.addBreakpoint({
+      sourceId,
+      line: lineOf("BREAK HERE #2", source)
+    });
+
+    var xValues = [];
+    var tempValues = [];
+
+    await session.continueUntilBreakpoint();
+    while (!session.view(trace.finished)) {
+      xValues.push(
+        Codec.Format.Utils.Inspect.nativize(await session.variable("x"))
+      );
+      tempValues.push(
+        Codec.Format.Utils.Inspect.nativize(await session.variable("temp"))
+      );
+      await session.continueUntilBreakpoint();
+    }
+
+    assert.deepEqual(xValues, [3, 5, 5, 3]);
+    assert.deepEqual(tempValues, [4, 6, 6, 4]);
   });
 
   it("Stays at correct stackframe after contract call", async function() {

--- a/packages/decoder/test/wire/contracts/MessageTest.sol
+++ b/packages/decoder/test/wire/contracts/MessageTest.sol
@@ -1,0 +1,18 @@
+pragma solidity ^0.6.1;
+
+contract ReceiveTest {
+
+  receive() external payable {
+  }
+
+  fallback() external {
+  }
+
+}
+
+contract FallbackTest {
+
+  fallback() external payable {
+  }
+
+}

--- a/packages/decoder/test/wire/contracts/WireTest.sol
+++ b/packages/decoder/test/wire/contracts/WireTest.sol
@@ -22,6 +22,15 @@ abstract contract WireTestAbstract {
   function danger() public virtual;
 }
 
+struct GlobalStruct {
+  uint x;
+  uint y;
+}
+
+enum GlobalEnum {
+  No, Yes
+}
+
 contract WireTest is WireTestParent, WireTestAbstract {
 
   function notImplemented() public {
@@ -68,6 +77,12 @@ contract WireTest is WireTestParent, WireTestAbstract {
 
   function moreStuff(WireTest notThis, uint[] memory bunchOfInts) public {
     emit MoreStuff(notThis, bunchOfInts);
+  }
+
+  event Globals(GlobalStruct, GlobalEnum);
+
+  function globalTest(GlobalStruct memory s, GlobalEnum e) public {
+    emit Globals(s, e);
   }
 
   event Danger(function() external);

--- a/packages/decoder/test/wire/migrations/2_deploy_contracts.js
+++ b/packages/decoder/test/wire/migrations/2_deploy_contracts.js
@@ -2,6 +2,8 @@ const DecoyLibrary = artifacts.require("DecoyLibrary");
 const DowngradeTest = artifacts.require("DowngradeTest");
 const WireTest = artifacts.require("WireTest");
 const WireTestLibrary = artifacts.require("WireTestLibrary");
+const ReceiveTest = artifacts.require("ReceiveTest");
+const FallbackTest = artifacts.require("FallbackTest");
 
 module.exports = function(deployer) {
   deployer.deploy(DecoyLibrary);
@@ -9,4 +11,6 @@ module.exports = function(deployer) {
   deployer.deploy(WireTestLibrary);
   deployer.link(WireTestLibrary, WireTest);
   deployer.deploy(WireTest, false, "0x", 0);
+  deployer.deploy(ReceiveTest);
+  deployer.deploy(FallbackTest);
 };

--- a/packages/decoder/test/wire/test/receive-test.js
+++ b/packages/decoder/test/wire/test/receive-test.js
@@ -1,0 +1,52 @@
+const debug = require("debug")("decoder:test:receive-test");
+const assert = require("chai").assert;
+
+const Decoder = require("../../..");
+
+const ReceiveTest = artifacts.require("ReceiveTest");
+const FallbackTest = artifacts.require("FallbackTest");
+
+contract("WireTest", function(accounts) {
+  it("should decode transactions that invoke fallback or receive", async function() {
+    let receiveTest = await ReceiveTest.deployed();
+    let fallbackTest = await FallbackTest.deployed();
+
+    const decoder = await Decoder.forProject(web3.currentProvider, [
+      FallbackTest,
+      ReceiveTest
+    ]);
+
+    let receiveHash = (await receiveTest.send(1)).tx;
+    let fallbackNoDataHash = (await fallbackTest.send(1)).tx;
+    let fallbackDataHash = (await receiveTest.sendTransaction({
+      from: accounts[0],
+      to: receiveTest.address,
+      data: "0xdeadbeef"
+    })).tx;
+
+    let receiveTx = await web3.eth.getTransaction(receiveHash);
+    let fallbackNoDataTx = await web3.eth.getTransaction(fallbackNoDataHash);
+    let fallbackDataTx = await web3.eth.getTransaction(fallbackDataHash);
+
+    let receiveDecoding = await decoder.decodeTransaction(receiveTx);
+    let fallbackNoDataDecoding = await decoder.decodeTransaction(
+      fallbackNoDataTx
+    );
+    let fallbackDataDecoding = await decoder.decodeTransaction(fallbackDataTx);
+
+    assert.strictEqual(receiveDecoding.kind, "message");
+    assert.strictEqual(receiveDecoding.class.typeName, "ReceiveTest");
+    assert.strictEqual(receiveDecoding.data, "0x");
+    assert.strictEqual(receiveDecoding.abi.type, "receive");
+
+    assert.strictEqual(fallbackNoDataDecoding.kind, "message");
+    assert.strictEqual(fallbackNoDataDecoding.class.typeName, "FallbackTest");
+    assert.strictEqual(fallbackNoDataDecoding.data, "0x");
+    assert.strictEqual(fallbackNoDataDecoding.abi.type, "fallback");
+
+    assert.strictEqual(fallbackDataDecoding.kind, "message");
+    assert.strictEqual(fallbackDataDecoding.class.typeName, "ReceiveTest");
+    assert.strictEqual(fallbackDataDecoding.data, "0xdeadbeef");
+    assert.strictEqual(fallbackDataDecoding.abi.type, "fallback");
+  });
+});

--- a/packages/decoder/test/wire/test/wire-test.js
+++ b/packages/decoder/test/wire/test/wire-test.js
@@ -38,14 +38,16 @@ contract("WireTest", _accounts => {
       ],
       ["hello", "hi", "hooblypoob"]
     ];
-
     let emitStuff = await deployedContract.emitStuff(...emitStuffArgs);
     let emitStuffHash = emitStuff.tx;
 
     let moreStuffArgs = [address, [8, 8, 8, 7, 8, 8, 8]];
-
     let moreStuff = await deployedContract.moreStuff(...moreStuffArgs);
     let moreStuffHash = moreStuff.tx;
+
+    let globalTestArgs = [{ x: 3, y: 5 }, 1];
+    let globalTest = await deployedContract.globalTest(...globalTestArgs);
+    let globalTestHash = globalTest.tx;
 
     let inheritedArg = [2, 3];
     let inherited = await deployedContract.inherited(inheritedArg);
@@ -76,6 +78,7 @@ contract("WireTest", _accounts => {
     let constructorTx = await web3.eth.getTransaction(constructorHash);
     let emitStuffTx = await web3.eth.getTransaction(emitStuffHash);
     let moreStuffTx = await web3.eth.getTransaction(moreStuffHash);
+    let globalTestTx = await web3.eth.getTransaction(globalTestHash);
     let inheritedTx = await web3.eth.getTransaction(inheritedHash);
     let getterTx1 = await web3.eth.getTransaction(getterHash1);
     let getterTx2 = await web3.eth.getTransaction(getterHash2);
@@ -86,6 +89,7 @@ contract("WireTest", _accounts => {
     let constructorDecoding = await decoder.decodeTransaction(constructorTx);
     let emitStuffDecoding = await decoder.decodeTransaction(emitStuffTx);
     let moreStuffDecoding = await decoder.decodeTransaction(moreStuffTx);
+    let globalTestDecoding = await decoder.decodeTransaction(globalTestTx);
     let inheritedDecoding = await decoder.decodeTransaction(inheritedTx);
     let getterDecoding1 = await decoder.decodeTransaction(getterTx1);
     let getterDecoding2 = await decoder.decodeTransaction(getterTx2);
@@ -153,6 +157,25 @@ contract("WireTest", _accounts => {
       moreStuffArgs[1]
     );
 
+    assert.strictEqual(globalTestDecoding.kind, "function");
+    assert.strictEqual(globalTestDecoding.abi.name, "globalTest");
+    assert.strictEqual(globalTestDecoding.class.typeName, "WireTest");
+    assert.lengthOf(globalTestDecoding.arguments, 2);
+    assert.strictEqual(globalTestDecoding.arguments[0].name, "s");
+    assert.deepEqual(
+      Codec.Format.Utils.Inspect.nativize(
+        globalTestDecoding.arguments[0].value
+      ),
+      globalTestArgs[0]
+    );
+    assert.strictEqual(globalTestDecoding.arguments[1].name, "e");
+    assert.strictEqual(
+      Codec.Format.Utils.Inspect.nativize(
+        globalTestDecoding.arguments[1].value
+      ),
+      "GlobalEnum.Yes"
+    );
+
     assert.strictEqual(inheritedDecoding.kind, "function");
     assert.strictEqual(inheritedDecoding.abi.name, "inherited");
     assert.strictEqual(inheritedDecoding.class.typeName, "WireTest"); //NOT WireTestParent
@@ -204,6 +227,7 @@ contract("WireTest", _accounts => {
     let constructorBlock = constructorTx.blockNumber;
     let emitStuffBlock = emitStuff.receipt.blockNumber;
     let moreStuffBlock = moreStuff.receipt.blockNumber;
+    let globalTestBlock = globalTest.receipt.blockNumber;
     let inheritedBlock = inherited.receipt.blockNumber;
     let indexTestBlock = indexTest.receipt.blockNumber;
     let libraryTestBlock = libraryTest.receipt.blockNumber;
@@ -228,6 +252,10 @@ contract("WireTest", _accounts => {
     let moreStuffEvents = await decoder.events({
       fromBlock: moreStuffBlock,
       toBlock: moreStuffBlock
+    });
+    let globalTestEvents = await decoder.events({
+      fromBlock: globalTestBlock,
+      toBlock: globalTestBlock
     });
     let inheritedEvents = await decoder.events({
       fromBlock: inheritedBlock,
@@ -263,6 +291,11 @@ contract("WireTest", _accounts => {
     let moreStuffEventDecodings = moreStuffEvents[0].decodings;
     assert.lengthOf(moreStuffEventDecodings, 1);
     let moreStuffEventDecoding = moreStuffEventDecodings[0];
+
+    assert.lengthOf(globalTestEvents, 1);
+    let globalTestEventDecodings = globalTestEvents[0].decodings;
+    assert.lengthOf(globalTestEventDecodings, 1);
+    let globalTestEventDecoding = globalTestEventDecodings[0];
 
     assert.lengthOf(inheritedEvents, 1);
     let inheritedEventDecodings = inheritedEvents[0].decodings;
@@ -356,6 +389,26 @@ contract("WireTest", _accounts => {
         moreStuffEventDecoding.arguments[1].value
       ),
       moreStuffArgs[1]
+    );
+
+    assert.strictEqual(globalTestEventDecoding.kind, "event");
+    assert.strictEqual(globalTestEventDecoding.abi.name, "Globals");
+    assert.strictEqual(globalTestEventDecoding.class.typeName, "WireTest");
+    assert.strictEqual(globalTestEventDecoding.definedIn.typeName, "WireTest");
+    assert.lengthOf(globalTestEventDecoding.arguments, 2);
+    assert.isUndefined(globalTestEventDecoding.arguments[0].name);
+    assert.deepEqual(
+      Codec.Format.Utils.Inspect.nativize(
+        globalTestEventDecoding.arguments[0].value
+      ),
+      globalTestArgs[0]
+    );
+    assert.isUndefined(globalTestEventDecoding.arguments[1].name);
+    assert.strictEqual(
+      Codec.Format.Utils.Inspect.nativize(
+        globalTestEventDecoding.arguments[1].value
+      ),
+      "GlobalEnum.Yes"
     );
 
     assert.strictEqual(inheritedEventDecoding.kind, "event");

--- a/packages/decoder/test/wire/test/wire-test.js
+++ b/packages/decoder/test/wire/test/wire-test.js
@@ -10,7 +10,7 @@ const WireTestParent = artifacts.require("WireTestParent");
 const WireTestLibrary = artifacts.require("WireTestLibrary");
 const WireTestAbstract = artifacts.require("WireTestAbstract");
 
-contract("WireTest", _accounts => {
+contract("WireTest", function(_accounts) {
   it("should correctly decode transactions and events", async function() {
     let deployedContract = await WireTest.new(true, "0xdeadbeef", 2);
     let address = deployedContract.address;


### PR DESCRIPTION
This PR mostly just adds tests for stuff in previous PRs that I added without tests because the tests were still on Solidity 0.5.x.

However, in adding these tests, I found that decoding of non-function-call transactions (ones that would hit the fallback function, e.g.) didn't actually work right, so I also put in a quick fix there.