### PR TITLE
Bug fix: Remove "development" default from debugger --network option

### DIFF
--- a/packages/core/lib/commands/debug.js
+++ b/packages/core/lib/commands/debug.js
@@ -7,8 +7,7 @@ const command = {
     },
     "network": {
       describe: "Network to connect to",
-      type: "string",
-      default: "development"
+      type: "string"
     },
     "fetch-external": {
       describe: "Allow debugging of external contracts",
@@ -23,7 +22,7 @@ const command = {
     options: [
       {
         option: "--network",
-        description: "Network to connect to.  Default: development"
+        description: "Network to connect to."
       },
       {
         option: "--fetch-external",


### PR DESCRIPTION
When I added the `--network` option to `debug`, I didn't realize that I shouldn't add a default network, because we already have a means for autodetecting the default network, and doing this would override it in bad ways.  Well, now that's removed.  Thanks to @kevinbluer for pointing out the issue.