### PR TITLE
Internal improvement: Update travis build to obtain solc 0.5.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
 
 install:
   - yarn bootstrap
-  - truffle obtain --solc=0.5.8
+  - truffle obtain --solc=0.5.16
 
 cache:
   directories:


### PR DESCRIPTION
Since Truffle defaults to compiling contracts and caching, postinstalling, obtaining `solc` v0.5.16 for users, we should have Travis CI do the same.