### PR TITLE
Oops, I misunderstood the `docker` option

### DIFF
--- a/packages/core/lib/test.js
+++ b/packages/core/lib/test.js
@@ -205,9 +205,7 @@ const Test = {
       quietWrite: true
     });
     if (config.compileAllDebug) {
-      let versionString =
-        ((compileConfig.compilers || {}).solc || {}).version ||
-        ((compileConfig.compilers || {}).solc || {}).docker;
+      let versionString = ((compileConfig.compilers || {}).solc || {}).version;
       //note: I'm relying here on the fact that the current
       //default version, 0.5.16, is <0.6.3
       //the following line works with prereleases

--- a/packages/core/lib/test.js
+++ b/packages/core/lib/test.js
@@ -210,13 +210,15 @@ const Test = {
       //default version, 0.5.16, is <0.6.3
       //the following line works with prereleases
       const satisfies = semver.satisfies(versionString, ">=0.6.3", {
-        includePrerelease: true
+        includePrerelease: true,
+        loose: true
       });
       //the following line doesn't, despite the flag, but does work with version ranges
       const intersects =
         semver.validRange(versionString) &&
         semver.intersects(versionString, ">=0.6.3", {
-          includePrerelease: true
+          includePrerelease: true,
+          loose: true
         }); //intersects will throw if given undefined so must ward against
       if (satisfies || intersects) {
         compileConfig = compileConfig.merge({


### PR DESCRIPTION
I thought you put a solc version there.  In fact it's a boolean that says whether to use docker.  Removing some code where I attempted to extract the solc version from the `docker` option.