### PR TITLE
Remove unreliable test

### DIFF
--- a/packages/compile-solidity/test/test_JSparser.js
+++ b/packages/compile-solidity/test/test_JSparser.js
@@ -22,7 +22,7 @@ describe("JSparser", () => {
     working_directory: __dirname
   };
 
-  it("resolves imports quickly when using solcjs parser instead of docker [ @native ]", done => {
+  it("resolves imports when using solcjs parser instead of docker [ @native ]", done => {
     options.compilers.solc.version = "0.4.22";
     options.compilers.solc.docker = true;
     options.contracts_directory = path.join(__dirname, "./sources/v0.4.x");
@@ -30,32 +30,6 @@ describe("JSparser", () => {
     const paths = [];
     paths.push(path.join(__dirname, "./sources/v0.4.x/ComplexOrdered.sol"));
     paths.push(path.join(__dirname, "./sources/v0.4.x/InheritB.sol"));
-
-    options.paths = paths;
-    options.resolver = new Resolver(options);
-
-    const config = Config.default().merge(options);
-
-    compile.with_dependencies(config, (err, result) => {
-      if (err) return done(err);
-
-      // This contract imports / inherits
-      assert(
-        result["ComplexOrdered"].contract_name === "ComplexOrdered",
-        "Should have compiled"
-      );
-      done();
-    });
-  }).timeout(20000);
-
-  it("resolves imports quickly when using solcjs parser instead of native solc", done => {
-    options.compilers.solc.version = "native";
-    delete options.compilers.solc.docker;
-    options.contracts_directory = path.join(__dirname, "./sources/v0.6.x");
-
-    const paths = [];
-    paths.push(path.join(__dirname, "./sources/v0.6.x/ComplexOrdered.sol"));
-    paths.push(path.join(__dirname, "./sources/v0.6.x/InheritB.sol"));
 
     options.paths = paths;
     options.resolver = new Resolver(options);


### PR DESCRIPTION
... and reword other test to serve to validate happy-path (instead of assuring quickness)

As an alternative, if we really wanted to tested the speed improvement, we'd have to measure the time of solcjs vs. native or docker parsers.