### PR TITLE
Set `maxBuffer` to avoid ENOBUFS error message

### DIFF
--- a/packages/compile-solidity/compilerSupplier/loadingStrategies/Docker.js
+++ b/packages/compile-solidity/compilerSupplier/loadingStrategies/Docker.js
@@ -6,6 +6,10 @@ const semver = require("semver");
 const LoadingStrategy = require("./LoadingStrategy");
 const VersionRange = require("./VersionRange");
 
+// Set a sensible limit for maxBuffer
+// See https://github.com/nodejs/node/pull/23027
+const maxBuffer = 1024 * 1024 * 10;
+
 class Docker extends LoadingStrategy {
   async load() {
     const versionString = await this.validateAndGetSolcVersion();
@@ -16,7 +20,7 @@ class Docker extends LoadingStrategy {
 
     try {
       return {
-        compile: options => String(execSync(command, { input: options })),
+        compile: options => String(execSync(command, { input: options, maxBuffer })),
         version: () => versionString
       };
     } catch (error) {


### PR DESCRIPTION
From version 12 on, node doesn't set a very high limit for `execSync`'s `maxBuffer` anymore. So we have to define that limit ourselves to avoid running into an ENOBUFS error for large contract suites.

See https://github.com/nodejs/node/pull/23027 and https://github.com/trufflesuite/truffle/commit/180359b3fc386ce112cc77e63628d2558e4abb08

To see that error message in a real-world project see https://app.circleci.com/pipelines/github/JoinColony/colonyNetwork/2377/workflows/eca45a24-a95a-4bad-8370-153e673cbb75/jobs/12639