### PR TITLE
Fix two decoder crashes

### DIFF
--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -813,7 +813,10 @@ export class ContractDecoder {
       //NOTE: does this change make this intermediate class essentially pointless?
       //Yes.  But not going to get rid of it now!
 
-      if (this.allocations.state[this.compilation.id][this.contractNode.id]) {
+      if (
+        this.allocations.state[this.compilation.id] &&
+        this.allocations.state[this.compilation.id][this.contractNode.id]
+      ) {
         this.stateVariableReferences = this.allocations.state[
           this.compilation.id
         ][this.contractNode.id].members;
@@ -1200,13 +1203,17 @@ export class ContractInstanceDecoder {
         this.contractCode,
         SolidityUtils.getHumanReadableSourceMap(this.contract.deployedSourceMap)
       );
-      let searchFunctions = asts.map(SolidityUtils.makeOverlapFunction);
-      this.internalFunctionsTable = SolidityUtils.getFunctionsByProgramCounter(
-        instructions,
-        asts,
-        searchFunctions,
-        this.compilation.id
-      );
+      try {
+        //this can fail if some of the source files are missing :(
+        this.internalFunctionsTable = SolidityUtils.getFunctionsByProgramCounter(
+          instructions,
+          asts,
+          asts.map(SolidityUtils.makeOverlapFunction),
+          this.compilation.id
+        );
+      } catch (_) {
+        //just leave the internal functions table undefined
+      }
     }
   }
 


### PR DESCRIPTION
This PR fixes two crashes in the decoder.

The first is the following: Suppose that state allocation fails for a given contract (which has an AST), and it's the only contract in its compilation.  When we attempt to create a contract decoder for that contract, we get a crash.  Why?  Well, since state allocation didn't succeed for any contracts in that compilation, the container for the compilation doesn't exist, and we get an error when we try to fetch the allocation for the specific contract from it.  Oops!  Now we check if it exists.

The second is that making the internal functions table really needs to be wrapped in a try/catch because there's a number of reasons it could fail!  So now it is.  We just swallow errors here; there's not really any way to recover from them except to just leave the internal functions table undefined.