### PR TITLE
Document `truffle compile --compiler` flag and add `none` as an option

### DIFF
--- a/packages/core/lib/commands/compile.js
+++ b/packages/core/lib/commands/compile.js
@@ -6,19 +6,19 @@ const command = {
   builder: {
     all: {
       type: "boolean",
-      default: false
+      default: false,
     },
     compiler: {
       type: "string",
-      default: null
+      default: null,
     },
     list: {
-      type: "string"
+      type: "string",
     },
     help: {
       type: "boolean",
-      default: "false"
-    }
+      default: "false",
+    },
   },
   help: {
     usage:
@@ -27,28 +27,33 @@ const command = {
       {
         option: "--all",
         description:
-          "Compile all contracts instead of only the contracts changed since last compile."
+          "Compile all contracts instead of only the contracts changed since last compile.",
       },
       {
         option: "--network <name>",
         description:
           "Specify the network to use, saving artifacts specific to that network. " +
-          " Network name must exist in the\n                    configuration."
+          " Network name must exist in the\n                    configuration.",
       },
       {
         option: "--list <filter>",
         description:
           "List all recent stable releases from solc-bin.  If filter is specified then it will display only " +
           "that\n                    type of release or docker tags. The filter parameter must be one of the following: " +
-          "prereleases,\n                    releases, latestRelease or docker."
+          "prereleases,\n                    releases, latestRelease or docker.",
       },
       {
         option: "--quiet",
-        description: "Suppress all compilation output."
-      }
-    ]
+        description: "Suppress all compilation output.",
+      },
+      {
+        option: "--compiler <compiler-name>",
+        description:
+          "Specify a single compiler to use (e.g. `--compiler=solc`)",
+      },
+    ],
   },
-  run: function(options, done) {
+  run: function (options, done) {
     const Contracts = require("@truffle/workflow-compile/new");
     const Config = require("@truffle/config");
     const config = Config.detect(options);
@@ -66,11 +71,11 @@ const command = {
     }
   },
 
-  listVersions: async function(options) {
+  listVersions: async function (options) {
     const { CompilerSupplier } = require("@truffle/compile-solidity");
     const supplier = new CompilerSupplier({
       solcConfig: options.compilers.solc,
-      events: options.events
+      events: options.events,
     });
 
     const log = options.logger.log;
@@ -92,7 +97,7 @@ const command = {
     return;
   },
 
-  shortener: function(key, val) {
+  shortener: function (key, val) {
     const defaultLength = 10;
 
     if (Array.isArray(val) && val.length > defaultLength) {
@@ -105,7 +110,7 @@ const command = {
     }
 
     return val;
-  }
+  },
 };
 
 module.exports = command;

--- a/packages/core/lib/commands/compile.js
+++ b/packages/core/lib/commands/compile.js
@@ -49,7 +49,7 @@ const command = {
       {
         option: "--compiler <compiler-name>",
         description:
-          "Specify a single compiler to use (e.g. `--compiler=solc`)",
+          "Specify a single compiler to use (e.g. `--compiler=solc`). Specify `none` to skip compilation.",
       },
     ],
   },

--- a/packages/core/lib/commands/migrate.js
+++ b/packages/core/lib/commands/migrate.js
@@ -4,41 +4,46 @@ const command = {
   builder: {
     "reset": {
       type: "boolean",
-      default: false,
+      default: false
     },
     "compile-all": {
-      describe: "recompile all contracts",
+      describe: "Recompile all contracts",
       type: "boolean",
-      default: false,
+      default: false
+    },
+    "compile-none": {
+      describe: "Do not compile contracts",
+      type: "boolean",
+      default: false
     },
     "dry-run": {
       describe: "Run migrations against an in-memory fork, for testing",
       type: "boolean",
-      default: false,
+      default: false
     },
     "skip-dry-run": {
       describe: "Skip the test or 'dry run' migrations",
       type: "boolean",
-      default: false,
+      default: false
     },
     "f": {
       describe: "Specify a migration number to run from",
-      type: "number",
+      type: "number"
     },
     "to": {
       describe: "Specify a migration number to run to",
-      type: "number",
+      type: "number"
     },
     "interactive": {
       describe: "Manually authorize deployments after seeing a preview",
       type: "boolean",
-      default: false,
+      default: false
     },
     "describe-json": {
       describe: "Adds extra verbosity to the status of an ongoing migration",
       type: "boolean",
-      default: false,
-    },
+      default: false
+    }
   },
   help: {
     usage:
@@ -52,55 +57,59 @@ const command = {
         option: "--reset",
         description:
           "Run all migrations from the beginning, instead of running from the last " +
-          "completed migration.",
+          "completed migration."
       },
       {
         option: "--f <number>",
         description:
           "Run contracts from a specific migration. The number refers to the prefix of " +
-          "the migration file.",
+          "the migration file."
       },
       {
         option: "--to <number>",
         description:
-          "Run contracts to a specific migration. The number refers to the prefix of the migration file.",
+          "Run contracts to a specific migration. The number refers to the prefix of the migration file."
       },
       {
         option: "--network <name>",
         description:
           "Specify the network to use, saving artifacts specific to that network. " +
-          "Network name must exist\n                    in the configuration.",
+          "Network name must exist\n                    in the configuration."
       },
       {
         option: "--compile-all",
         description:
           "Compile all contracts instead of intelligently choosing which contracts need to " +
-          "be compiled.",
+          "be compiled."
+      },
+      {
+        option: "--compile-none",
+        description: "Do not compile any contracts before migrating."
       },
       {
         option: "--verbose-rpc",
         description:
-          "Log communication between Truffle and the Ethereum client.",
+          "Log communication between Truffle and the Ethereum client."
       },
       {
         option: "--interactive",
         description:
-          "Prompt to confirm that the user wants to proceed after the dry run.",
+          "Prompt to confirm that the user wants to proceed after the dry run."
       },
       {
         option: "--dry-run",
-        description: "Only perform a test or 'dry run' migration.",
+        description: "Only perform a test or 'dry run' migration."
       },
       {
         option: "--skip-dry-run",
-        description: "Do not run a test or 'dry run' migration.",
+        description: "Do not run a test or 'dry run' migration."
       },
       {
         option: "--describe-json",
         description:
-          "Adds extra verbosity to the status of an ongoing migration",
-      },
-    ],
+          "Adds extra verbosity to the status of an ongoing migration"
+      }
+    ]
   },
 
   determineDryRunSettings: function (config, options) {
@@ -117,7 +126,7 @@ const command = {
       99, // Core
 
       7762959, // Musiccoin
-      61717561, // Aquachain
+      61717561 // Aquachain
     ];
 
     let dryRunOnly, skipDryRun;
@@ -188,6 +197,9 @@ const command = {
     tmp.setGracefulCleanup();
 
     const conf = Config.detect(options);
+    if (conf.compileNone || conf["compile-none"]) {
+      conf.compiler = "none";
+    }
 
     Contracts.compile(conf)
       .then(async () => {
@@ -195,7 +207,7 @@ const command = {
 
         const {
           dryRunOnly,
-          dryRunAndMigrations,
+          dryRunAndMigrations
         } = command.determineDryRunSettings(conf, options);
 
         if (dryRunOnly) {
@@ -209,7 +221,7 @@ const command = {
 
           let {
             config,
-            proceed,
+            proceed
           } = await command.prepareConfigForRealMigrations(
             currentBuild,
             options
@@ -227,7 +239,7 @@ const command = {
       // Copy artifacts to a temporary directory
       const temporaryDirectory = tmp.dirSync({
         unsafeCleanup: true,
-        prefix: "migrate-dry-run-",
+        prefix: "migrate-dry-run-"
       }).name;
 
       await promisifiedCopy(
@@ -260,7 +272,7 @@ const command = {
         }
       }
     }
-  },
+  }
 };
 
 module.exports = command;

--- a/packages/workflow-compile/legacy/index.js
+++ b/packages/workflow-compile/legacy/index.js
@@ -40,7 +40,7 @@ const Contracts = {
   // network_id: network id to link saved contract artifacts.
   // quiet: Boolean. Suppress output. Defaults to false.
   // strict: Boolean. Return compiler warnings as errors. Defaults to false.
-  compile: async function(options, callback) {
+  compile: async function (options, callback) {
     const callbackPassed = typeof callback === "function";
     try {
       const config = prepareConfig(options);
@@ -80,7 +80,13 @@ const Contracts = {
     }
   },
 
-  compileSources: async function(config, compilers) {
+  compileSources: async function (config, compilers) {
+    compilers = config.compiler
+      ? config.compiler === "none"
+        ? []
+        : [config.compiler]
+      : Object.keys(config.compilers);
+
     return Promise.all(
       compilers.map(async compiler => {
         const compile = SUPPORTED_COMPILERS[compiler];

--- a/packages/workflow-compile/new/index.js
+++ b/packages/workflow-compile/new/index.js
@@ -6,21 +6,21 @@ const { shimContract } = require("@truffle/compile-solidity/legacy/shims");
 const {
   reportCompilationStarted,
   reportNothingToCompile,
-  reportCompilationFinished
+  reportCompilationFinished,
 } = require("../reports");
 
 const SUPPORTED_COMPILERS = {
   solc: {
-    compiler: require("@truffle/compile-solidity/new")
+    compiler: require("@truffle/compile-solidity/new"),
   },
   vyper: {
     compiler: require("@truffle/compile-vyper"),
-    legacy: true
+    legacy: true,
   },
   external: {
     compiler: require("@truffle/external-compile"),
-    legacy: true
-  }
+    legacy: true,
+  },
 };
 
 async function compile(config) {
@@ -28,7 +28,9 @@ async function compile(config) {
   //
 
   const compilers = config.compiler
-    ? [config.compiler]
+    ? config.compiler === "none"
+      ? []
+      : [config.compiler]
     : Object.keys(config.compilers);
 
   // invoke compilers
@@ -47,7 +49,7 @@ async function compile(config) {
       const compile = legacy ? shimLegacy(method) : method;
 
       return {
-        [name]: await compile(config)
+        [name]: await compile(config),
       };
     })
   );
@@ -81,7 +83,7 @@ const Contracts = {
 
     if (compilerUsed) {
       config.compilersInfo[compilerUsed.name] = {
-        version: compilerUsed.version
+        version: compilerUsed.version,
       };
     }
 
@@ -92,12 +94,12 @@ const Contracts = {
     if (config.events) {
       config.events.emit("compile:succeed", {
         contractsBuildDirectory: config.contracts_build_directory,
-        compilersInfo: config.compilersInfo
+        compilersInfo: config.compilersInfo,
       });
     }
     return {
       contracts,
-      compilations
+      compilations,
     };
   },
 
@@ -112,7 +114,7 @@ const Contracts = {
 
     const artifacts = byContractName(contracts.map(shimContract));
     await config.artifactor.saveAll(artifacts);
-  }
+  },
 };
 
 module.exports = Contracts;


### PR DESCRIPTION
This option was previously excluded from `truffle help compile`, so this PR remedies that and also adds support for the special case `truffle compile --compiler=none`, which skips compilation.

This approach surfaced from issue #2021 