### PR TITLE
Remove unnecessary IO

### DIFF
--- a/packages/core/lib/commands/init.js
+++ b/packages/core/lib/commands/init.js
@@ -20,7 +20,7 @@ var command = {
     let inputPath;
     if (options._ && options._.length > 0) {
       inputPath = options._[0];
-      if (!fse.existsSync(inputPath)) fse.ensureDirSync(inputPath);
+      fse.ensureDirSync(inputPath);
     }
 
     // defer to `truffle unbox` command with "bare" box as arg


### PR DESCRIPTION
We can just use `ensureDirSync` since it ensures that the directory exists. If the directory structure does not exist, it is created. Like `mkdir -p`.  Docs - https://github.com/jprichardson/node-fs-extra/blob/master/docs/ensureDir.md