### PR TITLE
Internal improvement: Revert try/catch thing that was useless

### DIFF
--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -1333,7 +1333,7 @@ export class ContractInstanceDecoder {
    * See the documentation of the [[DecodedVariable]] type for more.
    *
    * Note that variable decoding can only operate in full mode; if the decoder wasn't able to
-   * start up in full mode, this method will throw an exception.
+   * start up in full mode, this method will throw a [[ContractAllocationFailedError]].
    *
    * Note that decoding mappings requires first watching mapping keys in order to get any results;
    * see the documentation for [[watchMappingKey]].

--- a/packages/decoder/lib/index.ts
+++ b/packages/decoder/lib/index.ts
@@ -174,13 +174,7 @@ import { ContractConstructorObject, ContractInstanceObject } from "./types";
 
 import { Compilations } from "@truffle/codec";
 
-let fs: any; //sorry
-try {
-  fs = require("fs"); //if this fails (say, in a web context)... then whatever! too bad!
-  //(sorry about the resulting untyped import :-/)
-} catch (_) {
-  //no alternative, just let fs be undefined
-}
+import fs from "fs";
 import path from "path";
 
 /**
@@ -465,10 +459,8 @@ function infoToCompilations(
       if (projectInfo.config.contracts_build_directory !== undefined) {
         let files = fs
           .readdirSync(projectInfo.config.contracts_build_directory)
-          .filter((file: any) => path.extname(file) === ".json"); //sorry about the any, I had to import fs untyped
-        let data: string[] = files.map((
-          file: any //same :-/
-        ) =>
+          .filter(file => path.extname(file) === ".json");
+        let data = files.map(file =>
           fs.readFileSync(
             path.join(projectInfo.config.contracts_build_directory, file),
             "utf8"


### PR DESCRIPTION
This PR reverts the try/catch added in #2975 since that turned out not to be the problem.

Also I added some additional specificity to the `variables()` documentation regarding what error it throws.