### PR TITLE
Remove node-dir dependency from debug-utils

### DIFF
--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -1,6 +1,4 @@
 var OS = require("os");
-var dir = require("node-dir");
-var path = require("path");
 var debug = require("debug")("debug-utils");
 var BN = require("bn.js");
 var util = require("util");
@@ -77,28 +75,6 @@ const DEFAULT_TAB_WIDTH = 8;
 
 var DebugUtils = {
   truffleColors, //make these externally available
-
-  gatherArtifacts: async function (config) {
-    // Gather all available contract artifacts
-    let files = await dir.promiseFiles(config.contracts_build_directory);
-
-    var contracts = files
-      .filter(file_path => {
-        return path.extname(file_path) === ".json";
-      })
-      .map(file_path => {
-        return path.basename(file_path, ".json");
-      })
-      .map(contract_name => {
-        return config.resolver.require(contract_name);
-      });
-
-    await Promise.all(
-      contracts.map(abstraction => abstraction.detectNetwork())
-    );
-
-    return contracts;
-  },
 
   //attempts to test whether a given compilation is a real compilation,
   //i.e., was compiled all at once.

--- a/packages/debug-utils/package.json
+++ b/packages/debug-utils/package.json
@@ -20,8 +20,7 @@
     "chalk": "^2.4.2",
     "debug": "^4.1.0",
     "highlight.js": "^9.15.8",
-    "highlightjs-solidity": "^1.0.18",
-    "node-dir": "0.1.17"
+    "highlightjs-solidity": "^1.0.18"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11369,7 +11369,7 @@ node-addon-api@^2.0.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
   integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
 
-node-dir@0.1.17, node-dir@^0.1.16:
+node-dir@^0.1.16:
   version "0.1.17"
   resolved "https://registry.yarnpkg.com/node-dir/-/node-dir-0.1.17.tgz#5f5665d93351335caabef8f1c554516cf5f1e4e5"
   integrity sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=


### PR DESCRIPTION
This PR removes the `gatherArtifacts` function from `debug-utils`, together with the `node-dir` dependency.  Instead the `gatherArtifacts` code is recreated separately in both places that use it (`core/lib/debug` and `debugger/test`).  Since we have basically this same code duplicated in so many places already, one more isn't really any harm...

This should address #3293.