### PR TITLE
Enhancement: Allow @truffle/decoder to fully decode internal function pointers

### DIFF
--- a/packages/codec/lib/format/values.ts
+++ b/packages/codec/lib/format/values.ts
@@ -490,13 +490,16 @@ export interface FunctionInternalValueInfoException {
 }
 
 /**
- * This type is used when decoding internal functions from the high-level
- * decoding interface, which presently doesn't support detailed decoding of
- * internal functions.  (The debugger, however, supports it!  You can get this
- * detailed information in the debugger!)  You'll still get the program counter
- * values, but further information will be absent.  Note you'll get this even
- * if really it should decode to an error, because the decoding interface
- * doesn't have the information to determine that it's an error.
+ * This type is used when decoding internal functions in contexts that don't
+ * support full decoding of such functions.  The high-level decoding interface
+ * can currently only sometimes perform such a full decoding.
+ *
+ * In contexts where such full decoding isn't supported, you'll get one of
+ * these; so you'll still get the program counter values, but further
+ * information will be absent.  Note you'll get this even if really it should
+ * decode to an error, because if there's insufficient information to determine
+ * additional function information, there's necessarily insufficient
+ * information to determine if it should be an error.
  *
  * @Category Function types
  */

--- a/packages/debugger/lib/helpers/index.js
+++ b/packages/debugger/lib/helpers/index.js
@@ -22,17 +22,6 @@ export function isSkippedNodeType(node) {
   );
 }
 
-export function getRange(node) {
-  // src: "<start>:<length>:<_>"
-  // returns [start, end]
-  let [start, length] = node.src
-    .split(":")
-    .slice(0, 2)
-    .map(i => parseInt(i));
-
-  return [start, start + length];
-}
-
 export function prefixName(prefix, fn) {
   Object.defineProperty(fn, "name", {
     value: `${prefix}.${fn.name}`,

--- a/packages/debugger/lib/solidity/selectors/index.js
+++ b/packages/debugger/lib/solidity/selectors/index.js
@@ -3,33 +3,11 @@ const debug = debugModule("debugger:solidity:selectors");
 
 import { createSelectorTree, createLeaf } from "reselect-tree";
 import SolidityUtils from "@truffle/solidity-utils";
-import CodeUtils from "@truffle/code-utils";
-import * as Codec from "@truffle/codec";
 
-import IntervalTree from "node-interval-tree";
-import jsonpointer from "json-pointer";
 import semver from "semver";
-import { getRange } from "lib/helpers";
 
 import evm from "lib/evm/selectors";
 import trace from "lib/trace/selectors";
-
-function getSourceRange(instruction = {}) {
-  return {
-    start: instruction.start || 0,
-    length: instruction.length || 0,
-    lines: instruction.range || {
-      start: {
-        line: 0,
-        column: 0
-      },
-      end: {
-        line: 0,
-        column: 0
-      }
-    }
-  };
-}
 
 function contextRequiresPhantomStackframes(context) {
   debug("context: %O", context);
@@ -40,48 +18,6 @@ function contextRequiresPhantomStackframes(context) {
       includePrerelease: true
     })
   );
-}
-
-function rangeNodes(node, pointer = "") {
-  if (node instanceof Array) {
-    return [].concat(
-      ...node.map((sub, i) => rangeNodes(sub, `${pointer}/${i}`))
-    );
-  } else if (node instanceof Object) {
-    let results = [];
-
-    if (node.src !== undefined && node.id !== undefined) {
-      //there are some "pseudo-nodes" with a src but no id.
-      //these will cause problems, so we want to exclude them.
-      //(to my knowledge this only happens with the externalReferences
-      //to an InlineAssembly node, so excluding them just means we find
-      //the InlineAssembly node instead, which is fine)
-      results.push({ pointer, node, range: getRange(node) });
-    }
-
-    return results.concat(
-      ...Object.keys(node).map(key =>
-        rangeNodes(node[key], `${pointer}/${key}`)
-      )
-    );
-  } else {
-    return [];
-  }
-}
-
-function findRange(findOverlappingRange, sourceStart, sourceLength) {
-  // find nodes that fully contain requested range,
-  // return one with longest pointer
-  // (note: returns { range, node, pointer }
-  let sourceEnd = sourceStart + sourceLength;
-  return findOverlappingRange(sourceStart, sourceLength)
-    .filter(({ range }) => sourceStart >= range[0] && sourceEnd <= range[1])
-    .reduce(
-      (acc, cur) => (cur.pointer.length >= acc.pointer.length ? cur : acc),
-      { pointer: "" }
-    );
-  //note we make sure to bias towards cur (the new value being compared) rather than acc (the old value)
-  //so that we don't actually get {pointer: ""} as our result
 }
 
 //function to create selectors that need both a current and next version
@@ -130,7 +66,7 @@ function createMultistepSelectors(stepSelector) {
     /**
      * .sourceRange
      */
-    sourceRange: createLeaf(["./instruction"], getSourceRange),
+    sourceRange: createLeaf(["./instruction"], SolidityUtils.getSourceRange),
 
     /**
      * .pointerAndNode
@@ -140,7 +76,11 @@ function createMultistepSelectors(stepSelector) {
 
       (findOverlappingRange, range) =>
         findOverlappingRange
-          ? findRange(findOverlappingRange, range.start, range.length)
+          ? SolidityUtils.findRange(
+              findOverlappingRange,
+              range.start,
+              range.length
+            )
           : null
     ),
 
@@ -260,104 +200,15 @@ let solidity = createSelectorTree({
       ["./sources", evm.current.context, "./humanReadableSourceMap"],
 
       (sources, context, sourceMap) => {
-        if (!context || !sources) {
-          return [];
-        }
-        let binary = context.binary;
-        if (!binary) {
+        if (!context) {
           return [];
         }
 
-        let numInstructions;
-        if (sourceMap) {
-          numInstructions = sourceMap.length;
-        } else {
-          //HACK
-          numInstructions = (binary.length - 2) / 2;
-          //this is actually an overestimate, but that's OK
-        }
-
-        //because we might be dealing with a constructor with arguments, we do
-        //*not* remove metadata manually
-        let instructions = CodeUtils.parseCode(binary, numInstructions);
-
-        if (!sourceMap) {
-          // HACK
-          // Let's create a source map to use since none exists. This source
-          // map maps just as many ranges as there are instructions (or
-          // possibly more), and marks them all as being Solidity-internal and
-          // not jumps.
-          sourceMap = new Array(instructions.length);
-          sourceMap.fill({
-            start: 0,
-            length: 0,
-            file: -1,
-            jump: "-",
-            modifierDepth: "0"
-          });
-        }
-
-        var lineAndColumnMappings = Object.assign(
-          {},
-          ...Object.entries(sources).map(([id, { source }]) => ({
-            [id]: SolidityUtils.getCharacterOffsetToLineAndColumnMapping(
-              source || ""
-            )
-          }))
+        return SolidityUtils.getProcessedInstructionsForBinary(
+          (sources || []).map(({ source }) => source),
+          context.binary,
+          sourceMap
         );
-
-        let primaryFile;
-        if (sourceMap[0]) {
-          primaryFile = sourceMap[0].file;
-        }
-        debug("primaryFile %o", primaryFile);
-
-        return instructions
-          .map((instruction, index) => {
-            // lookup source map by index and add `index` property to
-            // instruction
-            //
-
-            const instructionSourceMap = sourceMap[index] || {};
-
-            return {
-              instruction: { ...instruction, index },
-              instructionSourceMap
-            };
-          })
-          .map(({ instruction, instructionSourceMap }) => {
-            // add source map information to instruction, or defaults
-
-            const {
-              jump,
-              start = 0,
-              length = 0,
-              file = primaryFile,
-              modifierDepth = 0
-            } = instructionSourceMap;
-            const lineAndColumnMapping = lineAndColumnMappings[file] || {};
-            const range = {
-              start: lineAndColumnMapping[start] || {
-                line: null,
-                column: null
-              },
-              end: lineAndColumnMapping[start + length] || {
-                line: null,
-                column: null
-              }
-            };
-
-            return {
-              ...instruction,
-
-              jump,
-              start,
-              length,
-              file,
-              range,
-              modifierDepth
-            };
-          });
       }
     ),
 
@@ -416,70 +267,13 @@ let solidity = createSelectorTree({
       ],
       (instructions, sources, functions, { compilationId }) =>
         //note: we can skip an explicit null check on sources here because
-        //if sources is null then instructions = [] so the problematic code
-        //will never run
-        Object.assign(
-          {},
-          ...instructions
-            .filter(instruction => instruction.name === "JUMPDEST")
-            .filter(instruction => instruction.file !== -1)
-            //note that the designated invalid function *does* have an associated
-            //file, so it *is* safe to just filter out the ones that don't
-            .map(instruction => {
-              debug("instruction %O", instruction);
-              let sourceId = instruction.file;
-              let findOverlappingRange = functions[compilationId][sourceId];
-              let ast = sources[sourceId].ast;
-              let range = getSourceRange(instruction);
-              let { node, pointer } = findRange(
-                findOverlappingRange,
-                range.start,
-                range.length
-              );
-              if (!pointer) {
-                node = ast;
-              }
-              if (!node || node.nodeType !== "FunctionDefinition") {
-                //filter out JUMPDESTs that aren't function definitions...
-                //except for the designated invalid function
-                let nextInstruction = instructions[instruction.index + 1] || {};
-                if (nextInstruction.name === "INVALID") {
-                  //designated invalid, include it
-                  return {
-                    [instruction.pc]: {
-                      isDesignatedInvalid: true
-                    }
-                  };
-                } else {
-                  //not designated invalid, filter it out
-                  return {};
-                }
-              }
-              //otherwise, we're good to go, so let's find the contract node and
-              //put it all together
-              //to get the contract node, we go up twice from the function node;
-              //the path from one to the other should have a very specific form,
-              //so this is easy
-              let contractPointer = pointer.replace(/\/nodes\/\d+$/, "");
-              let contractNode = jsonpointer.get(ast, contractPointer);
-              return {
-                [instruction.pc]: {
-                  sourceIndex: sourceId,
-                  compilationId,
-                  pointer,
-                  node,
-                  name: node.name,
-                  id: node.id,
-                  mutability: Codec.Ast.Utils.mutability(node),
-                  contractPointer,
-                  contractNode,
-                  contractName: contractNode.name,
-                  contractId: contractNode.id,
-                  contractKind: contractNode.contractKind,
-                  isDesignatedInvalid: false
-                }
-              };
-            })
+        //if sources is null then instructions = [] so the problematic map
+        //never occurs
+        SolidityUtils.getFunctionsByProgramCounter(
+          instructions,
+          sources.map(({ ast }) => ast),
+          functions[compilationId],
+          compilationId
         )
     ),
 
@@ -567,16 +361,9 @@ let solidity = createSelectorTree({
         {},
         ...Object.entries(compilations).map(
           ([compilationId, { byId: sources }]) => ({
-            [compilationId]: sources.map(({ ast }) => {
-              let tree = new IntervalTree();
-              let ranges = rangeNodes(ast);
-              for (let { range, node, pointer } of ranges) {
-                let [start, end] = range;
-                tree.insert(start, end, { range, node, pointer });
-              }
-              return (sourceStart, sourceLength) =>
-                tree.search(sourceStart, sourceStart + sourceLength);
-            })
+            [compilationId]: sources.map(({ ast }) =>
+              SolidityUtils.makeOverlapFunction(ast)
+            )
           })
         )
       )

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -20,7 +20,6 @@
     "test:debug": "NODE_ENV=testing node --inspect ./node_modules/.bin/mocha-webpack --webpack-config webpack/webpack.config-test.js --recursive"
   },
   "dependencies": {
-    "@truffle/code-utils": "^1.2.14",
     "@truffle/codec": "^0.4.2",
     "@truffle/compile-solidity": "^4.2.25",
     "@truffle/expect": "^0.0.13",
@@ -66,7 +65,6 @@
     "istanbul-instrumenter-loader": "^3.0.1",
     "mocha": "5.2.0",
     "mocha-webpack": "^1.1.0",
-    "node-interval-tree": "^1.3.3",
     "nyc": "^13.0.1",
     "remotedev-server": "^0.3.1",
     "webpack": "^3.8.1",

--- a/packages/debugger/test/ast.js
+++ b/packages/debugger/test/ast.js
@@ -11,7 +11,7 @@ import Debugger from "lib/debugger";
 import solidity from "lib/solidity/selectors";
 import trace from "lib/trace/selectors";
 
-import { getRange } from "lib/helpers";
+import SolidityUtils from "@truffle/solidity-utils";
 
 const __VARIABLES = `
 pragma solidity ^0.6.1;
@@ -81,7 +81,7 @@ describe("AST", function() {
 
         let node = session.view(solidity.current.node);
 
-        let [nodeStart, nodeLength] = getRange(node);
+        let [nodeStart, nodeLength] = SolidityUtils.getRange(node);
         let nodeEnd = nodeStart + nodeLength;
 
         let pointer = session.view(solidity.current.pointer);

--- a/packages/decoder/lib/index.ts
+++ b/packages/decoder/lib/index.ts
@@ -5,8 +5,7 @@ This module provides an interface for decoding contract state, transaction
 calldata, events, and return values and revert strings.  It's an interface to
 the same low-level decoding functionality that Truffle Debugger uses.  However,
 it has additional functionality that the debugger does not need, and the
-debugger has additional functionality that this interface either does not need
-or cannot currently replicate.
+debugger has additional functionality that this decoder does not need.
 
 The interface is split into three classes: The wire decoder, the contract
 decoder, and the contract instance decoder.  The wire decoder is associated to
@@ -59,9 +58,16 @@ The decoder outputs lossless, machine-readable [[Format.Values.Result]] objects
 containing individual decoded values. See the [[Format|format documentation]]
 for an overview and complete module listing.
 
+Note that for technical reasons, the decoder cannot always fully decode
+internal function pointers, but it will do its best even when information is
+missing, and will still losslessly return what information it can.  If you want
+to make sure to get the full information, see the advice
+[here](../#decoding-modes) about how to make sure "full mode" works; the same
+applies to decoding of internal function pointers.
+
 ### Decoding modes and abification
 
-The decoder runs in either of two modes: full mode or ABI mdoe. Full mode
+The decoder runs in either of two modes: full mode or ABI mode. Full mode
 requires some additional constraints but returns substantially more detailed
 information. Please see the notes on [decoding modes](../#decoding-modes) for
 more about this distinction.

--- a/packages/decoder/package.json
+++ b/packages/decoder/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@truffle/codec": "^0.4.2",
     "@truffle/compile-solidity": "^4.2.25",
+    "@truffle/solidity-utils": "^1.2.8",
     "bn.js": "^4.11.8",
     "debug": "^4.1.0",
     "source-map-support": "^0.5.16",

--- a/packages/decoder/test/current/contracts/DecodingSample.sol
+++ b/packages/decoder/test/current/contracts/DecodingSample.sol
@@ -53,6 +53,7 @@ contract DecodingSample {
   E[]       dynamicArrayEnum;
 
   function() external functionExternal = this.example;
+  function() internal functionInternal;
 
   function example() public {
     functionExternal = this.example;
@@ -126,5 +127,7 @@ contract DecodingSample {
     varEnumMapping[E.EnumValTwo] = 2;
     varEnumMapping[E.EnumValThree] = 3;
     varEnumMapping[E.EnumValFour] = 4;
+
+    functionInternal = example;
   }
 }

--- a/packages/decoder/test/current/contracts/DowngradeTest.sol
+++ b/packages/decoder/test/current/contracts/DowngradeTest.sol
@@ -32,6 +32,8 @@ contract DowngradeTest is DowngradeTestParent {
 
   function() external doYouSeeMe = this.causeTrouble;
 
+  function() internal canYouReadMe = causeTrouble;
+
   function run(AsymmetricTriple memory at, Ternary t, DowngradeTest dt, address payable ap) public {
     emit TheWorks(at, t, dt, ap);
   }

--- a/packages/decoder/test/current/test/decoding-test.js
+++ b/packages/decoder/test/current/test/decoding-test.js
@@ -126,8 +126,6 @@ contract("DecodingSample", _accounts => {
     assert.equal(variables.dynamicArrayEnum[0], "DecodingSample.E.EnumValFour");
     assert.equal(variables.dynamicArrayEnum[1], "DecodingSample.E.EnumValTwo");
 
-    // const fixedStructArray = variables.fixedArrayStructS;
-
     assert.equal(variables.varMapping[2], 41);
     assert.equal(variables.varMapping[3], 107);
     assert.equal(variables.varAddressMapping[address], 683);
@@ -141,5 +139,7 @@ contract("DecodingSample", _accounts => {
       variables.functionExternal,
       "DecodingSample(" + address + ").example"
     );
+
+    assert.equal(variables.functionInternal, "DecodingSample.example");
   });
 });

--- a/packages/decoder/test/current/test/downgrade-test.js
+++ b/packages/decoder/test/current/test/downgrade-test.js
@@ -370,6 +370,27 @@ contract("DowngradeTest", function(accounts) {
     assert.strictEqual(decodedFunction.value.selector, selector);
   });
 
+  it("Partially decodes internal functions when unreliable order", async function() {
+    let mangledCompilations = clonedeep(compilations);
+    mangledCompilations[0].unreliableSourceOrder = true;
+
+    let deployedContract = await DowngradeTest.new();
+    let decoder = await Decoder.forContractInstance(deployedContract, {
+      compilations: mangledCompilations
+    });
+
+    let decodedFunction = await decoder.variable("canYouReadMe");
+    assert.strictEqual(decodedFunction.type.typeClass, "function");
+    assert.strictEqual(decodedFunction.type.visibility, "internal");
+    assert.strictEqual(decodedFunction.type.mutability, "nonpayable");
+    assert.isEmpty(decodedFunction.type.inputParameterTypes);
+    assert.isEmpty(decodedFunction.type.outputParameterTypes);
+    assert.strictEqual(decodedFunction.kind, "value");
+    assert.strictEqual(decodedFunction.value.kind, "unknown");
+    assert.strictEqual(decodedFunction.value.context.typeName, "DowngradeTest");
+    //we won't bother testing the PC values
+  });
+
   it("Decodes return values even with no deployedBytecode", async function() {
     let mangledCompilations = clonedeep(compilations);
     let downgradeTest = mangledCompilations[0].contracts.find(

--- a/packages/solidity-utils/index.js
+++ b/packages/solidity-utils/index.js
@@ -90,12 +90,13 @@ var SolidityUtils = {
 
   //sources: array of text sources (must be in order!)
   //binary: raw binary to process.  should not have unresolved links.
-  //sourceMap: its corresponding source map.  if left undefined,
+  //sourceMap: a processed source map as output by getHumanReadableSourceMap above
   //we... attempt to muddle through.
   getProcessedInstructionsForBinary: function(sources, binary, sourceMap) {
     if (!sources || !binary) {
       return [];
     }
+    debug("sourceMap: %O", sourceMap);
 
     let numInstructions;
     if (sourceMap) {

--- a/packages/solidity-utils/index.js
+++ b/packages/solidity-utils/index.js
@@ -1,4 +1,10 @@
-var debug = require("debug")("solidity-utils");
+const debug = require("debug")("solidity-utils");
+const CodeUtils = require("@truffle/code-utils");
+const Codec = require("@truffle/codec");
+const jsonpointer = require("json-pointer");
+//NOTE: for some reason using the default export isn't working??
+//so we're going to do this the "advanced usage" way...
+const { IntervalTree } = require("node-interval-tree");
 
 var SolidityUtils = {
   getCharacterOffsetToLineAndColumnMapping: function(source) {
@@ -80,6 +86,272 @@ var SolidityUtils = {
     }
 
     return processedSourceMap;
+  },
+
+  //sources: array of text sources (must be in order!)
+  //binary: raw binary to process.  should not have unresolved links.
+  //sourceMap: its corresponding source map.  if left undefined,
+  //we... attempt to muddle through.
+  getProcessedInstructionsForBinary: function(sources, binary, sourceMap) {
+    if (!sources || !binary) {
+      return [];
+    }
+
+    let numInstructions;
+    if (sourceMap) {
+      numInstructions = sourceMap.length;
+    } else {
+      //HACK
+      numInstructions = (binary.length - 2) / 2;
+      //this is actually an overestimate, but that's OK
+    }
+
+    //because we might be dealing with a constructor with arguments, we do
+    //*not* remove metadata manually
+    let instructions = CodeUtils.parseCode(binary, numInstructions);
+
+    if (!sourceMap) {
+      // HACK
+      // Let's create a source map to use since none exists. This source
+      // map maps just as many ranges as there are instructions (or
+      // possibly more), and marks them all as being Solidity-internal and
+      // not jumps.
+      sourceMap = new Array(instructions.length);
+      sourceMap.fill({
+        start: 0,
+        length: 0,
+        file: -1,
+        jump: "-",
+        modifierDepth: "0"
+      });
+    }
+
+    var lineAndColumnMappings = Object.assign(
+      {},
+      ...Object.entries(sources).map(([id, source]) => ({
+        [id]: SolidityUtils.getCharacterOffsetToLineAndColumnMapping(
+          source || ""
+        )
+      }))
+    );
+
+    let primaryFile;
+    if (sourceMap[0]) {
+      primaryFile = sourceMap[0].file;
+    }
+    debug("primaryFile %o", primaryFile);
+
+    return instructions
+      .map((instruction, index) => {
+        // lookup source map by index and add `index` property to
+        // instruction
+        //
+
+        const instructionSourceMap = sourceMap[index] || {};
+
+        instruction.index = index; //should be fine to modify this
+
+        return {
+          instruction,
+          instructionSourceMap
+        };
+      })
+      .map(({ instruction, instructionSourceMap }) => {
+        // add source map information to instruction, or defaults
+
+        //I think it is also OK to modify instruction here
+        ({
+          jump: instruction.jump,
+          start: instruction.start = 0,
+          length: instruction.length = 0,
+          file: instruction.file = primaryFile,
+          modifierDepth: instruction.modifierDepth = 0
+        } = instructionSourceMap);
+        const lineAndColumnMapping =
+          lineAndColumnMappings[instruction.file] || {};
+        instruction.range = {
+          start: lineAndColumnMapping[instruction.start] || {
+            line: null,
+            column: null
+          },
+          end: lineAndColumnMapping[instruction.start + instruction.length] || {
+            line: null,
+            column: null
+          }
+        };
+
+        return instruction;
+      });
+  },
+
+  //instructions: as output by the function above
+  //asts: array of abstract syntax trees for the sources. must be in order!
+  //overlapFunctions: an array of functions -- each one corresponding to the AST of the same index --
+  //that, given a start index and a length, will search for all nodes in that AST overlapping the
+  //given range, and will return an array of objects with fields node and pointer; node should
+  //be the corresponding node, and pointer a jsonpointer to it (from the AST root)
+  //compilationId: what it says.  the function will work fine without it.
+  getFunctionsByProgramCounter: function(
+    instructions,
+    asts,
+    overlapFunctions,
+    compilationId
+  ) {
+    return Object.assign(
+      {},
+      ...instructions
+        .filter(instruction => instruction.name === "JUMPDEST")
+        .filter(instruction => instruction.file !== -1)
+        //note that the designated invalid function *does* have an associated
+        //file, so it *is* safe to just filter out the ones that don't
+        .map(instruction => {
+          debug("instruction %O", instruction);
+          let sourceId = instruction.file;
+          let findOverlappingRange = overlapFunctions[sourceId];
+          let ast = asts[sourceId];
+          let range = SolidityUtils.getSourceRange(instruction);
+          let { node, pointer } = SolidityUtils.findRange(
+            findOverlappingRange,
+            range.start,
+            range.length
+          );
+          if (!pointer) {
+            node = ast;
+          }
+          if (!node || node.nodeType !== "FunctionDefinition") {
+            //filter out JUMPDESTs that aren't function definitions...
+            //except for the designated invalid function
+            let nextInstruction = instructions[instruction.index + 1] || {};
+            if (nextInstruction.name === "INVALID") {
+              //designated invalid, include it
+              return {
+                [instruction.pc]: {
+                  isDesignatedInvalid: true
+                }
+              };
+            } else {
+              //not designated invalid, filter it out
+              return {};
+            }
+          }
+          //otherwise, we're good to go, so let's find the contract node and
+          //put it all together
+          //to get the contract node, we go up twice from the function node;
+          //the path from one to the other should have a very specific form,
+          //so this is easy
+          let contractPointer = pointer.replace(/\/nodes\/\d+$/, "");
+          let contractNode = jsonpointer.get(ast, contractPointer);
+          return {
+            [instruction.pc]: {
+              sourceIndex: sourceId,
+              compilationId,
+              pointer,
+              node,
+              name: node.name,
+              id: node.id,
+              mutability: Codec.Ast.Utils.mutability(node),
+              contractPointer,
+              contractNode,
+              contractName: contractNode.name,
+              contractId: contractNode.id,
+              contractKind: contractNode.contractKind,
+              isDesignatedInvalid: false
+            }
+          };
+        })
+    );
+  },
+
+  getSourceRange: function(instruction = {}) {
+    return {
+      start: instruction.start || 0,
+      length: instruction.length || 0,
+      lines: instruction.range || {
+        start: {
+          line: 0,
+          column: 0
+        },
+        end: {
+          line: 0,
+          column: 0
+        }
+      }
+    };
+  },
+
+  //findOverlappingRange should be as described above
+  findRange: function(findOverlappingRange, sourceStart, sourceLength) {
+    // find nodes that fully contain requested range,
+    // return one with longest pointer
+    // (note: returns { range, node, pointer }
+    let sourceEnd = sourceStart + sourceLength;
+    return findOverlappingRange(sourceStart, sourceLength)
+      .filter(({ range }) => sourceStart >= range[0] && sourceEnd <= range[1])
+      .reduce(
+        (acc, cur) => (cur.pointer.length >= acc.pointer.length ? cur : acc),
+        { pointer: "" }
+      );
+    //note we make sure to bias towards cur (the new value being compared) rather than acc (the old value)
+    //so that we don't actually get {pointer: ""} as our result
+  },
+
+  //makes the overlap function for an AST
+  makeOverlapFunction: function(ast) {
+    let tree = new IntervalTree();
+    let ranges = SolidityUtils.rangeNodes(ast);
+    for (let { range, node, pointer } of ranges) {
+      let [start, end] = range;
+      //NOTE: we are doing this the "advanced usage" way because the
+      //other way isn't working for some reason
+      tree.insert({ low: start, high: end, data: { range, node, pointer } });
+    }
+    return (sourceStart, sourceLength) =>
+      //because we're doing this the "advanced usage" way, we have
+      //to extract data afterward
+      tree
+        .search(sourceStart, sourceStart + sourceLength)
+        .map(({ data }) => data);
+  },
+
+  //for use by makeOverlapFunction
+  rangeNodes: function(node, pointer = "") {
+    if (node instanceof Array) {
+      return [].concat(
+        ...node.map((sub, i) =>
+          SolidityUtils.rangeNodes(sub, `${pointer}/${i}`)
+        )
+      );
+    } else if (node instanceof Object) {
+      let results = [];
+
+      if (node.src !== undefined && node.id !== undefined) {
+        //there are some "pseudo-nodes" with a src but no id.
+        //these will cause problems, so we want to exclude them.
+        //(to my knowledge this only happens with the externalReferences
+        //to an InlineAssembly node, so excluding them just means we find
+        //the InlineAssembly node instead, which is fine)
+        results.push({ pointer, node, range: SolidityUtils.getRange(node) });
+      }
+
+      return results.concat(
+        ...Object.keys(node).map(key =>
+          SolidityUtils.rangeNodes(node[key], `${pointer}/${key}`)
+        )
+      );
+    } else {
+      return [];
+    }
+  },
+
+  getRange: function(node) {
+    // src: "<start>:<length>:<_>"
+    // returns [start, end]
+    let [start, length] = node.src
+      .split(":")
+      .slice(0, 2)
+      .map(i => parseInt(i));
+
+    return [start, start + length];
   }
 };
 

--- a/packages/solidity-utils/package.json
+++ b/packages/solidity-utils/package.json
@@ -21,6 +21,10 @@
     "access": "public"
   },
   "dependencies": {
-    "debug": "^4.1.1"
+    "@truffle/code-utils": "^1.2.14",
+    "@truffle/codec": "^0.4.2",
+    "debug": "^4.1.1",
+    "json-pointer": "^0.6.0",
+    "node-interval-tree": "^1.3.3"
   }
 }


### PR DESCRIPTION
This PR adds support for full decoding of internal function pointers to `@truffle/decoder`.

In order to allow this, a lot of code that used to live in the debugger has been moved to the `solidity-utils` package so that the decoder can import it.  Note that the `solidity-utils` package is uncompiled JS, so I had to eliminate two uses of object spreads.  Also, warning, `decoder` uses it as an untyped import!  But it's all localized to one little block where the internal functions table is set up.

(I did not change the fundamental architecture of internal function pointer decoding -- i.e., `codec` still just relies on a table that's passed in to decode these; it doesn't do the work of decoding them itself.)

There was also one really awkward thing wtih `IntervalTree`.  For reasons unknown to me, using `IntervalTree` the normal way -- via the default export -- didn't work in `solidity-utils`, despite having always worked in `debugger` (where it gets compiled with Babel and Webpack); Node complained that the default export isn't a constructor.  However, the "advanced" interface worked fine, so rather than trying to set up Babel or something, I just switched over to that.

Also: I hope it's OK that `solidity-utils` imports `codec` for one little utility function? :)  I mean, it's not circular or anything...

The internal functions table is set up in the `init` function of `ContractInstanceDecoder`; it's set there rather than in the constructor because it needs to know the contract's code.  Of course, if the decoder decides there's insufficient information, it will just leave the table `undefined`, and you just won't get the extra information.

I also updated documentation and added a test.

EDIT: This is actually kind of a breaking change to `decoder`, now that I think about it, in that it allows it to output stuff it wouldn't have before, so users of it will have to account for that.  (Note to @adrianmcli, although I believe you weren't yet handling function pointers anyway.)