### PR TITLE
Protect against null values for cborSegment

### DIFF
--- a/packages/codec/lib/contexts/utils.ts
+++ b/packages/codec/lib/contexts/utils.ts
@@ -178,8 +178,7 @@ export function normalizeContexts(contexts: Contexts): Contexts {
     .filter(context => context.externalSolidity)
     .map(context => extractCborInfo(context.binary))
     .filter(
-      cborSegment =>
-        cborSegment !== undefined && isCborWithHash(cborSegment.cbor)
+      cborSegment => cborSegment !== null && isCborWithHash(cborSegment.cbor)
     );
   const cborRegexps = externalCborInfo.map(cborInfo => ({
     input: new RegExp(cborInfo.cborSegment, "g"), //hex string so no need for escape


### PR DESCRIPTION
When determining affected instances

Got this stack trace when debugging another yam contract transaction:
```
truffle debug 0x1d64875b24732bc2e8880cd0870ea8e301ddde683ce81fea418e9ab4feea90bb --fetch-external
Starting Truffle Debugger...
✔ Compiling your contracts...
⠹ Getting and compiling external sources...TypeError: Cannot read property 'cbor' of null
    at Object.values.filter.map.filter.cborSegment (/Users/gnidan/src/work/truffle/packages/codec/lib/contexts/utils.ts:182:65)
    at Array.filter (<anonymous>)
    at Object.normalizeContexts (/Users/gnidan/src/work/truffle/packages/codec/lib/contexts/utils.ts:180:6)
    at Function.normalize (/Users/gnidan/src/work/truffle/packages/debugger/lib/session/index.js:248:37)
    at /Users/gnidan/src/work/truffle/packages/debugger/lib/session/index.js:445:41
    at Generator.next (<anonymous>)
    at step (/Users/gnidan/src/work/truffle/node_modules/babel-runtime/helpers/asyncToGenerator.js:17:30)
    at /Users/gnidan/src/work/truffle/node_modules/babel-runtime/helpers/asyncToGenerator.js:35:14
    at new Promise (<anonymous>)
    at new F (/Users/gnidan/src/work/truffle/node_modules/core-js/library/modules/_export.js:36:28)
    at /Users/gnidan/src/work/truffle/node_modules/babel-runtime/helpers/asyncToGenerator.js:14:12
    at D.addExternalCompilations (/Users/gnidan/src/work/truffle/packages/debugger/lib/session/index.js:444:47)
    at DebugExternalHandler.fetch (/Users/gnidan/src/work/truffle/packages/core/lib/debug/external.js:125:27)
    at process._tickCallback (internal/process/next_tick.js:68:7)
Truffle (unbundled) (core: 5.1.39)
Node v10.22.0
```

(Running with the prior bugfix changes on `develop`)