### PR TITLE
Add interface for decoding return values in decoder

### DIFF
--- a/packages/codec/docs/typedoc.json
+++ b/packages/codec/docs/typedoc.json
@@ -16,6 +16,7 @@
     "Enumerations",
     "Requests",
     "Decoding",
+    "Decoding convenience",
     "ABIfication",
     "General categories",
     "Elementary types",

--- a/packages/codec/lib/core.ts
+++ b/packages/codec/lib/core.ts
@@ -696,6 +696,20 @@ export function* decodeReturndata(
   return decodings;
 }
 
+/**
+ * Decodes the return data from a failed call.
+ *
+ * @param returndata The returned data, as a Uint8Array.
+ * @return An array of possible decodings.  At the moment it's
+ *   impossible for there to be more than one.  (If the call didn't actually
+ *   fail, or failed in a nonstandard way, you may get no decodings at all, though!)
+ *
+ *   Decodings can either be decodings of revert messages, or decodings
+ *   indicating that there was no revert message.  If somehow both were to be
+ *   possible, they'd go in that order, although as mentioned, there (at least
+ *   currently) isn't any way for that to occur.
+ * @Category Decoding convenience
+ */
 export function decodeRevert(returndata: Uint8Array): ReturndataDecoding[] {
   //coercing because TS doesn't know it'll finish in one go
   return <ReturndataDecoding[]>decodeReturndata(

--- a/packages/codec/lib/index.ts
+++ b/packages/codec/lib/index.ts
@@ -44,9 +44,8 @@
  * currently does not (although this is planned for the future).
  *
  * There is also functionality for decoding return values and revert messages
- * (currently mostly unused, intended to be hooked up later) as well as some
- * rudimentary encoding functionality, although currently that's just used
- * internally.  A better interface for these things is intended for the future.
+ * that goes beyond what's currently available in @truffle/decoder; this may get
+ * a better interface in the future.
  *
  * ## How to use
  *
@@ -257,6 +256,7 @@ export {
   DecodingMode,
   CalldataDecoding,
   LogDecoding,
+  ReturndataDecoding,
   FunctionDecoding,
   ConstructorDecoding,
   MessageDecoding,
@@ -264,6 +264,12 @@ export {
   UnknownCreationDecoding,
   EventDecoding,
   AnonymousDecoding,
+  ReturnDecoding,
+  BytecodeDecoding,
+  UnknownBytecodeDecoding,
+  SelfDestructDecoding,
+  RevertMessageDecoding,
+  EmptyFailureDecoding,
   AbiArgument,
   DecoderRequest,
   StorageRequest,

--- a/packages/decoder/lib/index.ts
+++ b/packages/decoder/lib/index.ts
@@ -2,12 +2,11 @@
 # Truffle Decoder
 
 This module provides an interface for decoding contract state, transaction
-calldata, and events.  It's an interface to the same low-level decoding
-functionality that Truffle Debugger uses.  However, it has additional
-functionality that the debugger does not need, and the debugger has additional
-functionality that this interface either does not need or cannot currently
-replicate.  In the future, this interface will also decode return values and
-revert strings.
+calldata, events, and return values and revert strings.  It's an interface to
+the same low-level decoding functionality that Truffle Debugger uses.  However,
+it has additional functionality that the debugger does not need, and the
+debugger has additional functionality that this interface either does not need
+or cannot currently replicate.
 
 The interface is split into three classes: The wire decoder, the contract
 decoder, and the contract instance decoder.  The wire decoder is associated to
@@ -154,6 +153,7 @@ export {
   StateVariable,
   DecodedLog,
   EventOptions,
+  ReturnOptions,
   Transaction,
   Log,
   BlockSpecifier
@@ -384,6 +384,12 @@ export async function forContractInstance(
   );
 }
 
+//Note: this function doesn't actually go in this category, but
+//I don't want an unsightly "Other functions" thing appearing,
+//so I'm hiding it here :)
+/**
+ * @category Provider-based Constructor
+ */
 function infoToCompilations(
   projectInfo: ProjectInfo | Artifact[],
   primaryArtifact?: Artifact

--- a/packages/decoder/lib/types.ts
+++ b/packages/decoder/lib/types.ts
@@ -136,7 +136,7 @@ export interface ContractInfo {
 }
 
 /**
- * The type of the options parameter to events().  This type will be expanded in the future
+ * The type of the options parameter to [[WireDecoder.events|events()]].  This type will be expanded in the future
  * as more filtering options are added.
  * @category Inputs
  */
@@ -162,6 +162,25 @@ export interface EventOptions {
    * address as undefined.
    */
   address?: string;
+}
+
+/**
+ * The type of the options parameter to [[ContractDecoder.decodeReturnValue|decodeReturnValue()]].
+ * @category Inputs
+ */
+export interface ReturnOptions {
+  /**
+   * The block in which the call was made.  Defaults to "latest".
+   */
+  block?: BlockSpecifier;
+  /**
+   * If included, tells the decoder to interpret the return data as
+   * the return data from a successful call (if `true` is passed) or
+   * as the return data from a failed call (if `false` is passed). If
+   * omitted or set to `undefined`, the decoder will account for both
+   * possibilities.
+   */
+  status?: boolean | undefined;
 }
 
 /**

--- a/packages/decoder/test/current/contracts/DowngradeTest.sol
+++ b/packages/decoder/test/current/contracts/DowngradeTest.sol
@@ -67,6 +67,10 @@ contract DowngradeTest is DowngradeTestParent {
   function emitParent() public {
     emit Inherited();
   }
+
+  function returnsStuff() public pure returns (Pair memory, Ternary) {
+    return (Pair(107, 683), Ternary.No);
+  }
 }
 
 library DecoyLibrary {

--- a/packages/decoder/test/current/contracts/WireTest.sol
+++ b/packages/decoder/test/current/contracts/WireTest.sol
@@ -174,6 +174,18 @@ contract WireTest is WireTestParent, WireTestAbstract {
     emit Overridden(107);
     emit WireTestParent.Overridden(683);
   }
+
+  function returnsStuff() public pure returns (Triple memory, Ternary) {
+    return (Triple(-1, 0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef, hex"deadbeef"), Ternary.No);
+  }
+
+  receive() external payable {
+  }
+
+  function boom() public returns (uint) {
+    selfdestruct(address(this));
+  }
+
 }
 
 library WireTestLibrary {

--- a/packages/decoder/test/current/test/wire-test.js
+++ b/packages/decoder/test/current/test/wire-test.js
@@ -892,4 +892,69 @@ contract("WireTest", function(_accounts) {
       [1, 2, 3, 4]
     );
   });
+
+  it("Decodes return values", async function() {
+    let deployedContract = await WireTest.deployed();
+
+    const decoder = await Decoder.forContract(WireTest, [
+      WireTest,
+      WireTestParent,
+      WireTestLibrary,
+      WireTestAbstract
+    ]);
+
+    let abiEntry = WireTest.abi.find(
+      ({ type, name }) => type === "function" && name === "returnsStuff"
+    );
+    let selector = web3.eth.abi.encodeFunctionSignature(abiEntry);
+
+    //we need the raw return data, and contract.call() does not exist yet,
+    //so we're going to have to use web3.eth.call()
+
+    let data = await web3.eth.call({
+      to: deployedContract.address,
+      data: selector
+    });
+
+    let decodings = await decoder.decodeReturnValue(abiEntry, data);
+    assert.lengthOf(decodings, 1);
+    let decoding = decodings[0];
+    assert.strictEqual(decoding.kind, "return");
+    assert.strictEqual(decoding.decodingMode, "full");
+    assert.lengthOf(decoding.arguments, 2);
+    assert.deepEqual(
+      Codec.Format.Utils.Inspect.nativize(decoding.arguments[0].value),
+      {
+        x: -1,
+        y: "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        z: "0xdeadbeef"
+      }
+    );
+    assert.strictEqual(
+      Codec.Format.Utils.Inspect.nativize(decoding.arguments[1].value),
+      "WireTest.Ternary.No"
+    );
+
+    //now: let's try decoding a self-destruct :)
+    let sdAbiEntry = WireTest.abi.find(
+      ({ type, name }) => type === "function" && name === "boom"
+    );
+    let sdSelector = web3.eth.abi.encodeFunctionSignature(sdAbiEntry);
+
+    //we need the raw return data, and contract.call() does not exist yet,
+    //so we're going to have to use web3.eth.call()
+
+    let sdData = await web3.eth.call({
+      to: deployedContract.address,
+      data: sdSelector
+    });
+
+    let sdDecodings = await decoder.decodeReturnValue(sdAbiEntry, sdData, {
+      status: true
+    });
+
+    assert.lengthOf(sdDecodings, 1);
+    assert.strictEqual(sdDecodings[0].kind, "selfdestruct");
+    assert.strictEqual(sdDecodings[0].decodingMode, "full");
+  });
 });


### PR DESCRIPTION
This PR adds an interface for decoding return values in `decoder`, which previously only existed as low-level functionality in `codec`.

Decoding these can be done with either the `ContractDecoder` or the `ContractInstanceDecoder` -- you need to have one of the for the contract that the return value was received from.  As usual, using the `ContractInstanceDecoder` allows for somewhat more robustness.

To use this, you pass the ABI of the function call you're decoding, the raw data you're decoding, and, optionally, the block the call occurred in and its return status.  (The latter two are grouped into an `options` argument.)

You can't use this to decode return values of constructor calls, even though that functionality exists in `codec`.

Note that normally allocation relies on a contract having `deployedBytecode`, but I realized people would probably be annoyed by it failing if that doesn't exist (especially since you're passing in the ABI!), so I added in functionality to allow it to work without that.  I thought about adding similar functionality to `decodeTransaction`, now that the `ContractDecoder` actually does things rather than just acting as a spawner, but I didn't because I was worried it would be too confusing.  (We may want to discuss the interface there to determine if there's a non-confusing way to do it?)

Hopefully this is useful @adrianmcli? :)