### PR TITLE
Bug fix: Fixes to phantom guard system and stacktraces

### DIFF
--- a/packages/debugger/lib/solidity/selectors/index.js
+++ b/packages/debugger/lib/solidity/selectors/index.js
@@ -16,7 +16,8 @@ function contextRequiresPhantomStackframes(context) {
     //we need this to be a boolean, not undefined, because it gets put in the state)
     semver.satisfies(context.compiler.version, ">=0.5.1", {
       includePrerelease: true
-    })
+    }) &&
+    !context.isConstructor //constructors should not get a phantom stackframe!
   );
 }
 
@@ -161,8 +162,10 @@ let solidity = createSelectorTree({
     /**
      * solidity.current.humanReadableSourceMap
      */
-    humanReadableSourceMap: createLeaf(["./sourceMap"], sourceMap =>
-      sourceMap ? SolidityUtils.getHumanReadableSourceMap(sourceMap) : null
+    humanReadableSourceMap: createLeaf(
+      ["./sourceMap"],
+      sourceMap =>
+        sourceMap ? SolidityUtils.getHumanReadableSourceMap(sourceMap) : null
     ),
 
     /**

--- a/packages/debugger/lib/stacktrace/actions/index.js
+++ b/packages/debugger/lib/stacktrace/actions/index.js
@@ -17,12 +17,11 @@ export function jumpOut(location) {
 }
 
 export const EXTERNAL_CALL = "STACKTRACE_EXTERNAL_CALL";
-export function externalCall(location, contractNode, skippedInReports) {
+export function externalCall(location, context) {
   return {
     type: EXTERNAL_CALL,
     location,
-    contractNode,
-    skippedInReports
+    context
   };
 }
 

--- a/packages/debugger/lib/stacktrace/reducers.js
+++ b/packages/debugger/lib/stacktrace/reducers.js
@@ -21,12 +21,11 @@ function callstack(state = [], action) {
         contractName:
           contractNode && contractNode.nodeType === "ContractDefinition"
             ? contractNode.name
-            : undefined,
+            : undefined
         //note we don't currently account for getters because currently
         //we can't; fallback, receive, constructors, & modifiers also remain
         //unaccounted for at present
         //(none of these things have associated jump-in markings!)
-        skippedInReports: false
       };
       return [...state, newFrame];
     case actions.JUMP_OUT:
@@ -40,13 +39,8 @@ function callstack(state = [], action) {
       newFrame = {
         type: "external",
         calledFromLocation: action.location,
-        skippedInReports: action.skippedInReports,
         functionName: undefined,
-        contractName:
-          action.contractNode &&
-          action.contractNode.nodeType === "ContractDefinition"
-            ? action.contractNode.name
-            : undefined
+        contractName: action.context.contractName
       };
       return [...state, newFrame];
     case actions.EXECUTE_RETURN:

--- a/packages/debugger/test/stacktrace.js
+++ b/packages/debugger/test/stacktrace.js
@@ -142,9 +142,12 @@ describe("Stack tracing", function() {
     let report = session.view(stacktrace.current.finalReport);
     let functionNames = report.map(({ functionName }) => functionName);
     assert.deepEqual(functionNames, [
+      undefined,
       "run",
+      undefined,
       "run3",
       "run2",
+      undefined,
       "run1",
       "runRequire"
     ]);
@@ -188,7 +191,15 @@ describe("Stack tracing", function() {
 
     let report = session.view(stacktrace.current.report);
     let functionNames = report.map(({ functionName }) => functionName);
-    assert.deepEqual(functionNames, ["run", "run2", "run1", "runRequire"]);
+    assert.deepEqual(functionNames, [
+      undefined,
+      "run",
+      undefined,
+      "run2",
+      undefined,
+      "run1",
+      "runRequire"
+    ]);
     let contractNames = report.map(({ contractName }) => contractName);
     assert(contractNames.every(name => name === "StacktraceTest"));
     let status = report[report.length - 1].status;
@@ -203,9 +214,12 @@ describe("Stack tracing", function() {
     report = session.view(stacktrace.current.report);
     functionNames = report.map(({ functionName }) => functionName);
     assert.deepEqual(functionNames, [
+      undefined,
       "run",
+      undefined,
       "run3",
       "run2",
+      undefined,
       "run1",
       "runRequire"
     ]);
@@ -245,9 +259,12 @@ describe("Stack tracing", function() {
     let report = session.view(stacktrace.current.finalReport);
     let functionNames = report.map(({ functionName }) => functionName);
     assert.deepEqual(functionNames, [
+      undefined,
       "run",
+      undefined,
       "run3",
       "run2",
+      undefined,
       "run1",
       "runPay",
       undefined
@@ -288,9 +305,12 @@ describe("Stack tracing", function() {
     let report = session.view(stacktrace.current.finalReport);
     let functionNames = report.map(({ functionName }) => functionName);
     assert.deepEqual(functionNames, [
+      undefined,
       "run",
+      undefined,
       "run3",
       "run2",
+      undefined,
       "run1",
       "runInternal",
       undefined
@@ -334,22 +354,29 @@ describe("Stack tracing", function() {
     let report = session.view(stacktrace.current.finalReport);
     let functionNames = report.map(({ functionName }) => functionName);
     assert.deepEqual(functionNames, [
+      undefined,
       "run",
+      undefined,
       "run3",
       "run2",
+      undefined,
       "run1",
       "runBoom",
+      undefined,
       "boom"
     ]);
     let contractNames = report.map(({ contractName }) => contractName);
     assert.strictEqual(contractNames[contractNames.length - 1], "Boom");
-    contractNames.pop();
+    contractNames.pop(); //top frame
+    assert.strictEqual(contractNames[contractNames.length - 1], "Boom");
+    contractNames.pop(); //second-top frame
     assert(contractNames.every(name => name === "StacktraceTest"));
     let status = report[report.length - 1].status;
     assert.isTrue(status);
     let location = report[report.length - 1].location;
-    let prevLocation = report[report.length - 2].location;
-    let prev2Location = report[report.length - 3].location;
+    //skip a frame for the junk frame
+    let prevLocation = report[report.length - 3].location;
+    let prev2Location = report[report.length - 4].location;
     assert.strictEqual(location.sourceRange.lines.start.line, failLine);
     assert.strictEqual(prevLocation.sourceRange.lines.start.line, callLine);
     assert.strictEqual(


### PR DESCRIPTION
This PR does a few things.

First, in `solidity`, it makes it so that the phantom-stackframe-guard system isn't invoked for constructors.  This is because constructors don't have a jump in marking, so it's inappropriate there.

(Ideally there'd be some way to turn it off for fallbacks/receives/getters, but, well, at least it shouldn't cause any harm there; yes, it can cause multiple functions to collapse into the same stackframe, but since they'll be different functions, it won't cause any variables to get mixed together.)

Secondly, in `stackframes`, I've removed the `skippedInReports` system -- no more skipping any stackframes.  Yeah, this will cause some extra stackframes to appear in reports that are basically junk, but, well, I figured I really don't want to skip fallbacks and receives in there; that would just be too confusing, IMO.

Finally, I fixed a bug in `stackframes` whereby external stackframes got the wrong contract name associated to them.  I forgot that `solidity.next` doesn't work across context changes, oops!  I replaced it with `evm`'s `callContext` mechanism instead.