### PR TITLE
Internal improvement: Change selectors field on Debugger back to a getter

### DIFF
--- a/packages/debugger/lib/debugger.js
+++ b/packages/debugger/lib/debugger.js
@@ -74,16 +74,18 @@ const Debugger = {
    * @example
    * Debugger.selectors.trace.steps
    */
-  selectors: createNestedSelector({
-    ast: astSelector,
-    data: dataSelector,
-    trace: traceSelector,
-    evm: evmSelector,
-    solidity: soliditySelector,
-    stacktrace: stacktraceSelector,
-    session: sessionSelector,
-    controller: controllerSelector
-  })
+  get selectors() {
+    return createNestedSelector({
+      ast: astSelector,
+      data: dataSelector,
+      trace: traceSelector,
+      evm: evmSelector,
+      solidity: soliditySelector,
+      stacktrace: stacktraceSelector,
+      session: sessionSelector,
+      controller: controllerSelector
+    });
+  }
 };
 
 export default Debugger;


### PR DESCRIPTION
Really minor thing, just changed the `selectors` field on `Debugger` back to a getter.  I only changed it away from a getter because I didn't realize you can use getters like that.  Turns out you can!