### PR TITLE
Update cli.js, improve help conditional

### DIFF
--- a/packages/core/cli.js
+++ b/packages/core/cli.js
@@ -41,7 +41,8 @@ listeners.forEach(listener => process.removeListener("warning", listener));
 let options = { logger: console };
 
 const inputArguments = process.argv.slice(2);
-const userWantsGeneralHelp = inputArguments.length && ['help', '--help'].includes(inputArguments[0]);
+const userWantsGeneralHelp = 
+  inputArguments.length === 1 && ['help', '--help'].includes(inputArguments[0]);
 
 if (userWantsGeneralHelp) {
   command.displayGeneralHelp();

--- a/packages/core/cli.js
+++ b/packages/core/cli.js
@@ -41,9 +41,7 @@ listeners.forEach(listener => process.removeListener("warning", listener));
 let options = { logger: console };
 
 const inputArguments = process.argv.slice(2);
-const userWantsGeneralHelp =
-  (inputArguments[0] === "help" || inputArguments[0] === "--help") &&
-  inputArguments.length === 1;
+const userWantsGeneralHelp = inputArguments.length && ['help', '--help'].includes(inputArguments[0]);
 
 if (userWantsGeneralHelp) {
   command.displayGeneralHelp();


### PR DESCRIPTION
The `inputArgument.length` check should be first to short circuit.  This looks like a bug.

Improve readability with `array.includes`.  Looks like there would be no benefit to amortize the creation of a `new Set(...etc)` since this is only called once per run?