### PR TITLE
Store resolver as a global variable during migrations

### DIFF
--- a/packages/migrate/index.js
+++ b/packages/migrate/index.js
@@ -144,6 +144,7 @@ const Migrate = {
     });
 
     try {
+      global.artifacts = clone.resolver;
       for (const migration of migrations) {
         await migration.run(clone);
       }
@@ -158,6 +159,8 @@ const Migrate = {
         error: error.toString()
       });
       throw error;
+    } finally {
+      delete global.artifacts;
     }
   },
 


### PR DESCRIPTION
Fixes https://github.com/trufflesuite/truffle/issues/3167

As I mentioned in https://github.com/trufflesuite/truffle/issues/3167#issuecomment-658450445, it's the use of `vm` that results in the `artifacts` global not being really a global. It's a variable defined in the context in which the migration script runs, and thus is not seen by modules that are `require`d.

I thought about this quite a bit and there is no way of using `vm` to define a real global value (that is inherited by required modules) that doesn't add a ton of complexity, particularly given the design of the `Migration` and `Require` abstractions. I also don't feel comfortable removing the use of `vm` entirely, which would be a significant architectural change, so I went with a mitigation for the issue I reported in https://github.com/trufflesuite/truffle/issues/3167.

I added just two lines that set the `artifacts` value in the `global` object for the duration of the migrations. This will be technically overriden in `Require.file` by adding it in the script context, but with the same value, so it should be fine.

I tested this manually and it had the intended effect. If you'd want me to add a test I'd appreciate some direction, since the existing tests don't seem well suited for this issue.