### PR TITLE
Update stacktracing for free & Yul functions

### DIFF
--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -589,6 +589,8 @@ var DebugUtils = {
         name = `${contractName}.${functionName}`;
       } else if (contractName) {
         name = contractName;
+      } else if (functionName) {
+        name = functionName;
       } else {
         name = "unknown function";
       }

--- a/packages/debugger/lib/stacktrace/reducers.js
+++ b/packages/debugger/lib/stacktrace/reducers.js
@@ -15,7 +15,9 @@ function callstack(state = [], action) {
         type: "internal",
         calledFromLocation: location,
         functionName:
-          functionNode && functionNode.nodeType === "FunctionDefinition"
+          functionNode &&
+          (functionNode.nodeType === "FunctionDefinition" ||
+            functionNode.nodeType === "YulFunctionDefinition")
             ? functionNode.name
             : undefined,
         contractName:


### PR DESCRIPTION
Free functions are likely coming to Solidity, and jumps on Yul functions are very likely coming to Solidity soon!  Better make sure our stacktracing can handle them!

This PR does two things:
1. It updates `formatStacktrace` in `debug-utils` to account for the possibility of a function with a name but no contract name;
2. It updates the stacktrace reducer to account for the possibility of a Yul function rather than a Solidity function.

And that's it, pretty straightforward!