### PR TITLE
Pass network as a named --network option instead of positionally

### DIFF
--- a/packages/core/lib/console-child.js
+++ b/packages/core/lib/console-child.js
@@ -2,15 +2,14 @@ const Command = require("../lib/command");
 const TruffleError = require("@truffle/error");
 const Config = require("@truffle/config");
 const Web3 = require("web3");
+const yargs = require("yargs");
 
 const input = process.argv[2].split(" -- ");
-
-const network = input[0].split(" ")[1];
 const inputStrings = input[1];
 
 //detect config so we can get the provider and resolver without having to serialize
 //and deserialize them
-const detectedConfig = Config.detect({ network: network });
+const detectedConfig = Config.detect({ network: yargs(input[0]).network });
 const customConfig = detectedConfig.networks.develop || {};
 
 //need host and port for provider url

--- a/packages/core/lib/console-child.js
+++ b/packages/core/lib/console-child.js
@@ -3,8 +3,10 @@ const TruffleError = require("@truffle/error");
 const Config = require("@truffle/config");
 const Web3 = require("web3");
 
-const inputStrings = process.argv[2];
-const network = process.argv[3];
+const input = process.argv[2].split(" -- ");
+
+const network = input[0].split(" ")[1];
+const inputStrings = input[1];
 
 //detect config so we can get the provider and resolver without having to serialize
 //and deserialize them

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -142,10 +142,12 @@ class Console extends EventEmitter {
 
     const spawnOptions = { stdio: ["inherit", "inherit", "inherit"] };
 
+    const spawnInput = "--network " + options.network + " -- " + inputStrings;
+
     try {
       spawnSync(
         "node",
-        ["--no-deprecation", childPath, inputStrings, options.network],
+        ["--no-deprecation", childPath, spawnInput],
         spawnOptions
       );
 


### PR DESCRIPTION
This PR moves the network value from being a positional argument sent to the child process to being a part of the input string that gets passed. The string is then split up and used as before in the `console-child.js` file. This code is in response to a comment on the original PR, but since it hasn't been decided whether we're doing it this way I wanted to make it a separate PR. Just wanted to save time in case we do go this route, we can just merge this in. 