### PR TITLE
Two debugger bug fixes, including unbreaking --fetch-external

### DIFF
--- a/packages/debugger/lib/evm/sagas/index.js
+++ b/packages/debugger/lib/evm/sagas/index.js
@@ -68,7 +68,7 @@ export function* addAffectedInstance(address, binary) {
 //that currently only happens when adding external compilations)
 export function* refreshInstances() {
   const instances = yield select(evm.current.codex.instances);
-  const affectedInstances = yield select(evm.transaction.displayInstances);
+  const affectedInstances = yield select(evm.transaction.affectedInstances);
   for (let [address, { binary }] of Object.entries(instances)) {
     const search = yield select(evm.info.binaries.search);
     const context = search(binary);

--- a/packages/debugger/lib/web3/adapter.js
+++ b/packages/debugger/lib/web3/adapter.js
@@ -20,7 +20,12 @@ export default class Web3Adapter {
         id: new Date().getTime()
       }
     );
-    if (result.error) {
+    if (!result.result) {
+      //we assume if there's no result then there is an error.
+      //note: some nodes may return an error even if there is a
+      //usable result, so we don't assume that the presence of
+      //an error means we should throw an error, but rather check
+      //for the absence of a result.
       throw new Error(result.error.message);
     } else {
       return result.result.structLogs;


### PR DESCRIPTION
Two bug fixes:

1. I accidentally broke `--fetch-external` with PR #3231; we don't have test cases for it unfortunately and I didn't think to test it.  This PR fixes that.

2. It turns out some Ethereum nodes, when you do `debug_traceTransaction`, will give you both an error *and* a result.  Meaning, there is a result, but they're also returning an error for some reason.  So now, to determine whether to throw, we check for the absence of a result, rather than the presence of an error.