### PR TITLE
Support arrays of tuples in ABI schema

### DIFF
--- a/packages/contract-schema/spec/abi.spec.json
+++ b/packages/contract-schema/spec/abi.spec.json
@@ -28,7 +28,7 @@
         { "type": "string", "pattern": "^bytes(\\[[0-9]*\\])*$" },
         { "type": "string", "pattern": "^function(\\[[0-9]*\\])*$" },
         { "type": "string", "pattern": "^string(\\[[0-9]*\\])*$" },
-        { "type": "string", "pattern": "^tuple$" }
+        { "type": "string", "pattern": "^tuple(\\[[0-9]*\\])*$" }
       ]
     },
 


### PR DESCRIPTION
To fix problem with ABI input type `tuple[]`

Raised on Spectrum [here](https://spectrum.chat/trufflesuite/truffle-teams/artifacts-upload-is-not-working~e6758041-1135-4857-9429-96c81e8ecfca)