### PR TITLE
Bug fix: Put fs import in a try/catch to avoid web problems 

### DIFF
--- a/packages/decoder/lib/index.ts
+++ b/packages/decoder/lib/index.ts
@@ -174,7 +174,13 @@ import { ContractConstructorObject, ContractInstanceObject } from "./types";
 
 import { Compilations } from "@truffle/codec";
 
-import fs from "fs";
+let fs: any; //sorry
+try {
+  fs = require("fs"); //if this fails (say, in a web context)... then whatever! too bad!
+  //(sorry about the resulting untyped import :-/)
+} catch (_) {
+  //no alternative, just let fs be undefined
+}
 import path from "path";
 
 /**
@@ -459,8 +465,10 @@ function infoToCompilations(
       if (projectInfo.config.contracts_build_directory !== undefined) {
         let files = fs
           .readdirSync(projectInfo.config.contracts_build_directory)
-          .filter(file => path.extname(file) === ".json");
-        let data = files.map(file =>
+          .filter((file: any) => path.extname(file) === ".json"); //sorry about the any, I had to import fs untyped
+        let data: string[] = files.map((
+          file: any //same :-/
+        ) =>
           fs.readFileSync(
             path.join(projectInfo.config.contracts_build_directory, file),
             "utf8"

--- a/packages/decoder/test/current/truffle-config.js
+++ b/packages/decoder/test/current/truffle-config.js
@@ -57,7 +57,7 @@ module.exports = {
   // Configure your compilers
   compilers: {
     solc: {
-      version: "0.6.5" // Fetch exact version from solc-bin (default: truffle's version)
+      version: "0.6.6" // Fetch exact version from solc-bin (default: truffle's version)
       // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
       // settings: {          // See the solidity docs for advice about optimization and evmVersion
       //  optimizer: {


### PR DESCRIPTION
Addresses a problem raised by @adrianmcli: Even just trying to *import* `fs` can go badly in some contexts where the file system isn't available, so I've stuck it in a try/catch.

This requires doing it via `require` rather than `import` (making it an an untyped import, oh well), but, yeah.

I thought about creating an additional error for trying to use it when the import failed, but I don't really think that's necessary.  If you're trying to use `fs` on web... like, you should know that's not going to work.