### PR TITLE
Convert Resolver.resolve to async

### DIFF
--- a/packages/compile-solidity/profiler/getImports.js
+++ b/packages/compile-solidity/profiler/getImports.js
@@ -15,7 +15,7 @@ const getImports = (file, { body, source }, solc, parserSolc) => {
   return imports.map(
     dependencyPath =>
       isExplicitlyRelative(dependencyPath)
-        ? source.resolve_dependency_path(file, dependencyPath)
+        ? source.resolveDependencyPath(file, dependencyPath)
         : dependencyPath
   );
 };

--- a/packages/core/lib/testing/testsource.js
+++ b/packages/core/lib/testing/testsource.js
@@ -101,7 +101,7 @@ module.exports = class TestSource {
     }
   }
 
-  resolve_dependency_path(importPath, dependencyPath) {
+  resolveDependencyPath(importPath, dependencyPath) {
     return dependencyPath;
   }
 };

--- a/packages/core/lib/testing/testsource.js
+++ b/packages/core/lib/testing/testsource.js
@@ -4,104 +4,104 @@ const fse = require("fs-extra");
 const contract = require("@truffle/contract");
 const find_contracts = require("@truffle/contract-sources");
 
-function TestSource(config) {
-  this.config = config;
-}
+module.exports = class TestSource {
+  constructor(config) {
+    this.config = config;
+  }
 
-TestSource.prototype.require = function() {
-  return null; // FSSource will get it.
-};
+  require() {
+    return null; // FSSource will get it.
+  }
 
-TestSource.prototype.resolve = async function(importPath) {
-  const self = this;
+  async resolve(importPath) {
+    const self = this;
 
-  if (importPath === "truffle/DeployedAddresses.sol") {
-    const sourceFiles = await find_contracts(this.config.contracts_directory);
+    if (importPath === "truffle/DeployedAddresses.sol") {
+      const sourceFiles = await find_contracts(this.config.contracts_directory);
 
-    let abstractionFiles;
-    const buildDirFiles = (abstractionFiles = fse.readdirSync(
-      self.config.contracts_build_directory
-    ));
-    abstractionFiles = buildDirFiles.filter(file => file.match(/^.*.json$/));
+      let abstractionFiles;
+      const buildDirFiles = (abstractionFiles = fse.readdirSync(
+        self.config.contracts_build_directory
+      ));
+      abstractionFiles = buildDirFiles.filter(file => file.match(/^.*.json$/));
 
-    const mapping = {};
+      const mapping = {};
 
-    const blacklist = new Set(["Assert", "DeployedAddresses"]);
+      const blacklist = new Set(["Assert", "DeployedAddresses"]);
 
-    // Ensure we have a mapping for source files and abstraction files
-    // to prevent any compile errors in tests.
-    sourceFiles.forEach(file => {
-      const name = path.basename(file, ".sol");
-      if (blacklist.has(name)) return;
-      mapping[name] = false;
-    });
-
-    abstractionFiles.forEach(file => {
-      const name = path.basename(file, ".json");
-      if (blacklist.has(name)) return;
-      mapping[name] = false;
-    });
-
-    const filesData = abstractionFiles.map(file => {
-      return fse.readFileSync(
-        path.join(self.config.contracts_build_directory, file),
-        "utf8"
-      );
-    });
-
-    const addresses = filesData
-      .map(data => JSON.parse(data))
-      .map(json => contract(json))
-      .map(c => {
-        c.setNetwork(self.config.network_id);
-        if (c.isDeployed()) return c.address;
-        return null;
+      // Ensure we have a mapping for source files and abstraction files
+      // to prevent any compile errors in tests.
+      sourceFiles.forEach(file => {
+        const name = path.basename(file, ".sol");
+        if (blacklist.has(name)) return;
+        mapping[name] = false;
       });
 
-    addresses.forEach((address, i) => {
-      const name = path.basename(abstractionFiles[i], ".json");
+      abstractionFiles.forEach(file => {
+        const name = path.basename(file, ".json");
+        if (blacklist.has(name)) return;
+        mapping[name] = false;
+      });
 
-      if (blacklist.has(name)) return;
+      const filesData = abstractionFiles.map(file => {
+        return fse.readFileSync(
+          path.join(self.config.contracts_build_directory, file),
+          "utf8"
+        );
+      });
 
-      mapping[name] = address;
-    });
+      const addresses = filesData
+        .map(data => JSON.parse(data))
+        .map(json => contract(json))
+        .map(c => {
+          c.setNetwork(self.config.network_id);
+          if (c.isDeployed()) return c.address;
+          return null;
+        });
 
-    const addressSource = Deployed.makeSolidityDeployedAddressesLibrary(
-      mapping,
-      self.config.compilers
-    );
-    return { body: addressSource, resolvedPath: importPath };
-  }
-  const assertLibraries = [
-    "Assert",
-    "AssertAddress",
-    "AssertAddressArray",
-    //      "AssertAddressPayableArray", only compatible w/ ^0.5.0
-    "AssertBalance",
-    "AssertBool",
-    "AssertBytes32",
-    "AssertBytes32Array",
-    "AssertGeneral",
-    "AssertInt",
-    "AssertIntArray",
-    "AssertString",
-    "AssertUint",
-    "AssertUintArray"
-  ];
+      addresses.forEach((address, i) => {
+        const name = path.basename(abstractionFiles[i], ".json");
 
-  for (const lib of assertLibraries) {
-    if (importPath === `truffle/${lib}.sol`) {
-      const body = fse.readFileSync(
-        path.resolve(path.join(__dirname, `${lib}.sol`)),
-        { encoding: "utf8" }
+        if (blacklist.has(name)) return;
+
+        mapping[name] = address;
+      });
+
+      const addressSource = Deployed.makeSolidityDeployedAddressesLibrary(
+        mapping,
+        self.config.compilers
       );
-      return { body, resolvedPath: importPath };
+      return { body: addressSource, filePath: importPath };
+    }
+    const assertLibraries = [
+      "Assert",
+      "AssertAddress",
+      "AssertAddressArray",
+      //      "AssertAddressPayableArray", only compatible w/ ^0.5.0
+      "AssertBalance",
+      "AssertBool",
+      "AssertBytes32",
+      "AssertBytes32Array",
+      "AssertGeneral",
+      "AssertInt",
+      "AssertIntArray",
+      "AssertString",
+      "AssertUint",
+      "AssertUintArray"
+    ];
+
+    for (const lib of assertLibraries) {
+      if (importPath === `truffle/${lib}.sol`) {
+        const body = fse.readFileSync(
+          path.resolve(path.join(__dirname, `${lib}.sol`)),
+          { encoding: "utf8" }
+        );
+        return { body, filePath: importPath };
+      }
     }
   }
-};
 
-TestSource.prototype.resolve_dependency_path = (importPath, dependencyPath) => {
-  return dependencyPath;
+  resolve_dependency_path(importPath, dependencyPath) {
+    return dependencyPath;
+  }
 };
-
-module.exports = TestSource;

--- a/packages/core/test/npm.js
+++ b/packages/core/test/npm.js
@@ -72,35 +72,31 @@ describe("NPM integration", function() {
     });
   });
 
-  it("successfully finds the correct source via Sources lookup", function(done) {
-    config.resolver.resolve(
+  it("successfully finds the correct source via Sources lookup", async function() {
+    const { body } = await config.resolver.resolve(
       "fake_source/contracts/Module.sol",
-      config.sources,
-      function(err, body) {
-        if (err) return done(err);
-
-        assert.equal(body, moduleSource);
-        done();
-      }
+      config.sources
     );
+    assert.equal(body, moduleSource);
   });
 
-  it("errors when module does not exist from any source", function(done) {
-    config.resolver.resolve(
-      "some_source/contracts/SourceDoesNotExist.sol",
-      config.sources,
-      function(err) {
-        if (!err) {
-          return assert.fail("Source lookup should have errored but didn't");
-        }
+  it("errors when module does not exist from any source", async function() {
+    try {
+      await config.resolver.resolve(
+        "some_source/contracts/SourceDoesNotExist.sol",
+        config.sources
+      );
+    } catch (err) {
+      assert.equal(
+        err.message,
+        "Could not find some_source/contracts/SourceDoesNotExist.sol from any sources"
+      );
 
-        assert.equal(
-          err.message,
-          "Could not find some_source/contracts/SourceDoesNotExist.sol from any sources"
-        );
-        done();
-      }
-    );
+      return;
+    }
+
+    // should not be reached
+    assert.fail("Source lookup should have errored but didn't");
   });
 
   it("contract compiliation successfully picks up modules and their dependencies", function(done) {

--- a/packages/resolver/lib/resolver.ts
+++ b/packages/resolver/lib/resolver.ts
@@ -5,13 +5,6 @@ const provision = require("@truffle/provisioner");
 import { ResolverSource } from "./source";
 import { constructSources } from "./sources";
 
-type Callback = (
-  err: Error | null,
-  body?: string,
-  filePath?: string,
-  source?: ResolverSource
-) => void;
-
 export class Resolver {
   options: any;
   sources: ResolverSource[];
@@ -39,20 +32,7 @@ export class Resolver {
     );
   }
 
-  resolve(importPath: string, importedFrom: string, callback: Callback) {
-    if (typeof importedFrom === "function") {
-      callback = importedFrom;
-      importedFrom = null;
-    }
-
-    this._resolve(importPath, importedFrom)
-      .then(({ body, filePath, source }) =>
-        callback(null, body, filePath, source)
-      )
-      .catch(error => callback(error));
-  }
-
-  private async _resolve(
+  async resolve(
     importPath: string,
     importedFrom: string
   ): Promise<{ body: string; filePath: string; source: ResolverSource }> {

--- a/packages/resolver/lib/source.ts
+++ b/packages/resolver/lib/source.ts
@@ -3,7 +3,7 @@ import { ContractObject } from "@truffle/contract-schema/spec";
 export interface ResolverSource {
   require(importPath: string, searchPath?: string): ContractObject | null;
   resolve(importPath: string, importedFrom: string): Promise<SourceResolution>;
-  resolve_dependency_path(importPath: string, dependencyPath: string): string;
+  resolveDependencyPath(importPath: string, dependencyPath: string): string;
 }
 
 export interface SourceResolution {

--- a/packages/resolver/lib/sources/ethpm-v1.ts
+++ b/packages/resolver/lib/sources/ethpm-v1.ts
@@ -117,7 +117,7 @@ export class EthPMv1 implements ResolverSource {
   // i.e., if some_module/contracts/MyContract.sol imported "./AnotherContract.sol",
   // we're going to resolve it to some_module/contracts/AnotherContract.sol, ensuring
   // that when this path is evaluated this source is used again.
-  resolve_dependency_path(importPath: string, dependencyPath: string) {
+  resolveDependencyPath(importPath: string, dependencyPath: string) {
     var dirname = path.dirname(importPath);
     var resolved_dependency_path = path.join(dirname, dependencyPath);
 

--- a/packages/resolver/lib/sources/fs.ts
+++ b/packages/resolver/lib/sources/fs.ts
@@ -80,7 +80,7 @@ export class FS implements ResolverSource {
   }
 
   // Here we're resolving from local files to local files, all absolute.
-  resolve_dependency_path(importPath: string, dependencyPath: string) {
+  resolveDependencyPath(importPath: string, dependencyPath: string) {
     const dirname = path.dirname(importPath);
     return path.resolve(path.join(dirname, dependencyPath));
   }

--- a/packages/resolver/lib/sources/globalnpm.ts
+++ b/packages/resolver/lib/sources/globalnpm.ts
@@ -57,7 +57,7 @@ export class GlobalNPM implements ResolverSource {
   // i.e., if some_module/contracts/MyContract.sol imported "./AnotherContract.sol",
   // we're going to resolve it to some_module/contracts/AnotherContract.sol, ensuring
   // that when this path is evaluated this source is used again.
-  resolve_dependency_path(importPath: string, dependencyPath: string) {
+  resolveDependencyPath(importPath: string, dependencyPath: string) {
     var dirname = path.dirname(importPath);
     return path.join(dirname, dependencyPath);
   }

--- a/packages/resolver/lib/sources/npm.ts
+++ b/packages/resolver/lib/sources/npm.ts
@@ -65,7 +65,7 @@ export class NPM implements ResolverSource {
   // i.e., if some_module/contracts/MyContract.sol imported "./AnotherContract.sol",
   // we're going to resolve it to some_module/contracts/AnotherContract.sol, ensuring
   // that when this path is evaluated this source is used again.
-  resolve_dependency_path(import_path: string, dependency_path: string) {
+  resolveDependencyPath(import_path: string, dependency_path: string) {
     var dirname = path.dirname(import_path);
     return path.join(dirname, dependency_path);
   }


### PR DESCRIPTION
ℹ️ **This is a breaking change to @truffle/resolver**

Besides the high-level change to promisify `resolver.resolve`, this PR also includes:

- Rename ResolverSource method `resolve_dependency_path` to `resolveDependencyPath`
- Rename `file` property to `filePath` in return value, since that's what it's called elsewhere (and it's more explicit)
- Convert various old-style classes to use `class` syntax