### PR TITLE
Bug fix: Fix tracking of Yul variables declared to be result of a call

### DIFF
--- a/packages/debugger/lib/data/selectors/index.js
+++ b/packages/debugger/lib/data/selectors/index.js
@@ -8,6 +8,7 @@ import semver from "semver";
 
 import { stableKeccak256, makePath } from "lib/helpers";
 
+import trace from "lib/trace/selectors";
 import evm from "lib/evm/selectors";
 import solidity from "lib/solidity/selectors";
 
@@ -1420,6 +1421,31 @@ const data = createSelectorTree({
 
         step =>
           ((step || {}).stack || []).map(word => Codec.Conversion.toBytes(word))
+      )
+    }
+  },
+
+  /**
+   * data.nextOfSameDepth
+   */
+  nextOfSameDepth: {
+    /**
+     * data.nextOfSameDepth.state
+     * Yes, I'm just repeating the code for data.current.state.stack here but
+     * with an extra guard... *still* not worth the trouble to factor out
+     * HOWEVER, this one also returns null if there is no nextOfSameDepth
+     */
+    state: {
+      /**
+       * data.nextOfSameDepth.state.stack
+       */
+      stack: createLeaf(
+        [trace.nextOfSameDepth],
+
+        step =>
+          step
+            ? (step.stack || []).map(word => Codec.Conversion.toBytes(word))
+            : null
       )
     }
   }

--- a/packages/debugger/test/data/yul.js
+++ b/packages/debugger/test/data/yul.js
@@ -23,6 +23,7 @@ contract AssemblyTest {
       let v := u
       let w := add(u, 3)
       let z := outside
+      let result := staticcall(0, 0, 0, 0, 0, 0)
       if sgt(z, 0) {
         let k := shl(1, z)
         log1(0, 0, k) //BREAK #1
@@ -113,6 +114,7 @@ describe("Assembly decoding", function() {
       v: 3,
       w: 6,
       z: 8,
+      result: 1,
       k: 16
     };
 
@@ -149,6 +151,7 @@ describe("Assembly decoding", function() {
       v: 3,
       w: 6,
       z: 8,
+      result: 1,
       n: 27,
       m: 5
     };

--- a/packages/debugger/test/data/yul.js
+++ b/packages/debugger/test/data/yul.js
@@ -23,7 +23,7 @@ contract AssemblyTest {
       let v := u
       let w := add(u, 3)
       let z := outside
-      let result := staticcall(0, 0, 0, 0, 0, 0)
+      let result := staticcall(gas(), 0, 0, 0, 0, 0) //identity fn
       if sgt(z, 0) {
         let k := shl(1, z)
         log1(0, 0, k) //BREAK #1


### PR DESCRIPTION
This PR fixes a bug pointed out by @gnidan, where if an assembly variable was declared with `let x:= call(...)` (or any of the other calling/creating opcodes), the debugger would fail to track it properly, instead attempting to allocate it stack slot -1.

The reason for this is that it assumes the variable will be on the top of the stack on the next instruction; but in a case like this, it actually won't be on top of the stack until the function returns.  So, we have to look ahead to when it returns, using the `nextOfSameDepth` mechanism we already have.

Since we now have *three* possible stacks we could be looking at, I decided to reorganize things a little.  Instead of `stack` and `alternateStack`, there's now just one `stack` variable, and I assign it one of three different selectors depending on the node type.

While I was at it, I also reorganized the beginning of the `data` saga somewhat, so it doesn't call all those selectors when there's no need.  Obviously I didn't do as much as I could have here, as I didn't bother breaking down further which ones are necessary by moving them into just the cases where they're necessary, but, well, it's a start.

I also added a test of this fix.