### PR TITLE
Bug fix: Correct typo on config command property

### DIFF
--- a/packages/core/lib/commands/config.js
+++ b/packages/core/lib/commands/config.js
@@ -16,11 +16,11 @@ const command = {
       },
       {
         option: "get",
-        discription: "Get a Truffle config option value."
+        description: "Get a Truffle config option value."
       },
       {
         option: "set",
-        discription: "Set a Truffle config option value."
+        description: "Set a Truffle config option value."
       }
     ]
   },


### PR DESCRIPTION
I done found a typo in `config.js` :)