### PR TITLE
Bug fix?: Implement typeString for TypeType

### DIFF
--- a/packages/codec/lib/format/types.ts
+++ b/packages/codec/lib/format/types.ts
@@ -708,6 +708,8 @@ export function typeStringWithoutLocation(dataType: Type): string {
         block: "block"
       };
       return variableNames[dataType.variable];
+    case "type":
+      return `type(${typeString(dataType.type)})`;
     case "function":
       let visibilityString: string;
       switch (dataType.visibility) {


### PR DESCRIPTION
The `typeString` function didn't cover type `type`.  Not sure this matters anywhere, but figured I should implement it since I noticed it missing.