### PR TITLE
Add workaround to avoid allocating obviously ill-formed ABI items

### DIFF
--- a/packages/codec/lib/abi-data/allocate/index.ts
+++ b/packages/codec/lib/abi-data/allocate/index.ts
@@ -748,6 +748,10 @@ function getCalldataAllocationsForContract(
     functionAllocations: {}
   };
   for (let abiEntry of abi) {
+    if (AbiDataUtils.abiEntryIsObviouslyIllTyped(abiEntry)) {
+      //hack workaround!
+      continue;
+    }
     switch (abiEntry.type) {
       case "constructor":
         allocations.constructorAllocation = allocateCalldataAndReturndata(
@@ -854,6 +858,10 @@ function getEventAllocationsForContract(
 ): EventAllocationTemporary[] {
   return abi
     .filter((abiEntry: AbiData.AbiEntry) => abiEntry.type === "event")
+    .filter(
+      (abiEntry: AbiData.EventAbiEntry) =>
+        !AbiDataUtils.abiEntryIsObviouslyIllTyped(abiEntry)
+    ) //hack workaround
     .map((abiEntry: AbiData.EventAbiEntry) => ({
       selector: AbiDataUtils.abiSelector(abiEntry),
       anonymous: abiEntry.anonymous,


### PR DESCRIPTION
This PR is intended to address #2723.  So, a little explanation here -- on investigation, it turned out that the actual problem was a *Solidity* error; the Solidity compiler was emitting ill-formed ABIs.  We can't really fix that -- and @Amxx will have to get that fixed, for obvious reasons! -- but I can at least add this workaround that should at least get his tests working again.  (And, to be clear, it *does* get the test in the reproduction example working.)

Note this is a real quick workaround that just checks for obvious ways in which an ABI may be ill-formed.  It does not actually do a full well-formedness check.  Because this is mostly a case we shouldn't have to deal with...