### PR TITLE
Downgrade semver to v6 to fix #2732

### DIFF
--- a/packages/codec/package.json
+++ b/packages/codec/package.json
@@ -59,7 +59,7 @@
     "lodash.escaperegexp": "^4.1.2",
     "lodash.partition": "^4.6.0",
     "lodash.sum": "^4.0.2",
-    "semver": "^6.1.1",
+    "semver": "^6.3.0",
     "source-map-support": "^0.5.13",
     "utf8": "^3.0.0",
     "web3-utils": "1.2.1"

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -34,7 +34,7 @@
     "redux-saga": "1.0.0",
     "remote-redux-devtools": "^0.5.12",
     "reselect-tree": "^1.3.1",
-    "semver": "^7.1.1",
+    "semver": "^6.3.0",
     "web3": "1.2.1",
     "web3-eth-abi": "1.2.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -13250,15 +13250,10 @@ semver@6.2.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.2.0.tgz#4d813d9590aaf8a9192693d6c85b9344de5901db"
   integrity sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==
 
-semver@^6.0.0, semver@^6.1.1, semver@^6.2.0, semver@^6.3.0:
+semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-
-semver@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.1.tgz#29104598a197d6cbe4733eeecbe968f7b43a9667"
-  integrity sha512-WfuG+fl6eh3eZ2qAf6goB7nhiCd7NPXhmyFxigB/TOkQyeLP8w8GsVehvtGNtnNmyboz4TgeK40B1Kbql/8c5A==
 
 semver@~5.4.1:
   version "5.4.1"


### PR DESCRIPTION
This PR downgrades semver from v7 to v6, because v7 isn't compatible with webpack (this is a [known issue](https://github.com/npm/node-semver/issues/306), apparently).  This should fix #2732.

(I also upgraded one case of 6.1.1 to 6.3.0, because why not.)