### PR TITLE
Bug fix: Fix Geth and Besu compatibility problems in debugger

### DIFF
--- a/packages/debugger/lib/evm/sagas/index.js
+++ b/packages/debugger/lib/evm/sagas/index.js
@@ -154,19 +154,16 @@ export function* callstackAndCodexSaga() {
     } else {
       yield put(actions.returnCall());
     }
-  } else if (yield select(evm.current.step.touchesStorage)) {
+  } else if (yield select(evm.current.step.isStore)) {
     let storageAddress = (yield select(evm.current.call)).storageAddress;
     let slot = yield select(evm.current.step.storageAffected);
-    //note we get next storage, since we're updating to that
-    let storage = yield select(evm.next.state.storage);
-    //normally we'd need a 0 fallback for this next line, but in this case we
-    //can be sure the value will be there, since we're touching that storage
-    if (yield select(evm.current.step.isStore)) {
-      yield put(actions.store(storageAddress, slot, storage[slot]));
-    } else {
-      //otherwise, it's a load
-      yield put(actions.load(storageAddress, slot, storage[slot]));
-    }
+    let storedValue = yield select(evm.current.step.valueStored);
+    yield put(actions.store(storageAddress, slot, storedValue));
+  } else if (yield select(evm.current.step.isLoad)) {
+    let storageAddress = (yield select(evm.current.call)).storageAddress;
+    let slot = yield select(evm.current.step.storageAffected);
+    let loadedValue = yield select(evm.current.step.valueLoaded);
+    yield put(actions.load(storageAddress, slot, loadedValue));
   }
 }
 


### PR DESCRIPTION
This PR supersedes #3095; it also is an attempt to address #2066, but a much better one.

This PR has two commits.  The first is taken straight from #3095.  It handles the Besu compatibility problem that Besu reports the stack and memory in a slightly different format than Geth and Ganache do.  This might change in future versions of Besu, since I alerted Pegasys to this discrepancy, but for now it's there and I figured we ought to be prepared to handle it.  It handles the problem by simply converting the trace on intake to Geth/Ganache format, so it will be in the right format the whole way through.

The second deals with how Geth and Besu handle storage.  (Although Geth is changing this to act like Ganache; [this](https://github.com/ethereum/go-ethereum/pull/21204) is their PR for it.  But I figured best to be as compatible as possible.)  The problem is that Geth, in its `storage` fields, only kept track of storage written to, not read from.  (Up till now, anyway.)  So, this PR changes it so that the codex system now keeps track of storage exclusively by looking at the stack; we look at the results of `SLOAD`s and the arguments to `SSTORE`s, and we completely ignore the `storage` field.  (Yup, really, we no longer do anything with it.)  So, this will now work regardless of the exact format of `storage`.

(Of course, it'll miss out if there were a hypothetical client that included *other* storage in there, but that's been true since I added the codex system, and such a client doesn't exist anyway.  Anyway if it did that would be a solvable problem, we'd just take account of its storage on startup.)

Hooray, Geth and Besu compatibility without hacking up the code!  And hopefully this puts #2066 to rest, although we'll need to check back with the user who originally filed it.