### PR TITLE
Put contract creations back in affectedInstances, without messing up the codex

### DIFF
--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -82,7 +82,7 @@ class DebugPrinter {
     const affectedInstances = this.session.view(session.info.affectedInstances);
 
     this.config.logger.log("");
-    this.config.logger.log("Addresses called: (not created)");
+    this.config.logger.log("Addresses affected:");
     this.config.logger.log(
       DebugUtils.formatAffectedInstances(affectedInstances)
     );
@@ -368,9 +368,7 @@ class DebugPrinter {
       const contractKind = decoding.contractKind || "contract";
       if (decoding.address !== undefined) {
         this.config.logger.log(
-          `Returned bytecode for a ${contractKind} ${
-            decoding.class.typeName
-          } at ${decoding.address}.`
+          `Returned bytecode for a ${contractKind} ${decoding.class.typeName} at ${decoding.address}.`
         );
       } else {
         this.config.logger.log(
@@ -418,9 +416,8 @@ class DebugPrinter {
       } else {
         //case 10b: otherwise
         this.config.logger.log("Returned values:");
-        const prefixes = values.map(
-          ({ name }, index) =>
-            name ? `${name}: ` : `Component #${index + 1}: `
+        const prefixes = values.map(({ name }, index) =>
+          name ? `${name}: ` : `Component #${index + 1}: `
         );
         const maxLength = Math.max(...prefixes.map(prefix => prefix.length));
         const paddedPrefixes = prefixes.map(prefix =>

--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -32,7 +32,7 @@ const commandReference = {
   "r": "reset",
   "t": "load new transaction",
   "T": "unload transaction",
-  "s": "print stacktrace",
+  "s": "print stacktrace"
 };
 
 const shortCommandReference = {
@@ -56,7 +56,7 @@ const shortCommandReference = {
   "r": "reset",
   "t": "load",
   "T": "unload",
-  "s": "stacktrace",
+  "s": "stacktrace"
 };
 
 const truffleColors = {
@@ -70,7 +70,7 @@ const truffleColors = {
   blue: chalk.hex("#25A9E0"),
   comment: chalk.hsl(30, 20, 50),
   watermelon: chalk.hex("#E86591"),
-  periwinkle: chalk.hex("#7F9DD1"),
+  periwinkle: chalk.hex("#7F9DD1")
 };
 
 const DEFAULT_TAB_WIDTH = 8;
@@ -83,18 +83,18 @@ var DebugUtils = {
     let files = await dir.promiseFiles(config.contracts_build_directory);
 
     var contracts = files
-      .filter((file_path) => {
+      .filter(file_path => {
         return path.extname(file_path) === ".json";
       })
-      .map((file_path) => {
+      .map(file_path => {
         return path.basename(file_path, ".json");
       })
-      .map((contract_name) => {
+      .map(contract_name => {
         return config.resolver.require(contract_name);
       });
 
     await Promise.all(
-      contracts.map((abstraction) => abstraction.detectNetwork())
+      contracts.map(abstraction => abstraction.detectNetwork())
     );
 
     return contracts;
@@ -127,7 +127,7 @@ var DebugUtils = {
     //check #3: are there any AST ID collisions?
     let astIds = new Set();
 
-    let allIDsUnseenSoFar = (node) => {
+    let allIDsUnseenSoFar = node => {
       if (Array.isArray(node)) {
         return node.every(allIDsUnseenSoFar);
       } else if (node !== null && typeof node === "object") {
@@ -145,7 +145,7 @@ var DebugUtils = {
     };
 
     //now: walk each AST
-    return compilation.sources.every((source) =>
+    return compilation.sources.every(source =>
       source ? allIDsUnseenSoFar(source.ast) : true
     );
   },
@@ -191,6 +191,10 @@ var DebugUtils = {
       return " " + address + "(UNKNOWN)";
     });
 
+    if (lines.length === 0) {
+      lines.push("No affected addresses found.");
+    }
+
     if (!hasAllSource) {
       lines.push("");
       lines.push(
@@ -209,7 +213,7 @@ var DebugUtils = {
       truffleColors.mint("(enter)") +
         " last command entered (" +
         shortCommandReference[lastCommand] +
-        ")",
+        ")"
     ];
 
     var commandSections = [
@@ -221,7 +225,7 @@ var DebugUtils = {
       ["b", "B", "c"],
       ["+", "-"],
       ["?"],
-      ["v", ":"],
+      ["v", ":"]
     ].map(function (shortcuts) {
       return shortcuts.map(DebugUtils.formatCommandDescription).join(", ");
     });
@@ -365,7 +369,7 @@ var DebugUtils = {
           pointerStart,
           pointerEnd,
           prefixLength
-        ),
+        )
       ],
       afterLines
     );
@@ -559,7 +563,7 @@ var DebugUtils = {
       colors: true,
       depth: null,
       maxArrayLength: null,
-      breakLength: 30,
+      breakLength: 30
     };
     let valueToInspect = nativized
       ? value
@@ -599,9 +603,9 @@ var DebugUtils = {
             source: { sourcePath },
             sourceRange: {
               lines: {
-                start: { line, column },
-              },
-            },
+                start: { line, column }
+              }
+            }
           } = location;
           locationString = sourcePath
             ? `${sourcePath}:${line + 1}:${column + 1}` //add 1 to account for 0-indexing
@@ -698,7 +702,7 @@ var DebugUtils = {
       "templateVariable": chalk,
       "template-variable": chalk,
       "addition": chalk,
-      "deletion": chalk,
+      "deletion": chalk
     };
 
     const options = {
@@ -708,7 +712,7 @@ var DebugUtils = {
       //handling padding & numbering manually
       lineNumbers: false,
       stripIndent: false,
-      codePad: 0,
+      codePad: 0
       //NOTE: you might think you should pass highlight: true,
       //but you'd be wrong!  I don't understand this either
     };
@@ -758,7 +762,7 @@ var DebugUtils = {
             ([key, value]) => key !== "constructor" || value !== undefined
           )
           .map(([key, value]) => ({
-            [key]: value, //don't clean yet!
+            [key]: value //don't clean yet!
           }))
       );
       //set up new seenSoFar
@@ -806,7 +810,7 @@ var DebugUtils = {
       if (compilationId !== undefined && id !== undefined) {
         sources[compilationId] = {
           ...sources[compilationId],
-          [id]: source,
+          [id]: source
         };
       }
       await bugger.stepNext();
@@ -814,7 +818,7 @@ var DebugUtils = {
     await bugger.reset();
     //flatten sources before returning
     return [].concat(...Object.values(sources).map(Object.values));
-  },
+  }
 };
 
 module.exports = DebugUtils;

--- a/packages/debugger/lib/evm/actions/index.js
+++ b/packages/debugger/lib/evm/actions/index.js
@@ -42,6 +42,16 @@ export function addInstance(address, context, binary) {
   };
 }
 
+export const ADD_DISPLAY_INSTANCE = "EVM_ADD_DISPLAY_INSTANCE";
+export function addDisplayInstance(address, context, binary) {
+  return {
+    type: ADD_DISPLAY_INSTANCE,
+    address,
+    context,
+    binary
+  };
+}
+
 export const REFRESH_INSTANCE = "EVM_REFRESH_INSTANCE";
 export function refreshInstances(address, context) {
   return {

--- a/packages/debugger/lib/evm/actions/index.js
+++ b/packages/debugger/lib/evm/actions/index.js
@@ -42,10 +42,10 @@ export function addInstance(address, context, binary) {
   };
 }
 
-export const ADD_DISPLAY_INSTANCE = "EVM_ADD_DISPLAY_INSTANCE";
-export function addDisplayInstance(address, context, binary) {
+export const ADD_AFFECTED_INSTANCE = "EVM_ADD_AFFECTED_INSTANCE";
+export function addAffectedInstance(address, context, binary) {
   return {
-    type: ADD_DISPLAY_INSTANCE,
+    type: ADD_AFFECTED_INSTANCE,
     address,
     context,
     binary

--- a/packages/debugger/lib/evm/reducers.js
+++ b/packages/debugger/lib/evm/reducers.js
@@ -142,13 +142,11 @@ function initialCall(state = null, action) {
   }
 }
 
-const DEFAULT_DISPLAY_INSTANCES = { byAddress: {} };
+const DEFAULT_AFFECTED_INSTANCES = { byAddress: {} };
 
-function displayInstances(state = DEFAULT_DISPLAY_INSTANCES, action) {
+function affectedInstances(state = DEFAULT_AFFECTED_INSTANCES, action) {
   switch (action.type) {
-    case actions.ADD_INSTANCE:
-    case actions.ADD_DISPLAY_INSTANCE:
-      //includes both real and display instances
+    case actions.ADD_AFFECTED_INSTANCE:
       const { address, binary, context } = action;
       return {
         byAddress: {
@@ -161,7 +159,7 @@ function displayInstances(state = DEFAULT_DISPLAY_INSTANCES, action) {
         }
       };
     case actions.UNLOAD_TRANSACTION:
-      return DEFAULT_DISPLAY_INSTANCES;
+      return DEFAULT_AFFECTED_INSTANCES;
     default:
       return state;
   }
@@ -171,7 +169,7 @@ const transaction = combineReducers({
   globals,
   status,
   initialCall,
-  displayInstances
+  affectedInstances
 });
 
 function callstack(state = [], action) {

--- a/packages/debugger/lib/evm/reducers.js
+++ b/packages/debugger/lib/evm/reducers.js
@@ -142,10 +142,36 @@ function initialCall(state = null, action) {
   }
 }
 
+const DEFAULT_DISPLAY_INSTANCES = { byAddress: {} };
+
+function displayInstances(state = DEFAULT_DISPLAY_INSTANCES, action) {
+  switch (action.type) {
+    case actions.ADD_INSTANCE:
+    case actions.ADD_DISPLAY_INSTANCE:
+      //includes both real and display instances
+      const { address, binary, context } = action;
+      return {
+        byAddress: {
+          ...state.byAddress,
+          [address]: {
+            address,
+            binary,
+            context
+          }
+        }
+      };
+    case actions.UNLOAD_TRANSACTION:
+      return DEFAULT_DISPLAY_INSTANCES;
+    default:
+      return state;
+  }
+}
+
 const transaction = combineReducers({
   globals,
   status,
-  initialCall
+  initialCall,
+  displayInstances
 });
 
 function callstack(state = [], action) {

--- a/packages/debugger/lib/evm/selectors/index.js
+++ b/packages/debugger/lib/evm/selectors/index.js
@@ -418,11 +418,11 @@ const evm = createSelectorTree({
     ),
 
     /**
-     * evm.transaction.displayInstances
+     * evm.transaction.affectedInstances
      */
-    displayInstances: createLeaf(
+    affectedInstances: createLeaf(
       ["/state"],
-      state => state.transaction.displayInstances.byAddress
+      state => state.transaction.affectedInstances.byAddress
     )
   },
 

--- a/packages/debugger/lib/evm/selectors/index.js
+++ b/packages/debugger/lib/evm/selectors/index.js
@@ -376,31 +376,32 @@ const evm = createSelectorTree({
    * evm.transaction
    */
   transaction: {
-    /*
+    /**
      * evm.transaction.globals
      */
     globals: {
-      /*
+      /**
        * evm.transaction.globals.tx
        */
       tx: createLeaf(["/state"], state => state.transaction.globals.tx),
-      /*
+
+      /**
        * evm.transaction.globals.block
        */
       block: createLeaf(["/state"], state => state.transaction.globals.block)
     },
 
-    /*
+    /**
      * evm.transaction.status
      */
     status: createLeaf(["/state"], state => state.transaction.status),
 
-    /*
+    /**
      * evm.transaction.initialCall
      */
     initialCall: createLeaf(["/state"], state => state.transaction.initialCall),
 
-    /*
+    /**
      * evm.transaction.startingContext
      */
     startingContext: createLeaf(
@@ -414,6 +415,14 @@ const evm = createSelectorTree({
         stack.length > 0
           ? determineFullContext(stack[0], instances, search, contexts)
           : null
+    ),
+
+    /**
+     * evm.transaction.displayInstances
+     */
+    displayInstances: createLeaf(
+      ["/state"],
+      state => state.transaction.displayInstances.byAddress
     )
   },
 

--- a/packages/debugger/lib/session/sagas/index.js
+++ b/packages/debugger/lib/session/sagas/index.js
@@ -208,8 +208,12 @@ function* recordSources(sources) {
   yield* solidity.addSources(sources);
 }
 
-function* recordInstance(address, binary, displayOnly) {
-  yield* evm.addInstance(address, binary, displayOnly);
+function* recordInstance(address, binary, affectedInstanceOnly) {
+  yield* evm.addAffectedInstance(address, binary);
+  if (!affectedInstanceOnly) {
+    //add it as a real codex instance
+    yield* evm.addInstance(address, binary);
+  }
 }
 
 function* ready() {

--- a/packages/debugger/lib/session/selectors/index.js
+++ b/packages/debugger/lib/session/selectors/index.js
@@ -21,7 +21,11 @@ const session = createSelectorTree({
      * session.info.affectedInstances
      */
     affectedInstances: createLeaf(
-      [evm.current.codex.instances, evm.info.contexts, solidity.info.sources],
+      [
+        evm.transaction.displayInstances,
+        evm.info.contexts,
+        solidity.info.sources
+      ],
 
       (instances, contexts, sources) =>
         Object.assign(

--- a/packages/debugger/lib/session/selectors/index.js
+++ b/packages/debugger/lib/session/selectors/index.js
@@ -19,10 +19,12 @@ const session = createSelectorTree({
   info: {
     /**
      * session.info.affectedInstances
+     * NOTE: this really belongs in session.transaction,
+     * but that would be a breaking change
      */
     affectedInstances: createLeaf(
       [
-        evm.transaction.displayInstances,
+        evm.transaction.affectedInstances,
         evm.info.contexts,
         solidity.info.sources
       ],


### PR DESCRIPTION
Basically, this PR makes `session.info.affectedInstances` include contract creations again, allowing for a better "addresses affected" display and more assurance of `--fetch-external` working properly (because that uses `affectedInstances`!), without messing up the debugger internals.

So, recall the history here.  Originally `affectedInstances` only included calls.  Then I added creations to it as well.  Then I made the codex system, and those didn't play nicely together, so I removed creations (except, oddly, if the transaction itself was a creation transaction, I didn't remove that; this appears to have been an oversight).  But... having creations in `affectedInstances` is nice.  Problem is, like I said, it doesn't play nicely with the codex system.

So, what do we do?  Separate the two.  Originally `affectedInstances` was based on `evm.info.instances`.  This got replaced by `evm.current.codex.instances`.  Well, now I've added `evm.transaction.instances`, which acts basically like the old `evm.info.instances`.  For internal purposes, the debugger will still use `evm.current.codex.instances`.  However, for `affectedInstances` it will now use `evm.transaction.instances`.

So now, when a transaction is loaded, and `processTrace` is called to find the addresses affected, we get both calls and creations, but we separate the two.  Addresses for calls get added to both; addresses for creations get added only to `evm.transaction.instances`.  Pretty simple, really.  And of course `evm.transaction.instances` is cleared out when the transaction is unloaded.

Also, I changed the text on the "addresses affected" display back to "addresses affected". :)  I also added some text to display if there are none.

(Sorry about all the `prettier` changes. :P )