### PR TITLE
Bug fix: Remove the use of fs-extra from @truffle/decoder

### DIFF
--- a/packages/decoder/lib/index.ts
+++ b/packages/decoder/lib/index.ts
@@ -173,7 +173,7 @@ import { ContractConstructorObject, ContractInstanceObject } from "./types";
 
 import { Compilations } from "@truffle/codec";
 
-import fs from "fs-extra";
+import fs from "fs";
 import path from "path";
 
 /**

--- a/packages/decoder/package.json
+++ b/packages/decoder/package.json
@@ -19,7 +19,6 @@
     "@truffle/solidity-utils": "^1.3.0",
     "bn.js": "^4.11.8",
     "debug": "^4.1.0",
-    "fs-extra": "^8.1.0",
     "source-map-support": "^0.5.16",
     "web3": "1.2.1"
   },
@@ -49,7 +48,6 @@
     "@types/big.js": "^4.0.5",
     "@types/bn.js": "^4.11.2",
     "@types/debug": "^0.0.31",
-    "@types/fs-extra": "^8.1.0",
     "@types/utf8": "^2.1.6",
     "@types/web3": "1.0.19",
     "chai": "^4.2.0",


### PR DESCRIPTION
This PR is intended to address #2841.  Turns out just importing `fs-extra` causes serious problems on web.  But also, I don't need it.  So, removing it.  Hopefully that'll fix the problem.  If not, we'll have to try hackier things...