### PR TITLE
Internal improvement: Speed up webpack build

### DIFF
--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "analyze": "./scripts/analyze.sh",
     "build": "yarn build-cli",
-    "build-cli": "NODE_OPTIONS='--max-old-space-size=4096' webpack --config ./webpack.config.js",
+    "build-cli": "webpack --config ./webpack.config.js",
     "postinstall": "node ./scripts/postinstall.js",
     "prepare": "yarn build",
     "publish:byoc": "node ./scripts/prereleaseVersion.js byoc-safe byoc",

--- a/packages/truffle/webpack.config.js
+++ b/packages/truffle/webpack.config.js
@@ -56,7 +56,12 @@ module.exports = {
     library: "",
     libraryTarget: "commonjs"
   },
-  devtool: "eval",
+  devtool: "source-map",
+
+  optimization: {
+    minimize: false
+  },
+
   module: {
     rules: [
       // ignores "#!/bin..." lines inside files

--- a/packages/truffle/webpack.config.js
+++ b/packages/truffle/webpack.config.js
@@ -7,6 +7,7 @@ const rootDir = path.join(__dirname, "../..");
 const outputDir = path.join(__dirname, "build");
 
 module.exports = {
+  mode: "production",
   entry: {
     cli: path.join(
       __dirname,
@@ -55,8 +56,7 @@ module.exports = {
     library: "",
     libraryTarget: "commonjs"
   },
-  devtool: "source-map",
-
+  devtool: "eval",
   module: {
     rules: [
       // ignores "#!/bin..." lines inside files
@@ -78,6 +78,26 @@ module.exports = {
     /^original-require$/,
     /^mocha$/
   ],
+
+  resolve: {
+    alias: {
+      "ws": path.join(__dirname, "./nil.js"),
+      "bn.js": path.join(
+        __dirname,
+        "../..",
+        "node_modules",
+        "bn.js",
+        "lib",
+        "bn.js"
+      ),
+      "original-fs": path.join(__dirname, "./nil.js"),
+      "scrypt": "js-scrypt"
+    }
+  },
+
+  stats: {
+    warnings: false
+  },
 
   plugins: [
     new webpack.DefinePlugin({
@@ -288,25 +308,5 @@ module.exports = {
 
     // Make web3 1.0 packable
     new webpack.IgnorePlugin(/^electron$/)
-  ],
-
-  resolve: {
-    alias: {
-      "ws": path.join(__dirname, "./nil.js"),
-      "bn.js": path.join(
-        __dirname,
-        "../..",
-        "node_modules",
-        "bn.js",
-        "lib",
-        "bn.js"
-      ),
-      "original-fs": path.join(__dirname, "./nil.js"),
-      "scrypt": "js-scrypt"
-    }
-  },
-
-  stats: {
-    warnings: false
-  }
+  ]
 };


### PR DESCRIPTION
Add 'mode' property to webpack config ~edit 'devtool' property for faster builds, and change the build script to not allocate extra memory for building as it is no longer needed with the updated 'devtool' setting~ and turn off minification to speed up the build.