### PR TITLE
Make some improvements to Truffle DB loaders tests

### DIFF
--- a/packages/db/src/loaders/artifacts/test/index.ts
+++ b/packages/db/src/loaders/artifacts/test/index.ts
@@ -514,7 +514,7 @@ describe("Compilation", () => {
 
     const loader = new ArtifactsLoader(db, compilationConfig);
     await loader.load();
-  });
+  }, 10000);
 
   afterAll(async () => {
     await Promise.all(

--- a/packages/db/src/loaders/artifacts/test/index.ts
+++ b/packages/db/src/loaders/artifacts/test/index.ts
@@ -469,10 +469,6 @@ describe("Compilation", () => {
     let previousContract = {
       name: "Migrations",
       abi: { json: JSON.stringify(artifacts[1].abi) },
-      sourceContract: { index: 0 },
-      compilation: {
-        id: expectedSolcCompilationId
-      },
       createBytecode: bytecodeIds[0],
       callBytecode: callBytecodeIds[0]
     };
@@ -483,11 +479,7 @@ describe("Compilation", () => {
 
     previousContractExpectedId = generateId({
       name: "Migrations",
-      abi: { json: JSON.stringify(artifacts[1].abi) },
-      sourceContract: { index: 0 },
-      compilation: {
-        id: expectedSolcCompilationId
-      }
+      abi: { json: JSON.stringify(artifacts[1].abi) }
     });
 
     previousContractNameRecord = {

--- a/packages/db/src/loaders/artifacts/test/index.ts
+++ b/packages/db/src/loaders/artifacts/test/index.ts
@@ -58,7 +58,12 @@ tmp.setGracefulCleanup();
 // minimal config
 const config = {
   contracts_build_directory: fixturesDirectory,
-  working_directory: tempDir.name
+  working_directory: tempDir.name,
+  db: {
+    adapter: {
+      name: "memory"
+    }
+  }
 };
 
 const compilationConfig = {

--- a/packages/db/src/loaders/artifacts/test/workflowCompileOutputMock/compilationOutput.json
+++ b/packages/db/src/loaders/artifacts/test/workflowCompileOutputMock/compilationOutput.json
@@ -16089,7 +16089,7 @@
         },
         "vyper": {
           "sourceIndexes": [
-            "/Users/fainashalts/solidity-magic-square/contracts/VyperStorage.sol"
+            "/Users/fainashalts/truffle-six/testing2/contracts/VyperStorage.vy"
           ],
           "contracts": [
             {


### PR DESCRIPTION
This PR is kind a mishmash of test updates.

Included changes:
- Remove a mock relation to an incorrect compilation
- Increase a timeout
- Fix a sourcePath mismatch
- Run the test DB instance using the memory adapter