### PR TITLE
Dependency update: Bump ts-node to 8.10.2

### DIFF
--- a/packages/artifactor/package.json
+++ b/packages/artifactor/package.json
@@ -32,7 +32,7 @@
     "mocha": "8.0.1",
     "require-nocache": "^1.0.0",
     "temp": "^0.8.3",
-    "ts-node": "^8.3.0",
+    "ts-node": "8.10.2",
     "typescript": "^3.6.3",
     "web3": "1.2.1"
   },

--- a/packages/blockchain-utils/package.json
+++ b/packages/blockchain-utils/package.json
@@ -25,7 +25,7 @@
     "@types/node": "^12.12.5",
     "@types/web3": "1.0.19",
     "mocha": "8.0.1",
-    "ts-node": "^8.3.0",
+    "ts-node": "8.10.2",
     "typescript": "^3.6.3"
   },
   "keywords": [

--- a/packages/box/package.json
+++ b/packages/box/package.json
@@ -30,7 +30,7 @@
     "@types/tmp": "^0.1.0",
     "mocha": "8.0.1",
     "sinon": "^6.3.4",
-    "ts-node": "^8.3.0",
+    "ts-node": "8.10.2",
     "typescript": "^3.6.3"
   },
   "keywords": [

--- a/packages/code-utils/package.json
+++ b/packages/code-utils/package.json
@@ -19,7 +19,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.6.8",
     "mocha": "8.0.1",
-    "ts-node": "^8.3.0",
+    "ts-node": "8.10.2",
     "typescript": "^3.6.3"
   },
   "publishConfig": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -37,7 +37,7 @@
     "@types/sinon": "^7.0.13",
     "mocha": "8.0.1",
     "sinon": "^7.5.0",
-    "ts-node": "^8.4.1",
+    "ts-node": "8.10.2",
     "typescript": "^3.6.3"
   },
   "keywords": [

--- a/packages/hdwallet-provider/package.json
+++ b/packages/hdwallet-provider/package.json
@@ -38,7 +38,7 @@
     "@types/web3-provider-engine": "^14.0.0",
     "ganache-core": "2.10.2",
     "mocha": "8.0.1",
-    "ts-node": "^8.4.1",
+    "ts-node": "8.10.2",
     "typescript": "^3.6.3"
   },
   "keywords": [

--- a/packages/interface-adapter/package.json
+++ b/packages/interface-adapter/package.json
@@ -32,7 +32,7 @@
     "@types/web3": "1.0.19",
     "ganache-core": "2.10.2",
     "mocha": "8.0.1",
-    "ts-node": "^8.0.3",
+    "ts-node": "8.10.2",
     "typescript": "^3.6.3"
   },
   "publishConfig": {

--- a/packages/resolver/package.json
+++ b/packages/resolver/package.json
@@ -38,7 +38,7 @@
     "@types/sinon": "^9.0.0",
     "mocha": "8.0.1",
     "sinon": "^7.3.1",
-    "ts-node": "^8.8.2",
+    "ts-node": "8.10.2",
     "typescript": "^3.8.3"
   },
   "keywords": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -14397,7 +14397,7 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.0, source-map-support@^0.5.1, source-map-support@^0.5.3, source-map-support@^0.5.6:
+source-map-support@^0.5.0, source-map-support@^0.5.1, source-map-support@^0.5.3:
   version "0.5.16"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042"
   integrity sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==
@@ -14405,7 +14405,7 @@ source-map-support@^0.5.0, source-map-support@^0.5.1, source-map-support@^0.5.3,
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map-support@^0.5.19:
+source-map-support@^0.5.17, source-map-support@^0.5.19:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -15467,26 +15467,15 @@ ts-invariant@^0.4.0:
   dependencies:
     tslib "^1.9.3"
 
-ts-node@^8.0.3, ts-node@^8.3.0, ts-node@^8.4.1:
-  version "8.5.4"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.5.4.tgz#a152add11fa19c221d0b48962c210cf467262ab2"
-  integrity sha512-izbVCRV68EasEPQ8MSIGBNK9dc/4sYJJKYA+IarMQct1RtEot6Xp0bXuClsbUSnKpg50ho+aOAx8en5c+y4OFw==
+ts-node@8.10.2:
+  version "8.10.2"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.10.2.tgz#eee03764633b1234ddd37f8db9ec10b75ec7fb8d"
+  integrity sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==
   dependencies:
     arg "^4.1.0"
     diff "^4.0.1"
     make-error "^1.1.1"
-    source-map-support "^0.5.6"
-    yn "^3.0.0"
-
-ts-node@^8.8.2:
-  version "8.8.2"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.8.2.tgz#0b39e690bee39ea5111513a9d2bcdc0bc121755f"
-  integrity sha512-duVj6BpSpUpD/oM4MfhO98ozgkp3Gt9qIp3jGxwU2DFvl/3IRaEAvbLa8G60uS7C77457e/m5TMowjedeRxI1Q==
-  dependencies:
-    arg "^4.1.0"
-    diff "^4.0.1"
-    make-error "^1.1.1"
-    source-map-support "^0.5.6"
+    source-map-support "^0.5.17"
     yn "3.1.1"
 
 tslib@^1.10.0, tslib@^1.9.0, tslib@^1.9.3:
@@ -16887,7 +16876,6 @@ websocket@1.0.29, "websocket@github:web3-js/WebSocket-Node#polyfill/globalThis":
   dependencies:
     debug "^2.2.0"
     es5-ext "^0.10.50"
-    gulp "^4.0.2"
     nan "^2.14.0"
     typedarray-to-buffer "^3.1.5"
     yaeti "^0.0.6"
@@ -17487,7 +17475,7 @@ yauzl@^2.4.2:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
 
-yn@3.1.1, yn@^3.0.0:
+yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==


### PR DESCRIPTION
In the interest of streamlining some dependency versions, various packages have had their ts-node dependency bumped to 8.10.2. Currently there are 4 different versions of this package used.