### PR TITLE
Bug fix: More Yul jump handling

### DIFF
--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -594,6 +594,7 @@ var DebugUtils = {
       } else {
         name = "unknown function";
       }
+      let locationString;
       if (location) {
         let {
           source: { sourcePath },
@@ -603,10 +604,13 @@ var DebugUtils = {
             }
           }
         } = location;
-        return `at ${name} (${sourcePath}:${line + 1}:${column + 1})`; //add 1 to account for 0-indexing
+        locationString = sourcePath
+          ? `${sourcePath}:${line + 1}:${column + 1}` //add 1 to account for 0-indexing
+          : "unknown location";
       } else {
-        return `at ${name} (unknown location)`;
+        locationString = "unknown location";
       }
+      return `at ${name} (${locationString})`;
     });
     let status = stacktrace[0].status;
     if (status != undefined) {

--- a/packages/debugger/lib/solidity/reducers.js
+++ b/packages/debugger/lib/solidity/reducers.js
@@ -76,12 +76,6 @@ function nextFrameIsPhantom(state = null, action) {
       return false;
     case actions.EXTERNAL_RETURN:
       return false;
-    case actions.JUMP:
-      if (action.jumpDirection === "o") {
-        return false;
-      } else {
-        return state;
-      }
     case actions.EXTERNAL_CALL:
       return action.guard;
     case actions.RESET:

--- a/packages/debugger/lib/solidity/sagas/index.js
+++ b/packages/debugger/lib/solidity/sagas/index.js
@@ -31,7 +31,11 @@ function* functionDepthSaga() {
     let jumpDirection = yield select(solidity.current.jumpDirection);
     debug("checking guard");
     let guard = yield select(solidity.current.nextFrameIsPhantom);
-    if (jumpDirection === "i" && guard) {
+    let nextSource = yield select(solidity.next.source);
+    if (jumpDirection === "i" && guard && nextSource.id !== undefined) {
+      //note: currently unmapped source will have id undefined, rather than
+      //id -1, in our internal representation.  Might want to change this
+      //later.
       yield put(actions.clearPhantomGuard());
     } else {
       yield put(actions.jump(jumpDirection));

--- a/packages/debugger/test/helpers.js
+++ b/packages/debugger/test/helpers.js
@@ -26,7 +26,7 @@ export async function prepareContracts(provider, sources = {}, migrations) {
 
   config.compilers = {
     solc: {
-      version: "0.6.9",
+      version: "0.6.11",
       settings: {
         optimizer: { enabled: false, runs: 200 },
         evmVersion: "constantinople"


### PR DESCRIPTION
Just some minor stuff to handle 0.6.11 better, although we handle it pretty well already.  This has basically two parts:

1. When printing a stacktrace, unmapped code is reported as "unknown location" instead of `undefined:1:1`.

2. Two changes to the phantom stackframe guard.  First, when checking whether to clear it, we check if you're jumping into unmapped code, and if so, we leave it alone.  Second, we no longer clear it on jump outs (that never really served any purpose anyway).  The former is so that jumps into unmapped code before the function starts don't screw things up; the latter is so that returning from that unmapped code doesn't screw things up.