### PR TITLE
Add `validate` function to `contract-schema` exported typings

### DIFF
--- a/packages/contract-schema/typings/index.d.ts
+++ b/packages/contract-schema/typings/index.d.ts
@@ -3,7 +3,11 @@ declare module "@truffle/contract-schema" {
   export { ContractObject } from "@truffle/contract-schema/spec";
 
   namespace Schema {
-    export function normalize(dirtyObj: object, opts?: object): ContractObject;
+    export function validate(contractObject: ContractObject): ContractObject;
+    export function normalize(
+      objDirty: object,
+      options?: object
+    ): ContractObject;
   }
 
   export default Schema;


### PR DESCRIPTION
This PR adds a missing exported function (`validate`) to the `contract-schema` typings

I also earmarked some updates to match the variable names in the `index.js` to the `index.d.ts`