### PR TITLE
Fix detection of local-vs-global types

### DIFF
--- a/packages/codec/lib/ast/import/index.ts
+++ b/packages/codec/lib/ast/import/index.ts
@@ -384,7 +384,7 @@ export function definitionToStoredType(
         let contractDefinition = Object.values(referenceDeclarations).find(
           node =>
             node.nodeType === "ContractDefinition" &&
-            node.nodes.some((subNode: AstNode) => subNode.id.toString() === id)
+            node.nodes.some((subNode: AstNode) => subNode.id === definition.id)
         );
         if (contractDefinition) {
           definingContract = <Format.Types.ContractTypeNative>(
@@ -429,9 +429,7 @@ export function definitionToStoredType(
         let contractDefinition = Object.values(referenceDeclarations).find(
           node =>
             node.nodeType === "ContractDefinition" &&
-            node.nodes.some(
-              (subNode: AstNode) => makeTypeId(subNode.id, compilationId) === id
-            )
+            node.nodes.some((subNode: AstNode) => subNode.id === definition.id)
         );
         if (contractDefinition) {
           definingContract = <Format.Types.ContractTypeNative>(

--- a/packages/codec/lib/ast/import/index.ts
+++ b/packages/codec/lib/ast/import/index.ts
@@ -384,7 +384,9 @@ export function definitionToStoredType(
         let contractDefinition = Object.values(referenceDeclarations).find(
           node =>
             node.nodeType === "ContractDefinition" &&
-            node.nodes.some((subNode: AstNode) => subNode.id === definition.id)
+            node.nodes.some(
+              (subNode: AstNode) => makeTypeId(subNode.id, compilationId) === id
+            )
         );
         if (contractDefinition) {
           definingContract = <Format.Types.ContractTypeNative>(
@@ -429,7 +431,9 @@ export function definitionToStoredType(
         let contractDefinition = Object.values(referenceDeclarations).find(
           node =>
             node.nodeType === "ContractDefinition" &&
-            node.nodes.some((subNode: AstNode) => subNode.id === definition.id)
+            node.nodes.some(
+              (subNode: AstNode) => makeTypeId(subNode.id, compilationId) === id
+            )
         );
         if (contractDefinition) {
           definingContract = <Format.Types.ContractTypeNative>(


### PR DESCRIPTION
Looks like I accidentally broke detection of which structs & enums are global and which are local!  Doesn't really affect anything at the moment but the type objects were wrong and it bugged me.  Anyway, fixed now.