### PR TITLE
Decoder typings fix

### DIFF
--- a/packages/decoder/package.json
+++ b/packages/decoder/package.json
@@ -3,13 +3,13 @@
   "version": "4.0.9",
   "description": "A decoder and encoder for Solidity variables of all sorts",
   "main": "dist/index.js",
-  "types": "lib/index.ts",
+  "types": "dist/index.d.ts",
   "directories": {
     "lib": "lib"
   },
   "scripts": {
     "prepare": "yarn build",
-    "build": "node_modules/.bin/tsc",
+    "build": "node_modules/.bin/tsc --declaration",
     "start": "node_modules/.bin/tsc --watch",
     "test": "cd test/wire && npx truffle test && cd ../storage && npx truffle test"
   },


### PR DESCRIPTION
The typings were not generated properly for the `@truffle/decoder` package.

According to these Typescript [docs](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html), typings should be generated with a `--declaration` flag which should yield a `*.d.ts` file. The example `package.json` is:

```json
{
    "name": "awesome",
    "author": "Vandelay Industries",
    "version": "1.0.0",
    "main": "./lib/main.js",
    "types": "./lib/main.d.ts"
}
```

But the current decoder has a `package.json` with the `types` property that just [points](https://github.com/trufflesuite/truffle/blob/develop/packages/decoder/package.json#L6) to its Typescript source (note the `*.ts` extension rather than `*.d.ts`):

```json
{
  "name": "@truffle/decoder",
  "version": "4.0.9",
  "description": "A decoder and encoder for Solidity variables of all sorts",
  "main": "dist/index.js",
  "types": "lib/index.ts",
}
```

This PR fixes this issue.

Please reference this issue here: https://github.com/trufflesuite/teams/pull/446#issuecomment-590519147