### PR TITLE
Use require in Migrations and update for 0.7.0 and future

### DIFF
--- a/packages/core/lib/commands/init/initSource/contracts/Migrations.sol
+++ b/packages/core/lib/commands/init/initSource/contracts/Migrations.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.4.21 <0.7.0;
+pragma solidity >=0.4.22 <0.8.0;
 
 contract Migrations {
   address public owner;
@@ -10,7 +10,11 @@ contract Migrations {
   }
 
   modifier restricted() {
-    if (msg.sender == owner) _;
+    require(
+      msg.sender == owner,
+      "This function is restricted to the contract's owner"
+    );
+    _;
   }
 
   function setCompleted(uint completed) public restricted {

--- a/packages/core/lib/commands/init/initSource/contracts/Migrations.sol
+++ b/packages/core/lib/commands/init/initSource/contracts/Migrations.sol
@@ -2,12 +2,8 @@
 pragma solidity >=0.4.22 <0.8.0;
 
 contract Migrations {
-  address public owner;
+  address public owner = msg.sender;
   uint public last_completed_migration;
-
-  constructor() public {
-    owner = msg.sender;
-  }
 
   modifier restricted() {
     require(


### PR DESCRIPTION
This PR does four things:

1. It updates the pragma in `Migrations.sol` so as to allow for Solidity 0.7.x
2. It addresses #3223, switching the `restricted` modifier to use `require`, and including a revert message
3. It fixes the lower bound on the pragma from 0.4.21 to 0.4.22.  Version 0.4.22 is both when the `constructor` keyword was introduced (so it should already have been that) and it's also when support for revert messages was introduced.
4. It replaces the explicit constructor with an initializer.  This is for improved compatibility.  Like, this would allow us to drop the low end of the required version below 0.4.22... except we can't actually, because I added a revert message. :P  But more importantly, it's for forward compatibility -- I believe it's planned that 0.8.0 will disallow putting explicit visibilities on constructors, so, yeah.

Of course we could also reduce the lower bound if we're willing to take out the revert message, but that's probably a bad trade. :P

Note this PR only addresses the copy of `Migrations.sol` that will be used by `truffle init`.  It does not address Truffle Boxes.  Uh, @cds-amal, any chance these changes could be made to those...?

(Thought: should we consider removing the upper bound entirely, so we don't have to keep updating that?)