### PR TITLE
Bug fix: Fix undefined this bug in rejectHijacker

### DIFF
--- a/packages/contract/lib/promievent.js
+++ b/packages/contract/lib/promievent.js
@@ -71,7 +71,7 @@ function PromiEvent(justPromise, bugger = undefined, isDeploy = false) {
   }
 
   this.resolve = resolve;
-  this.reject = rejectHijacker;
+  this.reject = rejectHijacker.bind(this);
   this.eventEmitter = eventEmitter;
   if (bugger) {
     this.debug = true;


### PR DESCRIPTION
In reponse to further detail on #3186.  Seems that `rejectHijacker` is failing to resolve `this` properly in certain contexts?  I don't know why, it's always worked fine for me, but this forces it to get it right by explicitly binding it.