### PR TITLE
Bug fix: Better locate allocations for decoding function return values

### DIFF
--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -105,9 +105,8 @@ export class WireDecoder {
     );
     this.deployedContexts = Object.assign(
       {},
-      ...Object.values(this.contexts).map(
-        context =>
-          !context.isConstructor ? { [context.context]: context } : {}
+      ...Object.values(this.contexts).map(context =>
+        !context.isConstructor ? { [context.context]: context } : {}
       )
     );
 
@@ -889,8 +888,7 @@ export class ContractDecoder {
     abi: AbiData.FunctionAbiEntry,
     data: string,
     options: DecoderTypes.ReturnOptions = {},
-    additionalContexts: Contexts.DecoderContexts = {},
-    contextHash: string = this.contextHash
+    additionalContexts: Contexts.DecoderContexts = {}
   ): Promise<ReturndataDecoding[]> {
     abi = {
       type: "function",
@@ -902,10 +900,10 @@ export class ContractDecoder {
 
     const selector = AbiData.Utils.abiSelector(abi);
     let allocation: AbiData.Allocate.ReturndataAllocation;
-    if (contextHash !== undefined) {
-      allocation = this.allocations.calldata.functionAllocations[contextHash][
-        selector
-      ].output;
+    if (this.contextHash !== undefined) {
+      allocation = this.allocations.calldata.functionAllocations[
+        this.contextHash
+      ][selector].output;
     } else {
       allocation = this.noBytecodeAllocations[selector].output;
     }
@@ -1194,12 +1192,12 @@ export class ContractInstanceDecoder {
       this.compilation.sources.every(source => !source || source.ast)
     ) {
       //WARNING: untyped code in this block!
-      let asts: Ast.AstNode[] = this.compilation.sources.map(
-        source => (source ? source.ast : undefined)
+      let asts: Ast.AstNode[] = this.compilation.sources.map(source =>
+        source ? source.ast : undefined
       );
       let instructions = SolidityUtils.getProcessedInstructionsForBinary(
-        this.compilation.sources.map(
-          source => (source ? source.source : undefined)
+        this.compilation.sources.map(source =>
+          source ? source.source : undefined
         ),
         this.contractCode,
         SolidityUtils.getHumanReadableSourceMap(this.contract.deployedSourceMap)
@@ -1657,8 +1655,7 @@ export class ContractInstanceDecoder {
       abi,
       data,
       options,
-      this.additionalContexts,
-      this.contextHash
+      this.additionalContexts
     );
   }
 

--- a/packages/decoder/test/current/contracts/WireTest.sol
+++ b/packages/decoder/test/current/contracts/WireTest.sol
@@ -12,6 +12,10 @@ contract WireTestParent {
   //no constructor
 
   event Overridden(uint);
+
+  function inheritedReturn() public pure returns (uint) {
+    return 1;
+  }
 }
 
 abstract contract WireTestAbstract {
@@ -20,6 +24,8 @@ abstract contract WireTestAbstract {
   event AbstractOverridden(uint indexed);
 
   function danger() public virtual;
+
+  function overriddenReturn() public pure virtual returns (uint);
 }
 
 struct GlobalStruct {
@@ -177,6 +183,10 @@ contract WireTest is WireTestParent, WireTestAbstract {
 
   function returnsStuff() public pure returns (Triple memory, Ternary) {
     return (Triple(-1, 0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef, hex"deadbeef"), Ternary.No);
+  }
+
+  function overriddenReturn() public pure override returns (uint) {
+    return 2;
   }
 
   receive() external payable {


### PR DESCRIPTION
(Sorry about all the `prettier` changes; the actual changes here, aside from the changes to the tests, are:
1. The deletion of line 893
2. The change to lines 905-908 (now 903-906)
3. The deletion of line 1661.)

This PR is in response to an issue pointed out by @tcoulter where the decoder could crash when decoding return values in certain situations.  Specifically, if contract `Derived` extends contract `Base`, where `Base` has no bytecode associated with it (say it's abstract or an interface), and you set up a decoder for `Base` but for an instance of `Derived`, then you'd get a crash when attempting to decode return values with it.

The reason is that, since `Base` has no bytecode, when the instance decoder is set up, it looks as the bytecode of the instance to determine a context hash, which is used for certain purposes.  However here it was used inappropriately -- it was used to look up the return value allocations, even though they won't be found there.  I can't tell why I originally did it this way; as best I can tell, this was just an error on my part.  The solution as best I can tell is to disregard the context hash of the instance decoder, for which I'm simply not seeing any relevance, and just use the context hash of the contract decoder, when performing the lookup.  This seems to work fine.

I also added a test of this functionality.  Thanks again to @tcoulter for pointing this out!