### PR TITLE
Enhancement: add --compile-all-debug flag to Truffle Test, also some aliases

### DIFF
--- a/packages/core/lib/commands/test/index.js
+++ b/packages/core/lib/commands/test/index.js
@@ -7,6 +7,11 @@ const command = {
       type: "boolean",
       default: false
     },
+    "compile-all-debug": {
+      describe: "Compile in debug mode",
+      type: "boolean",
+      default: false
+    },
     "debug": {
       describe: "Enable in-test debugging",
       type: "boolean",
@@ -39,7 +44,7 @@ const command = {
   },
   help: {
     usage:
-      "truffle test [<test_file>] [--compile-all] [--network <name>] [--verbose-rpc] [--show-events] [--debug] [--debug-global <identifier>] [--bail] [--stacktrace[-extra]]",
+      "truffle test [<test_file>] [--compile-all[-debug]] [--network <name>] [--verbose-rpc] [--show-events] [--debug] [--debug-global <identifier>] [--bail] [--stacktrace[-extra]]",
     options: [
       {
         option: "<test_file>",
@@ -52,6 +57,12 @@ const command = {
         description:
           "Compile all contracts instead of intelligently choosing which contracts need " +
           "to be compiled."
+      },
+      {
+        option: "--compile-all-debug",
+        description:
+          "Compile all contracts and do so in debug mode for extra revert info.  May " +
+          "cause errors on large\n                    contracts."
       },
       {
         option: "--network <name>",
@@ -96,9 +107,7 @@ const command = {
       },
       {
         option: "--stacktrace-extra",
-        description:
-          "Like --stacktrace, but compiles contracts in debug mode for additional revert info.  " +
-          "May cause\n                    errors on large contracts."
+        description: "Shortcut for --stacktrace --compile-all-debug."
       }
     ]
   },
@@ -126,9 +135,10 @@ const command = {
 
     if (config.stacktraceExtra) {
       config.stacktrace = true;
+      config.compileAllDebug = true;
     }
     // enables in-test debug() interrupt, or stacktraces, forcing compileAll
-    if (config.debug || config.stacktrace) {
+    if (config.debug || config.stacktrace || config.compileAllDebug) {
       config.compileAll = true;
     }
 

--- a/packages/core/lib/commands/test/index.js
+++ b/packages/core/lib/commands/test/index.js
@@ -27,11 +27,13 @@ const command = {
       default: false
     },
     "bail": {
+      alias: "b",
       describe: "Bail after first test failure",
       type: "boolean",
       default: false
     },
     "stacktrace": {
+      alias: "t",
       describe: "Produce Solidity stacktraces",
       type: "boolean",
       default: false
@@ -96,14 +98,14 @@ const command = {
       },
       {
         option: "--bail",
-        description: "Bail after first test failure"
+        description: "Bail after first test failure.  Alias: -b"
       },
       {
         option: "--stacktrace",
         description:
           "Allows for mixed JS/Solidity stacktraces when a Truffle Contract transaction " +
           "or deployment\n                    reverts.  Does not apply to calls or gas estimates.  " +
-          "Implies --compile-all.  Experimental."
+          "Implies --compile-all.  Experimental.  Alias: -t"
       },
       {
         option: "--stacktrace-extra",

--- a/packages/core/lib/test.js
+++ b/packages/core/lib/test.js
@@ -204,8 +204,10 @@ const Test = {
       quiet: config.runnerOutputOnly || config.quiet,
       quietWrite: true
     });
-    if (config.stacktraceExtra) {
-      let versionString = ((compileConfig.compilers || {}).solc || {}).version;
+    if (config.compileAllDebug) {
+      let versionString =
+        ((compileConfig.compilers || {}).solc || {}).version ||
+        ((compileConfig.compilers || {}).solc || {}).docker;
       //note: I'm relying here on the fact that the current
       //default version, 0.5.16, is <0.6.3
       //the following line works with prereleases
@@ -214,7 +216,7 @@ const Test = {
       });
       //the following line doesn't, despite the flag, but does work with version ranges
       const intersects =
-        versionString !== undefined &&
+        semver.validRange(versionString) &&
         semver.intersects(versionString, ">=0.6.3", {
           includePrerelease: true
         }); //intersects will throw if given undefined so must ward against
@@ -232,7 +234,7 @@ const Test = {
         });
       } else {
         config.logger.log(
-          "Warning: --stacktrace-extra acts like --stacktrace on Solidity <0.6.3"
+          "Warning: Extra revert strings unavailable on Solidity <0.6.3"
         );
       }
     }

--- a/packages/core/lib/test.js
+++ b/packages/core/lib/test.js
@@ -234,7 +234,9 @@ const Test = {
         });
       } else {
         config.logger.log(
-          "Warning: Extra revert strings unavailable on Solidity <0.6.3"
+          `\n${colors.bold(
+            "Warning:"
+          )} Extra revert string info requires Solidity v0.6.3 or higher. For more\n  information, see release notes <https://github.com/ethereum/solidity/releases/tag/v0.6.3>`
         );
       }
     }


### PR DESCRIPTION
This PR adds a `--compile-all-debug` flag to Truffle Test, which compiles all contracts in debug mode.  The `--stacktrace-extra` flag now just acts as `--stacktrace --compile-all-debug`.

Also, I changed the version detection to be less buggy.  I didn't account for the fact that there's, like, other things users can enter as versions.  So not all of them will work, but at least they won't crash!  I also checked the docker version string if there is one, although due to how docker does its versions this won't always work if you're using a nightly (but those are necessarily kind of unreliable anyways!).

Also, I added aliases `-b` for `--bail` and `-t` for `--stacktrace`.  Thinking maybe we should add more such aliases in general for, like, all our commands, but I'm starting with these.