### PR TITLE
Hide `truffle db` command

### DIFF
--- a/packages/core/lib/commands/index.js
+++ b/packages/core/lib/commands/index.js
@@ -4,7 +4,6 @@ module.exports = {
   config: require("./config"),
   console: require("./console"),
   create: require("./create"),
-  db: require("./db"),
   debug: require("./debug"),
   deploy: require("./deploy"),
   develop: require("./develop"),


### PR DESCRIPTION
To address the first concern in #3297 