### PR TITLE
Prevent some debugger crashes

### DIFF
--- a/packages/core/lib/debug/cli.js
+++ b/packages/core/lib/debug/cli.js
@@ -38,7 +38,11 @@ class CLIDebugger {
     let artifacts = await DebugUtils.gatherArtifacts(config);
     let shimmedCompilations = Codec.Compilations.Utils.shimArtifacts(artifacts);
     //if they were compiled simultaneously, yay, we can use it!
-    if (!shimmedCompilations.unreliableSourceOrder) {
+    if (
+      shimmedCompilations.every(
+        compilation => !compilation.unreliableSourceOrder
+      )
+    ) {
       return shimmedCompilations;
     }
     //if not, we have to recompile

--- a/packages/debugger/lib/data/selectors/index.js
+++ b/packages/debugger/lib/data/selectors/index.js
@@ -662,18 +662,18 @@ const data = createSelectorTree({
         (allocations, compilationId) =>
           Object.assign(
             {},
-            ...Object.entries(allocations[compilationId]).map(
-              ([id, allocation]) => ({
-                [id]: {
-                  members: Object.assign(
-                    {},
-                    ...allocation.members.map(memberAllocation => ({
-                      [memberAllocation.definition.id]: memberAllocation
-                    }))
-                  )
-                }
-              })
-            )
+            ...Object.entries(
+              compilationId ? allocations[compilationId] : {}
+            ).map(([id, allocation]) => ({
+              [id]: {
+                members: Object.assign(
+                  {},
+                  ...allocation.members.map(memberAllocation => ({
+                    [memberAllocation.definition.id]: memberAllocation
+                  }))
+                )
+              }
+            }))
           )
       )
     },

--- a/packages/debugger/lib/solidity/selectors/index.js
+++ b/packages/debugger/lib/solidity/selectors/index.js
@@ -33,7 +33,8 @@ function getSourceRange(instruction = {}) {
 function contextRequiresPhantomStackframes(context) {
   debug("context: %O", context);
   return (
-    context.compiler &&
+    context.compiler !== undefined && //(do NOT just put context.compiler here,
+    //we need this to be a boolean, not undefined, because it gets put in the state)
     semver.satisfies(context.compiler.version, ">=0.5.1", {
       includePrerelease: true
     })

--- a/packages/debugger/lib/solidity/selectors/index.js
+++ b/packages/debugger/lib/solidity/selectors/index.js
@@ -143,7 +143,7 @@ let solidity = createSelectorTree({
     sources: createLeaf(
       ["/info/sources", evm.current.context],
       (sources, context) =>
-        context ? sources[context.compilationId].byId : null
+        context ? (sources[context.compilationId] || { byId: null }).byId : null
     ),
 
     /**
@@ -197,7 +197,7 @@ let solidity = createSelectorTree({
       ["./sources", evm.current.context, "./humanReadableSourceMap"],
 
       (sources, context, sourceMap) => {
-        if (!context) {
+        if (!context || !sources) {
           return [];
         }
         let binary = context.binary;
@@ -351,6 +351,9 @@ let solidity = createSelectorTree({
     functionsByProgramCounter: createLeaf(
       ["./instructions", "./sources"],
       (instructions, sources) =>
+        //note: we can skip an explicit null check on sources here because
+        //if sources is null then instructions = [] so the problematic code
+        //will never run
         Object.assign(
           {},
           ...instructions


### PR DESCRIPTION
This PR does two things:

Firstly: It fixes #2879.  Um, so, I messed up the check of whether the debugger needs to recompile, and as a result instead of recompiling when it needed to, it was crashing.  Oops!  Fixed now.

(Very odd, since I could've sworn I'd seen it recompiling in some cases...?  A little unclear what's going on there, may be worth looking at...)

Secondly: It prevents various other debugger crashes that I accidentlly introduced in 5.1.16 when source code can't be found for the transaction being debugged.