### PR TITLE
Update repl.js improve readability & performance.

### DIFF
--- a/packages/core/lib/repl.js
+++ b/packages/core/lib/repl.js
@@ -49,9 +49,9 @@ ReplManager.prototype.start = function(options) {
       // If we exit for some reason, call done functions for good measure
       // then ensure the process is completely killed. Once the repl exits,
       // the process is in a bad state and can't be recovered (e.g., stdin is closed).
-      const doneFunctions = self.contexts.reduce((fns, ctx) => {
-        if (ctx.done) fns.push(ctx.done);
-        return fns;
+      const doneFunctions = self.contexts.reduce((functions, context) => {
+        if (context.done) functions.push(context.done);
+        return functions;
       }, []);
       async.series(doneFunctions, process.exit);
     });

--- a/packages/core/lib/repl.js
+++ b/packages/core/lib/repl.js
@@ -49,13 +49,10 @@ ReplManager.prototype.start = function(options) {
       // If we exit for some reason, call done functions for good measure
       // then ensure the process is completely killed. Once the repl exits,
       // the process is in a bad state and can't be recovered (e.g., stdin is closed).
-      var doneFunctions = self.contexts.map(function(context) {
-        return context.done
-          ? function() {
-              context.done();
-            }
-          : function() {};
-      });
+      const doneFunctions = self.contexts.reduce((fns, ctx) => {
+        if (ctx.done) fns.push(ctx.done);
+        return fns;
+      }, []);
       async.series(doneFunctions, function() {
         process.exit();
       });

--- a/packages/core/lib/repl.js
+++ b/packages/core/lib/repl.js
@@ -53,9 +53,7 @@ ReplManager.prototype.start = function(options) {
         if (ctx.done) fns.push(ctx.done);
         return fns;
       }, []);
-      async.series(doneFunctions, function() {
-        process.exit();
-      });
+      async.series(doneFunctions, process.exit);
     });
   }
 


### PR DESCRIPTION
No need to run `noop` functions, we can just make our own filter with a reduce to collect the `.done` methods.