### PR TITLE
Fix: Ensure provider check duration is shorter than interval frequency

### DIFF
--- a/packages/provider/index.js
+++ b/packages/provider/index.js
@@ -5,16 +5,16 @@ const wrapper = require("./wrapper");
 const DEFAULT_NETWORK_CHECK_TIMEOUT = 5000;
 
 module.exports = {
-  wrap: function(provider, options) {
+  wrap: function (provider, options) {
     return wrapper.wrap(provider, options);
   },
 
-  create: function(options) {
+  create: function (options) {
     const provider = this.getProvider(options);
     return this.wrap(provider, options);
   },
 
-  getProvider: function(options) {
+  getProvider: function (options) {
     let provider;
     if (options.provider && typeof options.provider === "function") {
       provider = options.provider();
@@ -33,7 +33,7 @@ module.exports = {
     return provider;
   },
 
-  testConnection: function(options) {
+  testConnection: function (options) {
     let networkCheckTimeout, networkType;
     const { networks, network } = options;
     if (networks && networks[network]) {
@@ -56,24 +56,29 @@ module.exports = {
         throw new Error(errorMessage);
       }, networkCheckTimeout);
 
-      const networkCheck = setInterval(() => {
-        interfaceAdapter
-          .getBlockNumber()
-          .then(() => {
-            clearTimeout(noResponseFromNetworkCall);
-            clearInterval(networkCheck);
-            resolve(true);
-          })
-          .catch(error => {
-            console.log(
-              "> Something went wrong while attempting to connect " +
-                "to the network. Check your network configuration."
-            );
-            clearTimeout(noResponseFromNetworkCall);
-            clearInterval(networkCheck);
-            reject(error);
-          });
-      });
+      let networkCheckDelay = 1;
+      (function networkCheck() {
+        setTimeout(() => {
+          interfaceAdapter
+            .getBlockNumber()
+            .then(() => {
+              clearTimeout(noResponseFromNetworkCall);
+              clearTimeout(networkCheck);
+              resolve(true);
+            })
+            .catch(error => {
+              console.log(
+                "> Something went wrong while attempting to connect " +
+                  "to the network. Check your network configuration."
+              );
+              clearTimeout(noResponseFromNetworkCall);
+              clearTimeout(networkCheck);
+              reject(error);
+            });
+          networkCheckDelay *= 2;
+          networkCheck();
+        }, networkCheckDelay);
+      })();
     });
-  }
+  },
 };

--- a/packages/provider/index.js
+++ b/packages/provider/index.js
@@ -58,23 +58,21 @@ module.exports = {
 
       let networkCheckDelay = 1;
       (function networkCheck() {
-        setTimeout(() => {
-          interfaceAdapter
-            .getBlockNumber()
-            .then(() => {
-              clearTimeout(noResponseFromNetworkCall);
-              clearTimeout(networkCheck);
-              resolve(true);
-            })
-            .catch(error => {
-              console.log(
-                "> Something went wrong while attempting to connect " +
-                  "to the network. Check your network configuration."
-              );
-              clearTimeout(noResponseFromNetworkCall);
-              clearTimeout(networkCheck);
-              reject(error);
-            });
+        setTimeout(async () => {
+          try {
+            await interfaceAdapter.getBlockNumber();
+            clearTimeout(noResponseFromNetworkCall);
+            clearTimeout(networkCheck);
+            return resolve(true);
+          } catch (error) {
+            console.log(
+              "> Something went wrong while attempting to connect " +
+                "to the network. Check your network configuration."
+            );
+            clearTimeout(noResponseFromNetworkCall);
+            clearTimeout(networkCheck);
+            return reject(error);
+          }
           networkCheckDelay *= 2;
           networkCheck();
         }, networkCheckDelay);


### PR DESCRIPTION
Implements provider check with exponential backoff using a recursive `setTimeout` pattern.

Resolves #3200.