### PR TITLE
Bug fix: Keep debugger from crashing when can't locate contract node

### DIFF
--- a/packages/debugger/lib/session/index.js
+++ b/packages/debugger/lib/session/index.js
@@ -171,8 +171,8 @@ export default class Session {
           compilation
         );
 
-        let contractId = contractNode.id;
-        let contractKind = contractNode.contractKind;
+        let contractId = contractNode ? contractNode.id : undefined;
+        let contractKind = contractNode ? contractNode.contractKind : undefined;
         abi = Codec.AbiData.Utils.schemaAbiToAbi(abi); //let's handle this up front
 
         debug("contractName %s", contractName);


### PR DESCRIPTION
Just another quick debugger crash fix...