### PR TITLE
Check analytics config before creating new process

### DIFF
--- a/packages/core/lib/services/analytics/index.js
+++ b/packages/core/lib/services/analytics/index.js
@@ -1,5 +1,15 @@
+const Config = require("@truffle/config");
+
 const analytics = {
-  send: function(eventObject) {
+  send: function (eventObject) {
+    const userConfig = Config.getUserConfig();
+
+    if (!userConfig.get("enableAnalytics")) {
+      // don't bother with creating a new process if we already
+      // know the user doesn't want to send analytics
+      return;
+    }
+
     let analyticsPath;
     const path = require("path");
     if (typeof BUNDLE_ANALYTICS_FILENAME !== "undefined") {


### PR DESCRIPTION
This PR checks the user config to see if the user even wants to send analytics before creating a child process. The child process will still check the user config for good redundancy, but it seemed redundant to spin up a process specifically for sending analytics when analytics were disabled.

This was primarily driven for development purposes. I run `node --inspect-brk=9229 packages/core/cli.js` to debug truffle internals, and this caused the fork process to also break and wait for debugger input to continue. This caused a process to keep the port 9229 bound indefinitely until killing or running the debugger