### PR TITLE
Ensure schema lists networks as type: object

### DIFF
--- a/packages/contract-schema/spec/contract-object.spec.json
+++ b/packages/contract-schema/spec/contract-object.spec.json
@@ -57,6 +57,7 @@
       }
     },
     "networks": {
+      "type": "object",
       "patternProperties": {
         "^[a-zA-Z0-9]+$": {
           "$ref": "network-object.spec.json#"


### PR DESCRIPTION
So I joined the JSON Schema Slack workspace and a helpful contributor found this to be missing. <3 thanks @ChALkeR!