### PR TITLE
Bug fix: Remove field to prevent clobbering network name in develop

### DIFF
--- a/packages/core/lib/commands/debug.js
+++ b/packages/core/lib/commands/debug.js
@@ -5,10 +5,6 @@ const command = {
     "_": {
       type: "string"
     },
-    "network": {
-      describe: "Network to connect to",
-      type: "string"
-    },
     "fetch-external": {
       describe: "Allow debugging of external contracts",
       alias: "x",

--- a/packages/environment/environment.js
+++ b/packages/environment/environment.js
@@ -9,7 +9,7 @@ const Provider = require("@truffle/provider");
 
 const Environment = {
   // It's important config is a Config object and not a vanilla object
-  detect: async function (config) {
+  detect: async function(config) {
     expect.options(config, ["networks"]);
 
     helpers.setUpConfig(config);
@@ -26,7 +26,7 @@ const Environment = {
   },
 
   // Ensure you call Environment.detect() first.
-  fork: async function (config) {
+  fork: async function(config) {
     expect.options(config, ["from", "provider", "networks", "network"]);
 
     const interfaceAdapter = createInterfaceAdapter({
@@ -64,7 +64,7 @@ const Environment = {
 
     config.networks[network] = {
       network_id: ganacheOptions.network_id,
-      provider: function () {
+      provider: function() {
         return new Web3.providers.HttpProvider(url, { keepAlive: false });
       }
     };
@@ -139,7 +139,7 @@ const helpers = {
         config.network = "ganache";
         config.networks[config.network] = {
           host: "127.0.0.1",
-          port: 9545,
+          port: 7545,
           network_id: 5777
         };
       }

--- a/packages/environment/environment.js
+++ b/packages/environment/environment.js
@@ -9,7 +9,7 @@ const Provider = require("@truffle/provider");
 
 const Environment = {
   // It's important config is a Config object and not a vanilla object
-  detect: async function(config) {
+  detect: async function (config) {
     expect.options(config, ["networks"]);
 
     helpers.setUpConfig(config);
@@ -26,7 +26,7 @@ const Environment = {
   },
 
   // Ensure you call Environment.detect() first.
-  fork: async function(config) {
+  fork: async function (config) {
     expect.options(config, ["from", "provider", "networks", "network"]);
 
     const interfaceAdapter = createInterfaceAdapter({
@@ -64,7 +64,7 @@ const Environment = {
 
     config.networks[network] = {
       network_id: ganacheOptions.network_id,
-      provider: function() {
+      provider: function () {
         return new Web3.providers.HttpProvider(url, { keepAlive: false });
       }
     };
@@ -139,7 +139,7 @@ const helpers = {
         config.network = "ganache";
         config.networks[config.network] = {
           host: "127.0.0.1",
-          port: 7545,
+          port: 9545,
           network_id: 5777
         };
       }


### PR DESCRIPTION
This is in response to https://github.com/trufflesuite/truffle/issues/3205.

UPDATE: Adding a field to the `builder` object for a command provides it a default when no other value is provided. In this case, the default was getting set to `undefined` and then overwriting `options.network` [here](https://github.com/trufflesuite/truffle/blob/develop/packages/core/lib/command.js#L134). Since it doesn't seem that we have much use for this property, this PR removes it for `debug`.

It still might be useful to keep `builder` around as it allows us to set defaults per command. However, we should be cautious about when to use those defaults.