### PR TITLE
On calls, pull defaultBlock from web3

### DIFF
--- a/packages/contract/lib/execute.js
+++ b/packages/contract/lib/execute.js
@@ -114,7 +114,7 @@ const execute = {
     const constructor = this;
 
     return function() {
-      let defaultBlock = this.web3.eth.defaultBlock;
+      let defaultBlock = constructor.web3.eth.defaultBlock;
       const args = Array.prototype.slice.call(arguments);
       const lastArg = args[args.length - 1];
       const promiEvent = PromiEvent();

--- a/packages/contract/lib/execute.js
+++ b/packages/contract/lib/execute.js
@@ -114,7 +114,7 @@ const execute = {
     const constructor = this;
 
     return function() {
-      let defaultBlock = "latest";
+      let defaultBlock = this.web3.eth.defaultBlock;
       const args = Array.prototype.slice.call(arguments);
       const lastArg = args[args.length - 1];
       const promiEvent = PromiEvent();

--- a/packages/contract/lib/execute.js
+++ b/packages/contract/lib/execute.js
@@ -114,7 +114,7 @@ const execute = {
     const constructor = this;
 
     return function() {
-      let defaultBlock = constructor.web3.eth.defaultBlock;
+      let defaultBlock = constructor.web3.eth.defaultBlock || "latest";
       const args = Array.prototype.slice.call(arguments);
       const lastArg = args[args.length - 1];
       const promiEvent = PromiEvent();


### PR DESCRIPTION
## Issue: 
Function calls using @truffle/contract (`.call()`) act as if `web3.eth.defaultBlock == 'latest'`, even when it isn't. 

The workaround is to add a parameter at the end of the parameter list for every `call()` which is `web3.eth.defaultBlock`.

This is not intuitive, not consistent with a prior major version, and the change does not appear easy to find in documentation.  It's also not clear that this is the best choice for behavior.

I think the behaviour is due to the [line](https://github.com/trufflesuite/truffle/blob/8b8b1aef0112c1e690479fba5da9a8d9d87e65db/packages/contract/lib/execute.js#L117): `let defaultBlock = "latest";` 

That was added in [this commit](https://github.com/trufflesuite/truffle/commit/c588b7d9dc849c53e1732c32144aa3b3b5131bee) by @cgewecke back on Jun 10, 2018, but I can't really find why; I don't see any associated PR/discussion.

This PR proposes changing that line to `let defaultBlock = this.web3.eth.defaultBlock;` but hasn't been tested.  The intended result includes:
  - Backwards compatibility: if you are using the workaround that you currently have to use, or if you are leaving the defaultBlock as 'latest' all the time, no behavior will change and no code changes are required.
  - If someone *is* changing web3.eth.defaultBlock, calls should respect that.

  