### PR TITLE
Feature: add michelson to ContractObject Schema

### DIFF
--- a/packages/contract-schema/README.md
+++ b/packages/contract-schema/README.md
@@ -7,7 +7,7 @@
 
 [@truffle/contract](https://github.com/trufflesuite/truffle/tree/develop/packages/contract) uses a
 formally specified<sup>[1](#footnote-1)</sup> JSON object format to represent
-Ethereum Virtual Machine (EVM) smart contracts. This representation is intended
+supported smart contracts. This representation is intended
 to facilitate the use of general purpose smart contract abstractions
 (such as @truffle/contract) by capturing relevant smart contract information in a
 persistent and portable manner.
@@ -32,8 +32,7 @@ with deployed contracts on-chain)
 
 <a name="footnote-1">1.</a> JSON Schema [http://json-schema.org](http://json-schema.org/)
 
-<a name="footnote-2">2.</a> Ethereum Contract JSON ABI [https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI#json](https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI#json)
-
+<a name="footnote-2">2.</a> Ethereum Contract JSON ABI [https://solidity.readthedocs.io/en/develop/abi-spec.html](https://solidity.readthedocs.io/en/develop/abi-spec.html). Note: Note: Tezos Contracts do not currently store a functional ABI.
 
 
 ## Properties
@@ -56,22 +55,31 @@ Name used to identify the contract. Semi-alphanumeric string.
 | JSON Schema | [abi.spec.json](spec/abi.spec.json) |
 | **required** |
 
+
 External programmatic description of contract's interface. The contract's ABI
 determines the means by which applications may interact with individual contract
 instances. Array of functions and events representing valid inputs and outputs
 for the instance.
 
 
-### `ast`
+### `metadata`
 
-| type | _object_ |
+| type | _string_ |
 | ---: | ---- |
 
-_not included in current version of this specification_
 
-Abstract Syntax Tree. A nested JSON object representation of contract source
-code, as output by compiler.
+Contract metadata. Stringified JSON.
 
+
+### `michelson`
+
+| type | _string_ |
+| ---: | ---- |
+
+
+Tezos instructions that run as part of a contract origination transaction.
+Constructor code for a new Tezos contract instance.
+Stringified array of JSON.
 
 
 ### `bytecode`
@@ -87,7 +95,6 @@ Specified as a hexadecimal string, may include `__`-prefixed (double underscore)
 link references.
 
 
-
 ### `deployedBytecode`
 
 | type | _string_ matching pattern `^0x0$\|^0x([a-fA-F0-9]{2}\|__.{38})+$` |
@@ -99,23 +106,6 @@ EVM instruction bytecode associated with contract that specifies behavior for
 incoming transactions/messages. Underlying implementation of ABI.
 Specified as a hexadecimal string, may include `__`-prefixed (double underscore)
 link references.
-
-
-### `source`
-
-| type | _string_ |
-| ---: | ---- |
-
-
-Uncompiled source code for contract. Text string.
-
-
-### `sourcePath`
-
-| type | _string_ |
-| ---: | ---- |
-
-File path for uncompiled source code.
 
 
 ### `sourceMap`
@@ -133,8 +123,96 @@ with origin statements in uncompiled `source`.
 | type | _string_ matching pattern `^[0-9;]*` |
 | ---: | ---- |
 
+
 Source mapping for `deployedBytecode`, pairing contract program data bytes
 with origin statements in uncompiled `source`.
+
+
+### `source`
+
+| type | _string_ |
+| ---: | ---- |
+
+
+Uncompiled source code for contract. Text string.
+
+
+### `sourcePath`
+
+| type | _string_ |
+| ---: | ---- |
+
+
+File path for uncompiled source code.
+
+
+### `ast`
+
+| type | _object_ |
+| ---: | ---- |
+
+
+_format not included in current version of this specification_
+
+Abstract Syntax Tree. A nested JSON object representation of contract source
+code, as output by compiler.
+
+
+### `legacyAST`
+
+| type | _object_ |
+| ---: | ---- |
+
+
+_format not included in current version of this specification_
+
+Legacy Abstract Syntax Tree. A nested JSON object representation of contract source
+code, as output by compiler.
+
+
+### `compiler`
+
+| type | _object_ |
+| ---: | ---- |
+
+
+Compiler information.
+
+
+### `name`
+
+| type | string |
+| ---: | ---- |
+
+
+Name of the compiler used.
+
+
+### `version`
+
+| type | string |
+| ---: | ---- |
+
+
+Version of the compiler used.
+
+
+### `networks`
+
+| type | _object_ |
+| ---: | ---- |
+
+
+Listing of contract instances. Object mapping network ID keys to network object
+values. Includes address information, links to other contract instances, and/or
+contract event logs.
+
+
+#### Properties (key matching `^[a-zA-Z0-9]+$`)
+
+| type | _object_ |
+| ---: | ---- |
+| ref | [Network Object](network-object.spec.md) |
 
 
 ### `schemaVersion`
@@ -142,8 +220,8 @@ with origin statements in uncompiled `source`.
 | type | _string_ matching pattern `[0-9]+\.[0-9]+\.[0-9]+` |
 | ---: | ---- |
 
-Version of this schema used by contract object representation.
 
+Version of this schema used by contract object representation.
 
 
 ### `updatedAt`
@@ -157,20 +235,31 @@ Time at which contract object representation was generated/most recently
 updated.
 
 
-### `networks`
+### `networkType`
 
-| type | _object_ |
+| type | string |
 | ---: | ---- |
 
-Listing of contract instances. Object mapping network ID keys to network object
-values. Includes address information, links to other contract instances, and/or
-contract event logs.
 
-#### Properties (key matching `^[a-zA-Z0-9]+$`)
+Specific blockchain network type targeted.
 
-| type | _object_ |
+
+### `devdoc`
+
+| type | string |
 | ---: | ---- |
-| ref | [Network Object](network-object.spec.md) |
+
+
+NatSpec developer documentation of the contract.
+
+
+### `userdoc`
+
+| type | string |
+| ---: | ---- |
+
+
+NatSpec user documentation of the contract.
 
 
 ## Custom Properties
@@ -180,20 +269,19 @@ contract event logs.
 | type | _string or number or object or array_ |
 | ---: | ---- |
 
+
 Objects following this schema may include additional properties with
 `x-`-prefixed keys.
 
 
-
 ## Definitions
-
-
 
 
 ### <a name="contract-object--bytecode">Bytecode</a>
 
 | type | _string_ matching pattern `^0x0$\|^0x([a-fA-F0-9]{2}\|__.{38})+$` |
 | ---: | ---- |
+
 
 `0x`-prefixed string representing compiled EVM machine language.
 

--- a/packages/contract-schema/README.md
+++ b/packages/contract-schema/README.md
@@ -239,6 +239,7 @@ updated.
 
 | type | string |
 | ---: | ---- |
+| default | `"ethereum"` |
 
 
 Specific blockchain network type targeted.

--- a/packages/contract-schema/index.js
+++ b/packages/contract-schema/index.js
@@ -63,6 +63,9 @@ var properties = {
   metadata: {
     sources: ["metadata"]
   },
+  michelson: {
+    sources: ["michelson"]
+  },
   bytecode: {
     sources: ["bytecode", "binary", "unlinked_binary", "evm.bytecode.object"],
     transform: function(value) {

--- a/packages/contract-schema/spec/contract-object.spec.json
+++ b/packages/contract-schema/spec/contract-object.spec.json
@@ -16,6 +16,10 @@
       "description": "Interface description returned by compiler for source"
     },
     "metadata": { "$ref": "#/definitions/Metadata" },
+    "michelson": {
+      "$ref": "#/definitions/Michelson",
+      "description": "Michelson sent as Tezos contract-creation transaction data"
+    },
     "bytecode": {
       "$ref": "#/definitions/Bytecode",
       "description": "Bytecode sent as contract-creation transaction data, with unresolved link references"
@@ -83,6 +87,10 @@
     },
 
     "Metadata": {
+      "type": "string"
+    },
+
+    "Michelson": {
       "type": "string"
     },
 

--- a/packages/contract-schema/spec/contract-object.spec.json
+++ b/packages/contract-schema/spec/contract-object.spec.json
@@ -3,7 +3,6 @@
   "$schema": "http://json-schema.org/schema#",
   "title": "Contract Object",
   "description": "Describes a contract consumable by Truffle, possibly including deployed instances on networks",
-
   "type": "object",
   "properties": {
     "contractName": {
@@ -15,7 +14,9 @@
       "$ref": "abi.spec.json#",
       "description": "Interface description returned by compiler for source"
     },
-    "metadata": { "$ref": "#/definitions/Metadata" },
+    "metadata": {
+      "$ref": "#/definitions/Metadata"
+    },
     "michelson": {
       "$ref": "#/definitions/Michelson",
       "description": "Michelson sent as Tezos contract-creation transaction data"
@@ -36,96 +37,118 @@
       "$ref": "#/definitions/SourceMap",
       "description": "Source mapping for contract bytecode"
     },
-    "source": { "$ref": "#/definitions/Source" },
-    "sourcePath": { "$ref": "#/definitions/SourcePath" },
-    "ast": { "$ref": "#/definitions/AST" },
-    "legacyAST": { "$ref": "#/definitions/LegacyAST" },
+    "source": {
+      "$ref": "#/definitions/Source"
+    },
+    "sourcePath": {
+      "$ref": "#/definitions/SourcePath"
+    },
+    "ast": {
+      "$ref": "#/definitions/AST"
+    },
+    "legacyAST": {
+      "$ref": "#/definitions/LegacyAST"
+    },
     "compiler": {
       "type": "object",
       "properties": {
-        "name": {"type": "string"},
-        "version": {"type": "string"}
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
       }
     },
     "networks": {
       "patternProperties": {
-        "^[a-zA-Z0-9]+$": { "$ref": "network-object.spec.json#" }
+        "^[a-zA-Z0-9]+$": {
+          "$ref": "network-object.spec.json#"
+        }
       },
       "additionalProperties": false
     },
-    "schemaVersion": { "$ref": "#/definitions/SchemaVersion" },
+    "schemaVersion": {
+      "$ref": "#/definitions/SchemaVersion"
+    },
     "updatedAt": {
       "type": "string",
       "format": "date-time"
     },
-    "networkType": { "$ref": "#/definitions/NetworkType" },
-    "devdoc": { "$ref": "#/definitions/NatSpec" },
-    "userdoc": { "$ref": "#/definitions/NatSpec" }
+    "networkType": {
+      "$ref": "#/definitions/NetworkType"
+    },
+    "devdoc": {
+      "$ref": "#/definitions/NatSpec"
+    },
+    "userdoc": {
+      "$ref": "#/definitions/NatSpec"
+    }
   },
   "required": [
     "abi"
   ],
   "patternProperties": {
-    "^x-": { "anyOf": [
-      { "type": "string" },
-      { "type": "boolean" },
-      { "type": "number" },
-      { "type": "object" },
-      { "type": "array" }
-    ]}
+    "^x-": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "object"
+        },
+        {
+          "type": "array"
+        }
+      ]
+    }
   },
   "additionalProperties": false,
-
   "definitions": {
     "ContractName": {
       "type": "string",
       "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$"
     },
-
     "NatSpec": {
       "type": "object"
     },
-
     "Metadata": {
       "type": "string"
     },
-
     "Michelson": {
       "type": "string"
     },
-
     "NetworkType": {
       "type": "string"
     },
-
     "Bytecode": {
       "type": "string",
       "pattern": "^0x0$|^0x([a-fA-F0-9]{2}|__.{38})+$"
     },
-
     "Source": {
       "type": "string"
     },
-
     "SourceMap": {
       "type": "string",
       "examples": [
         "315:637:1:-;;;452:55;;;;;;;-1:-1:-1;;;;;485:9:1;476:19;:8;:19;;;;;;;;;;498:5;476:27;;452:55;315:637;;;;;;;"
       ]
     },
-
     "SourcePath": {
       "type": "string"
     },
-
     "AST": {
       "type": "object"
     },
-
     "LegacyAST": {
       "type": "object"
     },
-
     "SchemaVersion": {
       "type": "string",
       "pattern": "[0-9]+\\.[0-9]+\\.[0-9]+"

--- a/packages/contract-schema/spec/contract-object.spec.json
+++ b/packages/contract-schema/spec/contract-object.spec.json
@@ -76,7 +76,8 @@
       "format": "date-time"
     },
     "networkType": {
-      "$ref": "#/definitions/NetworkType"
+      "$ref": "#/definitions/NetworkType",
+      "default": "ethereum"
     },
     "devdoc": {
       "$ref": "#/definitions/NatSpec"


### PR DESCRIPTION
Adds `michelson` to ContractObject schema.

Also prettifies the schema for readability & updates & re-orgs README to match current spec.