### PR TITLE
Internal Improvement: Fix quorum & geth ci again again again again

### DIFF
--- a/packages/contract/test/deploy.js
+++ b/packages/contract/test/deploy.js
@@ -105,14 +105,14 @@ describe("Deployments", function() {
         .catch(() => null);
     });
 
-    it("Errors with always failing transaction error if constructor reverts", async function() {
+    it("Errors with exeuction reverted transaction error if constructor reverts", async function() {
       try {
         await Example.new(13); // 13 fails a require gate
         assert.fail();
       } catch (e) {
-        const errorCorrect = e.message.includes("always failing transaction");
+        const errorCorrect = e.message.includes("execution reverted");
 
-        assert(errorCorrect, "Expected always failing transaction error");
+        assert(errorCorrect, "Expected execution reverted transaction error");
         assert(e.receipt === undefined, "Expected no receipt");
       }
     });

--- a/packages/contract/test/methods.js
+++ b/packages/contract/test/methods.js
@@ -456,15 +456,15 @@ describe("Methods", function() {
       }
     });
 
-    it("errors with failed tx message when gas not specified", async function() {
+    it("errors with invalid opcode message when gas not specified", async function() {
       const example = await Example.new(1);
       try {
         await example.triggerAssertError();
         assert.fail();
       } catch (e) {
         assert(
-          e.message.includes("failing transaction"),
-          "should return failed tx message!"
+          e.message.includes("invalid opcode"),
+          "should return invalid opcode message!"
         );
         assert(e.receipt === undefined, "Excected no receipt");
       }

--- a/packages/contract/test/methods.js
+++ b/packages/contract/test/methods.js
@@ -431,15 +431,15 @@ describe("Methods", function() {
       });
     });
 
-    it("errors with failed tx message", async function() {
+    it("errors with execution reverted message", async function() {
       const example = await Example.new(1);
       try {
         await example.triggerRequireError();
         assert.fail();
       } catch (e) {
         assert(
-          e.message.includes("failing transaction"),
-          "should return failed tx message!"
+          e.message.includes("execution reverted"),
+          "should return execution reverted tx message!"
         );
         assert(e.receipt === undefined, "Expected no receipt");
       }

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -49,8 +49,8 @@ elif [ "$QUORUM" = true ]; then
   sudo mv docker-compose /usr/local/bin
   git clone https://github.com/jpmorganchase/quorum-examples
   cd quorum-examples
-  docker-compose up -d
-  sleep 90
+  QUORUM_GETH_ARGS="-allow-insecure-unlock" docker-compose up -d
+  node ../scripts/wait-for-quorum-network.js
   lerna run --scope truffle test --stream -- --exit
 
 elif [ "$COLONY" = true ]; then

--- a/scripts/wait-for-quorum-network.js
+++ b/scripts/wait-for-quorum-network.js
@@ -1,0 +1,35 @@
+const Web3 = require("web3");
+const {
+  networks: { development: developmentNetworkConfig }
+} = require("../packages/truffle/test/sources/migrations/quorum/truffle-config");
+
+/**
+ * Retries the given function until it succeeds, given a number of retries and an interval between them.
+ * Defaults to retry 5 times with 1 sec in between.
+ * @param {Function} fn - Returns a promise
+ * @param {Number} retries - Number of retries.
+ * @param {Number} interval - Milliseconds between retries.
+ * @return {Promise<*>}
+ */
+async function retry(fn, retries = 5, interval = 1000) {
+  try {
+    return await fn();
+  } catch (error) {
+    if (retries) {
+      await new Promise(r => setTimeout(r, interval));
+      return retry(fn, retries - 1, interval);
+    }
+    throw new Error("Max retries reached");
+  }
+}
+
+const web3 = new Web3();
+web3.setProvider(
+  `http://${developmentNetworkConfig.host}:${developmentNetworkConfig.port}`
+);
+
+console.log("Waiting for the quorum network to be ready...");
+
+retry(web3.eth.getAccounts, (interval = 5000))
+  .then(() => console.log("Quorum network ready!"))
+  .catch(console.error);


### PR DESCRIPTION
quorum job stuff
----------------

`quorum-examples` bumped to `quorum` v2.6.0, which bumps `geth` internally, and requires passing the unlock accounts flag on startup for keystore accounts.

As part of this, I decided to remove the lazy `sleep` CI step and use a retry-promise script to poll the network and resolve before moving onto the `quorum` integration test.

geth job stuff
----------------
`geth` changed some more of their error handling, so relevant affected test cases have been updated to appropriately.