### PR TITLE
Update repl.js improve readability & performance

### DIFF
--- a/packages/core/lib/repl.js
+++ b/packages/core/lib/repl.js
@@ -1,6 +1,5 @@
 var repl = require("repl");
 var expect = require("@truffle/expect");
-var async = require("async");
 var EventEmitter = require("events");
 var inherits = require("util").inherits;
 
@@ -45,20 +44,19 @@ ReplManager.prototype.start = function(options) {
       eval: this.interpret.bind(this)
     });
 
-    this.repl.on("exit", function() {
+    this.repl.on("exit", async function() {
       // If we exit for some reason, call done functions for good measure
       // then ensure the process is completely killed. Once the repl exits,
       // the process is in a bad state and can't be recovered (e.g., stdin is closed).
-      var doneFunctions = self.contexts.map(function(context) {
-        return context.done
-          ? function() {
-              context.done();
-            }
-          : function() {};
-      });
-      async.series(doneFunctions, function() {
+      try {
+        for (const context of self.contexts) {
+          if (context.done) await context.done();
+        }
+      } catch (error) {
+        console.log(error);
+      } finally {
         process.exit();
-      });
+      }
     });
   }
 

--- a/packages/core/lib/repl.js
+++ b/packages/core/lib/repl.js
@@ -53,7 +53,7 @@ ReplManager.prototype.start = function(options) {
           if (context.done) await context.done();
         }
       } catch (error) {
-        console.log(error);
+        throw error;
       } finally {
         process.exit();
       }


### PR DESCRIPTION
No need to run noop functions.  We can also safely eliminate the `async` dependency if we just loop through and await each done function in a try/catch, finally we can `process.exit();`.

Attempt 2..

I also thought about
```javascript
self.contexts.reduce((prev, context) => {
  return context.done ? prev.then(() => context.done()) : prev;
}, Promise.resolve()).finally(process.exit());
```
But I think the `for..of` is more readable.