### PR TITLE
Whitelist missing solc options

### DIFF
--- a/packages/compile-solidity/run.js
+++ b/packages/compile-solidity/run.js
@@ -185,6 +185,8 @@ function prepareCompilerInput({ sources, targets, settings }) {
       optimizer: settings.optimizer,
       remappings: settings.remappings,
       debug: settings.debug,
+      metadata: settings.metadata,
+      libraries: settings.libraries,
       // Specify compilation targets. Each target uses defaultSelectors,
       // defaulting to single target `*` if targets are unspecified
       outputSelection: prepareOutputSelection({ targets })

--- a/packages/compile-solidity/run.js
+++ b/packages/compile-solidity/run.js
@@ -184,6 +184,7 @@ function prepareCompilerInput({ sources, targets, settings }) {
       evmVersion: settings.evmVersion,
       optimizer: settings.optimizer,
       remappings: settings.remappings,
+      debug: settings.debug,
       // Specify compilation targets. Each target uses defaultSelectors,
       // defaulting to single target `*` if targets are unspecified
       outputSelection: prepareOutputSelection({ targets })


### PR DESCRIPTION
This PR fixes #2902 by passing the `debug` option through to solc.  I didn't add any tests because I don't know this package well enough, sorry!  But I tested it manually and it works.

By the way, I was looking through the solc documentation for compiler options, and I noticed there's two other options we don't currently pass through: `metadata` and `libraries`.  Does anyone know if there's a reason for this?  It would be easy enough to add them in.  (Would allowing the user to set the metadata format cause any problems?  I have to imagine letting them manually specify libraries probably wouldn't, right?)