### PR TITLE
Bug fix: Add missing dependency to @truffle/contract

### DIFF
--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -24,6 +24,7 @@
     "@truffle/contract-schema": "^3.1.0",
     "@truffle/error": "^0.0.8",
     "@truffle/interface-adapter": "^0.4.6",
+    "@truffle/debug-utils": "^4.1.1",
     "bignumber.js": "^7.2.1",
     "ethereum-ens": "^0.8.0",
     "ethers": "^4.0.0-beta.1",


### PR DESCRIPTION
As mentioned in #3024, it looks like `@truffle/debug-utils` is missing from `@truffle/contract`'s `package.json`.