### PR TITLE
Internal Improvement: Add typeroots empty array to error and provisioner tsconfig.json files

### DIFF
--- a/packages/error/tsconfig.json
+++ b/packages/error/tsconfig.json
@@ -7,6 +7,8 @@
     "outDir": "./dist",
     "rootDir": "./",
     "strict": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "typeRoots": [
+    ]
   }
 }

--- a/packages/provisioner/tsconfig.json
+++ b/packages/provisioner/tsconfig.json
@@ -7,6 +7,8 @@
       "outDir": "./dist",
       "rootDir": "./",
       "strict": true,
-      "esModuleInterop": true
+      "esModuleInterop": true,
+      "typeRoots": [
+      ]
     }
   }


### PR DESCRIPTION
This PR adds empty `typeRoots` arrays to the `tsconfig.json` files of the `@truffle/provisioner` and `@truffle/error` packages. This will help ensure that the typeRoots for these packages do not need to be implicitly determined. Rather, all packages should explicitly define their typeRoots. 