### PR TITLE
Make `lerna bootstrap` work on Windows.

### DIFF
--- a/packages/contract-schema/package.json
+++ b/packages/contract-schema/package.json
@@ -14,7 +14,7 @@
     "spec": "./spec"
   },
   "scripts": {
-    "build": "./scripts/generate-declarations",
+    "build": "sh ./scripts/generate-declarations",
     "prepare": "yarn run build",
     "test": "mocha"
   },


### PR DESCRIPTION
One script definition in the `contract-schema` package was preventing `lerna bootstrap` from completing successfully on Windows. 