### PR TITLE
Fix nativize of TypeValueEnum

### DIFF
--- a/packages/codec/lib/format/utils/inspect.ts
+++ b/packages/codec/lib/format/utils/inspect.ts
@@ -594,7 +594,12 @@ function nativizeWithTable(
             )
           );
         case "enum":
-          return (<Format.Values.TypeValueEnum>result).value.map(nativize);
+          return Object.assign(
+            {},
+            ...(<Format.Values.TypeValueEnum>result).value.map(enumValue => ({
+              [enumValue.value.name]: nativize(enumValue)
+            }))
+          );
       }
     case "tuple":
       return (<Format.Values.TupleValue>result).value.map(({ value }) =>


### PR DESCRIPTION
This doesn't actually matter yet, but I just noticed that the `nativize` code for TypeValueEnum is wrong.  It should return an object indexed by the option names, but instead it returns an array.  Oops.  Fixed this.  (You know, for the future when it matters. :P )