### PR TITLE
Account for possibility of no known compiler in special decoding

### DIFF
--- a/packages/codec/lib/compiler/types.ts
+++ b/packages/codec/lib/compiler/types.ts
@@ -5,4 +5,7 @@ export interface CompilerVersion {
   //but they need to be optional for compilation reasons
 }
 
-export type SolidityFamily = "pre-0.5.0" | "0.5.x";
+//Note: 0.5.x should really be 0.5.x or 0.6.x, but for the sake
+//of not breaking things, I'm going to avoid changing this until
+//there's a need (which might happen when 0.7.x hits)
+export type SolidityFamily = "unknown" | "pre-0.5.0" | "0.5.x";

--- a/packages/codec/lib/compiler/utils.ts
+++ b/packages/codec/lib/compiler/utils.ts
@@ -5,6 +5,9 @@ import semver from "semver";
 import { CompilerVersion, SolidityFamily } from "./types";
 
 export function solidityFamily(compiler: CompilerVersion): SolidityFamily {
+  if (!compiler || compiler.name !== "solc") {
+    return "unknown";
+  }
   if (
     semver.satisfies(compiler.version, "~0.5 || >=0.5.0", {
       includePrerelease: true

--- a/packages/codec/lib/special/decode/index.ts
+++ b/packages/codec/lib/special/decode/index.ts
@@ -124,11 +124,12 @@ export function* decodeMagic(
   }
 }
 
-//NOTE: this is going to change again in 0.6.x!  be ready!
+//NOTE: this is likely going to change again in 0.7.x!  be ready!
 function senderType(
   compiler: Compiler.CompilerVersion
 ): Format.Types.AddressType {
   switch (Compiler.Utils.solidityFamily(compiler)) {
+    case "unknown":
     case "pre-0.5.0":
       return {
         typeClass: "address",
@@ -147,6 +148,7 @@ function externalAddressType(
   compiler: Compiler.CompilerVersion
 ): Format.Types.AddressType {
   switch (Compiler.Utils.solidityFamily(compiler)) {
+    case "unknown":
     case "pre-0.5.0":
       return {
         typeClass: "address",


### PR DESCRIPTION
One more quick PR to fix a debugger problem that can occur if it can't find the source code.  And then this should be it for now.

I made the choice to treat having no compiler like pre-0.5.0 Solidity for the purposes of decoding globally-available variables.  Notionally we could just exclude these entirely, I guess?  But whatever, this was easiest.