### PR TITLE
Avoid setting debugger: undefined on contract instances

### DIFF
--- a/packages/contract/lib/contract/index.js
+++ b/packages/contract/lib/contract/index.js
@@ -33,7 +33,9 @@ if (typeof Web3 === "object" && Object.keys(Web3).length === 0) {
     instance.contract = contract;
 
     //for stacktracing in tests
-    instance.debugger = constructor.debugger;
+    if (constructor.debugger) {
+      instance.debugger = constructor.debugger;
+    }
 
     // User defined methods, overloaded methods, events
     instance.abi.forEach(function(item) {


### PR DESCRIPTION
My `debugger` hack to make stacktraces work was causing contract instances to have a `debugger: undefined` field.  That's obviously pretty icky.  So, uh, making sure that's only set when `--stacktrace` is on.