### PR TITLE
Add optional `url` option to the config to use instead of host/port

### DIFF
--- a/packages/provider/index.js
+++ b/packages/provider/index.js
@@ -20,13 +20,13 @@ module.exports = {
       provider = options.provider();
     } else if (options.provider) {
       provider = options.provider;
-    } else if (options.websockets) {
+    } else if (options.websockets || /^wss?:\/\//.test(options.url)) {
       provider = new Web3.providers.WebsocketProvider(
-        "ws://" + options.host + ":" + options.port
+        options.url || "ws://" + options.host + ":" + options.port
       );
     } else {
       provider = new Web3.providers.HttpProvider(
-        `http://${options.host}:${options.port}`,
+        options.url || `http://${options.host}:${options.port}`,
         { keepAlive: false }
       );
     }

--- a/packages/provider/test/create.js
+++ b/packages/provider/test/create.js
@@ -31,6 +31,32 @@ describe("Provider", function() {
     }
   });
 
+  it("accepts url", async () => {
+    const provider = Provider.create({ url: `http://${host}:${port}` });
+    assert(provider);
+
+    try {
+      await Provider.testConnection({ provider });
+    } catch (error) {
+      assert.fail(error.message);
+    }
+  });
+
+  it("accepts uses url before host/port", async () => {
+    const provider = Provider.create({
+      url: `http://${host}:${port}`,
+      host: "invalidhost",
+      port: 42
+    });
+    assert(provider);
+
+    try {
+      await Provider.testConnection({ provider });
+    } catch (error) {
+      assert.fail(error.message);
+    }
+  });
+
   it("fails to connect to the wrong port", async () => {
     const provider = Provider.create({ host, port: "54321" });
 


### PR DESCRIPTION
This PR adds an optional `url` field to the truffle config to allow overriding host/port. This allows endpoints that have a path (i.e. https://mainnet.infura.io/v3/<key> and https://sandbox.truffleteams.com/<id>) as well as anything that uses TLS (aka `https` or `wss`)

Ideally, the motivation here is to reduce the number of steps for users to use a Truffle Teams Sandbox