### PR TITLE
Bug fix: Fix (?) command in debugger

### DIFF
--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -200,9 +200,9 @@ class DebugPrinter {
     }
 
     this.config.logger.log("");
-    expressions.forEach(function(expression) {
+    for (const expression of expressions) {
       this.config.logger.log("  " + expression);
-    });
+    }
   }
 
   printBreakpoints() {


### PR DESCRIPTION
The `?` command was broken if any watch expression were set due to the use of a non-lambda function.  Rather than switch to a lambda expression, I switched the `forEach` to a simple loop.  Now it works!