### PR TITLE
Fix default fallthrough in abi output allocation

### DIFF
--- a/packages/codec/lib/abi-data/allocate/index.ts
+++ b/packages/codec/lib/abi-data/allocate/index.ts
@@ -421,9 +421,11 @@ function allocateCalldataAndReturndata(
   switch (abiEntry.type) {
     case "function":
       outputParametersAbi = abiEntry.outputs;
+      break;
     case "constructor":
       //we just leave this empty for constructors
       outputParametersAbi = [];
+      break;
   }
   //now: do the allocation!
   let {


### PR DESCRIPTION
Default fall-through is a pain.  Here, it screwed up allocation for return values when in ABI mode.  Break statements added.  Fixed now.

Thanks to @adrianmcli for catching this.