### PR TITLE
Internal improvement: Swap out github download library

### DIFF
--- a/packages/box/box.ts
+++ b/packages/box/box.ts
@@ -116,7 +116,7 @@ const Box = {
     const tmpDir = tmp.dirSync({ unsafeCleanup });
     const unboxOptions = { logger, force };
     await Box.unbox(
-      `https://github.com/trufflesuite/truffle-init-${name}`,
+      `https://github.com:trufflesuite/truffle-init-${name}`,
       tmpDir.name,
       unboxOptions,
       config

--- a/packages/box/box.ts
+++ b/packages/box/box.ts
@@ -7,7 +7,61 @@ import fse from "fs-extra";
 import inquirer from "inquirer";
 import { sandboxOptions, unboxOptions } from "typings";
 
-function parseSandboxOptions(options: sandboxOptions) {
+/*
+ * accepts a number of different url and org/repo formats and returns the
+ * format required by https://www.npmjs.com/package/download-git-repo
+ * supported input formats are as follows:
+ *   - org/repo[#branch]
+ *   - https://github.com(/|:)<org>/<repo>[.git][#branch]
+ *   - git@github.com:<org>/<repo>[#branch]
+ */
+const normalizeURL = (
+  url = "https://github.com:trufflesuite/truffle-init-default"
+) => {
+  // remove the .git from the repo specifier
+  if (url.includes(".git")) {
+    url = url.replace(/.git$/, "");
+    url = url.replace(/.git#/, "#");
+    url = url.replace(/.git:/, ":");
+  }
+
+  // rewrite https://github.com/truffle-box/metacoin format in
+  //         https://github.com:truffle-box/metacoin format
+  if (url.match(/.com\//)) {
+    url = url.replace(/.com\//, ".com:");
+  }
+
+  // full URL already
+  if (url.includes("://")) {
+    return url;
+  }
+
+  if (url.includes("git@")) {
+    return url.replace("git@", "https://");
+  }
+
+  if (url.split("/").length === 2) {
+    // `org/repo`
+    return `https://github.com:${url}`;
+  }
+
+  if (!url.includes("/")) {
+    // repo name only
+    if (!url.includes("-box")) {
+      // check for branch
+      if (!url.includes("#")) {
+        url = `${url}-box`;
+      } else {
+        const index = url.indexOf("#");
+        url = `${url.substr(0, index)}-box${url.substr(index)}`;
+      }
+    }
+    return `https://github.com:truffle-box/${url}`;
+  }
+  throw new Error("Box specified in invalid format");
+};
+
+const parseSandboxOptions = (options: sandboxOptions) => {
   if (typeof options === "string") {
     // back compatibility for when `options` used to be `name`
     return {
@@ -15,7 +69,7 @@ function parseSandboxOptions(options: sandboxOptions) {
       unsafeCleanup: false,
       setGracefulCleanup: false,
       logger: console,
-      force: false
+      force: false,
     };
   } else if (typeof options === "object") {
     return {
@@ -23,10 +77,10 @@ function parseSandboxOptions(options: sandboxOptions) {
       unsafeCleanup: options.unsafeCleanup || false,
       setGracefulCleanup: options.setGracefulCleanup || false,
       logger: options.logger || console,
-      force: options.force || false
+      force: options.force || false,
     };
   }
-}
+};
 
 const Box = {
   unbox: async (
@@ -40,16 +94,18 @@ const Box = {
     const logger = options.logger || { log: () => {} };
     const unpackBoxOptions = {
       logger: options.logger,
-      force: options.force
+      force: options.force,
     };
 
     try {
+      const normalizedURL = normalizeURL(url);
+
       await Box.checkDir(options, destination);
       const tempDir = await utils.setUpTempDirectory(events);
       const tempDirPath = tempDir.path;
       tempDirCleanup = tempDir.cleanupCallback;
 
-      await utils.downloadBox(url, tempDirPath, events);
+      await utils.downloadBox(normalizedURL, tempDirPath, events);
 
       const boxConfig = await utils.readBoxConfig(tempDirPath);
 
@@ -85,8 +141,8 @@ const Box = {
             type: "confirm",
             name: "proceed",
             message: `Proceed anyway?`,
-            default: true
-          }
+            default: true,
+          },
         ];
         const answer = await inquirer.prompt(prompt);
         if (!answer.proceed) {
@@ -107,7 +163,7 @@ const Box = {
       unsafeCleanup,
       setGracefulCleanup,
       logger,
-      force
+      force,
     } = parseSandboxOptions(options);
 
     if (setGracefulCleanup) tmp.setGracefulCleanup();
@@ -122,7 +178,7 @@ const Box = {
       config
     );
     return Config.load(path.join(tmpDir.name, "truffle-config.js"), {});
-  }
+  },
 };
 
 export = Box;

--- a/packages/box/lib/utils/unbox.ts
+++ b/packages/box/lib/utils/unbox.ts
@@ -1,6 +1,6 @@
 import fse from "fs-extra";
 import path from "path";
-import ghdownload from "github-download";
+import download from "download-git-repo";
 import rp from "request-promise-native";
 import vcsurl from "vcsurl";
 import { parse as parseURL } from "url";
@@ -37,12 +37,15 @@ async function verifyURL(url: string) {
 }
 
 function fetchRepository(url: string, dir: string) {
-  return new Promise((accept, reject) =>
-    // Download the package from github.
-    ghdownload(url, dir)
-      .on("err", reject)
-      .on("end", accept)
-  );
+  return new Promise((accept, reject) => {
+    // Download the package from github - download(url, dir, options, cb)
+    download(url, dir, error => {
+      if (error) {
+        reject(error);
+      }
+      accept();
+    });
+  });
 }
 
 function prepareToCopyFiles(tempDir: string, { ignore }: boxConfig) {

--- a/packages/box/package.json
+++ b/packages/box/package.json
@@ -14,8 +14,8 @@
   "types": "./typings/index.d.ts",
   "dependencies": {
     "@truffle/config": "^1.2.22",
+    "download-git-repo": "^3.0.2",
     "fs-extra": "^8.1.0",
-    "github-download": "^0.5.0",
     "inquirer": "^7.0.0",
     "request": "^2.85.0",
     "request-promise-native": "^1.0.7",

--- a/packages/box/test/box.js
+++ b/packages/box/test/box.js
@@ -6,7 +6,7 @@ const sinon = require("sinon");
 const Config = require("@truffle/config");
 const Box = require("../");
 const TRUFFLE_BOX_DEFAULT =
-  "git@github.com:trufflesuite/truffle-init-default.git";
+  "https://github.com:trufflesuite/truffle-init-default";
 const utils = require("../dist/lib/utils");
 let options, cleanupCallback, config;
 

--- a/packages/box/typings/download-git-repo/index.d.ts
+++ b/packages/box/typings/download-git-repo/index.d.ts
@@ -1,0 +1,7 @@
+declare module "download-git-repo" {
+  export default function download(
+    url: string,
+    dir: string,
+    callback: (error: Error | undefined) => void
+  ): Promise<any>;
+}

--- a/packages/box/typings/github-download/index.d.ts
+++ b/packages/box/typings/github-download/index.d.ts
@@ -1,9 +1,0 @@
-declare module "github-download" {
-  interface GhDownloadEvent<T> {
-    on(handler: string, resp: { (resp?: Promise<any>): void }): any;
-  }
-  export default function ghdownload(
-    url: string,
-    dir: string
-  ): GhDownloadEvent<any>;
-}

--- a/packages/core/lib/commands/unbox.js
+++ b/packages/core/lib/commands/unbox.js
@@ -5,16 +5,27 @@
  * - a string containing a repo under the `truffle-box` org
  */
 function normalizeURL(
-  url = "https://github.com/trufflesuite/truffle-init-default"
+  url = "https://github.com:trufflesuite/truffle-init-default"
 ) {
+  // remove the .git from the repo specifier
+  if (url.includes(".git")) {
+    url = url.replace(/.git$/, "");
+    url = url.replace(/.git#/, "#");
+    url = url.replace(/.git:/, ":");
+  }
+
   // full URL already
-  if (url.includes("://") || url.includes("git@")) {
+  if (url.includes("://")) {
     return url;
+  }
+
+  if (url.includes("git@")) {
+    return url.replace("git@", "https://");
   }
 
   if (url.split("/").length === 2) {
     // `org/repo`
-    return `https://github.com/${url}`;
+    return `https://github.com:${url}`;
   }
 
   if (!url.includes("/")) {
@@ -28,7 +39,7 @@ function normalizeURL(
         url = `${url.substr(0, index)}-box${url.substr(index)}`;
       }
     }
-    return `https://github.com/truffle-box/${url}`;
+    return `https://github.com:truffle-box/${url}`;
   }
   throw new Error("Box specified in invalid format");
 }
@@ -46,6 +57,7 @@ function normalizeInput([url, subDir]) {
   try {
     // attempts to parse url from :path/to/subDir
     parsedUrl = url.match(/(.*):/)[1];
+
     // handles instance where full url is being passed w/o a path in url
     if (parsedUrl.includes("http") && !parsedUrl.includes("//")) {
       return { url, destination };
@@ -106,6 +118,7 @@ const command = {
     const config = Config.default().with({ logger: console });
 
     let { url, destination } = normalizeInput(options._);
+
     url = normalizeURL(url);
 
     const normalizedDestination = normalizeDestination(

--- a/packages/core/lib/commands/unbox.js
+++ b/packages/core/lib/commands/unbox.js
@@ -44,53 +44,13 @@ function normalizeURL(
   throw new Error("Box specified in invalid format");
 }
 
-function normalizeDestination(destination, working_directory) {
+function normalizeDestination(destination, workingDirectory) {
+  if (!destination) {
+    return workingDirectory;
+  }
   const path = require("path");
   if (path.isAbsolute(destination)) return destination;
-  return path.join(working_directory, destination);
-}
-
-function normalizeInput([url, subDir]) {
-  // The subDir argument will override paths in the url
-  let destination = subDir ? subDir : "";
-  let parsedUrl;
-  try {
-    // the following matches only when there is a :path/to/subDir format
-    const match = url.match(/^.*\.com:.*:/);
-    if (match) {
-      parsedUrl = match[0].slice(0, -1);
-    } else {
-      parsedUrl = url;
-    }
-
-    // handles instance where full url is being passed w/o a path in url
-    if (parsedUrl.includes("http") && !parsedUrl.includes("//")) {
-      return { url, destination };
-    }
-    // handles instance where git@ is being passed w/o a path in url
-    if (parsedUrl.includes("git") && !parsedUrl.includes("/")) {
-      return { url, destination };
-    }
-  } catch (_) {
-    // return url if regex fails (no path specified in url)
-    return { url, destination };
-  }
-
-  if (destination !== "") return { url, destination };
-
-  try {
-    // if a path was specified in the url
-    destination = url.match(/:(?!\/)(.*)/)[1]; // enforces relative paths
-    // parses again if passed url git@ with path
-    if (parsedUrl.includes("git@"))
-      destination = destination.match(/:(?!\/)(.*)/)[1];
-  } catch (_) {
-    throw new Error(
-      `${url} not allowed! Please use a relative path (:path/to/subDir)`
-    );
-  }
-  // returns the parsed url & relative path
-  return { url: parsedUrl, destination };
+  return path.join(workingDirectory, destination);
 }
 
 const command = {
@@ -122,7 +82,7 @@ const command = {
 
     const config = Config.default().with({ logger: console });
 
-    let { url, destination } = normalizeInput(options._);
+    let [url, destination] = options._;
 
     url = normalizeURL(url);
 

--- a/packages/core/lib/commands/unbox.js
+++ b/packages/core/lib/commands/unbox.js
@@ -1,63 +1,11 @@
-/*
- * returns a VCS url string given:
- * - a VCS url string
- * - a github `org/repo` string
- * - a string containing a repo under the `truffle-box` org
- */
-function normalizeURL(
-  url = "https://github.com:trufflesuite/truffle-init-default"
-) {
-  // remove the .git from the repo specifier
-  if (url.includes(".git")) {
-    url = url.replace(/.git$/, "");
-    url = url.replace(/.git#/, "#");
-    url = url.replace(/.git:/, ":");
-  }
-
-  // rewrite https://github.com/truffle-box/metacoin format in
-  //         https://github.com:truffle-box/metacoin format
-  if (url.match(/.com\//)) {
-    url = url.replace(/.com\//, ".com:");
-  }
-
-  // full URL already
-  if (url.includes("://")) {
-    return url;
-  }
-
-  if (url.includes("git@")) {
-    return url.replace("git@", "https://");
-  }
-
-  if (url.split("/").length === 2) {
-    // `org/repo`
-    return `https://github.com:${url}`;
-  }
-
-  if (!url.includes("/")) {
-    // repo name only
-    if (!url.includes("-box")) {
-      // check for branch
-      if (!url.includes("#")) {
-        url = `${url}-box`;
-      } else {
-        const index = url.indexOf("#");
-        url = `${url.substr(0, index)}-box${url.substr(index)}`;
-      }
-    }
-    return `https://github.com:truffle-box/${url}`;
-  }
-  throw new Error("Box specified in invalid format");
-}
-
-function normalizeDestination(destination, workingDirectory) {
+const normalizeDestination = (destination, workingDirectory) => {
   if (!destination) {
     return workingDirectory;
   }
   const path = require("path");
   if (path.isAbsolute(destination)) return destination;
   return path.join(workingDirectory, destination);
-}
+};
 
 const command = {
   command: "unbox",
@@ -96,8 +44,6 @@ const command = {
     const config = Config.default().with({ logger: console });
 
     let [url, destination] = options._;
-
-    url = normalizeURL(url);
 
     const normalizedDestination = normalizeDestination(
       destination,

--- a/packages/core/lib/commands/unbox.js
+++ b/packages/core/lib/commands/unbox.js
@@ -55,8 +55,13 @@ function normalizeInput([url, subDir]) {
   let destination = subDir ? subDir : "";
   let parsedUrl;
   try {
-    // attempts to parse url from :path/to/subDir
-    parsedUrl = url.match(/(.*):/)[1];
+    // the following matches only when there is a :path/to/subDir format
+    const match = url.match(/^.*\.com:.*:/);
+    if (match) {
+      parsedUrl = match[0].slice(0, -1);
+    } else {
+      parsedUrl = url;
+    }
 
     // handles instance where full url is being passed w/o a path in url
     if (parsedUrl.includes("http") && !parsedUrl.includes("//")) {
@@ -99,16 +104,16 @@ const command = {
         option: "<box_name>",
         description:
           "Name of the truffle box. If no box_name is specified, a default " +
-          "truffle box will be downloaded."
+          "truffle box will be downloaded.",
       },
       {
         option: "--force",
         description:
           "Unbox project in the current directory regardless of its " +
           "state. Be careful, this\n                    will potentially overwrite files " +
-          "that exist in the directory."
-      }
-    ]
+          "that exist in the directory.",
+      },
+    ],
   },
   run(options, done) {
     const Config = require("@truffle/config");
@@ -133,12 +138,12 @@ const command = {
     config.events.emit("unbox:start");
 
     Box.unbox(url, normalizedDestination, unboxOptions, config)
-      .then(async boxConfig => {
+      .then(async (boxConfig) => {
         await config.events.emit("unbox:succeed", { boxConfig });
         done();
       })
       .catch(done);
-  }
+  },
 };
 
 module.exports = command;

--- a/packages/core/lib/commands/unbox.js
+++ b/packages/core/lib/commands/unbox.js
@@ -58,8 +58,15 @@ const command = {
   description: "Download a Truffle Box, a pre-built Truffle project",
   builder: {},
   help: {
-    usage: "truffle unbox [<box_name>] [--force]",
+    usage: "truffle unbox [destination] [<box_name>] [--force]",
     options: [
+      {
+        option: "destination",
+        description:
+          "Path to the directory in which you would like " +
+          "to unbox the project files. If destination is\n                  " +
+          "  not provided, this defaults to the current directory.",
+      },
       {
         option: "<box_name>",
         description:

--- a/packages/core/lib/commands/unbox.js
+++ b/packages/core/lib/commands/unbox.js
@@ -14,6 +14,12 @@ function normalizeURL(
     url = url.replace(/.git:/, ":");
   }
 
+  // rewrite https://github.com/truffle-box/metacoin format in
+  //         https://github.com:truffle-box/metacoin format
+  if (url.match(/.com\//)) {
+    url = url.replace(/.com\//, ".com:");
+  }
+
   // full URL already
   if (url.includes("://")) {
     return url;

--- a/packages/core/test/lib/commands/unbox.js
+++ b/packages/core/test/lib/commands/unbox.js
@@ -45,16 +45,20 @@ describe("commands/unbox.js", () => {
     });
 
     describe("Error handling", () => {
-      it("throws when passed an invalid box format", () => {
-        invalidBoxFormats.forEach((val) => {
-          assert.throws(
-            () => {
-              unbox.run({ _: [`${val}`] });
-            },
-            Error,
-            "Error not thrown!"
+      it("throws when passed an invalid box format", async () => {
+        const promises = [];
+        for (const path of invalidBoxFormats) {
+          promises.push(
+            new Promise((resolve) => {
+              const callback = (error) => {
+                error ? assert(true) : assert(false);
+                resolve();
+              };
+              unbox.run({ _: [`${path}`] }, callback);
+            })
           );
-        });
+        }
+        return Promise.all(promises);
       });
     });
 

--- a/packages/core/test/lib/commands/unbox.js
+++ b/packages/core/test/lib/commands/unbox.js
@@ -16,12 +16,14 @@ describe("commands/unbox.js", () => {
     "//bare#truffle-test-branch",
   ];
   const validBoxInput = [
-    "https://github.com/truffle-box/bare-box",
-    "truffle-box/bare-box",
     "bare",
-    "git@github.com:truffle-box/bare-box",
+    "truffle-box/bare-box",
+    "truffle-box/bare-box#master",
+    "https://github.com/truffle-box/bare-box",
     "https://github.com:truffle-box/bare-box",
     "https://github.com/truffle-box/bare-box#master",
+    "git@github.com:truffle-box/bare-box",
+    "git@github.com:truffle-box/bare-box#master",
   ];
 
   describe("run", () => {

--- a/packages/core/test/lib/commands/unbox.js
+++ b/packages/core/test/lib/commands/unbox.js
@@ -11,16 +11,9 @@ describe("commands/unbox.js", () => {
     "//",
     "/truffle-box/bare-box",
     "//truffle-box/bare-box#truffle-test-branch",
-    "//truffle-box/bare-box#truffle-test-branch:path/SubDir",
+    "//truffle-box/bare-box#truffle-test-branch",
     "/bare/",
     "//bare#truffle-test-branch",
-    "//bare#truffle-test-branch:path/SubDir",
-  ];
-  const absolutePaths = [
-    "https://github.com/truffle-box/bare-box:/path/SubDir",
-    "truffle-box/bare-box:/path/subDir",
-    "bare:/path/subDir",
-    "git@github.com:truffle-box/bare-box:/path/subDir",
   ];
   const validBoxInput = [
     "https://github.com/truffle-box/bare-box",
@@ -28,12 +21,6 @@ describe("commands/unbox.js", () => {
     "bare",
     "git@github.com:truffle-box/bare-box",
     "https://github.com/truffle-box/bare-box#master",
-  ];
-  const relativePaths = [
-    "https://github.com/truffle-box/bare-box:path/SubDir",
-    "truffle-box/bare-box:path/subDir",
-    "bare:path/subDir",
-    "git@github.com:truffle-box/bare-box:path/subDir",
   ];
 
   describe("run", () => {
@@ -66,18 +53,6 @@ describe("commands/unbox.js", () => {
           );
         });
       });
-
-      it("throws when passed an absolute unbox path", () => {
-        absolutePaths.forEach((path) => {
-          assert.throws(
-            () => {
-              unbox.run({ _: [`${path}`] });
-            },
-            Error,
-            "Error not thrown!"
-          );
-        });
-      });
     });
 
     describe("successful unboxes", () => {
@@ -87,18 +62,6 @@ describe("commands/unbox.js", () => {
           promises.push(
             new Promise((resolve) => {
               unbox.run({ _: [`${val}`], force: true }, () => resolve());
-            })
-          );
-        });
-        Promise.all(promises).then(() => done());
-      }).timeout(10000);
-
-      it("runs when passed a relative unbox path", (done) => {
-        let promises = [];
-        relativePaths.forEach((path) => {
-          promises.push(
-            new Promise((resolve) => {
-              unbox.run({ _: [`${path}`], force: true }, () => resolve());
             })
           );
         });

--- a/packages/core/test/lib/commands/unbox.js
+++ b/packages/core/test/lib/commands/unbox.js
@@ -20,6 +20,7 @@ describe("commands/unbox.js", () => {
     "truffle-box/bare-box",
     "bare",
     "git@github.com:truffle-box/bare-box",
+    "https://github.com:truffle-box/bare-box",
     "https://github.com/truffle-box/bare-box#master",
   ];
 

--- a/packages/events/defaultSubscribers/unbox.js
+++ b/packages/events/defaultSubscribers/unbox.js
@@ -1,88 +1,91 @@
 const ora = require("ora");
 const OS = require("os");
 
-const formatCommands = commands => {
+const formatCommands = (commands) => {
   const names = Object.keys(commands);
-  const maxLength = Math.max.apply(null, names.map(name => name.length));
+  const maxLength = Math.max.apply(
+    null,
+    names.map((name) => name.length)
+  );
 
-  return names.map(name => {
+  return names.map((name) => {
     const spacing = Array(maxLength - name.length + 1).join(" ");
     return `  ${name}: ${spacing}${commands[name]}`;
   });
 };
 
 module.exports = {
-  initialization: function() {
+  initialization: function () {
     this.logger = console;
     this.ora = ora;
   },
   handlers: {
     "unbox:start": [
-      function() {
+      function () {
         this.logger.log(`${OS.EOL}Starting unbox...`);
         this.logger.log(`=================${OS.EOL}`);
-      }
+      },
     ],
     "unbox:preparingToDownload:start": [
-      function() {
+      function () {
         this.spinner = this.ora("Preparing to download box").start();
-      }
+      },
     ],
     "unbox:preparingToDownload:succeed": [
-      function() {
+      function () {
         this.spinner.succeed();
-      }
+      },
     ],
     "unbox:downloadingBox:start": [
-      function() {
+      function () {
         this.spinner = this.ora("Downloading").start();
-      }
+      },
     ],
     "unbox:downloadingBox:succeed": [
-      function() {
+      function () {
         this.spinner.succeed();
-      }
+      },
     ],
     "unbox:cleaningTempFiles:start": [
-      function() {
-        this.spinner = this.ora("cleaning up temporary files").start();
-      }
+      function () {
+        this.spinner = this.ora("Cleaning up temporary files").start();
+      },
     ],
     "unbox:cleaningTempFiles:succeed": [
-      function() {
+      function () {
         this.spinner.succeed();
-      }
+      },
     ],
     "unbox:settingUpBox:start": [
-      function() {
+      function () {
         this.spinner = this.ora("Setting up box").start();
-      }
+      },
     ],
     "unbox:settingUpBox:succeed": [
-      function() {
+      function () {
         this.spinner.succeed();
-      }
+      },
     ],
     "unbox:succeed": [
-      function({ boxConfig }) {
+      function ({ boxConfig }) {
         this.logger.log(`${OS.EOL}Unbox successful, sweet!${OS.EOL}`);
 
         const commandMessages = formatCommands(boxConfig.commands);
         if (commandMessages.length > 0) this.logger.log("Commands:" + OS.EOL);
 
-        commandMessages.forEach(message => this.logger.log(message));
+        commandMessages.forEach((message) => this.logger.log(message));
         this.logger.log("");
 
         if (boxConfig.epilogue) {
           this.logger.log(boxConfig.epilogue.replace("\n", OS.EOL));
         }
-      }
+      },
     ],
     "unbox:fail": [
-      function() {
+      function () {
         this.spinner.fail();
         this.logger.log("Unbox failed!");
-      }
-    ]
-  }
+      },
+    ],
+  },
 };

--- a/packages/truffle/test/scenarios/commands/init.js
+++ b/packages/truffle/test/scenarios/commands/init.js
@@ -11,7 +11,7 @@ describe("truffle init [ @standalone ]", () => {
     tempDir = tmp.dirSync({ unsafeCleanup: true });
     config = {
       working_directory: tempDir.name,
-      logger: { log: () => {} }
+      logger: { log: () => {} },
     };
   });
   afterEach(() => {
@@ -23,7 +23,7 @@ describe("truffle init [ @standalone ]", () => {
   }).timeout(30000);
 
   it("unboxes a project with a truffle config", async () => {
-    await CommandRunner.run("init", config);
+    await CommandRunner.run(`init ${tempDir.name}`, config);
     assert(fse.existsSync(path.join(tempDir.name, "truffle-config.js")));
   }).timeout(20000);
 

--- a/packages/truffle/test/scenarios/commands/unbox.js
+++ b/packages/truffle/test/scenarios/commands/unbox.js
@@ -67,26 +67,6 @@ describe("truffle unbox [ @standalone ]", () => {
         }).timeout(20000);
       });
 
-      describe("full url + branch + relativePath", () => {
-        it("unboxes successfully", async () => {
-          await CommandRunner.run(
-            "unbox https://github.com/truffle-box/bare-box#truffle-test-branch:path/to/subDir --force",
-            config
-          );
-          assert(
-            fse.existsSync(
-              path.join(
-                tempDir.name,
-                "path",
-                "to",
-                "subDir",
-                "truffle-config.js"
-              )
-            )
-          );
-        }).timeout(20000);
-      });
-
       describe("origin/master", () => {
         it("unboxes successfully", async () => {
           await CommandRunner.run("unbox truffle-box/bare-box", config);
@@ -101,26 +81,6 @@ describe("truffle unbox [ @standalone ]", () => {
             config
           );
           assert(fse.existsSync(path.join(tempDir.name, "truffle-config.js")));
-        }).timeout(20000);
-      });
-
-      describe("origin/master#branch:relativePath", () => {
-        it("unboxes successfully", async () => {
-          await CommandRunner.run(
-            "unbox truffle-box/bare-box#truffle-test-branch:path/to/subDir --force",
-            config
-          );
-          assert(
-            fse.existsSync(
-              path.join(
-                tempDir.name,
-                "path",
-                "to",
-                "subDir",
-                "truffle-config.js"
-              )
-            )
-          );
         }).timeout(20000);
       });
 
@@ -142,26 +102,6 @@ describe("truffle unbox [ @standalone ]", () => {
         it("unboxes successfully", async () => {
           await CommandRunner.run("unbox bare#truffle-test-branch", config);
           assert(fse.existsSync(path.join(tempDir.name, "truffle-config.js")));
-        }).timeout(20000);
-      });
-
-      describe("official truffle box + branch + relativePath", () => {
-        it("unboxes successfully", async () => {
-          await CommandRunner.run(
-            "unbox bare#truffle-test-branch:path/to/subDir --force",
-            config
-          );
-          assert(
-            fse.existsSync(
-              path.join(
-                tempDir.name,
-                "path",
-                "to",
-                "subDir",
-                "truffle-config.js"
-              )
-            )
-          );
         }).timeout(20000);
       });
 
@@ -196,26 +136,6 @@ describe("truffle unbox [ @standalone ]", () => {
             config
           );
           assert(fse.existsSync(path.join(tempDir.name, "truffle-config.js")));
-        }).timeout(20000);
-      });
-
-      describe("git@ ssh + branch + relativePath", () => {
-        it("unboxes successfully", async () => {
-          await CommandRunner.run(
-            "unbox git@github.com:truffle-box/bare-box#truffle-test-branch:path/to/subDir --force",
-            config
-          );
-          assert(
-            fse.existsSync(
-              path.join(
-                tempDir.name,
-                "path",
-                "to",
-                "subDir",
-                "truffle-config.js"
-              )
-            )
-          );
         }).timeout(20000);
       });
 
@@ -286,18 +206,6 @@ describe("truffle unbox [ @standalone ]", () => {
           } catch (error) {
             const output = logger.contents();
             assert(output.includes("doesn't exist."));
-          }
-        }).timeout(20000);
-      });
-
-      describe("absolutePaths", () => {
-        it("throws an error", async () => {
-          try {
-            await CommandRunner.run("unbox bare:/path/to/subDir", config);
-            assert(false, "This should have thrown an error.");
-          } catch (_error) {
-            const output = logger.contents();
-            assert(output.includes("not allowed!"));
           }
         }).timeout(20000);
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1082,6 +1082,11 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
   integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
 
+"@sindresorhus/is@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
+  integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
+
 "@sinonjs/commons@^1":
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.7.0.tgz#f90ffc52a2e519f018b13b6c4da03cbff36ebed6"
@@ -1922,11 +1927,6 @@ acorn@^7.0.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.0.tgz#949d36f2c292535da602283586c2477c57eb2d6c"
   integrity sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==
 
-adm-zip@~0.4.3:
-  version "0.4.13"
-  resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.4.13.tgz#597e2f8cc3672151e1307d3e95cddbc75672314a"
-  integrity sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw==
-
 aes-js@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-3.0.0.tgz#e21df10ad6c2053295bcbb8dab40b09dbea87e4d"
@@ -2178,6 +2178,13 @@ aproba@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-2.0.0.tgz#52520b8ae5b569215b354efc0caa3fe1e45a8adc"
   integrity sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==
+
+archive-type@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/archive-type/-/archive-type-4.0.0.tgz#f92e72233056dfc6969472749c267bdb046b1d70"
+  integrity sha1-+S5yIzBW38aWlHJ0nCZ72wRrHXA=
+  dependencies:
+    file-type "^4.2.0"
 
 archy@^1.0.0:
   version "1.0.0"
@@ -3575,6 +3582,19 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
+cacheable-request@^2.1.1:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-2.1.4.tgz#0d808801b6342ad33c91df9d0b44dc09b91e5c3d"
+  integrity sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=
+  dependencies:
+    clone-response "1.0.2"
+    get-stream "3.0.0"
+    http-cache-semantics "3.8.1"
+    keyv "3.0.0"
+    lowercase-keys "1.0.0"
+    normalize-url "2.0.1"
+    responselike "1.0.2"
+
 cacheable-request@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-6.1.0.tgz#20ffb8bd162ba4be11e9567d823db651052ca912"
@@ -3706,6 +3726,16 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
+
+caw@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/caw/-/caw-2.0.1.tgz#6c3ca071fc194720883c2dc5da9b074bfc7e9e95"
+  integrity sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==
+  dependencies:
+    get-proxy "^2.0.0"
+    isurl "^1.0.0-alpha5"
+    tunnel-agent "^0.6.0"
+    url-to-options "^1.0.1"
 
 center-align@^0.1.1:
   version "0.1.3"
@@ -4050,7 +4080,7 @@ clone-deep@^4.0.1:
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
 
-clone-response@^1.0.2:
+clone-response@1.0.2, clone-response@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/clone-response/-/clone-response-1.0.2.tgz#d1dc973920314df67fbeb94223b4ee350239e96b"
   integrity sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=
@@ -4313,7 +4343,7 @@ constants-browserify@^1.0.0, constants-browserify@~1.0.0:
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
   integrity sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=
 
-content-disposition@0.5.3:
+content-disposition@0.5.3, content-disposition@^0.5.2:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.3.tgz#e130caf7e7279087c5616c2007d0485698984fbd"
   integrity sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==
@@ -4824,6 +4854,20 @@ decompress@^4.0.0:
     pify "^2.3.0"
     strip-dirs "^2.0.0"
 
+decompress@^4.2.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/decompress/-/decompress-4.2.1.tgz#007f55cc6a62c055afa37c07eb6a4ee1b773f118"
+  integrity sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==
+  dependencies:
+    decompress-tar "^4.0.0"
+    decompress-tarbz2 "^4.0.0"
+    decompress-targz "^4.0.0"
+    decompress-unzip "^4.0.1"
+    graceful-fs "^4.1.10"
+    make-dir "^1.0.0"
+    pify "^2.3.0"
+    strip-dirs "^2.0.0"
+
 dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
@@ -5196,6 +5240,33 @@ dot-prop@^4.1.0, dot-prop@^4.2.0:
   integrity sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==
   dependencies:
     is-obj "^1.0.0"
+
+download-git-repo@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/download-git-repo/-/download-git-repo-3.0.2.tgz#8caae24fb2abd6453172deea5619036024f190f6"
+  integrity sha512-N8hWXD4hXqmEcNoR8TBYFntaOcYvEQ7Bz90mgm3bZRTuteGQqwT32VDMnTyD0KTEvb8BWrMc1tVmzuV9u/WrAg==
+  dependencies:
+    download "^7.1.0"
+    git-clone "^0.1.0"
+    rimraf "^3.0.0"
+
+download@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/download/-/download-7.1.0.tgz#9059aa9d70b503ee76a132897be6dec8e5587233"
+  integrity sha512-xqnBTVd/E+GxJVrX5/eUJiLYjCGPwMpdL+jGhGU57BvtcA7wwhtHVbXBeUk51kOpW3S7Jn3BQbN9Q1R1Km2qDQ==
+  dependencies:
+    archive-type "^4.0.0"
+    caw "^2.0.1"
+    content-disposition "^0.5.2"
+    decompress "^4.2.0"
+    ext-name "^5.0.0"
+    file-type "^8.1.0"
+    filenamify "^2.0.0"
+    get-stream "^3.0.0"
+    got "^8.3.1"
+    make-dir "^1.2.0"
+    p-event "^2.1.0"
+    pify "^3.0.0"
 
 drbg.js@^1.0.1:
   version "1.0.1"
@@ -6531,6 +6602,21 @@ express@^4.13.3, express@^4.14.0, express@^4.16.2, express@^4.16.3:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
+ext-list@^2.0.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/ext-list/-/ext-list-2.2.2.tgz#0b98e64ed82f5acf0f2931babf69212ef52ddd37"
+  integrity sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==
+  dependencies:
+    mime-db "^1.28.0"
+
+ext-name@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ext-name/-/ext-name-5.0.0.tgz#70781981d183ee15d13993c8822045c506c8f0a6"
+  integrity sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==
+  dependencies:
+    ext-list "^2.0.0"
+    sort-keys-length "^1.0.0"
+
 ext@^1.1.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ext/-/ext-1.4.0.tgz#89ae7a07158f79d35517882904324077e4379244"
@@ -6716,6 +6802,11 @@ file-type@^3.8.0:
   resolved "https://registry.yarnpkg.com/file-type/-/file-type-3.9.0.tgz#257a078384d1db8087bc449d107d52a52672b9e9"
   integrity sha1-JXoHg4TR24CHvESdEH1SpSZyuek=
 
+file-type@^4.2.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-4.4.0.tgz#1b600e5fca1fbdc6e80c0a70c71c8dba5f7906c5"
+  integrity sha1-G2AOX8ofvcboDApwxxyNul95BsU=
+
 file-type@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/file-type/-/file-type-5.2.0.tgz#2ddbea7c73ffe36368dfae49dc338c058c2b8ad6"
@@ -6726,6 +6817,11 @@ file-type@^6.1.0:
   resolved "https://registry.yarnpkg.com/file-type/-/file-type-6.2.0.tgz#e50cd75d356ffed4e306dc4f5bcf52a79903a919"
   integrity sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==
 
+file-type@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-8.1.0.tgz#244f3b7ef641bbe0cca196c7276e4b332399f68c"
+  integrity sha512-qyQ0pzAy78gVoJsmYeNgl8uH8yKhr1lVhW7JbzJmnlRi0I4R2eEDEJZVKG8agpDnLpacwNbDhLNG/LMdxHD2YQ==
+
 file-uri-to-path@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
@@ -6735,6 +6831,20 @@ filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
   integrity sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=
+
+filename-reserved-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz#abf73dfab735d045440abfea2d91f389ebbfa229"
+  integrity sha1-q/c9+rc10EVECr/qLZHzieu/oik=
+
+filenamify@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/filenamify/-/filenamify-2.1.0.tgz#88faf495fb1b47abfd612300002a16228c677ee9"
+  integrity sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==
+  dependencies:
+    filename-reserved-regex "^2.0.0"
+    strip-outer "^1.0.0"
+    trim-repeated "^1.0.0"
 
 filesize@^3.6.1:
   version "3.6.1"
@@ -7022,7 +7132,7 @@ fresh@0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
-from2@^2.1.0:
+from2@^2.1.0, from2@^2.1.1:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/from2/-/from2-2.3.0.tgz#8bfb5502bde4a4d36cfdeea007fcca21d7e382af"
   integrity sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=
@@ -7061,16 +7171,6 @@ fs-extra@6.0.1, fs-extra@^6.0.1:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
-
-fs-extra@^0.24.0:
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.24.0.tgz#d4e4342a96675cb7846633a6099249332b539952"
-  integrity sha1-1OQ0KpZnXLeEZjOmCZJJMytTmVI=
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^2.1.0"
-    path-is-absolute "^1.0.0"
-    rimraf "^2.2.8"
 
 fs-extra@^0.30.0:
   version "0.30.0"
@@ -7323,6 +7423,13 @@ get-port@^4.2.0:
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-4.2.0.tgz#e37368b1e863b7629c43c5a323625f95cf24b119"
   integrity sha512-/b3jarXkH8KJoOMQc3uVGHASwGLPq3gSFJ7tgJm2diza+bydJPTGOibin2steecKeOylE8oY2JERlVWkAJO6yw==
 
+get-proxy@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/get-proxy/-/get-proxy-2.1.0.tgz#349f2b4d91d44c4d4d4e9cba2ad90143fac5ef93"
+  integrity sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==
+  dependencies:
+    npm-conf "^1.1.0"
+
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
@@ -7333,6 +7440,11 @@ get-stdin@^6.0.0:
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
   integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
 
+get-stream@3.0.0, get-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+  integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
+
 get-stream@^2.2.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-2.3.1.tgz#5f38f93f346009666ee0150a054167f91bdd95de"
@@ -7340,11 +7452,6 @@ get-stream@^2.2.0:
   dependencies:
     object-assign "^4.0.1"
     pinkie-promise "^2.0.0"
-
-get-stream@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
-  integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
 
 get-stream@^4.0.0, get-stream@^4.1.0:
   version "4.1.0"
@@ -7376,6 +7483,11 @@ getport@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/getport/-/getport-0.1.0.tgz#abddf3d5d1e77dd967ccfa2b036a0a1fb26fd7f7"
   integrity sha1-q93z1dHnfdlnzPorA2oKH7Jv1/c=
+
+git-clone@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/git-clone/-/git-clone-0.1.0.tgz#0d76163778093aef7f1c30238f2a9ef3f07a2eb9"
+  integrity sha1-DXYWN3gJOu9/HDAjjyqe8/B6Lrk=
 
 git-raw-commits@2.0.0:
   version "2.0.0"
@@ -7425,16 +7537,6 @@ gitconfiglocal@^1.0.0:
   integrity sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=
   dependencies:
     ini "^1.3.2"
-
-github-download@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/github-download/-/github-download-0.5.0.tgz#f7647a70aac4326fb091e5786c8f66ae157da51b"
-  integrity sha1-92R6cKrEMm+wkeV4bI9mrhV9pRs=
-  dependencies:
-    adm-zip "~0.4.3"
-    fs-extra "^0.24.0"
-    request "^2.12.0"
-    vcsurl "~0.1.0"
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -7705,6 +7807,29 @@ got@^7.1.0:
     safe-buffer "^5.0.1"
     timed-out "^4.0.0"
     url-parse-lax "^1.0.0"
+    url-to-options "^1.0.1"
+
+got@^8.3.1:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/got/-/got-8.3.2.tgz#1d23f64390e97f776cac52e5b936e5f514d2e937"
+  integrity sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==
+  dependencies:
+    "@sindresorhus/is" "^0.7.0"
+    cacheable-request "^2.1.1"
+    decompress-response "^3.3.0"
+    duplexer3 "^0.1.4"
+    get-stream "^3.0.0"
+    into-stream "^3.1.0"
+    is-retry-allowed "^1.1.0"
+    isurl "^1.0.0-alpha5"
+    lowercase-keys "^1.0.0"
+    mimic-response "^1.0.0"
+    p-cancelable "^0.4.0"
+    p-timeout "^2.0.1"
+    pify "^3.0.0"
+    safe-buffer "^5.1.1"
+    timed-out "^4.0.1"
+    url-parse-lax "^3.0.0"
     url-to-options "^1.0.1"
 
 graceful-fs@4.X, graceful-fs@^4.0.0, graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.5, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.2:
@@ -8023,7 +8148,7 @@ htmlparser2@~3.8.1:
     entities "1.0"
     readable-stream "1.1"
 
-http-cache-semantics@^3.8.1:
+http-cache-semantics@3.8.1, http-cache-semantics@^3.8.1:
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz#39b0e16add9b605bf0a9ef3d9daaf4843b4cacd2"
   integrity sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==
@@ -8424,6 +8549,14 @@ interpret@1.2.0, interpret@^1.0.0, interpret@^1.0.1, interpret@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
   integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
+
+into-stream@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-3.1.0.tgz#96fb0a936c12babd6ff1752a17d05616abd094c6"
+  integrity sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=
+  dependencies:
+    from2 "^2.1.1"
+    p-is-promise "^1.1.0"
 
 invariant@^2.2.2:
   version "2.2.4"
@@ -8831,7 +8964,7 @@ is-relative@^1.0.0:
   dependencies:
     is-unc-path "^1.0.0"
 
-is-retry-allowed@^1.0.0:
+is-retry-allowed@^1.0.0, is-retry-allowed@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz#d778488bd0a4666a3be8a1482b9f2baafedea8b4"
   integrity sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==
@@ -9442,6 +9575,13 @@ keccakjs@^0.2.0:
   dependencies:
     browserify-sha3 "^0.0.4"
     sha3 "^1.2.2"
+
+keyv@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.0.0.tgz#44923ba39e68b12a7cec7df6c3268c031f2ef373"
+  integrity sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==
+  dependencies:
+    json-buffer "3.0.0"
 
 keyv@^3.0.0:
   version "3.1.0"
@@ -10257,6 +10397,11 @@ lower-case@^1.1.0, lower-case@^1.1.1, lower-case@^1.1.2:
   resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
   integrity sha1-miyr0bno4K6ZOkv31YdcOcQujqw=
 
+lowercase-keys@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
+  integrity sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=
+
 lowercase-keys@^1.0.0, lowercase-keys@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
@@ -10316,7 +10461,7 @@ macos-release@^2.2.0:
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.3.0.tgz#eb1930b036c0800adebccd5f17bc4c12de8bb71f"
   integrity sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA==
 
-make-dir@^1.0.0, make-dir@^1.3.0:
+make-dir@^1.0.0, make-dir@^1.2.0, make-dir@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
   integrity sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==
@@ -10708,6 +10853,11 @@ mime-db@1.42.0:
   version "1.42.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.42.0.tgz#3e252907b4c7adb906597b4b65636272cf9e7bac"
   integrity sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ==
+
+mime-db@^1.28.0:
+  version "1.44.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
+  integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
 
 mime-types@^2.1.12, mime-types@^2.1.16, mime-types@~2.1.19, mime-types@~2.1.24:
   version "2.1.25"
@@ -11338,6 +11488,15 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
+normalize-url@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-2.0.1.tgz#835a9da1551fa26f70e92329069a23aa6574d7e6"
+  integrity sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==
+  dependencies:
+    prepend-http "^2.0.0"
+    query-string "^5.0.1"
+    sort-keys "^2.0.0"
+
 normalize-url@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
@@ -11354,6 +11513,14 @@ npm-bundled@^1.0.1:
   integrity sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==
   dependencies:
     npm-normalize-package-bin "^1.0.1"
+
+npm-conf@^1.1.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/npm-conf/-/npm-conf-1.1.3.tgz#256cc47bd0e218c259c4e9550bf413bc2192aff9"
+  integrity sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==
+  dependencies:
+    config-chain "^1.1.11"
+    pify "^3.0.0"
 
 npm-lifecycle@^3.1.2:
   version "3.1.4"
@@ -11766,6 +11933,11 @@ p-cancelable@^0.3.0:
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-0.3.0.tgz#b9e123800bcebb7ac13a479be195b507b98d30fa"
   integrity sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==
 
+p-cancelable@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-0.4.1.tgz#35f363d67d52081c8d9585e37bcceb7e0bbcb2a0"
+  integrity sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==
+
 p-cancelable@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-1.1.0.tgz#d078d15a3af409220c886f1d9a0ca2e441ab26cc"
@@ -11776,10 +11948,22 @@ p-defer@^1.0.0:
   resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
   integrity sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=
 
+p-event@^2.1.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/p-event/-/p-event-2.3.1.tgz#596279ef169ab2c3e0cae88c1cfbb08079993ef6"
+  integrity sha512-NQCqOFhbpVTMX4qMe8PF8lbGtzZ+LCiN7pcNrb/413Na7+TRoe1xkKUzuWa/YEJdGQ0FvKtj35EEbDoVPO2kbA==
+  dependencies:
+    p-timeout "^2.0.1"
+
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
   integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
+
+p-is-promise@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-1.1.0.tgz#9c9456989e9f6588017b0434d56097675c3da05e"
+  integrity sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=
 
 p-is-promise@^2.0.0:
   version "2.1.0"
@@ -11866,6 +12050,13 @@ p-timeout@^1.1.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-1.2.1.tgz#5eb3b353b7fce99f101a1038880bb054ebbea386"
   integrity sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=
+  dependencies:
+    p-finally "^1.0.0"
+
+p-timeout@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-2.0.1.tgz#d8dd1979595d2dc0139e1fe46b8b646cb3cdf038"
+  integrity sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==
   dependencies:
     p-finally "^1.0.0"
 
@@ -13118,7 +13309,7 @@ request-promise@^4.2.2:
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-request@^2.12.0, request@^2.55.0, request@^2.79.0, request@^2.85.0, request@^2.87.0, request@^2.88.0:
+request@^2.55.0, request@^2.79.0, request@^2.85.0, request@^2.87.0, request@^2.88.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
@@ -13246,7 +13437,7 @@ resolve@~1.13.1:
   dependencies:
     path-parse "^1.0.6"
 
-responselike@^1.0.2:
+responselike@1.0.2, responselike@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/responselike/-/responselike-1.0.2.tgz#918720ef3b631c5642be068f15ade5a46f4ba1e7"
   integrity sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=
@@ -14053,6 +14244,20 @@ solc@^0.6.0:
     semver "^5.5.0"
     tmp "0.0.33"
 
+sort-keys-length@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/sort-keys-length/-/sort-keys-length-1.0.1.tgz#9cb6f4f4e9e48155a6aa0671edd336ff1479a188"
+  integrity sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=
+  dependencies:
+    sort-keys "^1.0.0"
+
+sort-keys@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-1.1.2.tgz#441b6d4d346798f1b4e49e8920adfba0e543f9ad"
+  integrity sha1-RBttTTRnmPG05J6JIK37oOVD+a0=
+  dependencies:
+    is-plain-obj "^1.0.0"
+
 sort-keys@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-2.0.0.tgz#658535584861ec97d730d6cf41822e1f56684128"
@@ -14538,6 +14743,13 @@ strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+
+strip-outer@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/strip-outer/-/strip-outer-1.0.1.tgz#b2fd2abf6604b9d1e6013057195df836b8a9d631"
+  integrity sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==
+  dependencies:
+    escape-string-regexp "^1.0.2"
 
 strong-log-transformer@^2.0.0:
   version "2.1.0"
@@ -15066,6 +15278,13 @@ trim-off-newlines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz#9f9ba9d9efa8764c387698bcbfeb2c848f11adb3"
   integrity sha1-n5up2e+odkw4dpi8v+sshI8RrbM=
 
+trim-repeated@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/trim-repeated/-/trim-repeated-1.0.0.tgz#e3646a2ea4e891312bf7eace6cfb05380bc01c21"
+  integrity sha1-42RqLqTokTEr9+rObPsFOAvAHCE=
+  dependencies:
+    escape-string-regexp "^1.0.2"
+
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
@@ -15305,11 +15524,6 @@ typescript@3.9.6:
   version "3.9.6"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.6.tgz#8f3e0198a34c3ae17091b35571d3afd31999365a"
   integrity sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==
-
-typescript@^3.8.3:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 typewise-core@^1.2, typewise-core@^1.2.0:
   version "1.2.0"
@@ -15691,7 +15905,7 @@ vary@^1, vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
-vcsurl@^0.1.1, vcsurl@~0.1.0:
+vcsurl@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/vcsurl/-/vcsurl-0.1.1.tgz#5e00a109e7381b55b5d45b892533c8ec35c9320c"
   integrity sha1-XgChCec4G1W11FuJJTPI7DXJMgw=


### PR DESCRIPTION
Recently there have been a number of errors related to downloading repos from github via the unbox and init command. A very short search suggested the possibility that these errors could be related to configuration of the library used to make http requests. Unfortunately, the `github-download` library is not super configurable and it has not been updated in 4 years. I found a different library that has much more activity (and has been much more recently updated) and so swapping it out seemed like it might be an easy shot at solving this problem. It also might just be good all around in general to update to a more relevant library.

A bunch of the URL validation/sanitization methods needed to be updated as the new library liked URLs of the format `https://github.com:trufflesuite/some-box` but not `https://github.com/trufflesuite/some-box` and not `git@github.com:trufflesuite/some-box`. In addition, it did not like the `.git` extension on the repo specifier and so a sanitization method for that needed to be included as well.