### PR TITLE
Internal improvement: Allow test suite success on Slack notification failure

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -47,6 +47,7 @@ jobs:
   slack_notification:
     needs: build
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: 8398a7/action-slack@v1.1.1
         with:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -50,6 +50,7 @@ jobs:
     continue-on-error: true
     steps:
       - uses: 8398a7/action-slack@v1.1.1
+        continue-on-error: true
         with:
           type: success
         env:


### PR DESCRIPTION
If the Slack notification fails, that shouldn't cause a test failure.  This change to the GHA YAML file should make that the case, if I've understood correctly.