### PR TITLE
Add deprecation messages for build and watch command

### DIFF
--- a/packages/core/lib/build.js
+++ b/packages/core/lib/build.js
@@ -116,6 +116,7 @@ const Build = {
             return callback(err);
           });
         }
+        return callback();
       });
     });
   }

--- a/packages/core/lib/commands/build.js
+++ b/packages/core/lib/commands/build.js
@@ -7,6 +7,15 @@ const command = {
     options: []
   },
   run: function(options, done) {
+    const OS = require("os");
+    const colors = require("colors");
+    const deprecationMessage = colors.yellow(
+      `> The build command is planned ` +
+        `for deprecation in version 6 of Truffle.${OS.EOL}> See ` +
+        `https://github.com/trufflesuite/truffle/issues/3226 for more ` +
+        `information.`
+    );
+    console.log(deprecationMessage);
     const Config = require("@truffle/config");
     const Build = require("../build");
     const config = Config.detect(options);

--- a/packages/core/lib/commands/watch.js
+++ b/packages/core/lib/commands/watch.js
@@ -11,6 +11,14 @@ const command = {
     options: []
   },
   run: function(options) {
+    const OS = require("os");
+    const deprecationMessage = colors.yellow(
+      `> The watch command is planned ` +
+        `for deprecation in version 6 of Truffle.${OS.EOL}` +
+        `> See https://github.com/trufflesuite/truffle/issues/3227 for more ` +
+        `information.`
+    );
+    console.log(deprecationMessage);
     const Config = require("@truffle/config");
     const sane = require("sane");
     const path = require("path");


### PR DESCRIPTION
Preparation for deprecation of `build` and `watch` in version 6 of Truffle.

Also a missing call to `callback` was causing build to hang when there is no build script present. This PR also fixes this.