### PR TITLE
Bug fix: Add AST ID collision check on debugger CLI startup

### DIFF
--- a/packages/core/lib/debug/cli.js
+++ b/packages/core/lib/debug/cli.js
@@ -38,11 +38,7 @@ class CLIDebugger {
     let artifacts = await DebugUtils.gatherArtifacts(config);
     let shimmedCompilations = Codec.Compilations.Utils.shimArtifacts(artifacts);
     //if they were compiled simultaneously, yay, we can use it!
-    if (
-      shimmedCompilations.every(
-        compilation => !compilation.unreliableSourceOrder
-      )
-    ) {
+    if (shimmedCompilations.every(DebugUtils.isUsableCompilation)) {
       return shimmedCompilations;
     }
     //if not, we have to recompile

--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -85,6 +85,44 @@ var DebugUtils = {
     }));
   },
 
+  //attempts to test whether a given compilation is a real compilation,
+  //i.e., was compiled all at once.
+  //if it is real, it will definitely pass this test, barring a Solidity bug.
+  //(anyway worst case failing it just results in a recompilation)
+  //if it isn't real, but passes this test anyway... well, I'm hoping it should
+  //still be usable all the same!
+  isUsableCompilation: function(compilation) {
+    //check #1: is the source order reliable?
+    if (compilation.unreliableSourceOrder) {
+      return false;
+    }
+
+    //check #2: are there any AST ID collisions?
+    let astIds = new Set();
+
+    let allIDsUnseenSoFar = node => {
+      if (Array.isArray(node)) {
+        return node.every(allIDsUnseenSoFar);
+      } else if (node !== null && typeof node === "object") {
+        if (node.id !== undefined) {
+          if (astIds.has(node.id)) {
+            return false;
+          } else {
+            astIds.add(node.id);
+          }
+        }
+        return Object.values(node).every(allIDsUnseenSoFar);
+      } else {
+        return true;
+      }
+    };
+
+    //now: walk each AST
+    return compilation.sources.every(
+      source => (source ? allIDsUnseenSoFar(source.ast) : true)
+    );
+  },
+
   formatStartMessage: function(withTransaction) {
     if (withTransaction) {
       return "Gathering information about your project and the transaction...";


### PR DESCRIPTION
When I made it so that the debugger doesn't have to recompile every time it starts up, I did this by checking each compilation's `unreliableSourceOrder` flag.  The idea being, if that flag wasn't set, then that compilation was usable by the debugger, and no recompilation was needed.

Unfortunately, that turns out not to be the case -- there can be times when a bad compilation nonetheless still has that flag unset.  This can result in AST ID collisions that crash the debugger.

To fix this, I've added a check for AST ID collisions to the debugger CLI startup.  Note that the debugger library makes no such check; this is purely a CLI feature.  (I didn't want the debugger walking the tree yet *again*... although I suppose I could add such a check to the existing initial walk fo the tree?  Not sure how much it matters; ultimately I'd just be making the debugger throw an exception.)  Anyway, if duplicate AST IDs are found, a recompilation is done.

Hopefully, that should catch all the bad fake compilations!  Or at least, hopefully, anything that passes this test is good enough for use, even if it's not a real compilation!

No tests are added; I tested this manually.  (To test the case of a collision, I manually edited the artifacts to create one.)