### PR TITLE
Bug fix: Account for Geth's not reporting storage that is read but not written

### DIFF
--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -429,6 +429,14 @@ class DebugPrinter {
     this.config.logger.log(DebugUtils.formatStacktrace(report));
   }
 
+  printUndefinedStorageWarning() {
+    this.config.logger.log(
+      `${colors.bold(
+        "Warning:"
+      )} The client is not reporting values of storage slots that have only been read from.  This may cause values to erroneously display as zero even after they have been read from, or cause zero to be tracked as a mapping key instead of the correct key.`
+    );
+  }
+
   async printWatchExpressionsResults(expressions) {
     debug("expressions %o", expressions);
     for (let expression of expressions) {

--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -460,7 +460,8 @@ var DebugUtils = {
     //note: we can use the default sort here; it will do the righ thing
     let slots = Object.keys(storage)
       .slice()
-      .sort();
+      .sort()
+      .filter(slot => storage[slot]); //remove undefined
 
     let formatted = slots.map((slot, index) => {
       if (

--- a/packages/debugger/lib/data/selectors/index.js
+++ b/packages/debugger/lib/data/selectors/index.js
@@ -1421,7 +1421,10 @@ const data = createSelectorTree({
         [solidity.current.nextMapped],
 
         step =>
-          ((step || {}).stack || []).map(word => Codec.Conversion.toBytes(word))
+          //padding is there to handle Besu
+          ((step || {}).stack || []).map(word =>
+            Codec.Conversion.toBytes(word, Codec.Evm.Utils.WORD_SIZE)
+          )
       )
     }
   },
@@ -1445,7 +1448,10 @@ const data = createSelectorTree({
 
         step =>
           step
-            ? (step.stack || []).map(word => Codec.Conversion.toBytes(word))
+            ? //padding is there to handle Besu
+              (step.stack || []).map(word =>
+                Codec.Conversion.toBytes(word, Codec.Evm.Utils.WORD_SIZE)
+              )
             : null
       )
     }

--- a/packages/debugger/lib/data/selectors/index.js
+++ b/packages/debugger/lib/data/selectors/index.js
@@ -618,7 +618,8 @@ const data = createSelectorTree({
           Object.assign(
             {},
             ...Object.entries(mapping).map(([address, word]) => ({
-              [`0x${address}`]: Codec.Conversion.toBytes(word)
+              [`0x${address}`]:
+                word !== undefined ? Codec.Conversion.toBytes(word) : undefined
             }))
           )
       ),

--- a/packages/debugger/lib/data/selectors/index.js
+++ b/packages/debugger/lib/data/selectors/index.js
@@ -1421,10 +1421,7 @@ const data = createSelectorTree({
         [solidity.current.nextMapped],
 
         step =>
-          //padding is there to handle Besu
-          ((step || {}).stack || []).map(word =>
-            Codec.Conversion.toBytes(word, Codec.Evm.Utils.WORD_SIZE)
-          )
+          ((step || {}).stack || []).map(word => Codec.Conversion.toBytes(word))
       )
     }
   },
@@ -1448,10 +1445,7 @@ const data = createSelectorTree({
 
         step =>
           step
-            ? //padding is there to handle Besu
-              (step.stack || []).map(word =>
-                Codec.Conversion.toBytes(word, Codec.Evm.Utils.WORD_SIZE)
-              )
+            ? (step.stack || []).map(word => Codec.Conversion.toBytes(word))
             : null
       )
     }

--- a/packages/debugger/lib/evm/selectors/index.js
+++ b/packages/debugger/lib/evm/selectors/index.js
@@ -661,7 +661,15 @@ const evm = createSelectorTree({
           )
         )
       )
-    }
+    },
+
+    /**
+     * evm.current.undefinedStorage
+     * for warning the user
+     */
+    undefinedStorage: createLeaf(["./codex/storage"], storage =>
+      Object.values(storage).includes(undefined)
+    )
   },
 
   /**

--- a/packages/debugger/lib/evm/selectors/index.js
+++ b/packages/debugger/lib/evm/selectors/index.js
@@ -19,19 +19,6 @@ import {
 
 const ZERO_WORD = "00".repeat(Codec.Evm.Utils.WORD_SIZE);
 
-//HACK
-function padHex(hexStringArray) {
-  if (!Array.isArray(hexStringArray)) {
-    return hexStringArray;
-  }
-  return hexStringArray.map(
-    //do not change this to 00, because Besu reports things truncated to
-    //the nybble, not to the byte
-    hexString =>
-      "0x" + hexString.slice(2).padStart(2 * Codec.Evm.Utils.WORD_SIZE, "0")
-  );
-}
-
 function determineFullContext(
   { address, binary },
   instances,
@@ -455,7 +442,7 @@ const evm = createSelectorTree({
     state: Object.assign(
       {},
       ...["depth", "error", "gas", "memory", "stack", "storage"].map(param => ({
-        [param]: createLeaf([trace.step], step => padHex(step[param]))
+        [param]: createLeaf([trace.step], step => step[param])
       }))
     ),
 
@@ -697,7 +684,7 @@ const evm = createSelectorTree({
     state: Object.assign(
       {},
       ...["depth", "error", "gas", "memory", "stack", "storage"].map(param => ({
-        [param]: createLeaf([trace.next], step => padHex(step[param]))
+        [param]: createLeaf([trace.next], step => step[param])
       }))
     ),
 
@@ -719,9 +706,7 @@ const evm = createSelectorTree({
     state: Object.assign(
       {},
       ...["depth", "error", "gas", "memory", "stack", "storage"].map(param => ({
-        [param]: createLeaf([trace.nextOfSameDepth], step =>
-          padHex(step[param])
-        )
+        [param]: createLeaf([trace.nextOfSameDepth], step => step[param])
       }))
     )
   }

--- a/packages/debugger/lib/evm/selectors/index.js
+++ b/packages/debugger/lib/evm/selectors/index.js
@@ -19,7 +19,7 @@ import {
 
 const ZERO_WORD = "00".repeat(Codec.Evm.Utils.WORD_SIZE);
 
-//HACK
+//HACK; for dealing with Besu
 function padHex(hexStringArray) {
   if (!Array.isArray(hexStringArray)) {
     return hexStringArray;
@@ -28,7 +28,9 @@ function padHex(hexStringArray) {
     //do not change this to 00, because Besu reports things truncated to
     //the nybble, not to the byte
     hexString =>
-      "0x" + hexString.slice(2).padStart(2 * Codec.Evm.Utils.WORD_SIZE, "0")
+      hexString.startsWith("0x")
+        ? hexString.slice(2).padStart(2 * Codec.Evm.Utils.WORD_SIZE, "0") //for Besu; do not put 0x on front!
+        : hexString //for Geth and Ganache, there is no 0x on front and no padding is needed
   );
 }
 

--- a/packages/debugger/lib/evm/selectors/index.js
+++ b/packages/debugger/lib/evm/selectors/index.js
@@ -19,7 +19,7 @@ import {
 
 const ZERO_WORD = "00".repeat(Codec.Evm.Utils.WORD_SIZE);
 
-//HACK; for dealing with Besu
+//HACK
 function padHex(hexStringArray) {
   if (!Array.isArray(hexStringArray)) {
     return hexStringArray;
@@ -28,9 +28,7 @@ function padHex(hexStringArray) {
     //do not change this to 00, because Besu reports things truncated to
     //the nybble, not to the byte
     hexString =>
-      hexString.startsWith("0x")
-        ? hexString.slice(2).padStart(2 * Codec.Evm.Utils.WORD_SIZE, "0") //for Besu; do not put 0x on front!
-        : hexString //for Geth and Ganache, there is no 0x on front and no padding is needed
+      "0x" + hexString.slice(2).padStart(2 * Codec.Evm.Utils.WORD_SIZE, "0")
   );
 }
 

--- a/packages/debugger/lib/evm/selectors/index.js
+++ b/packages/debugger/lib/evm/selectors/index.js
@@ -19,6 +19,19 @@ import {
 
 const ZERO_WORD = "00".repeat(Codec.Evm.Utils.WORD_SIZE);
 
+//HACK
+function padHex(hexStringArray) {
+  if (!Array.isArray(hexStringArray)) {
+    return hexStringArray;
+  }
+  return hexStringArray.map(
+    //do not change this to 00, because Besu reports things truncated to
+    //the nybble, not to the byte
+    hexString =>
+      "0x" + hexString.slice(2).padStart(2 * Codec.Evm.Utils.WORD_SIZE, "0")
+  );
+}
+
 function determineFullContext(
   { address, binary },
   instances,
@@ -442,7 +455,7 @@ const evm = createSelectorTree({
     state: Object.assign(
       {},
       ...["depth", "error", "gas", "memory", "stack", "storage"].map(param => ({
-        [param]: createLeaf([trace.step], step => step[param])
+        [param]: createLeaf([trace.step], step => padHex(step[param]))
       }))
     ),
 
@@ -684,7 +697,7 @@ const evm = createSelectorTree({
     state: Object.assign(
       {},
       ...["depth", "error", "gas", "memory", "stack", "storage"].map(param => ({
-        [param]: createLeaf([trace.next], step => step[param])
+        [param]: createLeaf([trace.next], step => padHex(step[param]))
       }))
     ),
 
@@ -706,7 +719,9 @@ const evm = createSelectorTree({
     state: Object.assign(
       {},
       ...["depth", "error", "gas", "memory", "stack", "storage"].map(param => ({
-        [param]: createLeaf([trace.nextOfSameDepth], step => step[param])
+        [param]: createLeaf([trace.nextOfSameDepth], step =>
+          padHex(step[param])
+        )
       }))
     )
   }


### PR DESCRIPTION
This PR is in response to issue #2066.  It turns out that the problem is that Geth, in its trace steps, only displays storage that has been *written to* in this transaction, not *read from* in this transaction.

This results in storage slots showing up in the codex with a value of `undefined`.  This causes problems when we want to convert that `undefined` to a `Uint8Array`.

There are two possible solutions to this.  The better solution is probably to simply not add `undefined`  to the codex.  However, @gnidan wanted us to add a user warning when this happens, so instead I went with the other solution -- just being OK with `undefined` and accounting for it.  Fortunately our existing code all checks `storage[slot] !== undefined`, not `slot in storage`, so not much code need change there.

As mentioned, I also added a user warning when this is detected.  It's only printed once each time through the transaction.

Of course, while this fixes the crash and similar, this is still going to cause a number of decoding problems when using the debugger with Geth.  I'll file an issue with them.