### PR TITLE
Fix @truffle/error package.json

### DIFF
--- a/packages/error/package.json
+++ b/packages/error/package.json
@@ -4,12 +4,8 @@
   "description": "Simple module that allows native Error objects to be extended",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
-  "directories": {
-    "doc": "./README.md",
-    "lib": "./dist"
-  },
   "files": [
-    "./dist/src"
+    "dist"
   ],
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
#3272 

Seems like @truffle/error wasn't getting of its files published!

This PR should fix that. Tested this using `yarn pack` and seems to work. Assuming this is good to go, will be pushing out an early Monday night release tonight.