### PR TITLE
Enhancement: Add selfdestruct recipients to addresses affected

### DIFF
--- a/packages/debugger/lib/helpers/index.js
+++ b/packages/debugger/lib/helpers/index.js
@@ -141,3 +141,12 @@ export function isCreateMnemonic(op) {
   const creates = ["CREATE", "CREATE2"];
   return creates.includes(op);
 }
+
+/*
+ * Given a mmemonic, determine whether it's the mnemonic of a self-destruct
+ * instruction
+ */
+export function isSelfDestructMnemonic(op) {
+  const creates = ["SELFDESTRUCT", "SUICIDE"]; //latter name shouldn't be used anymore but let's be safe
+  return creates.includes(op);
+}

--- a/packages/debugger/lib/session/sagas/index.js
+++ b/packages/debugger/lib/session/sagas/index.js
@@ -159,7 +159,9 @@ function* fetchTx(txHash) {
 
   //get addresses created/called during transaction
   debug("processing trace for addresses");
-  let { calls, creations } = yield* trace.processTrace(result.trace);
+  let { calls, creations, selfdestructs } = yield* trace.processTrace(
+    result.trace
+  );
   //add in the address of the call itself (if a call)
   if (result.address && !calls.includes(result.address)) {
     calls.push(result.address);
@@ -175,7 +177,7 @@ function* fetchTx(txHash) {
   }
 
   let blockNumber = result.block.number.toString(); //a BN is not accepted
-  let addresses = [...calls, ...creations];
+  let addresses = [...calls, ...creations, ...selfdestructs];
   let creationStartIndex = calls.length;
   debug("obtaining binaries");
   let binaries = yield* web3.obtainBinaries(addresses, blockNumber);


### PR DESCRIPTION
This PR adds self-destruct recipients to the list of addresses affected.

This is pretty straightforward; however I decided to rewrite the loop in `processTrace` so that it's only running over the trace once instead of multiple times.

I also restored the `isSelfDestructMnemonic` function which I had previously deleted for lack of use.

I didn't bother writing a test for this but I did test it manually.