### PR TITLE
Enhancement: Put (encoded) constructor arguments in affectedInstances

### DIFF
--- a/packages/debugger/lib/evm/actions/index.js
+++ b/packages/debugger/lib/evm/actions/index.js
@@ -43,12 +43,13 @@ export function addInstance(address, context, binary) {
 }
 
 export const ADD_AFFECTED_INSTANCE = "EVM_ADD_AFFECTED_INSTANCE";
-export function addAffectedInstance(address, context, binary) {
+export function addAffectedInstance(address, context, binary, constructorArgs) {
   return {
     type: ADD_AFFECTED_INSTANCE,
     address,
     context,
-    binary
+    binary,
+    constructorArgs
   };
 }
 

--- a/packages/debugger/lib/evm/actions/index.js
+++ b/packages/debugger/lib/evm/actions/index.js
@@ -43,13 +43,20 @@ export function addInstance(address, context, binary) {
 }
 
 export const ADD_AFFECTED_INSTANCE = "EVM_ADD_AFFECTED_INSTANCE";
-export function addAffectedInstance(address, context, binary, constructorArgs) {
+export function addAffectedInstance(
+  address,
+  context,
+  binary,
+  creationBinary,
+  creationContext
+) {
   return {
     type: ADD_AFFECTED_INSTANCE,
     address,
     context,
     binary,
-    constructorArgs
+    creationBinary, //may be undefined
+    creationContext
   };
 }
 

--- a/packages/debugger/lib/evm/reducers.js
+++ b/packages/debugger/lib/evm/reducers.js
@@ -147,7 +147,13 @@ const DEFAULT_AFFECTED_INSTANCES = { byAddress: {} };
 function affectedInstances(state = DEFAULT_AFFECTED_INSTANCES, action) {
   switch (action.type) {
     case actions.ADD_AFFECTED_INSTANCE:
-      const { address, binary, context, constructorArgs } = action;
+      const {
+        address,
+        binary,
+        context,
+        creationBinary,
+        creationContext
+      } = action;
       return {
         byAddress: {
           ...state.byAddress,
@@ -155,7 +161,8 @@ function affectedInstances(state = DEFAULT_AFFECTED_INSTANCES, action) {
             address,
             binary,
             context,
-            constructorArgs
+            creationBinary, //may be undefined
+            creationContext
           }
         }
       };

--- a/packages/debugger/lib/evm/reducers.js
+++ b/packages/debugger/lib/evm/reducers.js
@@ -147,14 +147,15 @@ const DEFAULT_AFFECTED_INSTANCES = { byAddress: {} };
 function affectedInstances(state = DEFAULT_AFFECTED_INSTANCES, action) {
   switch (action.type) {
     case actions.ADD_AFFECTED_INSTANCE:
-      const { address, binary, context } = action;
+      const { address, binary, context, constructorArgs } = action;
       return {
         byAddress: {
           ...state.byAddress,
           [address]: {
             address,
             binary,
-            context
+            context,
+            constructorArgs
           }
         }
       };

--- a/packages/debugger/lib/evm/sagas/index.js
+++ b/packages/debugger/lib/evm/sagas/index.js
@@ -50,15 +50,29 @@ export function* addInstance(address, binary) {
  * Adds known deployed instance of binary at address
  * to list of affected instances, *not* to codex
  *
+ * creationBinary may also be specified
+ *
  * @param {string} binary - may be undefined (e.g. precompiles)
  * @return {string} ID (0x-prefixed keccak of binary)
  */
-export function* addAffectedInstance(address, binary) {
+export function* addAffectedInstance(address, binary, creationBinary) {
   const search = yield select(evm.info.binaries.search);
   const context = search(binary);
+  let constructorArgs;
+
+  if (creationBinary) {
+    const creationContext = search(creationBinary);
+    if (creationContext) {
+      const contexts = yield select(evm.info.contexts);
+      const referenceBinary = contexts[creationContext].binary;
+      constructorArgs = creationBinary.slice(referenceBinary.length);
+    }
+  }
 
   //now, whether we needed a new context or not, add the instance
-  yield put(actions.addAffectedInstance(address, context, binary));
+  yield put(
+    actions.addAffectedInstance(address, context, binary, constructorArgs)
+  );
 
   return context;
 }

--- a/packages/debugger/lib/session/sagas/index.js
+++ b/packages/debugger/lib/session/sagas/index.js
@@ -168,17 +168,13 @@ function* fetchTx(txHash) {
   }
 
   //if a create, only add in address if it was successful
-  if (
-    result.binary &&
-    result.status &&
-    !creations.includes(result.storageAddress)
-  ) {
-    creations.push(result.storageAddress);
+  if (result.binary && result.status && !(result.storageAddress in creations)) {
+    creations[result.storageAddress] = result.binary;
   }
 
   let blockNumber = result.block.number.toString(); //a BN is not accepted
-  let addresses = [...calls, ...creations, ...selfdestructs];
-  let creationStartIndex = calls.length;
+  let addresses = [...calls, ...selfdestructs, ...Object.keys(creations)];
+  let nonCallStartIndex = calls.length;
   debug("obtaining binaries");
   let binaries = yield* web3.obtainBinaries(addresses, blockNumber);
 
@@ -189,7 +185,8 @@ function* fetchTx(txHash) {
         recordInstance,
         address,
         binaries[index],
-        index >= creationStartIndex
+        index >= nonCallStartIndex,
+        creations[address] //may be undefined
       )
     )
   );
@@ -210,8 +207,14 @@ function* recordSources(sources) {
   yield* solidity.addSources(sources);
 }
 
-function* recordInstance(address, binary, affectedInstanceOnly) {
-  yield* evm.addAffectedInstance(address, binary);
+//creationBinary can be omitted; should only be used for creations
+function* recordInstance(
+  address,
+  binary,
+  affectedInstanceOnly,
+  creationBinary
+) {
+  yield* evm.addAffectedInstance(address, binary, creationBinary);
   if (!affectedInstanceOnly) {
     //add it as a real codex instance
     yield* evm.addInstance(address, binary);

--- a/packages/debugger/lib/session/selectors/index.js
+++ b/packages/debugger/lib/session/selectors/index.js
@@ -33,7 +33,7 @@ const session = createSelectorTree({
         Object.assign(
           {},
           ...Object.entries(instances).map(
-            ([address, { context: contextId, binary }]) => {
+            ([address, { context: contextId, binary, constructorArgs }]) => {
               debug("instances %O", instances);
               debug("contexts %O", contexts);
               let context = contexts[contextId];
@@ -55,7 +55,8 @@ const session = createSelectorTree({
                 [address]: {
                   contractName,
                   source,
-                  binary
+                  binary,
+                  constructorArgs //will be defined only if created by this tx
                 }
               };
             }

--- a/packages/debugger/lib/session/selectors/index.js
+++ b/packages/debugger/lib/session/selectors/index.js
@@ -33,7 +33,15 @@ const session = createSelectorTree({
         Object.assign(
           {},
           ...Object.entries(instances).map(
-            ([address, { context: contextId, binary, constructorArgs }]) => {
+            ([
+              address,
+              {
+                context: contextId,
+                binary,
+                creationBinary,
+                creationContext: creationContextId
+              }
+            ]) => {
               debug("instances %O", instances);
               debug("contexts %O", contexts);
               let context = contexts[contextId];
@@ -50,6 +58,17 @@ const session = createSelectorTree({
                 primarySource !== undefined
                   ? sources[compilationId].byId[primarySource]
                   : undefined;
+
+              let constructorArgs;
+              if (creationBinary !== undefined) {
+                let creationContext = contexts[creationContextId];
+                if (creationContext !== null) {
+                  //slice off the bytecode part of the constructor to leave the arguments
+                  constructorArgs = creationBinary.slice(
+                    creationContext.binary.length
+                  );
+                }
+              }
 
               return {
                 [address]: {

--- a/packages/debugger/test/context.js
+++ b/packages/debugger/test/context.js
@@ -62,11 +62,29 @@ library TestLibrary {
 }
 `;
 
+const __CREATION = `
+pragma solidity ^0.6.5;
+
+contract CreationTest {
+  function run() public {
+    new Created(1);
+  }
+}
+
+contract Created {
+  uint it;
+  constructor(uint x) public {
+    it = x;
+  }
+}
+`;
+
 const __MIGRATION = `
 let OuterContract = artifacts.require("OuterContract");
 let InnerContract = artifacts.require("InnerContract");
 let ImmutableTest = artifacts.require("ImmutableTest");
 let TestLibrary = artifacts.require("TestLibrary");
+let CreationTest = artifacts.require("CreationTest");
 
 module.exports = async function(deployer) {
   await deployer.deploy(InnerContract);
@@ -75,6 +93,7 @@ module.exports = async function(deployer) {
   await deployer.deploy(TestLibrary);
   await deployer.link(TestLibrary, ImmutableTest);
   await deployer.deploy(ImmutableTest);
+  await deployer.deploy(CreationTest);
 };
 `;
 
@@ -85,20 +104,21 @@ let migrations = {
 let sources = {
   "OuterLibrary.sol": __OUTER,
   "InnerContract.sol": __INNER,
-  "ImmutableTest.sol": __IMMUTABLE
+  "ImmutableTest.sol": __IMMUTABLE,
+  "CreationTest.sol": __CREATION
 };
 
-describe("Contexts", function() {
+describe("Contexts", function () {
   var provider;
 
   var abstractions;
   var compilations;
 
-  before("Create Provider", async function() {
+  before("Create Provider", async function () {
     provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
   });
 
-  before("Prepare contracts and artifacts", async function() {
+  before("Prepare contracts and artifacts", async function () {
     this.timeout(30000);
 
     let prepared = await prepareContracts(provider, sources, migrations);
@@ -106,7 +126,7 @@ describe("Contexts", function() {
     compilations = prepared.compilations;
   });
 
-  it("returns view of addresses affected", async function() {
+  it("returns view of addresses affected", async function () {
     let outer = await abstractions.OuterContract.deployed();
     let inner = await abstractions.InnerContract.deployed();
 
@@ -144,7 +164,7 @@ describe("Contexts", function() {
     );
   });
 
-  it("correctly identifies context in presence of libraries and immutables", async function() {
+  it("correctly identifies context in presence of libraries and immutables", async function () {
     let ImmutableTest = await abstractions.ImmutableTest.deployed();
     let address = ImmutableTest.address;
     let TestLibrary = await abstractions.TestLibrary.deployed();
@@ -169,5 +189,37 @@ describe("Contexts", function() {
     assert.equal(affectedInstances[address].contractName, "ImmutableTest");
     assert.property(affectedInstances, libraryAddress);
     assert.equal(affectedInstances[libraryAddress].contractName, "TestLibrary");
+  });
+
+  it("determines encoded constructor arguments for creations", async function () {
+    let CreationTest = await abstractions.CreationTest.deployed();
+    let address = CreationTest.address;
+
+    let result = await CreationTest.run();
+    let txHash = result.tx;
+
+    let bugger = await Debugger.forTx(txHash, {
+      provider,
+      compilations,
+      lightMode: true
+    });
+    debug("debugger ready");
+
+    let affectedInstances = bugger.view(sessionSelector.info.affectedInstances);
+    debug("affectedInstances: %o", affectedInstances);
+
+    //just some sanity checks
+    assert.lengthOf(Object.keys(affectedInstances), 2);
+    assert.property(affectedInstances, address);
+    assert.equal(affectedInstances[address].contractName, "CreationTest");
+    //now...
+    let createdAddress = Object.keys(affectedInstances).find(
+      newAddress => newAddress !== address
+    );
+    assert.equal(affectedInstances[createdAddress].contractName, "Created");
+    assert.equal(
+      affectedInstances[createdAddress].constructorArgs,
+      "1".padStart(64, "0")
+    );
   });
 });


### PR DESCRIPTION
As requested by @gnidan.

This PR makes it so that the `affectedInstances` entry for addresses created during the transaction (note: I didn't include just internal creations, but also the transaction itself if it is a creation) now also contains a field, `constructorArgs`, containing the (encoded) constructor arguments.

This PR also fixes a small bug I accidentally introduced with #3323 -- in that PR, I accidentally removed the check to make sure that we only add contract creations to affectedInstances if the address isn't zero.  I've added it back in here.  Also, when writing #3323, I failed to notice that the variable `creationStartIndex` wasn't really named properly anymore; I've renamed it.

Anyway, the way this PR works is as follows.  During `processTrace`, for creations (that don't return the zero address), we now extract the binary as well as the address.  (Yes, the code for this is copypasted....)  We return this to the session saga `fetchTx`, which now does the same things as before, but also, when it calls `recordInstance`, passes along the creation binary if it's recording a creation.  (Otherwise, this remains undefined.)  This then passes it along to the evm saga `addAffectedInstance`, which now, if a creation binary was passed in, looks up the context for this in addition to its existing lookup of the deployed binary.  This all then gets stored in the `affectedInstances` state.

Finally, the `affectedInstances` selector in `session` now reads this information, and, if it finds a creation binary present (and a non-null context), it looks up the binary for that context and uses this to extract the arguments part of the creation binary.  This is what is then returned as `constructorArgs`.  Otherwise `constructorArgs` remains undefined.

The `refreshInstances` saga has also been updated appropriately.  Also, I added a test of this new functionality.

Note this PR does not attempt any decoding of the constructor arguments.  While it would almost certainly be possible to do this in some form (although not necessarily at debugger startup), doing this would add substantially to the difficulty, and would also be irrelevant for the purposes that @gnidan originally wanted this (which involve getting the encoded constructor arguments for use with Etherscan).