### PR TITLE
Bug fix: Fail inheritance search on bad base node type

### DIFF
--- a/packages/codec/lib/abi-data/allocate/index.ts
+++ b/packages/codec/lib/abi-data/allocate/index.ts
@@ -364,13 +364,17 @@ function allocateCalldataAndReturndata(
       //search through base contracts, from most derived (left) to most base (right)
       if (contractNode) {
         const linearizedBaseContracts = contractNode.linearizedBaseContracts;
+        debug("linearized: %O", linearizedBaseContracts);
         node = linearizedBaseContracts.reduce(
           (foundNode: Ast.AstNode, baseContractId: number) => {
             if (foundNode !== undefined) {
               return foundNode; //once we've found something, we don't need to keep looking
             }
             let baseContractNode = referenceDeclarations[baseContractId];
-            if (baseContractNode === undefined) {
+            if (
+              baseContractNode === undefined ||
+              baseContractNode.nodeType !== "ContractDefinition"
+            ) {
               return null; //return null rather than undefined so that this will propagate through
               //(i.e. by returning null here we give up the search)
               //(we don't want to continue due to possibility of grabbing the wrong override)

--- a/packages/codec/lib/abi-data/allocate/index.ts
+++ b/packages/codec/lib/abi-data/allocate/index.ts
@@ -370,7 +370,10 @@ function allocateCalldataAndReturndata(
             if (foundNode !== undefined) {
               return foundNode; //once we've found something, we don't need to keep looking
             }
-            let baseContractNode = referenceDeclarations[baseContractId];
+            let baseContractNode =
+              baseContractId === contractNode.id
+                ? contractNode //skip the lookup if we already have the right node! this is to reduce errors from collision
+                : referenceDeclarations[baseContractId];
             if (
               baseContractNode === undefined ||
               baseContractNode.nodeType !== "ContractDefinition"
@@ -603,7 +606,10 @@ function allocateEvent(
             return foundNode; //once we've found something, we don't need to keep looking
           }
           let baseContractNode = referenceDeclarations[baseContractId];
-          if (baseContractNode === undefined) {
+          if (
+            baseContractNode === undefined ||
+            baseContractNode.nodeType !== "ContractDefinition"
+          ) {
             debug("can't find base node, bailing!");
             return null; //return null rather than undefined so that this will propagate through
             //(i.e. by returning null here we give up the search)
@@ -984,7 +990,7 @@ export function getEventAllocations(
         for (let baseId of linearizedBaseContractsMinusSelf) {
           debug("checking base baseId: %d", baseId);
           let baseNode = referenceDeclarations[compilationId][baseId];
-          if (!baseNode) {
+          if (!baseNode || baseNode.nodeType !== "ContractDefinition") {
             debug("failed to find node for baseId: %d", baseId);
             break; //not a continue!
             //if we can't find the base node, it's better to stop the loop,


### PR DESCRIPTION
This PR is a (partial?) fix for the reopened #2723.  Basically, when going through the base contracts of a given contract to find where a given function is defined, I have code that says, give up if you fail to locate one of the base contracts.  However, I didn't have code that said, give up if due to ID collisions the "base contract" you locate is not a contract at all.  This caused an error when attempting to test @Amxx's project.

I'm actually still getting errors when I try to test his project, but they're unrelated errors and it's not clear they're our fault, so I'm putting up this PR as it is to just fix this one issue.

One thing worth noting: In the particular case at hand, the base contract we're trying to look up is actually the contract itself!  Wondering if perhaps I should put in code so that for the first contract in the base contracts list (i.e. the contract itself) we don't do a lookup, so that this sort of error can't happen unless there's a collision in one of the actual base contracts *other* than the contract itself?

Also: It's really weird that there was a collision here at all!  IDs are supposed to be unique within a compilation, I thought?  @Amxx might want to report that to Solidity...

(Nonetheless this is still our fault because we ought to be able to recover gracefully from such collisions one way or another.)