### PR TITLE
Add missing chai dev dependency in decoder

### DIFF
--- a/packages/decoder/package.json
+++ b/packages/decoder/package.json
@@ -48,6 +48,7 @@
     "@types/debug": "^0.0.31",
     "@types/utf8": "^2.1.6",
     "@types/web3": "1.0.19",
+    "chai": "^4.2.0",
     "lodash.clonedeep": "^4.5.0",
     "typescript": "^3.6.3"
   },


### PR DESCRIPTION
The decoder has been using chai in its tests, but this didn't appear in the package.json.  Now I've added it as a devDependency.