### PR TITLE
[hdwallet-provider] fix detection of websockets urls

### DIFF
--- a/packages/hdwallet-provider/src/index.ts
+++ b/packages/hdwallet-provider/src/index.ts
@@ -164,7 +164,7 @@ class HDWalletProvider {
       // Web3.providers.HttpProvider.prototype.send;
       let subProvider;
       const providerProtocol = (
-        Url.parse(provider).protocol || "http"
+        Url.parse(provider).protocol || "http:"
       ).toLowerCase();
 
       switch (providerProtocol) {

--- a/packages/hdwallet-provider/src/index.ts
+++ b/packages/hdwallet-provider/src/index.ts
@@ -168,9 +168,10 @@ class HDWalletProvider {
       ).toLowerCase();
 
       switch (providerProtocol) {
-        case "ws":
-        case "wss":
+        case "ws:":
+        case "wss:":
           subProvider = new Web3.providers.WebsocketProvider(provider);
+          break;
         default:
           // @ts-ignore: Incorrect typings in @types/web3
           subProvider = new Web3.providers.HttpProvider(provider, {


### PR DESCRIPTION
I was trying to use a websockets url in the hdwalletprovider.

```
networks: {
    launchpad: {
      provider: () => new HDWalletProvider(bpaasconfig.mnemonic, 'wss://xxx.settlemint.com/xxx/besu/ws'),
      gasPrice: '0',
      network_id: '*',
      websockets: true,
      production: false,
      gas: "0x1dcd6400"
    },
  },
```

I figured this was possible reading the code here

https://github.com/trufflesuite/truffle/blob/develop/packages/hdwallet-provider/src/index.ts#L166-L179

Some issues I detected:

- `providerProtocol` is actually `wss:` so the case never triggers
-  `case "wss":` does not have a `break;` so is always overridden

Quick workaround is passing in my own web3 provider, but this code exists so i made it work