### PR TITLE
Fix Local loading strategy by wrapping soljson

### DIFF
--- a/packages/compile-solidity/compilerSupplier/loadingStrategies/Local.js
+++ b/packages/compile-solidity/compilerSupplier/loadingStrategies/Local.js
@@ -1,6 +1,7 @@
 const path = require("path");
 const originalRequire = require("original-require");
 const LoadingStrategy = require("./LoadingStrategy");
+const solcWrap = require("solc/wrapper");
 
 class Local extends LoadingStrategy {
   load(localPath) {
@@ -8,18 +9,20 @@ class Local extends LoadingStrategy {
   }
 
   getLocalCompiler(localPath) {
-    let compiler, compilerPath;
+    let soljson, compilerPath, wrapped;
     compilerPath = path.isAbsolute(localPath)
       ? localPath
       : path.resolve(process.cwd(), localPath);
 
     try {
-      compiler = originalRequire(compilerPath);
-      this.removeListener();
+      soljson = originalRequire(compilerPath);
     } catch (error) {
       throw this.errors("noPath", localPath, error);
     }
-    return compiler;
+    //HACK: if it has a compile function, assume it's already wrapped
+    wrapped = soljson.compile ? soljson : solcWrap(soljson);
+    this.removeListener();
+    return wrapped;
   }
 }
 


### PR DESCRIPTION
This PR fixes the Local loading strategy, by wrapping the soljson before returning it.  Now you can indeed just point your solc version to a local soljson and it'll work.

To preserve compatibility with the old broken way (though I have to wonder if anyone was actually using that?), before wrapping, we check if `soljson.compile` exists, and if it does, we assume it's already wrapped, and refrain from wrapping it again.

Also, while I was at it, I converted `load()` to an `async` function instead of manually constructing a Promise, because there's really no reason for it to do that.