### PR TITLE
Bug fix: Prevent debugger from landing on nodes with no node type

### DIFF
--- a/packages/solidity-utils/index.js
+++ b/packages/solidity-utils/index.js
@@ -2,9 +2,7 @@ const debug = require("debug")("solidity-utils");
 const CodeUtils = require("@truffle/code-utils");
 const Codec = require("@truffle/codec");
 const jsonpointer = require("json-pointer");
-//NOTE: for some reason using the default export isn't working??
-//so we're going to do this the "advanced usage" way...
-const { IntervalTree } = require("node-interval-tree");
+const IntervalTree = require("node-interval-tree").default;
 
 var SolidityUtils = {
   getCharacterOffsetToLineAndColumnMapping: function(source) {
@@ -308,16 +306,10 @@ var SolidityUtils = {
     let ranges = SolidityUtils.rangeNodes(ast);
     for (let { range, node, pointer } of ranges) {
       let [start, end] = range;
-      //NOTE: we are doing this the "advanced usage" way because the
-      //other way isn't working for some reason
-      tree.insert({ low: start, high: end, data: { range, node, pointer } });
+      tree.insert(start, end, { range, node, pointer });
     }
     return (sourceStart, sourceLength) =>
-      //because we're doing this the "advanced usage" way, we have
-      //to extract data afterward
-      tree
-        .search(sourceStart, sourceStart + sourceLength)
-        .map(({ data }) => data);
+      tree.search(sourceStart, sourceStart + sourceLength);
   },
 
   //for use by makeOverlapFunction

--- a/packages/solidity-utils/index.js
+++ b/packages/solidity-utils/index.js
@@ -331,7 +331,9 @@ var SolidityUtils = {
     } else if (node instanceof Object) {
       let results = [];
 
-      if (node.src !== undefined) {
+      if (node.src !== undefined && node.nodeType !== undefined) {
+        //don't add "pseudo-nodes" (i.e.: outside variable references
+        //in assembly) with no nodeType
         results.push({ pointer, node, range: SolidityUtils.getRange(node) });
       }
 


### PR DESCRIPTION
It's the revenge of the pseudo-nodes!

Recently, for assembly handling, we had to allow the debugger to land on nodes with no ID, which previously was disallowed.  (By "land on" I'm not referring to where `n` stops, but rather to what goes into the interval tree to be counted as a node that the debugger has hit.)  But in doing so I allowed the debugger to land on nodes with no node type, which causes problems.  So, I have now explicitly disallowed that; those no longer go in the interval tree.

(What nodes, or pseudo-nodes, are these?  They're the references in assembly to outside variables, the same ones that caused us trouble initially and caused us to exclude nodes without IDs in the first place.)

Also, while I was at it, I switched our use of `IntervalTree` back to the usual way, rather than the "advanced usage" that we didn't really need.  The reason the usual way stopped working when I moved it to `solidity-utils` is because it's a default export, and I didn't realize that `require`, unlike `import`, won't get the default export by default.