### PR TITLE
Fix: Sanitize payloads for @truffle/hdwallet-provider

### DIFF
--- a/packages/hdwallet-provider/package.json
+++ b/packages/hdwallet-provider/package.json
@@ -18,6 +18,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@trufflesuite/web3-provider-engine": "15.0.13-0",
+    "@types/web3": "^1.0.20",
     "any-promise": "^1.3.0",
     "bindings": "^1.5.0",
     "ethereum-cryptography": "^0.1.3",
@@ -25,8 +26,7 @@
     "ethereumjs-tx": "^1.0.0",
     "ethereumjs-util": "^6.1.0",
     "ethereumjs-wallet": "^0.6.3",
-    "source-map-support": "^0.5.19",
-    "web3": "1.2.1"
+    "source-map-support": "^0.5.19"
   },
   "devDependencies": {
     "@types/bip39": "^2.4.2",
@@ -34,7 +34,6 @@
     "@types/ethereumjs-tx": "^1.0.1",
     "@types/ethereumjs-util": "^5.2.0",
     "@types/mocha": "^5.2.7",
-    "@types/web3": "^1.0.20",
     "@types/web3-provider-engine": "^14.0.0",
     "ganache-core": "2.10.2",
     "mocha": "8.0.1",

--- a/packages/hdwallet-provider/src/index.ts
+++ b/packages/hdwallet-provider/src/index.ts
@@ -11,8 +11,11 @@ import FiltersSubprovider from "@trufflesuite/web3-provider-engine/subproviders/
 import NonceSubProvider from "@trufflesuite/web3-provider-engine/subproviders/nonce-tracker";
 import HookedSubprovider from "@trufflesuite/web3-provider-engine/subproviders/hooked-wallet";
 import ProviderSubprovider from "@trufflesuite/web3-provider-engine/subproviders/provider";
+// @ts-ignore
+import RpcProvider from "@trufflesuite/web3-provider-engine/subproviders/rpc";
+// @ts-ignore
+import WebsocketProvider from "@trufflesuite/web3-provider-engine/subproviders/websocket";
 import Url from "url";
-import Web3 from "web3";
 import { JSONRPCRequestPayload, JSONRPCErrorCallback } from "ethereum-protocol";
 import { Callback, JsonRPCResponse } from "web3/providers";
 
@@ -161,10 +164,6 @@ class HDWalletProvider {
 
     this.engine.addProvider(new FiltersSubprovider());
     if (typeof provider === "string") {
-      // shim Web3 to give it expected sendAsync method. Needed if web3-engine-provider upgraded!
-      // Web3.providers.HttpProvider.prototype.sendAsync =
-      // Web3.providers.HttpProvider.prototype.send;
-      let subProvider;
       const providerProtocol = (
         Url.parse(provider).protocol || "http:"
       ).toLowerCase();
@@ -172,16 +171,11 @@ class HDWalletProvider {
       switch (providerProtocol) {
         case "ws:":
         case "wss:":
-          subProvider = new Web3.providers.WebsocketProvider(provider);
+          this.engine.addProvider(new WebsocketProvider({ rpcUrl: provider }));
           break;
         default:
-          // @ts-ignore: Incorrect typings in @types/web3
-          subProvider = new Web3.providers.HttpProvider(provider, {
-            keepAlive: false
-          });
+          this.engine.addProvider(new RpcProvider({ rpcUrl: provider }));
       }
-
-      this.engine.addProvider(new ProviderSubprovider(subProvider));
     } else {
       this.engine.addProvider(new ProviderSubprovider(provider));
     }


### PR DESCRIPTION
- rm `web3` dependency from `@truffle/hdwallet-provider`
- import & use `RpcProvider` & `WebsocketProvider` from `web3-provider-engine` where appropriate
- Implements bug fix upstream in https://github.com/MetaMask/web3-provider-engine/commit/bd9ff60ecd0a2f2624012e8d680049ccfb6aaed2

Resolves #3182.