### PR TITLE
Allow `0x` as valid bytecode in contract schema

### DIFF
--- a/packages/contract-schema/spec/contract-object.spec.json
+++ b/packages/contract-schema/spec/contract-object.spec.json
@@ -126,7 +126,7 @@
     },
     "Bytecode": {
       "type": "string",
-      "pattern": "^0x0$|^0x([a-fA-F0-9]{2}|__.{38})+$"
+      "pattern": "^0x0?$|^0x([a-fA-F0-9]{2}|__.{38})+$"
     },
     "ImmutableReferences": {
       "type": "object",


### PR DESCRIPTION
(Since this value is used for abstract contracts / interfaces.)

Raised in #3180 