### PR TITLE
Fix unable to add the package to @truffle/core in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ $ lerna create truffle-mycmd
 ### Add the package to `@truffle/core`
 
 ```shell
-$ lerna add truffle-mycmd --scope=core
+$ lerna add truffle-mycmd --scope=@truffle/core
 ```
 
 ### Create a new command in `@truffle/core`


### PR DESCRIPTION
Fix unable to add the package to @truffle/core in contributing guide

Ref: https://github.com/lerna/lerna/issues/1683