### PR TITLE
Enhancement: Add extremely hacky method to have debugger report transaction sources

### DIFF
--- a/packages/debugger/lib/controller/sagas/index.js
+++ b/packages/debugger/lib/controller/sagas/index.js
@@ -268,6 +268,29 @@ function* continueUntilBreakpoint(action) {
 }
 
 /**
+ * HACK warning!  This function modifies the debugger state
+ * and should only be used in light mode!
+ */
+export function* getTransactionSourcesAndReset() {
+  yield* reset();
+  let sources = {};
+  while (!(yield select(controller.current.trace.finished))) {
+    const source = yield select(controller.current.location.source);
+    const { compilationId, id } = source;
+    if (compilationId !== undefined && id !== undefined) {
+      sources[compilationId] = {
+        ...sources[compilationId],
+        [id]: source
+      };
+    }
+    yield* stepNext();
+  }
+  yield* reset();
+  //flatten sources before returning
+  return [].concat(...Object.values(sources).map(Object.values));
+}
+
+/**
  * reset -- reset the state of the debugger
  * (we'll just reset all submodules regardless of which are in use)
  */

--- a/packages/debugger/lib/session/index.js
+++ b/packages/debugger/lib/session/index.js
@@ -450,6 +450,18 @@ export default class Session {
     return await this.dispatch(actions.startFullMode());
   }
 
+  /**
+   * HACK warning!  This function modifies the debugger state
+   * and should only be used in light mode!
+   */
+  async getTransactionSourcesBeforeStarting() {
+    if (!this.view(session.status.loaded)) {
+      return null;
+    }
+    //warning! modifies state!
+    return await this._runSaga(controllerSagas.getTransactionSourcesAndReset);
+  }
+
   get selectors() {
     return createNestedSelector({
       ast,

--- a/packages/debugger/test/solidity.js
+++ b/packages/debugger/test/solidity.js
@@ -266,6 +266,22 @@ describe("Solidity Debugging", function() {
     assert.deepEqual(resolutions, expectedResolutions);
   });
 
+  it("determines used and unused sources", async function() {
+    let instance = await abstractions.SingleCall.deployed();
+    let receipt = await instance.run();
+    let txHash = receipt.tx;
+
+    let bugger = await Debugger.forTx(txHash, {
+      provider,
+      compilations,
+      lightMode: true
+    });
+
+    let sources = await bugger.getTransactionSourcesBeforeStarting();
+    assert.lengthOf(sources, 1);
+    assert(sources[0].sourcePath.endsWith("SingleCall.sol"));
+  });
+
   describe("Function Depth", function() {
     it("remains at 1 in absence of inner function calls", async function() {
       const maxExpected = 1;


### PR DESCRIPTION
As requested by @kevinbluer and @seesemichaelj.  I'd do a non-hacky way, but, well, as discussed I am busy and this was fast.

The code here is pretty straightforward, frankly.  It does a full step-through, recording all the sources used, then reports them all out at the end.  The horrible long-winded name is to remind you that it's a hack and should not be used for anything other than its specific intended purpose.

Caveats, of which there are many:
1. This method should **only be used in light mode**.  Please make sure to start the debugger in light mode if using it.
2. This method **modifies the debugger state**.  If you're using it for its intended purpose, though, that shouldn't be a problem.
3. After calling this method, the debugger **must be switched to full mode**, using the `startFullMode` method, before use.
4. Finally, **there is no way to switch back to light mode at present**, which means that if you want to switch transactions and then use this method to get the sources for the new transaction... too bad.  **You'll have to restart the debugger**.  Since I gather you're doing that anyway, I think that's probably fine.  But if you want a way to return to light mode so you can switch transactions and still do this, I could see about adding one.  But, like I said, this is was fast.

Again, reminder that this is a nasty hack and should not be used for any purposes other than its originally intended one.

I also added a test of this functionality.