### PR TITLE
Add no-op prepare script to packages missing it

### DIFF
--- a/packages/compile-solidity/package.json
+++ b/packages/compile-solidity/package.json
@@ -11,6 +11,7 @@
   "version": "4.3.19",
   "main": "index.js",
   "scripts": {
+    "prepare": "exit 0",
     "test": "./scripts/test.sh"
   },
   "dependencies": {

--- a/packages/compile-vyper/package.json
+++ b/packages/compile-vyper/package.json
@@ -7,6 +7,7 @@
   "version": "1.0.68",
   "main": "index.js",
   "scripts": {
+    "prepare": "exit 0",
     "test": "mocha"
   },
   "dependencies": {

--- a/packages/contract-sources/package.json
+++ b/packages/contract-sources/package.json
@@ -3,7 +3,9 @@
   "version": "0.1.7",
   "description": "Utility for finding all contracts within a directory",
   "main": "index.js",
-  "scripts": {},
+  "scripts": {
+    "prepare": "exit 0"
+  },
   "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/contract-sources",
   "keywords": [
     "ethereum",

--- a/packages/contract-tests/package.json
+++ b/packages/contract-tests/package.json
@@ -11,6 +11,7 @@
     "url": "git+https://github.com/trufflesuite/truffle.git"
   },
   "scripts": {
+    "prepare": "exit 0",
     "test": "./scripts/test.sh",
     "test:debug": "$(yarn bin)/mocha --inspect-brk",
     "test:trace": "$(yarn bin)/mocha --trace-warnings"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,6 +13,7 @@
     "truffle-exec": "./exec.js"
   },
   "scripts": {
+    "prepare": "exit 0",
     "test": "mocha ./test/** ./test/**/*"
   },
   "dependencies": {

--- a/packages/debug-utils/package.json
+++ b/packages/debug-utils/package.json
@@ -11,6 +11,7 @@
   "version": "4.2.5",
   "main": "index.js",
   "scripts": {
+    "prepare": "exit 0",
     "test": "mocha"
   },
   "dependencies": {

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -11,6 +11,7 @@
   "version": "3.1.35",
   "main": "index.js",
   "scripts": {
+    "prepare": "exit 0",
     "test": "mocha --no-warnings --timeout 10000 --exit"
   },
   "dependencies": {

--- a/packages/environment/package.json
+++ b/packages/environment/package.json
@@ -11,6 +11,9 @@
   },
   "version": "0.2.21",
   "main": "index.js",
+  "scripts": {
+    "prepare": "exit 0"
+  },
   "dependencies": {
     "@truffle/artifactor": "^4.0.74",
     "@truffle/error": "^0.0.10",

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -6,6 +6,9 @@
   "keywords": [],
   "author": "Nick D'Andrea and Tyler Feickert",
   "license": "ISC",
+  "scripts": {
+    "prepare": "exit 0"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -11,6 +11,7 @@
   "version": "0.0.14",
   "main": "index.js",
   "scripts": {
+    "prepare": "exit 0",
     "test": "mocha"
   },
   "devDependencies": {

--- a/packages/external-compile/package.json
+++ b/packages/external-compile/package.json
@@ -11,6 +11,7 @@
   "version": "1.0.34",
   "main": "index.js",
   "scripts": {
+    "prepare": "exit 0",
     "test": "mocha"
   },
   "dependencies": {

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -11,6 +11,7 @@
   "version": "3.1.35",
   "main": "index.js",
   "scripts": {
+    "prepare": "exit 0",
     "test": "mocha ./test/* ./test/**/*"
   },
   "dependencies": {

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -11,6 +11,7 @@
   "version": "0.2.20",
   "main": "index.js",
   "scripts": {
+    "prepare": "exit 0",
     "test": "mocha"
   },
   "types": "./typings/index.d.ts",

--- a/packages/reporters/package.json
+++ b/packages/reporters/package.json
@@ -6,7 +6,9 @@
   "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/reporters",
   "version": "1.1.0",
   "main": "index.js",
-  "scripts": {},
+  "scripts": {
+    "prepare": "exit 0"
+  },
   "dependencies": {
     "node-emoji": "^1.8.1",
     "ora": "^3.4.0",

--- a/packages/require/package.json
+++ b/packages/require/package.json
@@ -11,6 +11,7 @@
   "version": "2.0.50",
   "main": "require.js",
   "scripts": {
+    "prepare": "exit 0",
     "test": "mocha"
   },
   "dependencies": {

--- a/packages/solidity-utils/package.json
+++ b/packages/solidity-utils/package.json
@@ -3,7 +3,9 @@
   "version": "1.3.16",
   "description": "Utilities for Solidity contracts",
   "main": "index.js",
-  "scripts": {},
+  "scripts": {
+    "prepare": "exit 0"
+  },
   "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/solidity-utils",
   "keywords": [
     "ethereum",

--- a/packages/workflow-compile/package.json
+++ b/packages/workflow-compile/package.json
@@ -11,6 +11,7 @@
   "version": "2.1.48",
   "main": "index.js",
   "scripts": {
+    "prepare": "exit 0",
     "test": "mocha"
   },
   "dependencies": {


### PR DESCRIPTION
Thanks to @seesemichaelj for verifying that `exit 0` should be fine on Windows :)

See #3306 for something of a write-up on why this is necessary.