### PR TITLE
Use more explicit code style for new HDWalletProvider constructor interface

### DIFF
--- a/packages/hdwallet-provider/src/constructor/Constructor.ts
+++ b/packages/hdwallet-provider/src/constructor/Constructor.ts
@@ -16,8 +16,7 @@ export interface MnemonicSigningAuthority {
 }
 
 export interface PrivateKeysSigningAuthority {
-  privateKeys?: PrivateKey[];
-  privateKey?: PrivateKey;
+  privateKeys: PrivateKey[];
 }
 
 export type SigningAuthority =

--- a/packages/hdwallet-provider/src/constructor/Constructor.ts
+++ b/packages/hdwallet-provider/src/constructor/Constructor.ts
@@ -15,14 +15,14 @@ export interface MnemonicSigningAuthority {
   mnemonic: Mnemonic;
 }
 
-export interface PrivateKeySigningAuthority {
+export interface PrivateKeysSigningAuthority {
   privateKeys?: PrivateKey[];
   privateKey?: PrivateKey;
 }
 
 export type SigningAuthority =
   | MnemonicSigningAuthority
-  | PrivateKeySigningAuthority;
+  | PrivateKeysSigningAuthority;
 
 export interface CommonOptions {
   providerOrUrl: ProviderOrUrl;

--- a/packages/hdwallet-provider/src/constructor/LegacyConstructor.ts
+++ b/packages/hdwallet-provider/src/constructor/LegacyConstructor.ts
@@ -8,6 +8,8 @@ import {
   DerivationPath
 } from "./types";
 
+export type Credentials = MnemonicPhrase | PrivateKey | PrivateKey[];
+
 /*
  * namespace wrapper for old-style positional arguments
  */
@@ -15,7 +17,7 @@ type PossibleArguments = [
   /*
    * required
    */
-  MnemonicPhrase | PrivateKey[],
+  Credentials,
   ProviderOrUrl,
 
   /*

--- a/packages/hdwallet-provider/src/constructor/getOptions.ts
+++ b/packages/hdwallet-provider/src/constructor/getOptions.ts
@@ -93,7 +93,7 @@ const matchesNewOptions = (
   // beyond that, determine based on property inclusion check for required keys
   return (
     "providerOrUrl" in options &&
-    ("mnemonic" in options || "privateKeys" in options || "privateKey" in options)
+    ("mnemonic" in options || "privateKeys" in options)
   );
 };
 

--- a/packages/hdwallet-provider/src/constructor/getPrivateKeys.ts
+++ b/packages/hdwallet-provider/src/constructor/getPrivateKeys.ts
@@ -7,7 +7,7 @@ export const getPrivateKeys = (
 ): PrivateKey[] | undefined => {
   if ("privateKeys" in signingAuthority) {
     return signingAuthority.privateKeys;
-  } else if ("privateKey" in signingAuthority && signingAuthority.privateKey) {
-    return [signingAuthority.privateKey];
+  } else {
+    return undefined;
   }
 };

--- a/packages/hdwallet-provider/test/provider.test.ts
+++ b/packages/hdwallet-provider/test/provider.test.ts
@@ -205,24 +205,5 @@ describe("HD Wallet Provider", function () {
       const number = await web3.eth.getBlockNumber();
       assert(number === 0);
     });
-
-    it("provides for a private key", async () => {
-      const privateKey =
-        "3f841bf589fdf83a521e55d51afddc34fa65351161eead24f064855fc29c9580"; //random valid private key generated with ethkey
-      provider = new HDWalletProvider({
-        privateKey,
-        providerOrUrl: `http://localhost:${port}`
-      });
-      web3.setProvider(provider);
-
-      const addresses = provider.getAddresses();
-      assert.equal(addresses[0], "0xc515db5834d8f110eee96c3036854dbf1d87de2b");
-      addresses.forEach(address => {
-        assert(EthUtil.isValidAddress(address), "invalid address");
-      });
-
-      const number = await web3.eth.getBlockNumber();
-      assert(number === 0);
-    });
   });
 });


### PR DESCRIPTION
In response to https://github.com/richardpringle/truffle/pull/4, this PR goes a bit further to refine the in-progress work started by @richardpringle, @eggplantzzz, and myself to support mnemonic passphrases (which has turned into that, plus a constructor interface redesign + legacy support effort).

This PR offers to suggest alternatives for two aspects of the upstream PR:
- Use more type explicitness to distinguish between the currently-supported options for `new HDWallet()`'s first argument (mnemonic phrase, private key, or list of private keys)
- Don't add support for `{ privateKey }` as a way of using the new interface. We don't need it.

I also noticed some missing `typeRoots`, so there's a commit for that. Opening this as draft, at least because the `typeRoots` change should target `develop` (and is [here](https://github.com/trufflesuite/truffle/pull/3339/files)). I plan to rebase this out of the commit log here once that PR is in.

In addition, this changes a variable name that I named incorrectly in the first place.