### PR TITLE
Bump highlightjs-solidity version

### DIFF
--- a/packages/debug-utils/package.json
+++ b/packages/debug-utils/package.json
@@ -8,7 +8,7 @@
     "chalk": "^2.4.2",
     "debug": "^4.1.0",
     "highlight.js": "^9.15.8",
-    "highlightjs-solidity": "^1.0.10",
+    "highlightjs-solidity": "^1.0.11",
     "node-dir": "0.1.17"
   },
   "main": "index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7625,10 +7625,10 @@ highlight.js@^9.12.0, highlight.js@^9.15.8:
   dependencies:
     handlebars "^4.5.3"
 
-highlightjs-solidity@^1.0.10:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/highlightjs-solidity/-/highlightjs-solidity-1.0.10.tgz#4f03e6298cb914b232d531e54d589ccf906b24b8"
-  integrity sha512-frqjEl0EK89rAChdn+CpAISVH/nbC4YXPBGfpoc0n023pPDHH8dcVCqtQFrbZfQEpbsc7wGPRl2qsvGKg/NKGA==
+highlightjs-solidity@^1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/highlightjs-solidity/-/highlightjs-solidity-1.0.11.tgz#06449d7746960c7143f0af4d66bc4f1d48c77e95"
+  integrity sha512-NVilLoFVM/y/KqXdUMCqdCdaagLBb3Kw+pU8nTGiecwNYDodlGZPscdaK2dtXZQvKovP9rq9dZAjPDf0T0el4A==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Bump the version of highlightjs-solidity in order to be able to highlight the new `gas:`/`value:`/`salt:` syntax.