### PR TITLE
Fix type IDs on contract types from contexts & internal fns

### DIFF
--- a/packages/codec/lib/ast/import/index.ts
+++ b/packages/codec/lib/ast/import/index.ts
@@ -7,6 +7,7 @@ import * as Common from "@truffle/codec/common";
 import * as Compiler from "@truffle/codec/compiler";
 import * as Utils from "@truffle/codec/ast/utils";
 import { AstNode, AstNodes } from "@truffle/codec/ast/types";
+import { makeTypeId } from "@truffle/codec/contexts/import";
 
 //NOTE: the following function will *not* work for arbitrary nodes! It will,
 //however, work well enough for what we need.  I.e., it will:
@@ -475,11 +476,4 @@ export function definitionToStoredType(
       };
     }
   }
-}
-
-//I am deliberately *NOT* exporting this.
-//If you have to make a type ID, instead make the type and then
-//take its ID.
-function makeTypeId(astId: number, compilationId: string): string {
-  return `${compilationId}:${astId}`;
 }

--- a/packages/codec/lib/basic/decode/index.ts
+++ b/packages/codec/lib/basic/decode/index.ts
@@ -596,14 +596,7 @@ export function decodeInternalFunction(
   }
   let name = functionEntry.name;
   let mutability = functionEntry.mutability;
-  let definedIn: Format.Types.ContractType = {
-    typeClass: "contract" as const,
-    kind: "native" as const,
-    id: functionEntry.contractId.toString(),
-    typeName: functionEntry.contractName,
-    contractKind: functionEntry.contractKind,
-    payable: functionEntry.contractPayable
-  };
+  let definedIn = Evm.Import.functionTableEntryToType(functionEntry);
   return {
     type: dataType,
     kind: "value" as const,

--- a/packages/codec/lib/contexts/import/index.ts
+++ b/packages/codec/lib/contexts/import/index.ts
@@ -6,7 +6,7 @@ export function contextToType(context: Context): Format.Types.ContractType {
     return {
       typeClass: "contract",
       kind: "native",
-      id: context.contractId.toString(),
+      id: makeTypeId(context.contractId, context.compilationId),
       typeName: context.contractName,
       contractKind: context.contractKind,
       payable: context.payable
@@ -20,4 +20,12 @@ export function contextToType(context: Context): Format.Types.ContractType {
       payable: context.payable
     };
   }
+}
+
+//NOTE: I am exporting this for use in other import functions, but please don't
+//use this elsewhere!
+//If you have to make a type ID, instead make the type and then
+//take its ID.
+export function makeTypeId(astId: number, compilationId: string): string {
+  return `${compilationId}:${astId}`;
 }

--- a/packages/codec/lib/contexts/types.ts
+++ b/packages/codec/lib/contexts/types.ts
@@ -31,6 +31,7 @@ export interface DecoderContext {
     receive: AbiData.ReceiveAbiEntry | null; //set to null if none
   };
   compiler?: Compiler.CompilerVersion;
+  compilationId?: string;
 }
 
 export interface DebuggerContext {
@@ -46,6 +47,6 @@ export interface DebuggerContext {
   sourceMap?: string;
   primarySource?: number;
   compiler?: Compiler.CompilerVersion;
-  compilation?: string;
+  compilationId?: string;
   payable?: boolean;
 }

--- a/packages/codec/lib/evm/import/index.ts
+++ b/packages/codec/lib/evm/import/index.ts
@@ -1,0 +1,17 @@
+import * as Format from "@truffle/codec/format";
+import { makeTypeId } from "@truffle/codec/contexts/import";
+import { InternalFunction } from "@truffle/codec/evm/types";
+
+//creates a type object for the contract the function was defined in
+export function functionTableEntryToType(
+  functionEntry: InternalFunction
+): Format.Types.ContractTypeNative {
+  return {
+    typeClass: "contract" as const,
+    kind: "native" as const,
+    id: makeTypeId(functionEntry.contractId, functionEntry.compilationId),
+    typeName: functionEntry.contractName,
+    contractKind: functionEntry.contractKind,
+    payable: functionEntry.contractPayable
+  };
+}

--- a/packages/codec/lib/evm/index.ts
+++ b/packages/codec/lib/evm/index.ts
@@ -2,3 +2,6 @@ export * from "./types";
 
 import * as Utils from "./utils";
 export { Utils };
+
+import * as Import from "./import";
+export { Import };

--- a/packages/debugger/lib/data/selectors/index.js
+++ b/packages/debugger/lib/data/selectors/index.js
@@ -70,7 +70,8 @@ function debuggerContextToDecoderContext(context) {
     isConstructor,
     abi,
     payable,
-    compiler
+    compiler,
+    compilationId
   } = context;
   return {
     context: contextHash,
@@ -81,7 +82,8 @@ function debuggerContextToDecoderContext(context) {
     isConstructor,
     abi: Codec.AbiData.Utils.computeSelectors(abi),
     payable,
-    compiler
+    compiler,
+    compilationId
   };
 }
 

--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -76,7 +76,7 @@ export class WireDecoder {
         const deployedBytecode = shimBytecode(contract.deployedBytecode);
         const bytecode = shimBytecode(contract.bytecode);
         if (deployedBytecode && deployedBytecode !== "0x") {
-          deployedContext = Utils.makeContext(contract, node, compiler);
+          deployedContext = Utils.makeContext(contract, node, compilation);
           this.contexts[deployedContext.context] = deployedContext;
           //note that we don't set up deployedContexts until after normalization!
         }
@@ -84,7 +84,7 @@ export class WireDecoder {
           constructorContext = Utils.makeContext(
             contract,
             node,
-            compiler,
+            compilation,
             true
           );
           this.contexts[constructorContext.context] = constructorContext;
@@ -713,7 +713,7 @@ export class ContractDecoder {
       const unnormalizedContext = Utils.makeContext(
         this.contract,
         this.contractNode,
-        this.compilation.compiler || this.contract.compiler
+        this.compilation
       );
       this.contextHash = unnormalizedContext.context;
       //we now throw away the unnormalized context, instead fetching the correct one from
@@ -737,7 +737,7 @@ export class ContractDecoder {
                   //note that we immediately discard it!
                 },
                 this.contractNode,
-                compiler
+                this.compilation
               )
             }
           ],
@@ -1104,7 +1104,7 @@ export class ContractInstanceDecoder {
       const extraContext = Utils.makeContext(
         contractWithCode,
         this.contractNode,
-        this.compiler
+        this.compilation
       );
       this.contextHash = extraContext.context;
       this.additionalContexts = { [extraContext.context]: extraContext };

--- a/packages/decoder/lib/utils.ts
+++ b/packages/decoder/lib/utils.ts
@@ -32,7 +32,7 @@ export function nativizeDecoderVariables(
 export function makeContext(
   contract: Codec.Compilations.Contract,
   node: Codec.Ast.AstNode | undefined,
-  compiler: Codec.Compiler.CompilerVersion,
+  compilation: Codec.Compilations.Compilation,
   isConstructor = false
 ): Codec.Contexts.DecoderContext {
   const abi = Codec.AbiData.Utils.schemaAbiToAbi(contract.abi);
@@ -65,7 +65,8 @@ export function makeContext(
     abi: Codec.AbiData.Utils.computeSelectors(abi),
     payable: Codec.AbiData.Utils.abiHasPayableFallback(abi),
     fallbackAbi: { fallback, receive },
-    compiler: compiler || contract.compiler
+    compiler: compilation.compiler || contract.compiler,
+    compilationId: compilation.id
   };
 }
 


### PR DESCRIPTION
Big oops here: When moving everything over to the new style of type ID, I fixed two of the import functions, but I forgot one: `contextToType`.

This leaves us with a problem: Where should `makeTypeId` live?  It used to live in `ast/import`, because it was needed there but not in `abi-data/import`.  But now it's needed in `context/import` as well.  I opted to put it in `context/import` and have `ast/import` import it.

Except, there's one more place type objects were being made with old-style IDs... in `basic/decode`!  See, `decodeInternalFunction` was constructing some type objects manually.  We don't want that -- all such construction (and especially, any making of type IDs) should occur in an import function.

So, I added `evm/import` and a function for converting internal function table entries to types.  Hooray, abstraction restored!

...really, a better way to handle this would probably be to just put said types in the table, rather than requiring reconstructing it later, but, eh, this is good enough for now.  And I didn't want to cause merge conflicts with my other internal functions PR. :)