### PR TITLE
Add SPDX license identifiers to (non-test) contracts

### DIFF
--- a/packages/core/lib/commands/create/templates/Example.sol
+++ b/packages/core/lib/commands/create/templates/Example.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: MIT
 pragma solidity >= 0.5.0 < 0.7.0;
 
 contract Example {

--- a/packages/core/lib/commands/create/templates/Test.sol
+++ b/packages/core/lib/commands/create/templates/Test.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: MIT
 pragma solidity >= 0.4.15 < 0.7.0;
 
 import "truffle/DeployedAddresses.sol";

--- a/packages/core/lib/testing/Assert.sol
+++ b/packages/core/lib/testing/Assert.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: MIT
 // This file taken from here: https://raw.githubusercontent.com/smartcontractproduction/sol-unit/master/contracts/src/Assertions.sol
 // It was renamed to Assert.sol by Tim Coulter. Refactored for solidity 0.5.0 by Cruz Molina.
 

--- a/packages/core/lib/testing/AssertAddress.sol
+++ b/packages/core/lib/testing/AssertAddress.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: MIT
 pragma solidity >= 0.4.15 < 0.7.0;
 
 library AssertAddress {

--- a/packages/core/lib/testing/AssertAddressArray.sol
+++ b/packages/core/lib/testing/AssertAddressArray.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: MIT
 pragma solidity >= 0.4.15 < 0.7.0;
 
 library AssertAddressArray {

--- a/packages/core/lib/testing/AssertAddressPayableArray.sol
+++ b/packages/core/lib/testing/AssertAddressPayableArray.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: MIT
 pragma solidity ^0.6.0;
 
 library AssertAddressPayableArray {

--- a/packages/core/lib/testing/AssertBalance.sol
+++ b/packages/core/lib/testing/AssertBalance.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: MIT
 pragma solidity >= 0.4.15 < 0.7.0;
 
 library AssertBalance {

--- a/packages/core/lib/testing/AssertBool.sol
+++ b/packages/core/lib/testing/AssertBool.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: MIT
 pragma solidity >= 0.4.15 < 0.7.0;
 
 library AssertBool {

--- a/packages/core/lib/testing/AssertBytes32Array.sol
+++ b/packages/core/lib/testing/AssertBytes32Array.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: MIT
 pragma solidity >= 0.4.15 < 0.7.0;
 
 library AssertBytes32Array {

--- a/packages/core/lib/testing/AssertGeneral.sol
+++ b/packages/core/lib/testing/AssertGeneral.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: MIT
 pragma solidity >= 0.4.15 < 0.7.0;
 
 library AssertGeneral {

--- a/packages/core/lib/testing/AssertInt.sol
+++ b/packages/core/lib/testing/AssertInt.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: MIT
 pragma solidity >= 0.4.15 < 0.7.0;
 
 library AssertInt {

--- a/packages/core/lib/testing/AssertIntArray.sol
+++ b/packages/core/lib/testing/AssertIntArray.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: MIT
 pragma solidity >= 0.4.15 < 0.7.0;
 
 library AssertIntArray {

--- a/packages/core/lib/testing/AssertString.sol
+++ b/packages/core/lib/testing/AssertString.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: MIT
 pragma solidity >= 0.4.15 < 0.7.0;
 
 library AssertString {

--- a/packages/core/lib/testing/AssertUint.sol
+++ b/packages/core/lib/testing/AssertUint.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: MIT
 pragma solidity >= 0.4.15 < 0.7.0;
 
 library AssertUint {

--- a/packages/core/lib/testing/AssertUintArray.sol
+++ b/packages/core/lib/testing/AssertUintArray.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: MIT
 pragma solidity >= 0.4.15 < 0.7.0;
 
 library AssertUintArray {

--- a/packages/core/lib/testing/NewSafeSend.sol
+++ b/packages/core/lib/testing/NewSafeSend.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: MIT
 pragma solidity >= 0.5.0 < 0.7.0;
 
 contract NewSafeSend {

--- a/packages/core/lib/testing/OldSafeSend.sol
+++ b/packages/core/lib/testing/OldSafeSend.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: MIT
 pragma solidity ^0.4.22;
 
 contract OldSafeSend {

--- a/packages/core/lib/testing/deployed.js
+++ b/packages/core/lib/testing/deployed.js
@@ -11,6 +11,7 @@ var Deployed = {
 
     var source = "";
     source +=
+      "//SPDX-License-Identifier: MIT\n" +
       "pragma solidity >= 0.5.0 < 0.7.0; \n\n library DeployedAddresses {" +
       "\n";
 


### PR DESCRIPTION
Partial fix for #3051.  Adds SPDX license identifiers to all contracts we make available to users.  Left our own internal testing contracts alone.  Note (@cds-amal?) we'll also need to get the ones in `truffle-box`.