### PR TITLE
Optimize develop.js, reduce unnecessary looping

### DIFF
--- a/packages/core/lib/commands/develop.js
+++ b/packages/core/lib/commands/develop.js
@@ -27,14 +27,14 @@ const command = {
     const { Environment } = require("@truffle/environment");
 
     const commands = require("./index");
-    const excluded = ["console", "develop", "unbox", "init"];
+    const excluded = new Set(["console", "develop", "unbox", "init"]);
 
     const availableCommands = Object.keys(commands).filter(
-      name => !excluded.includes(name)
+      name => !excluded.has(name)
     );
 
     const consoleCommands = availableCommands.reduce(
-      (acc, name) => Object.assign({}, acc, { [name]: commands[name] }),
+      (acc, name) => Object.assign(acc, { [name]: commands[name] }),
       {}
     );
 

--- a/packages/core/lib/commands/develop.js
+++ b/packages/core/lib/commands/develop.js
@@ -29,14 +29,11 @@ const command = {
     const commands = require("./index");
     const excluded = new Set(["console", "develop", "unbox", "init"]);
 
-    const availableCommands = Object.keys(commands).filter(
-      name => !excluded.has(name)
-    );
-
-    const consoleCommands = availableCommands.reduce(
-      (acc, name) => Object.assign(acc, { [name]: commands[name] }),
-      {}
-    );
+    const consoleCommands = Object.keys(commands).reduce((acc, name) => {
+      return !excluded.has(name)
+        ? Object.assign(acc, { [name]: commands[name] })
+        : acc;
+    }, {});
 
     Environment.develop(config, ganacheOptions)
       .then(() => {


### PR DESCRIPTION
We can get O(1) lookups for every command.

Combine loops to aggregate `consoleCommands`.

No need to reassign the accumulator and copy the previous values in.  The accumulator starts as a fresh object so maintaining immutability has no benefit and only hinders performance.  If I'm not mistaken this was O(n!) and now its O(n).