### PR TITLE
Fix allocation of immutables for Solidity 0.6.6

### DIFF
--- a/packages/codec/docs/README.md
+++ b/packages/codec/docs/README.md
@@ -86,12 +86,30 @@ which accept decodings in either mode and always return ABI mode.
   multiple decodings (e.g. [[DecodedLog]]) may contain decodings in different
   modes.
 
-- You can only decode storage variables in full mode. If full mode fails
-  while decoding a storage variable, it will throw an exception.
+- You can only decode state variables in full mode. If full mode fails
+  while decoding a state variable, it will throw an exception.
 
 - If a contract `Base` declares an event `Event` and a contract `Derived`
   inheriting from `Base` overrides `Event`, if `Derived` then emits
   `Base.Event`, ABI mode may not be able to decode it.
+
+#### Additional notes on decoding state variables
+
+- While internal function pointers can only be decoded in full mode,
+  full mode still may not be able to determine all the information about
+  them.  Thus, for internal function pointers, you may get a bare-bones
+  decoding, or you may get a decoding with more information.
+
+- Solidity 0.6.5 contains a bug that may cause some state variables to
+  decode incorrectly if there is an immutable state variable which is
+  written to but never read from.
+
+- In any version of Solidity, it is impossible to decode an immutable
+  state variable which is written to but never read from; these will
+  decode to an error.
+
+- Not all constant state variables can presently be decoded; some of
+  these may simply decode to an error.
 
 ---
 

--- a/packages/codec/lib/ast/types.ts
+++ b/packages/codec/lib/ast/types.ts
@@ -7,7 +7,7 @@ export interface TypeDescriptions {
 
 export interface AstNode {
   constant?: boolean;
-  immutable?: boolean;
+  mutability?: "mutable" | "immutable" | "constant"; //variable, not function, mutability!
   id: number;
   name: string;
   canonicalName?: string;

--- a/packages/debugger/test/data/immutable.js
+++ b/packages/debugger/test/data/immutable.js
@@ -13,7 +13,7 @@ import * as Codec from "@truffle/codec";
 import solidity from "lib/solidity/selectors";
 
 const __IMMUTABLE = `
-pragma solidity ^0.6.5;
+pragma solidity ^0.6.6;
 
 contract Base {
   int8 immutable base = -37;

--- a/packages/debugger/test/data/immutable.js
+++ b/packages/debugger/test/data/immutable.js
@@ -28,6 +28,7 @@ contract ImmutableTest is Base {
   bool immutable truth;
   address immutable self;
   byte immutable secret;
+  uint8 immutable trulySecret;
 
   event Done();
 
@@ -36,6 +37,7 @@ contract ImmutableTest is Base {
     truth = true;
     self = address(this);
     secret = 0x88;
+    trulySecret = 23;
     emit Done(); //BREAK CONSTRUCTOR
   }
 
@@ -113,6 +115,10 @@ describe("Immutable state variables", function() {
     };
 
     assert.deepInclude(variables, expectedResult);
+
+    const trulySecret = await session.variable("trulySecret");
+    assert.strictEqual(trulySecret.kind, "error");
+    assert.strictEqual(trulySecret.error.kind, "UnusedImmutableError");
   });
 
   it("Decodes immutables properly in constructor", async function() {
@@ -145,7 +151,8 @@ describe("Immutable state variables", function() {
       background: "ImmutableTest.Color.Blue",
       truth: true,
       self: address,
-      secret: "0x88"
+      secret: "0x88",
+      trulySecret: 23
     };
 
     assert.deepInclude(variables, expectedResult);

--- a/packages/debugger/test/helpers.js
+++ b/packages/debugger/test/helpers.js
@@ -26,7 +26,7 @@ export async function prepareContracts(provider, sources = {}, migrations) {
 
   config.compilers = {
     solc: {
-      version: "0.6.5",
+      version: "0.6.6",
       settings: {
         optimizer: { enabled: false, runs: 200 },
         evmVersion: "constantinople"

--- a/packages/decoder/lib/index.ts
+++ b/packages/decoder/lib/index.ts
@@ -63,19 +63,15 @@ The decoder outputs lossless, machine-readable [[Format.Values.Result]] objects
 containing individual decoded values. See the [[Format|format documentation]]
 for an overview and complete module listing.
 
-Note that for technical reasons, the decoder cannot always fully decode
-internal function pointers, but it will do its best even when information is
-missing, and will still losslessly return what information it can.  If you want
-to make sure to get the full information, see the advice
-[here](../#decoding-modes) about how to make sure "full mode" works; the same
-applies to decoding of internal function pointers.
-
-### Decoding modes and abification
+### Decoding modes, abification, and caveats
 
 The decoder runs in either of two modes: full mode or ABI mode. Full mode
 requires some additional constraints but returns substantially more detailed
 information. Please see the notes on [decoding modes](../#decoding-modes) for
 more about this distinction.
+
+See also the notes about [decoding state variables](../#additional-notes-on-decoding-state-variables) for additional
+caveats about what may or may not be fully decodable.
 
 ### Basic usage examples
 


### PR DESCRIPTION
My previous PR got wrong just how immutable variables would be indicated in Solidity 0.6.6.  This PR fixes that.  It also adds a test of unused immutables, now that they are detectable.

Also, I added a bit to the codec/decoder docs.  Hopefully it's a good summary.