### PR TITLE
Bug fix: Detect external contracts that create other contracts

### DIFF
--- a/packages/codec/lib/contexts/utils.ts
+++ b/packages/codec/lib/contexts/utils.ts
@@ -8,20 +8,19 @@ import {
   DecoderContext,
   Context,
   Contexts,
-  DebuggerContexts,
+  DebuggerContexts
 } from "./types";
 import escapeRegExp from "lodash.escaperegexp";
+const cbor = require("borc"); //importing this untyped, sorry!
 
 //I split these next two apart because the type system was giving me trouble
 export function findDecoderContext(
   contexts: DecoderContexts,
   binary: string
 ): DecoderContext | null {
-  debug("binary %s", binary);
   let context = Object.values(contexts).find(context =>
     matchContext(context, binary)
   );
-  debug("context found: %O", context);
   return context !== undefined ? context : null;
 }
 
@@ -29,11 +28,9 @@ export function findDebuggerContext(
   contexts: DebuggerContexts,
   binary: string
 ): string | null {
-  debug("binary %s", binary);
   let context = Object.values(contexts).find(context =>
     matchContext(context, binary)
   );
-  debug("context found: %O", context);
   return context !== undefined ? context.context : null;
 }
 
@@ -80,12 +77,11 @@ export function normalizeContexts(contexts: Contexts): Contexts {
   let newContexts: Contexts = Object.assign(
     {},
     ...Object.entries(contexts).map(([contextHash, context]) => ({
-      [contextHash]: { ...context },
+      [contextHash]: { ...context }
     }))
   );
 
   debug("contexts cloned");
-  debug("cloned contexts: %O", newContexts);
 
   //next, we get all the library names and sort them descending by length.
   //We're going to want to go in descending order of length so that we
@@ -168,6 +164,8 @@ export function normalizeContexts(contexts: Contexts): Contexts {
     }
   }
 
+  debug("immutables complete");
+
   //one last step: if externalSolidity is set, we'll allow the CBOR to vary,
   //aside from the length (note: ideally here we would *only* dot-out the
   //metadata hash part of the CBOR, but, well, it's not worth the trouble
@@ -179,10 +177,13 @@ export function normalizeContexts(contexts: Contexts): Contexts {
   const externalCborInfo = Object.values(newContexts)
     .filter(context => context.externalSolidity)
     .map(context => extractCborInfo(context.binary))
-    .filter(cborSegment => cborSegment !== undefined);
+    .filter(
+      cborSegment =>
+        cborSegment !== undefined && isCborWithHash(cborSegment.cbor)
+    );
   const cborRegexps = externalCborInfo.map(cborInfo => ({
     input: new RegExp(cborInfo.cborSegment, "g"), //hex string so no need for escape
-    output: "..".repeat(cborInfo.cborLength) + cborInfo.cborLengthHex,
+    output: "..".repeat(cborInfo.cborLength) + cborInfo.cborLengthHex
   }));
   //HACK: we will replace *every* occurrence of *every* external CBOR occurring in
   //*every* external Solidity context, in order to cover created contracts
@@ -194,6 +195,8 @@ export function normalizeContexts(contexts: Contexts): Contexts {
       }
     }
   }
+
+  debug("external wildcards complete");
 
   //finally, return this mess!
   return newContexts;
@@ -231,6 +234,32 @@ function extractCborInfo(binary: string): CborInfo | null {
     cborEnd,
     cborLengthHex: lastTwoBytes,
     cbor,
-    cborSegment: cbor + lastTwoBytes,
+    cborSegment: cbor + lastTwoBytes
   };
+}
+
+function isCborWithHash(encoded: string): boolean {
+  debug("checking cbor");
+  let decodedMultiple: any[];
+  try {
+    decodedMultiple = cbor.decodeAll(encoded);
+  } catch (_) {
+    debug("invalid cbor!");
+    return false;
+  }
+  debug("all decoded: %O", decodedMultiple);
+  if (decodedMultiple.length !== 1) {
+    return false;
+  }
+  let decoded = decodedMultiple[0];
+  if (typeof decoded !== "object") {
+    return false;
+  }
+  //borc sometimes returns maps and sometimes objects,
+  //so let's make things consistent by converting to a map
+  if (!(decoded instanceof Map)) {
+    decoded = new Map(Object.entries(decoded));
+  }
+  const hashKeys = ["bzzr0", "bzzr1", "ipfs"];
+  return hashKeys.some(key => decoded.has(key));
 }

--- a/packages/codec/lib/contexts/utils.ts
+++ b/packages/codec/lib/contexts/utils.ts
@@ -8,7 +8,7 @@ import {
   DecoderContext,
   Context,
   Contexts,
-  DebuggerContexts
+  DebuggerContexts,
 } from "./types";
 import escapeRegExp from "lodash.escaperegexp";
 
@@ -80,7 +80,7 @@ export function normalizeContexts(contexts: Contexts): Contexts {
   let newContexts: Contexts = Object.assign(
     {},
     ...Object.entries(contexts).map(([contextHash, context]) => ({
-      [contextHash]: { ...context }
+      [contextHash]: { ...context },
     }))
   );
 
@@ -176,28 +176,51 @@ export function normalizeContexts(contexts: Contexts): Contexts {
   //but it's not worth the trouble to detect that either, because we really
   //don't support Solidity versions that old
   //note that the externalSolidity option should *only* be set for Solidity contracts!
+  const extractCbor = (binary: string) => {
+    const lastTwoBytes = binary.slice(2).slice(-2 * 2); //2 bytes * 2 for hex
+    //the slice(2) there may seem unnecessary; it's to handle the possibility that the contract
+    //has less than two bytes in its bytecode (that won't happen with Solidity, but let's be
+    //certain)
+    if (lastTwoBytes.length < 2 * 2) {
+      return undefined; //don't try to handle this case!
+    }
+    const cborLength: number = parseInt(lastTwoBytes, 16);
+    const cborEnd = binary.length - 2 * 2;
+    const cborStart = cborEnd - cborLength * 2;
+    //sanity check
+    if (cborStart < 2) {
+      //"0x"
+      return undefined; //don't try to handle this case!
+    }
+    return {
+      cborStart,
+      cborLength,
+      cborEnd,
+      cbor: binary.slice(cborStart, cborEnd),
+    };
+  };
+  const externalCbors = new Set(
+    Object.values(newContexts)
+      .filter(context => context.externalSolidity)
+      .map(context => extractCbor(context.binary).cbor)
+      .filter(cbor => cbor !== undefined)
+  );
   for (let context of Object.values(newContexts)) {
     if (context.externalSolidity) {
-      //last two bytes contain the cbor length
-      const lastTwoBytes = context.binary.slice(2).slice(-2 * 2); //2 bytes * 2 for hex
-      //the slice(2) there may seem unnecessary; it's to handle the possibility that the contract
-      //has less than two bytes in its bytecode (that won't happen with Solidity, but let's be
-      //certain)
-      if (lastTwoBytes.length < 2 * 2) {
-        continue; //don't try to handle this case!
+      let truncatedBinary = context.binary;
+      let cborInfo = extractCbor(truncatedBinary);
+      while (cborInfo && externalCbors.has(cborInfo.cbor)) {
+        const { cborStart, cborEnd, cborLength } = cborInfo;
+        //dot-out the cbor part of the binary
+        context.binary =
+          context.binary.slice(0, cborStart) +
+          "..".repeat(cborLength) +
+          context.binary.slice(cborEnd);
+        //cut off the final cbor & length; if the resulting cbor is among the external
+        //cbors, repeat
+        truncatedBinary = truncatedBinary.slice(0, cborStart);
+        cborInfo = extractCbor(truncatedBinary);
       }
-      const cborLength: number = parseInt(lastTwoBytes, 16);
-      const cborEnd = context.binary.length - 2 * 2;
-      const cborStart = cborEnd - cborLength * 2;
-      //sanity check
-      if (cborStart < 2) {
-        //"0x"
-        continue; //don't try to handle this case!
-      }
-      context.binary =
-        context.binary.slice(0, cborStart) +
-        "..".repeat(cborLength) +
-        context.binary.slice(cborEnd);
     }
   }
 

--- a/packages/codec/package.json
+++ b/packages/codec/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "big.js": "^5.2.2",
     "bn.js": "^4.11.8",
+    "borc": "^2.1.2",
     "debug": "^4.1.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.escaperegexp": "^4.1.2",

--- a/packages/core/lib/debug/compiler.js
+++ b/packages/core/lib/debug/compiler.js
@@ -5,15 +5,17 @@ class DebugCompiler {
     this.config = config;
   }
 
-  async compile() {
+  async compile(sources = undefined) {
     const compileConfig = this.config.with({ quiet: true });
 
-    const { contracts, sourceIndexes } = await compile.all(compileConfig);
+    const { contracts, sourceIndexes } = sources
+      ? await compile(sources, compileConfig) //used by external.js
+      : await compile.all(compileConfig);
 
     return { contracts, sourceIndexes };
   }
 }
 
 module.exports = {
-  DebugCompiler
+  DebugCompiler,
 };

--- a/packages/core/lib/debug/external.js
+++ b/packages/core/lib/debug/external.js
@@ -105,8 +105,8 @@ class DebugExternalHandler {
         //compile the sources
         const externalConfig = this.config.with({
           compilers: {
-            solc: options,
-          },
+            solc: options
+          }
         });
         const { contracts, sourceIndexes: files } = await new DebugCompiler(
           externalConfig
@@ -118,7 +118,8 @@ class DebugExternalHandler {
         const newCompilations = Codec.Compilations.Utils.shimArtifacts(
           contracts,
           files,
-          compilationId
+          compilationId,
+          true //mark compilation as external Solidity
         );
         //add it!
         await this.bugger.addExternalCompilations(newCompilations);
@@ -169,5 +170,5 @@ function getAnUnknownAddress(bugger, addressesToSkip) {
 }
 
 module.exports = {
-  DebugExternalHandler,
+  DebugExternalHandler
 };

--- a/packages/core/lib/debug/external.js
+++ b/packages/core/lib/debug/external.js
@@ -2,10 +2,6 @@ const debugModule = require("debug");
 const debug = debugModule("lib:debug:external");
 
 const Web3 = require("web3");
-const fs = require("fs-extra");
-const path = require("path");
-const tmp = require("tmp");
-tmp.setGracefulCleanup();
 
 const Codec = require("@truffle/codec");
 const Fetchers = require("@truffle/source-fetcher").default;
@@ -29,7 +25,7 @@ class DebugExternalHandler {
     debug("Fetchers: %o", Fetchers);
     const allFetchers = await Promise.all(
       Fetchers.map(
-        async (Fetcher) =>
+        async Fetcher =>
           await Fetcher.forNetworkId(
             networkId,
             this.config[Fetcher.fetcherName]
@@ -41,9 +37,7 @@ class DebugExternalHandler {
     let sortedFetchers = [];
     if (userFetcherNames) {
       for (let name of userFetcherNames) {
-        let Fetcher = allFetchers.find(
-          (Fetcher) => Fetcher.fetcherName === name
-        );
+        let Fetcher = allFetchers.find(Fetcher => Fetcher.fetcherName === name);
         if (Fetcher) {
           sortedFetchers.push(Fetcher);
         } else {
@@ -108,29 +102,15 @@ class DebugExternalHandler {
           //break out of the fetcher loop, since *no* fetcher will work here
           break;
         }
-        //make a temporary directory to store our downloads in
-        const sourceDirectory = tmp.dirSync({
-          unsafeCleanup: true,
-          prefix: "tmp-",
-        }).name;
-        debug("tempdir: %s", sourceDirectory);
-        //save the sources to the temporary directory
-        await Promise.all(
-          Object.entries(sources).map(async ([sourcePath, source]) => {
-            const temporaryPath = path.join(sourceDirectory, sourcePath);
-            await fs.outputFile(temporaryPath, source);
-          })
-        );
         //compile the sources
-        const temporaryConfig = this.config.with({
-          contracts_directory: sourceDirectory,
+        const externalConfig = this.config.with({
           compilers: {
             solc: options,
           },
         });
         const { contracts, sourceIndexes: files } = await new DebugCompiler(
-          temporaryConfig
-        ).compile();
+          externalConfig
+        ).compile(sources);
         debug("contracts: %o", contracts);
         debug("files: %O", files);
         //shim the result
@@ -138,8 +118,7 @@ class DebugExternalHandler {
         const newCompilations = Codec.Compilations.Utils.shimArtifacts(
           contracts,
           files,
-          compilationId,
-          true //externalSolidity flag
+          compilationId
         );
         //add it!
         await this.bugger.addExternalCompilations(newCompilations);
@@ -185,7 +164,7 @@ function getUnknownAddresses(bugger) {
 
 function getAnUnknownAddress(bugger, addressesToSkip) {
   return getUnknownAddresses(bugger).find(
-    (address) => !addressesToSkip.has(address)
+    address => !addressesToSkip.has(address)
   );
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3096,7 +3096,7 @@ big.js@^5.2.2:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
-bignumber.js@*:
+bignumber.js@*, bignumber.js@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.0.tgz#805880f84a329b5eac6e7cb6f8274b6d82bdf075"
   integrity sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==
@@ -3189,6 +3189,19 @@ boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
+
+borc@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/borc/-/borc-2.1.2.tgz#6ce75e7da5ce711b963755117dd1b187f6f8cf19"
+  integrity sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==
+  dependencies:
+    bignumber.js "^9.0.0"
+    buffer "^5.5.0"
+    commander "^2.15.0"
+    ieee754 "^1.1.13"
+    iso-url "~0.4.7"
+    json-text-sequence "~0.1.0"
+    readable-stream "^3.6.0"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -3481,6 +3494,14 @@ buffer@^5.0.2, buffer@^5.0.5, buffer@^5.2.1:
   version "5.4.3"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.4.3.tgz#3fbc9c69eb713d323e3fc1a895eee0710c072115"
   integrity sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+
+buffer@^5.5.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.6.0.tgz#a31749dc7d81d84db08abf937b6b8c4033f62786"
+  integrity sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -4212,7 +4233,7 @@ commander@3.0.2:
   resolved "https://registry.yarnpkg.com/commander/-/commander-3.0.2.tgz#6837c3fb677ad9933d1cfba42dd14d5117d6b39e"
   integrity sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==
 
-commander@^2.11.0, commander@^2.14.1, commander@^2.16.0, commander@^2.18.0, commander@^2.20.0, commander@^2.9.0, commander@~2.20.3:
+commander@^2.11.0, commander@^2.14.1, commander@^2.15.0, commander@^2.16.0, commander@^2.18.0, commander@^2.20.0, commander@^2.9.0, commander@~2.20.3:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -5005,6 +5026,11 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
+
+delimit-stream@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/delimit-stream/-/delimit-stream-0.1.0.tgz#9b8319477c0e5f8aeb3ce357ae305fc25ea1cd2b"
+  integrity sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs=
 
 depd@~1.1.2:
   version "1.1.2"
@@ -8269,7 +8295,7 @@ idna-uts46-hx@^2.3.1:
   dependencies:
     punycode "2.1.0"
 
-ieee754@^1.1.4:
+ieee754@^1.1.13, ieee754@^1.1.4:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
   integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
@@ -9069,6 +9095,11 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
+iso-url@~0.4.7:
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/iso-url/-/iso-url-0.4.7.tgz#de7e48120dae46921079fe78f325ac9e9217a385"
+  integrity sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog==
+
 isobject@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
@@ -9445,6 +9476,13 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
+
+json-text-sequence@~0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/json-text-sequence/-/json-text-sequence-0.1.1.tgz#a72f217dc4afc4629fff5feb304dc1bd51a2f3d2"
+  integrity sha1-py8hfcSvxGKf/1/rME3BvVGi89I=
+  dependencies:
+    delimit-stream "0.1.0"
 
 json5@^0.5.1:
   version "0.5.1"
@@ -13004,6 +13042,15 @@ readable-stream@^1.0.33:
     inherits "~2.0.1"
     isarray "0.0.1"
     string_decoder "~0.10.x"
+
+readable-stream@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
 
 readable-stream@~2.0.0:
   version "2.0.6"


### PR DESCRIPTION
This PR fixes a problem where a contract downloaded with `source-fetcher` might not be recognized if it in turn creates another contract.

The problem of course is the metadata hashes.  I already made it so that the CBOR structures at the ends of contracts are ignored for external contexts... but what about in the middle? If a contract creates another contract, or makes use of `type(C).runtimeCode` or `type(C).creationCode`, then you'll get metadata hashes somewhere in the *middle*.

I originally had a solution for this based on starting at the end and working backward, but I failed to notice that wouldn't work if our outer contract includes multiple inner contracts.  So here's a simpler, if somewhat hackier, solution.  For every contract marked as coming from an external source, note down the CBOR portion of its bytecode, extracted in the usual way.  Then, once again from every contract marked as external, replace any occurrence of *any* of these with dots, allowing for more general matches.

Strictly speaking this could generate some false positives, but I expect in practice it won't be a big deal.