### PR TITLE
Bug fix: Add mechanism for Truffle Test to reload contracts' JSON on deploy

### DIFF
--- a/packages/contract/lib/contract/constructorMethods.js
+++ b/packages/contract/lib/contract/constructorMethods.js
@@ -76,6 +76,9 @@ module.exports = Contract => ({
   },
 
   async deployed() {
+    if (this.reloadJson) {
+      this.reloadJson(); //truffle test monkey-patches in this method
+    }
     utils.checkProvider(this);
     await this.detectNetwork();
     utils.checkNetworkArtifactMatch(this);

--- a/packages/core/lib/test.js
+++ b/packages/core/lib/test.js
@@ -282,8 +282,15 @@ const Test = {
     global.assert = chai.assert;
     global.expect = chai.expect;
     global.artifacts = {
-      require: import_path => {
-        let contract = testResolver.require(import_path);
+      require: importPath => {
+        let contract = testResolver.require(importPath);
+        //HACK: both of the following should go by means
+        //of the provisioner, but I'm not sure how to make
+        //that work at the moment
+        contract.reloadJson = function() {
+          const reloaded = testResolver.require(importPath);
+          this._json = reloaded._json;
+        };
         if (bugger) {
           contract.debugger = bugger;
         }


### PR DESCRIPTION
This PR fixes #3023.  The basic idea is due to @gnidan.  It's quite simple actually.  Basically, it's only on the use of `deployed()` that we care about having the new info, so we modify `deployed()` to reload it.  Of course, we don't want to do this normally.  So, we have `deployed()` check for the presence of a `reloadJson()` method, and call it only if it exists.  Meanwhile, we have `test.js` set up a method `reloadJson()` on each contract, which does exactly that -- it reloads the JSON using the test resolver.  Pretty simple!

Note that `reloadJson`, like `debugger`, really ought to go by means of the provisioner, but I can't figure that out at the moment, so I'm just putting this bug fix up now and we can figure out the proper way to handle this (and the debugger attach) later.

No automated tests for this, but I tested it manually and it worked!