### PR TITLE
Enhancement: Add a Sourcify source-fetcher

### DIFF
--- a/packages/source-fetcher/lib/common.ts
+++ b/packages/source-fetcher/lib/common.ts
@@ -1,6 +1,7 @@
 //these imports aren't actually necessary, but why not :)
 import util from "util";
 import { setTimeout } from "timers";
+import * as Types from "./types";
 
 export const networksById: { [id: number]: string } = {
   1: "mainnet",
@@ -24,3 +25,11 @@ export function makeFilename(name: string, extension: string = ".sol"): string {
 export const makeTimer: (
   milliseconds: number
 ) => Promise<void> = util.promisify(setTimeout);
+
+export function removeLibraries(
+  settings: Types.SolcSettings
+): Types.SolcSettings {
+  let copySettings: Types.SolcSettings = { ...settings };
+  delete copySettings.libraries;
+  return copySettings;
+}

--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -201,7 +201,7 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
     return {
       sources: this.processSources(jsonInput.sources),
       options: {
-        language: "Solidity",
+        language: jsonInput.language,
         version: result.CompilerVersion,
         settings: this.removeLibraries(jsonInput.settings)
       }

--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -3,7 +3,12 @@ const debug = debugModule("source-fetcher:etherscan");
 
 import { Fetcher, FetcherConstructor } from "./types";
 import * as Types from "./types";
-import { networksById, makeFilename, makeTimer } from "./common";
+import {
+  networksById,
+  makeFilename,
+  makeTimer,
+  removeLibraries
+} from "./common";
 import request from "request-promise-native";
 
 //this looks awkward but the TS docs actually suggest this :P
@@ -76,7 +81,6 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
       await this.ready;
       const responsePromise = this.makeRequest(address);
       this.ready = makeTimer(this.delay);
-      //for now, we're just going to retry once if it fails
       try {
         return await responsePromise;
       } catch (error) {
@@ -203,7 +207,7 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
       options: {
         language: jsonInput.language,
         version: result.CompilerVersion,
-        settings: this.removeLibraries(jsonInput.settings)
+        settings: removeLibraries(jsonInput.settings) //we *don't* want to pass library info!  unlinked bytecode is better!
       }
     };
   }
@@ -237,15 +241,6 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
         optimizer
       };
     }
-  }
-
-  //we *don't* want to pass library info!  unlinked bytecode is better!
-  private static removeLibraries(
-    settings: Types.SolcSettings
-  ): Types.SolcSettings {
-    let copySettings: Types.SolcSettings = { ...settings };
-    delete copySettings.libraries;
-    return copySettings;
   }
 };
 

--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -58,8 +58,8 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
     this.ready = makeTimer(0); //at start, it's ready to go immediately
   }
 
-  private validNetwork: boolean;
-  private suffix: string;
+  private readonly validNetwork: boolean;
+  private readonly suffix: string;
 
   async isNetworkValid(): Promise<boolean> {
     return this.validNetwork;

--- a/packages/source-fetcher/lib/index.ts
+++ b/packages/source-fetcher/lib/index.ts
@@ -4,7 +4,8 @@ import { Fetcher, FetcherConstructor } from "./types";
 export { Fetcher, FetcherConstructor };
 
 import EtherscanFetcher from "./etherscan";
+import SourcifyFetcher from "./sourcify";
 
-const Fetchers: FetcherConstructor[] = [EtherscanFetcher];
+const Fetchers: FetcherConstructor[] = [EtherscanFetcher, SourcifyFetcher];
 
 export default Fetchers;

--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -3,7 +3,7 @@ const debug = debugModule("source-fetcher:sourcify");
 
 import { Fetcher, FetcherConstructor } from "./types";
 import * as Types from "./types";
-import { removeLibraries } from "./common";
+import { networksById, removeLibraries } from "./common";
 import request from "request-promise-native";
 
 //this looks awkward but the TS docs actually suggest this :P
@@ -25,21 +25,30 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     return new SourcifyFetcher(id);
   }
 
-  private networkId: number;
+  private readonly networkId: number;
+  private readonly networkName: string; //not really used as a class member atm
+  //but may be in the future
+  private readonly validNetwork: boolean;
 
-  private domain: string = "contractrepo.komputing.org";
+  private readonly domain: string = "contractrepo.komputing.org";
 
   constructor(networkId: number) {
-    //we'll just treat all network IDs as valid;
-    //that wouldn't work very well if we were using the IPFS interface,
-    //which goes by network name, but it'll work fine for the HTTP interface
-    //(no idea why they're different)
-    //(technically it should be chain ID but realistically it won't matter)
     this.networkId = networkId;
+    this.networkName = networksById[networkId];
+    const supportedNetworks = [
+      "mainnet",
+      "ropsten",
+      "kovan",
+      "rinkeby",
+      "goerli"
+    ];
+    this.validNetwork =
+      this.networkName !== undefined &&
+      supportedNetworks.includes(this.networkName);
   }
 
   async isNetworkValid(): Promise<boolean> {
-    return true;
+    return this.validNetwork;
   }
 
   async fetchSourcesForAddress(

--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -52,8 +52,11 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     const sources: Types.SourcesByPath = Object.assign(
       {},
       ...(await Promise.all(
-        Object.keys(metadata.sources).map(
-          async sourcePath => await this.getSource(address, sourcePath)
+        Object.entries(metadata.sources).map(
+          async ([sourcePath, { content: source }]) =>
+            source !== undefined
+              ? source //sourcify doesn't support this yet but they're planning it
+              : await this.getSource(address, sourcePath)
         )
       ))
     );

--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -1,0 +1,125 @@
+import debugModule from "debug";
+const debug = debugModule("source-fetcher:sourcify");
+
+import { Fetcher, FetcherConstructor } from "./types";
+import * as Types from "./types";
+import { removeLibraries } from "./common";
+import request from "request-promise-native";
+
+//this looks awkward but the TS docs actually suggest this :P
+const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
+  implements Fetcher {
+  get fetcherName(): string {
+    return "sourcify";
+  }
+  static get fetcherName(): string {
+    return "sourcify";
+  }
+
+  static async forNetworkId(
+    id: number,
+    options?: Types.FetcherOptions
+  ): Promise<SourcifyFetcher> {
+    //in the future, we may add protocol and node options,
+    //but these don't exist yet
+    return new SourcifyFetcher(id);
+  }
+
+  private networkId: number;
+
+  private domain: string = "contractrepo.komputing.org";
+
+  constructor(networkId: number) {
+    //we'll just treat all network IDs as valid;
+    //that wouldn't work very well if we were using the IPFS interface,
+    //which goes by network name, but it'll work fine for the HTTP interface
+    //(no idea why they're different)
+    //(technically it should be chain ID but realistically it won't matter)
+    this.networkId = networkId;
+  }
+
+  async isNetworkValid(): Promise<boolean> {
+    return true;
+  }
+
+  async fetchSourcesForAddress(
+    address: string
+  ): Promise<Types.SourceInfo | null> {
+    const metadata = await this.getMetadata(address);
+    if (!metadata) {
+      return null;
+    }
+    const sources: Types.SourcesByPath = Object.assign(
+      {},
+      ...(await Promise.all(
+        Object.keys(metadata.sources).map(
+          async sourcePath => await this.getSource(address, sourcePath)
+        )
+      ))
+    );
+    return {
+      sources,
+      options: {
+        language: metadata.language,
+        version: metadata.compiler.version,
+        settings: removeLibraries(metadata.settings)
+      }
+    };
+  }
+
+  private async getMetadata(
+    address: string
+  ): Promise<Types.SolcMetadata | null> {
+    try {
+      return await this.requestWithRetries<Types.SolcMetadata>({
+        uri: `https://${this.domain}/contract/${
+          this.networkId
+        }/${address}/metadata.json`,
+        json: true //turns on auto-parsing
+      });
+    } catch (error) {
+      //is this a 404 error? if so just return null
+      if (error.statusCode === 404) {
+        return null;
+      }
+      //otherwise, we've got a problem; rethrow the error
+      throw error;
+    }
+  }
+
+  private async getSource(
+    address: string,
+    sourcePath: string
+  ): Promise<string> {
+    return await this.requestWithRetries<string>({
+      uri: `https://${this.domain}/contract/${
+        this.networkId
+      }/${address}/sources/${sourcePath}`
+    });
+  }
+
+  private async requestWithRetries<T>(
+    requestObject: any //sorry, trying to import the type properly ran into problems
+  ): Promise<T> {
+    const allowedAttempts = 2; //for now, we'll just retry once if it fails
+    let lastError;
+    for (let attempt = 0; attempt < allowedAttempts; attempt++) {
+      const responsePromise = request(requestObject);
+      try {
+        return await responsePromise;
+      } catch (error) {
+        //check: is this a 404 error? if so give up
+        if (error.statusCode === 404) {
+          throw error;
+        }
+        //otherwise, just go back to the top of the loop to retry
+        lastError = error;
+      }
+    }
+    //if we've made it this far with no successful response, just
+    //throw the last error
+    throw lastError;
+  }
+};
+
+export default SourcifyFetcher;

--- a/packages/source-fetcher/lib/types.ts
+++ b/packages/source-fetcher/lib/types.ts
@@ -54,7 +54,9 @@ export interface SolcSettings {
 
 export interface SolcSources {
   [sourcePath: string]: {
-    content: string;
+    keccak256?: string;
+    content?: string; //for Etherscan we assume this exists
+    urls?: string;
   };
 }
 
@@ -63,6 +65,17 @@ export interface SolcInput {
   sources: SolcSources;
   settings: SolcSettings;
   //there's also outputSelection, but, frankly, we don't care about this
+}
+
+export interface SolcMetadata {
+  language: "Solidity" | "Yul";
+  compiler: {
+    version: string;
+  };
+  settings: SolcSettings;
+  sources: SolcSources;
+  version: number;
+  //there's also output, but we don't care about that
 }
 
 export interface LibrarySettings {

--- a/packages/source-fetcher/lib/types.ts
+++ b/packages/source-fetcher/lib/types.ts
@@ -33,7 +33,7 @@ export interface SourcesByPath {
 export type CompilerOptions = SolcOptions | VyperOptions; //note: only Solidity really supported atm
 
 export interface SolcOptions {
-  language: "Solidity";
+  language: "Solidity" | "Yul"; //again, only Solidity really supported atm
   version: string;
   settings: SolcSettings;
 }


### PR DESCRIPTION
This PR expands adds a source-fetcher for Sourcify.

Because Sourcify doesn't have multiple formats to deal with, it's mostly more straightforward to handle.  First, get the metadata.  Then get the sources.  If they're literal sources we can get them straight out of the metadata -- Sourcify doesn't actually support this yet but they're planning it -- otherwise we look them up by path.

I copied the retry logic from the Etherscan fetcher.  I removed the throttling; hopefully that doesn't cause any problems.

However, there are a few additional wrinkles worth noting.

First, for Sourcify, if Sourcify doesn't list a certain contract, there's no special error JSON we'll get back; rather, we'll just get a 404.  So, we now check errors to see whether they're 404 errors.  At the low level, when making requests, this means that if we get a 404 error we give up and don't retry.  At the high level, when getting metadata, this means that if we get a 404 we just return `null`, we don't throw an error.

Secondly, we access Sourcify via HTTPS, not via IPFS.  This is partly because IPFS is a pain, and partly because it just doesn't seem to have as many contracts listed as the web version??

Thirdly, *because* we only use the web version, I chose not to include any logic to determine whether the given network ID is supported, because, well, Sourcify will work exactly the same regardless.  If we were doing it the IPFS way, where things are done by name instead of numerical ID, I'd have to add this.

(Unless we wanted to try to rely on the symlinks, which... only `mainnet` and `goerli` even have symlinks apparently, so...)

Finally -- and this is a change to the Etherscan fetcher as well -- just to head off any potential problems with this, I added `"Yul"` as a possible option for `language`, alongside `"Solidity"` and `"Vyper"`.  Of course, like with Vyper, we won't do anything with Yul source, but that's why I added it -- I figure that just in case Yul source exists out there on Etherscan or Sourcify, we should handle it by ignoring it, rather than it causing an error, which is what would have happened before.

Anyway, on the whole, nothing complicated here.  Yay, Sourcify support!