### PR TITLE
Add --bail option for truffle test (solves #2848)

### DIFF
--- a/packages/core/lib/commands/test/index.js
+++ b/packages/core/lib/commands/test/index.js
@@ -20,11 +20,16 @@ const command = {
       describe: "Suppress all output except for test runner output.",
       type: "boolean",
       default: false
+    },
+    "bail": {
+      describe: "Bail after first test failure",
+      type: "boolean",
+      default: false
     }
   },
   help: {
     usage:
-      "truffle test [<test_file>] [--compile-all] [--network <name>] [--verbose-rpc] [--show-events] [--debug] [--debug-global <identifier>]",
+      "truffle test [<test_file>] [--compile-all] [--network <name>] [--verbose-rpc] [--show-events] [--debug] [--debug-global <identifier>] [--bail]",
     options: [
       {
         option: "<test_file>",
@@ -67,6 +72,10 @@ const command = {
       {
         option: "--runner-output-only",
         description: "Suppress all output except for test runner output."
+      },
+      {
+        option: "--bail",
+        description: "Bail after first test failure"
       }
     ]
   },

--- a/packages/core/lib/test.js
+++ b/packages/core/lib/test.js
@@ -153,6 +153,9 @@ const Test = {
     // Allow people to specify config.mocha in their config.
     const mochaConfig = config.mocha || {};
 
+    // Propagate --bail option to mocha
+    mochaConfig.bail = config.bail;
+
     // If the command line overrides color usage, use that.
     if (config.colors != null) mochaConfig.useColors = config.colors;
 


### PR DESCRIPTION
- Add --bail flag to the command object and help object
- Propagate this bail flag into mochaConfig

I'm not sure what the project's test workflow is, so let me know what kind of tests you need with it. Currently just tested it manually in one of my repos.

Fixes #2848 