### PR TITLE
Bug fix: Fix assertion library

### DIFF
--- a/packages/core/lib/testing/soliditytest.js
+++ b/packages/core/lib/testing/soliditytest.js
@@ -19,8 +19,10 @@ const SolidityTest = {
 
     // Set up our runner's needs first.
     suite.beforeAll("prepare suite", async function() {
-      await runner.initialize.bind(runner)();
+      // This compiles some native contracts (including the assertion library
+      // contracts) which need to be compiled before initializing the runner
       await self.compileNewAbstractInterface.bind(this)(runner);
+      await runner.initialize.bind(runner)();
       await self.deployTestDependencies.bind(
         this
       )(abstraction, dependencyPaths, runner);

--- a/packages/core/lib/testing/testrunner.js
+++ b/packages/core/lib/testing/testrunner.js
@@ -176,7 +176,7 @@ TestRunner.prototype.endTest = async function(mocha) {
   });
 
   const userDefinedEventLogs = logs.filter(log => {
-    return !log.decodings.length || log.decodings[0].abi.name !== "TestEvent";
+    return log.decodings.every(decoding => decoding.abi.name !== "TestEvent")
   });
 
   if (userDefinedEventLogs.length === 0) {

--- a/packages/core/lib/testing/testrunner.js
+++ b/packages/core/lib/testing/testrunner.js
@@ -175,11 +175,11 @@ TestRunner.prototype.endTest = async function(mocha) {
     fromBlock: this.currentTestStartBlock.toNumber()
   });
 
-  const filteredLogs = logs.filter(log => {
+  const userDefinedEventLogs = logs.filter(log => {
     return !log.decodings.length || log.decodings[0].abi.name !== "TestEvent";
   });
 
-  if (filteredLogs.length === 0) {
+  if (userDefinedEventLogs.length === 0) {
     this.logger.log("    > No events were emitted");
     return;
   }
@@ -188,7 +188,7 @@ TestRunner.prototype.endTest = async function(mocha) {
   this.logger.log("    ---------------------------");
   this.logger.log("");
 
-  for (const log of filteredLogs) {
+  for (const log of userDefinedEventLogs) {
     switch (log.decodings.length) {
       case 0:
         this.logger.log(`    Warning: Could not decode event!`);

--- a/packages/core/lib/testing/testrunner.js
+++ b/packages/core/lib/testing/testrunner.js
@@ -175,7 +175,11 @@ TestRunner.prototype.endTest = async function(mocha) {
     fromBlock: this.currentTestStartBlock.toNumber()
   });
 
-  if (logs.length === 0) {
+  const filteredLogs = logs.filter(log => {
+    return !log.decodings.length || log.decodings[0].abi.name !== "TestEvent";
+  });
+
+  if (filteredLogs.length === 0) {
     this.logger.log("    > No events were emitted");
     return;
   }
@@ -184,7 +188,7 @@ TestRunner.prototype.endTest = async function(mocha) {
   this.logger.log("    ---------------------------");
   this.logger.log("");
 
-  for (const log of logs) {
+  for (const log of filteredLogs) {
     switch (log.decodings.length) {
       case 0:
         this.logger.log(`    Warning: Could not decode event!`);


### PR DESCRIPTION
The Solidity assertion libraries have been broken as of Truffle 5.1.5 due to them not being compiled before initializing the decoder during testing. This PR flips the order of two lines of code that causes these libraries to be compiled before decoder initialization.

After fixing this, the test summary displayed a list of events emitted during the tests which included all of the `TestEvent`s (which is the mechanism by which the assertion libraries operate). Since this is not really information relevant to the user (in that the user does not need to know about these `TestEvent`s events being emitted during testing) they are now filtered out to avoid extra noise and confusion. The failures still display in the test summary as shown below.

<img width="797" alt="Screen Shot 2020-02-11 at 10 46 10 AM" src="https://user-images.githubusercontent.com/14827965/74268580-f1a66d00-4cbc-11ea-8a92-7e2058735183.png">

This is the result of running the test suite from a new MetaCoin box with `Assert.fail("Lets make it fail")` and `Assert.fail("bummer")` placed in the two Solidity tests.
