### PR TITLE
Enhancement: Group variables by section in debugger

### DIFF
--- a/packages/debugger/lib/data/selectors/index.js
+++ b/packages/debugger/lib/data/selectors/index.js
@@ -1201,6 +1201,37 @@ const data = createSelectorTree({
       },
 
       /**
+       * data.current.identifiers.sections
+       * intended for use by Teams Debugger
+       */
+      sections: createLeaf(["./refs"], refs => {
+        let sections = {
+          builtin: [],
+          contract: [],
+          local: []
+        };
+        for (const [identifier, ref] of Object.entries(refs)) {
+          switch (ref.location) {
+            case "special":
+              sections.builtin.push(identifier);
+              break;
+            case "stack":
+              sections.local.push(identifier);
+              break;
+            case "storage":
+            case "code":
+            case "nowhere":
+            case "memory":
+            case "definition":
+              sections.contract.push(identifier);
+              break;
+            //other cases shouldn't happen
+          }
+        }
+        return sections;
+      }),
+
+      /**
        * data.current.identifiers.refs
        *
        * current variables' value refs


### PR DESCRIPTION
@kevinbluer has requested that the debugger give information on which variables are builtins vs contract variables vs local variables for use in the teams debugger.  So, this PR adds a new selector to do this; the selector is `data.current.identifiers.sections`.

This selector returns an object with three fields: `builtin`, `contract`, and `local`, each of which is an array containing all in-scope variable names that go in the given section.  It should be pretty straightforward to use.

I basically did this a quick-and-dirty way by piggybacking off of `data.current.identifiers.refs`, identifying what section a given variable goes in by where it's stored.  So, variables with a location of `"special"` are builtins; a location of "`stack`" means a local; and a location of `"storage"`, `"code"`, `"nowhere"`, `"memory"`, or `"definition"` are contract variables.  (Other locations shouldn't occur.)

(In more detail: `"storage"` is most state variables; `"code"` is deployed immutables; `"nowhere"` is deployed immutables that are never actually read; `"memory"` is immutables in the constructor; and `"definition"` is constants.)

Maybe not the most robust way, but I figured, no need to do extra work here.

Hm, thought, I could also alter the CLI to use this as well...