### PR TITLE
Fix: Add some missing options to usage printout

### DIFF
--- a/packages/core/lib/commands/compile.js
+++ b/packages/core/lib/commands/compile.js
@@ -21,7 +21,8 @@ const command = {
     }
   },
   help: {
-    usage: "truffle compile [--list <filter>] [--all] [--network <name>]",
+    usage:
+      "truffle compile [--list <filter>] [--all] [--network <name>] [--quiet]",
     options: [
       {
         option: "--all",

--- a/packages/core/lib/commands/exec.js
+++ b/packages/core/lib/commands/exec.js
@@ -15,7 +15,7 @@ const command = {
     }
   },
   help: {
-    usage: "truffle exec <script.js> [--network <name>]",
+    usage: "truffle exec <script.js> [--network <name>] [--compile]",
     options: [
       {
         option: "<script.js>",


### PR DESCRIPTION
These options were missing from the main usage printouts for their respective commands.