### PR TITLE
Bug fix: Fix file extension check in console startup

### DIFF
--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -101,7 +101,7 @@ class Console extends EventEmitter {
       const unfilteredFiles = fse.readdirSync(
         this.options.contracts_build_directory
       );
-      files = unfilteredFiles.filter(file => file.match(".json") !== null);
+      files = unfilteredFiles.filter(file => file.endsWith(".json"));
     } catch (error) {
       // Error reading the build directory? Must mean it doesn't exist or we don't have access to it.
       // Couldn't provision the contracts if we wanted. It's possible we're hiding very rare FS


### PR DESCRIPTION
The console on startup would look for artifacts that contained `.json` in the file name.  I've changed it to look for ones that end in `.json`.  This avoids it from picking up, say, Vim swapfiles.