### PR TITLE
Add missing typeRoots

### DIFF
--- a/packages/hdwallet-provider/tsconfig.json
+++ b/packages/hdwallet-provider/tsconfig.json
@@ -19,7 +19,9 @@
     },
     "typeRoots": [
       "./typings",
-      "../../node_modules/@types/mocha"
+      "../../node_modules/@types/mocha",
+      "../../node_modules/@types/node",
+      "../../node_modules/@types/web3"
     ]
   },
   "include": [


### PR DESCRIPTION
For @types/node and @types/web3, since our setup is meant for everything to be listed explicitly in the tsconfig

(This caused trouble for me when I ran `yarn test`, for a reason I didn't look into [it worked before, also for a reason I didn't look into])