### PR TITLE
Fix for multiline import parsing

### DIFF
--- a/packages/compile-solidity/parser.js
+++ b/packages/compile-solidity/parser.js
@@ -49,13 +49,25 @@ module.exports = {
     // Filter out our forced import, then get the import paths of the rest.
     const imports = errors
       .filter(({ message }) => !message.includes(failingImportFileName))
-      .map(({ formattedMessage }) => {
-        const matches = formattedMessage.match(
-          /import[^'"]?.*("|')([^'"]+)("|')/
-        );
-
-        // Return the item between the quotes.
-        if (matches) return matches[2];
+      .map(({ formattedMessage, message }) => {
+        // Multiline import check which works for solcjs and solc
+        // solcjs: ^ (Relevant source part starts here and spans across multiple lines)
+        // solc: Spanning multiple lines.
+        if (formattedMessage.includes("multiple lines")) {
+          // Parse the import filename from the error message, this does not include the full path to the import
+          const matches = message.match(/Source[^'"]?.*?("|')([^'"]+)("|')/);
+          if (matches) {
+            // Extract the full path by matching against body with the import filename
+            const fullPathRegex = new RegExp(`("|')(.*${matches[2]})("|')`);
+            const importMatches = body.match(fullPathRegex);
+            if (importMatches) return importMatches[2];
+          }
+        } else {
+          const matches = formattedMessage.match(
+            /import[^'"]?.*("|')([^'"]+)("|')/
+          );
+          if (matches) return matches[2];
+        }
       })
       .filter(match => match !== undefined);
 

--- a/packages/compile-solidity/parser.js
+++ b/packages/compile-solidity/parser.js
@@ -66,6 +66,8 @@ module.exports = {
           const matches = formattedMessage.match(
             /import[^'"]?.*("|')([^'"]+)("|')/
           );
+
+          // Return the item between the quotes.
           if (matches) return matches[2];
         }
       })

--- a/packages/compile-solidity/test/sources/v0.4.15/MyContract.sol
+++ b/packages/compile-solidity/test/sources/v0.4.15/MyContract.sol
@@ -6,6 +6,13 @@ import "../../../path/to/AnotherDep.sol";
 import "ethpmpackage/Contract.sol";
 import { Something as MyGarbage } from "./somePath.sol";
 import"./someImportWithNoSpace.sol";
+import {
+    Something as RelativeMultilineImport
+} from "../../someRelativeMultilineImport.sol";
+import {
+    Something as AbsoluteMultilineImport
+} from "someAbsoluteMultilineImport.sol";
+
 
 contract MyContract {
 

--- a/packages/compile-solidity/test/test_parser.js
+++ b/packages/compile-solidity/test/test_parser.js
@@ -14,7 +14,9 @@ describe("Parser", () => {
     "../../../path/to/AnotherDep.sol",
     "ethpmpackage/Contract.sol",
     "./somePath.sol",
-    "./someImportWithNoSpace.sol"
+    "./someImportWithNoSpace.sol",
+    "../../someRelativeMultilineImport.sol",
+    "someAbsoluteMultilineImport.sol"
   ];
 
   before("get code", async () => {

--- a/packages/truffle/test/scenarios/commands/install.js
+++ b/packages/truffle/test/scenarios/commands/install.js
@@ -19,5 +19,5 @@ describe("truffle install [ @standalone ]", () => {
       path.join(config.working_directory, "installed_contracts")
     );
     assert(theInstallDirExists);
-  }).timeout(20000);
+  }).timeout(30000);
 });


### PR DESCRIPTION
Fix for https://github.com/trufflesuite/truffle/issues/3082.

Not very pretty. Both `solcjs` and `solc` only return the first line of the statement in `formattedMessage` so its not possible to grab the import. This detects multiline imports, parses the import name out of `message` and then parses the full path out of the import from `body`.

Single line import handling isn't changed.

Example of a formattedMessage for multiline import using `solcjs`:

```
  { component: 'general',
  formattedMessage:
   'ParsedContract.sol:3:1: ParserError: Source "@openzeppelin/contracts/utils/ReentrancyGuard.sol" not found: File import callback not supported\nimport { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";\n^----------------------------------------------------------------------------------^\n',
  message:
   'Source "@openzeppelin/contracts/utils/ReentrancyGuard.sol" not found: File import callback not supported',
  severity: 'error',
  sourceLocation: { end: 109, file: 'ParsedContract.sol', start: 25 },
  type: 'ParserError' }
```