### PR TITLE
Bug fix: Add proper padding to debugger's keccak256 function

### DIFF
--- a/packages/debugger/lib/helpers/index.js
+++ b/packages/debugger/lib/helpers/index.js
@@ -69,7 +69,10 @@ export function popNWhere(array, numToRemove, predicate) {
  * @return 0x-prefix string of keccak256 hash
  */
 export function keccak256(...args) {
-  return Codec.Conversion.toHexString(Codec.Evm.Utils.keccak256(...args));
+  return Codec.Conversion.toHexString(
+    Codec.Evm.Utils.keccak256(...args),
+    Codec.Evm.Utils.WORD_SIZE
+  );
 }
 
 /**


### PR DESCRIPTION
This PR fixes a bug where occasionally the debugger would compute the wrong address for a `CREATE2` that failed.

Normally the debugger reads addresses off the stack, but for failed creations, that's impossible.  For failed `CREATE`s we can't do anything about this, but for failed `CREATE2`s we can, and do, compute the address ourself.

However, sporadically, we'd compute the address incorrectly: The high byte would be zeroed out.  Why was this happening?

Well, it's due to us manipulating 32-byte words as hexstrings, largely.  We'd compute the appropriate hash, cut off the first 12 bytes, then checksum what remained to get our address.

Except... what if the string representing the hash was less than 32 bytes long?  Turns out, the debugger's `keccak256` function didn't include any padding.  So if the hash had a top byte of zero, the string would be **31** bytes long, and slicing off the first 12 bytes would leave only 19 bytes, not 20.  The top byte would get deleted.  So, when we converted it to a checksummed address, we'd get a top byte of zero.  As observed.

Now I added the padding, so the resulting hashes are always a full 32 bytes, and so our manipulations work.  Problem solved!