### PR TITLE
Enhancement: Enable configurable on-chain migration tracking

### DIFF
--- a/packages/core/lib/commands/migrate.js
+++ b/packages/core/lib/commands/migrate.js
@@ -6,6 +6,12 @@ const command = {
       type: "boolean",
       default: false
     },
+    "force": {
+      describe:
+        "Force migrations (disable and ignore on-chain migrations tracking)",
+      type: "boolean",
+      default: false
+    },
     "compile-all": {
       describe: "recompile all contracts",
       type: "boolean",
@@ -46,13 +52,18 @@ const command = {
       "                                " + // spacing to align with previous line
       "[--compile-all] [--verbose-rpc] [--interactive] [--dry-run]\n" +
       "                                " + // spacing to align with previous line
-      "[--skip-dry-run] [--describe-json]",
+      "[--skip-dry-run] [--describe-json] [--force]",
     options: [
       {
         option: "--reset",
         description:
           "Run all migrations from the beginning, instead of running from the last " +
           "completed migration."
+      },
+      {
+        option: "--force",
+        description:
+          "Force migrations (disable and ignore on-chain migrations tracking)"
       },
       {
         option: "--f <number>",

--- a/packages/interface-adapter/lib/adapter/tezos/index.ts
+++ b/packages/interface-adapter/lib/adapter/tezos/index.ts
@@ -48,8 +48,8 @@ export class TezosAdapter implements InterfaceAdapter {
   }
 
   public async getCode(address: string) {
-    //   return this.web3.eth.getCode(address);
-    return "0";
+    const storage = await this.tezos.contract.getStorage(address);
+    return storage as string;
   }
 
   public async getAccounts(config: Config) {

--- a/packages/migrate/test/index.js
+++ b/packages/migrate/test/index.js
@@ -62,6 +62,51 @@ describe("Migrate", () => {
           .catch(done);
       });
     });
+
+    describe("when force is set to true", () => {
+      before(() => {
+        options.force = true;
+      });
+
+      beforeEach(() => {
+        sinon.stub(Migrate, "runAll");
+      });
+      afterEach(() => {
+        Migrate.runAll.restore();
+      });
+
+      it("calls runAll then the callback", done => {
+        Migrate.run(options)
+          .then(() => {
+            assert(Migrate.runAll.calledWith(options));
+            done();
+          })
+          .catch(done);
+      });
+    });
+
+    describe("when force is not true", () => {
+      beforeEach(() => {
+        options.force = undefined;
+        sinon
+          .stub(Migrate, "lastCompletedMigration")
+          .returns(Promise.resolve(666));
+        sinon.stub(Migrate, "runFrom");
+      });
+      afterEach(() => {
+        Migrate.lastCompletedMigration.restore();
+        Migrate.runFrom.restore();
+      });
+
+      it("calls runFrom with the proper migration number", done => {
+        Migrate.run(options)
+          .then(() => {
+            assert(Migrate.runFrom.calledWith(667));
+            done();
+          })
+          .catch(done);
+      });
+    });
   });
 
   describe("runMigrations(migrations, options)", () => {


### PR DESCRIPTION
In `@truffle/core`:
  - Add `--force` flag to help menu and as valid option.
  `--force` flag completely disables and ignores the on-chain migrations
  tracking system

In `@truffle/migrate`:
  - Add on-chain tracking support for `tezos`-specific `Migrations` contract logic
  - Add checks for `--force` to enable expected behavior
  - Add test cases for `--force` usage

In `@truffle/interface-adapter`:
  - Replace `getCode` stub for `TezosAdapter` with the appropriate
  `@taquito` contract provider method