### PR TITLE
Bug fix: Bail out of event allocation grouping if can't find base contract's info

### DIFF
--- a/packages/codec/docs/README.md
+++ b/packages/codec/docs/README.md
@@ -61,11 +61,12 @@ which mode was used via the `"decodingMode"` field.
 
 To ensure full mode works:
   * Use Solidity v0.4.12 or higher;
+  * Ensure all contracts in your projects have distinct names;
   * Compile all your contracts at the same time;
   * Ensure all custom data types are declared in a file with at least one contract.
 
 (Our apologies for these technical limitations, but we are working to address
-these last two problems.)
+these last three problems.)
 
 If you can't use full mode or don't want to deal with the distinction,
 the decoder provides

--- a/packages/codec/lib/abi-data/allocate/index.ts
+++ b/packages/codec/lib/abi-data/allocate/index.ts
@@ -1010,7 +1010,7 @@ export function getEventAllocations(
           if (!baseContractInfo) {
             //similar to above... this failure case can happen when there are
             //two contracts with the same name and you attempt to use the
-            //artifacts (say you have contracts A, B, and B', where A inherits
+            //artifacts; say you have contracts A, B, and B', where A inherits
             //from B, and B and B' have the same name, and B' is the one that
             //gets the artifact; B will end up in reference declarations and so
             //get found above, but it won't appear in contracts, causing the

--- a/packages/codec/lib/abi-data/allocate/index.ts
+++ b/packages/codec/lib/abi-data/allocate/index.ts
@@ -971,6 +971,7 @@ export function getEventAllocations(
         allocationTemporary,
         compilationId
       } = individualAllocations[contextOrId][selector];
+      debug("allocationTemporary: %O", allocationTemporary);
       let allocationsTemporary = allocationTemporary.allocation
         ? [allocationTemporary]
         : []; //filter out undefined allocations
@@ -988,7 +989,7 @@ export function getEventAllocations(
         let linearizedBaseContractsMinusSelf = contractNode.linearizedBaseContracts.slice();
         linearizedBaseContractsMinusSelf.shift(); //remove contract itself; only want ancestors
         for (let baseId of linearizedBaseContractsMinusSelf) {
-          debug("checking base baseId: %d", baseId);
+          debug("checking baseId: %d", baseId);
           let baseNode = referenceDeclarations[compilationId][baseId];
           if (!baseNode || baseNode.nodeType !== "ContractDefinition") {
             debug("failed to find node for baseId: %d", baseId);
@@ -1000,18 +1001,30 @@ export function getEventAllocations(
           //we're just checking for whether we can *find* it
           //why? because if we couldn't find it, that means that events defined in
           //base contracts *weren't* skipped earlier, and so we shouldn't now add them in
-          debug("baseId: %d", baseId);
-          let baseContext = contracts.find(
+          let baseContractInfo = contracts.find(
             contractAllocationInfo =>
               contractAllocationInfo.compilationId === compilationId &&
               contractAllocationInfo.contractNode &&
               contractAllocationInfo.contractNode.id === baseId
-          ).deployedContext;
+          );
+          if (!baseContractInfo) {
+            //similar to above... this failure case can happen when there are
+            //two contracts with the same name and you attempt to use the
+            //artifacts (say you have contracts A, B, and B', where A inherits
+            //from B, and B and B' have the same name, and B' is the one that
+            //gets the artifact; B will end up in reference declarations and so
+            //get found above, but it won't appear in contracts, causing the
+            //problem here.  Unfortunately I don't know any great way to handle this,
+            //so, uh, we treat it as a failure same as above.
+            debug("failed to find contract info for baseId: %d", baseId);
+            break;
+          }
+          let baseContext = baseContractInfo.deployedContext;
           let baseKey = makeContractKey(baseContext, baseId, compilationId);
           if (individualAllocations[baseKey][selector] !== undefined) {
             let baseAllocation =
               individualAllocations[baseKey][selector].allocationTemporary;
-            debug("pushing inherited alloc from baseId: %d", baseId);
+            debug("(probably) pushing inherited alloc from baseId: %d", baseId);
             if (baseAllocation.allocation) {
               //don't push undefined!
               groupedAllocations[contextOrId][


### PR DESCRIPTION
This PR is intended to address #2876.  Allocation was failing at the event allocation grouping step on certain projects.  Now that I've reproduced the problem, I can finally see why this happens: Multiple contracts with the same name.

Basically this problem if you have contracts A, B, and B', where A inherits from B, B and B' have the same name, and B' rather than B is the one that ended up getting the artifact.  In this case, you can end up in the situation where the allocator can find the node for B, but then can't find the corresponding contract info object (since there's no artifact for it).  Thus the error, since I assumed having one necessarily means having the other.

Unfortunately, as the comment said, I don't really see any good way to truly fix this; instead I just bail out of allocation there and let it kind of fail.  After all, we can always fall back on ABI mode!  And have to handle the error *somehow* so that it doesn't screw up everybody's tests.  But that's basically how the decoder was made to work, after all -- it does the best it can, and it falls back on ABI mode when it can't!

I've also added this to the docs as an additional condition required for full mode.  I left it out before because, um... I didn't think of it.  Oh well.  Now it will be there.