### PR TITLE
Dependency Upgrade: ganache-core@2.9.2

### DIFF
--- a/packages/artifactor/package.json
+++ b/packages/artifactor/package.json
@@ -24,7 +24,7 @@
     "@types/node": "^12.6.2",
     "chai": "4.2.0",
     "debug": "^4.1.1",
-    "ganache-core": "2.8.0",
+    "ganache-core": "2.9.2",
     "mocha": "5.2.0",
     "require-nocache": "^1.0.0",
     "temp": "^0.8.3",

--- a/packages/compile-solidity/compilerSupplier/index.js
+++ b/packages/compile-solidity/compilerSupplier/index.js
@@ -7,7 +7,7 @@ const { Docker, Local, Native, VersionRange } = require("./loadingStrategies");
 class CompilerSupplier {
   constructor({ events, solcConfig }) {
     const { version, docker, compilerRoots, parser } = solcConfig;
-    const defaultSolcVersion = "0.5.12";
+    const defaultSolcVersion = "0.5.16";
     this.events = events;
     this.parser = parser;
     this.version = version ? version : defaultSolcVersion;

--- a/packages/contract-schema/package.json
+++ b/packages/contract-schema/package.json
@@ -1,28 +1,24 @@
 {
   "name": "@truffle/contract-schema",
-  "version": "3.0.20",
   "description": "JSON schema for contract artifacts",
-  "main": "index.js",
-  "typings": "./typings/index.d.ts",
-  "scripts": {
-    "prepare": "yarn run build",
-    "build": "./scripts/generate-declarations",
-    "test": "mocha"
-  },
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/contract-schema",
-  "keywords": [
-    "ethereum",
-    "json",
-    "schema",
-    "contract",
-    "artifacts"
-  ],
-  "author": "Tim Coulter <tim@trufflesuite.com>",
   "license": "MIT",
+  "author": "Tim Coulter <tim@trufflesuite.com>",
+  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/contract-schema#readme",
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/contract-schema",
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"
   },
-  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/contract-schema#readme",
+  "version": "3.0.20",
+  "main": "index.js",
+  "directories": {
+    "spec": "./spec"
+  },
+  "scripts": {
+    "build": "./scripts/generate-declarations",
+    "prepare": "yarn run build",
+    "test": "mocha"
+  },
+  "typings": "./typings/index.d.ts",
   "dependencies": {
     "ajv": "^6.10.0",
     "crypto-js": "^3.1.9-1",
@@ -31,11 +27,15 @@
   "devDependencies": {
     "json-schema-to-typescript": "^5.5.0",
     "mocha": "5.2.0",
-    "solc": "0.5.12"
+    "solc": "0.5.16"
   },
-  "directories": {
-    "spec": "./spec"
-  },
+  "keywords": [
+    "artifacts",
+    "contract",
+    "ethereum",
+    "json",
+    "schema"
+  ],
   "publishConfig": {
     "access": "public"
   }

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -37,7 +37,7 @@
     "browserify": "^14.0.0",
     "chai": "4.2.0",
     "debug": "^4.1.0",
-    "ganache-core": "2.8.0",
+    "ganache-core": "2.9.2",
     "mocha": "5.2.0",
     "sinon": "^7.3.2",
     "temp": "^0.8.3",

--- a/packages/contract/test/deploy.js
+++ b/packages/contract/test/deploy.js
@@ -214,9 +214,10 @@ describe("Deployments", function() {
       Example.autoGas = true;
     });
 
+    // Constructor in this test consumes ~6388773 (ganache) vs blockLimit of 6721975.
     it("should not multiply past the blockLimit", async function() {
       this.timeout(50000);
-      let iterations = 1000; // # of times to set a uint in a loop, consuming gas.
+      let iterations = 6000; // # of times to set a uint in a loop, consuming gas.
 
       const estimate = await Example.new.estimateGas(iterations);
       const block = await web3.eth.getBlock("latest");
@@ -224,8 +225,8 @@ describe("Deployments", function() {
 
       assert(multiplier === 1.25, "Multiplier should be initialized to 1.25");
       assert(
-        multiplier * estimate < block.gasLimit,
-        "Multiplied estimate should not be higher than the blockLimit"
+        multiplier * estimate > block.gasLimit,
+        "Multiplied estimate should be too high"
       );
       assert(estimate < block.gasLimit, "Estimate on it's own should be ok");
 

--- a/packages/contract/test/deploy.js
+++ b/packages/contract/test/deploy.js
@@ -214,7 +214,6 @@ describe("Deployments", function() {
       Example.autoGas = true;
     });
 
-    // Constructor in this test consumes ~6437823 (ganache) vs blockLimit of 6721975.
     it("should not multiply past the blockLimit", async function() {
       this.timeout(50000);
       let iterations = 1000; // # of times to set a uint in a loop, consuming gas.
@@ -225,8 +224,8 @@ describe("Deployments", function() {
 
       assert(multiplier === 1.25, "Multiplier should be initialized to 1.25");
       assert(
-        multiplier * estimate > block.gasLimit,
-        "Multiplied estimate should be too high"
+        multiplier * estimate < block.gasLimit,
+        "Multiplied estimate should not be higher than the blockLimit"
       );
       assert(estimate < block.gasLimit, "Estimate on it's own should be ok");
 

--- a/packages/contract/test/errors.js
+++ b/packages/contract/test/errors.js
@@ -231,7 +231,7 @@ describe("Client appends errors (vmErrorsOnRPCResponse)", function() {
     // NB: this error is different than the `invalid` opcode error
     // produced when the vmErrors flag is on.
     it("errors with OOG on internal OOG", async function() {
-      this.timeout(10000);
+      this.timeout(40000);
 
       const example = await Example.new(1);
       try {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,7 +50,7 @@
     "ethpm": "0.0.16",
     "ethpm-registry": "0.1.0-next.3",
     "fs-extra": "6.0.1",
-    "ganache-core": "2.8.0",
+    "ganache-core": "2.9.2",
     "glob": "^7.1.4",
     "hdkey": "^1.1.0",
     "mkdirp": "^0.5.1",

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -59,7 +59,7 @@
     "express": "^4.16.2",
     "faker": "^4.1.0",
     "fs-extra": "6.0.1",
-    "ganache-core": "2.8.0",
+    "ganache-core": "2.9.2",
     "istanbul-instrumenter-loader": "^3.0.1",
     "mocha": "5.2.0",
     "mocha-webpack": "^1.1.0",

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@truffle/reporters": "^1.0.18",
     "@truffle/workflow-compile": "^2.1.17",
-    "ganache-core": "2.8.0",
+    "ganache-core": "2.9.2",
     "mocha": "5.2.0",
     "sinon": "^7.3.2",
     "web3": "1.2.1"

--- a/packages/deployer/test/errors.js
+++ b/packages/deployer/test/errors.js
@@ -181,7 +181,7 @@ describe("Error cases", function() {
   });
 
   it("OOG (w/ estimate, hits block limit)", async function() {
-    this.timeout(30000);
+    this.timeout(100000);
 
     const migrate = function() {
       deployer.deploy(Loops);
@@ -213,8 +213,9 @@ describe("Error cases", function() {
       assert.fail();
     } catch (err) {
       assert(err.message.includes("Loops"));
-      assert(err.message.includes("code couldn't be stored"));
-      assert(err.message.includes("check your gas limit"));
+      assert(err.message.includes("out of gas"));
+      assert(err.message.includes("Gas sent"));
+      assert(err.message.includes("Block limit"));
     }
   });
 

--- a/packages/environment/package.json
+++ b/packages/environment/package.json
@@ -17,7 +17,7 @@
     "@truffle/expect": "^0.0.13",
     "@truffle/interface-adapter": "^0.4.2",
     "@truffle/resolver": "^5.0.25",
-    "ganache-core": "2.8.0",
+    "ganache-core": "2.9.2",
     "node-ipc": "^9.1.1",
     "web3": "1.2.1"
   },

--- a/packages/hdwallet-provider/package.json
+++ b/packages/hdwallet-provider/package.json
@@ -34,7 +34,7 @@
     "@types/ethereumjs-util": "^5.2.0",
     "@types/mocha": "^5.2.7",
     "@types/web3-provider-engine": "^14.0.0",
-    "ganache-core": "2.8.0",
+    "ganache-core": "2.9.2",
     "mocha": "6.2.0",
     "ts-node": "^8.4.1",
     "typescript": "^3.6.3"

--- a/packages/interface-adapter/package.json
+++ b/packages/interface-adapter/package.json
@@ -30,7 +30,7 @@
     "@types/lodash": "^4.14.136",
     "@types/mocha": "^5.2.6",
     "@types/web3": "1.0.19",
-    "ganache-core": "2.8.0",
+    "ganache-core": "2.9.2",
     "mocha": "^6.0.2",
     "ts-node": "^8.0.3",
     "typescript": "^3.6.3"

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -20,7 +20,7 @@
     "web3": "1.2.1"
   },
   "devDependencies": {
-    "ganache-core": "2.8.0",
+    "ganache-core": "2.9.2",
     "mocha": "5.2.0"
   },
   "keywords": [

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -40,7 +40,7 @@
     "copy-webpack-plugin": "^4.0.1",
     "eslint": "^5.7.0",
     "fs-extra": "6.0.1",
-    "ganache-core": "2.8.0",
+    "ganache-core": "2.9.2",
     "glob": "^7.1.2",
     "husky": "^1.1.2",
     "js-scrypt": "^0.2.0",

--- a/packages/truffle/scripts/postinstall.js
+++ b/packages/truffle/scripts/postinstall.js
@@ -2,16 +2,16 @@ const { statSync } = require("fs");
 const { execSync } = require("child_process");
 
 const bundledCLI = "./build/cli.bundled.js";
-const defaultSolc = "0.5.8";
+const defaultSolcVersion = "0.5.16";
 
 const postinstallObtain = () => {
   try {
     statSync(bundledCLI);
-    execSync(`node ${bundledCLI} obtain --solc=${defaultSolc}`);
+    execSync(`node ${bundledCLI} obtain --solc=${defaultSolcVersion}`);
   } catch ({ message }) {
     if (message.includes("no such file")) return;
     throw new Error(
-      `Error while attempting to download and cache solc ${defaultSolc}: ${message}`
+      `Error while attempting to download and cache solc ${defaultSolcVersion}: ${message}`
     );
   }
 };

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -10,7 +10,7 @@ run_geth() {
     -p 8545:8545 \
     -p 8546:8546 \
     -p 30303:30303 \
-    ethereum/client-go:v1.9.3 \
+    ethereum/client-go:latest \
     --rpc \
     --rpcaddr '0.0.0.0' \
     --rpcport 8545 \
@@ -35,7 +35,7 @@ if [ "$INTEGRATION" = true ]; then
 elif [ "$GETH" = true ]; then
 
   sudo apt install -y jq
-  docker pull ethereum/client-go:v1.9.3
+  docker pull ethereum/client-go:latest
   run_geth
   sleep 30
   lerna run --scope truffle test --stream -- --exit

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -23,6 +23,7 @@ run_geth() {
     --dev.period 0 \
     --allow-insecure-unlock \
     --targetgaslimit '7000000' \
+    --override.istanbul '0' \
     js ./scripts/geth-accounts.js \
     > /dev/null &
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13652,19 +13652,19 @@ socks@~2.3.2:
     ip "1.1.5"
     smart-buffer "^4.1.0"
 
-solc@0.5.12:
-  version "0.5.12"
-  resolved "https://registry.yarnpkg.com/solc/-/solc-0.5.12.tgz#e63047dce04c82ec6f469f6e28febfbde713b808"
-  integrity sha512-OX/AGZT04tuUsagoVXSZBiBZYJReA02hdwZOfRkB03/eeYP9Dl3pr+M+au+1MhssgiuWBlFPN7sRXFiqwkAW2g==
+solc@0.5.16:
+  version "0.5.16"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.5.16.tgz#6c8d710a3792ccc79db924606b558a1149b1c603"
+  integrity sha512-weEtRtisJyf+8UjELs7S4ST1KK7UIq6SRB7tpprfJBL9b5mTrZAT7m4gJKi2h6MiBpuSWfnraK8BnkyWzuTMRA==
   dependencies:
     command-exists "^1.2.8"
+    commander "3.0.2"
     fs-extra "^0.30.0"
     js-sha3 "0.8.0"
     memorystream "^0.3.1"
     require-from-string "^2.0.0"
     semver "^5.5.0"
     tmp "0.0.33"
-    yargs "^13.2.0"
 
 solc@^0.4.20:
   version "0.4.26"
@@ -16540,7 +16540,7 @@ yargs@13.2.4:
     y18n "^4.0.0"
     yargs-parser "^13.1.0"
 
-yargs@13.3.0, yargs@^13.2.0, yargs@^13.3.0:
+yargs@13.3.0, yargs@^13.3.0:
   version "13.3.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.0.tgz#4c657a55e07e5f2cf947f8a366567c04a0dedc83"
   integrity sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4208,6 +4208,11 @@ copy-webpack-plugin@^4.0.1:
     p-limit "^1.0.0"
     serialize-javascript "^1.4.0"
 
+core-js-pure@^3.0.1:
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.4.tgz#4bf1ba866e25814f149d4e9aaa08c36173506e3a"
+  integrity sha512-epIhRLkXdgv32xIUFaaAry2wdxZYBi6bgM7cB136dzzXXa+dFyRLTZeLUJxnd8ShrmyVXBub63n2NHo2JAt8Cw==
+
 core-js@^2.4.0, core-js@^2.5.0, core-js@^2.5.3, core-js@^2.6.5:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
@@ -5678,7 +5683,7 @@ ethereumjs-abi@0.6.7:
     bn.js "^4.11.8"
     ethereumjs-util "^6.0.0"
 
-ethereumjs-account@3.0.0:
+ethereumjs-account@3.0.0, ethereumjs-account@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ethereumjs-account/-/ethereumjs-account-3.0.0.tgz#728f060c8e0c6e87f1e987f751d3da25422570a9"
   integrity sha512-WP6BdscjiiPkQfF9PVfMcwx/rDvfZTjFKY0Uwc09zSQr9JfIVH87dYIJu0gNhBhpmovV4yq295fdllS925fnBA==
@@ -5696,14 +5701,14 @@ ethereumjs-account@^2.0.3:
     rlp "^2.0.0"
     safe-buffer "^5.1.1"
 
-ethereumjs-block@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/ethereumjs-block/-/ethereumjs-block-2.2.0.tgz#8c6c3ab4a5eff0a16d9785fbeedbe643f4dbcbef"
-  integrity sha512-Ye+uG/L2wrp364Zihdlr/GfC3ft+zG8PdHcRtsBFNNH1CkOhxOwdB8friBU85n89uRZ9eIMAywCq0F4CwT1wAw==
+ethereumjs-block@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/ethereumjs-block/-/ethereumjs-block-2.2.1.tgz#5fba423305b40ab6486a6b81922e5312b2667c8d"
+  integrity sha512-ze8I1844m5oKZL7hiHuezRcPzqdi4Iv0ssqQyuRaJ9Je0/YCYfXobJHvNLnex2ETgs5JypicdtLYrCNWdgcLvg==
   dependencies:
     async "^2.0.1"
     ethereumjs-common "^1.1.0"
-    ethereumjs-tx "^1.2.2"
+    ethereumjs-tx "^2.1.1"
     ethereumjs-util "^5.0.0"
     merkle-patricia-tree "^2.1.2"
 
@@ -5718,7 +5723,7 @@ ethereumjs-block@^1.2.2, ethereumjs-block@^1.4.1, ethereumjs-block@^1.6.0:
     ethereumjs-util "^5.0.0"
     merkle-patricia-tree "^2.1.2"
 
-ethereumjs-block@~2.2.0:
+ethereumjs-block@^2.2.1, ethereumjs-block@~2.2.0, ethereumjs-block@~2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/ethereumjs-block/-/ethereumjs-block-2.2.2.tgz#c7654be7e22df489fda206139ecd63e2e9c04965"
   integrity sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==
@@ -5729,21 +5734,26 @@ ethereumjs-block@~2.2.0:
     ethereumjs-util "^5.0.0"
     merkle-patricia-tree "^2.1.2"
 
-ethereumjs-blockchain@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/ethereumjs-blockchain/-/ethereumjs-blockchain-3.4.0.tgz#92240da6ecd86b3d8d324df69510b381f26c966b"
-  integrity sha512-wxPSmt6EQjhbywkFbftKcb0qRFIZWocHMuDa8/AB4eWL/UPYalNcDyLaxYbrDytmhHid3Uu8G/tA3C/TxZBuOQ==
+ethereumjs-blockchain@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/ethereumjs-blockchain/-/ethereumjs-blockchain-4.0.3.tgz#e013034633a30ad2006728e8e2b21956b267b773"
+  integrity sha512-0nJWbyA+Gu0ZKZr/cywMtB/77aS/4lOVsIKbgUN2sFQYscXO5rPbUfrEe7G2Zhjp86/a0VqLllemDSTHvx3vZA==
   dependencies:
     async "^2.6.1"
     ethashjs "~0.0.7"
-    ethereumjs-block "~2.2.0"
-    ethereumjs-common "^1.1.0"
-    ethereumjs-util "~6.0.0"
+    ethereumjs-block "~2.2.2"
+    ethereumjs-common "^1.5.0"
+    ethereumjs-util "~6.1.0"
     flow-stoplight "^1.0.0"
     level-mem "^3.0.1"
     lru-cache "^5.1.1"
-    safe-buffer "^5.1.2"
+    rlp "^2.2.2"
     semaphore "^1.1.0"
+
+ethereumjs-common@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/ethereumjs-common/-/ethereumjs-common-1.4.0.tgz#a940685f88f3c2587e4061630fe720b089c965b8"
+  integrity sha512-ser2SAplX/YI5W2AnzU8wmSjKRy4KQd4uxInJ36BzjS3m18E/B9QedPUIresZN1CSEQb/RgNQ2gN7C/XbpTafA==
 
 ethereumjs-common@^1.1.0, ethereumjs-common@^1.3.1, ethereumjs-common@^1.3.2, ethereumjs-common@^1.5.0:
   version "1.5.0"
@@ -5757,15 +5767,7 @@ ethereumjs-testrpc@^6.0.3:
   dependencies:
     webpack "^3.0.0"
 
-ethereumjs-tx@1.3.7, ethereumjs-tx@^1.0.0, ethereumjs-tx@^1.1.1, ethereumjs-tx@^1.2.0, ethereumjs-tx@^1.2.2, ethereumjs-tx@^1.3.3:
-  version "1.3.7"
-  resolved "https://registry.yarnpkg.com/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz#88323a2d875b10549b8347e09f4862b546f3d89a"
-  integrity sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==
-  dependencies:
-    ethereum-common "^0.0.18"
-    ethereumjs-util "^5.0.0"
-
-ethereumjs-tx@^2.1.1:
+ethereumjs-tx@2.1.1, ethereumjs-tx@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ethereumjs-tx/-/ethereumjs-tx-2.1.1.tgz#7d204e2b319156c9bc6cec67e9529424a26e8ccc"
   integrity sha512-QtVriNqowCFA19X9BCRPMgdVNJ0/gMBS91TQb1DfrhsbR748g4STwxZptFAwfqehMyrF8rDwB23w87PQwru0wA==
@@ -5773,7 +5775,15 @@ ethereumjs-tx@^2.1.1:
     ethereumjs-common "^1.3.1"
     ethereumjs-util "^6.0.0"
 
-ethereumjs-util@6.1.0:
+ethereumjs-tx@^1.0.0, ethereumjs-tx@^1.1.1, ethereumjs-tx@^1.2.0, ethereumjs-tx@^1.2.2, ethereumjs-tx@^1.3.3:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz#88323a2d875b10549b8347e09f4862b546f3d89a"
+  integrity sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==
+  dependencies:
+    ethereum-common "^0.0.18"
+    ethereumjs-util "^5.0.0"
+
+ethereumjs-util@6.1.0, ethereumjs-util@~6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz#e9c51e5549e8ebd757a339cc00f5380507e799c8"
   integrity sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==
@@ -5823,36 +5833,26 @@ ethereumjs-util@^6.0.0, ethereumjs-util@^6.1.0:
     rlp "^2.2.3"
     secp256k1 "^3.0.1"
 
-ethereumjs-util@~6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-6.0.0.tgz#f14841c182b918615afefd744207c7932c8536c0"
-  integrity sha512-E3yKUyl0Fs95nvTFQZe/ZSNcofhDzUsDlA5y2uoRmf1+Ec7gpGhNCsgKkZBRh7Br5op8mJcYF/jFbmjj909+nQ==
-  dependencies:
-    bn.js "^4.11.0"
-    create-hash "^1.1.2"
-    ethjs-util "^0.1.6"
-    keccak "^1.0.2"
-    rlp "^2.0.0"
-    safe-buffer "^5.1.1"
-    secp256k1 "^3.0.1"
-
-ethereumjs-vm@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ethereumjs-vm/-/ethereumjs-vm-3.0.0.tgz#70fea2964a6797724b0d93fe080f9984ad18fcdd"
-  integrity sha512-lNu+G/RWPRCrQM5s24MqgU75PEGiAhL4Ombw0ew6m08d+amsxf/vGAb98yDNdQqqHKV6JbwO/tCGfdqXGI6Cug==
+ethereumjs-vm@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ethereumjs-vm/-/ethereumjs-vm-4.1.1.tgz#ba6f565fd7788a0e7db494fa2096d45f9ea0802b"
+  integrity sha512-Bh2avDY9Hyon9TvJ/fmkdyd5JDnmTudLJ5oKhmTfXn0Jjq7UzP4YRNp7e5PWoWXSmdXAGXU9W0DXK5TV9Qy/NQ==
   dependencies:
     async "^2.1.2"
     async-eventemitter "^0.2.2"
-    ethereumjs-account "^2.0.3"
-    ethereumjs-block "~2.2.0"
-    ethereumjs-blockchain "^3.4.0"
-    ethereumjs-common "^1.1.0"
-    ethereumjs-util "^6.0.0"
+    core-js-pure "^3.0.1"
+    ethereumjs-account "^3.0.0"
+    ethereumjs-block "^2.2.1"
+    ethereumjs-blockchain "^4.0.2"
+    ethereumjs-common "^1.3.2"
+    ethereumjs-tx "^2.1.1"
+    ethereumjs-util "~6.1.0"
     fake-merkle-patricia-tree "^1.0.1"
     functional-red-black-tree "^1.0.1"
     merkle-patricia-tree "^2.3.2"
     rustbn.js "~0.2.0"
     safe-buffer "^5.1.1"
+    util.promisify "^1.0.0"
 
 ethereumjs-vm@^2.1.0, ethereumjs-vm@^2.3.4, ethereumjs-vm@^2.6.0:
   version "2.6.0"
@@ -5925,7 +5925,7 @@ ethjs-unit@0.1.6:
     bn.js "4.11.6"
     number-to-bn "1.7.0"
 
-ethjs-util@0.1.6, ethjs-util@^0.1.3, ethjs-util@^0.1.6:
+ethjs-util@0.1.6, ethjs-util@^0.1.3:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/ethjs-util/-/ethjs-util-0.1.6.tgz#f308b62f185f9fe6237132fb2a9818866a5cd536"
   integrity sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==
@@ -6794,10 +6794,10 @@ ganache-cli@^6.1.0:
     source-map-support "0.5.12"
     yargs "13.2.4"
 
-ganache-core@2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/ganache-core/-/ganache-core-2.8.0.tgz#eeadc7f7fc3a0c20d99f8f62021fb80b5a05490c"
-  integrity sha512-hfXqZGJx700jJqwDHNXrU2BnPYuETn1ekm36oRHuXY3oOuJLFs5C+cFdUFaBlgUxcau1dOgZUUwKqTAy0gTA9Q==
+ganache-core@2.9.2:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/ganache-core/-/ganache-core-2.9.2.tgz#1c7516f785669f35edac9ffaa40c3ece2749bf50"
+  integrity sha512-+BHzLDpickuq/f147ryoHClzSG7P9DfiOfwntEHbXFbfsLvmGCbE3TiKwwWkcVoiBdkN8ybyElWE0QoYe3/LOA==
   dependencies:
     abstract-leveldown "3.0.0"
     async "2.6.2"
@@ -6809,10 +6809,11 @@ ganache-core@2.8.0:
     eth-sig-util "2.3.0"
     ethereumjs-abi "0.6.7"
     ethereumjs-account "3.0.0"
-    ethereumjs-block "2.2.0"
-    ethereumjs-tx "1.3.7"
+    ethereumjs-block "2.2.1"
+    ethereumjs-common "1.4.0"
+    ethereumjs-tx "2.1.1"
     ethereumjs-util "6.1.0"
-    ethereumjs-vm "3.0.0"
+    ethereumjs-vm "4.1.1"
     heap "0.2.6"
     level-sublevel "6.6.4"
     levelup "3.1.1"
@@ -6825,7 +6826,7 @@ ganache-core@2.8.0:
     websocket "1.0.29"
   optionalDependencies:
     ethereumjs-wallet "0.6.3"
-    web3 "1.2.1"
+    web3 "1.2.4"
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -10708,7 +10709,7 @@ nan@2.13.2:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.13.2.tgz#f51dc7ae66ba7d5d55e1e6d4d8092e802c9aefe7"
   integrity sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==
 
-nan@^2.0.8, nan@^2.11.0, nan@^2.12.1, nan@^2.14.0, nan@^2.2.1:
+nan@^2.0.8, nan@^2.12.1, nan@^2.14.0, nan@^2.2.1:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
@@ -12965,7 +12966,7 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rlp@^2.0.0, rlp@^2.2.1, rlp@^2.2.3:
+rlp@^2.0.0, rlp@^2.2.1, rlp@^2.2.2, rlp@^2.2.3:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/rlp/-/rlp-2.2.4.tgz#d6b0e1659e9285fc509a5d169a9bd06f704951c1"
   integrity sha512-fdq2yYCWpAQBhwkZv+Z8o/Z4sPmYm1CUq6P7n6lVTOdb949CnqA0sndXal5C1NleSVSZm6q5F3iEbauyVln/iw==
@@ -15240,6 +15241,14 @@ util-promisify@^2.1.0:
   dependencies:
     object.getownpropertydescriptors "^2.0.3"
 
+util.promisify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.0.0.tgz#440f7165a459c9a16dc145eb8e72f35687097030"
+  integrity sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==
+  dependencies:
+    define-properties "^1.1.2"
+    object.getownpropertydescriptors "^2.0.3"
+
 util@0.10.3:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
@@ -15984,7 +15993,7 @@ web3@1.2.1:
     web3-shh "1.2.1"
     web3-utils "1.2.1"
 
-web3@^1.0.0-beta.34:
+web3@1.2.4, web3@^1.0.0-beta.34:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/web3/-/web3-1.2.4.tgz#6e7ab799eefc9b4648c2dab63003f704a1d5e7d9"
   integrity sha512-xPXGe+w0x0t88Wj+s/dmAdASr3O9wmA9mpZRtixGZxmBexAF0MjfqYM+MS4tVl5s11hMTN3AZb8cDD4VLfC57A==
@@ -16098,18 +16107,7 @@ webpack@^3.0.0, webpack@^3.12.0, webpack@^3.8.1:
     webpack-sources "^1.0.1"
     yargs "^8.0.2"
 
-websocket@1.0.29:
-  version "1.0.29"
-  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.29.tgz#3f83e49d3279657c58b02a22d90749c806101b98"
-  integrity sha512-WhU8jKXC8sTh6ocLSqpZRlOKMNYGwUvjA5+XcIgIk/G3JCaDfkZUr0zA19sVSxJ0TEvm0i5IBzr54RZC4vzW7g==
-  dependencies:
-    debug "^2.2.0"
-    gulp "^4.0.2"
-    nan "^2.11.0"
-    typedarray-to-buffer "^3.1.5"
-    yaeti "^0.0.6"
-
-"websocket@github:web3-js/WebSocket-Node#polyfill/globalThis":
+websocket@1.0.29, "websocket@github:web3-js/WebSocket-Node#polyfill/globalThis":
   version "1.0.29"
   resolved "https://codeload.github.com/web3-js/WebSocket-Node/tar.gz/905deb4812572b344f5801f8c9ce8bb02799d82e"
   dependencies:


### PR DESCRIPTION
This PR brings truffle's defaults up to ~latest Ethereum mainnet~ Istanbul (Muir Glaicier is latest).

Truffle will now spin up `ganache-core` using the `istanbul` hardfork by default.
Truffle will also postinstall & invoke `solc@0.5.16` which targets `istanbul` by default.

Also upgrades a `truffle@contract-schema`'s `solc` devDep to 0.5.16.