### PR TITLE
Bug fix: Fix decoding memory structs containing arrays of mappings

### DIFF
--- a/packages/codec/lib/memory/allocate/index.ts
+++ b/packages/codec/lib/memory/allocate/index.ts
@@ -23,13 +23,25 @@ export function getMemoryAllocations(
   return allocations;
 }
 
+export function isSkippedInMemoryStructs(dataType: Format.Types.Type): boolean {
+  if (dataType.typeClass === "mapping") {
+    return true;
+  } else if (dataType.typeClass === "array") {
+    return isSkippedInMemoryStructs(dataType.baseType);
+  } else {
+    return false;
+  }
+}
+
 //unlike in storage and calldata, we'll just return the one allocation, nothing fancy
 //that's because allocating one struct can never necessitate allocating another
 function allocateStruct(dataType: Format.Types.StructType): MemoryAllocation {
   let memberAllocations: MemoryMemberAllocation[] = [];
   let position = 0;
   for (const { name, type: memberType } of dataType.memberTypes) {
-    const length = memberType.typeClass === "mapping" ? 0 : Evm.Utils.WORD_SIZE;
+    const length = isSkippedInMemoryStructs(memberType)
+      ? 0
+      : Evm.Utils.WORD_SIZE;
     memberAllocations.push({
       name,
       type: memberType,

--- a/packages/codec/lib/memory/decode/index.ts
+++ b/packages/codec/lib/memory/decode/index.ts
@@ -10,6 +10,7 @@ import * as Bytes from "@truffle/codec/bytes";
 import * as Pointer from "@truffle/codec/pointer";
 import { DecoderRequest, DecoderOptions } from "@truffle/codec/types";
 import * as Evm from "@truffle/codec/evm";
+import { isSkippedInMemoryStructs } from "@truffle/codec/memory/allocate";
 import { DecodingError } from "@truffle/codec/errors";
 
 export function* decodeMemory(
@@ -19,16 +20,9 @@ export function* decodeMemory(
   options: DecoderOptions = {}
 ): Generator<DecoderRequest, Format.Values.Result, Uint8Array> {
   if (Format.Types.isReferenceType(dataType)) {
-    if (dataType.typeClass === "mapping") {
-      //special case: a mapping in memory is always empty
-      //(this is here and not in decodeMemoryReferenceByAddress
-      //since no addresses are involved, and it's not worth
-      //making into its own function)
-      return {
-        type: dataType,
-        kind: "value" as const,
-        value: []
-      };
+    if (isSkippedInMemoryStructs(dataType)) {
+      //special case; these types are always empty in memory
+      return decodeMemorySkippedType(dataType);
     } else {
       return yield* decodeMemoryReferenceByAddress(
         dataType,
@@ -39,6 +33,26 @@ export function* decodeMemory(
     }
   } else {
     return yield* Basic.Decode.decodeBasic(dataType, pointer, info, options);
+  }
+}
+
+function decodeMemorySkippedType(
+  dataType: Format.Types.Type
+): Format.Values.Result {
+  switch (dataType.typeClass) {
+    case "mapping":
+      return {
+        type: dataType,
+        kind: "value" as const,
+        value: []
+      };
+    case "array":
+      return {
+        type: dataType,
+        kind: "value" as const,
+        value: []
+      };
+    //other cases should not arise!
   }
 }
 


### PR DESCRIPTION
In Solidity prior to 0.7.0, it was possible to put struct types containing mappings in memory.  In the memory representation, the mapping would simply be skipped over.

However, what I did not account for is that it's possible to do the same thing with arrays of mappings!  And multidimensional arrays of mappings!  This PR fixes this oversight, which caused such structs in memory to decode incorrectly.

Now, when the allocator/decoder check for skipped types, instead of just checking for typeclass `"mapping"`, they use the new `isSkippedInMemoryStructs` function.

This PR doesn't add any tests, as all this stuff is illegal in 0.7.x and that's what the debugger tests are on.  But I tested it manually.