### PR TITLE
Remove redundant join/split

### DIFF
--- a/packages/core/lib/testing/testrunner.js
+++ b/packages/core/lib/testing/testrunner.js
@@ -104,15 +104,16 @@ TestRunner.prototype.endTest = async function(mocha) {
     return;
   }
 
-  function indent(unindented, indentation, initialPrefix = "") {
-    return unindented
-      .split("\n")
-      .map((line, index) =>
-        index === 0
-          ? initialPrefix + " ".repeat(indentation - initialPrefix) + line
-          : " ".repeat(indentation) + line
+  function indent(unindented, indentation, initialPrefix = "", split = "\n") {
+    const dedent = split === "\n" ? unindented.split(split) : unindented;
+    return dedent
+      .map(
+        (line, index) =>
+          index === 0
+            ? initialPrefix + " ".repeat(indentation - initialPrefix) + line
+            : " ".repeat(indentation) + line
       )
-      .join("\n");
+      .join(split);
   }
 
   function printEvent(decoding, indentation = 0, initialPrefix = "") {
@@ -122,28 +123,26 @@ TestRunner.prototype.endTest = async function(mocha) {
       : decoding.class.typeName;
     const eventName = decoding.abi.name;
     const fullEventName = anonymousPrefix + `${className}.${eventName}`;
-    const eventArgs = decoding.arguments
-      .map(({ name, indexed, value }) => {
-        let namePrefix = name ? `${name}: ` : "";
-        let indexedPrefix = indexed ? "<indexed> " : "";
-        let displayValue = util.inspect(
-          new Codec.Format.Utils.Inspect.ResultInspector(value),
-          {
-            depth: null,
-            colors: true,
-            maxArrayLength: null,
-            breakLength: 80 - indentation //should this include prefix lengths as well?
-          }
-        );
-        let typeString = ` (type: ${Codec.Format.Types.typeStringWithoutLocation(
-          value.type
-        )})`;
-        return namePrefix + indexedPrefix + displayValue + typeString;
-      })
-      .join(",\n");
+    const eventArgs = decoding.arguments.map(({ name, indexed, value }) => {
+      let namePrefix = name ? `${name}: ` : "";
+      let indexedPrefix = indexed ? "<indexed> " : "";
+      let displayValue = util.inspect(
+        new Codec.Format.Utils.Inspect.ResultInspector(value),
+        {
+          depth: null,
+          colors: true,
+          maxArrayLength: null,
+          breakLength: 80 - indentation //should this include prefix lengths as well?
+        }
+      );
+      let typeString = ` (type: ${Codec.Format.Types.typeStringWithoutLocation(
+        value.type
+      )})`;
+      return namePrefix + indexedPrefix + displayValue + typeString;
+    });
     if (decoding.arguments.length > 0) {
       return indent(
-        `${fullEventName}(\n${indent(eventArgs, 2)}\n)`,
+        `${fullEventName}(\n${indent(eventArgs, 2, "", ",\n")}\n)`,
         indentation,
         initialPrefix
       );

--- a/packages/core/lib/testing/testrunner.js
+++ b/packages/core/lib/testing/testrunner.js
@@ -104,11 +104,8 @@ TestRunner.prototype.endTest = async function(mocha) {
     return;
   }
 
-  function indent(input, indentation, initialPrefix = "", delimiter = "\n") {
-    // Note: delimiter is used to `split` only when input is a string.
-    // However, It is always used to `join`.
-    const unindented =
-      typeof input === "string" ? input.split(delimiter) : input;
+  function indent(input, indentation, initialPrefix = "") {
+    const unindented = typeof input === "string" ? input.split("\n") : input;
     return unindented
       .map(
         (line, index) =>
@@ -116,7 +113,7 @@ TestRunner.prototype.endTest = async function(mocha) {
             ? initialPrefix + " ".repeat(indentation - initialPrefix) + line
             : " ".repeat(indentation) + line
       )
-      .join(delimiter);
+      .join("\n");
   }
 
   function printEvent(decoding, indentation = 0, initialPrefix = "") {
@@ -141,11 +138,15 @@ TestRunner.prototype.endTest = async function(mocha) {
       let typeString = ` (type: ${Codec.Format.Types.typeStringWithoutLocation(
         value.type
       )})`;
-      return namePrefix + indexedPrefix + displayValue + typeString;
+      return namePrefix + indexedPrefix + displayValue + typeString + ",";
     });
+    {
+      const len = eventArgs.length - 1;
+      eventArgs[len] = eventArgs[len].slice(0, -1); // remove the final comma
+    }
     if (decoding.arguments.length > 0) {
       return indent(
-        `${fullEventName}(\n${indent(eventArgs, 2, "", ",\n")}\n)`,
+        `${fullEventName}(\n${indent(eventArgs, 2)}\n)`,
         indentation,
         initialPrefix
       );

--- a/packages/core/lib/testing/testrunner.js
+++ b/packages/core/lib/testing/testrunner.js
@@ -104,16 +104,19 @@ TestRunner.prototype.endTest = async function(mocha) {
     return;
   }
 
-  function indent(unindented, indentation, initialPrefix = "", split = "\n") {
-    const dedent = split === "\n" ? unindented.split(split) : unindented;
-    return dedent
+  function indent(input, indentation, initialPrefix = "", delimiter = "\n") {
+    // Note: delimiter is used to `split` only when input is a string.
+    // However, It is always used to `join`.
+    const unindented =
+      typeof input === "string" ? input.split(delimiter) : input;
+    return unindented
       .map(
         (line, index) =>
           index === 0
             ? initialPrefix + " ".repeat(indentation - initialPrefix) + line
             : " ".repeat(indentation) + line
       )
-      .join(split);
+      .join(delimiter);
   }
 
   function printEvent(decoding, indentation = 0, initialPrefix = "") {


### PR DESCRIPTION
I don't know how often this code runs.  Seems unnecessary to
`.join` on line 142 only to split and rejoin again in `indent`.

`indent` now checks for the default case and should behave as before.
If the `split` is not default it will treat unindented as an array.
It will then rejoin with the `split` parameter.