### PR TITLE
Feature: Add Quick-start templates for supported Tezos contracts

### DIFF
--- a/packages/core/lib/commands/create/templates/Example.ligo
+++ b/packages/core/lib/commands/create/templates/Example.ligo
@@ -1,0 +1,2 @@
+function main(const parameter: unit; const storage: unit): (list(operation) * unit) is
+    block { skip } with ((nil : list(operation)), unit)

--- a/packages/core/lib/commands/create/templates/Example.mligo
+++ b/packages/core/lib/commands/create/templates/Example.mligo
@@ -1,0 +1,5 @@
+type storage = unit
+
+let main(p, s : unit * storage) =
+  let storage = unit
+  in (([] : operation list), storage)

--- a/packages/core/lib/commands/create/templates/Example.py
+++ b/packages/core/lib/commands/create/templates/Example.py
@@ -1,0 +1,5 @@
+import smartpy as sp
+
+class Example(sp.Contract):
+    def __init__(self):
+        self.init()

--- a/packages/core/lib/commands/create/templates/Example.religo
+++ b/packages/core/lib/commands/create/templates/Example.religo
@@ -1,0 +1,6 @@
+type storage = unit;
+
+let main = ((p,storage): (unit, storage)) => {
+  let storage = unit;
+  (([]: list(operation)), storage);
+};

--- a/packages/core/lib/commands/index.js
+++ b/packages/core/lib/commands/index.js
@@ -3,7 +3,7 @@ module.exports = {
   compile: require("./compile"),
   config: require("./config"),
   console: require("./console"),
-  // create: require("./create"),
+  create: require("./create"),
   debug: require("./debug"),
   deploy: require("./deploy"),
   develop: require("./develop"),

--- a/packages/core/test/lib/create.js
+++ b/packages/core/test/lib/create.js
@@ -24,84 +24,214 @@ describe("create", function() {
     });
   });
 
-  it("creates a new contract", function(done) {
-    Create.contract(config.contracts_directory, "MyNewContract", function(err) {
-      if (err) return done(err);
+  it("creates a new solidity contract (by default)", function(done) {
+    Create.contract(
+      config.contracts_directory,
+      undefined,
+      "MyNewContract",
+      function(err) {
+        if (err) return done(err);
 
-      const expectedFile = path.join(
-        config.contracts_directory,
-        "MyNewContract.sol"
-      );
-      assert.isTrue(
-        fse.existsSync(expectedFile),
-        `Contract to be created doesns't exist, ${expectedFile}`
-      );
+        const expectedFile = path.join(
+          config.contracts_directory,
+          "MyNewContract.sol"
+        );
+        assert.isTrue(
+          fse.existsSync(expectedFile),
+          `Contract to be created doesns't exist, ${expectedFile}`
+        );
 
-      const fileData = fse.readFileSync(expectedFile, { encoding: "utf8" });
-      assert.isNotNull(fileData, "File's data is null");
-      assert.notEqual(fileData, "", "File's data is blank");
-      assert.isTrue(
-        fileData.includes("pragma solidity >= 0.5.0 < 0.7.0;"),
-        "File's solidity version does not match >= 0.5.0 < 0.7.0"
-      );
-      done();
-    });
+        const fileData = fse.readFileSync(expectedFile, { encoding: "utf8" });
+        assert.isNotNull(fileData, "File's data is null");
+        assert.notEqual(fileData, "", "File's data is blank");
+        assert.isTrue(
+          fileData.includes("pragma solidity >= 0.5.0 < 0.7.0;"),
+          "File's solidity version does not match >= 0.5.0 < 0.7.0"
+        );
+        done();
+      }
+    );
+  });
+
+  it("can create a new smartpy contract", function(done) {
+    Create.contract(
+      config.contracts_directory,
+      "smartpy",
+      "MyNewContract",
+      function(err) {
+        if (err) return done(err);
+
+        const expectedFile = path.join(
+          config.contracts_directory,
+          "MyNewContract.py"
+        );
+        assert.isTrue(
+          fse.existsSync(expectedFile),
+          `Contract to be created doesns't exist, ${expectedFile}`
+        );
+
+        const fileData = fse.readFileSync(expectedFile, { encoding: "utf8" });
+        assert.isNotNull(fileData, "File's data is null");
+        assert.notEqual(fileData, "", "File's data is blank");
+        assert.isTrue(
+          fileData.includes("import smartpy as sp"),
+          "Smartpy contract not created correctly"
+        );
+        done();
+      }
+    );
+  });
+
+  it("can create a new reasonligo contract", function(done) {
+    Create.contract(
+      config.contracts_directory,
+      "reasonligo",
+      "MyNewContract",
+      function(err) {
+        if (err) return done(err);
+
+        const expectedFile = path.join(
+          config.contracts_directory,
+          "MyNewContract.religo"
+        );
+        assert.isTrue(
+          fse.existsSync(expectedFile),
+          `Contract to be created doesns't exist, ${expectedFile}`
+        );
+
+        const fileData = fse.readFileSync(expectedFile, { encoding: "utf8" });
+        assert.isNotNull(fileData, "File's data is null");
+        assert.notEqual(fileData, "", "File's data is blank");
+        assert.isTrue(
+          fileData.includes("let main = "),
+          "Reasonligo contract not created correctly"
+        );
+        done();
+      }
+    );
+  });
+
+  it("can create a new cameligo contract", function(done) {
+    Create.contract(
+      config.contracts_directory,
+      "cameligo",
+      "MyNewContract",
+      function(err) {
+        if (err) return done(err);
+
+        const expectedFile = path.join(
+          config.contracts_directory,
+          "MyNewContract.mligo"
+        );
+        assert.isTrue(
+          fse.existsSync(expectedFile),
+          `Contract to be created doesns't exist, ${expectedFile}`
+        );
+
+        const fileData = fse.readFileSync(expectedFile, { encoding: "utf8" });
+        assert.isNotNull(fileData, "File's data is null");
+        assert.notEqual(fileData, "", "File's data is blank");
+        assert.isTrue(
+          fileData.includes("let main("),
+          "Cameligo contract not created correctly"
+        );
+        done();
+      }
+    );
+  });
+
+  it("can create a new pascaligo contract", function(done) {
+    Create.contract(
+      config.contracts_directory,
+      "pascaligo",
+      "MyNewContract",
+      function(err) {
+        if (err) return done(err);
+
+        const expectedFile = path.join(
+          config.contracts_directory,
+          "MyNewContract.ligo"
+        );
+        assert.isTrue(
+          fse.existsSync(expectedFile),
+          `Contract to be created doesns't exist, ${expectedFile}`
+        );
+
+        const fileData = fse.readFileSync(expectedFile, { encoding: "utf8" });
+        assert.isNotNull(fileData, "File's data is null");
+        assert.notEqual(fileData, "", "File's data is blank");
+        assert.isTrue(
+          fileData.includes("function main("),
+          "Pascaligo contract not created correctly"
+        );
+        done();
+      }
+    );
   });
 
   it("will not overwrite an existing contract (by default)", function(done) {
-    Create.contract(config.contracts_directory, "MyNewContract2", function(
-      err
-    ) {
-      if (err) return done(err);
+    Create.contract(
+      config.contracts_directory,
+      undefined,
+      "MyNewContract2",
+      function(err) {
+        if (err) return done(err);
 
-      const expectedFile = path.join(
-        config.contracts_directory,
-        "MyNewContract2.sol"
-      );
-      assert.isTrue(
-        fse.existsSync(expectedFile),
-        `Contract to be created doesns't exist, ${expectedFile}`
-      );
+        const expectedFile = path.join(
+          config.contracts_directory,
+          "MyNewContract2.sol"
+        );
+        assert.isTrue(
+          fse.existsSync(expectedFile),
+          `Contract to be created doesns't exist, ${expectedFile}`
+        );
 
-      Create.contract(config.contracts_directory, "MyNewContract2", function(
-        err
-      ) {
-        assert(err.message.includes("file exists"));
-        done();
-      });
-    });
+        Create.contract(
+          config.contracts_directory,
+          undefined,
+          "MyNewContract2",
+          function(err) {
+            assert(err.message.includes("file exists"));
+            done();
+          }
+        );
+      }
+    );
   });
 
   it("will overwrite an existing contract if the force option is enabled", function(done) {
-    Create.contract(config.contracts_directory, "MyNewContract3", function(
-      err
-    ) {
-      if (err) return done(err);
+    Create.contract(
+      config.contracts_directory,
+      undefined,
+      "MyNewContract3",
+      function(err) {
+        if (err) return done(err);
 
-      const expectedFile = path.join(
-        config.contracts_directory,
-        "MyNewContract3.sol"
-      );
-      assert.isTrue(
-        fse.existsSync(expectedFile),
-        `Contract to be created doesns't exist, ${expectedFile}`
-      );
+        const expectedFile = path.join(
+          config.contracts_directory,
+          "MyNewContract3.sol"
+        );
+        assert.isTrue(
+          fse.existsSync(expectedFile),
+          `Contract to be created doesns't exist, ${expectedFile}`
+        );
 
-      const options = { force: true };
-      Create.contract(
-        config.contracts_directory,
-        "MyNewContract3",
-        options,
-        function(err) {
-          assert(err === null);
-          done();
-        }
-      );
-    });
+        const options = { force: true };
+        Create.contract(
+          config.contracts_directory,
+          "MyNewContract3",
+          options,
+          function(err) {
+            assert(err === null);
+            done();
+          }
+        );
+      }
+    );
   });
 
   it("creates a new test", function(done) {
-    Create.test(config.test_directory, "MyNewTest", function(err) {
+    Create.test(config.test_directory, undefined, "MyNewTest", function(err) {
       if (err) return done(err);
 
       const expectedFile = path.join(config.test_directory, "my_new_test.js");
@@ -116,34 +246,37 @@ describe("create", function() {
 
       done();
     });
-  }); // it
+  });
 
   it("creates a new migration", function(done) {
-    Create.migration(config.migrations_directory, "MyNewMigration", function(
-      err
-    ) {
-      if (err) return done(err);
-      const files = glob.sync(`${config.migrations_directory}${path.sep}*`);
+    Create.migration(
+      config.migrations_directory,
+      undefined,
+      "MyNewMigration",
+      function(err) {
+        if (err) return done(err);
+        const files = glob.sync(`${config.migrations_directory}${path.sep}*`);
 
-      const found = false;
-      const expectedSuffix = "_my_new_migration.js";
+        const found = false;
+        const expectedSuffix = "_my_new_migration.js";
 
-      for (let file of files) {
-        if (
-          file.indexOf(expectedSuffix) ===
-          file.length - expectedSuffix.length
-        ) {
-          const fileData = fse.readFileSync(file, { encoding: "utf8" });
-          assert.isNotNull(fileData, "File's data is null");
-          assert.notEqual(fileData, "", "File's data is blank");
+        for (let file of files) {
+          if (
+            file.indexOf(expectedSuffix) ===
+            file.length - expectedSuffix.length
+          ) {
+            const fileData = fse.readFileSync(file, { encoding: "utf8" });
+            assert.isNotNull(fileData, "File's data is null");
+            assert.notEqual(fileData, "", "File's data is blank");
 
-          return done();
+            return done();
+          }
+        }
+
+        if (found === false) {
+          assert.fail("Could not find a file that matched expected name");
         }
       }
-
-      if (found === false) {
-        assert.fail("Could not find a file that matched expected name");
-      }
-    });
-  }); // it
+    );
+  });
 }).timeout(10000);


### PR DESCRIPTION
In `@truffle/core`:
- Re-enable `create` command export
- Cleanup old unused `builder` `truffle create` command object
- Add `SmartContractType` as optional CLI argument to pass in. Update
help usage, options, and descriptions.
- Add contract templates for:
  - SmartPy
  - PascaLigo
  - CameLigo
  - ReasonLigo
- Refactor `commands/create/index`:
  - Check for `smartContractType` passed
  - Throw helpful error if no `artifactType` passed
  - Throw helpful error if no `artifactName` passed
  - Pass `smartContractType` to `Create` object
- Refactor `commmands/create/helpers`:
  - Tweak `templates.contract.filename` to append contract file extension later
  - Rework `processFile` (use `fs.readFileSync`, rename some variables)
  - Slightly refactor `replaceContents`
  - Slightly refactor `toUnderscoreFromCamel`
  - Slightly refactor `Create.test` and `Create.migration`
  - Rework `Create.contract` to check for `smartContractType` and set
  `smartContractFileExtension`. Append and copy/replace appropriate
  contract template type. Defaults to solidity still
- Add test cases for new `truffle create` functionality