### PR TITLE
Set context vars

### DIFF
--- a/packages/core/lib/console-child.js
+++ b/packages/core/lib/console-child.js
@@ -11,8 +11,7 @@ const inputStrings = input[1];
 //and deserialize them
 const detectedConfig = Config.detect({ network: yargs(input[0]).argv.network });
 const customConfig = detectedConfig.networks.develop || {};
-// console.log("custom config? " + JSON.stringify(customConfig));
-// console.log("detected config " + JSON.stringify(detectedConfig));
+
 //need host and port for provider url
 const ganacheOptions = {
   host: customConfig.host || "127.0.0.1",

--- a/packages/core/lib/console-child.js
+++ b/packages/core/lib/console-child.js
@@ -9,9 +9,10 @@ const inputStrings = input[1];
 
 //detect config so we can get the provider and resolver without having to serialize
 //and deserialize them
-const detectedConfig = Config.detect({ network: yargs(input[0]).network });
+const detectedConfig = Config.detect({ network: yargs(input[0]).argv.network });
 const customConfig = detectedConfig.networks.develop || {};
-
+// console.log("custom config? " + JSON.stringify(customConfig));
+// console.log("detected config " + JSON.stringify(detectedConfig));
 //need host and port for provider url
 const ganacheOptions = {
   host: customConfig.host || "127.0.0.1",

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -60,11 +60,7 @@ class Console extends EventEmitter {
   }
 
   setContextVars(obj) {
-    const context = {};
-    Object.keys(obj || {}).forEach(function (key) {
-      context[key] = obj[key];
-    });
-    return context;
+    return { ...obj };
   }
 
   start() {

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -60,17 +60,21 @@ class Console extends EventEmitter {
 
   start() {
     try {
-      this.interfaceAdapter.getAccounts().then(fetchedAccounts => {
-        this.repl = repl.start({
-          prompt: "truffle(" + this.options.network + ")> ",
-          eval: this.interpret.bind(this)
-        });
+      this.repl = repl.start({
+        prompt: "truffle(" + this.options.network + ")> ",
+        eval: this.interpret.bind(this)
+      });
 
+      this.interfaceAdapter.getAccounts().then(fetchedAccounts => {
         this.repl.context.web3 = this.web3;
         this.repl.context.interfaceAdapter = this.interfaceAdapter;
         this.repl.context.accounts = fetchedAccounts;
+      });
+      this.provision();
 
-        this.provision();
+      //want repl to exit when it receives an exit command
+      this.repl.on("exit", () => {
+        process.exit();
       });
     } catch (error) {
       this.options.logger.log(
@@ -160,10 +164,7 @@ class Console extends EventEmitter {
     } catch (err) {
       callback(err);
     }
-    //want repl to exit when it receives an exit command
-    this.repl.on("exit", () => {
-      process.exit();
-    });
+
     //display prompt when child repl process is finished
     this.repl.displayPrompt();
   }

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -61,8 +61,6 @@ class Console extends EventEmitter {
   start() {
     try {
       this.interfaceAdapter.getAccounts().then(fetchedAccounts => {
-        const abstractions = this.provision();
-
         this.repl = repl.start({
           prompt: "truffle(" + this.options.network + ")> ",
           eval: this.interpret.bind(this)
@@ -72,7 +70,7 @@ class Console extends EventEmitter {
         this.repl.context.interfaceAdapter = this.interfaceAdapter;
         this.repl.context.accounts = fetchedAccounts;
 
-        this.resetContractsInConsoleContext(abstractions);
+        this.provision();
       });
     } catch (error) {
       this.options.logger.log(
@@ -131,11 +129,9 @@ class Console extends EventEmitter {
     });
 
     // make sure the repl gets the new contracts in its context
-    if (this.repl) {
-      Object.keys(contextVars || {}).forEach(key => {
-        this.repl.context[key] = contextVars[key];
-      });
-    }
+    Object.keys(contextVars || {}).forEach(key => {
+      this.repl.context[key] = contextVars[key];
+    });
   }
 
   runSpawn(inputStrings, options, callback) {

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -42,7 +42,6 @@ class Console extends EventEmitter {
       "build_directory"
     ]);
 
-    this.context = {};
     this.options = options;
 
     this.command = new Command(tasks);
@@ -73,13 +72,11 @@ class Console extends EventEmitter {
           eval: this.interpret.bind(this)
         });
 
-        this.resetContractsInConsoleContext(abstractions);
-
-        // set these repl context vars after setting contracts to
-        // make sure they don't get overwritten
         this.repl.context.web3 = this.web3;
         this.repl.context.interfaceAdapter = this.interfaceAdapter;
         this.repl.context.accounts = fetchedAccounts;
+
+        this.resetContractsInConsoleContext(abstractions);
       });
     } catch (error) {
       this.options.logger.log(
@@ -137,11 +134,12 @@ class Console extends EventEmitter {
       contextVars[abstraction.contract_name] = abstraction;
     });
 
-    this.context = this.setContextVars(contextVars);
-
     // make sure the repl gets the new contracts in its context
     if (this.repl) {
-      this.repl.context = this.context;
+      this.repl.context = {
+        ...this.repl.context,
+        ...this.setContextVars(contextVars)
+      };
     }
   }
 

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -149,7 +149,7 @@ class Console extends EventEmitter {
       childPath = path.join(__dirname, "../lib/console-child.js");
     }
 
-    const spawnOptions = { stdio: ["inherit", "inherit", "inherit"] };
+    const spawnOptions = { stdio: ["inherit", "inherit", "pipe"] };
 
     const spawnInput = "--network " + options.network + " -- " + inputStrings;
     try {

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -58,10 +58,6 @@ class Console extends EventEmitter {
     });
   }
 
-  setContextVars(obj) {
-    return { ...obj };
-  }
-
   start() {
     try {
       this.interfaceAdapter.getAccounts().then(fetchedAccounts => {
@@ -136,10 +132,9 @@ class Console extends EventEmitter {
 
     // make sure the repl gets the new contracts in its context
     if (this.repl) {
-      this.repl.context = {
-        ...this.repl.context,
-        ...this.setContextVars(contextVars)
-      };
+      Object.keys(contextVars || {}).forEach(key => {
+        this.repl.context[key] = contextVars[key];
+      });
     }
   }
 


### PR DESCRIPTION
This PR seeks to allow the re-introduction of the child process for commands from #3255, the `spawn-repl` branch, while fixing a  few issues: 

1. A bug where Artifacts were not available within the `truffle develop` and `truffle console` commands. It appears the context containing the contracts' artifacts was not properly being set for the new repl. 

To test that this bug is fixed: 
a) Run `truffle console` or `truffle develop` in an existing project that has already migrated its contracts. 
b) Enter the name of one of its contracts.
Expected: The artifact for that contract is printed in your terminal. 

a) Run `truffle console` or `truffle develop` in an existing project for which a migration has not been run. 
b) Enter the name of a contract in the project.
Expected: Error thrown
c) Run the `migrate` command
d) Enter the name of a contract in the project
Expected: The artifact is printed in your terminal.


2. This PR also updates the `stdio` handling of `stderr` in the spawn process, to keep warnings that have already been consoled in the parent process from being printed again. Specifically, this is in relation to the error about having two config files: 
```
Warning: Both truffle-config.js and truffle.js were found. Using truffle-config.js.
```

3. This PR also pull this `this.provision()` function call outside of the try/catch it was in, to ensure that if there is an error in that function that we are able to see it. 

4. This PR also fixes the use of yargs for properly getting and passing the network in the `console-child` file. (good catch on this bug @cds-amal!)

5. This work additionally ensures that assignments/scripts created in Javascript inside the child process persist between commands. You should be able to run `const [ownerAccount] = accounts` and access `ownerAccount` throughout your `develop` or `console` session.

Many thanks to @cds-amal for letting me bounce ideas off of him while figuring out this bug!