### PR TITLE
Fix some errors reported by xlab

### DIFF
--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -100,7 +100,19 @@ var DebugUtils = {
       return false;
     }
 
-    //check #2: are there any AST ID collisions?
+    //check #2: are source indices consecutive?
+    //(while nonconsecutivity should not be a problem by itself, this probably
+    //indicates a name collision of a sort that will be fatal for other
+    //reasons)
+    //NOTE: oddly, empty spots in an array will cause array.includes(undefined)
+    //to return true!  So I'm doing it this way even though it looks wrong
+    //(since the real concern is empty spots, not undefined, yet this turns
+    //this up anyhow)
+    if (compilation.sources.includes(undefined)) {
+      return false;
+    }
+
+    //check #3: are there any AST ID collisions?
     let astIds = new Set();
 
     let allIDsUnseenSoFar = node => {
@@ -121,8 +133,8 @@ var DebugUtils = {
     };
 
     //now: walk each AST
-    return compilation.sources.every(source =>
-      source ? allIDsUnseenSoFar(source.ast) : true
+    return compilation.sources.every(
+      source => (source ? allIDsUnseenSoFar(source.ast) : true)
     );
   },
 
@@ -591,8 +603,8 @@ var DebugUtils = {
           : "Error: Revert or exceptional halt"
       );
     }
-    let indented = lines.map((line, index) =>
-      index === 0 ? line : " ".repeat(indent) + line
+    let indented = lines.map(
+      (line, index) => (index === 0 ? line : " ".repeat(indent) + line)
     );
     return indented.join(OS.EOL);
   },
@@ -743,8 +755,9 @@ var DebugUtils = {
   cleanThis: function(variables, replacement) {
     return Object.assign(
       {},
-      ...Object.entries(variables).map(([variable, value]) =>
-        variable === "this" ? { [replacement]: value } : { [variable]: value }
+      ...Object.entries(variables).map(
+        ([variable, value]) =>
+          variable === "this" ? { [replacement]: value } : { [variable]: value }
       )
     );
   }

--- a/packages/debugger/lib/ast/sagas/index.js
+++ b/packages/debugger/lib/ast/sagas/index.js
@@ -10,7 +10,7 @@ import ast from "../selectors";
 import flatten from "lodash.flatten";
 
 function* walk(compilationId, sourceId, node, pointer = "", parentId = null) {
-  debug("walking %o %o", pointer, node);
+  debug("walking %d %o %o", sourceId, pointer, node);
 
   yield* handleEnter(compilationId, sourceId, node, pointer, parentId);
 
@@ -42,11 +42,11 @@ function* walk(compilationId, sourceId, node, pointer = "", parentId = null) {
 }
 
 function* handleEnter(compilationId, sourceId, node, pointer, parentId) {
+  debug("entering %d %s", sourceId, pointer);
+
   if (!(node instanceof Object)) {
     return;
   }
-
-  debug("entering %s", pointer);
 
   if (node.id !== undefined) {
     debug("%s recording scope %s", pointer, node.id);
@@ -61,20 +61,22 @@ function* handleEnter(compilationId, sourceId, node, pointer, parentId) {
     case "ContractDefinition":
     case "StructDefinition":
     case "EnumDefinition":
+      debug("%s recording type %o", pointer, node);
       yield* data.defineType(node, compilationId);
       break;
   }
 }
 
 function* handleExit(compilationId, sourceId, node, pointer) {
-  debug("exiting %s", pointer);
+  if (mystery.has(sourceId) && pointer.includes("AST")) {
+    debug("exiting %d %s", sourceId, pointer);
+  }
 
   // no-op right now
 }
 
 export function* visitAll() {
   let compilations = yield select(ast.views.sources);
-  debug("compilations: %O", compilations);
 
   let sources = flatten(
     Object.values(compilations).map(({ byId }) => byId)

--- a/packages/debugger/lib/ast/sagas/index.js
+++ b/packages/debugger/lib/ast/sagas/index.js
@@ -16,25 +16,11 @@ function* walk(compilationId, sourceId, node, pointer = "", parentId = null) {
 
   if (node instanceof Array) {
     for (let [i, child] of node.entries()) {
-      yield call(
-        walk,
-        compilationId,
-        sourceId,
-        child,
-        `${pointer}/${i}`,
-        parentId
-      );
+      yield* walk(compilationId, sourceId, child, `${pointer}/${i}`, parentId);
     }
   } else if (node instanceof Object) {
     for (let [key, child] of Object.entries(node)) {
-      yield call(
-        walk,
-        compilationId,
-        sourceId,
-        child,
-        `${pointer}/${key}`,
-        node.id
-      );
+      yield* walk(compilationId, sourceId, child, `${pointer}/${key}`, node.id);
     }
   }
 
@@ -68,9 +54,7 @@ function* handleEnter(compilationId, sourceId, node, pointer, parentId) {
 }
 
 function* handleExit(compilationId, sourceId, node, pointer) {
-  if (mystery.has(sourceId) && pointer.includes("AST")) {
-    debug("exiting %d %s", sourceId, pointer);
-  }
+  debug("exiting %d %s", sourceId, pointer);
 
   // no-op right now
 }

--- a/packages/debugger/lib/session/index.js
+++ b/packages/debugger/lib/session/index.js
@@ -120,7 +120,6 @@ export default class Session {
       let compiler = compilation.compiler; //note: we'll prefer one listed on contract or source
       sources[compilation.id] = [];
       for (let index in compilation.sources) {
-        debug("adding index: %d", index);
         //not the recommended way to iterate over an array,
         //but the order doesn't matter here so it's safe
         let source = compilation.sources[index];
@@ -135,7 +134,6 @@ export default class Session {
         };
       }
 
-      debug("sources: %o", sources[compilation.id]);
       for (let contract of compilation.contracts) {
         let {
           contractName,
@@ -161,7 +159,7 @@ export default class Session {
         if (primarySourceId !== undefined) {
           //I'm assuming this finds it! it had better!
           primarySourceIndex = compilation.sources.findIndex(
-            source => source.id === primarySourceId
+            source => source && source.id === primarySourceId
           );
         }
         //otherwise leave it undefined

--- a/packages/solidity-utils/index.js
+++ b/packages/solidity-utils/index.js
@@ -210,6 +210,10 @@ var SolidityUtils = {
           let sourceId = instruction.file;
           let findOverlappingRange = overlapFunctions[sourceId];
           let ast = asts[sourceId];
+          if (!ast) {
+            //if we can't get the ast... filter it out I guess
+            return {};
+          }
           let range = SolidityUtils.getSourceRange(instruction);
           let { node, pointer } = SolidityUtils.findRange(
             findOverlappingRange,


### PR DESCRIPTION
This PR fixes some problems reported by @xlab in #2977.

The first of these is that having nonconsecutive sources can crash the debugger.  I fixed both the part that xlab pointed out, and another point in the code I found that could have trouble on nonconsecutive sources (hopefully these were indeed the only such spots).

The second of these is a bit more mysterious: If the check that xlab pointed out was fixed, the debugger would hang on startup.  On investigation, I determined that there were two particular ASTs that would never finish walking.  I was unable to determine any reason for this.  However, I replaced the uses of `yield call(walk, ...)` in the AST saga with a simple `yield* walk(...)`, and this somehow caused the problem to go away.   (No, we're not somehow losing parallelism here; `yield call` is completely synchronous.)  I have no idea why; some sort of weird redux-saga internal thing got overloaded from all the effects, maybe?  IDK.  But this fixed the problem, so, uh, I'm sticking with it.

Finally, I altered the CLI logic to force a recompile if source indices are not consecutive.  Now, you may recall that the first commit in this PR fixes problems caused by nonconsecutive indices, so why do this?  Because nonconsecutive sources, while they should no longer *cause* a problem, still *indicate* a problem.  In the case of xlab's repo, the nonconsecutivity was due to name collisions, which Truffle infamously can't really handle.  Or at least, Truffle's *artifacts* can't handle this, but the raw compiler output can, so by forcing a recompile we avoid the problem.  (At the cost of a lot of time.)