### PR TITLE
Upgrade dependency: ganache-core@2.10.2

### DIFF
--- a/packages/artifactor/package.json
+++ b/packages/artifactor/package.json
@@ -24,7 +24,7 @@
     "@types/node": "^12.6.2",
     "chai": "4.2.0",
     "debug": "^4.1.1",
-    "ganache-core": "2.10.1",
+    "ganache-core": "2.10.2",
     "mocha": "5.2.0",
     "require-nocache": "^1.0.0",
     "temp": "^0.8.3",

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -37,7 +37,7 @@
     "browserify": "^14.0.0",
     "chai": "4.2.0",
     "debug": "^4.1.0",
-    "ganache-core": "2.10.1",
+    "ganache-core": "2.10.2",
     "mocha": "5.2.0",
     "sinon": "^7.3.2",
     "temp": "^0.8.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,7 +51,7 @@
     "ethpm": "0.0.16",
     "ethpm-registry": "0.1.0-next.3",
     "fs-extra": "6.0.1",
-    "ganache-core": "2.10.1",
+    "ganache-core": "2.10.2",
     "glob": "^7.1.4",
     "hdkey": "^1.1.0",
     "mkdirp": "^0.5.1",

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -59,7 +59,7 @@
     "express": "^4.16.2",
     "faker": "^4.1.0",
     "fs-extra": "6.0.1",
-    "ganache-core": "2.10.1",
+    "ganache-core": "2.10.2",
     "istanbul-instrumenter-loader": "^3.0.1",
     "mocha": "5.2.0",
     "mocha-webpack": "^1.1.0",

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@truffle/reporters": "^1.0.18",
     "@truffle/workflow-compile": "^2.1.21",
-    "ganache-core": "2.10.1",
+    "ganache-core": "2.10.2",
     "mocha": "5.2.0",
     "sinon": "^7.3.2",
     "web3": "1.2.1"

--- a/packages/environment/package.json
+++ b/packages/environment/package.json
@@ -17,7 +17,7 @@
     "@truffle/expect": "^0.0.13",
     "@truffle/interface-adapter": "^0.4.4",
     "@truffle/resolver": "^5.1.1",
-    "ganache-core": "2.10.1",
+    "ganache-core": "2.10.2",
     "node-ipc": "^9.1.1",
     "web3": "1.2.1"
   },

--- a/packages/hdwallet-provider/package.json
+++ b/packages/hdwallet-provider/package.json
@@ -34,7 +34,7 @@
     "@types/ethereumjs-util": "^5.2.0",
     "@types/mocha": "^5.2.7",
     "@types/web3-provider-engine": "^14.0.0",
-    "ganache-core": "2.10.1",
+    "ganache-core": "2.10.2",
     "mocha": "6.2.0",
     "ts-node": "^8.4.1",
     "typescript": "^3.6.3"

--- a/packages/interface-adapter/package.json
+++ b/packages/interface-adapter/package.json
@@ -30,7 +30,7 @@
     "@types/lodash": "^4.14.136",
     "@types/mocha": "^5.2.6",
     "@types/web3": "1.0.19",
-    "ganache-core": "2.10.1",
+    "ganache-core": "2.10.2",
     "mocha": "^6.0.2",
     "ts-node": "^8.0.3",
     "typescript": "^3.6.3"

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -20,7 +20,7 @@
     "web3": "1.2.1"
   },
   "devDependencies": {
-    "ganache-core": "2.10.1",
+    "ganache-core": "2.10.2",
     "mocha": "5.2.0"
   },
   "keywords": [

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -40,7 +40,7 @@
     "copy-webpack-plugin": "^4.0.1",
     "eslint": "^5.7.0",
     "fs-extra": "6.0.1",
-    "ganache-core": "2.10.1",
+    "ganache-core": "2.10.2",
     "glob": "^7.1.2",
     "husky": "^1.1.2",
     "js-scrypt": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5780,6 +5780,19 @@ ethereumjs-util@6.1.0, ethereumjs-util@~6.1.0:
     safe-buffer "^5.1.1"
     secp256k1 "^3.0.1"
 
+ethereumjs-util@6.2.0, ethereumjs-util@^6.0.0, ethereumjs-util@^6.1.0, ethereumjs-util@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz#23ec79b2488a7d041242f01e25f24e5ad0357960"
+  integrity sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==
+  dependencies:
+    "@types/bn.js" "^4.11.3"
+    bn.js "^4.11.0"
+    create-hash "^1.1.2"
+    ethjs-util "0.1.6"
+    keccak "^2.0.0"
+    rlp "^2.2.3"
+    secp256k1 "^3.0.1"
+
 ethereumjs-util@^4.0.1, ethereumjs-util@^4.3.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz#3e9428b317eebda3d7260d854fddda954b1f1bc6"
@@ -5802,19 +5815,6 @@ ethereumjs-util@^5.0.0, ethereumjs-util@^5.0.1, ethereumjs-util@^5.1.1, ethereum
     keccak "^1.0.2"
     rlp "^2.0.0"
     safe-buffer "^5.1.1"
-    secp256k1 "^3.0.1"
-
-ethereumjs-util@^6.0.0, ethereumjs-util@^6.1.0, ethereumjs-util@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz#23ec79b2488a7d041242f01e25f24e5ad0357960"
-  integrity sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==
-  dependencies:
-    "@types/bn.js" "^4.11.3"
-    bn.js "^4.11.0"
-    create-hash "^1.1.2"
-    ethjs-util "0.1.6"
-    keccak "^2.0.0"
-    rlp "^2.2.3"
     secp256k1 "^3.0.1"
 
 ethereumjs-vm@4.1.3:
@@ -6778,10 +6778,10 @@ ganache-cli@^6.1.0:
     source-map-support "0.5.12"
     yargs "13.2.4"
 
-ganache-core@2.10.1:
-  version "2.10.1"
-  resolved "https://registry.yarnpkg.com/ganache-core/-/ganache-core-2.10.1.tgz#89af8251b3a89593bfca46dfb837c230ca05e98f"
-  integrity sha512-C53TKRBWfMEeGAkH5idoCbBcNgKPJ+v1dFDVPKeg1D4ZA6N/PAo5HDVLS4UuZOthPqz9s+uEX6GdluOcXVvm4w==
+ganache-core@2.10.2:
+  version "2.10.2"
+  resolved "https://registry.yarnpkg.com/ganache-core/-/ganache-core-2.10.2.tgz#17c171c6c0195b6734a0dd741a9d2afd4f74e292"
+  integrity sha512-4XEO0VsqQ1+OW7Za5fQs9/Kk7o8M0T1sRfFSF8h9NeJ2ABaqMO5waqxf567ZMcSkRKaTjUucBSz83xNfZv1HDg==
   dependencies:
     abstract-leveldown "3.0.0"
     async "2.6.2"
@@ -6796,7 +6796,7 @@ ganache-core@2.10.1:
     ethereumjs-block "2.2.2"
     ethereumjs-common "1.5.0"
     ethereumjs-tx "2.1.2"
-    ethereumjs-util "6.1.0"
+    ethereumjs-util "6.2.0"
     ethereumjs-vm "4.1.3"
     heap "0.2.6"
     level-sublevel "6.6.4"


### PR DESCRIPTION
* @truffle/artifactor: 2.10.1 →  2.10.2
* @truffle/contract: 2.10.1 →  2.10.2
* @truffle/core: 2.10.1 →  2.10.2
* @truffle/debugger: 2.10.1 →  2.10.2
* @truffle/deployer: 2.10.1 →  2.10.2
* @truffle/environment: 2.10.1 →  2.10.2
* @truffle/hdwallet-provider: 2.10.1 →  2.10.2
* @truffle/interface-adapter: 2.10.1 →  2.10.2
* @truffle/provider: 2.10.1 →  2.10.2
* truffle: 2.10.1 →  2.10.2