### PR TITLE
Enhancement: Extend timeout override polling logic

### DIFF
--- a/packages/contract/lib/handlers.js
+++ b/packages/contract/lib/handlers.js
@@ -12,25 +12,28 @@ const handlers = {
   maxConfirmations: 24, // Maximum number of confirmation web3 emits
   defaultTimeoutBlocks: 50, // Maximum number of blocks web3 will wait before abandoning tx
   timeoutMessage: "50 blocks", // Substring of web3 timeout error.
+  defaultWeb3Error: "please check your gas limit", // Substring of default Web3 error
 
   // -----------------------------------  Helpers --------------------------------------------------
 
   /**
-   * Parses error message and determines if we should squash block timeout errors at user's request.
-   * @param  {Object} context execution state
-   * @param  {Object} error   error
+   * Parses error message and determines if we should squash web3 timeout errors at user's request.
+   * @param  {Object} contract contract instance
+   * @param  {Object} message  error message
    * @return {Boolean}
    */
-  ignoreTimeoutError: function(context, error) {
-    const timedOut =
-      error.message && error.message.includes(handlers.timeoutMessage);
+  ignoreTimeoutError({ contract }, { message }) {
+    const timedOut = message && message.includes(handlers.timeoutMessage);
 
     const shouldWait =
-      context.contract &&
-      context.contract.timeoutBlocks &&
-      context.contract.timeoutBlocks > handlers.defaultTimeoutBlocks;
+      contract &&
+      contract.timeoutBlocks &&
+      contract.timeoutBlocks > handlers.defaultTimeoutBlocks;
 
-    return timedOut && shouldWait;
+    const waitForTxPropagation =
+      message && message.includes(handlers.defaultWeb3Error);
+
+    return shouldWait && (timedOut || waitForTxPropagation);
   },
 
   /**

--- a/packages/contract/lib/override.js
+++ b/packages/contract/lib/override.js
@@ -3,6 +3,7 @@ const handlers = require("./handlers");
 
 const override = {
   timeoutMessage: "not mined within", // Substring of timeout err fired by web3
+  defaultWeb3Error: "please check your gas limit", // Substring of default Web3 error
   defaultMaxBlocks: 50, // Max # of blocks web3 will wait for a tx
   pollingInterval: 1000,
 
@@ -37,14 +38,9 @@ const override = {
   start: async function(context, web3Error) {
     const constructor = this;
     let currentBlock = override.defaultMaxBlocks;
-    const maxBlocks = constructor.timeoutBlocks;
-
-    const timedOut =
-      web3Error.message && web3Error.message.includes(override.timeoutMessage);
-    const shouldWait = maxBlocks > currentBlock;
 
     // Reject after attempting to get reason string if we shouldn't be waiting.
-    if (!timedOut || !shouldWait) {
+    if (!handlers.ignoreTimeoutError(context, web3Error)) {
       // We might have been routed here in web3 >= beta.34 by their own status check
       // error. We want to extract the receipt, emit a receipt event
       // and reject it ourselves.
@@ -83,6 +79,8 @@ const override = {
         .then(result => {
           if (!result) return;
 
+          // make sure reporter receives tx receipt promievent
+          handlers.receipt(context, result);
           result.contractAddress
             ? constructor
                 .at(result.contractAddress)

--- a/packages/contract/test/deploy.js
+++ b/packages/contract/test/deploy.js
@@ -272,5 +272,41 @@ describe("Deployments", function() {
         "Should have returned a usable contract instance"
       );
     });
+
+    it("should override gateway tx propagation delay err / return a usable instance", async () => {
+      // Mock web3 non-response, fire error @ block 50, resolve receipt @ block 52.
+      const tempSendTransaction = Example.web3.eth.sendTransaction;
+      const tempGetTransactionReceipt = Example.web3.eth.getTransactionReceipt;
+
+      Example.web3.eth.sendTransaction = util.fakeSendTransaction;
+      Example.web3.eth.getTransactionReceipt = util.fakeNoReceipt;
+      Example.timeoutBlocks = 52;
+
+      const example = await Example.new(1).on(
+        "transactionHash",
+        async function() {
+          for (var i = 1; i < 50; i++) {
+            await util.evm_mine();
+          }
+          await util.fakeGatewayDelay();
+          await util.evm_mine();
+          await util.evm_mine();
+          Example.web3.eth.getTransactionReceipt = util.fakeGotReceipt;
+          await util.evm_mine();
+        }
+      );
+
+      // Restore web3
+      Example.web3.eth.sendTransaction = tempSendTransaction;
+      Example.web3.eth.getTransactionReceipt = tempGetTransactionReceipt;
+
+      await example.setValue(77);
+      const newValue = await example.value();
+      assert.equal(
+        newValue,
+        77,
+        "Should have returned a usable contract instance"
+      );
+    }).timeout(50000);
   });
 });

--- a/packages/contract/test/util.js
+++ b/packages/contract/test/util.js
@@ -139,6 +139,13 @@ var util = {
     util.fakePromiEvent.reject(new Error(error));
   },
 
+  fakeGatewayDelay(msg) {
+    const error =
+      msg ||
+      "The contract code couldn't be stored, please check your gas limit";
+    util.fakePromiEvent.reject(new Error(error));
+  },
+
   fakeNoReceipt: function() {
     return Promise.resolve(null);
   },


### PR DESCRIPTION
- Include default Web3 error message as part of
contract deployment error handling
- Ignore default Web3 error message only when setting
a custom default block timeout greater than Web3's default (50)
- Ensure promievent receipt is fired when override logic
successfully returns a tx receipt
- Add test util method & test case for simulating tx propagation
 delays when deploying contracts via live network gateways
(Infura, Cloudflare, etc)

Using the [reproduction steps](https://github.com/trufflesuite/truffle/issues/2257#issuecomment-558919818) outlined in #2257 against this branch locally, it appears I have been able to overcome the gateway tx delays [discussed](https://github.com/trufflesuite/truffle/issues/1575#issuecomment-579560921) in #1575.

This is a short-term solution that neither adds a new flag or config option that users need to enable, nor requires building out completely new custom logic. Instead, it hooks into & extends the currently existing architecture and an already existent deployment config option.

It would be nice for this behavior to be default, but unfortunately Web3 appears to throw a generic error message whenever there is some JSON response it doesn't know how to handle. This makes it difficult to know when and where exactly it is running into this very specific issue (gateway tx propagation delay). 

Example usage:

```javascript
// truffle-config.js
module.exports = {
  networks: {
    ...
    goerli: {
      ...
      timeoutBlocks: 60 // must be greater than Web3's default (50)
    }
  }
};
```

Aims to resolve #1575 & #2257.

As an aside, there is possibly a fix in here for general `timeoutBlock` usage. It appears the current override logic was never hooked up to fire a receipt promievent to the reporter upon successfully returning a tx receipt. This was making actual migrations crash when smoke testing locally.