### PR TITLE
Dependency update: Update reselect-tree version

### DIFF
--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -35,7 +35,7 @@
     "redux-cli-logger": "^2.0.1",
     "redux-saga": "1.0.0",
     "remote-redux-devtools": "^0.5.12",
-    "reselect-tree": "^1.3.2",
+    "reselect-tree": "^1.3.3",
     "semver": "^6.3.0",
     "source-map-support": "^0.5.16",
     "web3": "1.2.1",

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -35,7 +35,7 @@
     "redux-cli-logger": "^2.0.1",
     "redux-saga": "1.0.0",
     "remote-redux-devtools": "^0.5.12",
-    "reselect-tree": "^1.3.1",
+    "reselect-tree": "^1.3.2",
     "semver": "^6.3.0",
     "source-map-support": "^0.5.16",
     "web3": "1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13140,10 +13140,10 @@ require-nocache@^1.0.0:
   resolved "https://registry.yarnpkg.com/require-nocache/-/require-nocache-1.0.0.tgz#a665d0b60a07e8249875790a4d350219d3c85fa3"
   integrity sha1-pmXQtgoH6CSYdXkKTTUCGdPIX6M=
 
-reselect-tree@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/reselect-tree/-/reselect-tree-1.3.2.tgz#f7a6a16e37ae7f81819206db639ac5233ef6f671"
-  integrity sha512-rloHBlvfEtZRc/ziNrxzMtsT/FDVmGaAdQDTDPLqygPG9T0XisFTZU5EKWq0lSVP/31GU2g5buBWZWOSBB3SCg==
+reselect-tree@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/reselect-tree/-/reselect-tree-1.3.3.tgz#999f5fd7167d0d2610d5e48dcf8a7c03b28d159a"
+  integrity sha512-sG5sRWghWuWx+E2GolRZIGTVVNkMMvJpjI36gQYSOEtwca11mHtfZre6A6HNztxQcZCYdIwOB6qXt7HrAHrx0w==
   dependencies:
     debug "^3.1.0"
     esdoc "^1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13140,10 +13140,10 @@ require-nocache@^1.0.0:
   resolved "https://registry.yarnpkg.com/require-nocache/-/require-nocache-1.0.0.tgz#a665d0b60a07e8249875790a4d350219d3c85fa3"
   integrity sha1-pmXQtgoH6CSYdXkKTTUCGdPIX6M=
 
-reselect-tree@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/reselect-tree/-/reselect-tree-1.3.1.tgz#e721f4c110d0e3d50edf24f0347e9e85e7d3c617"
-  integrity sha512-odL2qQPc5Wu5fGLH0zAWn3vLh9IOvrWEckvQL/mDiKAV48t3mpsTYbIZsNcu0CcVYAvkDxvcMvRB+19TOgyODg==
+reselect-tree@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/reselect-tree/-/reselect-tree-1.3.2.tgz#f7a6a16e37ae7f81819206db639ac5233ef6f671"
+  integrity sha512-rloHBlvfEtZRc/ziNrxzMtsT/FDVmGaAdQDTDPLqygPG9T0XisFTZU5EKWq0lSVP/31GU2g5buBWZWOSBB3SCg==
   dependencies:
     debug "^3.1.0"
     esdoc "^1.0.4"


### PR DESCRIPTION
Updating the reselect-tree version in the debugger to avoid problems with web.