### PR TITLE
Bump web3 1.2.1 => 1.2.5

### DIFF
--- a/packages/interface-adapter/package.json
+++ b/packages/interface-adapter/package.json
@@ -23,7 +23,7 @@
     "bn.js": "^4.11.8",
     "ethers": "^4.0.32",
     "source-map-support": "^0.5.19",
-    "web3": "1.2.1"
+    "web3": "1.2.5"
   },
   "devDependencies": {
     "@truffle/provider": "^0.2.11",


### PR DESCRIPTION
While not yet tested, this appears to be the minimum change needed to incorporate [this commit](https://github.com/ethereum/web3.js/commit/6432b70f7d66c0cc5a18cead7afa7d45e5bc4301) and be able to use the 'genesis' predefined block number.  If web3 did not break semver again, this should work.  However I recognize from past experience that's a questionable assumption.