### PR TITLE
Internal improvement: Set debugger webpack test config to development mode

### DIFF
--- a/packages/debugger/webpack/webpack.config-test.js
+++ b/packages/debugger/webpack/webpack.config-test.js
@@ -6,6 +6,7 @@ const WriteFilePlugin = require("write-file-webpack-plugin");
 const commonConfig = require("./webpack.config-common.js");
 
 module.exports = merge(commonConfig, {
+  mode: "development",
   module: {
     rules: [
       {


### PR DESCRIPTION
This doesn't matter too much but it's been bugging me.  The debugger tests should run in development mode, but since the webpack upgrade no mode has explicitly been set, and it's been defaulting to production (with a warning).  I'm now explicitly setting it to development.