### PR TITLE
Workaround Docker SmartPy permissions issue

### DIFF
--- a/packages/compile-smartpy/index.js
+++ b/packages/compile-smartpy/index.js
@@ -1,6 +1,8 @@
 const path = require("path");
 const { exec, spawn } = require("child_process");
 const fs = require("fs");
+const { promisify } = require("util");
+const promisifiedMkdirp = promisify(require("mkdirp"));
 const colors = require("colors");
 const minimatch = require("minimatch");
 const find_contracts = require("@truffle/contract-sources");
@@ -108,6 +110,9 @@ function execSmartPy(sourcePath, entryPoint, options) {
     const extension = path.extname(sourcePath);
     const basename = path.basename(sourcePath, extension);
     const contractName = basename;
+
+    if (!fs.existsSync(options.contracts_build_directory))
+      promisifiedMkdirp(options.contracts_build_directory);
 
     // Use spawn() instead of exec() here so that the OS can take care of escaping args.
     let docker = spawn("docker", [

--- a/packages/compile-smartpy/package.json
+++ b/packages/compile-smartpy/package.json
@@ -27,7 +27,8 @@
     "@truffle/compile-solidity": "^4.3.0-tezos.2",
     "@truffle/contract-sources": "^0.2.0-tezos.0",
     "colors": "^1.4.0",
-    "minimatch": "^3.0.4"
+    "minimatch": "^3.0.4",
+    "mkdirp": "0.5.1"
   },
   "devDependencies": {
     "@truffle/config": "^1.3.0-tezos.2",

--- a/packages/compile-smartpy/test/test_compiler.js
+++ b/packages/compile-smartpy/test/test_compiler.js
@@ -1,5 +1,4 @@
 const path = require("path");
-const { mkdirSync } = require("fs");
 const assert = require("assert");
 const Config = require("@truffle/config");
 const compile = require("../index");
@@ -13,7 +12,6 @@ describe("smartpy compiler", () => {
     _: []
   };
   const config = new Config().merge(defaultSettings);
-  mkdirSync(defaultSettings.contracts_build_directory);
 
   it("compiles smartpy contracts", done => {
     compile.all(config, (err, contracts, paths) => {


### PR DESCRIPTION
- Instead of allowing SmartPy-Basic to create the build directory,
have truffle/node make it:
  - Adds `mkdirp` as `@truffle/compile-smartpy` dependency
- Slightly adjust `@truffle/compile-smartpy` tests