### PR TITLE
Separate compilation record-keeping in Truffle DB loaders

### DIFF
--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -49,7 +49,9 @@ export class TruffleDB {
   }
 
   async loadCompilations(result: WorkflowCompileResult) {
-    const saga = generateCompileLoad(result);
+    const saga = generateCompileLoad(result, {
+      directory: this.context.workingDirectory
+    });
 
     let cur = saga.next();
     while (!cur.done) {

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -1,7 +1,11 @@
 import { GraphQLSchema, DocumentNode, parse, execute } from "graphql";
 
 import { schema } from "@truffle/db/data";
-
+import { generateCompileLoad } from "@truffle/db/loaders/commands";
+import {
+  WorkflowCompileResult,
+  WorkspaceRequest
+} from "@truffle/db/loaders/types";
 import { Workspace } from "@truffle/db/workspace";
 
 interface IConfig {
@@ -42,6 +46,26 @@ export class TruffleDB {
       typeof query !== "string" ? query : parse(query);
 
     return await execute(this.schema, document, null, this.context, variables);
+  }
+
+  async loadCompilations(result: WorkflowCompileResult) {
+    const saga = generateCompileLoad(result);
+
+    let cur = saga.next();
+    while (!cur.done) {
+      // HACK not sure why this is necessary; TS knows we're not done, so
+      // cur.value should only be WorkspaceRequest (first Generator param),
+      // not the return value (second Generator param)
+      const {
+        request,
+        variables
+      }: WorkspaceRequest = cur.value as WorkspaceRequest;
+      const response = await this.query(request, variables);
+
+      cur = saga.next(response);
+    }
+
+    return cur.value;
   }
 
   createContext(config: IConfig): IContext {

--- a/packages/db/src/loaders/commands/compile.ts
+++ b/packages/db/src/loaders/commands/compile.ts
@@ -12,6 +12,7 @@ import { generateBytecodesLoad } from "@truffle/db/loaders/resources/bytecodes";
 import { generateCompilationsLoad } from "@truffle/db/loaders/resources/compilations";
 import { generateContractsLoad } from "@truffle/db/loaders/resources/contracts";
 import { generateSourcesLoad } from "@truffle/db/loaders/resources/sources";
+import { generateProjectLoad } from "@truffle/db/loaders/resources/projects";
 
 /**
  * For a compilation result from @truffle/workflow-compile/new, generate a
@@ -22,8 +23,12 @@ import { generateSourcesLoad } from "@truffle/db/loaders/resources/sources";
  * and ultimately returns nothing when complete.
  */
 export function* generateCompileLoad(
-  result: WorkflowCompileResult
+  result: WorkflowCompileResult,
+  { directory }: { directory: string }
 ): Generator<WorkspaceRequest, any, WorkspaceResponse<string>> {
+  // start by adding loading the project resource
+  const project = yield* generateProjectLoad(directory);
+
   const resultCompilations = processResultCompilations(result);
 
   // for each compilation returned by workflow-compile:
@@ -70,7 +75,7 @@ export function* generateCompileLoad(
     );
   }
 
-  return { compilations, compilationContracts };
+  return { project, compilations, compilationContracts };
 }
 
 function processResultCompilations(

--- a/packages/db/src/loaders/commands/compile.ts
+++ b/packages/db/src/loaders/commands/compile.ts
@@ -1,0 +1,56 @@
+import { TruffleDB } from "@truffle/db/db";
+import {
+  WorkflowCompileResult,
+  CompilationData,
+  toIdObject,
+  WorkspaceRequest,
+  WorkspaceResponse
+} from "@truffle/db/loaders/types";
+
+import { generateCompilationsLoad } from "@truffle/db/loaders/resources/compilations";
+import { generateSourcesLoad } from "@truffle/db/loaders/resources/sources";
+
+/**
+ * For a compilation result from @truffle/workflow-compile/new, generate a
+ * sequence of GraphQL requests to submit to Truffle DB
+ *
+ * Returns a generator that yields requests to forward to Truffle DB.
+ * When calling `.next()` on this generator, pass any/all responses
+ * and ultimately returns nothing when complete.
+ */
+export function* generateCompileLoad(
+  result: WorkflowCompileResult
+): Generator<WorkspaceRequest, any, WorkspaceResponse<string>> {
+  const resultCompilations = processResultCompilations(result);
+
+  let loadableCompilations = [];
+  for (let compilation of resultCompilations) {
+    // add sources for each compilation
+    const sources: DataModel.ISource[] = yield* generateSourcesLoad(
+      compilation
+    );
+
+    // record compilation with its sources
+    loadableCompilations.push({
+      compilation,
+      sources: sources.map(toIdObject)
+    });
+  }
+
+  // then add compilations
+  const compilations = yield* generateCompilationsLoad(loadableCompilations);
+  return { compilations };
+}
+
+function processResultCompilations(
+  result: WorkflowCompileResult
+): CompilationData[] {
+  return Object.values(result.compilations)
+    .filter(({ contracts }) => contracts.length > 0)
+    .map(processResultCompilation);
+}
+
+function processResultCompilation(resultCompilation): CompilationData {
+  // just act as pass-through for now
+  return resultCompilation;
+}

--- a/packages/db/src/loaders/commands/index.ts
+++ b/packages/db/src/loaders/commands/index.ts
@@ -1,0 +1,1 @@
+export { generateCompileLoad } from "./compile";

--- a/packages/db/src/loaders/resources/bytecodes/index.ts
+++ b/packages/db/src/loaders/resources/bytecodes/index.ts
@@ -1,2 +1,50 @@
+import {
+  CompiledContract,
+  ContractBytecodes,
+  WorkspaceRequest,
+  WorkspaceResponse
+} from "@truffle/db/loaders/types";
+
 import { AddBytecodes } from "./add.graphql";
 export { AddBytecodes };
+
+/**
+ * @dev pre-condition: every contract should have both bytecodes
+ */
+export function* generateBytecodesLoad(
+  contracts: CompiledContract[]
+): Generator<
+  WorkspaceRequest,
+  ContractBytecodes[],
+  WorkspaceResponse<"bytecodesAdd", DataModel.IBytecodesAddPayload>
+> {
+  const { createBytecodes, callBytecodes } = contracts.reduce(
+    (
+      { createBytecodes, callBytecodes },
+      { deployedBytecode: callBytecode, bytecode: createBytecode }
+    ) => ({
+      createBytecodes: [...createBytecodes, createBytecode],
+      callBytecodes: [...callBytecodes, callBytecode]
+    }),
+    { createBytecodes: [], callBytecodes: [] }
+  );
+
+  // join array (it's okay)
+  const bytecodes = [...createBytecodes, ...callBytecodes];
+
+  const result = yield {
+    request: AddBytecodes,
+    variables: { bytecodes }
+  };
+
+  // now slice the array (told you it was okay)
+  const createBytecodesOffset = 0;
+  const callBytecodesOffset = createBytecodes.length;
+
+  // and use the slice indexes to group back into contracts
+  const addedBytecodes = result.data.workspace.bytecodesAdd.bytecodes;
+  return contracts.map((_, index) => ({
+    createBytecode: addedBytecodes[index + createBytecodesOffset],
+    callBytecode: addedBytecodes[index + callBytecodesOffset]
+  }));
+}

--- a/packages/db/src/loaders/resources/bytecodes/index.ts
+++ b/packages/db/src/loaders/resources/bytecodes/index.ts
@@ -1,6 +1,8 @@
 import {
+  CompilationData,
   CompiledContract,
-  ContractBytecodes,
+  toIdObject,
+  LoadedBytecodes,
   WorkspaceRequest,
   WorkspaceResponse
 } from "@truffle/db/loaders/types";
@@ -12,13 +14,20 @@ export { AddBytecodes };
  * @dev pre-condition: every contract should have both bytecodes
  */
 export function* generateBytecodesLoad(
-  contracts: CompiledContract[]
+  compilation: CompilationData
 ): Generator<
   WorkspaceRequest,
-  ContractBytecodes[],
+  LoadedBytecodes,
   WorkspaceResponse<"bytecodesAdd", DataModel.IBytecodesAddPayload>
 > {
-  const { createBytecodes, callBytecodes } = contracts.reduce(
+  // we're flattening in order to send all bytecodes in one big list
+  // (it's okay, we're gonna recreate the structure before we return)
+  const flattenedContracts: CompiledContract[] = compilation.sources
+    .map(({ contracts }) => contracts)
+    .flat();
+
+  // now pluck all the create/call bytecodes and concat them (creates first)
+  const { createBytecodes, callBytecodes } = flattenedContracts.reduce(
     (
       { createBytecodes, callBytecodes },
       { deployedBytecode: callBytecode, bytecode: createBytecode }
@@ -28,23 +37,40 @@ export function* generateBytecodesLoad(
     }),
     { createBytecodes: [], callBytecodes: [] }
   );
-
-  // join array (it's okay)
   const bytecodes = [...createBytecodes, ...callBytecodes];
 
+  // submit
   const result = yield {
     request: AddBytecodes,
     variables: { bytecodes }
   };
+  const addedBytecodes = result.data.workspace.bytecodesAdd.bytecodes.map(
+    toIdObject
+  );
 
-  // now slice the array (told you it was okay)
+  // okay, now the hard part, putting things back together the way they were!
+  // we'll start by zipping the creates/calls back
   const createBytecodesOffset = 0;
   const callBytecodesOffset = createBytecodes.length;
-
-  // and use the slice indexes to group back into contracts
-  const addedBytecodes = result.data.workspace.bytecodesAdd.bytecodes;
-  return contracts.map((_, index) => ({
+  const contractBytecodes = flattenedContracts.map((_, index) => ({
     createBytecode: addedBytecodes[index + createBytecodesOffset],
     callBytecode: addedBytecodes[index + callBytecodesOffset]
   }));
+
+  // we now have a flat list of pairs of bytecodes, one pair per contract.
+  //
+  // next: unflatten by following the compilation structure and consuming
+  // incrementally from the front of the flat list
+  const loadedBytecodes = { sources: [] };
+  for (const { contracts } of compilation.sources) {
+    const source = { contracts: [] };
+
+    for (const _ of contracts) {
+      source.contracts.push(contractBytecodes.shift());
+    }
+
+    loadedBytecodes.sources.push(source);
+  }
+
+  return loadedBytecodes;
 }

--- a/packages/db/src/loaders/resources/compilations/add.graphql.ts
+++ b/packages/db/src/loaders/resources/compilations/add.graphql.ts
@@ -44,26 +44,6 @@ export const AddCompilations = gql`
       compilationsAdd(input: { compilations: $compilations }) {
         compilations {
           id
-          compiler {
-            name
-            version
-          }
-          processedSources {
-            source {
-              contents
-              sourcePath
-            }
-            ast {
-              json
-            }
-          }
-          sources {
-            contents
-            sourcePath
-          }
-          sourceMaps {
-            json
-          }
         }
       }
     }

--- a/packages/db/src/loaders/resources/compilations/get.graphql.ts
+++ b/packages/db/src/loaders/resources/compilations/get.graphql.ts
@@ -1,0 +1,41 @@
+import gql from "graphql-tag";
+
+export const GetCompilation = gql`
+  query GetCompilation($id: ID!) {
+    workspace {
+      compilation(id: $id) {
+        id
+        compiler {
+          name
+        }
+        sourceMaps {
+          json
+        }
+        processedSources {
+          source {
+            sourcePath
+          }
+
+          contracts {
+            id
+            name
+            createBytecode {
+              id
+              bytes
+              linkReferences {
+                name
+              }
+            }
+            callBytecode {
+              id
+              bytes
+              linkReferences {
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;

--- a/packages/db/src/loaders/resources/compilations/index.ts
+++ b/packages/db/src/loaders/resources/compilations/index.ts
@@ -1,2 +1,82 @@
+import {
+  CompilationData,
+  IdObject,
+  WorkspaceRequest,
+  WorkspaceResponse
+} from "@truffle/db/loaders/types";
+
 import { AddCompilations } from "./add.graphql";
 export { AddCompilations };
+
+const compilationCompilerInput = ({
+  compilation: { contracts }
+}: {
+  compilation: CompilationData;
+}): DataModel.ICompilerInput => ({
+  name: contracts[0].compiler.name,
+  version: contracts[0].compiler.version
+});
+
+const compilationProcessedSourceInputs = ({
+  compilation: { contracts },
+  sources
+}: {
+  compilation: CompilationData;
+  sources: IdObject<DataModel.ISource>[];
+}): DataModel.ICompilationProcessedSourceInput[] =>
+  contracts.map(({ contractName: name, ast }, index) => ({
+    name,
+    source: sources[index],
+    ast: ast ? { json: JSON.stringify(ast) } : undefined
+  }));
+
+const compilationInput = ({
+  compilation,
+  sources
+}: {
+  compilation: CompilationData;
+  sources: IdObject<DataModel.ISource>[];
+}): DataModel.ICompilationInput => {
+  const compiler = compilationCompilerInput({ compilation });
+  const processedSources = compilationProcessedSourceInputs({
+    compilation,
+    sources
+  });
+
+  if (compiler.name === "solc") {
+    return {
+      compiler,
+      processedSources,
+      sources,
+      sourceMaps: compilation.contracts.map(({ sourceMap: json }) => ({ json }))
+    };
+  } else {
+    return {
+      compiler,
+      processedSources,
+      sources
+    };
+  }
+};
+
+type LoadableCompilation = {
+  compilation: CompilationData;
+  sources: IdObject<DataModel.ISource>[];
+};
+
+export function* generateCompilationsLoad(
+  loadableCompilations: LoadableCompilation[]
+): Generator<
+  WorkspaceRequest,
+  DataModel.ICompilation[],
+  WorkspaceResponse<"compilationsAdd", DataModel.ICompilationsAddPayload>
+> {
+  const compilations = loadableCompilations.map(compilationInput);
+
+  const result = yield {
+    request: AddCompilations,
+    variables: { compilations }
+  };
+
+  return result.data.workspace.compilationsAdd.compilations;
+}

--- a/packages/db/src/loaders/resources/contracts/add.graphql.ts
+++ b/packages/db/src/loaders/resources/contracts/add.graphql.ts
@@ -71,6 +71,7 @@ export const AddContracts = gql`
             }
           }
           createBytecode {
+            id
             bytes
             linkReferences {
               offsets
@@ -79,6 +80,7 @@ export const AddContracts = gql`
             }
           }
           callBytecode {
+            id
             bytes
             linkReferences {
               offsets

--- a/packages/db/src/loaders/resources/contracts/index.ts
+++ b/packages/db/src/loaders/resources/contracts/index.ts
@@ -1,2 +1,48 @@
+import {
+  CompiledContract,
+  ContractBytecodes,
+  IdObject,
+  toIdObject,
+  WorkspaceRequest,
+  WorkspaceResponse
+} from "@truffle/db/loaders/types";
+
 import { AddContracts } from "./add.graphql";
 export { AddContracts };
+
+/**
+ * @dev pre-condition: indexes of array arguments must align
+ *   (i.e., contractBytecodes[i] are bytecodes for the i-th compiledContract)
+ */
+export function* generateContractsLoad(
+  compiledContracts: CompiledContract[],
+  contractBytecodes: ContractBytecodes[],
+  compilation: IdObject<DataModel.ICompilation>
+): Generator<
+  WorkspaceRequest,
+  DataModel.IContract[],
+  WorkspaceResponse<"contractsAdd", DataModel.IContractsAddPayload>
+> {
+  const contracts = compiledContracts.map((contract, index) => {
+    const { contractName: name, abi: abiObject } = contract;
+    const { createBytecode, callBytecode } = contractBytecodes[index];
+
+    return {
+      name,
+      abi: {
+        json: JSON.stringify(abiObject)
+      },
+      compilation,
+      processedSource: { index },
+      createBytecode: toIdObject(createBytecode),
+      callBytecode: toIdObject(callBytecode)
+    };
+  });
+
+  const result = yield {
+    request: AddContracts,
+    variables: { contracts }
+  };
+
+  return result.data.workspace.contractsAdd.contracts;
+}

--- a/packages/db/src/loaders/resources/nameRecords/index.ts
+++ b/packages/db/src/loaders/resources/nameRecords/index.ts
@@ -1,2 +1,62 @@
+import {
+  WorkspaceRequest,
+  IdObject,
+  toIdObject,
+  WorkspaceResponse
+} from "@truffle/db/loaders/types";
+
 import { AddNameRecords } from "./add.graphql";
 export { AddNameRecords };
+
+interface Resource {
+  id: string;
+  name: string;
+}
+
+type ResolveFunc = (
+  name: string,
+  type: string
+) => Generator<
+  WorkspaceRequest,
+  DataModel.INameRecord | null,
+  WorkspaceResponse
+>;
+
+export function* generateNameRecordsLoad(
+  resources: Resource[],
+  type: string,
+  getCurrent: ResolveFunc
+): Generator<
+  WorkspaceRequest,
+  DataModel.INameRecord[],
+  WorkspaceResponse<"nameRecordsAdd", DataModel.INameRecordsAddPayload>
+> {
+  const nameRecords = [];
+  for (const resource of resources) {
+    const { name } = resource;
+
+    const current: DataModel.INameRecord = yield* getCurrent(name, type);
+
+    if (current) {
+      nameRecords.push({
+        name,
+        type,
+        resource: toIdObject(resource),
+        previous: toIdObject(current)
+      });
+    } else {
+      nameRecords.push({
+        name,
+        type,
+        resource: toIdObject(resource)
+      });
+    }
+  }
+
+  const result = yield {
+    request: AddNameRecords,
+    variables: { nameRecords }
+  };
+
+  return result.data.workspace.nameRecordsAdd.nameRecords;
+}

--- a/packages/db/src/loaders/resources/projects/index.ts
+++ b/packages/db/src/loaders/resources/projects/index.ts
@@ -25,3 +25,45 @@ export function* generateProjectLoad(
 
   return result.data.workspace.projectsAdd.projects[0];
 }
+
+export function* generateProjectNameResolve(
+  project: IdObject<DataModel.IProject>,
+  name: string,
+  type: string
+): Generator<
+  WorkspaceRequest,
+  DataModel.INameRecord,
+  WorkspaceResponse<"project", { resolve: DataModel.IProject["resolve"] }>
+> {
+  const result = yield {
+    request: ResolveProjectName,
+    variables: {
+      projectId: project.id,
+      name,
+      type
+    }
+  };
+
+  return result.data.workspace.project.resolve[0];
+}
+
+export function* generateProjectNamesAssign(
+  project: IdObject<DataModel.IProject>,
+  nameRecords: DataModel.INameRecord[]
+): Generator<
+  WorkspaceRequest,
+  void,
+  WorkspaceResponse<"projectNamesAssign", DataModel.IProjectNamesAssignPayload>
+> {
+  const projectNames = nameRecords.map(({ id, name, type }) => ({
+    project,
+    nameRecord: { id },
+    name,
+    type
+  }));
+
+  yield {
+    request: AssignProjectNames,
+    variables: { projectNames }
+  };
+}

--- a/packages/db/src/loaders/resources/projects/index.ts
+++ b/packages/db/src/loaders/resources/projects/index.ts
@@ -1,4 +1,27 @@
+import {
+  IdObject,
+  WorkspaceRequest,
+  WorkspaceResponse
+} from "@truffle/db/loaders/types";
+
 import { AddProjects } from "./add.graphql";
 import { AssignProjectNames } from "./assign.graphql";
 import { ResolveProjectName } from "./resolve.graphql";
 export { AddProjects, AssignProjectNames, ResolveProjectName };
+
+export function* generateProjectLoad(
+  directory: string
+): Generator<
+  WorkspaceRequest,
+  DataModel.IProject,
+  WorkspaceResponse<"projectsAdd", DataModel.IProjectsAddPayload>
+> {
+  const result = yield {
+    request: AddProjects,
+    variables: {
+      projects: [{ directory }]
+    }
+  };
+
+  return result.data.workspace.projectsAdd.projects[0];
+}

--- a/packages/db/src/loaders/resources/sources/index.ts
+++ b/packages/db/src/loaders/resources/sources/index.ts
@@ -1,2 +1,44 @@
+import {
+  CompiledContract,
+  CompilationData,
+  WorkspaceRequest,
+  WorkspaceResponse
+} from "@truffle/db/loaders/types";
+
 import { AddSources } from "./add.graphql";
 export { AddSources };
+
+const contractSourceInput = ({
+  contract: { sourcePath, source: contents }
+}: {
+  contract: CompiledContract;
+}): DataModel.ISourceInput => ({
+  contents,
+  sourcePath
+});
+
+const compilationSourceInputs = ({
+  compilation: { contracts }
+}: {
+  compilation: CompilationData;
+}): DataModel.ISourceInput[] =>
+  contracts.map(contract => contractSourceInput({ contract }));
+
+// returns list of IDs
+export function* generateSourcesLoad(
+  compilation: CompilationData
+): Generator<
+  WorkspaceRequest,
+  DataModel.ISource[],
+  WorkspaceResponse<"sourcesAdd", DataModel.ISourcesAddPayload>
+> {
+  // for each compilation, we need to load sources for each of the contracts
+  const sources = compilationSourceInputs({ compilation });
+
+  const result = yield {
+    request: AddSources,
+    variables: { sources }
+  };
+
+  return result.data.workspace.sourcesAdd.sources;
+}

--- a/packages/db/src/loaders/schema/artifactsLoader.ts
+++ b/packages/db/src/loaders/schema/artifactsLoader.ts
@@ -104,28 +104,6 @@ export class ArtifactsLoader {
 
         const contracts = compilationContracts[id];
 
-        const nameRecords: NameRecordObject[] = await Promise.all(
-          contracts.map(async contract => {
-            //check if there is already a current head for this item. if so save it as previous
-            let current: IdObject = await this.resolveProjectName(
-              project.id,
-              "Contract",
-              contract.name
-            );
-
-            return {
-              name: contract.name,
-              type: "Contract",
-              resource: {
-                id: contract.id
-              },
-              previous: current
-            };
-          })
-        );
-
-        await this.loadNameRecords(project.id, nameRecords);
-
         if (networks[0].length) {
           await this.loadContractInstances(contracts, networks);
         }
@@ -133,10 +111,7 @@ export class ArtifactsLoader {
     );
   }
 
-  async loadNameRecords(
-    projectId: string,
-    nameRecords: Array<NameRecordObject>
-  ) {
+  async loadNameRecords(projectId: string, nameRecords: NameRecordObject[]) {
     const nameRecordsResult = await this.db.query(AddNameRecords, {
       nameRecords: nameRecords
     });

--- a/packages/db/src/loaders/schema/test/index.ts
+++ b/packages/db/src/loaders/schema/test/index.ts
@@ -576,9 +576,12 @@ describe("Compilation", () => {
       expect(solcCompilation.processedSources[index].source.contents).toEqual(
         artifacts[index].source
       );
-      expect(solcCompilation.sourceMaps[index].json).toEqual(
-        artifacts[index].sourceMap
-      );
+
+      expect(
+        solcCompilation.sourceMaps.find(
+          ({ json }) => json === artifacts[index].sourceMap
+        )
+      ).toBeDefined();
     });
 
     const vyperCompilation = compilationsQuery[1].data.workspace.compilation;
@@ -730,7 +733,7 @@ describe("Compilation", () => {
   });
 
   it("loads contract instances", async () => {
-    for (let index in migratedArtifacts) {
+    for (const contractInstanceId of contractInstanceIds) {
       let {
         data: {
           workspace: {
@@ -750,27 +753,29 @@ describe("Compilation", () => {
             }
           }
         }
-      } = await db.query(
-        GetWorkspaceContractInstance,
-        contractInstanceIds[index]
+      } = await db.query(GetWorkspaceContractInstance, contractInstanceId);
+
+      const contractInstance = contractInstances.find(
+        contractInstance => name === contractInstance.contract.name
       );
 
-      expect(name).toEqual(contractInstances[index].contract.name);
-      expect(networkId).toEqual(contractInstances[index].network.networkId);
-      expect(address).toEqual(contractInstances[index].address);
+      expect(contractInstance).toBeDefined();
+
+      expect(name).toEqual(contractInstance.contract.name);
+      expect(networkId).toEqual(contractInstance.network.networkId);
+      expect(address).toEqual(contractInstance.address);
       expect(transactionHash).toEqual(
-        contractInstances[index].creation.transactionHash
+        contractInstance.creation.transactionHash
       );
       expect(bytes).toEqual(
-        contractInstances[index].creation.constructor.createBytecode.bytecode
-          .bytes
+        contractInstance.creation.constructor.createBytecode.bytecode.bytes
       );
       expect(linkReferences).toEqual(
-        contractInstances[index].creation.constructor.createBytecode.bytecode
+        contractInstance.creation.constructor.createBytecode.bytecode
           .linkReferences
       );
       expect(bytecode.bytes).toEqual(
-        contractInstances[index].callBytecode.bytecode.bytes
+        contractInstance.callBytecode.bytecode.bytes
       );
     }
   });

--- a/packages/db/src/loaders/types.ts
+++ b/packages/db/src/loaders/types.ts
@@ -1,0 +1,59 @@
+import { ContractObject } from "@truffle/contract-schema/spec";
+
+// NOTE we do not use the regular ContractObject type here because
+// @truffle/workflow-compile/new provides a different bytecode format than
+// @truffle/contract-schema defines
+export interface CompiledContract {
+  contractName: string;
+  abi: ContractObject["abi"];
+  bytecode: DataModel.IBytecode;
+  deployedBytecode: DataModel.IBytecode;
+  sourceMap: string;
+  deployedSourceMap: string;
+  source: string;
+  sourcePath: string;
+  ast: object;
+  compiler: {
+    name: string;
+    version: string;
+  };
+}
+
+export interface CompilationData {
+  sourceIndexes: string[];
+  contracts: CompiledContract[];
+}
+
+type Resource = {
+  id: string;
+};
+
+export type IdObject<R extends Resource = Resource> = {
+  [N in keyof R]: N extends "id" ? string : never
+};
+
+export const toIdObject = <R extends Resource>({ id }: R): IdObject<R> =>
+  ({
+    id
+  } as IdObject<R>);
+
+export interface WorkspaceRequest {
+  request: string; // GraphQL request
+  variables: {
+    [name: string]: any;
+  };
+}
+
+export type WorkspaceResponse<N extends string, R = any> = {
+  data: {
+    workspace: { [RequestName in N]: R };
+  };
+};
+
+/**
+ * Output format of @truffle/workflow-compile/new
+ */
+export interface WorkflowCompileResult {
+  compilations: { [compilerName: string]: CompilationData };
+  contracts: { [contractName: string]: ContractObject };
+}

--- a/packages/db/src/loaders/types.ts
+++ b/packages/db/src/loaders/types.ts
@@ -49,7 +49,7 @@ export interface WorkspaceRequest {
   };
 }
 
-export type WorkspaceResponse<N extends string, R = any> = {
+export type WorkspaceResponse<N extends string = string, R = any> = {
   data: {
     workspace: { [RequestName in N]: R };
   };

--- a/packages/db/src/loaders/types.ts
+++ b/packages/db/src/loaders/types.ts
@@ -20,13 +20,34 @@ export interface CompiledContract {
 }
 
 export interface CompilationData {
-  sourceIndexes: string[];
+  compiler: {
+    name: string;
+    version: string;
+  };
+  sources: SourceData[]; // ordered by index
+}
+
+export interface SourceData {
+  index: number;
+  input: DataModel.ISourceInput;
   contracts: CompiledContract[];
 }
 
-export interface ContractBytecodes {
-  createBytecode: DataModel.IBytecode;
-  callBytecode: DataModel.IBytecode;
+export interface LoadedSources {
+  [sourcePath: string]: IdObject<DataModel.ISource>;
+}
+
+// we track loaded bytecodes using the same structure as CompilationData:
+// - order sources
+// - order contracts for each source
+// - capture bytecodes for each contract
+export interface LoadedBytecodes {
+  sources: {
+    contracts: {
+      createBytecode: IdObject<DataModel.IBytecode>;
+      callBytecode: IdObject<DataModel.IBytecode>;
+    }[];
+  }[];
 }
 
 type Resource = {
@@ -59,6 +80,11 @@ export type WorkspaceResponse<N extends string = string, R = any> = {
  * Output format of @truffle/workflow-compile/new
  */
 export interface WorkflowCompileResult {
-  compilations: { [compilerName: string]: CompilationData };
+  compilations: {
+    [compilerName: string]: {
+      sourceIndexes: string[];
+      contracts: CompiledContract[];
+    };
+  };
   contracts: { [contractName: string]: ContractObject };
 }

--- a/packages/db/src/loaders/types.ts
+++ b/packages/db/src/loaders/types.ts
@@ -24,6 +24,11 @@ export interface CompilationData {
   contracts: CompiledContract[];
 }
 
+export interface ContractBytecodes {
+  createBytecode: DataModel.IBytecode;
+  callBytecode: DataModel.IBytecode;
+}
+
 type Resource = {
   id: string;
 };

--- a/packages/db/types/stub.d.ts
+++ b/packages/db/types/stub.d.ts
@@ -35,6 +35,7 @@ declare namespace DataModel {
   type ISourceInput = any;
   type ISourceRange = any;
   type ISourcesAddInput = any;
+  type ISourcesAddPayload = any;
 
   interface IWorkspaceQuery {
     [key: string]: any;

--- a/packages/db/types/stub.d.ts
+++ b/packages/db/types/stub.d.ts
@@ -9,6 +9,8 @@ declare namespace DataModel {
   type ICompilation = any;
   type ICompilationInput = any;
   type ICompilationProcessedSourceInput = any;
+  type ICompilationSourceMapInput = any;
+  type ICompilationSourceInput = any;
   type ICompilationsAddInput = any;
   type ICompilationsAddPayload = any;
   type ICompiler = any;

--- a/packages/db/types/stub.d.ts
+++ b/packages/db/types/stub.d.ts
@@ -24,6 +24,7 @@ declare namespace DataModel {
   type IInstruction = any;
   type INameRecord = any;
   type INameRecordsAddInput = any;
+  type INameRecordsAddPayload = any;
   type INetwork = any;
   type INetworkInput = any;
   type INetworksAddInput = any;
@@ -32,6 +33,7 @@ declare namespace DataModel {
   type IProjectsAddPayload = any;
   type IProjectName = any;
   type IProjectNameInput = any;
+  type IProjectNamesAssignPayload = any;
   type ISource = any;
   type ISourceInput = any;
   type ISourceRange = any;

--- a/packages/db/types/stub.d.ts
+++ b/packages/db/types/stub.d.ts
@@ -29,6 +29,7 @@ declare namespace DataModel {
   type INetworksAddInput = any;
   type IProject = any;
   type IProjectsAddInput = any;
+  type IProjectsAddPayload = any;
   type IProjectName = any;
   type IProjectNameInput = any;
   type ISource = any;


### PR DESCRIPTION
This PR refactors the artifactsLoader to expose `db.loadCompilations(workflowCompileResult)` as a standalone method. Previously, the artifactsLoader only offered the capability of forcing a recompilation and collecting all information in one fell swoop. Now, the artifactsLoader defers to `db.loadCompilations()`. This method is intended for use inside the rest of Truffle also, so that the artifactsLoader stops being the only way to load data into Truffle DB.

For reviewing this, probably best to step through the individual commits. Notes:
- The first four commits break specific resources out from the artifactsLoader and incorporate them into the new loaders framework
- The last (fifth) commit adds a pre-processing step at the very beginning, to structure the workflow-compile result into a form that more natively matches the structure we're looking for.

Let me know if you have questions, and I'll try to expand on this description with additional context!

Oh! Forgot to mention: @cds-amal was instrumental, helping me put this together several months ago when I started it 🙏 