### PR TITLE
Bug fix: Have nativizeVariables() return undefined for variables that throw

### DIFF
--- a/packages/codec/lib/format/utils/inspect.ts
+++ b/packages/codec/lib/format/utils/inspect.ts
@@ -452,9 +452,13 @@ export function nativizeVariables(variables: {
 }): { [name: string]: any } {
   return Object.assign(
     {},
-    ...Object.entries(variables).map(([name, value]) => ({
-      [name]: nativize(value)
-    }))
+    ...Object.entries(variables).map(([name, value]) => {
+      try {
+        return { [name]: nativize(value) };
+      } catch (_) {
+        return undefined; //I guess??
+      }
+    })
   );
 }
 


### PR DESCRIPTION
Problem I encountered while using the debugger: If even one numeric variable is too big to fit in a `number`, printing/watch expressions breaks entirely.  To remedy this, `nativizeVariables()` now catches errors and returns `undefined` for variables that can't be nativized.  Not great, but better than making it so that you can't even do `:9` if there happens to be a variable equal to 10^18.