### PR TITLE
Add missing decoder dependency in core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,7 @@
     "@truffle/contract-sources": "^0.1.7",
     "@truffle/debug-utils": "^2.1.5",
     "@truffle/debugger": "^6.1.5",
+    "@truffle/decoder": "^4.0.6",
     "@truffle/deployer": "^3.1.5",
     "@truffle/environment": "^0.1.25",
     "@truffle/error": "^0.0.8",


### PR DESCRIPTION
It looks like when I put the new decoder in `truffle test`, I forgot to ever actually add it as a dependency of `core`, yikes!  This PR does that.