### PR TITLE
Enhancement: Improve network check for congested networks

### DIFF
--- a/packages/provider/index.js
+++ b/packages/provider/index.js
@@ -55,20 +55,25 @@ module.exports = {
           "networks[networkName].networkCheckTimeout property to do this.";
         throw new Error(errorMessage);
       }, networkCheckTimeout);
-      interfaceAdapter
-        .getBlockNumber()
-        .then(() => {
-          clearTimeout(noResponseFromNetworkCall);
-          resolve(true);
-        })
-        .catch(error => {
-          console.log(
-            "> Something went wrong while attempting to connect " +
-              "to the network. Check your network configuration."
-          );
-          clearTimeout(noResponseFromNetworkCall);
-          reject(error);
-        });
+
+      const networkCheck = setInterval(() => {
+        interfaceAdapter
+          .getBlockNumber()
+          .then(() => {
+            clearTimeout(noResponseFromNetworkCall);
+            clearInterval(networkCheck);
+            resolve(true);
+          })
+          .catch(error => {
+            console.log(
+              "> Something went wrong while attempting to connect " +
+                "to the network. Check your network configuration."
+            );
+            clearTimeout(noResponseFromNetworkCall);
+            clearInterval(networkCheck);
+            reject(error);
+          });
+      });
     });
   }
 };


### PR DESCRIPTION
- Wraps `getBlockNumber` call within `Provider.testConnection` within a `setInterval`

When coupled with the `web3-provider-engine` [fix](https://github.com/trufflesuite/provider-engine/pull/6), enables smoother CLI production deployments. (Smoke-tested 20 consecutive successful deployments ✅).

Resolves #3133.