### PR TITLE
Various performance improvements to `resolver` package's `require`

### DIFF
--- a/packages/resolver/lib/sources/fs.ts
+++ b/packages/resolver/lib/sources/fs.ts
@@ -31,7 +31,11 @@ export class FS implements ResolverSource {
     searchPath = this.contractsBuildDirectory
   ) {
     // most cases we can use the `{name}.sol -> {name}.json` convention
+    // console.log(sourcePath);
+    // console.log(searchPath);
     const likelyFileBasename = path.basename(sourcePath, ".sol");
+    // console.log(likelyFileBasename);
+    // console.log(path.join(searchPath, `${likelyFileBasename}.json`));
     const likelyArtifactString = fs.readFileSync(
       path.join(searchPath, `${likelyFileBasename}.json`),
       "utf8"
@@ -41,22 +45,17 @@ export class FS implements ResolverSource {
     try {
       if (likelyArtifactString) {
         likelyArtifact = JSON.parse(likelyArtifactString);
+        return likelyArtifact;
       }
     } catch (e) {
       // do nothing, we'll handle this by doing a deeper search
-    }
-
-    if (
-      likelyArtifact &&
-      path.basename(likelyArtifact.sourcePath, ".sol") ===
-        path.basename(sourcePath, ".sol")
-    ) {
-      return likelyArtifact;
+      // console.log(e);
     }
 
     // we couldn't use the `{name}.sol --> {name}.json` convention, let's search
 
     const contractsBuildDirFiles = fs.readdirSync(searchPath);
+    // console.log(contractsBuildDirFiles);
     const filteredBuildArtifacts = contractsBuildDirFiles.filter(
       // we don't care about files that don't have the json extension
       // we also don't care about the file we already tried
@@ -73,9 +72,12 @@ export class FS implements ResolverSource {
         if (artifactString) {
           const artifact = JSON.parse(artifactString);
 
+          // console.log(artifact.sourcePath, sourcePath);
+
           if (
             path.basename(artifact.sourcePath, ".sol") ===
-            path.basename(sourcePath, ".sol")
+              path.basename(sourcePath, ".sol") ||
+            artifact.contractName === path.basename(sourcePath, ".sol")
           ) {
             return artifact;
           }

--- a/packages/resolver/lib/sources/fs.ts
+++ b/packages/resolver/lib/sources/fs.ts
@@ -26,12 +26,20 @@ export class FS implements ResolverSource {
     return result;
   }
 
+  /**
+   *
+   * @param importSourcePath The string in the require/import statement
+   *   This could be artifacts.require("Migrations") => "Migrations", or even
+   *   artifacts.require("Migrations.sol") => "Migrations.sol". This function handles both
+   * @param searchPath The location to search
+   * @returns The artifact as a JSON object
+   */
   searchForArtifact(
-    sourcePath: string,
+    importSourcePath: string,
     searchPath = this.contractsBuildDirectory
   ) {
     // most cases we can use the `{name}.sol -> {name}.json` convention
-    const likelyFileBasename = path.basename(sourcePath, ".sol");
+    const likelyFileBasename = path.basename(importSourcePath, ".sol");
     const likelyArtifactString = fs.readFileSync(
       path.join(searchPath, `${likelyFileBasename}.json`),
       "utf8"
@@ -41,9 +49,7 @@ export class FS implements ResolverSource {
     try {
       if (likelyArtifactString) {
         likelyArtifact = JSON.parse(likelyArtifactString);
-        if (likelyArtifact.sourcePath === sourcePath) {
-          return likelyArtifact;
-        }
+        return likelyArtifact;
       }
     } catch (e) {
       // do nothing, we'll handle this by doing a deeper search
@@ -70,8 +76,8 @@ export class FS implements ResolverSource {
 
           if (
             path.basename(artifact.sourcePath, ".sol") ===
-              path.basename(sourcePath, ".sol") ||
-            artifact.contractName === path.basename(sourcePath, ".sol")
+              path.basename(importSourcePath, ".sol") ||
+            artifact.contractName === path.basename(importSourcePath, ".sol")
           ) {
             return artifact;
           }

--- a/packages/resolver/lib/sources/fs.ts
+++ b/packages/resolver/lib/sources/fs.ts
@@ -31,11 +31,7 @@ export class FS implements ResolverSource {
     searchPath = this.contractsBuildDirectory
   ) {
     // most cases we can use the `{name}.sol -> {name}.json` convention
-    // console.log(sourcePath);
-    // console.log(searchPath);
     const likelyFileBasename = path.basename(sourcePath, ".sol");
-    // console.log(likelyFileBasename);
-    // console.log(path.join(searchPath, `${likelyFileBasename}.json`));
     const likelyArtifactString = fs.readFileSync(
       path.join(searchPath, `${likelyFileBasename}.json`),
       "utf8"
@@ -45,17 +41,17 @@ export class FS implements ResolverSource {
     try {
       if (likelyArtifactString) {
         likelyArtifact = JSON.parse(likelyArtifactString);
-        return likelyArtifact;
+        if (likelyArtifact.sourcePath === sourcePath) {
+          return likelyArtifact;
+        }
       }
     } catch (e) {
       // do nothing, we'll handle this by doing a deeper search
-      // console.log(e);
     }
 
     // we couldn't use the `{name}.sol --> {name}.json` convention, let's search
 
     const contractsBuildDirFiles = fs.readdirSync(searchPath);
-    // console.log(contractsBuildDirFiles);
     const filteredBuildArtifacts = contractsBuildDirFiles.filter(
       // we don't care about files that don't have the json extension
       // we also don't care about the file we already tried
@@ -71,8 +67,6 @@ export class FS implements ResolverSource {
       try {
         if (artifactString) {
           const artifact = JSON.parse(artifactString);
-
-          // console.log(artifact.sourcePath, sourcePath);
 
           if (
             path.basename(artifact.sourcePath, ".sol") ===


### PR DESCRIPTION
This PR is a quick solution to increasing the performance of the `resolver` package's `require` function. What it does:

- Reduce the number of `JSON.parse` to only execute once per JSON file per call to `require`. Before, we would parse the file until we found what we want, return just the name, and then read the file *again* and parse it
- "Heuristically" try the most likely file first. We have a convention that `ContractName.sol` becomes `ContractName.json`. I can't think of a scenario where this wouldn't happen (perhaps when the name of the file does not match the name of the contract, but I think things error in other places [solc maybe] when that doesn't match), but we use this to leverage the fact we could almost always only do one file read and JSON parse rather than potentially search through `n` files