### PR TITLE
Add stacktraces to debugger library and print them in CLI

### DIFF
--- a/packages/core/lib/debug/interpreter.js
+++ b/packages/core/lib/debug/interpreter.js
@@ -588,7 +588,8 @@ class DebugInterpreter {
       cmd !== "r" &&
       cmd !== "-" &&
       cmd !== "t" &&
-      cmd !== "T"
+      cmd !== "T" &&
+      cmd !== "s"
     ) {
       this.lastCommand = cmd;
     }

--- a/packages/core/lib/debug/interpreter.js
+++ b/packages/core/lib/debug/interpreter.js
@@ -432,6 +432,8 @@ class DebugInterpreter {
       //check if transaction failed
       if (!this.session.view(evm.transaction.status)) {
         this.printer.printRevertMessage();
+        this.printer.print("");
+        this.printer.printStacktrace(true); //final stacktrace
       } else {
         //case if transaction succeeded
         this.printer.print("Transaction completed successfully.");
@@ -521,6 +523,9 @@ class DebugInterpreter {
         await this.printer.printWatchExpressionsResults(
           this.enabledExpressions
         );
+        break;
+      case "s":
+        this.printer.printStacktrace(false); //intermediate stacktrace
         break;
       case "o":
       case "i":

--- a/packages/core/lib/debug/interpreter.js
+++ b/packages/core/lib/debug/interpreter.js
@@ -525,7 +525,12 @@ class DebugInterpreter {
         );
         break;
       case "s":
-        this.printer.printStacktrace(false); //intermediate stacktrace
+        if (this.session.view(selectors.session.status.loaded)) {
+          this.printer.printStacktrace(
+            this.session.view(trace.finished) //print final report if finished,
+            //intermediate if not
+          );
+        }
         break;
       case "o":
       case "i":

--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -8,7 +8,15 @@ const DebugUtils = require("@truffle/debug-utils");
 const Codec = require("@truffle/codec");
 
 const selectors = require("@truffle/debugger").selectors;
-const { session, solidity, trace, controller, data, evm } = selectors;
+const {
+  session,
+  solidity,
+  trace,
+  controller,
+  data,
+  evm,
+  stacktrace
+} = selectors;
 
 class DebugPrinter {
   constructor(config, session) {
@@ -231,7 +239,9 @@ class DebugPrinter {
   }
 
   printRevertMessage() {
-    this.config.logger.log("Transaction halted with a RUNTIME ERROR.");
+    this.config.logger.log(
+      DebugUtils.truffleColors.red("Transaction halted with a RUNTIME ERROR.")
+    );
     this.config.logger.log("");
     let rawRevertMessage = this.session.view(evm.current.step.returnValue);
     let revertDecodings = Codec.decodeRevert(
@@ -284,6 +294,16 @@ class DebugPrinter {
     }
     this.config.logger.log(
       "Please inspect your transaction parameters and contract code to determine the meaning of this error."
+    );
+  }
+
+  printStacktrace(final) {
+    this.config.logger.log("Stacktrace:");
+    this.config.logger.log(
+      DebugUtils.formatStacktrace(
+        this.session.view(stacktrace.current.report),
+        final
+      )
     );
   }
 

--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -299,12 +299,10 @@ class DebugPrinter {
 
   printStacktrace(final) {
     this.config.logger.log("Stacktrace:");
-    this.config.logger.log(
-      DebugUtils.formatStacktrace(
-        this.session.view(stacktrace.current.report),
-        final
-      )
-    );
+    let report = final
+      ? this.session.view(stacktrace.current.finalReport)
+      : this.session.view(stacktrace.current.report);
+    this.config.logger.log(DebugUtils.formatStacktrace(report));
   }
 
   async printWatchExpressionsResults(expressions) {

--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -556,7 +556,7 @@ var DebugUtils = {
       .join(OS.EOL);
   },
 
-  formatStacktrace: function(stacktrace, final = true, indent = 2) {
+  formatStacktrace: function(stacktrace, indent = 2) {
     //we want to print inner to outer, so first, let's
     //reverse
     stacktrace = stacktrace.slice().reverse(); //reverse is in-place so clone first
@@ -576,15 +576,13 @@ var DebugUtils = {
         return `at ${functionName} (unknown location)`;
       }
     });
-    if (final) {
-      let status = stacktrace[0].status;
-      if (status != undefined) {
-        lines.unshift(
-          status
-            ? "Error: Improper return (may be an unexpected self-destruct)"
-            : "Error: Revert or exceptional halt"
-        );
-      }
+    let status = stacktrace[0].status;
+    if (status != undefined) {
+      lines.unshift(
+        status
+          ? "Error: Improper return (may be an unexpected self-destruct)"
+          : "Error: Revert or exceptional halt"
+      );
     }
     let indented = lines.map((line, index) =>
       index === 0 ? line : " ".repeat(indent) + line

--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -560,8 +560,15 @@ var DebugUtils = {
     //we want to print inner to outer, so first, let's
     //reverse
     stacktrace = stacktrace.slice().reverse(); //reverse is in-place so clone first
-    let lines = stacktrace.map(({ name, location }) => {
-      let functionName = name ? `function ${name}` : "unknown function";
+    let lines = stacktrace.map(({ functionName, contractName, location }) => {
+      let name;
+      if (contractName && functionName) {
+        name = `${contractName}.${functionName}`;
+      } else if (contractName) {
+        name = contractName;
+      } else {
+        name = "unknown function";
+      }
       if (location) {
         let {
           source: { sourcePath },
@@ -571,9 +578,9 @@ var DebugUtils = {
             }
           }
         } = location;
-        return `at ${functionName} (${sourcePath}:${line + 1}:${column + 1})`; //add 1 to account for 0-indexing
+        return `at ${name} (${sourcePath}:${line + 1}:${column + 1})`; //add 1 to account for 0-indexing
       } else {
-        return `at ${functionName} (unknown location)`;
+        return `at ${name} (unknown location)`;
       }
     });
     let status = stacktrace[0].status;

--- a/packages/debugger/lib/controller/actions/index.js
+++ b/packages/debugger/lib/controller/actions/index.js
@@ -1,29 +1,29 @@
-export const ADVANCE = "ADVANCE";
+export const ADVANCE = "CONTROLLER_ADVANCE";
 export function advance(count) {
   return { type: ADVANCE, count };
 }
 
-export const STEP_NEXT = "STEP_NEXT";
+export const STEP_NEXT = "CONTROLLER_STEP_NEXT";
 export function stepNext() {
   return { type: STEP_NEXT };
 }
 
-export const STEP_OVER = "STEP_OVER";
+export const STEP_OVER = "CONTROLLER_STEP_OVER";
 export function stepOver() {
   return { type: STEP_OVER };
 }
 
-export const STEP_INTO = "STEP_INTO";
+export const STEP_INTO = "CONTROLLER_STEP_INTO";
 export function stepInto() {
   return { type: STEP_INTO };
 }
 
-export const STEP_OUT = "STEP_OUT";
+export const STEP_OUT = "CONTROLLER_STEP_OUT";
 export function stepOut() {
   return { type: STEP_OUT };
 }
 
-export const RESET = "RESET";
+export const RESET = "CONTROLLER_RESET";
 export function reset() {
   return { type: RESET };
 }
@@ -33,7 +33,7 @@ export function interrupt() {
   return { type: INTERRUPT };
 }
 
-export const CONTINUE = "CONTINUE";
+export const CONTINUE = "CONTROLLER_CONTINUE";
 export function continueUntilBreakpoint(breakpoints) {
   //"continue" is not a legal name
   return {
@@ -42,7 +42,7 @@ export function continueUntilBreakpoint(breakpoints) {
   };
 }
 
-export const ADD_BREAKPOINT = "ADD_BREAKPOINT";
+export const ADD_BREAKPOINT = "CONTROLLER_ADD_BREAKPOINT";
 export function addBreakpoint(breakpoint) {
   return {
     type: ADD_BREAKPOINT,
@@ -50,7 +50,7 @@ export function addBreakpoint(breakpoint) {
   };
 }
 
-export const REMOVE_BREAKPOINT = "REMOVE_BREAKPOINT";
+export const REMOVE_BREAKPOINT = "CONTROLLER_REMOVE_BREAKPOINT";
 export function removeBreakpoint(breakpoint) {
   return {
     type: REMOVE_BREAKPOINT,
@@ -58,21 +58,21 @@ export function removeBreakpoint(breakpoint) {
   };
 }
 
-export const REMOVE_ALL_BREAKPOINTS = "REMOVE_ALL_BREAKPOINTS";
+export const REMOVE_ALL_BREAKPOINTS = "CONTROLLER_REMOVE_ALL_BREAKPOINTS";
 export function removeAllBreakpoints() {
   return {
     type: REMOVE_ALL_BREAKPOINTS
   };
 }
 
-export const START_STEPPING = "START_STEPPING";
+export const START_STEPPING = "CONTROLLER_START_STEPPING";
 export function startStepping() {
   return {
     type: START_STEPPING
   };
 }
 
-export const DONE_STEPPING = "DONE_STEPPING";
+export const DONE_STEPPING = "CONTROLLER_DONE_STEPPING";
 export function doneStepping() {
   return {
     type: DONE_STEPPING

--- a/packages/debugger/lib/controller/sagas/index.js
+++ b/packages/debugger/lib/controller/sagas/index.js
@@ -9,6 +9,7 @@ import * as trace from "lib/trace/sagas";
 import * as data from "lib/data/sagas";
 import * as evm from "lib/evm/sagas";
 import * as solidity from "lib/solidity/sagas";
+import * as stacktrace from "lib/stacktrace/sagas";
 
 import * as actions from "../actions";
 
@@ -275,10 +276,12 @@ function* continueUntilBreakpoint(action) {
 
 /**
  * reset -- reset the state of the debugger
+ * (we'll just reset all submodules regardless of which are in use)
  */
 export function* reset() {
   yield* data.reset();
   yield* evm.reset();
   yield* solidity.reset();
   yield* trace.reset();
+  yield* stacktrace.reset();
 }

--- a/packages/debugger/lib/data/actions/index.js
+++ b/packages/debugger/lib/data/actions/index.js
@@ -1,4 +1,4 @@
-export const SCOPE = "SCOPE";
+export const SCOPE = "DATA_SCOPE";
 export function scope(id, pointer, parentId, sourceId, compilationId) {
   return {
     type: SCOPE,
@@ -10,7 +10,7 @@ export function scope(id, pointer, parentId, sourceId, compilationId) {
   };
 }
 
-export const DECLARE = "DECLARE_VARIABLE";
+export const DECLARE = "DATA_DECLARE_VARIABLE";
 export function declare(node, compilationId) {
   return {
     type: DECLARE,
@@ -19,7 +19,7 @@ export function declare(node, compilationId) {
   };
 }
 
-export const ASSIGN = "ASSIGN";
+export const ASSIGN = "DATA_ASSIGN";
 export function assign(assignments) {
   return {
     type: ASSIGN,
@@ -27,7 +27,7 @@ export function assign(assignments) {
   };
 }
 
-export const MAP_PATH_AND_ASSIGN = "MAP_PATH_AND_ASSIGN";
+export const MAP_PATH_AND_ASSIGN = "DATA_MAP_PATH_AND_ASSIGN";
 export function mapPathAndAssign(
   address,
   slot,
@@ -50,7 +50,7 @@ export function reset() {
   return { type: RESET };
 }
 
-export const DEFINE_TYPE = "DEFINE_TYPE";
+export const DEFINE_TYPE = "DATA_DEFINE_TYPE";
 export function defineType(node, compilationId) {
   return {
     type: DEFINE_TYPE,
@@ -59,7 +59,7 @@ export function defineType(node, compilationId) {
   };
 }
 
-export const ALLOCATE = "ALLOCATE";
+export const ALLOCATE = "DATA_ALLOCATE";
 export function allocate(storage, memory, abi, state) {
   return {
     type: ALLOCATE,

--- a/packages/debugger/lib/debugger.js
+++ b/packages/debugger/lib/debugger.js
@@ -11,6 +11,7 @@ import traceSelector from "./trace/selectors";
 import evmSelector from "./evm/selectors";
 import soliditySelector from "./solidity/selectors";
 import sessionSelector from "./session/selectors";
+import stacktraceSelector from "./stacktrace/selectors";
 import controllerSelector from "./controller/selectors";
 
 import { Compilations } from "@truffle/codec";
@@ -45,11 +46,19 @@ export default class Debugger {
    * @return {Debugger} instance
    */
   static async forTx(txHash, options = {}) {
-    let { contracts, files, provider, compilations } = options;
+    let {
+      contracts,
+      files,
+      provider,
+      compilations,
+      stacktrace,
+      noData
+    } = options;
+    let moduleOptions = { stacktrace, noData };
     if (!compilations) {
       compilations = Compilations.Utils.shimArtifacts(contracts, files);
     }
-    let session = new Session(compilations, provider, txHash);
+    let session = new Session(compilations, provider, moduleOptions, txHash);
 
     try {
       await session.ready();
@@ -69,11 +78,19 @@ export default class Debugger {
    * @return {Debugger} instance
    */
   static async forProject(options = {}) {
-    let { contracts, files, provider, compilations } = options;
+    let {
+      contracts,
+      files,
+      provider,
+      compilations,
+      stacktrace,
+      noData
+    } = options;
+    let moduleOptions = { stacktrace, noData };
     if (!compilations) {
       compilations = Compilations.Utils.shimArtifacts(contracts, files);
     }
-    let session = new Session(compilations, provider);
+    let session = new Session(compilations, provider, moduleOptions);
 
     await session.ready();
 
@@ -110,6 +127,7 @@ export default class Debugger {
       trace: traceSelector,
       evm: evmSelector,
       solidity: soliditySelector,
+      stacktrace: stacktraceSelector,
       session: sessionSelector,
       controller: controllerSelector
     });

--- a/packages/debugger/lib/debugger.js
+++ b/packages/debugger/lib/debugger.js
@@ -46,19 +46,11 @@ export default class Debugger {
    * @return {Debugger} instance
    */
   static async forTx(txHash, options = {}) {
-    let {
-      contracts,
-      files,
-      provider,
-      compilations,
-      stacktrace,
-      noData
-    } = options;
-    let moduleOptions = { stacktrace, noData };
+    let { contracts, files, provider, compilations, lightMode } = options;
     if (!compilations) {
       compilations = Compilations.Utils.shimArtifacts(contracts, files);
     }
-    let session = new Session(compilations, provider, moduleOptions, txHash);
+    let session = new Session(compilations, provider, { lightMode }, txHash);
 
     try {
       await session.ready();
@@ -78,19 +70,11 @@ export default class Debugger {
    * @return {Debugger} instance
    */
   static async forProject(options = {}) {
-    let {
-      contracts,
-      files,
-      provider,
-      compilations,
-      stacktrace,
-      noData
-    } = options;
-    let moduleOptions = { stacktrace, noData };
+    let { contracts, files, provider, compilations, lightMode } = options;
     if (!compilations) {
       compilations = Compilations.Utils.shimArtifacts(contracts, files);
     }
-    let session = new Session(compilations, provider, moduleOptions);
+    let session = new Session(compilations, provider, { lightMode });
 
     await session.ready();
 

--- a/packages/debugger/lib/evm/actions/index.js
+++ b/packages/debugger/lib/evm/actions/index.js
@@ -43,7 +43,7 @@ export function addInstance(address, context, binary) {
   };
 }
 
-export const SAVE_GLOBALS = "SAVE_GLOBALS";
+export const SAVE_GLOBALS = "EVM_SAVE_GLOBALS";
 export function saveGlobals(origin, gasprice, block) {
   return {
     type: SAVE_GLOBALS,
@@ -53,7 +53,7 @@ export function saveGlobals(origin, gasprice, block) {
   };
 }
 
-export const SAVE_STATUS = "SAVE_STATUS";
+export const SAVE_STATUS = "EVM_SAVE_STATUS";
 export function saveStatus(status) {
   return {
     type: SAVE_STATUS,
@@ -61,7 +61,7 @@ export function saveStatus(status) {
   };
 }
 
-export const CALL = "CALL";
+export const CALL = "EVM_CALL";
 export function call(address, data, storageAddress, sender, value) {
   return {
     type: CALL,
@@ -73,7 +73,7 @@ export function call(address, data, storageAddress, sender, value) {
   };
 }
 
-export const CREATE = "CREATE";
+export const CREATE = "EVM_CREATE";
 export function create(binary, storageAddress, sender, value) {
   return {
     type: CREATE,
@@ -84,14 +84,14 @@ export function create(binary, storageAddress, sender, value) {
   };
 }
 
-export const RETURN_CALL = "RETURN_CALL";
+export const RETURN_CALL = "EVM_RETURN_CALL";
 export function returnCall() {
   return {
     type: RETURN_CALL
   };
 }
 
-export const RETURN_CREATE = "RETURN_CREATE";
+export const RETURN_CREATE = "EVM_RETURN_CREATE";
 export function returnCreate(address, code, context) {
   return {
     type: RETURN_CREATE,
@@ -101,14 +101,14 @@ export function returnCreate(address, code, context) {
   };
 }
 
-export const FAIL = "FAIL";
+export const FAIL = "EVM_FAIL";
 export function fail() {
   return {
     type: FAIL
   };
 }
 
-export const STORE = "STORE";
+export const STORE = "EVM_STORE";
 export function store(address, slot, value) {
   return {
     type: STORE,
@@ -118,7 +118,7 @@ export function store(address, slot, value) {
   };
 }
 
-export const LOAD = "LOAD";
+export const LOAD = "EVM_LOAD";
 export function load(address, slot, value) {
   return {
     type: LOAD,

--- a/packages/debugger/lib/helpers/index.js
+++ b/packages/debugger/lib/helpers/index.js
@@ -32,6 +32,25 @@ export function prefixName(prefix, fn) {
 }
 
 /**
+ * returns a new array which is a copy of array but with
+ * elements popped from the top until numToRemove elements
+ * satisfying the predicate have been removed (or until the
+ * array is empty)
+ */
+export function popNWhere(array, numToRemove, predicate) {
+  let newArray = array.slice();
+  //I'm going to write this the C way, hope you don't mind :P
+  while (numToRemove > 0 && newArray.length > 0) {
+    let top = newArray[newArray.length - 1];
+    if (predicate(top)) {
+      numToRemove--;
+    }
+    newArray.pop();
+  }
+  return newArray;
+}
+
+/**
  * @return 0x-prefix string of keccak256 hash
  */
 export function keccak256(...args) {

--- a/packages/debugger/lib/session/actions/index.js
+++ b/packages/debugger/lib/session/actions/index.js
@@ -7,7 +7,7 @@ export function start(provider, txHash) {
   };
 }
 
-export const LOAD_TRANSACTION = "LOAD_TRANSACTION";
+export const LOAD_TRANSACTION = "SESSION_LOAD_TRANSACTION";
 export function loadTransaction(txHash) {
   return {
     type: LOAD_TRANSACTION,
@@ -20,7 +20,7 @@ export function interrupt() {
   return { type: INTERRUPT };
 }
 
-export const UNLOAD_TRANSACTION = "UNLOAD_TRANSACTION";
+export const UNLOAD_TRANSACTION = "SESSION_UNLOAD_TRANSACTION";
 export function unloadTransaction() {
   return {
     type: UNLOAD_TRANSACTION
@@ -49,14 +49,7 @@ export function error(error) {
   };
 }
 
-export const CLEAR_ERROR = "CLEAR_ERROR";
-export function clearError() {
-  return {
-    type: CLEAR_ERROR
-  };
-}
-
-export const RECORD_CONTRACTS = "RECORD_CONTRACTS";
+export const RECORD_CONTRACTS = "SESSION_RECORD_CONTRACTS";
 export function recordContracts(contexts, sources) {
   return {
     type: RECORD_CONTRACTS,
@@ -65,7 +58,7 @@ export function recordContracts(contexts, sources) {
   };
 }
 
-export const SAVE_TRANSACTION = "SAVE_TRANSACTION";
+export const SAVE_TRANSACTION = "SESSION_SAVE_TRANSACTION";
 export function saveTransaction(transaction) {
   return {
     type: SAVE_TRANSACTION,
@@ -73,7 +66,7 @@ export function saveTransaction(transaction) {
   };
 }
 
-export const SAVE_RECEIPT = "SAVE_RECEIPT";
+export const SAVE_RECEIPT = "SESSION_SAVE_RECEIPT";
 export function saveReceipt(receipt) {
   return {
     type: SAVE_RECEIPT,
@@ -81,7 +74,7 @@ export function saveReceipt(receipt) {
   };
 }
 
-export const SAVE_BLOCK = "SAVE_BLOCK";
+export const SAVE_BLOCK = "SESSION_SAVE_BLOCK";
 export function saveBlock(block) {
   return {
     type: SAVE_BLOCK,

--- a/packages/debugger/lib/session/index.js
+++ b/packages/debugger/lib/session/index.js
@@ -29,11 +29,13 @@ export default class Session {
    * txHash parameter is now optional!
    * @private
    */
-  constructor(compilations, provider, txHash) {
+  constructor(compilations, provider, moduleOptions, txHash) {
     /**
      * @private
      */
-    let { store, sagaMiddleware } = configureStore(reducer, rootSaga);
+    let { store, sagaMiddleware } = configureStore(reducer, rootSaga, [
+      moduleOptions
+    ]);
     this._store = store;
     this._sagaMiddleware = sagaMiddleware;
 

--- a/packages/debugger/lib/session/reducers.js
+++ b/packages/debugger/lib/session/reducers.js
@@ -8,6 +8,7 @@ import evm from "lib/evm/reducers";
 import solidity from "lib/solidity/reducers";
 import trace from "lib/trace/reducers";
 import controller from "lib/controller/reducers";
+import stacktrace from "lib/stacktrace/reducers";
 
 import * as actions from "./actions";
 
@@ -85,6 +86,7 @@ const reduceState = combineReducers({
   data,
   evm,
   solidity,
+  stacktrace,
   trace,
   controller
 });

--- a/packages/debugger/lib/session/sagas/index.js
+++ b/packages/debugger/lib/session/sagas/index.js
@@ -8,6 +8,7 @@ import { prefixName } from "lib/helpers";
 import * as ast from "lib/ast/sagas";
 import * as controller from "lib/controller/sagas";
 import * as solidity from "lib/solidity/sagas";
+import * as stacktrace from "lib/stacktrace/sagas";
 import * as evm from "lib/evm/sagas";
 import * as trace from "lib/trace/sagas";
 import * as data from "lib/data/sagas";
@@ -34,9 +35,9 @@ function* listenerSaga() {
   }
 }
 
-export function* saga() {
+export function* saga(moduleOptions) {
   debug("starting listeners");
-  yield* forkListeners();
+  yield* forkListeners(moduleOptions);
 
   // receiving & saving contracts into state
   debug("waiting for contract information");
@@ -56,13 +57,15 @@ export function* saga() {
   let { txHash, provider } = yield take(actions.START);
   debug("starting");
 
-  debug("visiting ASTs");
-  // visit asts
-  yield* ast.visitAll();
+  if (!moduleOptions.noData) {
+    debug("visiting ASTs");
+    // visit asts
+    yield* ast.visitAll();
 
-  //save allocation table
-  debug("saving allocation table");
-  yield* data.recordAllocations();
+    //save allocation table
+    debug("saving allocation table");
+    yield* data.recordAllocations();
+  }
 
   //initialize web3 adapter
   yield* web3.init(provider);
@@ -90,15 +93,22 @@ export function* processTransaction(txHash) {
 
 export default prefixName("session", saga);
 
-function* forkListeners() {
+function* forkListeners(moduleOptions) {
   yield fork(listenerSaga); //session listener; this one is separate, sorry
   //(I didn't want to mess w/ the existing structure of defaults)
-  return yield all(
-    [controller, data, evm, solidity, trace, web3].map(
-      app => fork(app.saga)
-      //ast no longer has a listener
-    )
-  );
+  let mainApps = [evm, solidity];
+  let otherApps = [trace, controller, web3];
+  if (!moduleOptions.noData) {
+    mainApps.push(data);
+  }
+  if (moduleOptions.stacktrace) {
+    mainApps.push(stacktrace);
+  }
+  const submoduleCount = mainApps.length;
+  //I'm being lazy, so I'll just pass the submodule count to all of
+  //them even though only trace cares :P
+  const apps = mainApps.concat(otherApps);
+  return yield all(apps.map(app => fork(app.saga, submoduleCount)));
 }
 
 function* fetchTx(txHash) {
@@ -135,8 +145,9 @@ function* fetchTx(txHash) {
   );
 
   debug("sending initial call");
-  yield* evm.begin(result);
-  yield* solidity.begin(); //note: these must occur in this order
+  yield* evm.begin(result); //note: this must occur *before* the other two
+  yield* solidity.begin();
+  yield* stacktrace.begin();
 }
 
 function* recordContexts(...contexts) {
@@ -161,12 +172,14 @@ function* error(err) {
   yield put(actions.error(err));
 }
 
+//we'll just unload all modules regardless of which ones are currently present...
 export function* unload() {
   debug("unloading");
   yield* data.reset();
   yield* solidity.unload();
   yield* evm.unload();
   yield* trace.unload();
+  yield* stacktrace.unload();
   yield put(actions.unloadTransaction());
 }
 

--- a/packages/debugger/lib/session/sagas/index.js
+++ b/packages/debugger/lib/session/sagas/index.js
@@ -57,7 +57,7 @@ export function* saga(moduleOptions) {
   let { txHash, provider } = yield take(actions.START);
   debug("starting");
 
-  if (!moduleOptions.noData) {
+  if (!moduleOptions.lightMode) {
     debug("visiting ASTs");
     // visit asts
     yield* ast.visitAll();
@@ -96,14 +96,11 @@ export default prefixName("session", saga);
 function* forkListeners(moduleOptions) {
   yield fork(listenerSaga); //session listener; this one is separate, sorry
   //(I didn't want to mess w/ the existing structure of defaults)
-  let mainApps = [evm, solidity];
-  let otherApps = [trace, controller, web3];
-  if (!moduleOptions.noData) {
+  let mainApps = [evm, solidity, stacktrace];
+  if (!moduleOptions.lightMode) {
     mainApps.push(data);
   }
-  if (moduleOptions.stacktrace) {
-    mainApps.push(stacktrace);
-  }
+  let otherApps = [trace, controller, web3];
   const submoduleCount = mainApps.length;
   //I'm being lazy, so I'll just pass the submodule count to all of
   //them even though only trace cares :P

--- a/packages/debugger/lib/solidity/actions/index.js
+++ b/packages/debugger/lib/solidity/actions/index.js
@@ -6,7 +6,7 @@ export function addSources(compilations) {
   };
 }
 
-export const JUMP = "JUMP";
+export const JUMP = "SOLIDITY_JUMP";
 export function jump(jumpDirection) {
   return {
     type: JUMP,
@@ -14,17 +14,17 @@ export function jump(jumpDirection) {
   };
 }
 
-export const EXTERNAL_CALL = "EXTERNAL_CALL";
+export const EXTERNAL_CALL = "SOLIDITY_EXTERNAL_CALL";
 export function externalCall(guard) {
   return { type: EXTERNAL_CALL, guard };
 }
 
-export const EXTERNAL_RETURN = "EXTERNAL_RETURN";
+export const EXTERNAL_RETURN = "SOLIDITY_EXTERNAL_RETURN";
 export function externalReturn() {
   return { type: EXTERNAL_RETURN };
 }
 
-export const CLEAR_PHANTOM_GUARD = "CLEAR_PHANTOM_GUARD";
+export const CLEAR_PHANTOM_GUARD = "SOLIDITY_CLEAR_PHANTOM_GUARD";
 export function clearPhantomGuard() {
   return { type: CLEAR_PHANTOM_GUARD };
 }

--- a/packages/debugger/lib/solidity/sagas/index.js
+++ b/packages/debugger/lib/solidity/sagas/index.js
@@ -41,10 +41,8 @@ function* functionDepthSaga() {
     } else {
       yield put(actions.jump(jumpDirection));
     }
-  } else if (
-    (yield select(solidity.current.willCall)) ||
-    (yield select(solidity.current.willCreate))
-  ) {
+  } else if (yield select(solidity.current.willCall)) {
+    //note: includes creations
     debug("checking if guard needed");
     let guard = yield select(solidity.current.callRequiresPhantomFrame);
     yield put(actions.externalCall(guard));

--- a/packages/debugger/lib/solidity/sagas/index.js
+++ b/packages/debugger/lib/solidity/sagas/index.js
@@ -27,11 +27,6 @@ function* functionDepthSaga() {
     //we do this case first so we can be sure we're not failing in any of the
     //other cases below!
     yield put(actions.externalReturn());
-  } else if (
-    yield select(solidity.current.willCallOrCreateButInstantlyReturn)
-  ) {
-    //do nothing
-    //again, we put this second so we can be sure the other cases are not this
   } else if (yield select(solidity.current.willJump)) {
     let jumpDirection = yield select(solidity.current.jumpDirection);
     debug("checking guard");
@@ -42,7 +37,7 @@ function* functionDepthSaga() {
       yield put(actions.jump(jumpDirection));
     }
   } else if (yield select(solidity.current.willCall)) {
-    //note: includes creations
+    //note: includes creations; does not include insta-returns
     debug("checking if guard needed");
     let guard = yield select(solidity.current.callRequiresPhantomFrame);
     yield put(actions.externalCall(guard));

--- a/packages/debugger/lib/solidity/selectors/index.js
+++ b/packages/debugger/lib/solidity/selectors/index.js
@@ -161,10 +161,8 @@ let solidity = createSelectorTree({
     /**
      * solidity.current.humanReadableSourceMap
      */
-    humanReadableSourceMap: createLeaf(
-      ["./sourceMap"],
-      sourceMap =>
-        sourceMap ? SolidityUtils.getHumanReadableSourceMap(sourceMap) : null
+    humanReadableSourceMap: createLeaf(["./sourceMap"], sourceMap =>
+      sourceMap ? SolidityUtils.getHumanReadableSourceMap(sourceMap) : null
     ),
 
     /**
@@ -298,19 +296,15 @@ let solidity = createSelectorTree({
 
     /**
      * solidity.current.willCall
-     * note: includes creations
+     * note: includes creations, does *not* include instareturns
      */
     willCall: createLeaf(
-      [evm.current.step.isCall, evm.current.step.isCreate],
-      (isCall, isCreate) => isCall || isCreate
-    ),
-
-    /**
-     * solidity.current.willCallOrCreateButInstantlyReturn
-     */
-    willCallOrCreateButInstantlyReturn: createLeaf(
-      [evm.current.step.isInstantCallOrCreate],
-      x => x
+      [
+        evm.current.step.isCall,
+        evm.current.step.isCreate,
+        evm.current.step.isInstantCallOrCreate
+      ],
+      (isCall, isCreate, isInstant) => (isCall || isCreate) && !isInstant
     ),
 
     /**

--- a/packages/debugger/lib/solidity/selectors/index.js
+++ b/packages/debugger/lib/solidity/selectors/index.js
@@ -298,13 +298,12 @@ let solidity = createSelectorTree({
 
     /**
      * solidity.current.willCall
+     * note: includes creations
      */
-    willCall: createLeaf([evm.current.step.isCall], x => x),
-
-    /**
-     * solidity.current.willCreate
-     */
-    willCreate: createLeaf([evm.current.step.isCreate], x => x),
+    willCall: createLeaf(
+      [evm.current.step.isCall, evm.current.step.isCreate],
+      (isCall, isCreate) => isCall || isCreate
+    ),
 
     /**
      * solidity.current.willCallOrCreateButInstantlyReturn

--- a/packages/debugger/lib/stacktrace/actions/index.js
+++ b/packages/debugger/lib/stacktrace/actions/index.js
@@ -1,9 +1,10 @@
 export const JUMP_IN = "STACKTRACE_JUMP_IN";
-export function jumpIn(location, functionNode) {
+export function jumpIn(location, functionNode, contractNode) {
   return {
     type: JUMP_IN,
     location,
-    functionNode
+    functionNode,
+    contractNode
   };
 }
 
@@ -16,10 +17,11 @@ export function jumpOut(location) {
 }
 
 export const EXTERNAL_CALL = "STACKTRACE_EXTERNAL_CALL";
-export function externalCall(location, skippedInReports) {
+export function externalCall(location, contractNode, skippedInReports) {
   return {
     type: EXTERNAL_CALL,
     location,
+    contractNode,
     skippedInReports
   };
 }

--- a/packages/debugger/lib/stacktrace/actions/index.js
+++ b/packages/debugger/lib/stacktrace/actions/index.js
@@ -48,14 +48,6 @@ export function markReturnPosition(location) {
   };
 }
 
-//note: no reducer explicitly listens for this, but justReturned depends on it
-export const CLEAR_RETURN_MARKER = "CLEAR_RETURN_MARKER";
-export function clearReturnMarker() {
-  return {
-    type: CLEAR_RETURN_MARKER
-  };
-}
-
 export const RESET = "STACKTRACE_RESET";
 export function reset() {
   return {

--- a/packages/debugger/lib/stacktrace/actions/index.js
+++ b/packages/debugger/lib/stacktrace/actions/index.js
@@ -1,49 +1,52 @@
 export const JUMP_IN = "STACKTRACE_JUMP_IN";
-export function jumpIn(from, functionNode) {
+export function jumpIn(location, functionNode) {
   return {
     type: JUMP_IN,
-    from,
+    location,
     functionNode
   };
 }
 
 export const JUMP_OUT = "STACKTRACE_JUMP_OUT";
-export function jumpOut() {
+export function jumpOut(location) {
   return {
-    type: JUMP_OUT
+    type: JUMP_OUT,
+    location
   };
 }
 
 export const EXTERNAL_CALL = "STACKTRACE_EXTERNAL_CALL";
-export function externalCall(from, skippedInReports) {
+export function externalCall(location, skippedInReports) {
   return {
     type: EXTERNAL_CALL,
-    from,
+    location,
     skippedInReports
   };
 }
 
 export const EXTERNAL_RETURN = "STACKTRACE_EXTERNAL_RETURN";
-export function externalReturn(from, status) {
+export function externalReturn(from, status, location) {
   return {
     type: EXTERNAL_RETURN,
     from,
-    status
+    status,
+    location
   };
 }
 
 export const EXECUTE_RETURN = "EXECUTE_RETURN";
-export function executeReturn(counter) {
+export function executeReturn(counter, location) {
   return {
     type: EXECUTE_RETURN,
-    counter
+    counter,
+    location
   };
 }
 
-export const MARK_RETURN_POSITION = "MARK_RETURN_POSITION";
-export function markReturnPosition(location) {
+export const UPDATE_POSITION = "UPDATE_POSITION";
+export function updatePosition(location) {
   return {
-    type: MARK_RETURN_POSITION,
+    type: UPDATE_POSITION,
     location
   };
 }

--- a/packages/debugger/lib/stacktrace/actions/index.js
+++ b/packages/debugger/lib/stacktrace/actions/index.js
@@ -1,0 +1,71 @@
+export const JUMP_IN = "STACKTRACE_JUMP_IN";
+export function jumpIn(from, functionNode) {
+  return {
+    type: JUMP_IN,
+    from,
+    functionNode
+  };
+}
+
+export const JUMP_OUT = "STACKTRACE_JUMP_OUT";
+export function jumpOut() {
+  return {
+    type: JUMP_OUT
+  };
+}
+
+export const EXTERNAL_CALL = "STACKTRACE_EXTERNAL_CALL";
+export function externalCall(from, skippedInReports) {
+  return {
+    type: EXTERNAL_CALL,
+    from,
+    skippedInReports
+  };
+}
+
+export const EXTERNAL_RETURN = "STACKTRACE_EXTERNAL_RETURN";
+export function externalReturn(from, status) {
+  return {
+    type: EXTERNAL_RETURN,
+    from,
+    status
+  };
+}
+
+export const EXECUTE_RETURN = "EXECUTE_RETURN";
+export function executeReturn(counter) {
+  return {
+    type: EXECUTE_RETURN,
+    counter
+  };
+}
+
+export const MARK_RETURN_POSITION = "MARK_RETURN_POSITION";
+export function markReturnPosition(location) {
+  return {
+    type: MARK_RETURN_POSITION,
+    location
+  };
+}
+
+//note: no reducer explicitly listens for this, but justReturned depends on it
+export const CLEAR_RETURN_MARKER = "CLEAR_RETURN_MARKER";
+export function clearReturnMarker() {
+  return {
+    type: CLEAR_RETURN_MARKER
+  };
+}
+
+export const RESET = "STACKTRACE_RESET";
+export function reset() {
+  return {
+    type: RESET
+  };
+}
+
+export const UNLOAD_TRANSACTION = "STACKTRACE_UNLOAD_TRANSACTION";
+export function unloadTransaction() {
+  return {
+    type: UNLOAD_TRANSACTION
+  };
+}

--- a/packages/debugger/lib/stacktrace/actions/index.js
+++ b/packages/debugger/lib/stacktrace/actions/index.js
@@ -34,7 +34,7 @@ export function externalReturn(from, status, location) {
   };
 }
 
-export const EXECUTE_RETURN = "EXECUTE_RETURN";
+export const EXECUTE_RETURN = "STACKTRACE_EXECUTE_RETURN";
 export function executeReturn(counter, location) {
   return {
     type: EXECUTE_RETURN,
@@ -43,7 +43,7 @@ export function executeReturn(counter, location) {
   };
 }
 
-export const UPDATE_POSITION = "UPDATE_POSITION";
+export const UPDATE_POSITION = "STACKTRACE_UPDATE_POSITION";
 export function updatePosition(location) {
   return {
     type: UPDATE_POSITION,

--- a/packages/debugger/lib/stacktrace/reducers.js
+++ b/packages/debugger/lib/stacktrace/reducers.js
@@ -2,11 +2,11 @@ import debugModule from "debug";
 const debug = debugModule("debugger:stacktrace:reducers");
 
 import { combineReducers } from "redux";
+import { popNWhere } from "lib/helpers";
 
 import * as actions from "./actions";
 
 function callstack(state = [], action) {
-  let top;
   let newFrame;
   switch (action.type) {
     case actions.JUMP_IN:
@@ -26,7 +26,7 @@ function callstack(state = [], action) {
       };
       return [...state, newFrame];
     case actions.JUMP_OUT:
-      top = state[state.length - 1];
+      let top = state[state.length - 1];
       if (top && top.type === "internal") {
         return state.slice(0, -1);
       } else {
@@ -41,17 +41,11 @@ function callstack(state = [], action) {
       };
       return [...state, newFrame];
     case actions.EXECUTE_RETURN:
-      let newState = state.slice(); //clone the state
-      //I'm going to write this the C way, hope you don't mind :P
-      let counter = action.counter;
-      while (counter > 0 && newState.length > 0) {
-        top = newState[newState.length - 1];
-        if (top.type === "external") {
-          counter--;
-        }
-        newState.pop();
-      }
-      return newState;
+      return popNWhere(
+        state,
+        action.counter,
+        frame => frame.type === "external"
+      );
     case actions.RESET:
       return [state[0]];
     case actions.UNLOAD_TRANSACTION:

--- a/packages/debugger/lib/stacktrace/reducers.js
+++ b/packages/debugger/lib/stacktrace/reducers.js
@@ -1,0 +1,132 @@
+import { combineReducers } from "redux";
+
+import * as actions from "./actions";
+
+function callstack(state = [], action) {
+  let top;
+  let newFrame;
+  switch (action.type) {
+    case actions.JUMP_IN:
+      let { from, functionNode } = action;
+      newFrame = {
+        type: "internal",
+        calledFromPosition: from,
+        name:
+          functionNode && functionNode.nodeType === "FunctionDefinition"
+            ? functionNode.name
+            : undefined,
+        //note we don't currently account for getters because currently
+        //we can't; fallback, receive, constructors, & modifiers also remain
+        //unaccounted for at present
+        //(none of these things have associated jump-in markings!)
+        skippedInReports: false
+      };
+      return [...state, newFrame];
+    case actions.JUMP_OUT:
+      top = state[state.length - 1];
+      if (top && top.type === "internal") {
+        return state.slice(0, -1);
+      } else {
+        return state;
+      }
+    case actions.EXTERNAL_CALL:
+      newFrame = {
+        type: "external",
+        calledFromPosition: action.from,
+        skippedInReports: action.skippedInReports,
+        name: undefined
+      };
+      return [...state, newFrame];
+    case actions.EXECUTE_RETURN:
+      let newState = state.slice(); //clone the state
+      //I'm going to write this the C way, hope you don't mind :P
+      let counter = action.counter;
+      while (counter > 0 && newState.length > 0) {
+        top = newState[newState.length - 1];
+        if (top.type === "external") {
+          counter--;
+        }
+        newState.pop();
+      }
+      return newState;
+    case actions.RESET:
+      return [state[0]];
+    case actions.UNLOAD_TRANSACTION:
+      return [];
+    default:
+      //note that we don't do anything on EXTERNAL_RETURN!
+      //the callstack only changes on EXECUTE_RETURN!
+      return state;
+  }
+}
+
+function returnCounter(state = 0, action) {
+  switch (action.type) {
+    case actions.EXTERNAL_RETURN:
+      return state + 1;
+    case actions.EXECUTE_RETURN:
+    case actions.RESET:
+    case actions.UNLOAD_TRANSACTION:
+      return 0;
+    default:
+      return state;
+  }
+}
+
+function markedPosition(state = null, action) {
+  switch (action.type) {
+    case actions.MARK_RETURN_POSITION:
+      return actions.location;
+    case actions.EXECUTE_RETURN:
+    case actions.RESET:
+    case actions.UNLOAD_TRANSACTION:
+      return null;
+    default:
+      return state;
+  }
+}
+
+function innerReturnPosition(state = null, action) {
+  switch (action.type) {
+    case actions.EXTERNAL_RETURN:
+      return action.from;
+    case actions.EXECUTE_RETURN:
+    case actions.RESET:
+    case actions.UNLOAD_TRANSACTION:
+      return null;
+    default:
+      return state;
+  }
+}
+
+function innerReturnStatus(state = null, action) {
+  switch (action.type) {
+    case actions.EXTERNAL_RETURN:
+      return action.status;
+    case actions.EXECUTE_RETURN:
+    case actions.RESET:
+    case actions.UNLOAD_TRANSACTION:
+      return null;
+    default:
+      return state;
+  }
+}
+
+function justReturned(_state = false, action) {
+  return action.type === actions.EXTERNAL_RETURN;
+}
+
+const proc = combineReducers({
+  callstack,
+  returnCounter,
+  markedPosition,
+  innerReturnPosition,
+  innerReturnStatus,
+  justReturned
+});
+
+const reducer = combineReducers({
+  proc
+});
+
+export default reducer;

--- a/packages/debugger/lib/stacktrace/reducers.js
+++ b/packages/debugger/lib/stacktrace/reducers.js
@@ -1,3 +1,6 @@
+import debugModule from "debug";
+const debug = debugModule("debugger:stacktrace:reducers");
+
 import { combineReducers } from "redux";
 
 import * as actions from "./actions";
@@ -76,7 +79,7 @@ function returnCounter(state = 0, action) {
 function markedPosition(state = null, action) {
   switch (action.type) {
     case actions.MARK_RETURN_POSITION:
-      return actions.location;
+      return action.location;
     case actions.EXECUTE_RETURN:
     case actions.RESET:
     case actions.UNLOAD_TRANSACTION:
@@ -112,8 +115,17 @@ function innerReturnStatus(state = null, action) {
   }
 }
 
-function justReturned(_state = false, action) {
-  return action.type === actions.EXTERNAL_RETURN;
+function justReturned(state = false, action) {
+  switch (action.type) {
+    case actions.EXTERNAL_RETURN:
+      debug("setting returned flag");
+      return true;
+    case actions.MARK_RETURN_POSITION:
+      debug("clearing returned flag");
+      return false;
+    default:
+      return state;
+  }
 }
 
 const proc = combineReducers({

--- a/packages/debugger/lib/stacktrace/reducers.js
+++ b/packages/debugger/lib/stacktrace/reducers.js
@@ -10,13 +10,17 @@ function callstack(state = [], action) {
   let newFrame;
   switch (action.type) {
     case actions.JUMP_IN:
-      let { location, functionNode } = action;
+      let { location, functionNode, contractNode } = action;
       newFrame = {
         type: "internal",
         calledFromLocation: location,
-        name:
+        functionName:
           functionNode && functionNode.nodeType === "FunctionDefinition"
             ? functionNode.name
+            : undefined,
+        contractName:
+          contractNode && contractNode.nodeType === "ContractDefinition"
+            ? contractNode.name
             : undefined,
         //note we don't currently account for getters because currently
         //we can't; fallback, receive, constructors, & modifiers also remain
@@ -37,7 +41,12 @@ function callstack(state = [], action) {
         type: "external",
         calledFromLocation: action.location,
         skippedInReports: action.skippedInReports,
-        name: undefined
+        functionName: undefined,
+        contractName:
+          action.contractNode &&
+          action.contractNode.nodeType === "ContractDefinition"
+            ? action.contractNode.name
+            : undefined
       };
       return [...state, newFrame];
     case actions.EXECUTE_RETURN:

--- a/packages/debugger/lib/stacktrace/sagas/index.js
+++ b/packages/debugger/lib/stacktrace/sagas/index.js
@@ -1,0 +1,70 @@
+import debugModule from "debug";
+const debug = debugModule("debugger:stacktrace:sagas");
+
+import { put, takeEvery, select } from "redux-saga/effects";
+import { prefixName } from "lib/helpers";
+
+import * as actions from "../actions";
+import { TICK } from "lib/trace/actions";
+import * as trace from "lib/trace/sagas";
+
+import stacktrace from "../selectors";
+
+function* tickSaga() {
+  debug("got TICK");
+
+  yield* stacktraceSaga();
+  yield* trace.signalTickSagaCompletion();
+}
+
+function* stacktraceSaga() {
+  //different possible outcomes:
+  const { source, sourceRange } = yield select(stacktrace.current.location);
+  const currentLocation = { source, sourceRange }; //leave out the node
+  if (yield select(stacktrace.current.willJumpIn)) {
+    const nextLocation = yield select(stacktrace.next.location);
+    yield put(actions.jumpIn(currentLocation, nextLocation.node)); //in this case we only want the node
+  } else if (yield select(stacktrace.current.willJumpOut)) {
+    yield put(actions.jumpOut());
+  } else if (yield select(stacktrace.current.willCall)) {
+    //an external frame marked "skip in reports" will be, for reporting
+    //purposes, combined with the frame above, unless that also is a
+    //marker frame (combined in the appropriate sense)
+    //note: includes creations
+    const skipInReports = yield select(
+      stacktrace.current.nextFrameIsSkippedInReports
+    );
+    yield put(actions.externalCall(currentLocation, skipInReports));
+  } else if (yield select(stacktrace.current.willReturn)) {
+    const status = yield select(stacktrace.current.returnStatus);
+    yield put(actions.externalReturn(currentLocation, status));
+  } else if (yield select(stacktrace.current.positionChanged)) {
+    const returnCounter = yield select(stacktrace.current.returnCounter);
+    yield put(actions.executeReturn(returnCounter));
+  } else if (yield select(stacktrace.current.justReturned)) {
+    yield put(actions.markReturnPosition(currentLocation));
+  } else {
+    yield put(actions.clearReturnMarker());
+  }
+}
+
+export function* reset() {
+  yield put(actions.reset());
+}
+
+export function* unload() {
+  yield put(actions.unloadTransaction());
+}
+
+export function* begin() {
+  const skipInReports = yield select(
+    stacktrace.current.nextFrameIsSkippedInReports
+  );
+  yield put(actions.externalCall(null, skipInReports));
+}
+
+export function* saga() {
+  yield takeEvery(TICK, tickSaga);
+}
+
+export default prefixName("stacktrace", saga);

--- a/packages/debugger/lib/stacktrace/sagas/index.js
+++ b/packages/debugger/lib/stacktrace/sagas/index.js
@@ -19,7 +19,11 @@ function* tickSaga() {
 
 function* stacktraceSaga() {
   //different possible outcomes:
-  const { source, sourceRange } = yield select(stacktrace.current.location);
+  const {
+    source: { id, compilationId, sourcePath },
+    sourceRange
+  } = yield select(stacktrace.current.location);
+  const source = { id, compilationId, sourcePath }; //leave out everything else
   const currentLocation = { source, sourceRange }; //leave out the node
   if (yield select(stacktrace.current.willJumpIn)) {
     const nextLocation = yield select(stacktrace.next.location);

--- a/packages/debugger/lib/stacktrace/selectors/index.js
+++ b/packages/debugger/lib/stacktrace/selectors/index.js
@@ -1,0 +1,187 @@
+import debugModule from "debug";
+const debug = debugModule("debugger:stacktrace:selectors");
+
+import { createSelectorTree, createLeaf } from "reselect-tree";
+
+import solidity from "lib/solidity/selectors";
+
+import zipWith from "lodash.zipwith";
+
+const identity = x => x;
+
+function createMultistepSelectors(stepSelector) {
+  return {
+    /**
+     * .location
+     */
+    location: {
+      /**
+       * .source
+       */
+      source: createLeaf([stepSelector.source], identity),
+      /**
+       * .sourceRange
+       */
+      sourceRange: createLeaf([stepSelector.sourceRange], identity),
+      /**
+       * .node
+       */
+      node: createLeaf([stepSelector.node], identity)
+    }
+  };
+}
+
+let stacktrace = createSelectorTree({
+  /**
+   * stacktrace.state
+   */
+  state: state => state.stacktrace,
+
+  /**
+   * stacktrace.current
+   */
+  current: {
+    /**
+     * stacktrace.current.callstack
+     */
+    callstack: createLeaf(["/state"], state => state.proc.callstack),
+    /**
+     * stacktrace.current.returnCounter
+     */
+    returnCounter: createLeaf(["/state"], state => state.proc.returnCounter),
+    /**
+     * stacktrace.current.markedPosition
+     */
+    markedPosition: createLeaf(["/state"], state => state.proc.markedPosition),
+    /**
+     * stacktrace.current.innerReturnPosition
+     */
+    innerReturnPosition: createLeaf(
+      ["/state"],
+      state => state.proc.innerReturnPosition
+    ),
+    /**
+     * stacktrace.current.innerReturnStatus
+     */
+    innerReturnStatus: createLeaf(
+      ["/state"],
+      state => state.proc.innerReturnStatus
+    ),
+    /**
+     * stacktrace.current.justReturned
+     */
+    justReturned: createLeaf(["/state"], state => state.proc.justReturned),
+    ...createMultistepSelectors(solidity.current),
+    /**
+     * stacktrace.current.willJumpIn
+     */
+    willJumpIn: createLeaf(
+      [solidity.current.willJump, solidity.current.jumpDirection],
+      (willJump, jumpDirection) => willJump && jumpDirection === "i"
+    ),
+    /**
+     * stacktrace.current.willJumpOut
+     */
+    willJumpOut: createLeaf(
+      [solidity.current.willJump, solidity.current.jumpDirection],
+      (willJump, jumpDirection) => willJump && jumpDirection === "o"
+    ),
+    /**
+     * stacktrace.current.willCall
+     * note: includes creations!
+     */
+    willCall: createLeaf([solidity.current.willCall], identity),
+    /**
+     * stacktrace.current.nextFrameIsSkippedInReports
+     */
+    nextFrameIsSkippedInReports: createLeaf(
+      [solidity.current.nextFrameIsPhantom],
+      identity
+    ),
+    /**
+     * stacktrace.current.willReturn
+     */
+    willReturn: createLeaf([solidity.current.willReturn], identity),
+    /**
+     * stacktrace.current.returnStatus
+     */
+    returnStatus: createLeaf(
+      ["./willReturn", solidity.current.willFail],
+      (returns, failing) => (returns ? !failing : null)
+    ),
+    /**
+     * stacktrace.current.positionChanged
+     */
+    positionChanged: createLeaf(
+      ["./location", "./markedPosition"],
+      (currentLocation, markedLocation) =>
+        Boolean(markedLocation) && //if there's no marked position, we don't need this check
+        Boolean(currentLocation) && //if current location is unmapped, we consider ourselves to have not moved
+        (currentLocation.source.compilationId !==
+          markedLocation.source.compilationId ||
+          currentLocation.source.id !== markedLocation.source.id ||
+          currentLocation.sourceRange.start !==
+            markedLocation.sourceRange.start ||
+          currentLocation.sourceRange.length !==
+            markedLocation.sourceRange.length)
+    ),
+    /**
+     * stacktrace.current.report
+     * Contains the report object for outside consumption.
+     * Still needs to be processed into a string, mind you.
+     */
+    report: createLeaf(
+      ["./callstack", "./innerReturnPosition", "./innerReturnStatus"],
+      (rawStack, finalLocation, status) => {
+        //step 1: process skipped frames
+        let callstack = [];
+        //we're doing a C-style loop here!
+        //because we want to skip some items <grin>
+        for (let i = 0; i < rawStack.length; i++) {
+          const frame = rawStack[i];
+          if (
+            frame.skippedInReports &&
+            i < rawStack.length - 1 &&
+            rawStack[i + 1].type === "internal"
+          ) {
+            const combinedFrame = {
+              //only including the relevant info here
+              calledFromPosition: frame.calledFromPosition,
+              name: rawStack[i + 1].name
+            };
+            callstack.push(combinedFrame);
+            i++; //!! SKIP THE NEXT FRAME!
+          } else {
+            //ordinary case: just push the frame
+            callstack.push(frame);
+          }
+        }
+        debug("callstack: %O", callstack);
+        //step 2: shift everything over by 1 and recombine :)
+        let locations = callstack.map(frame => frame.calledFromPosition);
+        //remove initial null, add final location on end
+        locations.shift();
+        locations.push(finalLocation);
+        debug("locations: %O", locations);
+        const names = callstack.map(frame => frame.name);
+        debug("names: %O", names);
+        let report = zipWith(locations, names, (location, name) => ({
+          location,
+          name
+        }));
+        //finally: set the status in the top frame
+        report[report.length - 1].status = status;
+        return report;
+      }
+    )
+  },
+
+  /**
+   * stacktrace.next
+   */
+  next: {
+    ...createMultistepSelectors(solidity.next)
+  }
+});
+
+export default stacktrace;

--- a/packages/debugger/lib/stacktrace/selectors/index.js
+++ b/packages/debugger/lib/stacktrace/selectors/index.js
@@ -45,14 +45,17 @@ let stacktrace = createSelectorTree({
      * stacktrace.current.callstack
      */
     callstack: createLeaf(["/state"], state => state.proc.callstack),
+
     /**
      * stacktrace.current.returnCounter
      */
     returnCounter: createLeaf(["/state"], state => state.proc.returnCounter),
+
     /**
      * stacktrace.current.markedPosition
      */
     markedPosition: createLeaf(["/state"], state => state.proc.markedPosition),
+
     /**
      * stacktrace.current.innerReturnPosition
      */
@@ -60,6 +63,7 @@ let stacktrace = createSelectorTree({
       ["/state"],
       state => state.proc.innerReturnPosition
     ),
+
     /**
      * stacktrace.current.innerReturnStatus
      */
@@ -67,11 +71,14 @@ let stacktrace = createSelectorTree({
       ["/state"],
       state => state.proc.innerReturnStatus
     ),
+
     /**
      * stacktrace.current.justReturned
      */
     justReturned: createLeaf(["/state"], state => state.proc.justReturned),
+
     ...createMultistepSelectors(solidity.current),
+
     /**
      * stacktrace.current.willJumpIn
      */
@@ -79,6 +86,7 @@ let stacktrace = createSelectorTree({
       [solidity.current.willJump, solidity.current.jumpDirection],
       (willJump, jumpDirection) => willJump && jumpDirection === "i"
     ),
+
     /**
      * stacktrace.current.willJumpOut
      */
@@ -86,11 +94,13 @@ let stacktrace = createSelectorTree({
       [solidity.current.willJump, solidity.current.jumpDirection],
       (willJump, jumpDirection) => willJump && jumpDirection === "o"
     ),
+
     /**
      * stacktrace.current.willCall
      * note: includes creations!
      */
     willCall: createLeaf([solidity.current.willCall], identity),
+
     /**
      * stacktrace.current.nextFrameIsSkippedInReports
      */
@@ -98,10 +108,12 @@ let stacktrace = createSelectorTree({
       [solidity.current.nextFrameIsPhantom],
       identity
     ),
+
     /**
      * stacktrace.current.willReturn
      */
     willReturn: createLeaf([solidity.current.willReturn], identity),
+
     /**
      * stacktrace.current.returnStatus
      */
@@ -109,22 +121,23 @@ let stacktrace = createSelectorTree({
       ["./willReturn", solidity.current.willFail],
       (returns, failing) => (returns ? !failing : null)
     ),
+
     /**
-     * stacktrace.current.positionChanged
+     * stacktrace.current.positionWillChange
      */
-    positionChanged: createLeaf(
-      ["./location", "./markedPosition"],
-      (currentLocation, markedLocation) =>
+    positionWillChange: createLeaf(
+      ["/next/location", "./markedPosition"],
+      (nextLocation, markedLocation) =>
         Boolean(markedLocation) && //if there's no marked position, we don't need this check
-        Boolean(currentLocation) && //if current location is unmapped, we consider ourselves to have not moved
-        (currentLocation.source.compilationId !==
+        Boolean(nextLocation.source) &&
+        nextLocation.source.id !== undefined && //if next location is unmapped, we consider ourselves to have not moved
+        (nextLocation.source.compilationId !==
           markedLocation.source.compilationId ||
-          currentLocation.source.id !== markedLocation.source.id ||
-          currentLocation.sourceRange.start !==
-            markedLocation.sourceRange.start ||
-          currentLocation.sourceRange.length !==
-            markedLocation.sourceRange.length)
+          nextLocation.source.id !== markedLocation.source.id ||
+          nextLocation.sourceRange.start !== markedLocation.sourceRange.start ||
+          nextLocation.sourceRange.length !== markedLocation.sourceRange.length)
     ),
+
     /**
      * stacktrace.current.report
      * Contains the report object for outside consumption.

--- a/packages/debugger/lib/stacktrace/selectors/index.js
+++ b/packages/debugger/lib/stacktrace/selectors/index.js
@@ -133,16 +133,23 @@ let stacktrace = createSelectorTree({
      * stacktrace.current.positionWillChange
      */
     positionWillChange: createLeaf(
-      ["/next/location", "./lastPosition"],
-      (nextLocation, lastLocation) =>
-        Boolean(lastLocation) && //if there's no last position, we don't need this check
-        Boolean(nextLocation.source) &&
-        nextLocation.source.id !== undefined && //if next location is unmapped, we consider ourselves to have not moved
-        (nextLocation.source.compilationId !==
-          lastLocation.source.compilationId ||
-          nextLocation.source.id !== lastLocation.source.id ||
-          nextLocation.sourceRange.start !== lastLocation.sourceRange.start ||
-          nextLocation.sourceRange.length !== lastLocation.sourceRange.length)
+      ["/next/location", "/current/location", "./lastPosition"],
+      (nextLocation, currentLocation, lastLocation) => {
+        let oldLocation =
+          currentLocation.source.id !== undefined
+            ? currentLocation
+            : lastLocation;
+        return (
+          Boolean(oldLocation) && //if there's no current or last position, we don't need this check
+          Boolean(nextLocation.source) &&
+          nextLocation.source.id !== undefined && //if next location is unmapped, we consider ourselves to have not moved
+          (nextLocation.source.compilationId !==
+            oldLocation.source.compilationId ||
+            nextLocation.source.id !== oldLocation.source.id ||
+            nextLocation.sourceRange.start !== oldLocation.sourceRange.start ||
+            nextLocation.sourceRange.length !== oldLocation.sourceRange.length)
+        );
+      }
     ),
 
     /**

--- a/packages/debugger/lib/store/common.js
+++ b/packages/debugger/lib/store/common.js
@@ -7,6 +7,7 @@ import createSagaMiddleware from "redux-saga";
 export default function configureStore(
   reducer,
   saga,
+  sagaArgs,
   initialState,
   composeEnhancers
 ) {
@@ -23,7 +24,7 @@ export default function configureStore(
     composeEnhancers(applyMiddleware(sagaMiddleware))
   );
 
-  sagaMiddleware.run(saga);
+  sagaMiddleware.run(saga, ...sagaArgs);
 
   return { store, sagaMiddleware };
 }

--- a/packages/debugger/lib/trace/actions/index.js
+++ b/packages/debugger/lib/trace/actions/index.js
@@ -1,4 +1,4 @@
-export const SAVE_STEPS = "SAVE_STEPS";
+export const SAVE_STEPS = "TRACE_SAVE_STEPS";
 export function saveSteps(steps) {
   return {
     type: SAVE_STEPS,
@@ -6,22 +6,22 @@ export function saveSteps(steps) {
   };
 }
 
-export const NEXT = "NEXT";
+export const NEXT = "TRACE_NEXT";
 export function next() {
   return { type: NEXT };
 }
 
-export const TICK = "TICK";
+export const TICK = "TRACE_TICK";
 export function tick() {
   return { type: TICK };
 }
 
-export const TOCK = "TOCK";
+export const TOCK = "TRACE_TOCK";
 export function tock() {
   return { type: TOCK };
 }
 
-export const END_OF_TRACE = "EOT";
+export const END_OF_TRACE = "TRACE_EOT";
 export function endTrace() {
   return { type: END_OF_TRACE };
 }
@@ -36,7 +36,7 @@ export function unloadTransaction() {
   return { type: UNLOAD_TRANSACTION };
 }
 
-export const BACKTICK = "BACKTICK";
+export const BACKTICK = "TRACE_BACKTICK";
 export function backtick() {
   return { type: BACKTICK };
 }

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -30,6 +30,7 @@
     "json-stable-stringify": "^1.0.1",
     "lodash.flatten": "^4.4.0",
     "lodash.sum": "^4.0.2",
+    "lodash.zipwith": "^4.2.0",
     "redux": "^3.7.2",
     "redux-cli-logger": "^2.0.1",
     "redux-saga": "1.0.0",

--- a/packages/debugger/test/stacktrace.js
+++ b/packages/debugger/test/stacktrace.js
@@ -140,8 +140,16 @@ describe("Stack tracing", function() {
     await session.continueUntilBreakpoint(); //run till end
 
     let report = session.view(stacktrace.current.finalReport);
-    let names = report.map(({ name }) => name);
-    assert.deepEqual(names, ["run", "run3", "run2", "run1", "runRequire"]);
+    let functionNames = report.map(({ functionName }) => functionName);
+    assert.deepEqual(functionNames, [
+      "run",
+      "run3",
+      "run2",
+      "run1",
+      "runRequire"
+    ]);
+    let contractNames = report.map(({ contractName }) => contractName);
+    assert(contractNames.every(name => name === "StacktraceTest"));
     let status = report[report.length - 1].status;
     assert.isFalse(status);
     let location = report[report.length - 1].location;
@@ -179,8 +187,10 @@ describe("Stack tracing", function() {
     await session.continueUntilBreakpoint(); //run till EMIT
 
     let report = session.view(stacktrace.current.report);
-    let names = report.map(({ name }) => name);
-    assert.deepEqual(names, ["run", "run2", "run1", "runRequire"]);
+    let functionNames = report.map(({ functionName }) => functionName);
+    assert.deepEqual(functionNames, ["run", "run2", "run1", "runRequire"]);
+    let contractNames = report.map(({ contractName }) => contractName);
+    assert(contractNames.every(name => name === "StacktraceTest"));
     let status = report[report.length - 1].status;
     assert.isUndefined(status);
     let location = report[report.length - 1].location;
@@ -191,8 +201,16 @@ describe("Stack tracing", function() {
     await session.continueUntilBreakpoint(); //run till EMIT again
 
     report = session.view(stacktrace.current.report);
-    names = report.map(({ name }) => name);
-    assert.deepEqual(names, ["run", "run3", "run2", "run1", "runRequire"]);
+    functionNames = report.map(({ functionName }) => functionName);
+    assert.deepEqual(functionNames, [
+      "run",
+      "run3",
+      "run2",
+      "run1",
+      "runRequire"
+    ]);
+    contractNames = report.map(({ contractName }) => contractName);
+    assert(contractNames.every(name => name === "StacktraceTest"));
     status = report[report.length - 1].status;
     assert.isUndefined(status);
     location = report[report.length - 1].location;
@@ -225,8 +243,8 @@ describe("Stack tracing", function() {
     await session.continueUntilBreakpoint(); //run till end
 
     let report = session.view(stacktrace.current.finalReport);
-    let names = report.map(({ name }) => name);
-    assert.deepEqual(names, [
+    let functionNames = report.map(({ functionName }) => functionName);
+    assert.deepEqual(functionNames, [
       "run",
       "run3",
       "run2",
@@ -234,6 +252,8 @@ describe("Stack tracing", function() {
       "runPay",
       undefined
     ]);
+    let contractNames = report.map(({ contractName }) => contractName);
+    assert(contractNames.every(name => name === "StacktraceTest"));
     let status = report[report.length - 1].status;
     assert.isFalse(status);
     let location = report[report.length - 2].location; //note, -2 because of undefined on top
@@ -266,8 +286,8 @@ describe("Stack tracing", function() {
     await session.continueUntilBreakpoint(); //run till end
 
     let report = session.view(stacktrace.current.finalReport);
-    let names = report.map(({ name }) => name);
-    assert.deepEqual(names, [
+    let functionNames = report.map(({ functionName }) => functionName);
+    assert.deepEqual(functionNames, [
       "run",
       "run3",
       "run2",
@@ -275,6 +295,10 @@ describe("Stack tracing", function() {
       "runInternal",
       undefined
     ]);
+    let contractNames = report.map(({ contractName }) => contractName);
+    assert.isUndefined(contractNames[contractNames.length - 1]);
+    contractNames.pop();
+    assert(contractNames.every(name => name === "StacktraceTest"));
     let status = report[report.length - 1].status;
     assert.isFalse(status);
     let location = report[report.length - 2].location; //note, -2 because of undefined on top
@@ -308,8 +332,19 @@ describe("Stack tracing", function() {
     await session.continueUntilBreakpoint(); //run till end
 
     let report = session.view(stacktrace.current.finalReport);
-    let names = report.map(({ name }) => name);
-    assert.deepEqual(names, ["run", "run3", "run2", "run1", "runBoom", "boom"]);
+    let functionNames = report.map(({ functionName }) => functionName);
+    assert.deepEqual(functionNames, [
+      "run",
+      "run3",
+      "run2",
+      "run1",
+      "runBoom",
+      "boom"
+    ]);
+    let contractNames = report.map(({ contractName }) => contractName);
+    assert.strictEqual(contractNames[contractNames.length - 1], "Boom");
+    contractNames.pop();
+    assert(contractNames.every(name => name === "StacktraceTest"));
     let status = report[report.length - 1].status;
     assert.isTrue(status);
     let location = report[report.length - 1].location;

--- a/packages/debugger/test/stacktrace.js
+++ b/packages/debugger/test/stacktrace.js
@@ -117,6 +117,7 @@ describe("Stack tracing", function() {
   });
 
   it("Generates correct stack trace on a revert", async function() {
+    this.timeout(12000);
     let instance = await abstractions.StacktraceTest.deployed();
     //HACK: because this transaction fails, we have to extract the hash from
     //the resulting exception (there is supposed to be a non-hacky way but it
@@ -150,6 +151,7 @@ describe("Stack tracing", function() {
   });
 
   it("Generates correct stack trace on paying an unpayable contract", async function() {
+    this.timeout(12000);
     let instance = await abstractions.StacktraceTest.deployed();
     //HACK: because this transaction fails, we have to extract the hash from
     //the resulting exception (there is supposed to be a non-hacky way but it
@@ -190,6 +192,7 @@ describe("Stack tracing", function() {
   });
 
   it("Generates correct stack trace on calling an invalid internal function", async function() {
+    this.timeout(12000);
     let instance = await abstractions.StacktraceTest.deployed();
     //HACK: because this transaction fails, we have to extract the hash from
     //the resulting exception (there is supposed to be a non-hacky way but it
@@ -230,6 +233,7 @@ describe("Stack tracing", function() {
   });
 
   it("Generates correct stack trace on unexpected self-destruct", async function() {
+    this.timeout(12000);
     let instance = await abstractions.StacktraceTest.deployed();
     //HACK: because this transaction fails, we have to extract the hash from
     //the resulting exception (there is supposed to be a non-hacky way but it

--- a/yarn.lock
+++ b/yarn.lock
@@ -9457,6 +9457,11 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
+lodash.zipwith@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.zipwith/-/lodash.zipwith-4.2.0.tgz#afacf03fd2f384af29e263c3c6bda3b80e3f51fd"
+  integrity sha1-r6zwP9LzhK8p4mPDxr2juA4/Uf0=
+
 lodash@4.17.14:
   version "4.17.14"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
@@ -15639,6 +15644,7 @@ websocket@1.0.29, "websocket@github:web3-js/WebSocket-Node#polyfill/globalThis":
   dependencies:
     debug "^2.2.0"
     es5-ext "^0.10.50"
+    gulp "^4.0.2"
     nan "^2.14.0"
     typedarray-to-buffer "^3.1.5"
     yaeti "^0.0.6"


### PR DESCRIPTION
This PR adds stacktraces to the debugger!  Also some other things.

Stacktraces are done as part of a new submodule, the `stacktrace` submodule.  Did this really need to be a new submodule?  Maybe not.  But I find it easier to think about this way.  And this way it's clear that the stack tracing functions are kind of specialized and should not be confused for keeping track of stack frames for other purposes.

(Keeping track of stack frames the ordinary way is pretty easy -- the difficult thing about stack tracing is *not* always throwing away returned stack frames!)

Btw: This PR also introduces the "light mode" option to the debugger.  This option turns off the data submodule.  It's intended for when I integrate the debugger's stack tracing with `truffle test`, since we won't need the data submodule then, but currently it sits unused (intending to get to that in my next PR, though).  Note that, for simplicity, it doesn't strictly speaking turn off *everything* `data`, it just prevents the data saga listener from spawning (and tells the `trace` saga to adjust how many `BACKTICK`s it expects appropriately).  So, the `data` reducers will still be running, listening to each event (and then doing nothing in response to each one); the `data` selectors will still exist, although they should never be computed as nothing will ever call any of them; and also `reset` and `unloadTransaction` will still send out their appropriate `data` actions, not that those are performance problems.  Still, yeah, that was what was convenient to do.

I've modified the CLI appropriately -- now when a transaction finishes, if it failed, it'll print a stacktrace.  You can also manually print a stacktrace at any time with the `s` command, if that's something you want to do.  Also, not really related, but I decided that the "Transaction halted with a runtime error" message could use a nice red color, so I added that. :)  (`DebugUtils` now exports `truffleColors` to make this possible.)

Note that the debugger itself doesn't produce a text stacktrace; the stacktrace obtained from the selector `stacktrace.current.report` is a JS object with various stacktrace information.  To process it into text, one may use the `formatStacktrace` function in `DebugUtils`.  (The tests I added, for instance, just use it directly, rather than processing it into text, for obvious reasons.)

The stacktrace object is an array of frames.  Each frame has properties `name` and `location`, corresponding to a line of the stacktrace; `name` is the name of the function (may be `undefined`, which `formatStacktrace` will process into `"unknown function"`), and `location` is the location in the source where that stackframe *ends*, i.e., where it made the call to the next frame, or, for the final frame, where it returned (or, if you're doing this in the middle rather than at the end so it hasn't yet returned, the current position).  The final frame also has an additional property `status` (well, it will have this once the trace has finished; for intermediate stacktraces it may not), which indicates whether the return from that frame had status `false` (a revert) or `true` (a technically-successful return that in this context probably indicates an unexpected selfdestruct).

The implementation is pretty primitive still.  For instance, it can give you a function's *name*... but not the name of the contract it's defined in, which is not really how a stacktrace should go.  But, this is what I could do real fast without reworking existing systems.  Still, it gives line and column numbers, so, eh.

Also, because it relies on jump markings, it has a number of limitations.  For instance:

1. Modifiers and base constructors don't get a separate stacktrace line, but rather appear as part of the function that calls them
2. Constructors, fallback functions, receive functions, and getters will all appear as "unknown function"
3. If you're using a version of Solidity prior to 0.5.1, the first function of each EVM stackframe will appear as "unknown function"

But, hey, it's an initial version.  Though fixing these things... uh... not easy... oh well!

Tangential note: I did rework some `solidity` selectors in the process of writing this because they didn't work in the way I expected and this way less work has to be done in the saga.

OK.  The big question: How does it all work, under the hood?

Well, first let's answer that question ignoring the hard part.  If we ignore the hard part, then the way it works is quite simple.  On a jump in you add an internal stackframe, mark the location you jumped into it from, and mark the name of the function you jumped into by looking at the node you're on.  (Note that in the state, or in the `stacktrace.current.callstack` that exposes said state, each frame has the location it was entered from, not the location it was exited from; the `stacktrace.current.report` selector is responsible for changing things into the latter form.)  On a jump out you pop a stackframe (unless the top frame is external, just to be safe).  On a call, or on transaction start, you add an external stackframe, marking the location as always (though you can leave out the name here, there won't be anything), and also marking whether it should be skipped in reports -- external stackframes get this marking as long as they were compiled with Solidity 0.5.1 or later.  (A stackframe marked as skippable in reports will appear "merged" with the following stackframe in the report in an appropriate manner, unless there is no following stackframe or the following stackframe is external.)  And on an EVM halt, you pop stackframes until you've popped an external stackframe.  Simple, right?

The problem, of course, is that if you actually popped stackframes on an EVM halt like that, you'd be left with no stacktrace at the end!  The point of a stacktrace isn't to show where you currently are, but to show where *in the code* the revert occurred.  If the revert occurred several EVM calls deep, and you go popping the stack when the EVM returns... all that information is going to be lost.  (Even if it weren't several EVM calls deep, it'd be lost without a special case to not pop the stack at the end of the transaction, but obviously that's not how we're going to handle this as we aim to be more general.)  So, we need to somehow *not* do that.

So, instead, an `EXTERNAL_RETURN` action won't cause any stack-popping at all, but will instead merely increment the `returnCounter`.  The key here is that if a call reverts (or unexpectedly self-destructs), and then the call beneath it reverts as a result, the call beneath it *will stay in the same place in the code* while it does so, rather than moving on.  So, we watch for a change in position.  (Note that we do not consider entering unmapped code, or exiting it, to be a change in position; we only consider mapped positions.)  If a change in position occurs, we then act on the return counter, firing an `EXECUTE_RETURN` action, popping stack frames until we've popped `returnCounter` external stackframes, and resetting the return counter to 0.  But if we stay in place, and an additional revert happens before we change position, well, then the return counter will simply increment again, waiting to execute until a position change occurs!  (Not one from reverting, obviously.)  And if we hit the end of the trace before we ever get a chance to do that `EXECUTE_RETURN`, then, well, we're left with dead stackframes still sitting unpopped on our callstack... which is exactly what we want!

So, that's the basic workings.  Before we conclude, though, why don't we take a brief look at all the new state this submodule has added?

The submodule's `proc` reducers (there are only `proc` reducers, no `info`) are as follows:

1. `callstack` -- The workings of this have basically already been described.  It basically acts like you'd expect a callstack to act, except that instead of popping on `EXTERNAL_RETURN`, it does nothing, and only pops (to a variable extent) on `EXECUTE_RETURN`.
2. `returnCounter` -- again, this has already been described.
3. `innerReturnPosition` -- this is the position that the revert happened at.  It's what the report uses for the location for the final frame.  (Well, OK, often it'll be `null`, in which case the report will use `lastPosition` (coming up) instead, but for the final stacktrace this is what will get used.)  It gets stored on `EXTERNAL_RETURN` (if it's not already set -- we want the *innermost* return), and cleared on `EXECUTE_RETURN`.
4. `innerReturnStatus` -- similar, except this has the return status of that innermost return.  Stored on `EXTERNAL_RETURN` if it's not already set, cleared on `EXECUTE_RETURN`.  (Note that in this case, by "set" I mean "not `null`" rather than "`true`", and by "cleared", I mean "set to `null`", not "set to `false`"!)
5. `lastPosition` -- Holds the last position we've been to, excluding unmapped code, both for comparison against current position (to determine whether to act on that positive return counter) and for reporting in the final stackframe (if `innerReturnPosition` isn't set).  OK, strictly speaking, this probably didn't need to go in the state, but it was the easiest way.  The alternative way would've been to... you know how we have `data.nextMapped`, in order to look ahead in the trace to the next mapped step for certain `data` stuff?  Notionally we could have a `stacktrace.lastMapped`, looking backward in the trace.  But, I thought it was easier to just put it in the state.  So, here it is.

So that's an overview of the new `stacktrace` submodule!  But hopefully *this* transaction completes successfully. :)