### PR TITLE
Permit querying compilations for related contracts in Truffle DB

### DIFF
--- a/packages/db/src/artifacts/schema.ts
+++ b/packages/db/src/artifacts/schema.ts
@@ -126,19 +126,18 @@ export const schema = mergeSchemas({
       name: {
         fragment: `... on ContractObject { name: contractName }`
       },
-      sourceContract: {
+      processedSource: {
         fragment: `... on ContractObject {
           ast { json }
           source { contents, sourcePath }
         }`,
         resolve: obj => {
-          const { name, source, ast } = obj;
-          const sourceContract = {
-            name: name,
+          const { source, ast } = obj;
+          const processedSource = {
             source: source,
             ast: ast
           };
-          return sourceContract;
+          return processedSource;
         }
       },
       createBytecode: {

--- a/packages/db/src/artifacts/test/index.ts
+++ b/packages/db/src/artifacts/test/index.ts
@@ -37,8 +37,7 @@ const GetContract = `
     artifacts {
       contract(name: $name) {
         name
-        sourceContract {
-          name
+        processedSource {
           source {
             contents
             sourcePath
@@ -59,7 +58,7 @@ const GetContractBytecodes = `
     artifacts {
       contract(name: $name) {
         name
-        sourceContract {
+        processedSource {
           name
           source {
             contents
@@ -121,15 +120,14 @@ describe("Artifacts queries", () => {
 
     const { contract } = artifacts;
     expect(contract).toHaveProperty("name");
-    expect(contract).toHaveProperty("sourceContract");
+    expect(contract).toHaveProperty("processedSource");
 
-    const { name, sourceContract, abi } = contract;
+    const { name, processedSource, abi } = contract;
     expect(name).toEqual(Migrations.contractName);
-    expect(sourceContract).toHaveProperty("name");
-    expect(sourceContract).toHaveProperty("ast");
-    expect(sourceContract).toHaveProperty("source");
+    expect(processedSource).toHaveProperty("ast");
+    expect(processedSource).toHaveProperty("source");
 
-    const { ast, source } = sourceContract;
+    const { ast, source } = processedSource;
     expect(source).toHaveProperty("contents");
     expect(source).toHaveProperty("sourcePath");
 
@@ -150,13 +148,13 @@ describe("Artifacts queries", () => {
     const { contract } = artifacts;
     expect(contract).toHaveProperty("name");
     expect(contract).toHaveProperty("abi");
-    expect(contract).toHaveProperty("sourceContract");
+    expect(contract).toHaveProperty("processedSource");
     expect(contract).toHaveProperty("createBytecode");
     expect(contract).toHaveProperty("callBytecode");
 
     const {
       name,
-      sourceContract,
+      processedSource,
       abi,
       createBytecode,
       callBytecode
@@ -165,9 +163,8 @@ describe("Artifacts queries", () => {
     expect(createBytecode).toEqual(shimBytecode(Migrations.bytecode));
     expect(callBytecode).toEqual(shimBytecode(Migrations.deployedBytecode));
 
-    expect(sourceContract).toHaveProperty("name");
-    expect(sourceContract).toHaveProperty("source");
-    const { source } = sourceContract;
+    expect(processedSource).toHaveProperty("source");
+    const { source } = processedSource;
     expect(source).not.toEqual(null);
   });
 
@@ -187,7 +184,7 @@ describe("Artifacts queries", () => {
           }
           contract {
             name
-            sourceContract {
+            processedSource {
               name
               source {
                 contents
@@ -223,15 +220,14 @@ describe("Artifacts queries", () => {
     const { contract, callBytecode } = contractInstance;
     expect(contract).toHaveProperty("name");
     expect(contract).toHaveProperty("abi");
-    expect(contract).toHaveProperty("sourceContract");
+    expect(contract).toHaveProperty("processedSource");
 
-    const { name, sourceContract, abi } = contract;
+    const { name, processedSource, abi } = contract;
     expect(name).toEqual(Migrations.contractName);
-    expect(sourceContract).toHaveProperty("name");
-    expect(sourceContract).toHaveProperty("ast");
-    expect(sourceContract).toHaveProperty("source");
+    expect(processedSource).toHaveProperty("ast");
+    expect(processedSource).toHaveProperty("source");
 
-    const { ast, source } = sourceContract;
+    const { ast, source } = processedSource;
     expect(source).toHaveProperty("contents");
     expect(source).toHaveProperty("sourcePath");
     expect(name).toEqual(Migrations.contractName);

--- a/packages/db/src/loaders/resources/compilations/add.graphql.ts
+++ b/packages/db/src/loaders/resources/compilations/add.graphql.ts
@@ -11,11 +11,11 @@ export const AddCompilations = gql`
     id: ID!
   }
 
-  input CompilationSourceContractSourceInput {
+  input CompilationProcessedSourceSourceInput {
     id: ID!
   }
 
-  input CompilationSourceContractAstInput {
+  input CompilationProcessedSourceAstInput {
     json: String!
   }
 
@@ -23,16 +23,16 @@ export const AddCompilations = gql`
     json: String!
   }
 
-  input CompilationSourceContractInput {
+  input CompilationProcessedSourceInput {
     name: String
-    source: CompilationSourceContractSourceInput
-    ast: CompilationSourceContractAstInput
+    source: CompilationProcessedSourceSourceInput
+    ast: CompilationProcessedSourceAstInput
   }
 
   input CompilationInput {
     compiler: CompilerInput!
-    contracts: [CompilationSourceContractInput!]
     sources: [CompilationSourceInput!]!
+    processedSources: [CompilationProcessedSourceInput!]
     sourceMaps: [CompilationSourceMapInput]
   }
   input CompilationsAddInput {
@@ -48,8 +48,7 @@ export const AddCompilations = gql`
             name
             version
           }
-          contracts {
-            name
+          processedSources {
             source {
               contents
               sourcePath

--- a/packages/db/src/loaders/resources/contracts/add.graphql.ts
+++ b/packages/db/src/loaders/resources/contracts/add.graphql.ts
@@ -10,7 +10,7 @@ export const AddContracts = gql`
     id: ID!
   }
 
-  input ContractSourceContractInput {
+  input ContractProcessedSourceInput {
     index: FileIndex
   }
 
@@ -27,7 +27,7 @@ export const AddContracts = gql`
     name: String
     abi: AbiInput
     compilation: ContractCompilationInput
-    sourceContract: ContractSourceContractInput
+    processedSource: ContractProcessedSourceInput
     createBytecode: ContractBytecodeInput
     callBytecode: ContractBytecodeInput
   }
@@ -41,8 +41,7 @@ export const AddContracts = gql`
           abi {
             json
           }
-          sourceContract {
-            name
+          processedSource {
             source {
               contents
               sourcePath

--- a/packages/db/src/loaders/schema/artifactsLoader.ts
+++ b/packages/db/src/loaders/schema/artifactsLoader.ts
@@ -216,7 +216,7 @@ export class ArtifactsLoader {
         compilation: {
           id: compilationId
         },
-        sourceContract: {
+        processedSource: {
           index: index
         },
         createBytecode: {
@@ -309,7 +309,7 @@ export class ArtifactsLoader {
     return sources.map(({ id }) => ({ id }));
   }
 
-  async compilationSourceContracts(
+  async compilationProcessedSources(
     compilation: Array<ContractObject>,
     sourceIds: Array<IdObject>
   ) {
@@ -322,7 +322,7 @@ export class ArtifactsLoader {
 
   async setCompilation(organizedCompilation: Array<ContractObject>) {
     const sourceIds = await this.loadCompilationSources(organizedCompilation);
-    const sourceContracts = await this.compilationSourceContracts(
+    const processedSources = await this.compilationProcessedSources(
       organizedCompilation,
       sourceIds
     );
@@ -332,7 +332,7 @@ export class ArtifactsLoader {
         name: organizedCompilation[0]["compiler"]["name"],
         version: organizedCompilation[0]["compiler"]["version"]
       },
-      contracts: sourceContracts,
+      processedSources,
       sources: sourceIds
     };
 

--- a/packages/db/src/loaders/schema/test/index.ts
+++ b/packages/db/src/loaders/schema/test/index.ts
@@ -204,17 +204,13 @@ const GetWorkspaceContract = gql`
         callBytecode {
           bytes
         }
-        sourceContract {
+        processedSource {
           source {
             contents
             sourcePath
           }
           ast {
             json
-          }
-          source {
-            contents
-            sourcePath
           }
         }
         compilation {
@@ -226,8 +222,7 @@ const GetWorkspaceContract = gql`
             contents
             sourcePath
           }
-          contracts {
-            name
+          processedSources {
             source {
               contents
               sourcePath
@@ -247,8 +242,7 @@ const GetWorkspaceCompilation: boolean = gql`
           name
           version
         }
-        contracts {
-          name
+        processedSources {
           source {
             contents
             sourcePath
@@ -579,8 +573,8 @@ describe("Compilation", () => {
     solcCompilation.sources.map((source, index) => {
       expect(source.id).toEqual(sourceIds[index].id);
       expect(source["contents"]).toEqual(artifacts[index].source);
-      expect(solcCompilation.contracts[index].name).toEqual(
-        artifacts[index].contractName
+      expect(solcCompilation.processedSources[index].source.contents).toEqual(
+        artifacts[index].source
       );
       expect(solcCompilation.sourceMaps[index].json).toEqual(
         artifacts[index].sourceMap
@@ -594,8 +588,8 @@ describe("Compilation", () => {
     expect(vyperCompilation.sources.length).toEqual(1);
     expect(vyperCompilation.sources[0].id).toEqual(sourceIds[3].id);
     expect(vyperCompilation.sources[0].contents).toEqual(artifacts[3].source);
-    expect(vyperCompilation.contracts[0].name).toEqual(
-      artifacts[3].contractName
+    expect(vyperCompilation.processedSources[0].source.contents).toEqual(
+      artifacts[3].source
     );
   });
 
@@ -636,7 +630,7 @@ describe("Compilation", () => {
       let expectedId = generateId({
         name: artifacts[index].contractName,
         abi: { json: JSON.stringify(artifacts[index].abi) },
-        sourceContract: {
+        processedSource: {
           index: artifacts[index].compiler.name === "solc" ? +index : 0
         },
         compilation: {
@@ -675,7 +669,7 @@ describe("Compilation", () => {
             contract: {
               id,
               name,
-              sourceContract: {
+              processedSource: {
                 source: { contents }
               },
               compilation: {

--- a/packages/db/src/schema.graphql
+++ b/packages/db/src/schema.graphql
@@ -66,6 +66,7 @@ type AbiItem {
 
 type ProcessedSource {
   source: Source!
+  contracts: [Contract]!
   ast: AST
 }
 

--- a/packages/db/src/schema.graphql
+++ b/packages/db/src/schema.graphql
@@ -49,7 +49,7 @@ type Contract implements Named {
   source: Source
   abi: ABI
   compilation: Compilation
-  sourceContract: SourceContract
+  processedSource: ProcessedSource
   createBytecode: Bytecode
   callBytecode: Bytecode
 }
@@ -64,9 +64,8 @@ type AbiItem {
   type: String
 }
 
-type SourceContract {
-  name: String
-  source: Source
+type ProcessedSource {
+  source: Source!
   ast: AST
 }
 
@@ -144,7 +143,7 @@ type SourceMap {
 type Compilation {
   compiler: Compiler!
   sources: [Source]!
-  contracts: [SourceContract]!
+  processedSources: [ProcessedSource]!
   sourceMaps: [SourceMap]
 }
 

--- a/packages/db/src/workspace/definitions.ts
+++ b/packages/db/src/workspace/definitions.ts
@@ -42,7 +42,11 @@ export type WorkspaceCollections = {
 
 export const definitions: Definitions<WorkspaceCollections> = {
   contracts: {
-    createIndexes: [],
+    createIndexes: [
+      {
+        fields: ["compilation.id", "processedSource.index"]
+      }
+    ],
     idFields: ["name", "abi", "processedSource", "compilation"]
   },
   sources: {

--- a/packages/db/src/workspace/definitions.ts
+++ b/packages/db/src/workspace/definitions.ts
@@ -43,7 +43,7 @@ export type WorkspaceCollections = {
 export const definitions: Definitions<WorkspaceCollections> = {
   contracts: {
     createIndexes: [],
-    idFields: ["name", "abi", "sourceContract", "compilation"]
+    idFields: ["name", "abi", "processedSource", "compilation"]
   },
   sources: {
     createIndexes: [],

--- a/packages/db/src/workspace/schema.ts
+++ b/packages/db/src/workspace/schema.ts
@@ -509,6 +509,14 @@ export const schema = mergeSchemas({
       sources: {
         resolve: ({ sources }, _, { workspace }) =>
           Promise.all(sources.map(source => workspace.source(source)))
+      },
+      processedSources: {
+        resolve: ({ id, processedSources }, _, { workspace }) =>
+          processedSources.map((processedSource, index) => ({
+            ...processedSource,
+            compilation: { id },
+            index
+          }))
       }
     },
     Contract: {
@@ -588,6 +596,15 @@ export const schema = mergeSchemas({
     ProcessedSource: {
       source: {
         resolve: ({ source }, _, { workspace }) => workspace.source(source)
+      },
+      contracts: {
+        resolve: ({ compilation, index }, _, { workspace }) =>
+          workspace.databases.find("contracts", {
+            selector: {
+              "compilation.id": compilation.id,
+              "processedSource.index": index
+            }
+          })
       }
     }
   }

--- a/packages/db/src/workspace/schema.ts
+++ b/packages/db/src/workspace/schema.ts
@@ -115,7 +115,7 @@ export const schema = mergeSchemas({
       id: ID!
     }
 
-    input ContractSourceContractInput {
+    input ContractProcessedSourceInput {
       index: FileIndex
     }
 
@@ -127,7 +127,7 @@ export const schema = mergeSchemas({
       name: String!
       abi: AbiInput
       compilation: ContractCompilationInput
-      sourceContract: ContractSourceContractInput
+      processedSource: ContractProcessedSourceInput
       createBytecode: ContractBytecodeInput
       callBytecode: ContractBytecodeInput
     }
@@ -150,18 +150,18 @@ export const schema = mergeSchemas({
       id: ID!
     }
 
-    input CompilationSourceContractSourceInput {
+    input CompilationProcessedSourceSourceInput {
       id: ID!
     }
 
-    input CompilationSourceContractAstInput {
+    input CompilationProcessedSourceAstInput {
       json: String!
     }
 
-    input CompilationSourceContractInput {
+    input CompilationProcessedSourceInput {
       name: String
-      source: CompilationSourceContractSourceInput
-      ast: CompilationSourceContractAstInput
+      source: CompilationProcessedSourceSourceInput
+      ast: CompilationProcessedSourceAstInput
     }
 
     input CompilationSourceMapInput {
@@ -170,7 +170,7 @@ export const schema = mergeSchemas({
 
     input CompilationInput {
       compiler: CompilerInput!
-      contracts: [CompilationSourceContractInput!]
+      processedSources: [CompilationProcessedSourceInput!]
       sources: [CompilationSourceInput!]!
       sourceMaps: [CompilationSourceMapInput]
     }
@@ -516,14 +516,12 @@ export const schema = mergeSchemas({
         resolve: ({ compilation }, _, { workspace }) =>
           workspace.compilation(compilation)
       },
-      sourceContract: {
+      processedSource: {
         fragment: `... on Contract { compilation { id } }`,
-        resolve: async ({ sourceContract, compilation }, _, { workspace }) => {
-          const { contracts: sourceContracts } = await workspace.compilation(
-            compilation
-          );
+        resolve: async ({ processedSource, compilation }, _, { workspace }) => {
+          const { processedSources } = await workspace.compilation(compilation);
 
-          return sourceContracts[sourceContract.index];
+          return processedSources[processedSource.index];
         }
       },
       createBytecode: {
@@ -587,7 +585,7 @@ export const schema = mergeSchemas({
         }
       }
     },
-    SourceContract: {
+    ProcessedSource: {
       source: {
         resolve: ({ source }, _, { workspace }) => workspace.source(source)
       }

--- a/packages/db/src/workspace/test/compilation.graphql.ts
+++ b/packages/db/src/workspace/test/compilation.graphql.ts
@@ -72,6 +72,30 @@ export const GetCompilation = gql`
   }
 `;
 
+export const GetCompilationWithContracts = gql`
+  query GetCompilation($id: ID!) {
+    compilation(id: $id) {
+      id
+      compiler {
+        name
+        version
+      }
+      sources {
+        id
+        contents
+      }
+      processedSources {
+        contracts {
+          id
+        }
+        source {
+          contents
+        }
+      }
+    }
+  }
+`;
+
 export const GetAllCompilations = gql`
   query getAllCompilations {
     compilations {

--- a/packages/db/src/workspace/test/compilation.graphql.ts
+++ b/packages/db/src/workspace/test/compilation.graphql.ts
@@ -14,7 +14,7 @@ export const AddCompilation = gql`
           {
             compiler: { name: $compilerName, version: $compilerVersion }
             sourceMaps: [{ json: $sourceMap }]
-            contracts: [
+            processedSources: [
               {
                 name: "testing"
                 ast: { json: $abi }
@@ -37,7 +37,7 @@ export const AddCompilation = gql`
         sourceMaps {
           json
         }
-        contracts {
+        processedSources {
           source {
             contents
             sourcePath
@@ -45,7 +45,6 @@ export const AddCompilation = gql`
           ast {
             json
           }
-          name
         }
       }
     }
@@ -64,7 +63,7 @@ export const GetCompilation = gql`
         id
         contents
       }
-      contracts {
+      processedSources {
         source {
           contents
         }

--- a/packages/db/src/workspace/test/compilation.spec.ts
+++ b/packages/db/src/workspace/test/compilation.spec.ts
@@ -43,7 +43,7 @@ describe("Compilation", () => {
     for (let compilation of compilations) {
       expect(compilation).toHaveProperty("compiler");
       expect(compilation).toHaveProperty("sources");
-      const { compiler, sources, contracts, sourceMaps } = compilation;
+      const { compiler, sources, processedSources, sourceMaps } = compilation;
 
       expect(compiler).toHaveProperty("name");
 
@@ -52,12 +52,11 @@ describe("Compilation", () => {
         expect(source).toHaveProperty("contents");
       }
 
-      expect(contracts).toHaveLength(1);
+      expect(processedSources).toHaveLength(1);
 
-      for (let contract of contracts) {
-        expect(contract).toHaveProperty("source");
-        expect(contract).toHaveProperty("name");
-        expect(contract).toHaveProperty("ast");
+      for (let processedSource of processedSources) {
+        expect(processedSource).toHaveProperty("source");
+        expect(processedSource).toHaveProperty("ast");
       }
     }
   });

--- a/packages/db/src/workspace/test/contract.graphql.ts
+++ b/packages/db/src/workspace/test/contract.graphql.ts
@@ -7,7 +7,7 @@ export const GetContract = gql`
       abi {
         json
       }
-      sourceContract {
+      processedSource {
         source {
           contents
         }
@@ -23,7 +23,7 @@ export const GetAllContracts = gql`
   query getAllContracts {
     contracts {
       name
-      sourceContract {
+      processedSource {
         name
       }
       source {
@@ -37,7 +37,7 @@ export const GetAllContracts = gql`
           version
         }
       }
-      sourceContract {
+      processedSource {
         source {
           sourcePath
         }
@@ -60,7 +60,7 @@ export const AddContracts = gql`
             name: $contractName
             abi: { json: $abi }
             compilation: { id: $compilationId }
-            sourceContract: { index: 0 }
+            processedSource: { index: 0 }
             constructor: { createBytecode: { bytecode: { id: $bytecodeId } } }
           }
         ]
@@ -69,7 +69,7 @@ export const AddContracts = gql`
       contracts {
         id
         name
-        sourceContract {
+        processedSource {
           name
           source {
             contents

--- a/packages/db/src/workspace/test/contract.spec.ts
+++ b/packages/db/src/workspace/test/contract.spec.ts
@@ -67,19 +67,18 @@ describe("Contract", () => {
 
     expect(contract).toHaveProperty("id");
     expect(contract).toHaveProperty("name");
-    expect(contract).toHaveProperty("sourceContract");
+    expect(contract).toHaveProperty("processedSource");
 
-    const { sourceContract } = contract;
-    expect(sourceContract).toHaveProperty("name");
-    expect(sourceContract).toHaveProperty("source");
-    expect(sourceContract).toHaveProperty("ast");
+    const { processedSource } = contract;
+    expect(processedSource).toHaveProperty("source");
+    expect(processedSource).toHaveProperty("ast");
   });
 
   test("can be queried", async () => {
     expectedId = generateId({
       name: Migrations.contractName,
       abi: { json: JSON.stringify(Migrations.abi) },
-      sourceContract: { index: 0 },
+      processedSource: { index: 0 },
       compilation: { id: compilationId }
     });
 
@@ -91,7 +90,7 @@ describe("Contract", () => {
 
     const { contract } = getContractResult;
     expect(contract).toHaveProperty("name");
-    expect(contract).toHaveProperty("sourceContract");
+    expect(contract).toHaveProperty("processedSource");
     expect(contract).toHaveProperty("abi");
   });
 
@@ -106,11 +105,11 @@ describe("Contract", () => {
     const firstContract = contracts[0];
 
     expect(firstContract).toHaveProperty("name");
-    expect(firstContract).toHaveProperty("sourceContract");
+    expect(firstContract).toHaveProperty("processedSource");
     expect(firstContract).toHaveProperty("abi");
     expect(firstContract).toHaveProperty("abi.json");
     expect(firstContract).toHaveProperty("compilation");
     expect(firstContract).toHaveProperty("compilation.compiler.version");
-    expect(firstContract).toHaveProperty("sourceContract.source.sourcePath");
+    expect(firstContract).toHaveProperty("processedSource.source.sourcePath");
   });
 });

--- a/packages/db/src/workspace/test/contractInstance.spec.ts
+++ b/packages/db/src/workspace/test/contractInstance.spec.ts
@@ -38,7 +38,7 @@ describe("Contract Instance", () => {
           id: generateId({
             name: Migrations.contractName,
             abi: { json: JSON.stringify(Migrations.abi) },
-            sourceContract: { index: 0 },
+            processedSource: { index: 0 },
             compilation: {
               id:
                 "0x7f91bdeb02ae5fd772f829f41face7250ce9eada560e3e7fa7ed791c40d926bd"

--- a/packages/db/types/stub.d.ts
+++ b/packages/db/types/stub.d.ts
@@ -8,7 +8,7 @@ declare namespace DataModel {
   type IBytecodesAddPayload = any;
   type ICompilation = any;
   type ICompilationInput = any;
-  type ICompilationSourceContractInput = any;
+  type ICompilationProcessedSourceInput = any;
   type ICompilationsAddInput = any;
   type ICompilationsAddPayload = any;
   type ICompiler = any;


### PR DESCRIPTION
This PR does two things:

- Rename `SourceContract` -> `ProcessedSource`. The former name turns out to be incorrect, since sources can have multiple contracts, so "processed source" more generally represents the idea here. As a consequence of this change, also remove the `name` field from that object, since it becomes meaningless.

- Add a `contracts` field to ProcessedSource for compilations. This allows the retrieval of all related contracts given only a compilation ID.

Note: it'd be ideal if processed sources could also represent other top-levels, like structs and enums, but (a) that's out of scope for an initial implementation, and (b) those aren't even exposed by Solidity (alas)