### PR TITLE
Internal improvement: Swap out TravisCI for CircleCI for Colony job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,22 @@
+version: 2.1
+orbs:
+  node: circleci/node@2.1.1
+jobs:
+  build-and-test:
+    executor:
+      name: node/default
+    steps:
+      - checkout
+      - run: npm i -g yarn
+      - run: yarn bootstrap
+      - run: truffle obtain --solc=0.5.16
+      - run: COLONY=true yarn ci
+
+workflows:
+  colony:
+    jobs:
+      - build-and-test:
+          filters:
+            branches:
+              only:
+                - develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,6 @@ matrix:
       env: FABRICEVM=true
     - node_js: 8
       env: COVERAGE=true
-    - if: |
-        branch = develop AND \
-        type = push
-      node_js: 10
-      env: COLONY=true
   allow_failures:
     - node_js: 8
       env: COVERAGE=true


### PR DESCRIPTION
[Travis has a job timeout of 50 minutes](https://docs.travis-ci.com/user/customizing-the-build#build-timeouts). Lately the `COLONY` job has been timin' out, likely due to `ganache-cli` being slower post gas estimation refactoring/bug fixes.

[CircleCI supports longer running jobs](https://app.circleci.com/pipelines/github/JoinColony/colonyNetwork/2175/workflows/623c74b6-bfab-4dee-9d33-f08e5a211e68/jobs/11866/parallel-runs/0/steps/0-106), so let's use it for this one instead!