### PR TITLE
Upgrade dependency: ganache-core@2.11.2

### DIFF
--- a/packages/artifactor/package.json
+++ b/packages/artifactor/package.json
@@ -28,7 +28,7 @@
     "@types/node": "^12.6.2",
     "chai": "4.2.0",
     "debug": "^4.1.1",
-    "ganache-core": "2.10.2",
+    "ganache-core": "2.11.2",
     "mocha": "8.0.1",
     "require-nocache": "^1.0.0",
     "sinon": "^9.0.2",

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -41,7 +41,7 @@
     "chai": "4.2.0",
     "debug": "^4.1.0",
     "exorcist": "^1.0.1",
-    "ganache-core": "2.10.2",
+    "ganache-core": "2.11.2",
     "mocha": "8.0.1",
     "sinon": "9.0.2",
     "uglify-es": "^3.3.9"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,7 +51,7 @@
     "ethpm": "0.0.16",
     "ethpm-registry": "0.1.0-next.3",
     "fs-extra": "^8.1.0",
-    "ganache-core": "2.10.2",
+    "ganache-core": "2.11.2",
     "glob": "^7.1.4",
     "hdkey": "^1.1.0",
     "mocha": "8.0.1",

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -62,7 +62,7 @@
     "express": "^4.16.2",
     "faker": "^4.1.0",
     "fs-extra": "^8.1.0",
-    "ganache-core": "2.10.2",
+    "ganache-core": "2.11.2",
     "istanbul-instrumenter-loader": "^3.0.1",
     "mocha": "5.2.0",
     "mocha-webpack": "2.0.0-beta.0",

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@truffle/reporters": "^1.1.0",
     "@truffle/workflow-compile": "^2.1.44",
-    "ganache-core": "2.10.2",
+    "ganache-core": "2.11.2",
     "mocha": "8.0.1",
     "sinon": "9.0.2",
     "web3": "1.2.1"

--- a/packages/environment/package.json
+++ b/packages/environment/package.json
@@ -17,7 +17,7 @@
     "@truffle/expect": "^0.0.14",
     "@truffle/interface-adapter": "^0.4.13",
     "@truffle/resolver": "^6.0.11",
-    "ganache-core": "2.10.2",
+    "ganache-core": "2.11.2",
     "node-ipc": "^9.1.1",
     "source-map-support": "^0.5.19",
     "web3": "1.2.1"

--- a/packages/hdwallet-provider/package.json
+++ b/packages/hdwallet-provider/package.json
@@ -35,7 +35,7 @@
     "@types/ethereumjs-util": "^5.2.0",
     "@types/mocha": "^5.2.7",
     "@types/web3-provider-engine": "^14.0.0",
-    "ganache-core": "2.10.2",
+    "ganache-core": "2.11.2",
     "mocha": "8.0.1",
     "ts-node": "8.10.2",
     "typescript": "3.9.6"

--- a/packages/interface-adapter/package.json
+++ b/packages/interface-adapter/package.json
@@ -30,7 +30,7 @@
     "@types/bn.js": "^4.11.4",
     "@types/mocha": "^5.2.6",
     "@types/web3": "1.0.19",
-    "ganache-core": "2.10.2",
+    "ganache-core": "2.11.2",
     "mocha": "8.0.1",
     "ts-node": "8.10.2",
     "typescript": "3.9.6"

--- a/packages/interface-adapter/test/fabric-evm-getId.test.ts
+++ b/packages/interface-adapter/test/fabric-evm-getId.test.ts
@@ -16,9 +16,7 @@ async function prepareGanache(
 ): Promise<{ server: Server; interfaceAdapter: InterfaceAdapter }> {
   return new Promise((resolve, reject) => {
     const server = Ganache.server();
-    server.listen(port, (err: Error) => {
-      if (err) reject(err);
-
+    server.listen(port, () => {
       const interfaceAdapter = createInterfaceAdapter({
         provider: new Web3.providers.HttpProvider(`http://127.0.0.1:${port}`),
         networkType: fabricEvmEnabled ? "fabric-evm" : "ethereum"
@@ -31,8 +29,8 @@ async function prepareGanache(
   });
 }
 
-describe("fabric-evm getId Overload", function() {
-  it("returns networkID as valid string instead of number w/ fabric-evm=true", async function() {
+describe("fabric-evm getId Overload", function () {
+  it("returns networkID as valid string instead of number w/ fabric-evm=true", async function () {
     return new Promise(async (resolve, reject) => {
       let preparedGanache;
       try {
@@ -48,7 +46,7 @@ describe("fabric-evm getId Overload", function() {
     });
   });
 
-  it("returns networkID as number w/ fabric-evm=false", async function() {
+  it("returns networkID as number w/ fabric-evm=false", async function () {
     return new Promise(async (resolve, reject) => {
       let preparedGanache;
       try {

--- a/packages/interface-adapter/test/quorum-decodeParameters.test.ts
+++ b/packages/interface-adapter/test/quorum-decodeParameters.test.ts
@@ -15,9 +15,7 @@ async function prepareGanache(
 ): Promise<{ server: Server; web3Shim: Web3Shim }> {
   return new Promise((resolve, reject) => {
     const server = Ganache.server();
-    server.listen(port, (err: Error) => {
-      if (err) reject(err);
-
+    server.listen(port, () => {
       const web3Shim = new Web3Shim({
         provider: new Web3.providers.HttpProvider(`http://127.0.0.1:${port}`),
         networkType: quorumEnabled ? "quorum" : "ethereum"
@@ -33,8 +31,8 @@ async function prepareGanache(
 const expectedOutput = [{ name: "retVal", type: "uint256" }];
 const emptyByte = "";
 
-describe("Quorum decodeParameters Overload", function() {
-  it("decodes an empty byte to a '0' string value w/ quorum=true", async function() {
+describe("Quorum decodeParameters Overload", function () {
+  it("decodes an empty byte to a '0' string value w/ quorum=true", async function () {
     return new Promise(async (resolve, reject) => {
       let preparedGanache;
       try {
@@ -55,7 +53,7 @@ describe("Quorum decodeParameters Overload", function() {
   });
 
   // ganache-core uses web3@1.0.0-beta.35 which doesn't include the 'Out of Gas?' decoder guard!
-  it.skip("throws an 'Out of Gas?' error when decoding an empty byte w/ quorum=false", async function() {
+  it.skip("throws an 'Out of Gas?' error when decoding an empty byte w/ quorum=false", async function () {
     return new Promise(async (resolve, reject) => {
       let preparedGanache: any;
       try {

--- a/packages/interface-adapter/test/quorum-getBlock.test.ts
+++ b/packages/interface-adapter/test/quorum-getBlock.test.ts
@@ -20,9 +20,7 @@ async function prepareGanache(
     const server = Ganache.server({
       time: genesisBlockTime
     });
-    server.listen(port, (err: Error) => {
-      if (err) reject(err);
-
+    server.listen(port, () => {
       const interfaceAdapter = createInterfaceAdapter({
         provider: new Web3.providers.HttpProvider(`http://127.0.0.1:${port}`),
         networkType: quorumEnabled ? "quorum" : "ethereum"
@@ -35,8 +33,8 @@ async function prepareGanache(
   });
 }
 
-describe("Quorum getBlock Overload", function() {
-  it("recovers block timestamp as hexstring instead of number w/ quorum=true", async function() {
+describe("Quorum getBlock Overload", function () {
+  it("recovers block timestamp as hexstring instead of number w/ quorum=true", async function () {
     return new Promise(async (resolve, reject) => {
       let preparedGanache;
       try {
@@ -56,7 +54,7 @@ describe("Quorum getBlock Overload", function() {
     });
   });
 
-  it("recovers block timestamp as number w/ quorum=false", async function() {
+  it("recovers block timestamp as number w/ quorum=false", async function () {
     return new Promise(async (resolve, reject) => {
       let preparedGanache;
       try {

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -20,7 +20,7 @@
     "web3": "1.2.1"
   },
   "devDependencies": {
-    "ganache-core": "2.10.2",
+    "ganache-core": "2.11.2",
     "mocha": "8.0.1"
   },
   "keywords": [

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -40,7 +40,7 @@
     "copy-webpack-plugin": "^5.1.1",
     "eslint": "^5.7.0",
     "fs-extra": "^8.1.0",
-    "ganache-core": "2.10.2",
+    "ganache-core": "2.11.2",
     "glob": "^7.1.2",
     "husky": "^1.1.2",
     "js-scrypt": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6338,10 +6338,10 @@ ethereumjs-util@^7.0.2:
     ethjs-util "0.1.6"
     rlp "^2.2.4"
 
-ethereumjs-vm@4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/ethereumjs-vm/-/ethereumjs-vm-4.1.3.tgz#dc8eb45f47d775da9f0b2437d5e20896fdf66f37"
-  integrity sha512-RTrD0y7My4O6Qr1P2ZIsMfD6RzL6kU/RhBZ0a5XrPzAeR61crBS7or66ohDrvxDI/rDBxMi+6SnsELih6fzalw==
+ethereumjs-vm@4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/ethereumjs-vm/-/ethereumjs-vm-4.2.0.tgz#e885e861424e373dbc556278f7259ff3fca5edab"
+  integrity sha512-X6qqZbsY33p5FTuZqCnQ4+lo957iUJMM6Mpa6bL4UW0dxM6WmDSHuI4j/zOp1E2TDKImBGCJA9QPfc08PaNubA==
   dependencies:
     async "^2.1.2"
     async-eventemitter "^0.2.2"
@@ -7324,10 +7324,10 @@ ganache-cli@^6.1.0:
     source-map-support "0.5.12"
     yargs "13.2.4"
 
-ganache-core@2.10.2:
-  version "2.10.2"
-  resolved "https://registry.yarnpkg.com/ganache-core/-/ganache-core-2.10.2.tgz#17c171c6c0195b6734a0dd741a9d2afd4f74e292"
-  integrity sha512-4XEO0VsqQ1+OW7Za5fQs9/Kk7o8M0T1sRfFSF8h9NeJ2ABaqMO5waqxf567ZMcSkRKaTjUucBSz83xNfZv1HDg==
+ganache-core@2.11.2:
+  version "2.11.2"
+  resolved "https://registry.yarnpkg.com/ganache-core/-/ganache-core-2.11.2.tgz#821a8e7beaa65b32e408ccae2e2ec49194c4e378"
+  integrity sha512-yZSMdR2xtqG2IdApeB6OywtMxwcHMp6Y5TUBwPyKe5/GripP8xnEpSKBluhxoyqEotg+Z2S8mjIXJyAm+NnMGw==
   dependencies:
     abstract-leveldown "3.0.0"
     async "2.6.2"
@@ -7343,11 +7343,12 @@ ganache-core@2.10.2:
     ethereumjs-common "1.5.0"
     ethereumjs-tx "2.1.2"
     ethereumjs-util "6.2.0"
-    ethereumjs-vm "4.1.3"
+    ethereumjs-vm "4.2.0"
     heap "0.2.6"
     level-sublevel "6.6.4"
     levelup "3.1.1"
     lodash "4.17.14"
+    lru-cache "5.1.1"
     merkle-patricia-tree "2.3.2"
     seedrandom "3.0.1"
     source-map-support "0.5.12"
@@ -10453,6 +10454,13 @@ lowercase-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
   integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
 
+lru-cache@5.1.1, lru-cache@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
+  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
+  dependencies:
+    yallist "^3.0.2"
+
 lru-cache@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-3.2.0.tgz#71789b3b7f5399bec8565dda38aa30d2a097efee"
@@ -10467,13 +10475,6 @@ lru-cache@^4.0.1:
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
-
-lru-cache@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
-  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
-  dependencies:
-    yallist "^3.0.2"
 
 lru-queue@0.1:
   version "0.1.0"


### PR DESCRIPTION
* @truffle/artifactor: 2.10.2 →  2.11.2
* @truffle/contract: 2.10.2 →  2.11.2
* @truffle/core: 2.10.2 →  2.11.2
* @truffle/debugger: 2.10.2 →  2.11.2
* @truffle/deployer: 2.10.2 →  2.11.2
* @truffle/environment: 2.10.2 →  2.11.2
* @truffle/hdwallet-provider: 2.10.2 →  2.11.2
* @truffle/interface-adapter: 2.10.2 →  2.11.2
* @truffle/provider: 2.10.2 →  2.11.2
* truffle: 2.10.2 →  2.11.2