### PR TITLE
Add named events to logger

### DIFF
--- a/packages/contract/lib/utils/index.js
+++ b/packages/contract/lib/utils/index.js
@@ -81,8 +81,8 @@ const Utils = {
   },
 
   consoleLog(receiptLogs) {
-    const TruffleLogEvents = receiptLogs.filter(x => x.event === "_TruffleLog");
-    TruffleLogEvents.forEach(event => {
+    const logEvents = receiptLogs.filter(x => x.event === "_TruffleLog");
+    logEvents.forEach(event => {
       const result = event.args;
 
       // A mapping to show how to output into our console
@@ -101,6 +101,34 @@ const Utils = {
       types.forEach(type => {
         if (result.hasOwnProperty(type)) {
           console.log(outputMap[type]);
+        }
+      });
+    });
+
+    const namedLogEvents = receiptLogs.filter(
+      x => x.event === "_TruffleLogNamed"
+    );
+    namedLogEvents.forEach(event => {
+      const result = event.args;
+
+      // A mapping to show how to output into our console
+      const outputMap = {
+        num: result[1].toString(),
+        boolean: result[1],
+        str: result[1],
+        b32: result[1],
+        addr: result[1]
+      };
+
+      // A list of all "supported" types: ["num", "boolean", "str", ...]
+      const types = Object.keys(outputMap);
+
+      // Find out what type our result is, and log it out if it matches
+      types.forEach(type => {
+        if (result.hasOwnProperty(type)) {
+          const label = web3Utils.toAscii(result[0]);
+          const value = outputMap[type];
+          console.log(label, value);
         }
       });
     });

--- a/packages/core/lib/logging/Console.sol
+++ b/packages/core/lib/logging/Console.sol
@@ -8,6 +8,13 @@ library Console {
   event _TruffleLog(bytes32 b32);
   event _TruffleLog(address addr);
 
+  event _TruffleLogNamed(bytes32 label, bool boolean);
+  event _TruffleLogNamed(bytes32 label, int num);
+  event _TruffleLogNamed(bytes32 label, uint num);
+  event _TruffleLogNamed(bytes32 label, string str);
+  event _TruffleLogNamed(bytes32 label, bytes32 b32);
+  event _TruffleLogNamed(bytes32 label, address addr);
+
   function log(bool x) public {
     emit _TruffleLog(x);
   }
@@ -30,5 +37,29 @@ library Console {
 
   function log(address x) public {
     emit _TruffleLog(x);
+  }
+
+  function log(bytes32 x, bool y) public {
+    emit _TruffleLogNamed(x, y);
+  }
+
+  function log(bytes32 x, int y) public {
+    emit _TruffleLogNamed(x, y);
+  }
+
+  function log(bytes32 x, uint y) public {
+    emit _TruffleLogNamed(x, y);
+  }
+
+  function log(bytes32 x, string memory y) public {
+    emit _TruffleLogNamed(x, y);
+  }
+
+  function log(bytes32 x, bytes32 y) public {
+    emit _TruffleLogNamed(x, y);
+  }
+
+  function log(bytes32 x, address y) public {
+    emit _TruffleLogNamed(x, y);
   }
 }


### PR DESCRIPTION
This adds the ability to prefix your log events with a short string (one that fits within 32 bytes, because technically it is getting parsed as `bytes32`). For example:

```
Console.log("This is myBool", myBool);
Console.log("This is myInt", myInt);
Console.log("This is myUint", myUint);
Console.log("This is myString", myString);
Console.log("This is myBytes32", myBytes32);
Console.log("This is myAddress", myAddress);
```

This will provide the following output:

```
This is myBool true
This is myInt -4321
This is myUint 1234
This is myString myString
This is myBytes32 0x6d79427974657333320000000000000000000000000000000000000000000000
This is myAddress 0x8990214b1304955D07bBEA94D9B0C2728097c3EB
```

Thanks to @nsward for his suggestion here: https://github.com/trufflesuite/truffle-logger-example/issues/3#issuecomment-574549320