### PR TITLE
Optimize console.js

### DIFF
--- a/packages/core/lib/commands/console.js
+++ b/packages/core/lib/commands/console.js
@@ -27,16 +27,14 @@ const command = {
 
     // This require a smell?
     const commands = require("./index");
-    const excluded = ["console", "init", "watch", "develop"];
+    const excluded = new Set(["console", "init", "watch", "develop"]);
 
-    const availableCommands = Object.keys(commands).filter(name => {
-      return excluded.indexOf(name) === -1;
-    });
-
-    const consoleCommands = {};
-    availableCommands.forEach(name => {
-      consoleCommands[name] = commands[name];
-    });
+    const consoleCommands = Object.keys(commands).reduce((acc, name) => {
+      if (!excluded.has(name)) {
+        acc[name] = commands[name];
+      }
+      return acc;
+    }, {});
 
     Environment.detect(config)
       .then(() => {

--- a/packages/core/lib/commands/console.js
+++ b/packages/core/lib/commands/console.js
@@ -30,10 +30,9 @@ const command = {
     const excluded = new Set(["console", "init", "watch", "develop"]);
 
     const consoleCommands = Object.keys(commands).reduce((acc, name) => {
-      if (!excluded.has(name)) {
-        acc[name] = commands[name];
-      }
-      return acc;
+      return !excluded.has(name)
+        ? Object.assign(acc, { [name]: commands[name] })
+        : acc;
     }, {});
 
     Environment.detect(config)


### PR DESCRIPTION
O(1) lookups with `Set` vs `Array.indexOf`.

Aggregate `consoleCommands` in one `reduce` to eliminate the need to loop with `filter` then `forEach`.