### PR TITLE
Internal improvement: Unskip globally-available variables tests

### DIFF
--- a/packages/debugger/test/data/global.js
+++ b/packages/debugger/test/data/global.js
@@ -195,7 +195,7 @@ describe("Globally-available variables", function() {
   });
 
   it("Gets globals correctly in nested call", async function() {
-    this.timeout(8000);
+    this.timeout(12000);
     let instance = await abstractions.GlobalTest.deployed();
     let receipt = await instance.runRun(9, { value: 100 });
     let txHash = receipt.tx;
@@ -319,7 +319,7 @@ describe("Globally-available variables", function() {
   });
 
   it("Gets globals correctly in nested creation", async function() {
-    this.timeout(8000);
+    this.timeout(12000);
     let instance = await abstractions.GlobalTest.deployed();
     let receipt = await instance.runCreate(9, { value: 100 });
     let txHash = receipt.tx;

--- a/packages/debugger/test/data/global.js
+++ b/packages/debugger/test/data/global.js
@@ -155,12 +155,10 @@ describe("Globally-available variables", function() {
   var files;
 
   before("Create Provider", async function() {
-    this.skip();
     provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
   });
 
   before("Prepare contracts and artifacts", async function() {
-    this.skip();
     this.timeout(30000);
 
     let prepared = await prepareContracts(provider, sources, migrations);
@@ -170,7 +168,6 @@ describe("Globally-available variables", function() {
   });
 
   it("Gets globals correctly in simple call", async function() {
-    this.skip();
     this.timeout(8000);
     let instance = await abstractions.GlobalTest.deployed();
     let receipt = await instance.run(9, { value: 100 });
@@ -198,7 +195,6 @@ describe("Globally-available variables", function() {
   });
 
   it("Gets globals correctly in nested call", async function() {
-    this.skip();
     this.timeout(8000);
     let instance = await abstractions.GlobalTest.deployed();
     let receipt = await instance.runRun(9, { value: 100 });
@@ -232,7 +228,6 @@ describe("Globally-available variables", function() {
   });
 
   it("Gets globals correctly in static call", async function() {
-    this.skip();
     this.timeout(8000);
     let instance = await abstractions.GlobalTest.deployed();
     let receipt = await instance.runStatic(9);
@@ -266,7 +261,6 @@ describe("Globally-available variables", function() {
   });
 
   it("Gets globals correctly in library call", async function() {
-    this.skip();
     this.timeout(8000);
     let instance = await abstractions.GlobalTest.deployed();
     let receipt = await instance.runLib(9, { value: 100 });
@@ -299,7 +293,6 @@ describe("Globally-available variables", function() {
   });
 
   it("Gets globals correctly in simple creation", async function() {
-    this.skip();
     this.timeout(8000);
     let contract = await abstractions.CreationTest.new(9, { value: 100 });
     let txHash = contract.transactionHash;
@@ -326,7 +319,6 @@ describe("Globally-available variables", function() {
   });
 
   it("Gets globals correctly in nested creation", async function() {
-    this.skip();
     this.timeout(8000);
     let instance = await abstractions.GlobalTest.deployed();
     let receipt = await instance.runCreate(9, { value: 100 });


### PR DESCRIPTION
Now that we're on ganache-core 2.9.1, where the timestamp bug is fixed, we can finally turn on the globally-available variables tests and not have them fail due to timestamp problems!  Hooray!