### PR TITLE
Manually determine addresses of failed CREATE2s (also: a jump fix)

### DIFF
--- a/packages/debugger/lib/evm/selectors/index.js
+++ b/packages/debugger/lib/evm/selectors/index.js
@@ -8,6 +8,7 @@ import trace from "lib/trace/selectors";
 
 import * as Codec from "@truffle/codec";
 import {
+  keccak256,
   isCallMnemonic,
   isCreateMnemonic,
   isShortCallMnemonic,
@@ -16,6 +17,8 @@ import {
   isStaticCallMnemonic,
   isNormalHaltingMnemonic
 } from "lib/helpers";
+
+const ZERO_WORD = "00".repeat(Codec.Evm.Utils.WORD_SIZE);
 
 function determineFullContext(
   { address, binary },
@@ -80,14 +83,6 @@ function createStepSelectors(step, state = null) {
     programCounter: createLeaf(["./trace"], step => (step ? step.pc : null)),
 
     /**
-     * .isJump
-     */
-    isJump: createLeaf(
-      ["./trace"],
-      step => step.op != "JUMPDEST" && step.op.indexOf("JUMP") == 0
-    ),
-
-    /**
      * .isCall
      *
      * whether the opcode will switch to another calling context
@@ -128,8 +123,14 @@ function createStepSelectors(step, state = null) {
 
     /**
      * .isCreate
+     * (includes CREATE2)
      */
     isCreate: createLeaf(["./trace"], step => isCreateMnemonic(step.op)),
+
+    /**
+     * .isCreate2
+     */
+    isCreate2: createLeaf(["./trace"], step => step.op === "CREATE2"),
 
     /**
      * .isHalting
@@ -146,12 +147,12 @@ function createStepSelectors(step, state = null) {
     /*
      * .isStore
      */
-    isStore: createLeaf(["./trace"], step => step.op == "SSTORE"),
+    isStore: createLeaf(["./trace"], step => step.op === "SSTORE"),
 
     /*
      * .isLoad
      */
-    isLoad: createLeaf(["./trace"], step => step.op == "SLOAD"),
+    isLoad: createLeaf(["./trace"], step => step.op === "SLOAD"),
 
     /*
      * .touchesStorage
@@ -166,7 +167,7 @@ function createStepSelectors(step, state = null) {
 
   if (state) {
     const isRelative = path =>
-      typeof path == "string" &&
+      typeof path === "string" &&
       (path.startsWith("./") || path.startsWith("../"));
 
     if (isRelative(state)) {
@@ -174,6 +175,16 @@ function createStepSelectors(step, state = null) {
     }
 
     Object.assign(base, {
+      /**
+       * .isJump
+       */
+      isJump: createLeaf(
+        ["./trace", state],
+        (step, { stack }) =>
+          step.op === "JUMP" ||
+          (step.op === "JUMPI" && stack[stack.length - 2] !== ZERO_WORD)
+      ),
+
       /**
        * .callAddress
        *
@@ -451,14 +462,45 @@ const evm = createSelectorTree({
        * address created by the current create step
        */
       createdAddress: createLeaf(
-        ["./isCreate", "/nextOfSameDepth/state/stack"],
-        (isCreate, stack) => {
+        [
+          "./isCreate",
+          "/nextOfSameDepth/state/stack",
+          "./isCreate2",
+          "./create2Address"
+        ],
+        (isCreate, stack, isCreate2, create2Address) => {
           if (!isCreate) {
             return null;
           }
-          let address = stack[stack.length - 1];
-          return Codec.Evm.Utils.toAddress(address);
+          let address = Codec.Evm.Utils.toAddress(stack[stack.length - 1]);
+          if (address === Codec.Evm.Utils.ZERO_ADDRESS && isCreate2) {
+            return create2Address;
+          }
+          return address;
         }
+      ),
+
+      create2Address: createLeaf(
+        ["./isCreate2", "./createBinary", "../call", "../state/stack"],
+        (isCreate2, binary, { storageAddress }, stack) =>
+          Codec.Evm.Utils.toAddress(
+            "0x" +
+              keccak256({
+                type: "bytes",
+                value:
+                  //slice 2's are for cutting off initial "0x" where we've prepended this
+                  //0xff, then address, then salt, then code hash
+                  "0xff" +
+                  storageAddress.slice(2) +
+                  stack[stack.length - 4] +
+                  keccak256({ type: "bytes", value: binary }).slice(2)
+              }).slice(
+                2 +
+                  2 * (Codec.Evm.Utils.WORD_SIZE - Codec.Evm.Utils.ADDRESS_SIZE)
+              )
+            //slice off initial 0x and initial 12 bytes (note we've re-prepended the
+            //0x at the beginning)
+          )
       ),
 
       /**
@@ -524,7 +566,6 @@ const evm = createSelectorTree({
           if (remaining <= 1) {
             return finalStatus;
           } else {
-            const ZERO_WORD = "00".repeat(Codec.Evm.Utils.WORD_SIZE);
             return stack[stack.length - 1] !== ZERO_WORD;
           }
         }

--- a/packages/debugger/test/data/global.js
+++ b/packages/debugger/test/data/global.js
@@ -13,7 +13,7 @@ import * as Codec from "@truffle/codec";
 import solidity from "lib/solidity/selectors";
 
 const __GLOBAL = `
-pragma solidity ^0.6.1;
+pragma solidity ^0.6.2;
 
 contract GlobalTest {
 
@@ -56,7 +56,7 @@ contract GlobalTest {
   }
 
   function runRun(uint x) public payable {
-    this.run.value(msg.value / 2)(x);
+    this.run{value: msg.value / 2}(x);
   }
 
   function staticTest(uint x) public view returns (uint) {
@@ -84,7 +84,16 @@ contract GlobalTest {
   }
 
   function runCreate(uint x) public payable {
-    (new CreationTest).value(msg.value / 2)(x);
+    new CreationTest{value: msg.value / 2}(x, true);
+  }
+
+  function runFailedCreate2(uint x) public payable {
+    try new CreationTest{
+      value: msg.value / 2,
+      salt: 0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+    }(x, false) {
+    } catch (bytes memory) {
+    }
   }
 }
 
@@ -97,14 +106,15 @@ contract CreationTest {
 
   event Done(uint x);
 
-  constructor(uint x) public payable {
+  constructor(uint x, bool succeed) public payable {
     _this = this;
     _now = now;
     _msg = GlobalTest.Msg(msg.data, msg.sender, msg.sig, msg.value);
     _tx = GlobalTest.Tx(tx.origin, tx.gasprice);
     _block = GlobalTest.Block(block.coinbase, block.difficulty,
       block.gaslimit, block.number, block.timestamp);
-    emit Done(x); //BREAK CREATE
+    require(succeed); //BREAK CREATE
+    emit Done(x);
   }
 }
 
@@ -306,6 +316,37 @@ describe("Globally-available variables", function() {
     this.timeout(12000);
     let instance = await abstractions.GlobalTest.deployed();
     let receipt = await instance.runCreate(9, { value: 100 });
+    let txHash = receipt.tx;
+
+    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+
+    let session = bugger.connect();
+
+    let sourceId = session.view(solidity.current.source).id;
+    let compilationId = session.view(solidity.current.source).compilationId;
+    let source = session.view(solidity.current.source).source;
+    await session.addBreakpoint({
+      sourceId,
+      compilationId,
+      line: lineOf("BREAK CREATE", source)
+    });
+    await session.continueUntilBreakpoint();
+
+    const variables = Codec.Format.Utils.Inspect.nativizeVariables(
+      await session.variables()
+    );
+
+    assert.equal(variables.this, variables._this);
+    assert.deepEqual(variables.msg, variables._msg);
+    assert.deepEqual(variables.tx, variables._tx);
+    assert.deepEqual(variables.block, variables._block);
+    assert.equal(variables.now, variables._now);
+  });
+
+  it("Gets globals correctly in failed CREATE2", async function() {
+    this.timeout(12000);
+    let instance = await abstractions.GlobalTest.deployed();
+    let receipt = await instance.runFailedCreate2(9, { value: 100 });
     let txHash = receipt.tx;
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });


### PR DESCRIPTION
This PR is kind of a minor fix for the debugger.  One of the debugger's problems is that on a failed contract creation (excepting the initial call -- if it's the initial call it works fine, at least with Ganache, but this may be client-dependent), the debugger can't determine the address and so can't set global variables appropriately, instead reporting zero for the address.

There's a good reason it can't determine the address; to do so it would need the nonce, and to get the nonce we'd need reconstruct mode (#2894), which isn't likely to happen anytime soon.  But, that only applies to CREATE!  For a CREATE2, there's no reason it can't *manually* determine the address!  So, now it does that, instead of reporting zero.

I also added a test of this.

Also, uh, I kind of crammed a fix for our jump detection into the same commit.  Sorry.  Can separate it out if we really need, I imagine.  Anyway: Our jump detection system assumed that `JUMPI` -- the conditional jump instruction -- always jumps, instead of actually checking whether conditional is true causing a jump to actually occur.  This has never mattered thus far and likely never will, but I figured it was worth fixing.