### PR TITLE
Display all migration gas numbers in dec and hex formats

### DIFF
--- a/packages/reporters/reporters/migrations-V5/messages.js
+++ b/packages/reporters/reporters/migrations-V5/messages.js
@@ -29,6 +29,10 @@ class MigrationsMessages {
     return `MIGRATION_STATUS:${JSON.stringify(msg)}`;
   }
 
+  decAndHex(num) {
+    return `${Number(num).toString(10)} (0x${Number(num).toString(16)})`;
+  }
+
   // ----------------------------------- Interactions ----------------------------------------------
 
   questions(kind) {
@@ -81,14 +85,14 @@ class MigrationsMessages {
       intWithGas: () =>
         `${prefix}"${data.contract.contractName}" ran out of gas ` +
         `(using a value you set in your network config or deployment parameters.)\n` +
-        `   * Block limit:  ${data.blockLimit}\n` +
-        `   * Gas sent:     ${data.gas}\n`,
+        `   * Block limit:  ${this.decAndHex(data.blockLimit)}\n` +
+        `   * Gas sent:     ${this.decAndHex(data.gas)}\n`,
 
       intNoGas: () =>
         `${prefix}"${data.contract.contractName}" ran out of gas ` +
         `(using Truffle's estimate.)\n` +
-        `   * Block limit:  ${data.blockLimit}\n` +
-        `   * Gas sent:     ${data.estimate}\n` +
+        `   * Block limit:  ${this.decAndHex(data.blockLimit)}\n` +
+        `   * Gas sent:     ${this.decAndHex(data.estimate)}\n` +
         `   * Try:\n` +
         `      + Setting a higher gas estimate multiplier for this contract\n` +
         `      + Using the solc optimizer settings in 'truffle-config.js'\n` +
@@ -145,8 +149,8 @@ class MigrationsMessages {
       blockWithGas: () =>
         `${prefix}"${data.contract.contractName}" exceeded the block limit ` +
         `(with a gas value you set).\n` +
-        `   * Block limit:  ${data.blockLimit}\n` +
-        `   * Gas sent:     ${data.gas}\n` +
+        `   * Block limit:  ${this.decAndHex(data.blockLimit)}\n` +
+        `   * Gas sent:     ${this.decAndHex(data.gas)}\n` +
         `   * Try:\n` +
         `      + Sending less gas.\n` +
         `      + Setting a higher network block limit if you are on a\n` +
@@ -155,7 +159,7 @@ class MigrationsMessages {
       blockNoGas: () =>
         `${prefix}"${data.contract.contractName}" exceeded the block limit ` +
         `(using Truffle's estimate).\n` +
-        `   * Block limit: ${data.blockLimit}\n` +
+        `   * Block limit: ${this.decAndHex(data.blockLimit)}\n` +
         `   * Report this error in the Truffle issues on Github. It should not happen.\n` +
         `   * Try: setting gas manually in 'truffle-config.js' or as parameter to 'deployer.deploy'\n`,
 
@@ -273,7 +277,7 @@ class MigrationsMessages {
         output +=
           `   > ${"account:".padEnd(20)} ${data.from}\n` +
           `   > ${"balance:".padEnd(20)} ${data.balance}\n` +
-          `   > ${"gas used:".padEnd(20)} ${data.gas}\n` +
+          `   > ${"gas used:".padEnd(20)} ${self.decAndHex(data.gas)}\n` +
           `   > ${"gas price:".padEnd(20)} ${data.gasPrice} gwei\n` +
           `   > ${"value sent:".padEnd(20)} ${data.value} ETH\n` +
           `   > ${"total cost:".padEnd(20)} ${data.cost} ETH\n`;
@@ -395,7 +399,7 @@ class MigrationsMessages {
         output +=
           `> Network name:    '${data.network}'\n` +
           `> Network id:      ${data.networkId}\n` +
-          `> Block gas limit: ${data.blockLimit}\n`;
+          `> Block gas limit: ${self.decAndHex(data.blockLimit)}\n`;
 
         return output;
       },


### PR DESCRIPTION
closes #2799
- Add `decAndHex(num)` utlity function that displays a number as decimal with hex in parenthesis
- Use this utility in all migration messages that print gas

I wasn't sure what the versioning process is, so I left the versions as is. But since the dependencies are `core` depends on `migrate` depends on `reporters`, both `reporters` and `migrate` need a version bump to be included in core.