### PR TITLE
Don't attempt to allocate ABI entries with storage pointers

### DIFF
--- a/packages/codec/lib/abi-data/allocate/index.ts
+++ b/packages/codec/lib/abi-data/allocate/index.ts
@@ -758,8 +758,14 @@ function getCalldataAllocationsForContract(
     functionAllocations: {}
   };
   for (let abiEntry of abi) {
-    if (AbiDataUtils.abiEntryIsObviouslyIllTyped(abiEntry)) {
-      //hack workaround!
+    if (
+      AbiDataUtils.abiEntryIsObviouslyIllTyped(abiEntry) ||
+      AbiDataUtils.abiEntryHasStorageParameters(abiEntry)
+    ) {
+      //the first of these conditions is a hack workaround for a Solidity bug.
+      //the second of these is because... seriously? we're not handling these
+      //(at least not for now!) (these only exist prior to Solidity 0.5.6,
+      //thankfully)
       continue;
     }
     switch (abiEntry.type) {

--- a/packages/codec/lib/abi-data/utils.ts
+++ b/packages/codec/lib/abi-data/utils.ts
@@ -221,7 +221,7 @@ function abiParameterIsObviouslyIllTyped(
 
 export function abiEntryHasStorageParameters(abiEntry: Abi.AbiEntry): boolean {
   const isStorage = (parameter: Abi.AbiParameter) =>
-    parameter.type.endsWith("storage");
+    parameter.type.endsWith(" storage");
   switch (abiEntry.type) {
     case "fallback":
     case "receive":

--- a/packages/codec/lib/abi-data/utils.ts
+++ b/packages/codec/lib/abi-data/utils.ts
@@ -222,18 +222,11 @@ function abiParameterIsObviouslyIllTyped(
 export function abiEntryHasStorageParameters(abiEntry: Abi.AbiEntry): boolean {
   const isStorage = (parameter: Abi.AbiParameter) =>
     parameter.type.endsWith(" storage");
-  switch (abiEntry.type) {
-    case "fallback":
-    case "receive":
-      return false;
-    case "constructor":
-    case "event":
-      return abiEntry.inputs.some(isStorage);
-    case "function":
-      return (
-        abiEntry.inputs.some(isStorage) || abiEntry.outputs.some(isStorage)
-      );
-    //Note the lack of recursion!  Storage parameters can only occur at
-    //top level so there's no need to recurse here
-  }
+  return (
+    abiEntry.type === "function" &&
+    (abiEntry.inputs.some(isStorage) || abiEntry.outputs.some(isStorage))
+  );
+  //Note the lack of recursion!  Storage parameters can only occur at
+  //top level so there's no need to recurse here
+  //(they can also only occur for functions)
 }

--- a/packages/codec/lib/abi-data/utils.ts
+++ b/packages/codec/lib/abi-data/utils.ts
@@ -218,3 +218,22 @@ function abiParameterIsObviouslyIllTyped(
     return baseTypeClassIsObviouslyWrong;
   }
 }
+
+export function abiEntryHasStorageParameters(abiEntry: Abi.AbiEntry): boolean {
+  const isStorage = (parameter: Abi.AbiParameter) =>
+    parameter.type.endsWith("storage");
+  switch (abiEntry.type) {
+    case "fallback":
+    case "receive":
+      return false;
+    case "constructor":
+    case "event":
+      return abiEntry.inputs.some(isStorage);
+    case "function":
+      return (
+        abiEntry.inputs.some(isStorage) || abiEntry.outputs.some(isStorage)
+      );
+    //Note the lack of recursion!  Storage parameters can only occur at
+    //top level so there's no need to recurse here
+  }
+}


### PR DESCRIPTION
Prior to Solidity 0.5.6, the Solidity compiler would put a lot of stuff in library ABIs that it doesn't anymore.  Like... functions that took or returned storage pointers!  Those can't actually validly go in the ABI, and yet it would output an ABI entry for them anyway.

While I want to handle the mess that is library functions someday (there are so many problems with these...), that day is not today.  So, for now, I want to explicitly exclude such invalid ABIs.  There was no check for these before, but now I've added one...