### PR TITLE
Internal improvement: Expand TypeType to cover enums as well

### DIFF
--- a/packages/codec/lib/format/types.ts
+++ b/packages/codec/lib/format/types.ts
@@ -497,11 +497,17 @@ export interface MagicType {
 }
 
 /**
- * Type of a type!  This is currently only used for contract types, but
- * may expand in the future.
+ * Type of a type!  This is currently only used for contract types and enum
+ * types, but may expand in the future.
  * @Category Special container types (debugger-only)
  */
-export interface TypeType {
+export type TypeType = TypeTypeContract | TypeTypeEnum;
+
+/**
+ * Type of a contract type
+ * @Category Special container types (debugger-only)
+ */
+export interface TypeTypeContract {
   typeClass: "type";
   type: ContractTypeNative;
   /**
@@ -509,6 +515,15 @@ export interface TypeType {
    * **non-inherited** state variables
    */
   stateVariableTypes?: NameTypePair[];
+}
+
+/**
+ * Type of an enum type
+ * @Category Special container types (debugger-only)
+ */
+export interface TypeTypeEnum {
+  typeClass: "type";
+  type: EnumType;
 }
 
 /**

--- a/packages/codec/lib/format/utils/inspect.ts
+++ b/packages/codec/lib/format/utils/inspect.ts
@@ -175,17 +175,24 @@ export class ResultInspector {
             }
           }
           case "type": {
-            //same as struct case but w/o circularity check
-            let coercedResult = <Format.Values.TypeValue>this.result;
-            return util.inspect(
-              Object.assign(
-                {},
-                ...coercedResult.value.map(({ name, value }) => ({
-                  [name]: new ResultInspector(value)
-                }))
-              ),
-              options
-            );
+            switch (this.result.type.type.typeClass) {
+              case "contract":
+                //same as struct case but w/o circularity check
+                return util.inspect(
+                  Object.assign(
+                    {},
+                    ...(<Format.Values.TypeValueContract>this.result).value.map(
+                      ({ name, value }) => ({
+                        [name]: new ResultInspector(value)
+                      })
+                    )
+                  ),
+                  options
+                );
+              case "enum": {
+                return enumTypeName(this.result.type.type);
+              }
+            }
           }
           case "magic":
             return util.inspect(
@@ -576,12 +583,19 @@ function nativizeWithTable(
       }
     }
     case "type":
-      return Object.assign(
-        {},
-        ...(<Format.Values.TypeValue>result).value.map(({ name, value }) => ({
-          [name]: nativize(value)
-        }))
-      );
+      switch (result.type.type.typeClass) {
+        case "contract":
+          return Object.assign(
+            {},
+            ...(<Format.Values.TypeValueContract>result).value.map(
+              ({ name, value }) => ({
+                [name]: nativize(value)
+              })
+            )
+          );
+        case "enum":
+          return (<Format.Values.TypeValueEnum>result).value.map(nativize);
+      }
     case "tuple":
       return (<Format.Values.TupleValue>result).value.map(({ value }) =>
         nativize(value)

--- a/packages/codec/lib/format/values.ts
+++ b/packages/codec/lib/format/values.ts
@@ -318,7 +318,8 @@ export interface MagicValue {
 }
 
 /**
- * A type's value (or error)
+ * A type's value (or error); currently only allows contract types and
+ * enum types
  *
  * @Category Special container types (debugger-only)
  */
@@ -327,17 +328,39 @@ export type TypeResult = TypeValue | Errors.TypeErrorResult;
 /**
  * A type's value -- for now, we consider the value of a contract type to
  * consist of the values of its non-inherited state variables in the current
- * context.  May contain errors.
+ * context, and the value of an enum type to be an array of its possible options
+ * (as Values).  May contain errors.
  *
  * @Category Special container types (debugger-only)
  */
-export interface TypeValue {
-  type: Types.TypeType;
+export type TypeValue = TypeValueContract | TypeValueEnum;
+
+/**
+ * A contract type's value (see [[TypeValue]])
+ *
+ * @Category Special container types (debugger-only)
+ */
+export interface TypeValueContract {
+  type: Types.TypeTypeContract;
   kind: "value";
   /**
    * these must be stored in order!
    */
   value: NameValuePair[];
+}
+
+/**
+ * An enum type's value (see [[TypeValue]])
+ *
+ * @Category Special container types (debugger-only)
+ */
+export interface TypeValueEnum {
+  type: Types.TypeTypeEnum;
+  kind: "value";
+  /**
+   * these must be stored in order!
+   */
+  value: EnumValue[];
 }
 
 /*


### PR DESCRIPTION
This PR expands `TypeType` in `codec` so that it covers enums as well as contracts.  An enum type's value is an array of its different options.  It also updates the inspect utilities to inspect/nativize these properly.

This doesn't really have any effect at the moment; it's just some preparation for some future debugger improvements.

Note that merging this would require updating the `cheerios` branch appropriately (PR #2901).