### PR TITLE
Track collection of current names per project in Truffle DB

### DIFF
--- a/packages/truffle-db/src/loaders/artifacts/index.ts
+++ b/packages/truffle-db/src/loaders/artifacts/index.ts
@@ -17,7 +17,7 @@ import {
   AddNameRecords,
   AddNetworks,
   AddProjects,
-  GetCurrent,
+  ResolveProjectName,
   AssignProjectNames
 } from "../queries";
 
@@ -176,8 +176,12 @@ export class ArtifactsLoader {
     });
   }
 
-  async getCurrent(projectId: string, type: string, name: string) {
-    let { data } = await this.db.query(GetCurrent, { projectId, type, name });
+  async resolveProjectName(projectId: string, type: string, name: string) {
+    let { data } = await this.db.query(ResolveProjectName, {
+      projectId,
+      type,
+      name
+    });
 
     if (data.workspace.project.resolve.length > 0) {
       return {
@@ -237,7 +241,7 @@ export class ArtifactsLoader {
     const nameRecords = await Promise.all(
       contractObjects.map(async (contract, index) => {
         //check if there is already a current head for this item. if so save it as previous
-        let current: IdObject = await this.getCurrent(
+        let current: IdObject = await this.resolveProjectName(
           projectId,
           "Contract",
           contract.name
@@ -413,7 +417,7 @@ export class ArtifactsLoader {
         const nameRecords = await Promise.all(
           configNetworks.map(async (network, index) => {
             //check if there is already a current head for this item. if so save it as previous
-            let current: IdObject = await this.getCurrent(
+            let current: IdObject = await this.resolveProjectName(
               projectId,
               "Network",
               network.name

--- a/packages/truffle-db/src/loaders/artifacts/test/index.ts
+++ b/packages/truffle-db/src/loaders/artifacts/test/index.ts
@@ -8,7 +8,7 @@ import {
   AddProjects,
   AssignProjectNames,
   AddNameRecords,
-  GetCurrent
+  ResolveProjectName
 } from "truffle-db/loaders/queries";
 import { generateId } from "truffle-db/helpers";
 import * as Contracts from "@truffle/workflow-compile/new";
@@ -710,7 +710,7 @@ describe("Compilation", () => {
             project: { resolve }
           }
         }
-      } = await db.query(GetCurrent, {
+      } = await db.query(ResolveProjectName, {
         projectId,
         name: artifacts[index].contractName,
         type: "Contract"

--- a/packages/truffle-db/src/loaders/queries/index.ts
+++ b/packages/truffle-db/src/loaders/queries/index.ts
@@ -5,3 +5,4 @@ export { AddContracts } from "./contracts";
 export { AddContractInstances } from "./contractInstances";
 export { AddNameRecords } from "./nameRecords";
 export { AddNetworks } from "./networks";
+export { AddProjects, GetCurrent, AssignProjectNames } from "./projects";

--- a/packages/truffle-db/src/loaders/queries/index.ts
+++ b/packages/truffle-db/src/loaders/queries/index.ts
@@ -5,4 +5,8 @@ export { AddContracts } from "./contracts";
 export { AddContractInstances } from "./contractInstances";
 export { AddNameRecords } from "./nameRecords";
 export { AddNetworks } from "./networks";
-export { AddProjects, GetCurrent, AssignProjectNames } from "./projects";
+export {
+  AddProjects,
+  ResolveProjectName,
+  AssignProjectNames
+} from "./projects";

--- a/packages/truffle-db/src/loaders/queries/nameRecords.ts
+++ b/packages/truffle-db/src/loaders/queries/nameRecords.ts
@@ -21,18 +21,13 @@ export const AddNameRecords = gql`
       nameRecordsAdd(input: { nameRecords: $nameRecords }) {
         nameRecords {
           id
+          name
+          type
           resource {
             name
-            ... on Network {
-              networkId
-            }
-            ... on Contract {
-              abi {
-                json
-              }
-            }
           }
           previous {
+            id
             name
           }
         }

--- a/packages/truffle-db/src/loaders/queries/projects.ts
+++ b/packages/truffle-db/src/loaders/queries/projects.ts
@@ -1,7 +1,7 @@
 import gql from "graphql-tag";
 
-export const GetCurrent = gql`
-  query GetCurrent($projectId: ID!, $type: String!, $name: String!) {
+export const ResolveProjectName = gql`
+  query ResolveProjectName($projectId: ID!, $type: String!, $name: String!) {
     workspace {
       project(id: $projectId) {
         resolve(type: $type, name: $name) {

--- a/packages/truffle-db/src/loaders/queries/projects.ts
+++ b/packages/truffle-db/src/loaders/queries/projects.ts
@@ -1,0 +1,67 @@
+import gql from "graphql-tag";
+
+export const GetCurrent = gql`
+  query GetCurrent($projectId: ID!, $type: String!, $name: String!) {
+    workspace {
+      project(id: $projectId) {
+        resolve(type: $type, name: $name) {
+          id
+          resource {
+            id
+            name
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const AddProjects = gql`
+  input ProjectInput {
+    directory: String!
+  }
+
+  mutation AddProjects($projects: [ProjectInput!]!) {
+    workspace {
+      projectsAdd(input: { projects: $projects }) {
+        projects {
+          id
+          directory
+        }
+      }
+    }
+  }
+`;
+
+export const AssignProjectNames = gql`
+  input ProjectInput {
+    id: ID!
+  }
+
+  input NameRecordInput {
+    id: ID!
+  }
+
+  input ProjectNameInput {
+    project: ProjectInput!
+    name: String!
+    type: String!
+    nameRecord: NameRecordInput!
+  }
+
+  mutation AssignProjectNames($projectNames: [ProjectNameInput!]!) {
+    workspace {
+      projectNamesAssign(input: { projectNames: $projectNames }) {
+        projectNames {
+          name
+          type
+          nameRecord {
+            resource {
+              id
+            }
+          }
+        }
+      }
+    }
+  }
+`;

--- a/packages/truffle-db/src/schema.graphql
+++ b/packages/truffle-db/src/schema.graphql
@@ -10,8 +10,9 @@ scalar FileIndex
 type Project {
   name: String
   directory: String!
-  names(type: String!): [NameRecord] # null means unknown type
-  resolve(type: String!, name: String!): NameRecord
+  contract(name: String!): Contract
+  network(name: String!): Network
+  resolve(type: String, name: String): [NameRecord] # null means unknown type
 }
 
 type NameRecord {

--- a/packages/truffle-db/src/workspace/definitions.ts
+++ b/packages/truffle-db/src/workspace/definitions.ts
@@ -41,7 +41,7 @@ export const definitions: Definitions<WorkspaceCollections> = {
     idFields: ["name", "abi", "sourceContract", "compilation"]
   },
   sources: {
-    createIndexes: [{ fields: ["contents"] }, { fields: ["sourcePath"] }],
+    createIndexes: [],
     idFields: ["contents", "sourcePath"]
   },
   compilations: {
@@ -53,7 +53,7 @@ export const definitions: Definitions<WorkspaceCollections> = {
     idFields: ["bytes", "linkReferences"]
   },
   networks: {
-    createIndexes: [{ fields: ["id"] }],
+    createIndexes: [],
     idFields: ["networkId", "historicBlock"]
   },
   contractInstances: {
@@ -61,11 +61,11 @@ export const definitions: Definitions<WorkspaceCollections> = {
     idFields: ["address", "network"]
   },
   nameRecords: {
-    createIndexes: [{ fields: ["id"] }],
+    createIndexes: [],
     idFields: ["name", "type", "resource", "previous"]
   },
   projects: {
-    createIndexes: [{ fields: ["id"] }],
+    createIndexes: [],
     idFields: ["directory"]
   }
 };

--- a/packages/truffle-db/src/workspace/definitions.ts
+++ b/packages/truffle-db/src/workspace/definitions.ts
@@ -33,6 +33,11 @@ export type WorkspaceCollections = {
     resource: DataModel.IProject;
     input: DataModel.IProjectsAddInput;
   };
+  projectNames: {
+    resource: DataModel.IProjectName;
+    input: DataModel.IProjectNameInput;
+    mutable: true;
+  };
 };
 
 export const definitions: Definitions<WorkspaceCollections> = {
@@ -67,5 +72,19 @@ export const definitions: Definitions<WorkspaceCollections> = {
   projects: {
     createIndexes: [],
     idFields: ["directory"]
+  },
+  projectNames: {
+    createIndexes: [
+      {
+        fields: ["project.id"]
+      },
+      {
+        fields: ["project.id", "type"]
+      },
+      {
+        fields: ["project.id", "name", "type"]
+      }
+    ],
+    idFields: ["project", "name", "type"]
   }
 };

--- a/packages/truffle-db/src/workspace/index.ts
+++ b/packages/truffle-db/src/workspace/index.ts
@@ -134,6 +134,22 @@ export class Workspace {
     return await this.databases.get("projects", id);
   }
 
+  async projectNames({
+    project,
+    name,
+    type
+  }): Promise<DataModel.INameRecord[]> {
+    const results = await this.databases.find("projectNames", {
+      selector: { "project.id": project.id, name, type }
+    });
+    const nameRecordIds = results.map(({ nameRecord: { id } }) => id);
+    return await this.databases.find("nameRecords", {
+      selector: {
+        id: { $in: nameRecordIds }
+      }
+    });
+  }
+
   /***************************************************************************
    * Mutations
    ***************************************************************************/
@@ -174,6 +190,12 @@ export class Workspace {
 
   async projectsAdd({ input }): Promise<{ projects: DataModel.IProject[] }> {
     return await this.databases.add("projects", input);
+  }
+
+  async projectNamesAssign({
+    input
+  }): Promise<{ projectNames: DataModel.IProjectName[] }> {
+    return await this.databases.update("projectNames", input);
   }
 
   /***************************************************************************

--- a/packages/truffle-db/src/workspace/pouch/databases.ts
+++ b/packages/truffle-db/src/workspace/pouch/databases.ts
@@ -4,14 +4,14 @@ import PouchDBFind from "pouchdb-find";
 import { generateId } from "truffle-db/helpers";
 
 import {
-  AddInput,
-  AddPayload,
   CollectionDatabases,
   CollectionName,
   CollectionResult,
   Collections,
   Definition,
   Definitions,
+  Input,
+  Payload,
   Resource
 } from "./types";
 
@@ -131,14 +131,14 @@ export abstract class Databases<C extends Collections> {
 
   public async add<N extends CollectionName<C>>(
     collectionName: N,
-    input: AddInput<C, N>
-  ): Promise<AddPayload<C, N>> {
+    input: Input<C, N>
+  ): Promise<Payload<C, N>> {
     await this.ready;
 
     const { idFields } = this.definitions[collectionName];
 
     const resources = await Promise.all(
-      input[collectionName].map(async (resourceInput: AddInput<C, N>) => {
+      input[collectionName].map(async (resourceInput: Input<C, N>) => {
         const id = generateId(
           idFields.reduce(
             (obj, field) => ({
@@ -169,6 +169,6 @@ export abstract class Databases<C extends Collections> {
 
     return ({
       [collectionName]: resources
-    } as unknown) as AddPayload<C, N>;
+    } as unknown) as Payload<C, N>;
   }
 }

--- a/packages/truffle-db/src/workspace/pouch/types.ts
+++ b/packages/truffle-db/src/workspace/pouch/types.ts
@@ -30,12 +30,12 @@ export type Resource<
   N extends CollectionName<C>
 > = C[N]["resource"];
 
-export type AddInput<
+export type Input<
   C extends Collections,
   N extends CollectionName<C>
 > = C[N]["input"];
 
-export type AddPayload<C extends Collections, N extends CollectionName<C>> = {
+export type Payload<C extends Collections, N extends CollectionName<C>> = {
   [K in N]: Resource<C, N>[]
 };
 

--- a/packages/truffle-db/src/workspace/pouch/types.ts
+++ b/packages/truffle-db/src/workspace/pouch/types.ts
@@ -4,6 +4,7 @@ export type Collections = {
   [collectionName: string]: {
     resource: any;
     input: any;
+    mutable?: boolean;
   };
 };
 
@@ -43,3 +44,7 @@ export type Definition<
   C extends Collections,
   N extends CollectionName<C>
 > = Definitions<C>[N];
+
+export type MutableCollectionName<C extends Collections> = {
+  [K in CollectionName<C>]: C[K]["mutable"] extends true ? K : never
+}[CollectionName<C>];

--- a/packages/truffle-db/src/workspace/schema.ts
+++ b/packages/truffle-db/src/workspace/schema.ts
@@ -37,6 +37,12 @@ export const schema = mergeSchemas({
         extend interface Named {
           id: ID!
         }
+        type ProjectName {
+          project: Project!
+          name: String!
+          type: String!
+          nameRecord: NameRecord!
+        }
         `
       ]
     }),
@@ -299,6 +305,21 @@ export const schema = mergeSchemas({
       projects: [Project!]!
     }
 
+    input ProjectNameInput {
+      project: ResourceInput!
+      name: String!
+      type: String!
+      nameRecord: ResourceInput!
+    }
+
+    input ProjectNamesAssignInput {
+      projectNames: [ProjectNameInput!]!
+    }
+
+    type ProjectNamesAssignPayload {
+      projectNames: [ProjectName!]!
+    }
+
     type Mutation {
       sourcesAdd(input: SourcesAddInput!): SourcesAddPayload
       bytecodesAdd(input: BytecodesAddInput!): BytecodesAddPayload
@@ -308,6 +329,7 @@ export const schema = mergeSchemas({
       networksAdd(input: NetworksAddInput!): NetworksAddPayload
       nameRecordsAdd(input: NameRecordsAddInput!): NameRecordsAddPayload
       projectsAdd(input:ProjectsAddInput!):ProjectsAddPayload
+      projectNamesAssign(input: ProjectNamesAssignInput): ProjectNamesAssignPayload
     } `
   ],
 
@@ -399,6 +421,10 @@ export const schema = mergeSchemas({
       projectsAdd: {
         resolve: (_, { input }, { workspace }) =>
           workspace.projectsAdd({ input })
+      },
+      projectNamesAssign: {
+        resolve: (_, { input }, { workspace }) =>
+          workspace.projectNamesAssign({ input })
       }
     },
     Named: {
@@ -424,6 +450,55 @@ export const schema = mergeSchemas({
               return null;
           }
         }
+      }
+    },
+    Project: {
+      resolve: {
+        resolve: async ({ id }, { name, type }, { workspace }) => {
+          return await workspace.projectNames({
+            project: { id },
+            name,
+            type
+          });
+        }
+      },
+      network: {
+        resolve: async ({ id }, { name }, { workspace }) => {
+          const nameRecords = await workspace.projectNames({
+            project: { id },
+            type: "Network",
+            name
+          });
+          if (nameRecords.length === 0) {
+            return;
+          }
+          const { resource } = nameRecords[0];
+          return await workspace.network(resource);
+        }
+      },
+      contract: {
+        resolve: async ({ id }, { name }, { workspace }) => {
+          const nameRecords = await workspace.projectNames({
+            project: { id },
+            type: "Contract",
+            name
+          });
+          if (nameRecords.length === 0) {
+            return;
+          }
+          const { resource } = nameRecords[0];
+          return await workspace.contract(resource);
+        }
+      }
+    },
+    ProjectName: {
+      project: {
+        resolve: ({ project: { id } }, _, { workspace }) =>
+          workspace.project({ id })
+      },
+      nameRecord: {
+        resolve: ({ nameRecord: { id } }, _, { workspace }) =>
+          workspace.nameRecord({ id })
       }
     },
     Compilation: {

--- a/packages/truffle-db/src/workspace/schema.ts
+++ b/packages/truffle-db/src/workspace/schema.ts
@@ -423,8 +423,9 @@ export const schema = mergeSchemas({
           workspace.projectsAdd({ input })
       },
       projectNamesAssign: {
-        resolve: (_, { input }, { workspace }) =>
-          workspace.projectNamesAssign({ input })
+        resolve: (_, { input }, { workspace }) => {
+          return workspace.projectNamesAssign({ input });
+        }
       }
     },
     Named: {
@@ -450,6 +451,9 @@ export const schema = mergeSchemas({
               return null;
           }
         }
+      },
+      previous: {
+        resolve: ({ id }, _, { workspace }) => workspace.nameRecord({ id })
       }
     },
     Project: {

--- a/packages/truffle-db/src/workspace/test/projects.graphql.ts
+++ b/packages/truffle-db/src/workspace/test/projects.graphql.ts
@@ -9,12 +9,63 @@ export const GetProject = gql`
   }
 `;
 
+export const LookupNames = gql`
+  query LookupNames(
+    $projectId: ID!
+    $networkName: String!
+    $contractName: String!
+  ) {
+    project(id: $projectId) {
+      network(name: $networkName) {
+        name
+      }
+      contract(name: $contractName) {
+        name
+      }
+    }
+  }
+`;
+
 export const AddProject = gql`
   mutation AddProject($directory: String!) {
     projectsAdd(input: { projects: [{ directory: $directory }] }) {
       projects {
         directory
         id
+      }
+    }
+  }
+`;
+
+export const AssignProjectName = gql`
+  mutation AssignProjectName(
+    $projectId: ID!
+    $name: String!
+    $type: String!
+    $nameRecordId: ID!
+  ) {
+    projectNamesAssign(
+      input: {
+        projectNames: [
+          {
+            project: { id: $projectId }
+            name: $name
+            type: $type
+            nameRecord: { id: $nameRecordId }
+          }
+        ]
+      }
+    ) {
+      projectNames {
+        project {
+          id
+        }
+        nameRecord {
+          resource {
+            name
+            id
+          }
+        }
       }
     }
   }

--- a/packages/truffle-db/src/workspace/test/projects.spec.ts
+++ b/packages/truffle-db/src/workspace/test/projects.spec.ts
@@ -1,5 +1,10 @@
 import { generateId, Migrations, WorkspaceClient } from "./utils";
-import { AddProject, GetProject } from "./projects.graphql";
+import {
+  GetProject,
+  LookupNames,
+  AddProject,
+  AssignProjectName
+} from "./projects.graphql";
 import { AddNetworks } from "./network.graphql";
 import { AddNameRecord } from "./nameRecord.graphql";
 import { AddContracts } from "./contract.graphql";
@@ -8,6 +13,10 @@ describe("Project", () => {
   let wsClient;
   let projectId;
   let addProjectResult;
+  let addNetworkId;
+  let addContractId;
+  let projectNamesAssignNetworkResult;
+  let projectNamesAssignContractResult;
 
   beforeAll(async () => {
     wsClient = new WorkspaceClient();
@@ -17,6 +26,73 @@ describe("Project", () => {
     });
 
     projectId = addProjectResult.projectsAdd.projects[0].id;
+
+    // add network and network name record
+    let addNetworkResult = await wsClient.execute(AddNetworks, {
+      name: "ganache",
+      networkId: Object.keys(Migrations.networks)[0],
+      height: 1,
+      hash: "0xcba0b90a5e65512202091c12a2e3b328f374715b9f1c8f32cb4600c726fe2aa6"
+    });
+
+    addNetworkId = addNetworkResult.networksAdd.networks[0].id;
+
+    let addNetworkNameRecordResult = await wsClient.execute(AddNameRecord, {
+      name: "ganache",
+      type: "Network",
+      resource: {
+        id: addNetworkId
+      }
+    });
+
+    let addNetworkNameRecordId =
+      addNetworkNameRecordResult.nameRecordsAdd.nameRecords[0].id;
+
+    //add name records to project
+    const networkVariables = {
+      projectId,
+      name: "ganache",
+      type: "Network",
+      nameRecordId: addNetworkNameRecordId
+    };
+
+    projectNamesAssignNetworkResult = await wsClient.execute(
+      AssignProjectName,
+      networkVariables
+    );
+
+    // add contract and contract name record
+    let addContractResult = await wsClient.execute(AddContracts, {
+      contractName: "Migrations",
+      compilationId: "123",
+      bytecodeId: "1234",
+      abi: JSON.stringify(Migrations.abi)
+    });
+
+    addContractId = addContractResult.contractsAdd.contracts[0].id;
+
+    let addContractNameRecordResult = await wsClient.execute(AddNameRecord, {
+      name: "Migrations",
+      type: "Contract",
+      resource: {
+        id: addContractId
+      }
+    });
+
+    let addContractNameRecordId =
+      addContractNameRecordResult.nameRecordsAdd.nameRecords[0].id;
+
+    const contractVariables = {
+      projectId,
+      name: "Migrations",
+      type: "Contract",
+      nameRecordId: addContractNameRecordId
+    };
+
+    projectNamesAssignContractResult = await wsClient.execute(
+      AssignProjectName,
+      contractVariables
+    );
   });
 
   test("can be added", async () => {
@@ -26,6 +102,40 @@ describe("Project", () => {
     expect(projects).toHaveLength(1);
     const project = projects[0];
     expect(project.directory).toEqual("test/path");
+  });
+
+  test("can be updated with project names", async () => {
+    {
+      // network
+      expect(projectNamesAssignNetworkResult).toHaveProperty(
+        "projectNamesAssign"
+      );
+      const { projectNamesAssign } = projectNamesAssignNetworkResult;
+      expect(projectNamesAssign).toHaveProperty("projectNames");
+      const { projectNames } = projectNamesAssign;
+      const projectName = projectNames[0];
+      expect(projectName).toHaveProperty("project");
+      expect(projectName).toHaveProperty("nameRecord");
+      const { project, nameRecord } = projectName;
+      expect(nameRecord.resource.name).toEqual("ganache");
+      expect(nameRecord.resource.id).toEqual(addNetworkId);
+    }
+
+    {
+      // contract
+      expect(projectNamesAssignContractResult).toHaveProperty(
+        "projectNamesAssign"
+      );
+      const { projectNamesAssign } = projectNamesAssignContractResult;
+      expect(projectNamesAssign).toHaveProperty("projectNames");
+      const { projectNames } = projectNamesAssign;
+      const projectName = projectNames[0];
+      expect(projectName).toHaveProperty("project");
+      expect(projectName).toHaveProperty("nameRecord");
+      const { project, nameRecord } = projectName;
+      expect(nameRecord.resource.name).toEqual("Migrations");
+      expect(nameRecord.resource.id).toEqual(addContractId);
+    }
   });
 
   test("can be queried", async () => {
@@ -42,5 +152,23 @@ describe("Project", () => {
 
     expect(project.id).toEqual(expectedId);
     expect(project.directory).toEqual("test/path");
+  });
+
+  test("can be used to lookup names", async () => {
+    const executionResult = await wsClient.execute(LookupNames, {
+      projectId,
+      networkName: "ganache",
+      contractName: "Migrations"
+    });
+
+    expect(executionResult).toHaveProperty("project");
+    const { project } = executionResult;
+
+    expect(project).toHaveProperty("network");
+    expect(project).toHaveProperty("contract");
+    const { network, contract } = project;
+
+    expect(network.name).toEqual("ganache");
+    expect(contract.name).toEqual("Migrations");
   });
 });

--- a/packages/truffle-db/types/stub.d.ts
+++ b/packages/truffle-db/types/stub.d.ts
@@ -29,6 +29,8 @@ declare namespace DataModel {
   type INetworksAddInput = any;
   type IProject = any;
   type IProjectsAddInput = any;
+  type IProjectName = any;
+  type IProjectNameInput = any;
   type ISource = any;
   type ISourceInput = any;
   type ISourceRange = any;


### PR DESCRIPTION
- Expand workspace databases with support for mutable collections
- Define projectNames mutable collection
- Add queries to resolve current name
- Add mutation to assign current names
- Ensure loader assigns names based on previously current names

Thanks to @fainashalts for much of this work :)