### PR TITLE
Fix stepOver to work properly with changes of file

### DIFF
--- a/packages/debugger/lib/controller/sagas/index.js
+++ b/packages/debugger/lib/controller/sagas/index.js
@@ -197,16 +197,15 @@ function* stepOver() {
     !finished &&
     // we haven't jumped out
     currentDepth >= startingDepth &&
-    // we haven't changed file
-    currentLocation.source.id === startingLocation.source.id &&
-    currentLocation.source.compilationId ===
-      startingLocation.source.compilationId &&
     // either: function depth is greater than starting (ignore function calls)
     // or, if we're at the same depth, keep stepping until we're on a new
-    // line.
+    // line (which may be in a new file)
     (currentDepth > startingDepth ||
-      currentLocation.sourceRange.lines.start.line ===
-        startingLocation.sourceRange.lines.start.line)
+      (currentLocation.source.id === startingLocation.source.id &&
+        currentLocation.source.compilationId ===
+          startingLocation.source.compilationId &&
+        currentLocation.sourceRange.lines.start.line ===
+          startingLocation.sourceRange.lines.start.line))
   );
 }
 


### PR DESCRIPTION
It seems that when I added multi-compilation to support to the debugger, the way I integrated it into `stepOver` was wrong -- I treated any change of file as a reason to stop stepping.  Now I've put that check where it belongs, alongside the line check; a change of file is only a reason to stop stepping if you're at, not beyond, the starting depth.