### PR TITLE
Fix tab handling in debugger CLI display

### DIFF
--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -39,8 +39,9 @@ class DebugPrinter {
       this.colorizedSources[compilationId] = {};
       for (const source of compilation.byId) {
         const id = source.id;
-        const uncolorized = source.source;
-        const colorized = DebugUtils.colorize(uncolorized);
+        const raw = source.source;
+        const detabbed = DebugUtils.tabsToSpaces(raw);
+        const colorized = DebugUtils.colorize(detabbed);
         this.colorizedSources[compilationId][id] = colorized;
       }
     }


### PR DESCRIPTION
**Note: breaks debug-utils**

I noticed that the debugger CLI doesn't really handle tabs in source files very well.  (Likely it might've back before colorization, but I never thought to check that interaction until now.)  I fixed it up so it does.  Long story short, I determined the only way to do this really is, when colorizing source files, detab them first.  (But *don't* detab the uncolorized source!)

I also generally improved our existing detabbing so it actually emulates tab stops instead of just replacing them with a fixed number of spaces.

I also set the default tab width to 8, as that's the most common, but of course that's easy enough to change.  Although it should probably be abstracted a little differently?  Ah well.

I guess this is a breaking change to debug-utils, since some functions now assume certain input has been detabbed.