### PR TITLE
Bug fix: Combine & improve return/revert detection

### DIFF
--- a/packages/debugger/lib/evm/sagas/index.js
+++ b/packages/debugger/lib/evm/sagas/index.js
@@ -75,6 +75,12 @@ function* tickSaga() {
   yield* trace.signalTickSagaCompletion();
 }
 
+//NOTE: We don't account here for multiple simultaneous returns.
+//Such a case is *vanishingly* unlikely to come up in real code
+//so it's simply not worth the trouble.  Such a case will screw
+//up the debugger pretty good as a result.
+//(...but I might go back and do it later. :P )
+
 export function* callstackAndCodexSaga() {
   if (yield select(evm.current.step.isExceptionalHalting)) {
     //let's handle this case first so we can be sure everything else is *not*
@@ -121,7 +127,7 @@ export function* callstackAndCodexSaga() {
 
     yield put(actions.create(binary, createdAddress, sender, value));
     //as above, storageAddress handles when calling from a creation call
-  } else if (yield select(evm.current.step.isHalting)) {
+  } else if (yield select(evm.current.step.isNormalHalting)) {
     debug("got return");
 
     let { binary, storageAddress } = yield select(evm.current.call);

--- a/packages/debugger/lib/evm/selectors/index.js
+++ b/packages/debugger/lib/evm/selectors/index.js
@@ -14,8 +14,7 @@ import {
   isShortCallMnemonic,
   isDelegateCallMnemonicBroad,
   isDelegateCallMnemonicStrict,
-  isStaticCallMnemonic,
-  isNormalHaltingMnemonic
+  isStaticCallMnemonic
 } from "lib/helpers";
 
 const ZERO_WORD = "00".repeat(Codec.Evm.Utils.WORD_SIZE);
@@ -131,18 +130,6 @@ function createStepSelectors(step, state = null) {
      * .isCreate2
      */
     isCreate2: createLeaf(["./trace"], step => step.op === "CREATE2"),
-
-    /**
-     * .isHalting
-     *
-     * whether the instruction halts or returns from a calling context
-     * NOTE: this covers only ordinary halts, not exceptional halts;
-     * but it doesn't check the return status, so any normal halting
-     * instruction will qualify here
-     */
-    isHalting: createLeaf(["./trace"], step =>
-      isNormalHaltingMnemonic(step.op)
-    ),
 
     /*
      * .isStore
@@ -513,14 +500,13 @@ const evm = createSelectorTree({
        * are we doing a call or create for which there are no trace steps?
        * This can happen if:
        * 1. we call a precompile
-       * 2. we call an externally-owned account
+       * 2. we call an externally-owned account (or other account w/no code)
        * 3. we do a call or create but the call stack is exhausted
        * 4. we attempt to transfer more ether than we have
        */
       isInstantCallOrCreate: createLeaf(
-        ["./isCall", "./isCreate", "/current/state/depth", "/next/state/depth"],
-        (calls, creates, currentDepth, nextDepth) =>
-          (calls || creates) && currentDepth === nextDepth
+        ["./isCall", "./isCreate", "./isContextChange"],
+        (calls, creates, contextChange) => (calls || creates) && !contextChange
       ),
 
       /**
@@ -533,26 +519,38 @@ const evm = createSelectorTree({
       ),
 
       /**
+       * .isNormalHalting
+       */
+      isNormalHalting: createLeaf(
+        ["./isHalting", "./returnStatus"],
+        (isHalting, status) => isHalting && status
+      ),
+
+      /**
+       * .isHalting
+       *
+       * whether the instruction halts or returns from a calling context
+       * NOTE: this covers only ordinary halts, not exceptional halts;
+       * but it doesn't check the return status, so any normal halting
+       * instruction will qualify here
+       */
+      isHalting: createLeaf(
+        ["/current/state/depth", "/next/state/depth"],
+        (currentDepth, nextDepth) => nextDepth < currentDepth
+      ),
+
+      /**
        * evm.current.step.isExceptionalHalting
        */
       isExceptionalHalting: createLeaf(
-        [
-          "./isHalting",
-          "/current/state/depth",
-          "/next/state/depth",
-          "./returnStatus"
-        ],
-        (halting, currentDepth, nextDepth, status) =>
-          halting
-            ? !status //if deliberately halting, check the return status
-            : nextDepth < currentDepth //if not on a deliberate halt, any halt
-        //is an exceptional halt
+        ["./isHalting", "./returnStatus"],
+        (isHalting, status) => isHalting && !status
       ),
 
       /**
        * evm.current.step.returnStatus
-       * checks the return status of the *current* halting instruction (for
-       * normal halts only)
+       * checks the return status of the *current* halting instruction
+       * returns null if not halting
        * (returns a boolean -- true for success, false for failure)
        */
       returnStatus: createLeaf(

--- a/packages/debugger/lib/helpers/index.js
+++ b/packages/debugger/lib/helpers/index.js
@@ -123,13 +123,3 @@ export function isCreateMnemonic(op) {
   const creates = ["CREATE", "CREATE2"];
   return creates.includes(op);
 }
-
-/*
- * Given a mmemonic, determine whether it's the mnemonic of a normal
- * halting instruction
- */
-export function isNormalHaltingMnemonic(op) {
-  const halts = ["STOP", "RETURN", "SELFDESTRUCT", "SUICIDE"];
-  //the mnemonic SUICIDE is no longer used, but just in case, I'm including it
-  return halts.includes(op);
-}

--- a/packages/debugger/lib/solidity/sagas/index.js
+++ b/packages/debugger/lib/solidity/sagas/index.js
@@ -23,7 +23,7 @@ function* tickSaga() {
 }
 
 function* functionDepthSaga() {
-  if (yield select(solidity.current.willFail)) {
+  if (yield select(solidity.current.willReturn)) {
     //we do this case first so we can be sure we're not failing in any of the
     //other cases below!
     yield put(actions.externalReturn());
@@ -41,8 +41,6 @@ function* functionDepthSaga() {
     debug("checking if guard needed");
     let guard = yield select(solidity.current.callRequiresPhantomFrame);
     yield put(actions.externalCall(guard));
-  } else if (yield select(solidity.current.willReturn)) {
-    yield put(actions.externalReturn());
   }
 }
 

--- a/packages/debugger/lib/solidity/selectors/index.js
+++ b/packages/debugger/lib/solidity/selectors/index.js
@@ -312,16 +312,13 @@ let solidity = createSelectorTree({
 
     /**
      * solidity.current.willReturn
+     *
+     * covers both normal returns & failures
      */
     willReturn: createLeaf(
       [evm.current.step.isHalting],
       isHalting => isHalting
     ),
-
-    /**
-     * solidity.current.willFail
-     */
-    willFail: createLeaf([evm.current.step.isExceptionalHalting], x => x),
 
     /**
      * solidity.current.nextMapped

--- a/packages/debugger/lib/stacktrace/sagas/index.js
+++ b/packages/debugger/lib/stacktrace/sagas/index.js
@@ -27,7 +27,7 @@ function* stacktraceSaga() {
   let positionUpdated = false;
   //different possible outcomes:
   //first: are we returning?
-  if (yield select(stacktrace.current.willReturnOrFail)) {
+  if (yield select(stacktrace.current.willReturn)) {
     const status = yield select(stacktrace.current.returnStatus);
     debug("returning!");
     yield put(actions.externalReturn(lastLocation, status, currentLocation));

--- a/packages/debugger/lib/stacktrace/selectors/index.js
+++ b/packages/debugger/lib/stacktrace/selectors/index.js
@@ -176,25 +176,9 @@ let stacktrace = createSelectorTree({
     willReturn: createLeaf([solidity.current.willReturn], identity),
 
     /**
-     * stacktrace.current.willFail
-     */
-    willFail: createLeaf([solidity.current.willFail], identity),
-
-    /**
-     * stacktrace.current.willReturnOrFail
-     */
-    willReturnOrFail: createLeaf(
-      ["./willReturn", "./willFail"],
-      (willReturn, willFail) => willReturn || willFail
-    ),
-
-    /**
      * stacktrace.current.returnStatus
      */
-    returnStatus: createLeaf(
-      ["./willReturn", "./willFail"],
-      (returns, fails) => (returns ? true : fails ? false : null)
-    ),
+    returnStatus: createLeaf([evm.current.step.returnStatus], identity),
 
     /**
      * stacktrace.current.revertString


### PR DESCRIPTION
This PR accounts for the possibility of normal halting without a normal halting instruction (a `RETURN`, `STOP`, or `SELFDESTRUCT`). Admittedly such a case is vanishingly unlikely to come up in real code (it requires running off the end of the code, something that nothing produced with the Solidity compiler will ever do), but, eh, may as well since it's easy.

You may notice I renamed or got rid of some selectors.  The name `isHalting` had just gotten too misleading and so I renamed it.  Similarly, constantly distinguishing between normal halts and exceptional halts was just like... we don't need that distinction in most places.  Specifically, `solidity` and `stacktrace` don't need it; only `evm` needs it.  So that distinction is gone in most places, and now in `evm` the distinction is made by checking `evm.current.returnStatus`, not by checking what the type of instruction is.