### PR TITLE
Update codec to handle array slices

### DIFF
--- a/packages/codec/lib/stack/decode/index.ts
+++ b/packages/codec/lib/stack/decode/index.ts
@@ -68,87 +68,33 @@ export function* decodeLiteral(
       case "calldata":
         //next: do we have a calldata pointer?
 
-        //if it's a string or bytes, we will interpret the pointer ourself and skip
-        //straight to decodeBytes.  this is to allow us to correctly handle the
-        //case of msg.data used as a mapping key (or, as of 0.6.0, slices)
-        if (dataType.typeClass === "bytes" || dataType.typeClass === "string") {
-          let startAsBN = Conversion.toBN(
-            pointer.literal.slice(0, Evm.Utils.WORD_SIZE)
-          );
-          let lengthAsBN = Conversion.toBN(
+        //if it's a lookup type, it'll need special handling
+        if (
+          dataType.typeClass === "bytes" ||
+          dataType.typeClass === "string" ||
+          (dataType.typeClass === "array" && dataType.kind === "dynamic")
+        ) {
+          const lengthAsBN = Conversion.toBN(
             pointer.literal.slice(Evm.Utils.WORD_SIZE)
           );
-          let start: number;
-          let length: number;
-          try {
-            start = startAsBN.toNumber();
-          } catch (_) {
-            return <
-              | Format.Errors.BytesDynamicErrorResult
-              | Format.Errors.StringErrorResult
-            >{
-              //again with the TS failures...
-              type: dataType,
-              kind: "error" as const,
-              error: {
-                kind: "OverlargePointersNotImplementedError" as const,
-                pointerAsBN: startAsBN
-              }
-            };
-          }
-          try {
-            length = lengthAsBN.toNumber();
-          } catch (_) {
-            return <
-              | Format.Errors.BytesDynamicErrorResult
-              | Format.Errors.StringErrorResult
-            >{
-              //again with the TS failures...
-              type: dataType,
-              kind: "error" as const,
-              error: {
-                kind: "OverlongArraysAndStringsNotImplementedError" as const,
-                lengthAsBN
-              }
-            };
-          }
-          let newPointer = {
-            location: "calldata" as "calldata",
-            start,
-            length
-          };
-          return yield* Bytes.Decode.decodeBytes(dataType, newPointer, info);
-        }
-
-        //otherwise, is it a dynamic array?
-        if (dataType.typeClass === "array" && dataType.kind === "dynamic") {
-          //in this case, we're actually going to *throw away* the length info,
-          //because it makes the logic simpler -- we'll get the length info back
-          //from calldata
-          //WARNING: this approach will *not* decode slices correctly!
-          //But, there's presently no need for the debugger to decode slices of arrays
-          //(as opposed to of strings/bytestrings),
-          //so this can be addressed later perhaps?
-          let locationOnly = pointer.literal.slice(0, Evm.Utils.WORD_SIZE);
-          //HACK -- in order to read the correct location, we need to add an offset
-          //of -32 (since, again, we're throwing away the length info), so we pass
-          //that in as the "base" value
+          const locationOnly = pointer.literal.slice(0, Evm.Utils.WORD_SIZE);
           return yield* AbiData.Decode.decodeAbiReferenceByAddress(
             dataType,
             { location: "stackliteral" as const, literal: locationOnly },
             info,
-            { abiPointerBase: -Evm.Utils.WORD_SIZE }
+            {
+              abiPointerBase: 0, //let's be explicit
+              lengthOverride: lengthAsBN
+            }
           );
         } else {
           //multivalue case -- this case is straightforward
-          //pass in 0 as the base since this is an absolute pointer
-          //(yeah we don't need to but let's be explicit)
           return yield* AbiData.Decode.decodeAbiReferenceByAddress(
             dataType,
             pointer,
             info,
             {
-              abiPointerBase: 0
+              abiPointerBase: 0 //let's be explicit
             }
           );
         }

--- a/packages/codec/lib/types.ts
+++ b/packages/codec/lib/types.ts
@@ -503,4 +503,5 @@ export interface DecoderOptions {
   allowRetry?: boolean; //turns on error-throwing for retry-allowed errors only
   abiPointerBase?: number; //what relative pointers should be considered relative to
   memoryVisited?: number[]; //for circularity detection
+  lengthOverride?: BN; //if present, causes the ABI decoder to use this length instead of reading it from the data
 }

--- a/packages/debugger/test/helpers.js
+++ b/packages/debugger/test/helpers.js
@@ -26,7 +26,7 @@ export async function prepareContracts(provider, sources = {}, migrations) {
 
   config.compilers = {
     solc: {
-      version: "0.6.6",
+      version: "0.6.9",
       settings: {
         optimizer: { enabled: false, runs: 200 },
         evmVersion: "constantinople"


### PR DESCRIPTION
This PR updates codec to be able to handle array slices.

Now, array slices are not new in 0.6.9, but what is new is having any reason to decode them.  Now that it's possible to stick them in a calldata local, we have to be able to decode them.

In order to handle this, I've added a new `lengthOverride` option to decoding in codec.  Now, when decoding a dynamically-sized calldata type from the stack, the stack decoder will pass this option to the ABI decoder.  If it is passed, the ABI decoder will use this rather than reading the length out of calldata, and also will not increment `startPosition`, since having `lengthOverride` present means that the pointer points to the start of the data excluding the length.

This actually allows us to simplify the stack decoder, since all dynamically-sized calldata types are once again handled in a unified manner, and it allows us to remove a bunch of ugly error-checking that would now be redundant with the existing error-checking in the ABI decoder.  (Previously, for strings and bytestrings in calldata, the stack decoder would bypass the ABI decoder and call `decodeBytes` itself.  Now it all goes through the ABI decoder like it used to.)

Also I added a test.