### PR TITLE
Enhancement: Debugger/decoder support for free functions

### DIFF
--- a/packages/codec/lib/basic/decode/index.ts
+++ b/packages/codec/lib/basic/decode/index.ts
@@ -641,7 +641,8 @@ export function decodeInternalFunction(
   }
   let name = functionEntry.name;
   let mutability = functionEntry.mutability;
-  let definedIn = Evm.Import.functionTableEntryToType(functionEntry);
+  let definedIn = Evm.Import.functionTableEntryToType(functionEntry); //may be null
+  let id = Evm.Import.makeInternalFunctionId(functionEntry);
   return {
     type: dataType,
     kind: "value" as const,
@@ -651,6 +652,7 @@ export function decodeInternalFunction(
       deployedProgramCounter: deployedPc,
       constructorProgramCounter: constructorPc,
       name,
+      id,
       definedIn,
       mutability
     }

--- a/packages/codec/lib/evm/import/index.ts
+++ b/packages/codec/lib/evm/import/index.ts
@@ -6,6 +6,10 @@ import { InternalFunction } from "@truffle/codec/evm/types";
 export function functionTableEntryToType(
   functionEntry: InternalFunction
 ): Format.Types.ContractTypeNative {
+  if (functionEntry.contractNode === null) {
+    //for free functions
+    return null;
+  }
   return {
     typeClass: "contract" as const,
     kind: "native" as const,
@@ -14,4 +18,10 @@ export function functionTableEntryToType(
     contractKind: functionEntry.contractKind,
     payable: functionEntry.contractPayable
   };
+}
+
+export function makeInternalFunctionId(
+  functionEntry: InternalFunction
+): string {
+  return `${functionEntry.compilationId}:${functionEntry.id}`;
 }

--- a/packages/codec/lib/format/utils/inspect.ts
+++ b/packages/codec/lib/format/utils/inspect.ts
@@ -17,8 +17,8 @@ interface InspectOptions {
 function cleanStylize(options: InspectOptions) {
   return Object.assign(
     {},
-    ...Object.entries(options).map(
-      ([key, value]) => (key === "stylize" ? {} : { [key]: value })
+    ...Object.entries(options).map(([key, value]) =>
+      key === "stylize" ? {} : { [key]: value }
     )
   );
 }
@@ -126,12 +126,12 @@ export class ResultInspector {
           case "mapping":
             return util.inspect(
               new Map(
-                (<Format.Values.MappingValue>this.result).value.map(
-                  ({ key, value }) => [
-                    new ResultInspector(key),
-                    new ResultInspector(value)
-                  ]
-                )
+                (<Format.Values.MappingValue>(
+                  this.result
+                )).value.map(({ key, value }) => [
+                  new ResultInspector(key),
+                  new ResultInspector(value)
+                ])
               ),
               options
             );
@@ -232,9 +232,7 @@ export class ResultInspector {
                     break;
                   case "invalid":
                   case "unknown":
-                    firstLine = `[Function: Unknown selector ${
-                      coercedResult.value.selector
-                    } of`;
+                    firstLine = `[Function: Unknown selector ${coercedResult.value.selector} of`;
                     break;
                 }
                 let secondLine = `${contractString}]`;
@@ -254,23 +252,24 @@ export class ResultInspector {
                 );
                 switch (coercedResult.value.kind) {
                   case "function":
-                    return options.stylize(
-                      `[Function: ${coercedResult.value.definedIn.typeName}.${
-                        coercedResult.value.name
-                      }]`,
-                      "special"
-                    );
+                    if (coercedResult.value.definedIn) {
+                      return options.stylize(
+                        `[Function: ${coercedResult.value.definedIn.typeName}.${coercedResult.value.name}]`,
+                        "special"
+                      );
+                    } else {
+                      return options.stylize(
+                        `[Function: ${coercedResult.value.name}]`,
+                        "special"
+                      );
+                    }
                   case "exception":
                     return coercedResult.value.deployedProgramCounter === 0
                       ? options.stylize(`[Function: <zero>]`, "special")
                       : options.stylize(`[Function: assert(false)]`, "special");
                   case "unknown":
                     let firstLine = `[Function: decoding not supported (raw info:`;
-                    let secondLine = `deployed PC=${
-                      coercedResult.value.deployedProgramCounter
-                    }, constructor PC=${
-                      coercedResult.value.constructorProgramCounter
-                    })]`;
+                    let secondLine = `deployed PC=${coercedResult.value.deployedProgramCounter}, constructor PC=${coercedResult.value.constructorProgramCounter})]`;
                     let breakingSpace =
                       firstLine.length + secondLine.length + 1 >
                       options.breakLength
@@ -290,35 +289,21 @@ export class ResultInspector {
         let errorResult = <Format.Errors.ErrorResult>this.result; //the hell?? why couldn't it make this inference??
         switch (errorResult.error.kind) {
           case "UintPaddingError":
-            return `Uint has incorrect padding (expected padding: ${
-              errorResult.error.paddingType
-            }) (raw value ${errorResult.error.raw})`;
+            return `Uint has incorrect padding (expected padding: ${errorResult.error.paddingType}) (raw value ${errorResult.error.raw})`;
           case "IntPaddingError":
-            return `Int has incorrect padding (expected padding: ${
-              errorResult.error.paddingType
-            }) (raw value ${errorResult.error.raw})`;
+            return `Int has incorrect padding (expected padding: ${errorResult.error.paddingType}) (raw value ${errorResult.error.raw})`;
           case "UintPaddingError":
-            return `Ufixed has (expected padding: ${
-              errorResult.error.paddingType
-            }) (raw value ${errorResult.error.raw})`;
+            return `Ufixed has (expected padding: ${errorResult.error.paddingType}) (raw value ${errorResult.error.raw})`;
           case "FixedPaddingError":
-            return `Fixed has incorrect padding (expected padding: ${
-              errorResult.error.paddingType
-            }) (raw value ${errorResult.error.raw})`;
+            return `Fixed has incorrect padding (expected padding: ${errorResult.error.paddingType}) (raw value ${errorResult.error.raw})`;
           case "BoolOutOfRangeError":
             return `Invalid boolean (numeric value ${errorResult.error.rawAsBN.toString()})`;
           case "BoolPaddingError":
-            return `Boolean has incorrect padding (expected padding: ${
-              errorResult.error.paddingType
-            }) (raw value ${errorResult.error.raw})`;
+            return `Boolean has incorrect padding (expected padding: ${errorResult.error.paddingType}) (raw value ${errorResult.error.raw})`;
           case "BytesPaddingError":
-            return `Bytestring has extra trailing bytes (padding error) (raw value ${
-              errorResult.error.raw
-            })`;
+            return `Bytestring has extra trailing bytes (padding error) (raw value ${errorResult.error.raw})`;
           case "AddressPaddingError":
-            return `Address has incorrect padding (expected padding: ${
-              errorResult.error.paddingType
-            }) (raw value ${errorResult.error.raw})`;
+            return `Address has incorrect padding (expected padding: ${errorResult.error.paddingType}) (raw value ${errorResult.error.raw})`;
           case "EnumOutOfRangeError":
             return `Invalid ${enumTypeName(
               errorResult.error.type
@@ -336,39 +321,21 @@ export class ResultInspector {
               errorResult.error.type.id
             } (numeric value ${errorResult.error.rawAsBN.toString()})`;
           case "ContractPaddingError":
-            return `Contract address has incorrect padding (expected padding: ${
-              errorResult.error.paddingType
-            }) (raw value ${errorResult.error.raw})`;
+            return `Contract address has incorrect padding (expected padding: ${errorResult.error.paddingType}) (raw value ${errorResult.error.raw})`;
           case "FunctionExternalNonStackPaddingError":
-            return `External function has incorrect padding (expected padding: ${
-              errorResult.error.paddingType
-            }) (raw value ${errorResult.error.raw})`;
+            return `External function has incorrect padding (expected padding: ${errorResult.error.paddingType}) (raw value ${errorResult.error.raw})`;
           case "FunctionExternalStackPaddingError":
-            return `External function address or selector has extra leading bytes (padding error) (raw address ${
-              errorResult.error.rawAddress
-            }, raw selector ${errorResult.error.rawSelector})`;
+            return `External function address or selector has extra leading bytes (padding error) (raw address ${errorResult.error.rawAddress}, raw selector ${errorResult.error.rawSelector})`;
           case "FunctionInternalPaddingError":
-            return `Internal function has incorrect padding (expected padding: ${
-              errorResult.error.paddingType
-            }) (raw value ${errorResult.error.raw})`;
+            return `Internal function has incorrect padding (expected padding: ${errorResult.error.paddingType}) (raw value ${errorResult.error.raw})`;
           case "NoSuchInternalFunctionError":
-            return `Invalid function (Deployed PC=${
-              errorResult.error.deployedProgramCounter
-            }, constructor PC=${
-              errorResult.error.constructorProgramCounter
-            }) of contract ${errorResult.error.context.typeName}`;
+            return `Invalid function (Deployed PC=${errorResult.error.deployedProgramCounter}, constructor PC=${errorResult.error.constructorProgramCounter}) of contract ${errorResult.error.context.typeName}`;
           case "DeployedFunctionInConstructorError":
-            return `Deployed-style function (PC=${
-              errorResult.error.deployedProgramCounter
-            }) in constructor`;
+            return `Deployed-style function (PC=${errorResult.error.deployedProgramCounter}) in constructor`;
           case "MalformedInternalFunctionError":
-            return `Malformed internal function w/constructor PC only (value: ${
-              errorResult.error.constructorProgramCounter
-            })`;
+            return `Malformed internal function w/constructor PC only (value: ${errorResult.error.constructorProgramCounter})`;
           case "IndexedReferenceTypeError": //for this one we'll bother with some line-wrapping
-            let firstLine = `Cannot decode indexed parameter of reference type ${
-              errorResult.error.type.typeClass
-            }`;
+            let firstLine = `Cannot decode indexed parameter of reference type ${errorResult.error.type.typeClass}`;
             let secondLine = `(raw value ${errorResult.error.raw})`;
             let breakingSpace =
               firstLine.length + secondLine.length + 1 > options.breakLength
@@ -433,9 +400,7 @@ function formatCircular(loopLength: number, options: InspectOptions): string {
 function enumFullName(value: Format.Values.EnumValue): string {
   switch (value.type.kind) {
     case "local":
-      return `${value.type.definingContractName}.${value.type.typeName}.${
-        value.value.name
-      }`;
+      return `${value.type.definingContractName}.${value.type.typeName}.${value.value.name}`;
     case "global":
       return `${value.type.typeName}.${value.value.name}`;
   }
@@ -624,9 +589,9 @@ function nativizeWithTable(
     case "magic":
       return Object.assign(
         {},
-        ...Object.entries((<Format.Values.MagicValue>result).value).map(
-          ([key, value]) => ({ [key]: nativize(value) })
-        )
+        ...Object.entries(
+          (<Format.Values.MagicValue>result).value
+        ).map(([key, value]) => ({ [key]: nativize(value) }))
       );
     case "enum":
       return enumFullName(<Format.Values.EnumValue>result);
@@ -638,26 +603,22 @@ function nativizeWithTable(
           let coercedResult = <Format.Values.FunctionExternalValue>result;
           switch (coercedResult.value.kind) {
             case "known":
-              return `${coercedResult.value.contract.class.typeName}(${
-                coercedResult.value.contract.address
-              }).${coercedResult.value.abi.name}`;
+              return `${coercedResult.value.contract.class.typeName}(${coercedResult.value.contract.address}).${coercedResult.value.abi.name}`;
             case "invalid":
-              return `${coercedResult.value.contract.class.typeName}(${
-                coercedResult.value.contract.address
-              }).call(${coercedResult.value.selector}...)`;
+              return `${coercedResult.value.contract.class.typeName}(${coercedResult.value.contract.address}).call(${coercedResult.value.selector}...)`;
             case "unknown":
-              return `${coercedResult.value.contract.address}.call(${
-                coercedResult.value.selector
-              }...)`;
+              return `${coercedResult.value.contract.address}.call(${coercedResult.value.selector}...)`;
           }
         }
         case "internal": {
           let coercedResult = <Format.Values.FunctionInternalValue>result;
           switch (coercedResult.value.kind) {
             case "function":
-              return `${coercedResult.value.definedIn.typeName}.${
-                coercedResult.value.name
-              }`;
+              if (coercedResult.value.definedIn) {
+                return `${coercedResult.value.definedIn.typeName}.${coercedResult.value.name}`;
+              } else {
+                return coercedResult.value.name;
+              }
             case "exception":
               return coercedResult.value.deployedProgramCounter === 0
                 ? `<zero>`

--- a/packages/codec/lib/format/values.ts
+++ b/packages/codec/lib/format/values.ts
@@ -492,7 +492,14 @@ export interface FunctionInternalValueInfoKnown {
   deployedProgramCounter: number;
   constructorProgramCounter: number;
   name: string;
-  definedIn: Types.ContractType;
+  /**
+   * Is null for a free function
+   */
+  definedIn: Types.ContractType | null;
+  /**
+   * An internal opaque ID
+   */
+  id: string;
   mutability?: Common.Mutability;
   //may have more optional fields added later
 }

--- a/packages/debugger/test/data/function-decoding.js
+++ b/packages/debugger/test/data/function-decoding.js
@@ -52,7 +52,7 @@ contract ExternalsDerived is ExternalsBase {
 `;
 
 const __INTERNALS = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.7.1;
 
 contract InternalsBase {
 
@@ -72,6 +72,10 @@ library InternalsLib {
   }
 }
 
+function freeFn() {
+  InternalsLib.libraryFn();
+}
+
 contract InternalsTest is InternalsBase {
 
   function inherited() public override {
@@ -85,12 +89,14 @@ contract InternalsTest is InternalsBase {
     function() internal derivedFn;
     function() internal baseFn;
     function() internal libFn;
+    function() internal storedFreeFn;
     function() internal readFromConstructor;
 
     plainFn = run;
     derivedFn = InternalsTest.inherited;
     baseFn = InternalsBase.inherited;
     libFn = InternalsLib.libraryFn;
+    storedFreeFn = freeFn;
     readFromConstructor = storageFn;
 
     emit Log(2); //BREAK HERE (DEPLOYED)
@@ -101,11 +107,13 @@ contract InternalsTest is InternalsBase {
     function() internal derivedFn;
     function() internal baseFn;
     function() internal libFn;
+    function() internal storedFreeFn;
 
     plainFn = run;
     derivedFn = InternalsTest.inherited;
     baseFn = InternalsBase.inherited;
     libFn = InternalsLib.libraryFn;
+    storedFreeFn = freeFn;
 
     storageFn = run;
 
@@ -206,6 +214,7 @@ describe("Function Pointer Decoding", function () {
       derivedFn: "InternalsTest.inherited",
       baseFn: "InternalsBase.inherited",
       libFn: "InternalsLib.libraryFn",
+      storedFreeFn: "freeFn",
       storageFn: "InternalsTest.run",
       readFromConstructor: "InternalsTest.run"
     };
@@ -241,6 +250,7 @@ describe("Function Pointer Decoding", function () {
       derivedFn: "InternalsTest.inherited",
       baseFn: "InternalsBase.inherited",
       libFn: "InternalsLib.libraryFn",
+      storedFreeFn: "freeFn",
       storageFn: "InternalsTest.run"
     };
 

--- a/packages/debugger/test/data/function-decoding.js
+++ b/packages/debugger/test/data/function-decoding.js
@@ -90,6 +90,7 @@ contract InternalsTest is InternalsBase {
     function() internal baseFn;
     function() internal libFn;
     function() internal storedFreeFn;
+    function() internal undefFn;
     function() internal readFromConstructor;
 
     plainFn = run;
@@ -108,6 +109,7 @@ contract InternalsTest is InternalsBase {
     function() internal baseFn;
     function() internal libFn;
     function() internal storedFreeFn;
+    function() internal undefFn;
 
     plainFn = run;
     derivedFn = InternalsTest.inherited;
@@ -215,6 +217,7 @@ describe("Function Pointer Decoding", function () {
       baseFn: "InternalsBase.inherited",
       libFn: "InternalsLib.libraryFn",
       storedFreeFn: "freeFn",
+      undefFn: "assert(false)",
       storageFn: "InternalsTest.run",
       readFromConstructor: "InternalsTest.run"
     };
@@ -251,6 +254,7 @@ describe("Function Pointer Decoding", function () {
       baseFn: "InternalsBase.inherited",
       libFn: "InternalsLib.libraryFn",
       storedFreeFn: "freeFn",
+      undefFn: "assert(false)",
       storageFn: "InternalsTest.run"
     };
 

--- a/packages/debugger/test/helpers.js
+++ b/packages/debugger/test/helpers.js
@@ -25,7 +25,7 @@ export async function prepareContracts(provider, sources = {}, migrations) {
 
   config.compilers = {
     solc: {
-      version: "0.7.0",
+      version: "0.7.1",
       settings: {
         optimizer: { enabled: false, runs: 200 },
         evmVersion: "constantinople"

--- a/packages/solidity-utils/index.js
+++ b/packages/solidity-utils/index.js
@@ -5,7 +5,7 @@ const jsonpointer = require("json-pointer");
 const IntervalTree = require("node-interval-tree").default;
 
 var SolidityUtils = {
-  getCharacterOffsetToLineAndColumnMapping: function(source) {
+  getCharacterOffsetToLineAndColumnMapping: function (source) {
     var mapping = [];
 
     source = source.split("");
@@ -13,7 +13,7 @@ var SolidityUtils = {
     var line = 0;
     var column = 0;
 
-    source.forEach(function(character) {
+    source.forEach(function (character) {
       if (character === "\n") {
         line += 1;
         column = -1;
@@ -35,7 +35,7 @@ var SolidityUtils = {
     return mapping;
   },
 
-  getHumanReadableSourceMap: function(sourceMap) {
+  getHumanReadableSourceMap: function (sourceMap) {
     const instructions = sourceMap.split(";");
 
     let processedInstruction = {}; //persists across instructions for when info doesn't change
@@ -90,7 +90,7 @@ var SolidityUtils = {
   //binary: raw binary to process.  should not have unresolved links.
   //sourceMap: a processed source map as output by getHumanReadableSourceMap above
   //we... attempt to muddle through.
-  getProcessedInstructionsForBinary: function(sources, binary, sourceMap) {
+  getProcessedInstructionsForBinary: function (sources, binary, sourceMap) {
     if (!sources || !binary) {
       return [];
     }
@@ -190,7 +190,7 @@ var SolidityUtils = {
   //given range, and will return an array of objects with fields node and pointer; node should
   //be the corresponding node, and pointer a jsonpointer to it (from the AST root)
   //compilationId: what it says.  the function will work fine without it.
-  getFunctionsByProgramCounter: function(
+  getFunctionsByProgramCounter: function (
     instructions,
     asts,
     overlapFunctions,
@@ -244,6 +244,11 @@ var SolidityUtils = {
           //so this is easy
           let contractPointer = pointer.replace(/\/nodes\/\d+$/, "");
           let contractNode = jsonpointer.get(ast, contractPointer);
+          if (contractNode.nodeType !== "ContractDefinition") {
+            //if it's a free function, there is no contract pointer or contract node
+            contractPointer = null;
+            contractNode = null;
+          }
           return {
             [instruction.pc]: {
               sourceIndex: sourceId,
@@ -255,9 +260,12 @@ var SolidityUtils = {
               mutability: Codec.Ast.Utils.mutability(node),
               contractPointer,
               contractNode,
-              contractName: contractNode.name,
-              contractId: contractNode.id,
-              contractKind: contractNode.contractKind,
+              contractName: contractNode ? contractNode.name : null,
+              contractId: contractNode ? contractNode.id : null,
+              contractKind: contractNode ? contractNode.contractKind : null,
+              contractPayable: contractNode
+                ? Codec.Ast.Utils.isContractPayable(contractNode)
+                : null,
               isDesignatedInvalid: false
             }
           };
@@ -265,7 +273,7 @@ var SolidityUtils = {
     );
   },
 
-  getSourceRange: function(instruction = {}) {
+  getSourceRange: function (instruction = {}) {
     return {
       start: instruction.start || 0,
       length: instruction.length || 0,
@@ -283,7 +291,7 @@ var SolidityUtils = {
   },
 
   //findOverlappingRange should be as described above
-  findRange: function(findOverlappingRange, sourceStart, sourceLength) {
+  findRange: function (findOverlappingRange, sourceStart, sourceLength) {
     // find nodes that fully contain requested range,
     // return one with longest pointer
     // (note: returns { range, node, pointer }
@@ -301,7 +309,7 @@ var SolidityUtils = {
   },
 
   //makes the overlap function for an AST
-  makeOverlapFunction: function(ast) {
+  makeOverlapFunction: function (ast) {
     let tree = new IntervalTree();
     let ranges = SolidityUtils.rangeNodes(ast);
     for (let { range, node, pointer } of ranges) {
@@ -313,7 +321,7 @@ var SolidityUtils = {
   },
 
   //for use by makeOverlapFunction
-  rangeNodes: function(node, pointer = "") {
+  rangeNodes: function (node, pointer = "") {
     if (node instanceof Array) {
       return [].concat(
         ...node.map((sub, i) =>
@@ -339,7 +347,7 @@ var SolidityUtils = {
     }
   },
 
-  getRange: function(node) {
+  getRange: function (node) {
     // src: "<start>:<length>:<_>"
     // returns [start, end]
     let [start, length] = node.src


### PR DESCRIPTION
The main point of this PR is to support free functions in the debugger and decoder, but it ended up doing a few other things as well.  One thing this PR does *not* do, by the way, is making sure that the globally-available variable `this` isn't available in free functions... because it turned out our existing code already did that!  Hooray!  So, really, the main thing ended up just being supporting decoding of function pointers to free functions.

So, first off, this meant a change to the decoder output format.  The `definedIn` field on a `FunctionInternalValueInfoKnown` is now allowed to be `null` to indicate a free function.  Also, a new field has been added to this interface: `id`, an internal ID used for internal functions just in case two free functions somehow have the same name.  (It is constructed in the way you would expect, from compilation ID and AST ID.)

But also this meant:
1. Having `getFunctionsByProgramCounter` in `solidity-utils` (sorry for all the prettier changes -- all the real changes are to that one function) check whether the function's contract node is, in fact, a valid contract node, and make it `null` otherwise
2. Having `functionTableEntryToType` recognize when it's been passed a free function and return `null`
3. Having `decodeInternalFunction` tag all valid internal functions with an ID.

In addition, I updated `nativize` and `ResultInspector` to account for the case of free functions (sorry for all the prettier changes to this file; but you can find the real changes here by looking for `if (coercedResult.value.definedIn)`.)

Still, nothing too complicated.  I also added a test of decoding these.

...but also, some other changes snuck their way into this PR...

First, I noticed that `functionTableEntryToType` was setting the `payable` field based on a field (`contractPayable`) that was never actually set in `getFunctionsByProgramCounter`!  So, uh, I changed the latter to actually set that field.

Secondly, I noticed that some uninitialized internal function pointers weren't decoding properly.  It seems the problem is that, at some point, they changed it so that the designated invalid function has a source index of -1.  So, I made another change to  `getFunctionsByProgramCounter` to account for this case.  Instructions with source index -1 are no longer filtered out; instead they're checked to see whether they might be the designated invalid function.

The fact that this had silently broken bothered me, so I added a test of this, too.

And, that's the entirety of this PR!  Not actually that complicated.