### PR TITLE
Internal improvement: Remove taquito (tezos) from global truffle contexts

### DIFF
--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -74,9 +74,6 @@ class Console extends EventEmitter {
           web3: this.interfaceAdapter.web3
             ? this.interfaceAdapter.web3
             : undefined,
-          tezos: this.interfaceAdapter.tezos
-            ? this.interfaceAdapter.tezos
-            : undefined,
           accounts
         },
         interpreter: this.interpret.bind(this),

--- a/packages/core/lib/test.js
+++ b/packages/core/lib/test.js
@@ -207,7 +207,6 @@ const Test = {
     compilation
   }) {
     global.web3 = interfaceAdapter.web3 ? interfaceAdapter.web3 : undefined;
-    global.tezos = interfaceAdapter.tezos ? interfaceAdapter.tezos : undefined;
     global.assert = chai.assert;
     global.expect = chai.expect;
     global.artifacts = {

--- a/packages/migrate/migration.js
+++ b/packages/migrate/migration.js
@@ -23,13 +23,14 @@ class Migration {
   /**
    * Loads & validates migration, then runs it.
    * @param  {Object}   options  config and command-line
-   * @param  {Object}   context  interfaceAdapter
+   * @param  {Object}   context  migrations script context
    * @param  {Object}   deployer truffle module
    * @param  {Object}   resolver truffle module
+   * @param  {Object}   interfaceAdapter interfaceAdapter
    */
-  async _load(options, context, deployer, resolver) {
+  async _load(options, context, deployer, resolver, interfaceAdapter) {
     // Load assets and run `execute`
-    const accounts = await context.interfaceAdapter.getAccounts(options);
+    const accounts = await interfaceAdapter.getAccounts(options);
     const requireOptions = {
       file: this.file,
       context,
@@ -164,7 +165,7 @@ class Migration {
     };
 
     await this.emitter.emit("preMigrate", preMigrationsData);
-    await this._load(options, context, deployer, resolver);
+    await this._load(options, context, deployer, resolver, interfaceAdapter);
   }
 
   prepareForMigrations(options) {
@@ -181,8 +182,6 @@ class Migration {
     // Initial context.
     const context = {
       web3: interfaceAdapter.web3 ? interfaceAdapter.web3 : undefined,
-      tezos: interfaceAdapter.tezos ? interfaceAdapter.tezos : undefined,
-      interfaceAdapter,
       config: this.config
     };
 

--- a/packages/require/require.js
+++ b/packages/require/require.js
@@ -114,8 +114,7 @@ const Require = {
       const fn = this.file({
         file: options.file,
         context: {
-          web3: interfaceAdapter.web3 ? interfaceAdapter.web3 : undefined,
-          tezos: interfaceAdapter.tezos ? interfaceAdapter.tezos : undefined
+          web3: interfaceAdapter.web3 ? interfaceAdapter.web3 : undefined
         },
         resolver: options.resolver
       });


### PR DESCRIPTION
- Make users bring their own version of taquito into
truffle contexts (migrations, tests, the repl, etc).
- Remove InterfaceAdapter from migrations context