### PR TITLE
Nativize boolean-out-of-range errors to true (instead of undefined)

### DIFF
--- a/packages/codec/lib/format/utils/inspect.ts
+++ b/packages/codec/lib/format/utils/inspect.ts
@@ -475,7 +475,12 @@ function nativizeWithTable(
   seenSoFar: any[]
 ): any {
   if (result.kind === "error") {
-    return undefined;
+    switch (result.error.kind) {
+      case "BoolOutOfRangeError":
+        return true;
+      default:
+        return undefined;
+    }
   }
   //NOTE: for simplicity, only arrays & structs will call nativizeWithTable;
   //other containers will just call nativize because they can get away with it


### PR DESCRIPTION
This PR makes it so that `nativize` converts out-of-range booleans to `true` rather than `undefined`.  This is in order to work better in watch expressions, since when used as mapping keys, out-of-range booleans are treated as `true`.