### PR TITLE
Fix console.warn in truffle test

### DIFF
--- a/packages/core/lib/test.js
+++ b/packages/core/lib/test.js
@@ -58,7 +58,7 @@ const Test = {
     // e.g., https://github.com/ethereum/web3.js/blob/master/lib/web3/allevents.js#L61
     // Output looks like this during tests: https://gist.github.com/tcoulter/1988349d1ec65ce6b958
     const warn = config.logger.warn;
-    config.logger.warn = message => {
+    config.logger.warn = function(message) {
       if (message === "cannot find event for log") {
         return;
       } else {


### PR DESCRIPTION
Addresses #2481.

Before: Calling `console.warn()` during Truffle tests would print out the Truffle config and obscure whatever message was meant to be printed.

After: `console.warn()` works as expected.

====

repro steps:

Simple Truffle test that demonstrates the bug and the fix:

```javascript
console.warn('Test console.warn()');
describe('noop', function() { it('noop', () => {}); });
```

Run with e.g. `truffle test test/basic.js`