### PR TITLE
Internal improvement: Remove "experimental" from debugger help text

### DIFF
--- a/packages/core/lib/commands/debug.js
+++ b/packages/core/lib/commands/debug.js
@@ -1,7 +1,6 @@
 const command = {
   command: "debug",
-  description:
-    "Interactively debug any transaction on the blockchain (experimental)",
+  description: "Interactively debug any transaction on the blockchain",
   builder: {
     "_": {
       type: "string"


### PR DESCRIPTION
We removed it from `truffle help`, but not `truffle help debug`.  Now should be gone entirely.