### PR TITLE
Enhancement: Include immutables when decoding returned bytecode

### DIFF
--- a/packages/codec/lib/abi-data/allocate/types.ts
+++ b/packages/codec/lib/abi-data/allocate/types.ts
@@ -129,23 +129,40 @@ export interface EventArgumentAllocation {
 }
 
 //now let's go back ands fill in returndata
-type ReturndataKind =
-  | "return"
-  | "revert"
-  | "failure"
-  | "selfdestruct"
-  | "bytecode";
+type ReturndataKind = FunctionReturndataKind | ConstructorReturndataKind;
 
-export interface ReturndataAllocation {
+type FunctionReturndataKind = "return" | "revert" | "failure" | "selfdestruct";
+type ConstructorReturndataKind = "bytecode";
+
+export type ReturndataAllocation =
+  | FunctionReturndataAllocation
+  | ConstructorReturndataAllocation;
+
+export interface FunctionReturndataAllocation {
+  kind: FunctionReturndataKind;
   selector: Uint8Array;
-  arguments: ReturndataArgumentAllocation[]; //ignored if kind="bytecode"
+  arguments: ReturndataArgumentAllocation[];
   allocationMode: DecodingMode;
-  kind: ReturndataKind;
+}
+
+export interface ConstructorReturndataAllocation {
+  kind: ConstructorReturndataKind;
+  selector: Uint8Array; //must be empty, but is required for type niceness
+  immutables?: ReturnImmutableAllocation[];
+  delegatecallGuard: boolean;
+  allocationMode: DecodingMode;
 }
 
 export interface ReturndataArgumentAllocation {
   name: string;
   type: Format.Types.Type;
+  pointer: Pointer.ReturndataPointer;
+}
+
+export interface ReturnImmutableAllocation {
+  name: string;
+  type: Format.Types.Type;
+  definedIn: Format.Types.ContractType;
   pointer: Pointer.ReturndataPointer;
 }
 

--- a/packages/codec/lib/abi-data/allocate/types.ts
+++ b/packages/codec/lib/abi-data/allocate/types.ts
@@ -60,12 +60,12 @@ export interface CalldataAllocations {
 }
 
 export interface CalldataConstructorAllocations {
-  [contextHash: string]: CalldataAndReturndataAllocation;
+  [contextHash: string]: CalldataAndReturndataAllocation; //note: just constructor ones
 }
 
 export interface CalldataFunctionAllocations {
   [contextHash: string]: {
-    [selector: string]: CalldataAndReturndataAllocation;
+    [selector: string]: CalldataAndReturndataAllocation; //note: just function ones
   };
 }
 

--- a/packages/codec/lib/abify.ts
+++ b/packages/codec/lib/abify.ts
@@ -365,6 +365,12 @@ export function abifyReturndataDecoding(
           value: abifyResult(argument.value, userDefinedTypes)
         }))
       };
+    case "bytecode":
+      return {
+        ...decoding,
+        decodingMode: "abi",
+        immutables: undefined
+      };
     default:
       return {
         ...decoding,

--- a/packages/codec/lib/core.ts
+++ b/packages/codec/lib/core.ts
@@ -535,7 +535,9 @@ export function* decodeReturndata(
       //bytecode is special and can't really be integrated with the other cases.
       //so it gets its own function.
       const decoding = yield* decodeBytecode(info);
-      decodings.push(decoding);
+      if (decoding) {
+        decodings.push(decoding);
+      }
       continue;
     }
     let decodingMode: DecodingMode = allocation.allocationMode; //starts out here; degrades to abi if necessary
@@ -667,7 +669,7 @@ function* decodeBytecode(
   info: Evm.EvmInfo
 ): Generator<
   DecoderRequest,
-  BytecodeDecoding | UnknownBytecodeDecoding,
+  BytecodeDecoding | UnknownBytecodeDecoding | null,
   Uint8Array
 > {
   let decodingMode: DecodingMode = "full"; //as always, degrade as necessary
@@ -709,6 +711,9 @@ function* decodeBytecode(
           decodingMode = "abi";
           immutables = undefined;
           break;
+        } else {
+          //otherwise, this isn't a valid decoding I guess
+          return null;
         }
       }
       immutables.push({

--- a/packages/codec/lib/decode.ts
+++ b/packages/codec/lib/decode.ts
@@ -65,6 +65,7 @@ function* decodeDispatch(
       //(if it's a nowhere pointer, this will return an error result, of course)
       //also: we force zero-padding!
       return yield* Basic.Decode.decodeBasic(dataType, pointer, info, {
+        ...options,
         paddingMode: "zero"
       });
 
@@ -73,6 +74,7 @@ function* decodeDispatch(
       //rather than located via a pointer -- only comes up when decoding immutables
       //in a constructor.  thus, we turn on the forceRightPadding option.
       return yield* Memory.Decode.decodeMemory(dataType, pointer, info, {
+        ...options,
         paddingMode: "right"
       });
   }

--- a/packages/codec/lib/index.ts
+++ b/packages/codec/lib/index.ts
@@ -271,6 +271,7 @@ export {
   RevertMessageDecoding,
   EmptyFailureDecoding,
   AbiArgument,
+  StateVariable,
   DecoderRequest,
   StorageRequest,
   CodeRequest

--- a/packages/codec/lib/storage/allocate/index.ts
+++ b/packages/codec/lib/storage/allocate/index.ts
@@ -59,11 +59,6 @@ interface StorageAllocationInfo {
   allocations: StorageAllocations;
 }
 
-interface DefinitionPair {
-  definition: Ast.AstNode;
-  definedIn?: Ast.AstNode;
-}
-
 //contracts contains only the contracts to be allocated; any base classes not
 //being allocated should just be in referenceDeclarations
 export function getStorageAllocations(

--- a/packages/codec/lib/types.ts
+++ b/packages/codec/lib/types.ts
@@ -46,6 +46,28 @@ export type ReturndataDecoding =
 export type DecodingMode = "full" | "abi";
 
 /**
+ * Used for representing decoded state variables.
+ * @category Output
+ */
+export interface StateVariable {
+  /**
+   * The name of the variable.  Note that due to inheritance, this may not be unique
+   * among the contract's state variables.
+   */
+  name: string;
+  /**
+   * The class of the contract that defined the variable, as a Format.Types.ContractType.
+   * Note that this class may differ from that of the contract being decoded, due
+   * to inheritance.
+   */
+  class: Format.Types.ContractType;
+  /**
+   * The decoded value of the variable.  Note this is a Format.Values.Result, so it may be an error.
+   */
+  value: Format.Values.Result;
+}
+
+/**
  * This type represents a transaction decoding for an ordinary function call to a known class;
  * not a constructor call, not a fallback call.
  * @Category Output
@@ -398,6 +420,11 @@ export interface BytecodeDecoding {
    * The class of contract being constructed, as a Format.Types.ContractType.
    */
   class: Format.Types.ContractType;
+  /**
+   * Decodings for any immutable state variables the created contract contains.
+   * Omitted in ABI mode.
+   */
+  immutables?: StateVariable[];
   /**
    * The bytecode of the contract that was created.
    */

--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -377,6 +377,22 @@ class DebugPrinter {
           `Returned bytecode for a ${contractKind} ${decoding.class.typeName}.`
         );
       }
+      if (decoding.immutables && decoding.immutables.length > 0) {
+        this.config.logger.log("Immutable values:");
+        const prefixes = decoding.immutables.map(
+          ({ name, class: { typeName } }) => `${typeName}.${name}: `
+        );
+        const maxLength = Math.max(...prefixes.map(prefix => prefix.length));
+        const paddedPrefixes = prefixes.map(prefix =>
+          prefix.padStart(maxLength)
+        );
+        for (let index = 0; index < decoding.immutables.length; index++) {
+          const { value } = decoding.immutables[index];
+          const prefix = paddedPrefixes[index];
+          const formatted = DebugUtils.formatValue(value, maxLength);
+          this.config.logger.log(prefix + formatted);
+        }
+      }
       this.config.logger.log("");
     } else if (decodings[0].kind === "revert") {
       //case 9: revert (with message)

--- a/packages/decoder/lib/types.ts
+++ b/packages/decoder/lib/types.ts
@@ -7,9 +7,14 @@ import {
   Compilations,
   Contexts,
   CalldataDecoding,
-  LogDecoding
+  LogDecoding,
+  StateVariable
 } from "@truffle/codec";
 import Web3 from "web3";
+
+//this used to be defined here, so let's continue
+//to export it
+export { StateVariable };
 
 /**
  * This type represents information about a Truffle project that can be used to
@@ -69,27 +74,6 @@ export interface ContractState {
    * The contract's code, as a hexidecimal string.
    */
   code: string;
-}
-
-/**
- * This type represents one of the decoded contract's state variables.
- * @category Results
- */
-export interface StateVariable {
-  /**
-   * The name of the variable.  Note that due to inheritance, this may not be unique.
-   */
-  name: string;
-  /**
-   * The class of the contract that defined the variable, as a Format.Types.ContractType.
-   * Note that this class may differ from that of the contract being decoded, due
-   * to inheritance.
-   */
-  class: Format.Types.ContractType;
-  /**
-   * The decoded value of the variable.  Note this is a Format.Values.Result, so it may be an error.
-   */
-  value: Format.Values.Result;
 }
 
 /**


### PR DESCRIPTION
Really, linked libraries ought to be included as well, but, eh.  It's just gonna have to wait.  There's a reason I didn't do that initially (despite linked libraries having certainly existing back then) and continue to hold off on it now.

Anyway.  This enhancement to `@truffle/codec` makes it so that, when you decode the bytecode returned from a constructor call, the decoded output includes the values of all immutable variables, in addition to what was already present.  Note that this information is only present in full mode, and the abify functions now strip it out.

(Well, not *all* immutables -- I left out any ones that are never actually used.  It was just easier this way.  This is a little inconsistent with how allocation of state variables works, since there they're included.)

In addition, this PR adds support for this in the debugger CLI, so now when debugging a contract creation transaction, if the transaction concludes successfully you will see the immutables printed out at the end.

There are a few parts to this.  Obviously it needs support in `decodeReturndata`; this now simply yields to a new function `decodeBytecode` for the bytecode case, as it was simply getting too complicated not to be its own function.  Note that immutables are returned as `StateVariable`s, which means I had to make that a codec type rather than just a decoder type.  Decoder still re-exports it of course.  (Note that if something goes wrong during decoding, we fall back to ABI mode as usual, but in this case that doesn't mean abifying the immutables, it means not returning them at all.  Yay, simpler error handling!)

But then of course it needed allocation support too, and this got maybe a little hacky.  Now when we allocate a constructor, we associate it both with the constructor context *and* with the deployed context.  This is because when decoding returned bytecode, we determine the context based on that bytecode, so we need to be able to look up the returndata allocation based on that.  This makes the input/output pairing a bit redundant in the constructor case, since we're really only ever using the input in the constructor context and the output in the deployed context, but oh well.

Since constructor allocation is now more involved, I changed it from initially allocating a default constructor allocation and then overwriting it later, to now only invoking the default constructor allocation at the end if no other constructor allocation has been recorded.

One more thing of note -- I figured while I was at it, why not have the question "is there a delegatecall guard" be part of the allocation too?  After all, we're pre-allocating everything else. :)  So, now it is.

Btw I had to stick one type coercion in there because Typescript is a pain sometimes. <shrug>

Also, you may notice I factored out `findNodeAndContract` into its own function.  I wasn't about to write that code a third time.

Also I added tests.