### PR TITLE
Dependency update: Update source-map-support version

### DIFF
--- a/packages/artifactor/package.json
+++ b/packages/artifactor/package.json
@@ -17,7 +17,7 @@
     "fs-extra": "^8.1.0",
     "lodash.assign": "^4.2.0",
     "lodash.merge": "^4.6.2",
-    "source-map-support": "^0.5.16"
+    "source-map-support": "^0.5.19"
   },
   "devDependencies": {
     "@truffle/contract": "^4.2.3",

--- a/packages/blockchain-utils/package.json
+++ b/packages/blockchain-utils/package.json
@@ -34,6 +34,6 @@
     "access": "public"
   },
   "dependencies": {
-    "source-map-support": "^0.5.16"
+    "source-map-support": "^0.5.19"
   }
 }

--- a/packages/box/package.json
+++ b/packages/box/package.json
@@ -19,7 +19,7 @@
     "inquirer": "^7.0.0",
     "request": "^2.85.0",
     "request-promise-native": "^1.0.7",
-    "source-map-support": "^0.5.16",
+    "source-map-support": "^0.5.19",
     "tmp": "0.0.33",
     "vcsurl": "^0.1.1"
   },

--- a/packages/code-utils/package.json
+++ b/packages/code-utils/package.json
@@ -23,6 +23,6 @@
     "access": "public"
   },
   "dependencies": {
-    "source-map-support": "^0.5.16"
+    "source-map-support": "^0.5.19"
   }
 }

--- a/packages/codec/package.json
+++ b/packages/codec/package.json
@@ -60,7 +60,7 @@
     "lodash.partition": "^4.6.0",
     "lodash.sum": "^4.0.2",
     "semver": "^6.3.0",
-    "source-map-support": "^0.5.16",
+    "source-map-support": "^0.5.19",
     "utf8": "^3.0.0",
     "web3-utils": "1.2.1"
   },

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -43,7 +43,7 @@
     "lodash.merge": "^4.6.2",
     "module": "^1.2.5",
     "original-require": "1.0.1",
-    "source-map-support": "^0.5.16"
+    "source-map-support": "^0.5.19"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -29,7 +29,7 @@
     "ethereum-ens": "^0.8.0",
     "ethers": "^4.0.0-beta.1",
     "exorcist": "^1.0.1",
-    "source-map-support": "^0.5.16",
+    "source-map-support": "^0.5.19",
     "web3": "1.2.1",
     "web3-core-helpers": "1.2.1",
     "web3-core-promievent": "1.2.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -62,7 +62,7 @@
     "safe-eval": "^0.4.1",
     "sane": "^4.0.2",
     "semver": "^6.3.0",
-    "source-map-support": "^0.5.16",
+    "source-map-support": "^0.5.19",
     "spawn-args": "^0.1.0",
     "temp": "^0.8.3",
     "universal-analytics": "^0.4.17",

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -37,7 +37,7 @@
     "remote-redux-devtools": "^0.5.12",
     "reselect-tree": "^1.3.1",
     "semver": "^6.3.0",
-    "source-map-support": "^0.5.16",
+    "source-map-support": "^0.5.19",
     "web3": "1.2.1",
     "web3-eth-abi": "1.2.1"
   },

--- a/packages/decoder/package.json
+++ b/packages/decoder/package.json
@@ -19,7 +19,7 @@
     "@truffle/solidity-utils": "^1.3.4",
     "bn.js": "^4.11.8",
     "debug": "^4.1.0",
-    "source-map-support": "^0.5.16",
+    "source-map-support": "^0.5.19",
     "web3": "1.2.1"
   },
   "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/codec",

--- a/packages/environment/package.json
+++ b/packages/environment/package.json
@@ -19,7 +19,7 @@
     "@truffle/resolver": "^5.1.12",
     "ganache-core": "2.10.2",
     "node-ipc": "^9.1.1",
-    "source-map-support": "^0.5.16",
+    "source-map-support": "^0.5.19",
     "web3": "1.2.1"
   },
   "devDependencies": {

--- a/packages/hdwallet-provider/package.json
+++ b/packages/hdwallet-provider/package.json
@@ -24,7 +24,7 @@
     "ethereumjs-tx": "^1.0.0",
     "ethereumjs-util": "^6.1.0",
     "ethereumjs-wallet": "^0.6.3",
-    "source-map-support": "^0.5.16",
+    "source-map-support": "^0.5.19",
     "web3": "1.2.1",
     "web3-provider-engine": "https://github.com/trufflesuite/provider-engine#web3-one"
   },

--- a/packages/interface-adapter/package.json
+++ b/packages/interface-adapter/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "bn.js": "^4.11.8",
     "ethers": "^4.0.32",
-    "source-map-support": "^0.5.16",
+    "source-map-support": "^0.5.19",
     "web3": "1.2.1"
   },
   "devDependencies": {

--- a/packages/resolver/package.json
+++ b/packages/resolver/package.json
@@ -33,7 +33,7 @@
     "detect-installed": "^2.0.4",
     "get-installed-path": "^4.0.8",
     "glob": "^7.1.6",
-    "source-map-support": "^0.5.16",
+    "source-map-support": "^0.5.19",
     "supports-color": "^7.1.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14070,10 +14070,18 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.0, source-map-support@^0.5.1, source-map-support@^0.5.16, source-map-support@^0.5.3, source-map-support@^0.5.6:
+source-map-support@^0.5.0, source-map-support@^0.5.1, source-map-support@^0.5.3, source-map-support@^0.5.6:
   version "0.5.16"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042"
   integrity sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map-support@^0.5.19:
+  version "0.5.19"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
+  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"


### PR DESCRIPTION
In #2580, @nogo10 complained of a problem with source-map-support but also suggested that upgrading to 0.5.19 should fix it?  Well, I've thrown up a quick PR to do that and hopefully it does.