### PR TITLE
Fix: Prefix creation of migration template scripts correctly

### DIFF
--- a/packages/core/lib/commands/create/helpers.js
+++ b/packages/core/lib/commands/create/helpers.js
@@ -97,12 +97,12 @@ const Create = {
     });
   },
 
-  test: (directory, _smartContractType, contractName, options, callback) => {
+  test: (directory, _smartContractType, testName, options, callback) => {
     if (typeof options === "function") {
       callback = options;
     }
 
-    let underscored = toUnderscoreFromCamel(contractName);
+    let underscored = toUnderscoreFromCamel(testName);
     underscored = underscored.replace(/\./g, "_");
     const from = templates.test.filename;
     const to = join(directory, underscored + ".js");
@@ -116,7 +116,7 @@ const Create = {
     copyFile(from, to, err => {
       if (err) return callback(err);
 
-      replaceContents(to, templates.contract.name, contractName, err => {
+      replaceContents(to, templates.contract.name, testName, err => {
         if (err) return callback(err);
         replaceContents(to, templates.contract.variable, underscored, callback);
       });
@@ -126,7 +126,7 @@ const Create = {
   migration: (
     directory,
     _smartContractType,
-    contractName,
+    migrationsName,
     options,
     callback
   ) => {
@@ -134,12 +134,14 @@ const Create = {
       callback = options;
     }
 
-    let underscored = toUnderscoreFromCamel(contractName || "");
+    let underscored = toUnderscoreFromCamel(migrationsName || "");
     underscored = underscored.replace(/\./g, "_");
     const from = templates.migration.filename;
-    let filename = (new Date().getTime() / 1000) | 0; // Only do seconds.
+    const currentMigrationsDirectory = fs.readdirSync(directory);
+    const migrationsPrefix = currentMigrationsDirectory.length + 1;
+    let filename = migrationsPrefix;
 
-    if (contractName != null && contractName !== "") {
+    if (migrationsName != null && migrationsName !== "") {
       filename += "_" + underscored;
     }
 

--- a/packages/core/test/lib/create.js
+++ b/packages/core/test/lib/create.js
@@ -258,19 +258,22 @@ describe("create", function() {
         const files = glob.sync(`${config.migrations_directory}${path.sep}*`);
 
         const found = false;
-        const expectedSuffix = "_my_new_migration.js";
+        let prefixCounter = 1;
 
-        for (let file of files) {
-          if (
-            file.indexOf(expectedSuffix) ===
-            file.length - expectedSuffix.length
-          ) {
-            const fileData = fse.readFileSync(file, { encoding: "utf8" });
-            assert.isNotNull(fileData, "File's data is null");
-            assert.notEqual(fileData, "", "File's data is blank");
+        for (const file of files) {
+          const fileData = fse.readFileSync(file, { encoding: "utf8" });
+          const fileBasename = path.basename(file);
+          assert(
+            parseInt(fileBasename) === prefixCounter,
+            `migration prefix incorrect, should be ${prefixCounter} instead of ${parseInt(
+              fileBasename
+            )}`
+          );
+          assert.isNotNull(fileData, "File's data is null");
+          assert.notEqual(fileData, "", "File's data is blank");
+          prefixCounter++;
 
-            return done();
-          }
+          return done();
         }
 
         if (found === false) {


### PR DESCRIPTION
- Rename internally used vars correctly
- Swap out prefix logic to prefix new migration scripts according to
current migration directory state
- Update `truffle create migration` test case for new prefix logic