### PR TITLE
Bug fix: Use console as default logger

### DIFF
--- a/packages/config/src/configDefaults.ts
+++ b/packages/config/src/configDefaults.ts
@@ -55,9 +55,7 @@ export const getInitialConfig = ({
       },
       vyper: {}
     },
-    logger: {
-      log() {}
-    }
+    logger: console
   };
 };
 


### PR DESCRIPTION
Previously `config.logger` was set to a dummy method.
```
logger: { log: () => {} }
```
As this was the case, whenever `config.events.updateSubscriberOptions` was executed, this method would clobber whatever logger was instantiated for the subscribers. I believe the proper behavior here is to set this property to default to `console`.