### PR TITLE
Reduce unnecessary repetition of loops

### DIFF
--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -28,8 +28,7 @@ class DebugPrinter {
       try {
         selector = expr
           .split(".")
-          .filter(next => next.length > 0)
-          .reduce((sel, next) => sel[next], selectors);
+          .reduce((sel, next) => next.length ? sel[next] : sel, selectors);
       } catch (_) {
         throw new Error("Unknown selector: %s", expr);
       }
@@ -336,17 +335,16 @@ class DebugPrinter {
 
     debug("variables %o", variables);
 
+    const variableKeys = Object.keys(variables);
+
     // Get the length of the longest name.
-    const longestNameLength = Math.max.apply(
-      null,
-      Object.keys(variables).map(function(name) {
-        return name.length;
-      })
-    );
+    const longestNameLength = variableKeys.reduce((longest, name) => {
+      return name.length > longest ? name.length : longest;
+    }, -Infinity);
 
     this.config.logger.log();
 
-    Object.keys(variables).forEach(name => {
+    variableKeys.forEach(name => {
       let paddedName = name + ":";
 
       while (paddedName.length <= longestNameLength) {


### PR DESCRIPTION
No need to loop through with `filter` then `reduce`.  Since filter can be implemented with a reduce we can eliminate the need to loop through `expr.split(".")`'s output twice.

`Object.keys(obj)` is actually a `O(n)` operation.  Lets do this once and save the output.
We can also eliminate the need to map (`O(n)`) this before passing the result to Math.max which is a `O(n)` operation as well. If we just perform the operation in one `reduce` statement.

Nothing imperative here, just low hanging fruit.