### PR TITLE
Bundle commands separately

### DIFF
--- a/packages/core/cli.js
+++ b/packages/core/cli.js
@@ -31,7 +31,12 @@ if (!semver.satisfies(process.version, ">=" + minimumNodeVersion)) {
 
 const Command = require("./lib/command");
 
-const command = new Command(require("./commands.bundled.js"));
+// enable Truffle to run both from the bundles out of packages/dist
+// and using the raw JS directly - we inject BUNDLE_VERSION when building
+const command =
+  typeof BUNDLE_VERSION !== "undefined"
+    ? new Command(require("./commands.bundled.js"))
+    : new Command(require("./lib/commands"));
 
 // This should be removed when issue is resolved upstream:
 // https://github.com/ethereum/web3.js/issues/1648

--- a/packages/core/cli.js
+++ b/packages/core/cli.js
@@ -31,7 +31,7 @@ if (!semver.satisfies(process.version, ">=" + minimumNodeVersion)) {
 
 const Command = require("./lib/command");
 
-const command = new Command(require("./lib/commands"));
+const command = new Command(require("./commands.bundled.js"));
 
 // This should be removed when issue is resolved upstream:
 // https://github.com/ethereum/web3.js/issues/1648
@@ -49,7 +49,7 @@ if (userWantsGeneralHelp) {
   process.exit(0);
 }
 
-command.run(inputArguments, options, function(err) {
+command.run(inputArguments, options, function (err) {
   if (err) {
     if (err instanceof TaskError) {
       analytics.send({

--- a/packages/core/lib/console-child.js
+++ b/packages/core/lib/console-child.js
@@ -29,7 +29,7 @@ detectedConfig.networks.develop = {
   }
 };
 
-const command = new Command(require("../lib/commands"));
+const command = new Command(require("./commands.bundled.js"));
 
 command.run(inputStrings, detectedConfig, error => {
   if (error) {

--- a/packages/core/lib/console-child.js
+++ b/packages/core/lib/console-child.js
@@ -29,7 +29,12 @@ detectedConfig.networks.develop = {
   }
 };
 
-const command = new Command(require("./commands.bundled.js"));
+// enable Truffle to run both from the bundles out of packages/dist
+// and using the raw JS directly - we inject BUNDLE_VERSION when building
+const command =
+  typeof BUNDLE_VERSION !== "undefined"
+    ? new Command(require("./commands.bundled.js"))
+    : new Command(require("./commands"));
 
 command.run(inputStrings, detectedConfig, error => {
   if (error) {

--- a/packages/truffle/webpack.config.js
+++ b/packages/truffle/webpack.config.js
@@ -47,6 +47,14 @@ module.exports = {
       "@truffle/core",
       "lib",
       "console-child.js"
+    ),
+    commands: path.join(
+      __dirname,
+      "../..",
+      "node_modules",
+      "@truffle/core",
+      "lib",
+      "commands/index.js"
     )
   },
 
@@ -89,7 +97,9 @@ module.exports = {
     // Here, we leave it as an external, and use the original-require
     // module that's a dependency of Truffle instead.
     /^original-require$/,
-    /^mocha$/
+    /^mocha$/,
+    // this is the commands portion shared by cli.js and console-child.js
+    /^\.\/commands.bundled.js$/
   ],
 
   resolve: {


### PR DESCRIPTION
Split code shared by `cli.js` and `console-child.js` out into its own bundle