### PR TITLE
Replace new Buffer() calls via patch to avoid deprecation warnings:

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "bootstrap": "npx lerna bootstrap",
-    "prepare": "lerna run prepare --stream --concurrency=1",
+    "prepare": "patch-package && lerna run prepare --stream --concurrency=1",
     "publish-release": "./scripts/publish-release.sh",
     "publish-dist-tag": "./scripts/publish-dist-tag.sh",
     "prepare-release": "./scripts/prepare-release.sh",
@@ -20,6 +20,8 @@
     "lerna-update-wizard": "^0.16.0",
     "lint-staged": "^7.3.0",
     "nyc": "^13.0.1",
+    "patch-package": "^6.2.2",
+    "postinstall-prepare": "^1.0.1",
     "prettier": "^2.0.5",
     "prs-merged-since": "^1.1.0"
   },

--- a/packages/codec/lib/conversion.ts
+++ b/packages/codec/lib/conversion.ts
@@ -143,7 +143,7 @@ export function toBytes(
 
     //note that the argument for toTwos is given in bits
     return new Uint8Array(
-      data.toTwos(length * 8).toArrayLike(Buffer.alloc as any, "be", length)
+      data.toTwos(length * 8).toArrayLike(Buffer, "be", length)
     ); //big-endian
   }
 }

--- a/packages/codec/lib/conversion.ts
+++ b/packages/codec/lib/conversion.ts
@@ -143,7 +143,7 @@ export function toBytes(
 
     //note that the argument for toTwos is given in bits
     return new Uint8Array(
-      data.toTwos(length * 8).toArrayLike(Buffer, "be", length)
+      data.toTwos(length * 8).toArrayLike(Buffer.alloc as any, "be", length)
     ); //big-endian
   }
 }

--- a/patches/buffer-to-arraybuffer+0.0.5.patch
+++ b/patches/buffer-to-arraybuffer+0.0.5.patch
@@ -1,0 +1,12 @@
+diff --git a/node_modules/buffer-to-arraybuffer/buffer-to-arraybuffer.js b/node_modules/buffer-to-arraybuffer/buffer-to-arraybuffer.js
+index d79d1a2..b5829b3 100644
+--- a/node_modules/buffer-to-arraybuffer/buffer-to-arraybuffer.js
++++ b/node_modules/buffer-to-arraybuffer/buffer-to-arraybuffer.js
+@@ -1,5 +1,6 @@
+ (function(root) {
+-  var isArrayBufferSupported = (new Buffer(0)).buffer instanceof ArrayBuffer;
++  const alloc = require('buffer-alloc')
++  var isArrayBufferSupported = (alloc(0)).buffer instanceof ArrayBuffer;
+ 
+   var bufferToArrayBuffer = isArrayBufferSupported ? bufferToArrayBufferSlice : bufferToArrayBufferCycle;
+ 

--- a/patches/eth-sig-util++ethereumjs-abi++ethereumjs-util+4.5.1.patch
+++ b/patches/eth-sig-util++ethereumjs-abi++ethereumjs-util+4.5.1.patch
@@ -1,0 +1,128 @@
+diff --git a/node_modules/eth-sig-util/node_modules/ethereumjs-abi/node_modules/ethereumjs-util/dist/index.js b/node_modules/eth-sig-util/node_modules/ethereumjs-abi/node_modules/ethereumjs-util/dist/index.js
+index aa4c08d..349ccfa 100644
+--- a/node_modules/eth-sig-util/node_modules/ethereumjs-abi/node_modules/ethereumjs-util/dist/index.js
++++ b/node_modules/eth-sig-util/node_modules/ethereumjs-abi/node_modules/ethereumjs-util/dist/index.js
+@@ -13,6 +13,7 @@ var assert = require('assert');
+ var rlp = require('rlp');
+ var BN = require('bn.js');
+ var createHash = require('create-hash');
++const bufferFrom = require('buffer-from');
+ 
+ /**
+  * the max integer that this VM can handle (a ```BN```)
+@@ -36,7 +37,7 @@ exports.SHA3_NULL_S = 'c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045
+  * SHA3-256 hash of null (a ```Buffer```)
+  * @var {Buffer} SHA3_NULL
+  */
+-exports.SHA3_NULL = new Buffer(exports.SHA3_NULL_S, 'hex');
++exports.SHA3_NULL = bufferFrom(exports.SHA3_NULL_S, 'hex');
+ 
+ /**
+  * SHA3-256 of an RLP of an empty array (a ```String```)
+@@ -48,7 +49,7 @@ exports.SHA3_RLP_ARRAY_S = '1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a1
+  * SHA3-256 of an RLP of an empty array (a ```Buffer```)
+  * @var {Buffer} SHA3_RLP_ARRAY
+  */
+-exports.SHA3_RLP_ARRAY = new Buffer(exports.SHA3_RLP_ARRAY_S, 'hex');
++exports.SHA3_RLP_ARRAY = bufferFrom(exports.SHA3_RLP_ARRAY_S, 'hex');
+ 
+ /**
+  * SHA3-256 hash of the RLP of null  (a ```String```)
+@@ -60,7 +61,7 @@ exports.SHA3_RLP_S = '56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e3
+  * SHA3-256 hash of the RLP of null (a ```Buffer```)
+  * @var {Buffer} SHA3_RLP
+  */
+-exports.SHA3_RLP = new Buffer(exports.SHA3_RLP_S, 'hex');
++exports.SHA3_RLP = bufferFrom(exports.SHA3_RLP_S, 'hex');
+ 
+ /**
+  * [`BN`](https://github.com/indutny/bn.js)
+@@ -87,7 +88,7 @@ exports.secp256k1 = secp256k1;
+  * @return {Buffer}
+  */
+ exports.zeros = function (bytes) {
+-  var buf = new Buffer(bytes);
++  var buf = bufferFrom(bytes);
+   buf.fill(0);
+   return buf;
+ };
+@@ -154,20 +155,20 @@ exports.unpad = exports.stripZeros = function (a) {
+ exports.toBuffer = function (v) {
+   if (!Buffer.isBuffer(v)) {
+     if (Array.isArray(v)) {
+-      v = new Buffer(v);
++      v = bufferFrom(v);
+     } else if (typeof v === 'string') {
+       if (exports.isHexPrefixed(v)) {
+-        v = new Buffer(exports.padToEven(exports.stripHexPrefix(v)), 'hex');
++        v = bufferFrom(exports.padToEven(exports.stripHexPrefix(v)), 'hex');
+       } else {
+-        v = new Buffer(v);
++        v = bufferFrom(v);
+       }
+     } else if (typeof v === 'number') {
+       v = exports.intToBuffer(v);
+     } else if (v === null || v === undefined) {
+-      v = new Buffer([]);
++      v = bufferFrom([]);
+     } else if (v.toArray) {
+       // converts a BN to a Buffer
+-      v = new Buffer(v.toArray());
++      v = bufferFrom(v.toArray());
+     } else {
+       throw new Error('invalid type');
+     }
+@@ -200,7 +201,7 @@ exports.intToHex = function (i) {
+  */
+ exports.intToBuffer = function (i) {
+   var hex = exports.intToHex(i);
+-  return new Buffer(hex.slice(2), 'hex');
++  return bufferFrom(hex.slice(2), 'hex');
+ };
+ 
+ /**
+@@ -245,7 +246,7 @@ exports.fromSigned = function (num) {
+  * @return {Buffer}
+  */
+ exports.toUnsigned = function (num) {
+-  return new Buffer(num.toTwos(256).toArray());
++  return bufferFrom(num.toTwos(256).toArray());
+ };
+ 
+ /**
+@@ -342,7 +343,7 @@ exports.isValidPrivate = function (privateKey) {
+ exports.isValidPublic = function (publicKey, sanitize) {
+   if (publicKey.length === 64) {
+     // Convert to SEC1 for secp256k1
+-    return secp256k1.publicKeyVerify(Buffer.concat([new Buffer([4]), publicKey]));
++    return secp256k1.publicKeyVerify(Buffer.concat([bufferFrom([4]), publicKey]));
+   }
+ 
+   if (!sanitize) {
+@@ -537,7 +538,7 @@ exports.generateAddress = function (from, nonce) {
+     // read the RLP documentation for an answer if you dare
+     nonce = null;
+   } else {
+-    nonce = new Buffer(nonce.toArray());
++    nonce = bufferFrom(nonce.toArray());
+   }
+ 
+   // Only take the lower 160bits of the hash
+@@ -661,7 +662,7 @@ exports.defineProperties = function (self, fields, data) {
+       v = exports.toBuffer(v);
+ 
+       if (v.toString('hex') === '00' && !field.allowZero) {
+-        v = new Buffer([]);
++        v = bufferFrom([]);
+       }
+ 
+       if (field.allowLess && field.length) {
+@@ -699,7 +700,7 @@ exports.defineProperties = function (self, fields, data) {
+   // if the constuctor is passed data
+   if (data) {
+     if (typeof data === 'string') {
+-      data = new Buffer(exports.stripHexPrefix(data), 'hex');
++      data = bufferFrom(exports.stripHexPrefix(data), 'hex');
+     }
+ 
+     if (Buffer.isBuffer(data)) {

--- a/patches/ethjs-util+0.1.6.patch
+++ b/patches/ethjs-util+0.1.6.patch
@@ -1,0 +1,39 @@
+diff --git a/node_modules/ethjs-util/src/index.js b/node_modules/ethjs-util/src/index.js
+index 7e73f02..b35c7a4 100644
+--- a/node_modules/ethjs-util/src/index.js
++++ b/node_modules/ethjs-util/src/index.js
+@@ -1,5 +1,7 @@
+ const isHexPrefixed = require('is-hex-prefixed');
+ const stripHexPrefix = require('strip-hex-prefix');
++const alloc = require('buffer-alloc');
++const bufferFrom = require('buffer-from');
+ 
+ /**
+  * Pads a `String` to have an even length
+@@ -39,7 +41,7 @@ function intToHex(i) {
+ function intToBuffer(i) {
+   const hex = intToHex(i);
+ 
+-  return new Buffer(padToEven(hex.slice(2)), 'hex');
++  return alloc(padToEven(hex.slice(2)), 'hex');
+ }
+ 
+ /**
+@@ -79,7 +81,7 @@ function arrayContainsArray(superset, subset, some) {
+  * @returns {String} ascii string representation of hex value
+  */
+ function toUtf8(hex) {
+-  const bufferValue = new Buffer(padToEven(stripHexPrefix(hex).replace(/^0+|0+$/g, '')), 'hex');
++  const bufferValue = alloc(padToEven(stripHexPrefix(hex).replace(/^0+|0+$/g, '')), 'hex');
+ 
+   return bufferValue.toString('utf8');
+ }
+@@ -116,7 +118,7 @@ function toAscii(hex) {
+  * @returns {String} hex representation of input string
+  */
+ function fromUtf8(stringValue) {
+-  const str = new Buffer(stringValue, 'utf8');
++  const str = bufferFrom(stringValue, 'utf8');
+ 
+   return `0x${padToEven(str.toString('hex')).replace(/^0+|0+$/g, '')}`;
+ }

--- a/patches/xhr2-cookies+1.1.0.patch
+++ b/patches/xhr2-cookies+1.1.0.patch
@@ -1,0 +1,56 @@
+diff --git a/node_modules/xhr2-cookies/dist/xml-http-request-upload.js b/node_modules/xhr2-cookies/dist/xml-http-request-upload.js
+index 60ddb3e..43b6352 100644
+--- a/node_modules/xhr2-cookies/dist/xml-http-request-upload.js
++++ b/node_modules/xhr2-cookies/dist/xml-http-request-upload.js
+@@ -1,4 +1,5 @@
+ "use strict";
++const bufferFrom = require('buffer-from');
+ var __extends = (this && this.__extends) || (function () {
+     var extendStatics = Object.setPrototypeOf ||
+         ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+@@ -32,13 +33,13 @@ var XMLHttpRequestUpload = /** @class */ (function (_super) {
+             if (data.length !== 0) {
+                 this._contentType = 'text/plain;charset=UTF-8';
+             }
+-            this._body = new Buffer(data, 'utf-8');
++            this._body = bufferFrom(data, 'utf-8');
+         }
+         else if (Buffer.isBuffer(data)) {
+             this._body = data;
+         }
+         else if (data instanceof ArrayBuffer) {
+-            var body = new Buffer(data.byteLength);
++            var body = bufferFrom(data.byteLength);
+             var view = new Uint8Array(data);
+             for (var i = 0; i < data.byteLength; i++) {
+                 body[i] = view[i];
+@@ -46,7 +47,7 @@ var XMLHttpRequestUpload = /** @class */ (function (_super) {
+             this._body = body;
+         }
+         else if (data.buffer && data.buffer instanceof ArrayBuffer) {
+-            var body = new Buffer(data.byteLength);
++            var body = bufferFrom(data.byteLength);
+             var offset = data.byteOffset;
+             var view = new Uint8Array(data.buffer);
+             for (var i = 0; i < data.byteLength; i++) {
+diff --git a/node_modules/xhr2-cookies/dist/xml-http-request.js b/node_modules/xhr2-cookies/dist/xml-http-request.js
+index d12254d..e6836eb 100644
+--- a/node_modules/xhr2-cookies/dist/xml-http-request.js
++++ b/node_modules/xhr2-cookies/dist/xml-http-request.js
+@@ -17,6 +17,7 @@ var __assign = (this && this.__assign) || Object.assign || function(t) {
+     }
+     return t;
+ };
++const bufferFrom = require('buffer-from');
+ Object.defineProperty(exports, "__esModule", { value: true });
+ var http = require("http");
+ var https = require("https");
+@@ -301,7 +302,7 @@ var XMLHttpRequest = /** @class */ (function (_super) {
+         if (this._response !== response) {
+             return;
+         }
+-        this._responseParts.push(new Buffer(data));
++        this._responseParts.push(bufferFrom(data));
+         this._loadedBytes += data.length;
+         if (this.readyState !== XMLHttpRequest.LOADING) {
+             this._setReadyState(XMLHttpRequest.LOADING);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1792,6 +1792,11 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 "@zerollup/ts-helpers@^1.7.4":
   version "1.7.4"
   resolved "https://registry.yarnpkg.com/@zerollup/ts-helpers/-/ts-helpers-1.7.4.tgz#59ac8c643b8cc6def5449691630091226991da36"
@@ -7026,6 +7031,14 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
+find-yarn-workspace-root@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-1.2.1.tgz#40eb8e6e7c2502ddfaa2577c176f221422f860db"
+  integrity sha512-dVtfb0WuQG+8Ag2uWkbG79hOUzEsRrhBzgfn86g2sJPkzmcpGdghbNTfUKGTxymFrY/tLIodDzLoW9nOJ4FY8Q==
+  dependencies:
+    fs-extra "^4.0.3"
+    micromatch "^3.1.4"
+
 findup-sync@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-3.0.0.tgz#17b108f9ee512dfb7a5c7f3c8b27ea9e1a9c08d1"
@@ -7264,10 +7277,19 @@ fs-extra@^2.0.0:
     graceful-fs "^4.1.2"
     jsonfile "^2.1.0"
 
-fs-extra@^4.0.2:
+fs-extra@^4.0.2, fs-extra@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
   integrity sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs-extra@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
@@ -9712,6 +9734,13 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
   integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
+
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
 
 klaw@^1.0.0:
   version "1.3.1"
@@ -12396,6 +12425,24 @@ pascalcase@^0.1.1:
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
 
+patch-package@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-6.2.2.tgz#71d170d650c65c26556f0d0fbbb48d92b6cc5f39"
+  integrity sha512-YqScVYkVcClUY0v8fF0kWOjDYopzIM8e3bj/RU1DPeEF14+dCGm6UeOYm4jvCyxqIEQ5/eJzmbWfDWnUleFNMg==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^2.4.2"
+    cross-spawn "^6.0.5"
+    find-yarn-workspace-root "^1.2.1"
+    fs-extra "^7.0.1"
+    is-ci "^2.0.0"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.0"
+    rimraf "^2.6.3"
+    semver "^5.6.0"
+    slash "^2.0.0"
+    tmp "^0.0.33"
+
 path-browserify@0.0.1, path-browserify@~0.0.0:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.1.tgz#e6c4ddd7ed3aa27c68a20cc4e50e1a4ee83bbc4a"
@@ -12616,6 +12663,11 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
+
+postinstall-prepare@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/postinstall-prepare/-/postinstall-prepare-1.0.1.tgz#dac9b5d91b054389141b13c0192eb68a0aa002b5"
+  integrity sha512-4zxO4DjrV0XfD+ABUFEP0MiQmhKOGBnov5LfLsra/XVOUcQ5gMLLMcV3b8K8wJUfNDv1ozleGblYb06gPbjVUQ==
 
 precond@0.2:
   version "0.2.3"


### PR DESCRIPTION
This PR attempts to address node deprecation warnings for the use of `new Buffer()` via `patch-package`, which allows us to make the changes to packages we depend on but cannot directly change at this time. With this change, a diff has been created that will be applies to these packages before they are built via webpack. There is also a change in `codec/lib/conversion.ts` with the same goal of avoiding the deprecation warning.

- Replace new Buffer() in relevant node_modules
- Replace Buffer with Buffer.alloc in codec/lib/conversion.ts
- Add patch-package to prepare script