### PR TITLE
Internal improvement: Remove unused method getCommitFromVersion

### DIFF
--- a/packages/compile-solidity/compilerSupplier/loadingStrategies/VersionRange.js
+++ b/packages/compile-solidity/compilerSupplier/loadingStrategies/VersionRange.js
@@ -62,10 +62,6 @@ class VersionRange extends LoadingStrategy {
     });
   }
 
-  getCommitFromVersion(versionString) {
-    return "commit." + versionString.match(/commit\.(.*?)\./)[1];
-  }
-
   getMostRecentVersionOfCompiler(versions) {
     return versions.reduce((mostRecentVersionFileName, fileName) => {
       const match = fileName.match(/v\d+\.\d+\.\d+.*/);
@@ -101,7 +97,7 @@ class VersionRange extends LoadingStrategy {
     const url = this.config.compilerRoots[index] + fileName;
     const { events } = this.config;
     events.emit("downloadCompiler:start", {
-      attemptNumber: index + 1
+      attemptNumber: index + 1,
     });
     try {
       const response = await request.get(url, { gzip: true, timeout: 30000 });


### PR DESCRIPTION
I found a method in `VersionRange` referenced in https://github.com/trufflesuite/truffle/issues/1131 that seems to be unused. Removing it here.