### PR TITLE
Bug fixes: Fix step into; fix help display; make i & u repeatable

### DIFF
--- a/packages/core/lib/debug/interpreter.js
+++ b/packages/core/lib/debug/interpreter.js
@@ -597,12 +597,10 @@ class DebugInterpreter {
         //nothing to print
         break;
       default:
-        this.printer.printHelp();
+        this.printer.printHelp(this.lastCommand);
     }
 
     if (
-      cmd !== "i" &&
-      cmd !== "u" &&
       cmd !== "b" &&
       cmd !== "B" &&
       cmd !== "v" &&

--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -98,9 +98,9 @@ class DebugPrinter {
     }
   }
 
-  printHelp() {
+  printHelp(lastCommand) {
     this.config.logger.log("");
-    this.config.logger.log(DebugUtils.formatHelp());
+    this.config.logger.log(DebugUtils.formatHelp(lastCommand));
   }
 
   printFile() {

--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -35,6 +35,30 @@ const commandReference = {
   "s": "print stacktrace"
 };
 
+const shortCommandReference = {
+  "o": "step over",
+  "i": "step into",
+  "u": "step out",
+  "n": "step next",
+  ";": "step instruction",
+  "p": "print state",
+  "l": "print context",
+  "h": "print help",
+  "v": "print variables",
+  ":": "evaluate",
+  "+": "add watch",
+  "-": "remove watch",
+  "?": "list watches & breakpoints",
+  "b": "add breakpoint",
+  "B": "remove breakpoint",
+  "c": "continue",
+  "q": "quit",
+  "r": "reset",
+  "t": "load",
+  "T": "unload",
+  "s": "stacktrace"
+};
+
 const truffleColors = {
   mint: chalk.hex("#3FE0C5"),
   orange: chalk.hex("#E4A663"),
@@ -179,16 +203,12 @@ var DebugUtils = {
     return lines.join(OS.EOL);
   },
 
-  formatHelp: function(lastCommand) {
-    if (!lastCommand) {
-      lastCommand = "n";
-    }
-
+  formatHelp: function(lastCommand = "n") {
     var prefix = [
       "Commands:",
       truffleColors.mint("(enter)") +
         " last command entered (" +
-        commandReference[lastCommand] +
+        shortCommandReference[lastCommand] +
         ")"
     ];
 


### PR DESCRIPTION
This PR does several things.  First of all, it fixes #3114.  The `stepInto` function now checks for whether the current line has changed, rather than the current location.  Also, I removed some special cases that just don't seem necessary.

Secondly, the debugger CLI didn't treat `i` and `u` as repeatable; I removed that.

Finally, I fixed the help printout, which would always show the last entered command as step next, regardless of what it actually was.