### PR TITLE
Fix: Remove problematic debugging output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,10 @@ matrix:
       env: FABRICEVM=true
     - node_js: 8
       env: COVERAGE=true
-    - node_js: 10
+    - if: |
+        branch = develop AND \
+        type = push
+      node_js: 10
       env: COLONY=true
   allow_failures:
     - node_js: 8

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,7 @@ matrix:
       env: FABRICEVM=true
     - node_js: 8
       env: COVERAGE=true
-    - if: |
-        branch = develop AND \
-        type = push
-      node_js: 10
+    - node_js: 10
       env: COLONY=true
   allow_failures:
     - node_js: 8

--- a/packages/codec/lib/abi-data/allocate/index.ts
+++ b/packages/codec/lib/abi-data/allocate/index.ts
@@ -983,11 +983,6 @@ export function getEventAllocations(
           //why? because if we couldn't find it, that means that events defined in
           //base contracts *weren't* skipped earlier, and so we shouldn't now add them in
           debug("baseId: %d", baseId);
-          debug("ids: %o", contracts.map(({ contractNode: { id } }) => id));
-          debug(
-            "names: %o",
-            contracts.map(({ contractNode: { name } }) => name)
-          );
           let baseContext = contracts.find(
             contractAllocationInfo =>
               contractAllocationInfo.compilationId === compilationId &&


### PR DESCRIPTION
My previous PR, #2851, seems to be causing the Colony tests to fail.  The reason for this seems to be some debugging output I left in that foolishly includes some dereferencing (which, obviously, can fail).  So, I'm just deleting that debugging output.