### PR TITLE
Enhancement: Have debugger print return values on successful completion

### DIFF
--- a/packages/codec/lib/abi-data/allocate/index.ts
+++ b/packages/codec/lib/abi-data/allocate/index.ts
@@ -759,6 +759,10 @@ function getCalldataAllocationsForContract(
     //(if it doesn't then it will remain as default)
     functionAllocations: {}
   };
+  if (!abi) {
+    //if no ABI, can't do much!
+    return allocations;
+  }
   for (let abiEntry of abi) {
     if (
       AbiDataUtils.abiEntryIsObviouslyIllTyped(abiEntry) ||

--- a/packages/core/lib/debug/interpreter.js
+++ b/packages/core/lib/debug/interpreter.js
@@ -431,12 +431,13 @@ class DebugInterpreter {
       this.printer.print("");
       //check if transaction failed
       if (!this.session.view(evm.transaction.status)) {
-        this.printer.printRevertMessage();
+        await this.printer.printRevertMessage();
         this.printer.print("");
         this.printer.printStacktrace(true); //final stacktrace
       } else {
         //case if transaction succeeded
         this.printer.print("Transaction completed successfully.");
+        await this.printer.printReturnValue();
       }
     }
 
@@ -462,6 +463,9 @@ class DebugInterpreter {
         break;
       case "v":
         await this.printer.printVariables();
+        if (this.session.view(trace.finished)) {
+          await this.printer.printReturnValue();
+        }
         break;
       case ":":
         watchExpressionAnalytics(cmdArgs);

--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -237,15 +237,14 @@ class DebugPrinter {
     }
   }
 
-  printRevertMessage() {
+  //this doesn't really *need* to be async as we could use codec directly, but, eh
+  async printRevertMessage() {
     this.config.logger.log(
       DebugUtils.truffleColors.red("Transaction halted with a RUNTIME ERROR.")
     );
     this.config.logger.log("");
-    let rawRevertMessage = this.session.view(evm.current.step.returnValue);
-    let revertDecodings = Codec.decodeRevert(
-      Codec.Conversion.toBytes(rawRevertMessage)
-    );
+    const revertDecodings = await this.session.returnValue(); //in this context we know it's a revert
+    debug("revertDecodings: %o", revertDecodings);
     switch (revertDecodings.length) {
       case 0:
         this.config.logger.log(
@@ -253,7 +252,7 @@ class DebugPrinter {
         );
         break;
       case 1:
-        let revertDecoding = revertDecodings[0];
+        const revertDecoding = revertDecodings[0];
         switch (revertDecoding.kind) {
           case "failure":
             this.config.logger.log(
@@ -261,7 +260,7 @@ class DebugPrinter {
             );
             break;
           case "revert":
-            let revertStringInfo = revertDecoding.arguments[0].value.value;
+            const revertStringInfo = revertDecoding.arguments[0].value.value;
             let revertString;
             switch (revertStringInfo.kind) {
               case "valid":
@@ -294,6 +293,118 @@ class DebugPrinter {
     this.config.logger.log(
       "Please inspect your transaction parameters and contract code to determine the meaning of this error."
     );
+  }
+
+  async printReturnValue() {
+    //note: when printing revert messages, this will do so in a somewhat
+    //different way than printRevertMessage does
+    const allocationFound = Boolean(
+      this.session.view(data.current.returnAllocation)
+    );
+    const decodings = await this.session.returnValue();
+    debug("decodings: %o", decodings);
+    if (!allocationFound && decodings.length === 0) {
+      //case 1: no allocation found, decoding failed
+      this.config.logger.log("");
+      this.config.logger.log(
+        "A value was returned but it could not be decoded."
+      );
+      this.config.logger.log("");
+    } else if (!allocationFound && decodings[0].status === true) {
+      //case 2: no allocation found, decoding succeeded, but not a revert
+      //(i.e. it's a presumed selfdestruct; no value was returned)
+      //do nothing
+    } else if (allocationFound && decodings.length === 0) {
+      //case 3: allocation found but decoding failed
+      this.config.logger.log("");
+      this.config.logger.log("The return value could not be decoded.");
+      this.config.logger.log("");
+    } else if (allocationFound && decodings[0].kind === "selfdestruct") {
+      //case 4: allocation found, apparent self-destruct (note due to the use of [0] this
+      //won't occur if no return value was expected, as return takes priority over selfdestruct)
+      //Oops -- in an actual selfdestruct, we won't have the code! >_>
+      //(Not until reconstruct mode exists...) Oh well, leaving this in
+      this.config.logger.log("");
+      this.config.logger.log(
+        "No value was returned even though one was expected.  This may indicate a self-destruct."
+      );
+      this.config.logger.log("");
+    } else if (decodings[0].kind === "failure") {
+      //case 5: revert (no message)
+      this.config.logger.log("");
+      this.config.logger.log("There was no revert message.");
+      this.config.logger.log("");
+    } else if (decodings[0].kind === "unknownbytecode") {
+      //case 6: unknown bytecode
+      this.config.logger.log("");
+      this.config.logger.log(
+        "Bytecode was returned, but it could not be identified."
+      );
+      this.config.logger.log("");
+    } else if (
+      decodings[0].kind === "return" &&
+      decodings[0].arguments.length === 0
+    ) {
+      //case 7: return values but with no content
+      //do nothing
+    } else if (decodings[0].kind === "bytecode") {
+      //case 8: known bytecode
+      this.config.logger.log("");
+      const decoding = decodings[0];
+      const contractKind = decoding.contractKind || "contract";
+      if (decoding.address !== undefined) {
+        this.config.logger.log(
+          `Returned bytecode for a ${contractKind} ${
+            decoding.class.typeName
+          } at ${decoding.address}.`
+        );
+      } else {
+        this.config.logger.log(
+          `Returned bytecode for a ${contractKind} ${decoding.class.typeName}.`
+        );
+      }
+      this.config.logger.log("");
+    } else if (decodings[0].kind === "revert") {
+      //case 9: revert (with message)
+      this.config.logger.log("");
+      const prefix = "Revert string: ";
+      const value = decodings[0].arguments[0].value;
+      const formatted = DebugUtils.formatValue(value, prefix.length);
+      this.config.logger.log(prefix + formatted);
+      this.config.logger.log("");
+    } else if (
+      decodings[0].kind === "return" &&
+      decodings[0].arguments.length > 0
+    ) {
+      //case 10: actual return values to print!
+      this.config.logger.log("");
+      const values = decodings[0].arguments;
+      if (values.length === 1 && !values[0].name) {
+        //case 10a: if there's only one value and it's unnamed
+        const value = values[0].value;
+        const prefix = "Returned value: ";
+        const formatted = DebugUtils.formatValue(value, prefix.length);
+        this.config.logger.log(prefix + formatted);
+      } else {
+        //case 10b: otherwise
+        this.config.logger.log("Returned values:");
+        const prefixes = values.map(
+          ({ name }, index) =>
+            name ? `${name}: ` : `Component #${index + 1}: `
+        );
+        const maxLength = Math.max(...prefixes.map(prefix => prefix.length));
+        const paddedPrefixes = prefixes.map(prefix =>
+          prefix.padStart(maxLength)
+        );
+        for (let index = 0; index < values.length; index++) {
+          const { value } = values[index];
+          const prefix = paddedPrefixes[index];
+          const formatted = DebugUtils.formatValue(value, maxLength);
+          this.config.logger.log(prefix + formatted);
+        }
+      }
+      this.config.logger.log("");
+    }
   }
 
   printStacktrace(final) {

--- a/packages/debugger/lib/data/actions/index.js
+++ b/packages/debugger/lib/data/actions/index.js
@@ -60,12 +60,13 @@ export function defineType(node, compilationId) {
 }
 
 export const ALLOCATE = "DATA_ALLOCATE";
-export function allocate(storage, memory, abi, state) {
+export function allocate(storage, memory, abi, calldata, state) {
   return {
     type: ALLOCATE,
     storage,
     memory,
     abi,
+    calldata,
     state
   };
 }

--- a/packages/debugger/lib/data/reducers.js
+++ b/packages/debugger/lib/data/reducers.js
@@ -123,6 +123,7 @@ function allocations(state = DEFAULT_ALLOCATIONS, action) {
       storage: action.storage,
       memory: action.memory,
       abi: action.abi,
+      calldata: action.calldata,
       state: action.state
     };
   } else {

--- a/packages/debugger/lib/data/sagas/index.js
+++ b/packages/debugger/lib/data/sagas/index.js
@@ -36,22 +36,19 @@ function* tickSaga() {
 }
 
 export function* decode(definition, ref, compilationId) {
-  let userDefinedTypes = yield select(data.views.userDefinedTypes);
-  let state = yield select(data.current.state);
-  let mappingKeys = yield select(data.views.mappingKeys);
-  let allocations = yield select(data.info.allocations);
-  let instances = yield select(data.views.instances);
-  let contexts = yield select(data.views.contexts);
-  let currentContext = yield select(data.current.context);
-  let internalFunctionsTable = yield select(
+  const userDefinedTypes = yield select(data.views.userDefinedTypes);
+  const state = yield select(data.current.state);
+  const mappingKeys = yield select(data.views.mappingKeys);
+  const allocations = yield select(data.info.allocations);
+  const contexts = yield select(data.views.contexts);
+  const currentContext = yield select(data.current.context);
+  const internalFunctionsTable = yield select(
     data.current.functionsByProgramCounter
   );
-  let blockNumber = yield select(data.views.blockNumber);
 
-  let ZERO_WORD = new Uint8Array(Codec.Evm.Utils.WORD_SIZE); //automatically filled with zeroes
-  let NO_CODE = new Uint8Array(); //empty array
+  const ZERO_WORD = new Uint8Array(Codec.Evm.Utils.WORD_SIZE); //automatically filled with zeroes
 
-  let decoder = Codec.decodeVariable(
+  const decoder = Codec.decodeVariable(
     definition,
     ref,
     {
@@ -79,24 +76,7 @@ export function* decode(definition, ref, compilationId) {
         response = ZERO_WORD;
         break;
       case "code":
-        let address = request.address;
-        if (address in instances) {
-          response = instances[address];
-        } else if (address === Codec.Evm.Utils.ZERO_ADDRESS) {
-          //HACK: to avoid displaying the zero address to the user as an
-          //affected address just because they decoded a contract or external
-          //function variable that hadn't been initialized yet, we give the
-          //zero address's codelessness its own private cache :P
-          response = NO_CODE;
-        } else {
-          //I don't want to write a new web3 saga, so let's just use
-          //obtainBinaries with a one-element array
-          debug("fetching binary");
-          let binary = (yield* web3.obtainBinaries([address], blockNumber))[0];
-          debug("adding instance");
-          yield* evm.addInstance(address, binary);
-          response = Codec.Conversion.toBytes(binary);
-        }
+        response = yield* requestCode(request.address);
         break;
       default:
         debug("unrecognized request type!");
@@ -108,6 +88,74 @@ export function* decode(definition, ref, compilationId) {
   debug("done decoding");
   debug("decoded value: %O", result.value);
   return result.value;
+}
+
+export function* decodeReturnValue() {
+  const userDefinedTypes = yield select(data.views.userDefinedTypes);
+  const state = yield select(data.next.state); //next state has the return data
+  const allocations = yield select(data.info.allocations);
+  const contexts = yield select(data.views.contexts);
+  const status = yield select(data.current.returnStatus); //may be undefined
+  const returnAllocation = yield select(data.current.returnAllocation); //may be null
+
+  const decoder = Codec.decodeReturndata(
+    {
+      userDefinedTypes,
+      state,
+      allocations,
+      contexts
+    },
+    returnAllocation,
+    status
+  );
+
+  debug("beginning decoding");
+  let result = decoder.next();
+  while (!result.done) {
+    debug("request received");
+    let request = result.value;
+    let response;
+    switch (request.type) {
+      //skip storage case, it won't happen here
+      case "code":
+        response = yield* requestCode(request.address);
+        break;
+      default:
+        debug("unrecognized request type!");
+    }
+    debug("sending response");
+    result = decoder.next(response);
+  }
+  //at this point, result.value holds the final value
+  debug("done decoding");
+  return result.value;
+}
+
+//NOTE: calling this *can* add a new instance, which will not
+//go away on a reset!  Yes, this is a little weird, but we
+//decided this is OK for now
+function* requestCode(address) {
+  const NO_CODE = new Uint8Array(); //empty array
+  const blockNumber = yield select(data.views.blockNumber);
+  const instances = yield select(data.views.instances);
+
+  if (address in instances) {
+    return instances[address];
+  } else if (address === Codec.Evm.Utils.ZERO_ADDRESS) {
+    //HACK: to avoid displaying the zero address to the user as an
+    //affected address just because they decoded a contract or external
+    //function variable that hadn't been initialized yet, we give the
+    //zero address's codelessness its own private cache :P
+    return NO_CODE;
+  } else {
+    //I don't want to write a new web3 saga, so let's just use
+    //obtainBinaries with a one-element array
+    debug("fetching binary");
+    let binary = (yield* web3.obtainBinaries([address], blockNumber))[0];
+    debug("adding instance");
+    yield* evm.addInstance(address, binary);
+    return Codec.Conversion.toBytes(binary);
+  }
 }
 
 function* variablesAndMappingsSaga() {
@@ -684,8 +732,14 @@ export function* recordAllocations() {
   const memoryAllocations = Codec.Memory.Allocate.getMemoryAllocations(
     userDefinedTypes
   );
-  const calldataAllocations = Codec.AbiData.Allocate.getAbiAllocations(
+  const abiAllocations = Codec.AbiData.Allocate.getAbiAllocations(
     userDefinedTypes
+  );
+  const calldataAllocations = Codec.AbiData.Allocate.getCalldataAllocations(
+    contracts,
+    referenceDeclarations,
+    userDefinedTypes,
+    abiAllocations
   );
   const stateAllocations = Codec.Storage.Allocate.getStateAllocations(
     contracts,
@@ -697,6 +751,7 @@ export function* recordAllocations() {
     actions.allocate(
       storageAllocations,
       memoryAllocations,
+      abiAllocations,
       calldataAllocations,
       stateAllocations
     )

--- a/packages/debugger/lib/data/selectors/index.js
+++ b/packages/debugger/lib/data/selectors/index.js
@@ -369,6 +369,12 @@ const data = createSelectorTree({
                 context.compilationId === compilationId &&
                 context.contractId === id
             );
+            let constructorContext = Object.values(contexts).find(
+              context =>
+                context.isConstructor &&
+                context.compilationId === compilationId &&
+                context.contractId === id
+            );
             let immutableReferences = deployedContext
               ? deployedContext.immutableReferences
               : undefined;
@@ -376,10 +382,14 @@ const data = createSelectorTree({
               contractNode: scopes[compilationId][id].definition,
               compilationId,
               immutableReferences,
-              //we don't just use deployedContext because it might not exist!
+              //we don't just use deployedContext to get compiler because it might not exist!
               compiler:
                 sources[compilationId].byId[scopes[compilationId][id].sourceId]
-                  .compiler
+                  .compiler,
+              //the following three are only needed for decoding return values
+              abi: (deployedContext || {}).abi,
+              deployedContext,
+              constructorContext
             };
           })
     ),
@@ -496,7 +506,12 @@ const data = createSelectorTree({
       /*
        * data.info.allocations.abi
        */
-      abi: createLeaf(["/state"], state => state.info.allocations.abi)
+      abi: createLeaf(["/state"], state => state.info.allocations.abi),
+
+      /*
+       * data.info.allocations.calldata
+       */
+      calldata: createLeaf(["/state"], state => state.info.allocations.calldata)
     },
 
     /**
@@ -837,7 +852,7 @@ const data = createSelectorTree({
 
     address: createLeaf([evm.current.call], call => call.storageAddress),
 
-    /*
+    /**
      * data.current.functionsByProgramCounter
      */
     functionsByProgramCounter: createLeaf(
@@ -845,7 +860,7 @@ const data = createSelectorTree({
       functions => functions
     ),
 
-    /*
+    /**
      * data.current.context
      */
     context: createLeaf([evm.current.context], debuggerContextToDecoderContext),
@@ -1177,7 +1192,46 @@ const data = createSelectorTree({
             )
           )
       )
-    }
+    },
+
+    /**
+     * data.current.returnStatus
+     */
+    returnStatus: createLeaf(
+      [evm.current.step.returnStatus],
+      status => (status === null ? undefined : status) //convert null to undefined to be safe
+    ),
+
+    /**
+     * data.current.returnAllocation
+     */
+    returnAllocation: createLeaf(
+      [evm.current.call, "/current/context", "/info/allocations/calldata"],
+      (
+        { data: calldata },
+        { context, isConstructor },
+        { constructorAllocations, functionAllocations }
+      ) => {
+        if (isConstructor) {
+          //we're in a constructor call
+          let allocation = constructorAllocations[context];
+          if (!allocation) {
+            return null;
+          }
+          return allocation.output;
+        } else {
+          //usual case
+          let selector = calldata.slice(0, 2 + 4 * 2); //extract first 4 bytes of hex string
+          debug("selector: %s", selector);
+          debug("bySelector: %o", functionAllocations[context]);
+          let allocation = (functionAllocations[context] || {})[selector];
+          if (!allocation) {
+            return null;
+          }
+          return allocation.output;
+        }
+      }
+    )
   },
 
   /**
@@ -1197,6 +1251,16 @@ const data = createSelectorTree({
         [evm.next.state.stack],
 
         words => (words || []).map(word => Codec.Conversion.toBytes(word))
+      ),
+
+      /**
+       * data.next.state.returndata
+       * NOTE: this is only for use by returnValue(); this is *not*
+       * an accurate reflection of the current contents of returndata!
+       * we don't track that at the moment
+       */
+      returndata: createLeaf([evm.current.step.returnValue], data =>
+        Codec.Conversion.toBytes(data)
       )
     },
 

--- a/packages/debugger/lib/evm/selectors/index.js
+++ b/packages/debugger/lib/evm/selectors/index.js
@@ -208,7 +208,13 @@ function createStepSelectors(step, state = null) {
           const offset = parseInt(stack[stack.length - 2], 16) * 2;
           const length = parseInt(stack[stack.length - 3], 16) * 2;
 
-          return "0x" + memory.join("").substring(offset, offset + length);
+          return (
+            "0x" +
+            memory
+              .join("")
+              .substring(offset, offset + length)
+              .padEnd(length, "00")
+          );
         }
       ),
 
@@ -234,7 +240,13 @@ function createStepSelectors(step, state = null) {
           const offset = parseInt(stack[stack.length - 4 + argOffset], 16) * 2;
           const length = parseInt(stack[stack.length - 5 + argOffset], 16) * 2;
 
-          return "0x" + memory.join("").substring(offset, offset + length);
+          return (
+            "0x" +
+            memory
+              .join("")
+              .substring(offset, offset + length)
+              .padEnd(length, "00")
+          );
         }
       ),
 
@@ -599,7 +611,13 @@ const evm = createSelectorTree({
           const offset = parseInt(stack[stack.length - 1], 16) * 2;
           const length = parseInt(stack[stack.length - 2], 16) * 2;
 
-          return "0x" + memory.join("").substring(offset, offset + length);
+          return (
+            "0x" +
+            memory
+              .join("")
+              .substring(offset, offset + length)
+              .padEnd(length, "00")
+          );
         }
       )
     },

--- a/packages/debugger/lib/session/index.js
+++ b/packages/debugger/lib/session/index.js
@@ -387,9 +387,10 @@ export default class Session {
   }
 
   async returnValue() {
-    if (!this.view(session.status.loaded)) {
-      //note: will also return null if not on a trace step that
-      //is returning due to how decodeReturnValue works
+    if (
+      !this.view(session.status.loaded) ||
+      !this.view(evm.current.step.isHalting)
+    ) {
       return null;
     }
     return await this._runSaga(dataSagas.decodeReturnValue);

--- a/packages/debugger/lib/session/index.js
+++ b/packages/debugger/lib/session/index.js
@@ -386,6 +386,15 @@ export default class Session {
     return decoded;
   }
 
+  async returnValue() {
+    if (!this.view(session.status.loaded)) {
+      //note: will also return null if not on a trace step that
+      //is returning due to how decodeReturnValue works
+      return null;
+    }
+    return await this._runSaga(dataSagas.decodeReturnValue);
+  }
+
   callstack() {
     if (!this.view(session.status.loaded)) {
       return null;

--- a/packages/debugger/test/data/returnvalue.js
+++ b/packages/debugger/test/data/returnvalue.js
@@ -139,22 +139,6 @@ describe("Return value decoding", function() {
     assert.strictEqual(decoding.address, instance.address);
   });
 
-  it("Decodes constructor selfdestruct", async function() {
-    this.timeout(30000);
-
-    let instance = await abstractions.ReturnValues.new(true); //web3 doesn't cause a problem here, huh
-    let txHash = instance.transactionHash;
-
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
-
-    await bugger.continueUntilBreakpoint(); //run till end
-
-    const decodings = await bugger.returnValue();
-    assert.lengthOf(decodings, 2);
-    assert.strictEqual(decodings[0].kind, "selfdestruct");
-    assert.strictEqual(decodings[1].kind, "unknownbytecode"); //technically empty return could be unknown bytecode :P
-  });
-
   it("Decodes messageless revert", async function() {
     this.timeout(9000);
 

--- a/packages/debugger/test/data/returnvalue.js
+++ b/packages/debugger/test/data/returnvalue.js
@@ -1,0 +1,209 @@
+import debugModule from "debug";
+const debug = debugModule("test:data:returnvalue");
+
+import { assert } from "chai";
+
+import Ganache from "ganache-core";
+
+import { prepareContracts } from "../helpers";
+import Debugger from "lib/debugger";
+
+import * as Codec from "@truffle/codec";
+
+const __RETURNVALUES = `
+pragma solidity ^0.6.6;
+
+contract ReturnValues {
+  constructor(bool fail) public {
+    if(fail) {
+      selfdestruct(tx.origin);
+    }
+  }
+
+  function fail() public {
+    revert();
+  }
+
+  function failNoisy() public {
+    revert("Noise!");
+  }
+
+  function pair() public returns (int x, int) {
+    return (-1, -2);
+  }
+}
+
+library ReturnLibrary {
+}
+`;
+
+const __MIGRATION = `
+var ReturnValues = artifacts.require("ReturnValues");
+var ReturnLibrary = artifacts.require("ReturnLibrary");
+
+module.exports = function(deployer) {
+  deployer.deploy(ReturnValues, false);
+  deployer.deploy(ReturnLibrary);
+};
+`;
+
+let sources = {
+  "ReturnValues.sol": __RETURNVALUES
+};
+
+let migrations = {
+  "2_deploy_contracts.js": __MIGRATION
+};
+
+describe("Return value decoding", function() {
+  var provider;
+
+  var abstractions;
+  var compilations;
+
+  before("Create Provider", async function() {
+    provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
+  });
+
+  before("Prepare contracts and artifacts", async function() {
+    this.timeout(30000);
+
+    let prepared = await prepareContracts(provider, sources, migrations);
+    abstractions = prepared.abstractions;
+    compilations = prepared.compilations;
+  });
+
+  it("Decodes return values correctly", async function() {
+    this.timeout(9000);
+
+    let instance = await abstractions.ReturnValues.deployed();
+    let receipt = await instance.pair();
+    let txHash = receipt.tx;
+
+    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+
+    await bugger.continueUntilBreakpoint(); //run till end
+
+    const decodings = await bugger.returnValue();
+    assert.lengthOf(decodings, 1);
+    const decoding = decodings[0];
+    assert.strictEqual(decoding.kind, "return");
+    const outputs = decoding.arguments;
+    assert.lengthOf(outputs, 2);
+    assert.strictEqual(outputs[0].name, "x");
+    assert.isUndefined(outputs[1].name);
+    const values = outputs.map(({ value }) =>
+      Codec.Format.Utils.Inspect.nativize(value)
+    );
+    assert.deepEqual(values, [-1, -2]);
+  });
+
+  it("Decodes bytecode", async function() {
+    this.timeout(12000);
+
+    let instance = await abstractions.ReturnValues.new(false);
+    let txHash = instance.transactionHash;
+    debug("txHash: %s", txHash);
+
+    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+
+    debug("about to run!");
+    await bugger.continueUntilBreakpoint(); //run till end
+    debug("ran!");
+
+    const decodings = await bugger.returnValue();
+    assert.lengthOf(decodings, 1);
+    const decoding = decodings[0];
+    assert.strictEqual(decoding.kind, "bytecode");
+    assert.strictEqual(decoding.class.typeName, "ReturnValues");
+  });
+
+  it("Decodes library bytecode", async function() {
+    this.timeout(12000);
+
+    let instance = await abstractions.ReturnLibrary.new();
+    let txHash = instance.transactionHash;
+    debug("txHash: %s", txHash);
+
+    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+
+    debug("about to run!");
+    await bugger.continueUntilBreakpoint(); //run till end
+    debug("ran!");
+
+    const decodings = await bugger.returnValue();
+    assert.lengthOf(decodings, 1);
+    const decoding = decodings[0];
+    assert.strictEqual(decoding.kind, "bytecode");
+    assert.strictEqual(decoding.class.typeName, "ReturnLibrary");
+    assert.strictEqual(decoding.address, instance.address);
+  });
+
+  it("Decodes constructor selfdestruct", async function() {
+    this.timeout(30000);
+
+    let instance = await abstractions.ReturnValues.new(true); //web3 doesn't cause a problem here, huh
+    let txHash = instance.transactionHash;
+
+    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+
+    await bugger.continueUntilBreakpoint(); //run till end
+
+    const decodings = await bugger.returnValue();
+    assert.lengthOf(decodings, 2);
+    assert.strictEqual(decodings[0].kind, "selfdestruct");
+    assert.strictEqual(decodings[1].kind, "unknownbytecode"); //technically empty return could be unknown bytecode :P
+  });
+
+  it("Decodes messageless revert", async function() {
+    this.timeout(9000);
+
+    //HACK: because this transaction makes web3 throw, we have to extract the hash from
+    //the resulting exception (there is supposed to be a non-hacky way but it
+    //does not presently work)
+    let instance = await abstractions.ReturnValues.deployed();
+    let txHash;
+    try {
+      await instance.fail(); //web3 throws on failure
+    } catch (error) {
+      txHash = error.hashes[0]; //it's the only hash involved
+    }
+
+    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+
+    await bugger.continueUntilBreakpoint(); //run till end
+
+    const decodings = await bugger.returnValue();
+    assert.lengthOf(decodings, 1);
+    const decoding = decodings[0];
+    assert.strictEqual(decoding.kind, "failure");
+  });
+
+  it("Decodes revert string", async function() {
+    this.timeout(9000);
+
+    //HACK: because this transaction makes web3 throw, we have to extract the hash from
+    //the resulting exception (there is supposed to be a non-hacky way but it
+    //does not presently work)
+    let instance = await abstractions.ReturnValues.deployed();
+    let txHash;
+    try {
+      await instance.failNoisy(); //web3 throws on failure
+    } catch (error) {
+      txHash = error.hashes[0]; //it's the only hash involved
+    }
+
+    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+
+    await bugger.continueUntilBreakpoint(); //run till end
+
+    const decodings = await bugger.returnValue();
+    assert.lengthOf(decodings, 1);
+    const decoding = decodings[0];
+    assert.strictEqual(decoding.kind, "revert");
+    const outputs = decoding.arguments;
+    assert.lengthOf(outputs, 1);
+    const message = Codec.Format.Utils.Inspect.nativize(outputs[0].value);
+    assert.strictEqual(message, "Noise!");
+  });
+});


### PR DESCRIPTION
This PR adds a `returnValue` method to the `Session` class.  Running this method once the transaction is complete will decode the return value (or revert message).  This PR also adds code in the CLI to print the return value; it will print on successful completion.  It will also print if you hit `v` once the transaction is done, alongside the other variables.  Decoding of revert strings is now done this way also -- the CLI no longer invokes `Codec`'s `decodeRevert` to do the decoding itself, but just uses `session.returnValue()`.  If the transaction reverted, hitting `v` once the transaction is complete will now the revert string as well as the variables.

The debugger side of this is pretty straightforward.  We now need to allocate calldata as well, so we do.  We pass some info to the allocator that we weren't before in order to make this possible.  We determine what allocation to use by looking at the current context and (if we're not in a constructor) reading the current selector out of the calldata.  If it doesn't match any function (such as if we're in a fallback function), then, oh well, guess we're only decoding reverts.  Also, note that we do pass the return status to `Codec.decodeReturndata` so it can distinguish between successful returns and reverts.

The CLI has some fairly detailed logic to make sure that what we print makes sense.  For instance, if there's no return value, but none was expected, we don't print anything at all.  Etc.  I'm not going to list all the cases here.

(For decoding bytecode, it would be really nice if we could include the linked libraries and immutables in the decoding, but the former is a problem due to our old bytecode format, and the latter... might be doable but I haven't looked into it yet.  Not going to consider this high-priority though.)

Anyway, this was largely pretty straightforward, so I don't have a lot to say here.  Um, I factored out the code-requesting part of `decode` into its own saga, for obvious reasons.  I guess that's worth noting.

Btw, that self-destruct test that I removed because it doesn't work, does work when I do it manually, but it seems web3 poses a problem when I try to do it in automated tests, and for whatever reason, even the usual try/catch didn't work here... (I guess probably because this is purely a web3 error, rather than Ganache's default mode throwing an error like usual?)

Also, I fixed a bug in the EVM selectors -- they couldn't read past the end of memory before.  Now they can.