### PR TITLE
Remove unused projectInfoComputed state & selector

### DIFF
--- a/packages/debugger/lib/session/reducers.js
+++ b/packages/debugger/lib/session/reducers.js
@@ -25,15 +25,6 @@ function ready(state = false, action) {
   }
 }
 
-function projectInfoComputed(state = false, action) {
-  switch (action.type) {
-    case actions.PROJECT_INFO_COMPUTED:
-      return true;
-    default:
-      return state;
-  }
-}
-
 function lastLoadingError(state = null, action) {
   switch (action.type) {
     case actions.ERROR:
@@ -84,7 +75,6 @@ function block(state = {}, action) {
 const session = combineReducers({
   ready,
   lastLoadingError,
-  projectInfoComputed,
   transaction,
   receipt,
   block

--- a/packages/debugger/lib/session/selectors/index.js
+++ b/packages/debugger/lib/session/selectors/index.js
@@ -125,15 +125,7 @@ const session = createSelectorTree({
     /*
      * session.status.loaded
      */
-    loaded: createLeaf([trace.loaded], loaded => loaded),
-
-    /*
-     * session.status.projectInfoComputed
-     */
-    projectInfoComputed: createLeaf(
-      ["/state"],
-      state => state.projectInfoComputed
-    )
+    loaded: createLeaf([trace.loaded], loaded => loaded)
   }
 });
 


### PR DESCRIPTION
I noticed that the `projectInfoComputed` state and selector were still hanging around, from when we had the idea of the debugger separately signalling to the CLI when it was done computing the project info.  Now that we're not doing that, this doesn't actually do anything; there's no action hooked up for the reducer to respond to, so the reducer doesn't do anything and the selector is useless.  So, deleting all this code!