### PR TITLE
Remove nonexistent setting that wouldn't work

### DIFF
--- a/packages/core/lib/commands/test/index.js
+++ b/packages/core/lib/commands/test/index.js
@@ -132,7 +132,6 @@ const command = {
         mnemonic:
           "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat",
         gasLimit: config.gas,
-        noVMErrorsOnRPCResponse: true,
         time: config.genesis_time
       };
       Develop.connectOrStart(


### PR DESCRIPTION
Ganache neither defines `noVMErrorsOnRPCResponse`, nor can Truffle make use of the intended option `vmErrorsOnRPCResponse: false`, since that behavior would be a breaking change (identified thanks to #2733)