### PR TITLE
Bug fix: Fix message displayed in stacktrace on selfdestruct

### DIFF
--- a/packages/core/lib/commands/test/index.js
+++ b/packages/core/lib/commands/test/index.js
@@ -92,7 +92,7 @@ const command = {
         description:
           "Allows for mixed JS/Solidity stacktraces when a Truffle Contract transaction " +
           "or deployment\n                    reverts.  Does not apply to calls or gas estimates.  " +
-          "Implies --compile-all."
+          "Implies --compile-all.  Experimental."
       },
       {
         option: "--stacktrace-extra",

--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -133,8 +133,8 @@ var DebugUtils = {
     };
 
     //now: walk each AST
-    return compilation.sources.every(
-      source => (source ? allIDsUnseenSoFar(source.ast) : true)
+    return compilation.sources.every(source =>
+      source ? allIDsUnseenSoFar(source.ast) : true
     );
   },
 
@@ -601,15 +601,15 @@ var DebugUtils = {
       lines.unshift(
         status
           ? message !== undefined
-            ? "Error: Improper return (may be an unexpected self-destruct)"
-            : `Error: Improper return (caused message: ${message})`
+            ? `Error: Improper return (caused message: ${message})`
+            : "Error: Improper return (may be an unexpected self-destruct)"
           : message !== undefined
-            ? `Error: Revert (message: ${message})`
-            : "Error: Revert or exceptional halt"
+          ? `Error: Revert (message: ${message})`
+          : "Error: Revert or exceptional halt"
       );
     }
-    let indented = lines.map(
-      (line, index) => (index === 0 ? line : " ".repeat(indent) + line)
+    let indented = lines.map((line, index) =>
+      index === 0 ? line : " ".repeat(indent) + line
     );
     return indented.join(OS.EOL);
   },
@@ -760,9 +760,8 @@ var DebugUtils = {
   cleanThis: function(variables, replacement) {
     return Object.assign(
       {},
-      ...Object.entries(variables).map(
-        ([variable, value]) =>
-          variable === "this" ? { [replacement]: value } : { [variable]: value }
+      ...Object.entries(variables).map(([variable, value]) =>
+        variable === "this" ? { [replacement]: value } : { [variable]: value }
       )
     );
   }


### PR DESCRIPTION
In the recent PR to put stacktraces in test (#3005), I accidentally got the branches of the ternary mixed up regarding what message to display on a selfdestruct.  This PR fixes that.  Oops!