### PR TITLE
Enhancement: Add contract addresses to stacktraces

### DIFF
--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -32,7 +32,7 @@ const commandReference = {
   "r": "reset",
   "t": "load new transaction",
   "T": "unload transaction",
-  "s": "print stacktrace"
+  "s": "print stacktrace",
 };
 
 const shortCommandReference = {
@@ -56,7 +56,7 @@ const shortCommandReference = {
   "r": "reset",
   "t": "load",
   "T": "unload",
-  "s": "stacktrace"
+  "s": "stacktrace",
 };
 
 const truffleColors = {
@@ -70,7 +70,7 @@ const truffleColors = {
   blue: chalk.hex("#25A9E0"),
   comment: chalk.hsl(30, 20, 50),
   watermelon: chalk.hex("#E86591"),
-  periwinkle: chalk.hex("#7F9DD1")
+  periwinkle: chalk.hex("#7F9DD1"),
 };
 
 const DEFAULT_TAB_WIDTH = 8;
@@ -78,23 +78,23 @@ const DEFAULT_TAB_WIDTH = 8;
 var DebugUtils = {
   truffleColors, //make these externally available
 
-  gatherArtifacts: async function(config) {
+  gatherArtifacts: async function (config) {
     // Gather all available contract artifacts
     let files = await dir.promiseFiles(config.contracts_build_directory);
 
     var contracts = files
-      .filter(file_path => {
+      .filter((file_path) => {
         return path.extname(file_path) === ".json";
       })
-      .map(file_path => {
+      .map((file_path) => {
         return path.basename(file_path, ".json");
       })
-      .map(contract_name => {
+      .map((contract_name) => {
         return config.resolver.require(contract_name);
       });
 
     await Promise.all(
-      contracts.map(abstraction => abstraction.detectNetwork())
+      contracts.map((abstraction) => abstraction.detectNetwork())
     );
 
     return contracts;
@@ -106,7 +106,7 @@ var DebugUtils = {
   //(anyway worst case failing it just results in a recompilation)
   //if it isn't real, but passes this test anyway... well, I'm hoping it should
   //still be usable all the same!
-  isUsableCompilation: function(compilation) {
+  isUsableCompilation: function (compilation) {
     //check #1: is the source order reliable?
     if (compilation.unreliableSourceOrder) {
       return false;
@@ -127,7 +127,7 @@ var DebugUtils = {
     //check #3: are there any AST ID collisions?
     let astIds = new Set();
 
-    let allIDsUnseenSoFar = node => {
+    let allIDsUnseenSoFar = (node) => {
       if (Array.isArray(node)) {
         return node.every(allIDsUnseenSoFar);
       } else if (node !== null && typeof node === "object") {
@@ -145,12 +145,12 @@ var DebugUtils = {
     };
 
     //now: walk each AST
-    return compilation.sources.every(
-      source => (source ? allIDsUnseenSoFar(source.ast) : true)
+    return compilation.sources.every((source) =>
+      source ? allIDsUnseenSoFar(source.ast) : true
     );
   },
 
-  formatStartMessage: function(withTransaction) {
+  formatStartMessage: function (withTransaction) {
     if (withTransaction) {
       return "Gathering information about your project and the transaction...";
     } else {
@@ -158,26 +158,26 @@ var DebugUtils = {
     }
   },
 
-  formatTransactionStartMessage: function() {
+  formatTransactionStartMessage: function () {
     return "Gathering information about the transaction...";
   },
 
-  formatCommandDescription: function(commandId) {
+  formatCommandDescription: function (commandId) {
     return (
       truffleColors.mint(`(${commandId})`) + " " + commandReference[commandId]
     );
   },
 
-  formatPrompt: function(network, txHash) {
+  formatPrompt: function (network, txHash) {
     return txHash !== undefined
       ? `debug(${network}:${txHash.substring(0, 10)}...)> `
       : `debug(${network})> `;
   },
 
-  formatAffectedInstances: function(instances) {
+  formatAffectedInstances: function (instances) {
     var hasAllSource = true;
 
-    var lines = Object.keys(instances).map(function(address) {
+    var lines = Object.keys(instances).map(function (address) {
       var instance = instances[address];
 
       if (instance.contractName) {
@@ -203,13 +203,13 @@ var DebugUtils = {
     return lines.join(OS.EOL);
   },
 
-  formatHelp: function(lastCommand = "n") {
+  formatHelp: function (lastCommand = "n") {
     var prefix = [
       "Commands:",
       truffleColors.mint("(enter)") +
         " last command entered (" +
         shortCommandReference[lastCommand] +
-        ")"
+        ")",
     ];
 
     var commandSections = [
@@ -221,8 +221,8 @@ var DebugUtils = {
       ["b", "B", "c"],
       ["+", "-"],
       ["?"],
-      ["v", ":"]
-    ].map(function(shortcuts) {
+      ["v", ":"],
+    ].map(function (shortcuts) {
       return shortcuts.map(DebugUtils.formatCommandDescription).join(", ");
     });
 
@@ -233,7 +233,7 @@ var DebugUtils = {
     return lines.join(OS.EOL);
   },
 
-  tabsToSpaces: function(inputLine, tabLength = DEFAULT_TAB_WIDTH) {
+  tabsToSpaces: function (inputLine, tabLength = DEFAULT_TAB_WIDTH) {
     //note: I'm going to assume for these purposes that everything is
     //basically ASCII and I don't have to worry about astral planes or
     //grapheme clusters.  Sorry. :-/
@@ -262,13 +262,13 @@ var DebugUtils = {
     return line;
   },
 
-  formatLineNumberPrefix: function(line, number, cols) {
+  formatLineNumberPrefix: function (line, number, cols) {
     const prefix = String(number).padStart(cols) + ": ";
 
     return prefix + line;
   },
 
-  formatLinePointer: function(
+  formatLinePointer: function (
     line,
     startCol,
     endCol,
@@ -310,7 +310,7 @@ var DebugUtils = {
   //been split into lines here, they're not the raw text
   //ALSO: assuming here that colorized source has been detabbed
   //but that uncolorized source has not
-  formatRangeLines: function(
+  formatRangeLines: function (
     source,
     range,
     uncolorizedSource,
@@ -365,7 +365,7 @@ var DebugUtils = {
           pointerStart,
           pointerEnd,
           prefixLength
-        )
+        ),
       ],
       afterLines
     );
@@ -373,7 +373,7 @@ var DebugUtils = {
     return allLines.join(OS.EOL);
   },
 
-  formatBreakpointLocation: function(
+  formatBreakpointLocation: function (
     breakpoint,
     here,
     currentCompilationId,
@@ -401,7 +401,7 @@ var DebugUtils = {
     }
   },
 
-  formatInstruction: function(traceIndex, traceLength, instruction) {
+  formatInstruction: function (traceIndex, traceLength, instruction) {
     return (
       "(" +
       traceIndex +
@@ -412,7 +412,7 @@ var DebugUtils = {
     );
   },
 
-  formatPC: function(pc) {
+  formatPC: function (pc) {
     let hex = pc.toString(16);
     if (hex.length % 2 !== 0) {
       hex = "0" + hex; //ensure even length
@@ -420,7 +420,7 @@ var DebugUtils = {
     return "  PC = " + pc.toString() + " = 0x" + hex;
   },
 
-  formatStack: function(stack) {
+  formatStack: function (stack) {
     //stack here is an array of hex words (no "0x")
     var formatted = stack.map((item, index) => {
       item = truffleColors.orange(item);
@@ -443,7 +443,7 @@ var DebugUtils = {
     return formatted.join(OS.EOL);
   },
 
-  formatMemory: function(memory) {
+  formatMemory: function (memory) {
     //note memory here is an array of hex words (no "0x"),
     //not a single long hex string
 
@@ -473,14 +473,12 @@ var DebugUtils = {
     return formatted.join(OS.EOL);
   },
 
-  formatStorage: function(storage) {
+  formatStorage: function (storage) {
     //storage here is an object mapping hex words to hex words (no 0x)
 
     //first: sort the keys (slice to clone as sort is in-place)
     //note: we can use the default sort here; it will do the righ thing
-    let slots = Object.keys(storage)
-      .slice()
-      .sort();
+    let slots = Object.keys(storage).slice().sort();
 
     let formatted = slots.map((slot, index) => {
       if (
@@ -504,7 +502,7 @@ var DebugUtils = {
     return formatted.join(OS.EOL);
   },
 
-  formatCalldata: function(calldata) {
+  formatCalldata: function (calldata) {
     //takes a Uint8Array
     let selector = calldata.slice(0, Codec.Evm.Utils.SELECTOR_SIZE);
     let words = [];
@@ -556,12 +554,12 @@ var DebugUtils = {
     return formatted.join(OS.EOL);
   },
 
-  formatValue: function(value, indent = 0, nativized = false) {
+  formatValue: function (value, indent = 0, nativized = false) {
     let inspectOptions = {
       colors: true,
       depth: null,
       maxArrayLength: null,
-      breakLength: 30
+      breakLength: 30,
     };
     let valueToInspect = nativized
       ? value
@@ -577,41 +575,45 @@ var DebugUtils = {
       .join(OS.EOL);
   },
 
-  formatStacktrace: function(stacktrace, indent = 2) {
+  formatStacktrace: function (stacktrace, indent = 2) {
     //get message from stacktrace
     const message = stacktrace[0].message;
     //we want to print inner to outer, so first, let's
     //reverse
     stacktrace = stacktrace.slice().reverse(); //reverse is in-place so clone first
-    let lines = stacktrace.map(({ functionName, contractName, location }) => {
-      let name;
-      if (contractName && functionName) {
-        name = `${contractName}.${functionName}`;
-      } else if (contractName) {
-        name = contractName;
-      } else if (functionName) {
-        name = functionName;
-      } else {
-        name = "unknown function";
+    let lines = stacktrace.map(
+      ({ functionName, contractName, address, location }) => {
+        let name;
+        if (contractName && functionName) {
+          name = `${contractName}.${functionName}`;
+        } else if (contractName) {
+          name = contractName;
+        } else if (functionName) {
+          name = functionName;
+        } else {
+          name = "unknown function";
+        }
+        let locationString;
+        if (location) {
+          let {
+            source: { sourcePath },
+            sourceRange: {
+              lines: {
+                start: { line, column },
+              },
+            },
+          } = location;
+          locationString = sourcePath
+            ? `${sourcePath}:${line + 1}:${column + 1}` //add 1 to account for 0-indexing
+            : "unknown location";
+        } else {
+          locationString = "unknown location";
+        }
+        let addressString =
+          address !== undefined ? `address ${address}` : "unknown address";
+        return `at ${name} [${addressString}] (${locationString})`;
       }
-      let locationString;
-      if (location) {
-        let {
-          source: { sourcePath },
-          sourceRange: {
-            lines: {
-              start: { line, column }
-            }
-          }
-        } = location;
-        locationString = sourcePath
-          ? `${sourcePath}:${line + 1}:${column + 1}` //add 1 to account for 0-indexing
-          : "unknown location";
-      } else {
-        locationString = "unknown location";
-      }
-      return `at ${name} (${locationString})`;
-    });
+    );
     let status = stacktrace[0].status;
     if (status != undefined) {
       lines.unshift(
@@ -620,17 +622,17 @@ var DebugUtils = {
             ? `Error: Improper return (caused message: ${message})`
             : "Error: Improper return (may be an unexpected self-destruct)"
           : message !== undefined
-            ? `Error: Revert (message: ${message})`
-            : "Error: Revert or exceptional halt"
+          ? `Error: Revert (message: ${message})`
+          : "Error: Revert or exceptional halt"
       );
     }
-    let indented = lines.map(
-      (line, index) => (index === 0 ? line : " ".repeat(indent) + line)
+    let indented = lines.map((line, index) =>
+      index === 0 ? line : " ".repeat(indent) + line
     );
     return indented.join(OS.EOL);
   },
 
-  colorize: function(code) {
+  colorize: function (code) {
     //I'd put these outside the function
     //but then it gives me errors, because
     //you can't just define self-referential objects like that...
@@ -696,7 +698,7 @@ var DebugUtils = {
       "templateVariable": chalk,
       "template-variable": chalk,
       "addition": chalk,
-      "deletion": chalk
+      "deletion": chalk,
     };
 
     const options = {
@@ -706,7 +708,7 @@ var DebugUtils = {
       //handling padding & numbering manually
       lineNumbers: false,
       stripIndent: false,
-      codePad: 0
+      codePad: 0,
       //NOTE: you might think you should pass highlight: true,
       //but you'd be wrong!  I don't understand this either
     };
@@ -717,7 +719,7 @@ var DebugUtils = {
   //note that this is written in terms of mutating things
   //rather than just using map() due to the need to handle
   //circular objects
-  cleanConstructors: function(object, seenSoFar = new Map()) {
+  cleanConstructors: function (object, seenSoFar = new Map()) {
     debug("object %o", object);
     if (seenSoFar.has(object)) {
       return seenSoFar.get(object);
@@ -756,7 +758,7 @@ var DebugUtils = {
             ([key, value]) => key !== "constructor" || value !== undefined
           )
           .map(([key, value]) => ({
-            [key]: value //don't clean yet!
+            [key]: value, //don't clean yet!
           }))
       );
       //set up new seenSoFar
@@ -773,12 +775,11 @@ var DebugUtils = {
   },
 
   //HACK
-  cleanThis: function(variables, replacement) {
+  cleanThis: function (variables, replacement) {
     return Object.assign(
       {},
-      ...Object.entries(variables).map(
-        ([variable, value]) =>
-          variable === "this" ? { [replacement]: value } : { [variable]: value }
+      ...Object.entries(variables).map(([variable, value]) =>
+        variable === "this" ? { [replacement]: value } : { [variable]: value }
       )
     );
   },
@@ -795,7 +796,7 @@ var DebugUtils = {
    * way at the moment to switch back into light mode in order to re-run
    * this function.  You do *not* want to run this in full mode.
    */
-  getTransactionSourcesBeforeStarting: async function(bugger) {
+  getTransactionSourcesBeforeStarting: async function (bugger) {
     await bugger.reset();
     let sources = {};
     const { controller } = bugger.selectors;
@@ -805,7 +806,7 @@ var DebugUtils = {
       if (compilationId !== undefined && id !== undefined) {
         sources[compilationId] = {
           ...sources[compilationId],
-          [id]: source
+          [id]: source,
         };
       }
       await bugger.stepNext();
@@ -813,7 +814,7 @@ var DebugUtils = {
     await bugger.reset();
     //flatten sources before returning
     return [].concat(...Object.values(sources).map(Object.values));
-  }
+  },
 };
 
 module.exports = DebugUtils;

--- a/packages/debugger/lib/stacktrace/actions/index.js
+++ b/packages/debugger/lib/stacktrace/actions/index.js
@@ -4,7 +4,7 @@ export function jumpIn(location, functionNode, contractNode) {
     type: JUMP_IN,
     location,
     functionNode,
-    contractNode
+    contractNode,
   };
 }
 
@@ -12,16 +12,17 @@ export const JUMP_OUT = "STACKTRACE_JUMP_OUT";
 export function jumpOut(location) {
   return {
     type: JUMP_OUT,
-    location
+    location,
   };
 }
 
 export const EXTERNAL_CALL = "STACKTRACE_EXTERNAL_CALL";
-export function externalCall(location, context) {
+export function externalCall(location, context, address) {
   return {
     type: EXTERNAL_CALL,
     location,
-    context
+    context,
+    address,
   };
 }
 
@@ -31,7 +32,7 @@ export function externalReturn(from, status, location) {
     type: EXTERNAL_RETURN,
     from,
     status,
-    location
+    location,
   };
 }
 
@@ -40,7 +41,7 @@ export function executeReturn(counter, location) {
   return {
     type: EXECUTE_RETURN,
     counter,
-    location
+    location,
   };
 }
 
@@ -48,20 +49,20 @@ export const UPDATE_POSITION = "STACKTRACE_UPDATE_POSITION";
 export function updatePosition(location) {
   return {
     type: UPDATE_POSITION,
-    location
+    location,
   };
 }
 
 export const RESET = "STACKTRACE_RESET";
 export function reset() {
   return {
-    type: RESET
+    type: RESET,
   };
 }
 
 export const UNLOAD_TRANSACTION = "STACKTRACE_UNLOAD_TRANSACTION";
 export function unloadTransaction() {
   return {
-    type: UNLOAD_TRANSACTION
+    type: UNLOAD_TRANSACTION,
   };
 }

--- a/packages/debugger/lib/stacktrace/reducers.js
+++ b/packages/debugger/lib/stacktrace/reducers.js
@@ -14,6 +14,7 @@ function callstack(state = [], action) {
       newFrame = {
         type: "internal",
         calledFromLocation: location,
+        address: state[state.length - 1].address,
         functionName:
           functionNode &&
           (functionNode.nodeType === "FunctionDefinition" ||
@@ -23,7 +24,7 @@ function callstack(state = [], action) {
         contractName:
           contractNode && contractNode.nodeType === "ContractDefinition"
             ? contractNode.name
-            : undefined
+            : undefined,
         //note we don't currently account for getters because currently
         //we can't; fallback, receive, constructors, & modifiers also remain
         //unaccounted for at present
@@ -40,16 +41,17 @@ function callstack(state = [], action) {
     case actions.EXTERNAL_CALL:
       newFrame = {
         type: "external",
+        address: action.address,
         calledFromLocation: action.location,
         functionName: undefined,
-        contractName: action.context.contractName
+        contractName: action.context.contractName,
       };
       return [...state, newFrame];
     case actions.EXECUTE_RETURN:
       return popNWhere(
         state,
         action.counter,
-        frame => frame.type === "external"
+        (frame) => frame.type === "external"
       );
     case actions.RESET:
       return [state[0]];
@@ -132,11 +134,11 @@ const proc = combineReducers({
   returnCounter,
   lastPosition,
   innerReturnPosition,
-  innerReturnStatus
+  innerReturnStatus,
 });
 
 const reducer = combineReducers({
-  proc
+  proc,
 });
 
 export default reducer;

--- a/packages/debugger/lib/stacktrace/sagas/index.js
+++ b/packages/debugger/lib/stacktrace/sagas/index.js
@@ -58,9 +58,6 @@ function* stacktraceSaga() {
     yield put(actions.jumpOut(currentLocation));
     positionUpdated = true;
   } else if (yield select(stacktrace.current.willCall)) {
-    //an external frame marked "skip in reports" will be, for reporting
-    //purposes, combined with the frame above, unless that also is an
-    //external frame (combined in the appropriate sense)
     //note: includes creations
     //note: does *not* include calls that insta-return.  logically speaking,
     //such calls should be a call + a return in one, right? and we could do that,
@@ -70,7 +67,8 @@ function* stacktraceSaga() {
     //NOTE: we can't use stacktrace.next.location here as that
     //doesn't work across call contexts!
     const nextContext = yield select(stacktrace.current.callContext);
-    yield put(actions.externalCall(currentLocation, nextContext));
+    const nextAddress = yield select(stacktrace.current.callAddress);
+    yield put(actions.externalCall(currentLocation, nextContext, nextAddress));
     positionUpdated = true;
   }
   //finally, if no other action updated the position, do so here
@@ -89,7 +87,8 @@ export function* unload() {
 
 export function* begin() {
   const context = yield select(stacktrace.current.context);
-  yield put(actions.externalCall(null, context));
+  const address = yield select(stacktrace.current.address);
+  yield put(actions.externalCall(null, context, address));
 }
 
 export function* saga() {

--- a/packages/debugger/lib/stacktrace/selectors/index.js
+++ b/packages/debugger/lib/stacktrace/selectors/index.js
@@ -11,23 +11,24 @@ import zipWith from "lodash.zipwith";
 import { popNWhere } from "lib/helpers";
 import * as Codec from "@truffle/codec";
 
-const identity = x => x;
+const identity = (x) => x;
 
 function generateReport(callstack, location, status, message) {
   //step 1: shift everything over by 1 and recombine :)
-  let locations = callstack.map(frame => frame.calledFromLocation);
+  let locations = callstack.map((frame) => frame.calledFromLocation);
   //remove initial null, add final location on end
   locations.shift();
   locations.push(location);
   debug("locations: %O", locations);
-  const names = callstack.map(({ functionName, contractName }) => ({
+  const names = callstack.map(({ functionName, contractName, address }) => ({
     functionName,
-    contractName
+    contractName,
+    address,
   }));
   debug("names: %O", names);
   let report = zipWith(locations, names, (location, nameInfo) => ({
     ...nameInfo,
-    location
+    location,
   }));
   //finally: set the status in the top frame
   //and the message in the bottom
@@ -61,7 +62,7 @@ function createMultistepSelectors(stepSelector) {
       /**
        * .pointer
        */
-      pointer: createLeaf([stepSelector.pointer], identity)
+      pointer: createLeaf([stepSelector.pointer], identity),
     },
 
     /**
@@ -71,7 +72,7 @@ function createMultistepSelectors(stepSelector) {
       ["./location/source", "./location/sourceRange"],
       ({ id, compilationId, sourcePath }, sourceRange) => ({
         source: { id, compilationId, sourcePath },
-        sourceRange
+        sourceRange,
       })
     ),
 
@@ -91,7 +92,7 @@ function createMultistepSelectors(stepSelector) {
               pointer.replace(/\/nodes\/\d+$/, "") //cut off end
             )
           : ast
-    )
+    ),
   };
 }
 
@@ -99,7 +100,7 @@ let stacktrace = createSelectorTree({
   /**
    * stacktrace.state
    */
-  state: state => state.stacktrace,
+  state: (state) => state.stacktrace,
 
   /**
    * stacktrace.current
@@ -108,24 +109,24 @@ let stacktrace = createSelectorTree({
     /**
      * stacktrace.current.callstack
      */
-    callstack: createLeaf(["/state"], state => state.proc.callstack),
+    callstack: createLeaf(["/state"], (state) => state.proc.callstack),
 
     /**
      * stacktrace.current.returnCounter
      */
-    returnCounter: createLeaf(["/state"], state => state.proc.returnCounter),
+    returnCounter: createLeaf(["/state"], (state) => state.proc.returnCounter),
 
     /**
      * stacktrace.current.lastPosition
      */
-    lastPosition: createLeaf(["/state"], state => state.proc.lastPosition),
+    lastPosition: createLeaf(["/state"], (state) => state.proc.lastPosition),
 
     /**
      * stacktrace.current.innerReturnPosition
      */
     innerReturnPosition: createLeaf(
       ["/state"],
-      state => state.proc.innerReturnPosition
+      (state) => state.proc.innerReturnPosition
     ),
 
     /**
@@ -133,7 +134,7 @@ let stacktrace = createSelectorTree({
      */
     innerReturnStatus: createLeaf(
       ["/state"],
-      state => state.proc.innerReturnStatus
+      (state) => state.proc.innerReturnStatus
     ),
 
     ...createMultistepSelectors(solidity.current),
@@ -181,6 +182,44 @@ let stacktrace = createSelectorTree({
     returnStatus: createLeaf([evm.current.step.returnStatus], identity),
 
     /**
+     * stacktrace.current.address
+     * Initial call can't be a delegate, so we just use the storage address
+     * (thus allowing us to handle both calls & creates in one)
+     */
+    address: createLeaf([evm.current.call], (call) => call.storageAddress),
+
+    /**
+     * stacktrace.current.callAddress
+     *
+     * Covers both calls and creates
+     * NOTE: for this selector, we treat delegates just like any other call!
+     * we want to report the *code* address here, not the storage address
+     * (exception: for creates we report the storage address, as that's where
+     * the code *will* live)
+     */
+    callAddress: createLeaf(
+      [
+        evm.current.step.isCall,
+        evm.current.step.isCreate,
+        evm.current.step.callAddress,
+        evm.current.step.createdAddress,
+      ],
+      (isCall, isCreate, callAddress, createdAddress) => {
+        if (isCall) {
+          return callAddress;
+        } else if (isCreate) {
+          if (createdAddress !== Codec.Evm.Utils.ZERO_ADDRESS) {
+            return createdAddress;
+          } else {
+            return undefined; //if created address appears to be 0, omit it
+          }
+        } else {
+          return null; //I guess??
+        }
+      }
+    ),
+
+    /**
      * stacktrace.current.revertString
      * Crudely decodes the current revert string.
      * Not meant to account for crazy things, just there to produce
@@ -188,7 +227,7 @@ let stacktrace = createSelectorTree({
      */
     revertString: createLeaf(
       [evm.current.step.returnValue],
-      rawRevertMessage => {
+      (rawRevertMessage) => {
         let revertDecodings = Codec.decodeRevert(
           Codec.Conversion.toBytes(rawRevertMessage)
         );
@@ -247,7 +286,7 @@ let stacktrace = createSelectorTree({
         "./callstack",
         "./innerReturnPosition",
         "./innerReturnStatus",
-        "./revertString"
+        "./revertString",
       ],
       generateReport
     ),
@@ -264,28 +303,28 @@ let stacktrace = createSelectorTree({
         "./callstack",
         "./returnCounter",
         "./lastPosition",
-        "/current/strippedLocation"
+        "/current/strippedLocation",
       ],
       (callstack, returnCounter, lastPosition, currentLocation) =>
         generateReport(
           popNWhere(
             callstack,
             returnCounter,
-            frame => frame.type === "external"
+            (frame) => frame.type === "external"
           ),
           currentLocation || lastPosition,
           null,
           undefined
         )
-    )
+    ),
   },
 
   /**
    * stacktrace.next
    */
   next: {
-    ...createMultistepSelectors(solidity.next)
-  }
+    ...createMultistepSelectors(solidity.next),
+  },
 });
 
 export default stacktrace;

--- a/packages/debugger/test/stacktrace.js
+++ b/packages/debugger/test/stacktrace.js
@@ -83,7 +83,7 @@ contract Boom {
 `;
 
 let sources = {
-  "StacktraceTest.sol": __STACKTRACE
+  "StacktraceTest.sol": __STACKTRACE,
 };
 
 const __MIGRATION = `
@@ -95,20 +95,20 @@ module.exports = function(deployer) {
 `;
 
 let migrations = {
-  "2_deploy_contracts.js": __MIGRATION
+  "2_deploy_contracts.js": __MIGRATION,
 };
 
-describe("Stack tracing", function() {
+describe("Stack tracing", function () {
   var provider;
 
   var abstractions;
   var compilations;
 
-  before("Create Provider", async function() {
+  before("Create Provider", async function () {
     provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
   });
 
-  before("Prepare contracts and artifacts", async function() {
+  before("Prepare contracts and artifacts", async function () {
     this.timeout(30000);
 
     let prepared = await prepareContracts(provider, sources, migrations);
@@ -116,7 +116,7 @@ describe("Stack tracing", function() {
     compilations = prepared.compilations;
   });
 
-  it("Generates correct stack trace on a revert", async function() {
+  it("Generates correct stack trace on a revert", async function () {
     this.timeout(12000);
     let instance = await abstractions.StacktraceTest.deployed();
     //HACK: because this transaction fails, we have to extract the hash from
@@ -132,7 +132,7 @@ describe("Stack tracing", function() {
     let bugger = await Debugger.forTx(txHash, {
       provider,
       compilations,
-      lightMode: true
+      lightMode: true,
     });
 
     let source = bugger.view(solidity.current.source);
@@ -151,10 +151,12 @@ describe("Stack tracing", function() {
       "run2",
       undefined,
       "run1",
-      "runRequire"
+      "runRequire",
     ]);
     let contractNames = report.map(({ contractName }) => contractName);
-    assert(contractNames.every(name => name === "StacktraceTest"));
+    assert(contractNames.every((name) => name === "StacktraceTest"));
+    let addresses = report.map(({ address }) => address);
+    assert(addresses.every((address) => address === instance.address));
     let status = report[report.length - 1].status;
     assert.isFalse(status);
     let location = report[report.length - 1].location;
@@ -163,7 +165,7 @@ describe("Stack tracing", function() {
     assert.strictEqual(prevLocation.sourceRange.lines.start.line, callLine);
   });
 
-  it("Generates correct stack trace at an intermediate state", async function() {
+  it("Generates correct stack trace at an intermediate state", async function () {
     this.timeout(12000);
     let instance = await abstractions.StacktraceTest.deployed();
     //HACK: because this transaction fails, we have to extract the hash from
@@ -179,7 +181,7 @@ describe("Stack tracing", function() {
     let bugger = await Debugger.forTx(txHash, {
       provider,
       compilations,
-      lightMode: true
+      lightMode: true,
     });
 
     let source = bugger.view(solidity.current.source);
@@ -188,7 +190,7 @@ describe("Stack tracing", function() {
     let breakpoint = {
       sourceId: source.id,
       compilationId: source.compilationId,
-      line: breakLine
+      line: breakLine,
     };
     await bugger.addBreakpoint(breakpoint);
     await bugger.continueUntilBreakpoint(); //run till EMIT
@@ -202,10 +204,12 @@ describe("Stack tracing", function() {
       "run2",
       undefined,
       "run1",
-      "runRequire"
+      "runRequire",
     ]);
     let contractNames = report.map(({ contractName }) => contractName);
-    assert(contractNames.every(name => name === "StacktraceTest"));
+    assert(contractNames.every((name) => name === "StacktraceTest"));
+    let addresses = report.map(({ address }) => address);
+    assert(addresses.every((address) => address === instance.address));
     let status = report[report.length - 1].status;
     assert.isUndefined(status);
     let location = report[report.length - 1].location;
@@ -225,10 +229,12 @@ describe("Stack tracing", function() {
       "run2",
       undefined,
       "run1",
-      "runRequire"
+      "runRequire",
     ]);
     contractNames = report.map(({ contractName }) => contractName);
-    assert(contractNames.every(name => name === "StacktraceTest"));
+    assert(contractNames.every((name) => name === "StacktraceTest"));
+    addresses = report.map(({ address }) => address);
+    assert(addresses.every((address) => address === instance.address));
     status = report[report.length - 1].status;
     assert.isUndefined(status);
     location = report[report.length - 1].location;
@@ -237,7 +243,7 @@ describe("Stack tracing", function() {
     assert.strictEqual(prevLocation.sourceRange.lines.start.line, callLine);
   });
 
-  it("Generates correct stack trace on paying an unpayable contract", async function() {
+  it("Generates correct stack trace on paying an unpayable contract", async function () {
     this.timeout(12000);
     let instance = await abstractions.StacktraceTest.deployed();
     //HACK: because this transaction fails, we have to extract the hash from
@@ -253,7 +259,7 @@ describe("Stack tracing", function() {
     let bugger = await Debugger.forTx(txHash, {
       provider,
       compilations,
-      lightMode: true
+      lightMode: true,
     });
 
     let source = bugger.view(solidity.current.source);
@@ -273,10 +279,12 @@ describe("Stack tracing", function() {
       undefined,
       "run1",
       "runPay",
-      undefined
+      undefined,
     ]);
     let contractNames = report.map(({ contractName }) => contractName);
-    assert(contractNames.every(name => name === "StacktraceTest"));
+    assert(contractNames.every((name) => name === "StacktraceTest"));
+    let addresses = report.map(({ address }) => address);
+    assert(addresses.every((address) => address === instance.address));
     let status = report[report.length - 1].status;
     assert.isFalse(status);
     let location = report[report.length - 2].location; //note, -2 because of undefined on top
@@ -285,7 +293,7 @@ describe("Stack tracing", function() {
     assert.strictEqual(prevLocation.sourceRange.lines.start.line, callLine);
   });
 
-  it("Generates correct stack trace on calling an invalid internal function", async function() {
+  it("Generates correct stack trace on calling an invalid internal function", async function () {
     this.timeout(12000);
     let instance = await abstractions.StacktraceTest.deployed();
     //HACK: because this transaction fails, we have to extract the hash from
@@ -301,7 +309,7 @@ describe("Stack tracing", function() {
     let bugger = await Debugger.forTx(txHash, {
       provider,
       compilations,
-      lightMode: true
+      lightMode: true,
     });
 
     let source = bugger.view(solidity.current.source);
@@ -321,12 +329,14 @@ describe("Stack tracing", function() {
       undefined,
       "run1",
       "runInternal",
-      undefined
+      undefined,
     ]);
     let contractNames = report.map(({ contractName }) => contractName);
     assert.isUndefined(contractNames[contractNames.length - 1]);
     contractNames.pop();
-    assert(contractNames.every(name => name === "StacktraceTest"));
+    assert(contractNames.every((name) => name === "StacktraceTest"));
+    let addresses = report.map(({ address }) => address);
+    assert(addresses.every((address) => address === instance.address));
     let status = report[report.length - 1].status;
     assert.isFalse(status);
     let location = report[report.length - 2].location; //note, -2 because of undefined on top
@@ -335,7 +345,7 @@ describe("Stack tracing", function() {
     assert.strictEqual(prevLocation.sourceRange.lines.start.line, callLine);
   });
 
-  it("Generates correct stack trace on unexpected self-destruct", async function() {
+  it("Generates correct stack trace on unexpected self-destruct", async function () {
     this.timeout(12000);
     let instance = await abstractions.StacktraceTest.deployed();
     //HACK: because this transaction fails, we have to extract the hash from
@@ -351,7 +361,7 @@ describe("Stack tracing", function() {
     let bugger = await Debugger.forTx(txHash, {
       provider,
       compilations,
-      lightMode: true
+      lightMode: true,
     });
 
     let source = bugger.view(solidity.current.source);
@@ -373,14 +383,22 @@ describe("Stack tracing", function() {
       "run1",
       "runBoom",
       undefined,
-      "boom"
+      "boom",
     ]);
     let contractNames = report.map(({ contractName }) => contractName);
     assert.strictEqual(contractNames[contractNames.length - 1], "Boom");
     contractNames.pop(); //top frame
     assert.strictEqual(contractNames[contractNames.length - 1], "Boom");
     contractNames.pop(); //second-top frame
-    assert(contractNames.every(name => name === "StacktraceTest"));
+    assert(contractNames.every((name) => name === "StacktraceTest"));
+    let addresses = report.map(({ address }) => address);
+    assert.strictEqual(
+      addresses[addresses.length - 1],
+      addresses[addresses.length - 2]
+    );
+    addresses.pop();
+    addresses.pop();
+    assert(addresses.every((address) => address === instance.address));
     let status = report[report.length - 1].status;
     assert.isTrue(status);
     let location = report[report.length - 1].location;


### PR DESCRIPTION
As requested by @shanecarey17 on Gitter.

Basically this is pretty straightforward -- stacktraces now contain the contract address.  We do this by getting the address whenever we make an external call and putting it in the trace; that's basically it, really.  However, a few subtleties to note:

1. Since it's a stacktrace, I decided it was most appropriate to print the code address, not the storage address, when calling a library.
2. Of course, for contract creations, the eventual storage address is what will be shown (including if it fails and it's not created).
3. However, if there's a failed creation we can't determine the address for, we'll just print that we don't know the address.

Edit: Also I added tests of this to our existing stacktrace test cases, although I didn't add any *new* tests to test external calls or library calls (we do already have a test with a creation call).