### PR TITLE
Throw an error when web3-provider-engine fails to start

### DIFF
--- a/packages/hdwallet-provider/src/index.ts
+++ b/packages/hdwallet-provider/src/index.ts
@@ -183,7 +183,11 @@ class HDWalletProvider {
     } else {
       this.engine.addProvider(new ProviderSubprovider(provider));
     }
-    this.engine.start(); // Required by the provider engine.
+
+    // Required by the provider engine.
+    this.engine.start(err => {
+      if (err) throw err;
+    });
   }
 
   public send(

--- a/packages/hdwallet-provider/typings/web3-provider-engine/index.d.ts
+++ b/packages/hdwallet-provider/typings/web3-provider-engine/index.d.ts
@@ -23,7 +23,7 @@ declare class Web3ProviderEngine implements Provider {
   ): void;
   addProvider(provider: any): void;
   // start block polling
-  start(callback?: () => void): void;
+  start(callback?: (error?: Error) => void): void;
   // stop block polling
   stop(): void;
 }


### PR DESCRIPTION
Fixes https://github.com/trufflesuite/truffle/issues/2655

Previously, the node process would just exit silently. This would happen for example if you used an invalid API key (example below).

```js
const provider = new HDWalletProvider(
  'abc',
  `https://rinkeby.infura.io/v3/FAKE_API_KEY`
);
console.log('sending...');
provider.sendAsync({ jsonrpc: '2.0', id: 1, method: 'net_version', params: [] }, (err, res) => {
  // never called
  console.log('response', err, res);
});
```

This commit adds a missing callback to throw an error when the 'web3-provider-engine fails' to start the 'eth-block-tracker'.