### PR TITLE
Bug fix: Make debugger robust against lack of trace steps and add warnings

### DIFF
--- a/packages/core/lib/debug/interpreter.js
+++ b/packages/core/lib/debug/interpreter.js
@@ -503,9 +503,14 @@ class DebugInterpreter {
           temporaryPrintouts.add(location);
         }
         if (this.session.view(selectors.session.status.loaded)) {
-          this.printer.printInstruction(temporaryPrintouts);
-          this.printer.printFile();
-          this.printer.printState();
+          if (this.session.view(trace.steps).length > 0) {
+            this.printer.printInstruction(temporaryPrintouts);
+            this.printer.printFile();
+            this.printer.printState();
+          } else {
+            //if there are no trace steps, let's just print a warning message
+            this.printer.print("No trace steps to inspect.");
+          }
         }
         //finally, print watch expressions
         await this.printer.printWatchExpressionsResults(
@@ -556,6 +561,7 @@ class DebugInterpreter {
       case "r":
         if (this.session.view(selectors.session.status.loaded)) {
           this.printer.printAddressesAffected();
+          this.printer.warnIfNoSteps();
           this.printer.printFile();
           this.printer.printState();
         }
@@ -563,6 +569,7 @@ class DebugInterpreter {
       case "t":
         if (!loadFailed) {
           this.printer.printAddressesAffected();
+          this.printer.warnIfNoSteps();
           this.printer.printFile();
           this.printer.printState();
         } else if (this.session.view(selectors.session.status.isError)) {

--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -91,9 +91,9 @@ class DebugPrinter {
   warnIfNoSteps() {
     if (this.session.view(trace.steps).length === 0) {
       this.config.logger.log(
-        colors.bold(
-          "Warning: this transaction has no trace steps. This may happen if you are attempting to debug a transaction sent to an externally-owned accounts, or if the node you are connecting to failed to produce a trace for some reason. Please check your configuration and try again."
-        )
+        `${colors.bold(
+          "Warning:"
+        )} this transaction has no trace steps. This may happen if you are attempting to debug a transaction sent to an externally-owned accounts, or if the node you are connecting to failed to produce a trace for some reason. Please check your configuration and try again.`
       );
     }
   }
@@ -288,7 +288,9 @@ class DebugPrinter {
                 ).toString();
                 this.config.logger.log(`Revert message: ${revertString}`);
                 this.config.logger.log(
-                  colors.bold("Warning: This message contained invalid UTF-8.")
+                  `${colors.bold(
+                    "Warning:"
+                  )} This message contained invalid UTF-8.`
                 );
                 break;
             }

--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -63,6 +63,7 @@ class DebugPrinter {
 
   printSessionLoaded() {
     this.printAddressesAffected();
+    this.warnIfNoSteps();
     this.printHelp();
     debug("Help printed");
     this.printFile();
@@ -84,6 +85,12 @@ class DebugPrinter {
     this.config.logger.log(
       DebugUtils.formatAffectedInstances(affectedInstances)
     );
+  }
+
+  warnIfNoSteps() {
+    if (this.session.view(trace.steps).length === 0) {
+      this.config.logger.log("Warning: This transaction has no trace steps.");
+    }
   }
 
   printHelp() {

--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -6,6 +6,7 @@ const safeEval = require("safe-eval");
 
 const DebugUtils = require("@truffle/debug-utils");
 const Codec = require("@truffle/codec");
+const colors = require("colors");
 
 const selectors = require("@truffle/debugger").selectors;
 const {
@@ -89,7 +90,11 @@ class DebugPrinter {
 
   warnIfNoSteps() {
     if (this.session.view(trace.steps).length === 0) {
-      this.config.logger.log("Warning: This transaction has no trace steps.");
+      this.config.logger.log(
+        colors.bold(
+          "Warning: this transaction has no trace steps. This may happen if you are attempting to debug a transaction sent to an externally-owned accounts, or if the node you are connecting to failed to produce a trace for some reason. Please check your configuration and try again."
+        )
+      );
     }
   }
 
@@ -283,7 +288,7 @@ class DebugPrinter {
                 ).toString();
                 this.config.logger.log(`Revert message: ${revertString}`);
                 this.config.logger.log(
-                  "Warning: This message contained invalid UTF-8."
+                  colors.bold("Warning: This message contained invalid UTF-8.")
                 );
                 break;
             }

--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -93,7 +93,7 @@ class DebugPrinter {
       this.config.logger.log(
         `${colors.bold(
           "Warning:"
-        )} this transaction has no trace steps. This may happen if you are attempting to debug a transaction sent to an externally-owned accounts, or if the node you are connecting to failed to produce a trace for some reason. Please check your configuration and try again.`
+        )} this transaction has no trace steps. This may happen if you are attempting to debug a transaction sent to an externally-owned account, or if the node you are connecting to failed to produce a trace for some reason. Please check your configuration and try again.`
       );
     }
   }

--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -133,8 +133,8 @@ var DebugUtils = {
     };
 
     //now: walk each AST
-    return compilation.sources.every(source =>
-      source ? allIDsUnseenSoFar(source.ast) : true
+    return compilation.sources.every(
+      source => (source ? allIDsUnseenSoFar(source.ast) : true)
     );
   },
 
@@ -182,7 +182,9 @@ var DebugUtils = {
     if (!hasAllSource) {
       lines.push("");
       lines.push(
-        "Warning: The source code for one or more contracts could not be found."
+        chalk.bold(
+          "Warning: The source code for one or more contracts could not be found."
+        )
       );
     }
 
@@ -604,12 +606,12 @@ var DebugUtils = {
             ? `Error: Improper return (caused message: ${message})`
             : "Error: Improper return (may be an unexpected self-destruct)"
           : message !== undefined
-          ? `Error: Revert (message: ${message})`
-          : "Error: Revert or exceptional halt"
+            ? `Error: Revert (message: ${message})`
+            : "Error: Revert or exceptional halt"
       );
     }
-    let indented = lines.map((line, index) =>
-      index === 0 ? line : " ".repeat(indent) + line
+    let indented = lines.map(
+      (line, index) => (index === 0 ? line : " ".repeat(indent) + line)
     );
     return indented.join(OS.EOL);
   },
@@ -760,8 +762,9 @@ var DebugUtils = {
   cleanThis: function(variables, replacement) {
     return Object.assign(
       {},
-      ...Object.entries(variables).map(([variable, value]) =>
-        variable === "this" ? { [replacement]: value } : { [variable]: value }
+      ...Object.entries(variables).map(
+        ([variable, value]) =>
+          variable === "this" ? { [replacement]: value } : { [variable]: value }
       )
     );
   }

--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -182,9 +182,9 @@ var DebugUtils = {
     if (!hasAllSource) {
       lines.push("");
       lines.push(
-        chalk.bold(
-          "Warning: The source code for one or more contracts could not be found."
-        )
+        `${chalk.bold(
+          "Warning:"
+        )} The source code for one or more contracts could not be found.`
       );
     }
 

--- a/packages/debugger/lib/data/selectors/index.js
+++ b/packages/debugger/lib/data/selectors/index.js
@@ -1116,8 +1116,9 @@ const data = createSelectorTree({
           };
 
           if (
-            scope.nodeType.startsWith("Yul") ||
-            scope.nodeType === "InlineAssembly"
+            scope &&
+            (scope.nodeType.startsWith("Yul") ||
+              scope.nodeType === "InlineAssembly")
           ) {
             //builtins aren't visible in Yul
             return variables;

--- a/packages/debugger/lib/evm/selectors/index.js
+++ b/packages/debugger/lib/evm/selectors/index.js
@@ -542,13 +542,14 @@ const evm = createSelectorTree({
        * .isHalting
        *
        * whether the instruction halts or returns from a calling context
-       * NOTE: this covers only ordinary halts, not exceptional halts;
-       * but it doesn't check the return status, so any normal halting
-       * instruction will qualify here
+       * HACK: the check for stepsRemainining === 0 is a hack to cover
+       * the special case when there are no trace steps; normally this
+       * is unnecessary because the spoofed step past the end covers it
        */
       isHalting: createLeaf(
-        ["/current/state/depth", "/next/state/depth"],
-        (currentDepth, nextDepth) => nextDepth < currentDepth
+        ["/current/state/depth", "/next/state/depth", trace.stepsRemaining],
+        (currentDepth, nextDepth, stepsRemaining) =>
+          nextDepth < currentDepth || stepsRemaining === 0
       ),
 
       /**

--- a/packages/debugger/lib/solidity/selectors/index.js
+++ b/packages/debugger/lib/solidity/selectors/index.js
@@ -147,7 +147,11 @@ let solidity = createSelectorTree({
     sources: createLeaf(
       ["/info/sources", evm.current.context],
       (sources, context) =>
-        context ? (sources[context.compilationId] || { byId: null }).byId : null
+        context
+          ? context.compilationId !== undefined
+            ? (sources[context.compilationId] || { byId: null }).byId
+            : [] //unknown context, return no sources
+          : null //no tx loaded, return null
     ),
 
     /**

--- a/packages/debugger/lib/trace/selectors/index.js
+++ b/packages/debugger/lib/trace/selectors/index.js
@@ -64,10 +64,13 @@ let trace = createSelectorTree({
    * trace.step
    *
    * current trace step
+   * HACK: if no steps,
+   * we will return a spoofed "past end" step
    */
   step: createLeaf(
     ["./steps", "./index"],
-    (steps, index) => (steps ? steps[index] : null) //null if no tx loaded
+    (steps, index) =>
+      steps ? (steps.length > 0 ? steps[index] : PAST_END_OF_TRACE) : null //null if no tx loaded
   ),
 
   /**


### PR DESCRIPTION
This PR fixes various errors that would come up if the transaction had no trace steps.  Some of these bugs were actually relevant even when there were trace steps, oops!

It also makes some changes to the CLI: it makes it so that `p` when there are no trace steps prints a message about this rather than nonsense, and it also adds warning messages on startup (or reset or transaction load) if the transaction has no trace steps.