### PR TITLE
Change Buffer to Uint8Array to avoid deprecation warning

### DIFF
--- a/packages/codec/lib/conversion.ts
+++ b/packages/codec/lib/conversion.ts
@@ -143,7 +143,7 @@ export function toBytes(
 
     //note that the argument for toTwos is given in bits
     return new Uint8Array(
-      data.toTwos(length * 8).toArrayLike(Buffer, "be", length)
+      data.toTwos(length * 8).toArrayLike(Uint8Array as any, "be", length)
     ); //big-endian
   }
 }

--- a/packages/codec/lib/conversion.ts
+++ b/packages/codec/lib/conversion.ts
@@ -142,9 +142,8 @@ export function toBytes(
     }
 
     //note that the argument for toTwos is given in bits
-    return new Uint8Array(
-      data.toTwos(length * 8).toArrayLike(Uint8Array as any, "be", length)
-    ); //big-endian
+    return data.toTwos(length * 8).toArrayLike(Uint8Array as any, "be", length);
+    //big-endian
   }
 }
 


### PR DESCRIPTION
This PR changes the Buffer type being passed to BN.js via the `toArrayLike()`method, because somehow this was triggering a deprecation warning from node in the `spawn-repl` branch. A Buffer is technically a Uint8Array, so I think this should be ok, but would love someone with a better understanding of the `codec` code to take a look and make sure this doesn't break anything. 