### PR TITLE
Bug fix: Improve version checking during testing

### DIFF
--- a/packages/compile-solidity/compilerSupplier/index.js
+++ b/packages/compile-solidity/compilerSupplier/index.js
@@ -4,10 +4,11 @@ const semver = require("semver");
 
 const { Docker, Local, Native, VersionRange } = require("./loadingStrategies");
 
+const defaultSolcVersion = "0.5.16";
+
 class CompilerSupplier {
   constructor({ events, solcConfig }) {
     const { version, docker, compilerRoots, parser } = solcConfig;
-    const defaultSolcVersion = "0.5.16";
     this.events = events;
     this.parser = parser;
     this.version = version ? version : defaultSolcVersion;
@@ -118,6 +119,10 @@ class CompilerSupplier {
           latestRelease: list.latestRelease
         };
       });
+  }
+
+  static getDefaultVersion() {
+    return defaultSolcVersion;
   }
 }
 

--- a/packages/compile-solidity/compilerSupplier/rangeUtils.js
+++ b/packages/compile-solidity/compilerSupplier/rangeUtils.js
@@ -1,14 +1,14 @@
 const semver = require("semver");
-const CompilerSupplier = require("@truffle/compile-solidity/compilerSupplier/");
-const Native = require("@truffle/compile-solidity/compilerSupplier/loadingStrategies/Native");
-const Local = require("@truffle/compile-solidity/compilerSupplier/loadingStrategies/Local");
+const CompilerSupplier = require(".");
+const Native = require("./loadingStrategies/Native");
+const Local = require("./loadingStrategies/Local");
 const path = require("path");
 const fs = require("fs-extra");
 
-const Version = {
+const RangeUtils = {
   //takes a version string which may be native or local, and resolves
   //it to one which is (presumably) either a version or a version range
-  resolveVersionString: function (version) {
+  resolveToRange: function (version) {
     if (!version) {
       return CompilerSupplier.getDefaultVersion();
     }
@@ -22,28 +22,28 @@ const Version = {
     return version;
   },
 
-  //please pass in a resolved version only
-  //(may be an individual version or a range)
-  versionIsAtLeast: function (version, comparisonVersion) {
+  //parameter range may be either an individual version or a range
+  rangeContainsAtLeast: function (range, comparisonVersion) {
     //the following line works with prereleases
-    const individualAtLeast = semver.gte(version, comparisonVersion, {
+    const individualAtLeast = semver.gte(range, comparisonVersion, {
       includePrerelease: true,
       loose: true
     });
     //the following line doesn't, despite the flag, but does work with version ranges
     const rangeAtLeast =
-      semver.validRange(version) &&
-      !semver.ltr(comparisonVersion, version, {
+      semver.validRange(range) &&
+      !semver.ltr(comparisonVersion, range, {
         includePrerelease: true,
         loose: true
       }); //intersects will throw if given undefined so must ward against
     return individualAtLeast || rangeAtLeast;
   },
 
-  //please pass in a resolved version only
+  //parameter version may be either an individual version or a range
+  //first case is there to handle ranges, second to handle anything else
   coerce: function (version) {
     return semver.validRange(version) || semver.coerce(version).toString();
   }
 };
 
-module.exports = Version;
+module.exports = RangeUtils;

--- a/packages/core/lib/test.js
+++ b/packages/core/lib/test.js
@@ -12,7 +12,7 @@ const TestRunner = require("./testing/TestRunner");
 const TestResolver = require("./testing/TestResolver");
 const TestSource = require("./testing/TestSource");
 const SolidityTest = require("./testing/SolidityTest");
-const Version = require("./testing/Version");
+const RangeUtils = require("@truffle/compile-solidity/compilerSupplier/rangeUtils");
 const expect = require("@truffle/expect");
 const Migrate = require("@truffle/migrate");
 const Profiler = require("@truffle/compile-solidity/profiler");
@@ -211,8 +211,8 @@ const Test = {
     });
     if (config.compileAllDebug) {
       let versionString = ((compileConfig.compilers || {}).solc || {}).version;
-      versionString = Version.resolveVersionString(versionString);
-      if (Version.versionIsAtLeast(versionString, "0.6.3")) {
+      versionString = RangeUtils.resolveToRange(versionString);
+      if (RangeUtils.rangeContainsAtLeast(versionString, "0.6.3")) {
         compileConfig = compileConfig.merge({
           compilers: {
             solc: {

--- a/packages/core/lib/testing/Assert.sol
+++ b/packages/core/lib/testing/Assert.sol
@@ -2,7 +2,7 @@
 // This file taken from here: https://raw.githubusercontent.com/smartcontractproduction/sol-unit/master/contracts/src/Assertions.sol
 // It was renamed to Assert.sol by Tim Coulter. Refactored for solidity 0.5.0 by Cruz Molina.
 
-pragma solidity >= 0.4.15 < 0.7.0;
+pragma solidity >= 0.4.15 < 0.8.0;
 
 import "truffle/AssertString.sol";
 import "truffle/AssertBytes32.sol";

--- a/packages/core/lib/testing/AssertAddress.sol
+++ b/packages/core/lib/testing/AssertAddress.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity >= 0.4.15 < 0.7.0;
+pragma solidity >= 0.4.15 < 0.8.0;
 
 library AssertAddress {
 

--- a/packages/core/lib/testing/AssertAddressArray.sol
+++ b/packages/core/lib/testing/AssertAddressArray.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity >= 0.4.15 < 0.7.0;
+pragma solidity >= 0.4.15 < 0.8.0;
 
 library AssertAddressArray {
     

--- a/packages/core/lib/testing/AssertAddressPayableArray.sol
+++ b/packages/core/lib/testing/AssertAddressPayableArray.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.6.0;
+pragma solidity >= 0.6.0 < 0.8.0;
 
 library AssertAddressPayableArray {
 

--- a/packages/core/lib/testing/AssertBalance.sol
+++ b/packages/core/lib/testing/AssertBalance.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity >= 0.4.15 < 0.7.0;
+pragma solidity >= 0.4.15 < 0.8.0;
 
 library AssertBalance {
 

--- a/packages/core/lib/testing/AssertBool.sol
+++ b/packages/core/lib/testing/AssertBool.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity >= 0.4.15 < 0.7.0;
+pragma solidity >= 0.4.15 < 0.8.0;
 
 library AssertBool {
 

--- a/packages/core/lib/testing/AssertBytes32.sol
+++ b/packages/core/lib/testing/AssertBytes32.sol
@@ -1,4 +1,4 @@
-pragma solidity >= 0.4.15 < 0.7.0;
+pragma solidity >= 0.4.15 < 0.8.0;
 
 library AssertBytes32 {
 

--- a/packages/core/lib/testing/AssertBytes32Array.sol
+++ b/packages/core/lib/testing/AssertBytes32Array.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity >= 0.4.15 < 0.7.0;
+pragma solidity >= 0.4.15 < 0.8.0;
 
 library AssertBytes32Array {
     

--- a/packages/core/lib/testing/AssertGeneral.sol
+++ b/packages/core/lib/testing/AssertGeneral.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity >= 0.4.15 < 0.7.0;
+pragma solidity >= 0.4.15 < 0.8.0;
 
 library AssertGeneral {
 

--- a/packages/core/lib/testing/AssertInt.sol
+++ b/packages/core/lib/testing/AssertInt.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity >= 0.4.15 < 0.7.0;
+pragma solidity >= 0.4.15 < 0.8.0;
 
 library AssertInt {
 

--- a/packages/core/lib/testing/AssertIntArray.sol
+++ b/packages/core/lib/testing/AssertIntArray.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity >= 0.4.15 < 0.7.0;
+pragma solidity >= 0.4.15 < 0.8.0;
 
 library AssertIntArray {
 

--- a/packages/core/lib/testing/AssertString.sol
+++ b/packages/core/lib/testing/AssertString.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity >= 0.4.15 < 0.7.0;
+pragma solidity >= 0.4.15 < 0.8.0;
 
 library AssertString {
 

--- a/packages/core/lib/testing/AssertUint.sol
+++ b/packages/core/lib/testing/AssertUint.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity >= 0.4.15 < 0.7.0;
+pragma solidity >= 0.4.15 < 0.8.0;
 
 library AssertUint {
 

--- a/packages/core/lib/testing/AssertUintArray.sol
+++ b/packages/core/lib/testing/AssertUintArray.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity >= 0.4.15 < 0.7.0;
+pragma solidity >= 0.4.15 < 0.8.0;
 
 library AssertUintArray {
 

--- a/packages/core/lib/testing/Deployed.js
+++ b/packages/core/lib/testing/Deployed.js
@@ -1,9 +1,12 @@
 const web3Utils = require("web3-utils");
 const semver = require("semver");
 const Native = require("@truffle/compile-solidity/compilerSupplier/loadingStrategies/Native");
+const Local = require("@truffle/compile-solidity/compilerSupplier/loadingStrategies/Local");
+const path = require("path");
+const fs = require("fs-extra");
 
 var Deployed = {
-  makeSolidityDeployedAddressesLibrary: function(
+  makeSolidityDeployedAddressesLibrary: function (
     mapping,
     { solc: { version } }
   ) {
@@ -15,7 +18,7 @@ var Deployed = {
       "pragma solidity >= 0.5.0 < 0.7.0; \n\n library DeployedAddresses {" +
       "\n";
 
-    Object.keys(mapping).forEach(function(name) {
+    Object.keys(mapping).forEach(function (name) {
       var address = mapping[name];
 
       var body = "revert();";
@@ -37,18 +40,42 @@ var Deployed = {
 
     source += "}";
 
+    //note: default version is 0.5.16 which does not require any modifications
+    //so we can skip this block for it
     if (version) {
-      if (version === "native") version = new Native().load().version();
-      const v = semver.coerce(version);
-      if (semver.lt(v, "0.5.0")) source = source.replace(/ payable/gm, "");
-      source = source.replace(/0\.5\.0/gm, v);
+      //if version was native or local, must determine what version that
+      //actually corresponds to
+      if (version === "native") {
+        version = new Native().load().version();
+      } else if (fs.existsSync(version) && path.isAbsolute(version)) {
+        version = new Local({ version }).load().version();
+      }
+      //otherwise, version is a version string or version range string
+      const versionBefore = semver.satisfies(version, "0.4.x || <0.4.0", {
+        includePrerelease: true,
+        loose: true
+      });
+      const rangeBefore =
+        semver.validRange(version) &&
+        semver.gtr("0.5.0", versionString, {
+          includePrerelease: true,
+          loose: true
+        }); //gtr will throw if given undefined so must ward against
+      if (versionBefore || rangeBefore) {
+        //remove "payable"s if we're before 0.5.0
+        source = source.replace(/ payable/gm, "");
+      }
+      //regardless of version, replace all pragmas with the new version
+      const coercedVersion =
+        semver.validRange(version) || semver.coerce(version).toString();
+      source = source.replace(/0\.5\.0/gm, coercedVersion);
     }
 
     return source;
   },
 
   // Pulled from ethereumjs-util, but I don't want all its dependencies at the moment.
-  toChecksumAddress: function(address) {
+  toChecksumAddress: function (address) {
     address = address.toLowerCase().replace("0x", "");
     const hash = web3Utils.sha3(address).replace("0x", "");
     var ret = "0x";

--- a/packages/core/lib/testing/Deployed.js
+++ b/packages/core/lib/testing/Deployed.js
@@ -15,7 +15,7 @@ var Deployed = {
     var source = "";
     source +=
       "//SPDX-License-Identifier: MIT\n" +
-      "pragma solidity >= 0.5.0 < 0.7.0; \n\n library DeployedAddresses {" +
+      "pragma solidity >= 0.5.0 < 0.8.0; \n\n library DeployedAddresses {" +
       "\n";
 
     Object.keys(mapping).forEach(function (name) {

--- a/packages/core/lib/testing/Deployed.js
+++ b/packages/core/lib/testing/Deployed.js
@@ -39,7 +39,7 @@ var Deployed = {
     version = Version.resolveVersionString(version);
     if (!Version.versionIsAtLeast(version, "0.5.0")) {
       //remove "payable"s if we're before 0.5.0
-      source = source.replace(/ payable/gm, "");
+      source = source.replace(/address payable/gm, "address");
     }
     //regardless of version, replace all pragmas with the new version
     const coercedVersion = Version.coerce(version);

--- a/packages/core/lib/testing/Deployed.js
+++ b/packages/core/lib/testing/Deployed.js
@@ -1,5 +1,5 @@
 const web3Utils = require("web3-utils");
-const Version = require("./Version");
+const RangeUtils = require("@truffle/compile-solidity/compilerSupplier/rangeUtils");
 
 var Deployed = {
   makeSolidityDeployedAddressesLibrary: function (
@@ -36,13 +36,13 @@ var Deployed = {
 
     source += "}";
 
-    version = Version.resolveVersionString(version);
-    if (!Version.versionIsAtLeast(version, "0.5.0")) {
+    version = RangeUtils.resolveToRange(version);
+    if (!RangeUtils.rangeContainsAtLeast(version, "0.5.0")) {
       //remove "payable"s if we're before 0.5.0
       source = source.replace(/address payable/gm, "address");
     }
     //regardless of version, replace all pragmas with the new version
-    const coercedVersion = Version.coerce(version);
+    const coercedVersion = RangeUtils.coerce(version);
     source = source.replace(/0\.5\.0/gm, coercedVersion);
 
     return source;

--- a/packages/core/lib/testing/NewSafeSend.sol
+++ b/packages/core/lib/testing/NewSafeSend.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity >= 0.5.0 < 0.7.0;
+pragma solidity >= 0.5.0 < 0.8.0;
 
 contract NewSafeSend {
   address payable public recipient;

--- a/packages/core/lib/testing/SolidityTest.js
+++ b/packages/core/lib/testing/SolidityTest.js
@@ -1,7 +1,7 @@
 const TestCase = require("mocha/lib/test.js");
 const Suite = require("mocha/lib/suite.js");
 const Deployer = require("@truffle/deployer");
-const Version = require("./Version");
+const RangeUtils = require("@truffle/compile-solidity/compilerSupplier/rangeUtils");
 const compile = require("@truffle/compile-solidity/new");
 const { shimContract } = require("@truffle/compile-solidity/legacy/shims");
 const path = require("path");
@@ -111,8 +111,8 @@ const SolidityTest = {
     debug("compiling");
     const config = runner.config;
     let solcVersion = config.compilers.solc.version;
-    solcVersion = Version.resolveVersionString(solcVersion);
-    SafeSend = Version.versionIsAtLeast(solcVersion, "0.5.0")
+    solcVersion = RangeUtils.resolveToRange(solcVersion);
+    SafeSend = RangeUtils.rangeContainsAtLeast(solcVersion, "0.5.0")
       ? "NewSafeSend.sol"
       : "OldSafeSend.sol";
 

--- a/packages/core/lib/testing/Version.js
+++ b/packages/core/lib/testing/Version.js
@@ -1,0 +1,49 @@
+const semver = require("semver");
+const CompilerSupplier = require("@truffle/compile-solidity/compilerSupplier/");
+const Native = require("@truffle/compile-solidity/compilerSupplier/loadingStrategies/Native");
+const Local = require("@truffle/compile-solidity/compilerSupplier/loadingStrategies/Local");
+const path = require("path");
+const fs = require("fs-extra");
+
+const Version = {
+  //takes a version string which may be native or local, and resolves
+  //it to one which is (presumably) either a version or a version range
+  resolveVersionString: function (version) {
+    if (!version) {
+      return CompilerSupplier.getDefaultVersion();
+    }
+    //if version was native or local, must determine what version that
+    //actually corresponds to
+    if (version === "native") {
+      return new Native().load().version();
+    } else if (fs.existsSync(version) && path.isAbsolute(version)) {
+      return new Local({ version }).load().version();
+    }
+    return version;
+  },
+
+  //please pass in a resolved version only
+  //(may be an individual version or a range)
+  versionIsAtLeast: function (version, comparisonVersion) {
+    //the following line works with prereleases
+    const individualAtLeast = semver.gte(version, comparisonVersion, {
+      includePrerelease: true,
+      loose: true
+    });
+    //the following line doesn't, despite the flag, but does work with version ranges
+    const rangeAtLeast =
+      semver.validRange(version) &&
+      !semver.ltr(comparisonVersion, version, {
+        includePrerelease: true,
+        loose: true
+      }); //intersects will throw if given undefined so must ward against
+    return individualAtLeast || rangeAtLeast;
+  },
+
+  //please pass in a resolved version only
+  coerce: function (version) {
+    return semver.validRange(version) || semver.coerce(version).toString();
+  }
+};
+
+module.exports = Version;


### PR DESCRIPTION
This PR is in response to #3292.  It attempts to make version-checking in `truffle test` better and more consistent.  Right now, `test.js` and `testing/Deployed.js` both attempt to check what Solidity version is being used, but they do so in different ways, each with different pitfalls.  This PR has them do it the same way, in a way that should be more robust than what either was doing before.

Note that I basically relied on copy-paste here.  However it may be worth factoring this somehow?  I figured I'd PR this initial version and we could perhaps figure that out later.

Bascailly, before, `test.js` wanted to know whether the version was at least 0.6.3, while `testing/Deployed.js` wanted to know whether it was prior to 0.5.0.  The former could handle versions and version ranges, but not the native or local cases.  The latter could handle native and local, but might have encountered problems on version ranges.  I've made the two now work basically the same by combining the methods that the two used.

So, now, both will handle native and local by using the appropriate loading strategy to determine what version that corresponds to.  Note I didn't make it work this way in general, despite how that would have cut down on code, because that might involve a network connection for a specified version or version range.  (Also, note that both of these continue to rely on the fact that the default version is 0.5.16...)

As for individual versions and version ranges, those are now handled using appropriate semver functions.  Note that I used `semver.gtr` to make sure that, for a version range, the replacement only happens if the version is *entirely* before 0.5.0.  ~~Also on the individual version check, I wrote `0.4.x || <0.4.0` rather than `<0.5.0` in order to handle prereleases better.~~ (That last bit ended up being scrapped, see comments below.)

Also, while I was at it, I changed the pragmas in `testing` to say `< 0.8.0` instead of `< 0.7.0`.  That's not related to the main point of this PR but I thew it in there.

Note: Not sure if I tested this enough?