### PR TITLE
Add `_truffle_workflow_compile` to allow Teams to save compiler output

### DIFF
--- a/packages/workflow-compile/.gitignore
+++ b/packages/workflow-compile/.gitignore
@@ -58,3 +58,6 @@ typings/
 .env
 
 package-lock.json
+
+# commit the bin directory with scripts
+!bin

--- a/packages/workflow-compile/bin/_truffle_workflow_compile
+++ b/packages/workflow-compile/bin/_truffle_workflow_compile
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+// This file is a simple CLI for running workflow-compile
+// while saving the artifact files **and** the compilation results
+// Usage: _truffle_workflow_compile <output-file-for-compilation-results>
+
+const path = require("path");
+const fs = require("fs");
+const Contracts = require("../new");
+const TruffleConfig = require("@truffle/config");
+
+const argIndexForFile =
+  process.argv.findIndex(arg => path.basename(arg) === path.basename(__filename));
+
+if (
+  argIndexForFile < 0 ||
+  (argIndexForFile + 1) >= process.argv.length
+) {
+  throw new Error("Must provide a file to save compilation results to");
+}
+
+// Get the filename the user provided to save the compilation results to
+const compilationOutputFile = path.resolve(
+  path.join(
+    process.cwd(),
+    process.argv[argIndexForFile + 1]
+  )
+);
+
+// Load the truffle project configuration, throws if it can't find it
+const config = TruffleConfig.detect({ working_directory: process.cwd() });
+
+// compile all sources, regardless
+config.compileAll = true;
+
+(async () => {
+  // compile the contracts
+  const compilationOutput = await Contracts.compile(config);
+
+  // save artifact files
+  await Contracts.save(config, compilationOutput.contracts);
+
+  // save compilation output, overwriting if it exists
+  fs.writeFileSync(
+    compilationOutputFile,
+    JSON.stringify(compilationOutput),
+    { encoding: "utf8" }
+  );
+})();

--- a/packages/workflow-compile/package.json
+++ b/packages/workflow-compile/package.json
@@ -9,6 +9,9 @@
     "url": "https://github.com/trufflesuite/truffle/issues"
   },
   "version": "2.1.41",
+  "bin": {
+    "_truffle_workflow_compile": "./bin/_truffle_workflow_compile"
+  },
   "main": "index.js",
   "scripts": {
     "test": "mocha"


### PR DESCRIPTION
Since Teams uses a bash interface to run commands in the build/deployment containers, we need a CLI interface to anything we execute with Truffle. To support Teams debugger usage, we'd like to save the compiler output from `@truffle/workflow-compile::compile()`. Rather than managing our own internal script in the Teams codebase, I believe it makes sense for this to live in the Truffle codebase

This PR adds that script as a `bin` in `packages/workflow-compile`