### PR TITLE
Move develop network defaults to @truffle/config

### DIFF
--- a/packages/config/src/configDefaults.ts
+++ b/packages/config/src/configDefaults.ts
@@ -20,7 +20,18 @@ export const getInitialConfig = ({
     truffle_directory,
     working_directory,
     network,
-    networks: {},
+    networks: {
+      develop: {
+        host: "127.0.0.1",
+        port: 9545,
+        network_id: 5777,
+        accounts: 10,
+        defaultEtherBalance: 100,
+        blockTime: 0,
+        gas: 0x6691b7,
+        gasPrice: 0x77359400
+      }
+    },
     verboseRpc: false,
     gas: null,
     gasPrice: null,

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -24,7 +24,7 @@ class TruffleConfig {
     workingDirectory?: string,
     network?: any
   ) {
-    this._deepCopy = ["compilers"];
+    this._deepCopy = ["networks", "compilers"];
     this._values = getInitialConfig({
       truffleDirectory,
       workingDirectory,
@@ -61,7 +61,7 @@ class TruffleConfig {
     Object.defineProperty(this, propertyName, {
       get:
         descriptor.get ||
-        function() {
+        function () {
           // value is specified
           if (propertyName in self._values) {
             return self._values[propertyName];
@@ -77,7 +77,7 @@ class TruffleConfig {
         },
       set:
         descriptor.set ||
-        function(value) {
+        function (value) {
           self._values[propertyName] = descriptor.transform
             ? descriptor.transform(value)
             : value;

--- a/packages/core/lib/commands/develop.js
+++ b/packages/core/lib/commands/develop.js
@@ -54,7 +54,7 @@ const command = {
     const customConfig = config.networks.develop || {};
 
     const { mnemonic, accounts, privateKeys } = mnemonicInfo.getAccountsInfo(
-      customConfig.accounts || 10
+      customConfig.accounts
     );
 
     const onMissing = () => "**";
@@ -67,16 +67,16 @@ const command = {
     const ipcOptions = { log: options.log };
 
     const ganacheOptions = {
-      host: customConfig.host || "127.0.0.1",
-      port: customConfig.port || 9545,
-      network_id: customConfig.network_id || 5777,
-      total_accounts: customConfig.accounts || 10,
-      default_balance_ether: customConfig.defaultEtherBalance || 100,
-      blockTime: customConfig.blockTime || 0,
+      host: customConfig.host,
+      port: customConfig.port,
+      network_id: customConfig.network_id,
+      total_accounts: customConfig.accounts,
+      default_balance_ether: customConfig.defaultEtherBalance,
+      blockTime: customConfig.blockTime,
       fork: customConfig.fork,
       mnemonic,
-      gasLimit: customConfig.gas || 0x6691b7,
-      gasPrice: customConfig.gasPrice || 0x77359400,
+      gasLimit: customConfig.gas,
+      gasPrice: customConfig.gasPrice,
       noVMErrorsOnRPCResponse: true,
       time: config.genesis_time
     };

--- a/packages/core/lib/commands/networks.js
+++ b/packages/core/lib/commands/networks.js
@@ -1,4 +1,6 @@
-var command = {
+const { callbackify } = require("util");
+
+const command = {
   command: "networks",
   description: "Show addresses for deployed contracts on each network",
   builder: {
@@ -19,22 +21,20 @@ var command = {
       }
     ]
   },
-  run: function(options, done) {
+  run: callbackify(async options => {
     const Config = require("@truffle/config");
     const Networks = require("../networks");
 
     const config = Config.detect(options);
 
     if (options.clean) {
-      Networks.clean(config)
-        .then(() => done())
-        .catch(done);
-    } else {
-      Networks.display(config)
-        .then(() => done())
-        .catch(done);
+      await Networks.clean(config);
+
+      return;
     }
-  }
+
+    await Networks.display(config);
+  })
 };
 
 module.exports = command;


### PR DESCRIPTION
- Specify `develop` defaults in configDefaults
- Ensure we mark `networks` as object for "deep copy"
- Remove defaults from lib/commands/develop