### PR TITLE
Pull name logic and projects loading into separate commands

### DIFF
--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -37,6 +37,10 @@ interface ITruffleDB {
   query: (query: DocumentNode | string, variables: any) => Promise<any>;
 }
 
+type LoaderOptions = {
+  names: boolean;
+};
+
 export class TruffleDB {
   schema: GraphQLSchema;
   context: IContext;
@@ -90,7 +94,7 @@ export class TruffleDB {
   async loadCompilations(
     project: DataModel.IProject,
     result: WorkflowCompileResult,
-    names: boolean
+    options: LoaderOptions
   ) {
     const saga = generateCompileLoad(result);
 
@@ -104,7 +108,7 @@ export class TruffleDB {
       cur = saga.next(response);
     }
 
-    if (names === true) {
+    if (options && options.names === true) {
       await this.loadNames(project, cur.value.contractsByCompilation);
     }
 

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -93,10 +93,11 @@ export class TruffleDB {
   }
 
   async loadCompilations(
-    project: DataModel.IProject,
     result: WorkflowCompileResult,
     options: LoaderOptions
   ) {
+    const project = await this.loadProject();
+
     const saga = generateCompileLoad(result);
 
     let cur = saga.next();

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -84,16 +84,11 @@ export class TruffleDB {
     project: DataModel.IProject,
     contractsByCompilation: Array<DataModel.IContract[]>
   ) {
-    const namesLoader = generateNamesLoad(
+    return await this.runLoader(
+      generateNamesLoad,
       toIdObject(project),
       contractsByCompilation
     );
-    let curNames = namesLoader.next();
-
-    while (!curNames.done) {
-      const namesResponse = await this.getWorkspaceResponse(curNames.value);
-      curNames = namesLoader.next(namesResponse);
-    }
   }
 
   async loadProject(): Promise<DataModel.IProject> {

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -50,7 +50,7 @@ export class TruffleDB {
     return await execute(this.schema, document, null, this.context, variables);
   }
 
-  *loadNames(
+  *generateLoadNames(
     project: DataModel.IProject,
     contractsByCompilation: Array<DataModel.IContract[]>
   ): Generator<WorkspaceRequest, any, WorkspaceResponse<string>> {
@@ -94,7 +94,7 @@ export class TruffleDB {
     }
 
     if (names === true) {
-      const namesLoader = this.loadNames(
+      const namesLoader = this.generateLoadNames(
         cur.value.project,
         cur.value.contractsByCompilation
       );

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -4,6 +4,7 @@ import { generateCompileLoad } from "@truffle/db/loaders/commands";
 import { WorkspaceRequest } from "@truffle/db/loaders/types";
 import { WorkflowCompileResult } from "@truffle/compile-common";
 import { Workspace } from "@truffle/db/workspace";
+import { projectLoadGenerate } from "@truffle/db/loaders/commands";
 
 interface IConfig {
   contracts_build_directory: string;
@@ -49,17 +50,48 @@ export class TruffleDB {
     project: DataModel.IProject,
     contractsByCompilation: Array<DataModel.IContract[]>
   ) {
-    const namesLoader = generateNamesLoad(project, contractsByCompilation);
+    const namesLoader = generateNamesLoad(
+      toIdObject(project),
+      contractsByCompilation
+    );
     let curNames = namesLoader.next();
+
     while (!curNames.done) {
-      curNames = namesLoader.next();
+      const {
+        request,
+        variables
+      }: WorkspaceRequest = curNames.value as WorkspaceRequest;
+      const namesResponse: WorkspaceResponse = await this.query(
+        request,
+        variables
+      );
+
+      curNames = namesLoader.next(namesResponse);
     }
   }
 
-  async loadCompilations(result: WorkflowCompileResult, names: boolean) {
-    const saga = generateCompileLoad(result, {
+  async loadProject(): Promise<DataModel.IProject> {
+    const projectRequest = projectLoadGenerate({
       directory: this.context.workingDirectory
-    });
+    }).next();
+
+    // this gets the response using that request, the project
+    const {
+      request,
+      variables
+    }: WorkspaceRequest = projectRequest.value as WorkspaceRequest;
+    const response = await this.query(request, variables);
+    const projectResponse = response.data.workspace.projectsAdd.projects[0];
+
+    return projectResponse;
+  }
+
+  async loadCompilations(
+    project: DataModel.IProject,
+    result: WorkflowCompileResult,
+    names: boolean
+  ) {
+    const saga = generateCompileLoad(result);
 
     let cur = saga.next();
 
@@ -77,7 +109,7 @@ export class TruffleDB {
     }
 
     if (names === true) {
-      this.loadNames(cur.value.project, cur.value.contractsByCompilation);
+      await this.loadNames(project, cur.value.contractsByCompilation);
     }
 
     return cur.value;

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -4,7 +4,8 @@ import { generateCompileLoad } from "@truffle/db/loaders/commands";
 import {
   WorkspaceRequest,
   WorkspaceResponse,
-  toIdObject
+  toIdObject,
+  NamedResource
 } from "@truffle/db/loaders/types";
 import { WorkflowCompileResult } from "@truffle/compile-common";
 import { Workspace } from "@truffle/db/workspace";
@@ -88,14 +89,11 @@ export class TruffleDB {
     return current.value;
   }
 
-  async loadNames(
-    project: DataModel.IProject,
-    contractsByCompilation: Array<DataModel.IContract[]>
-  ) {
+  async loadNames(project: DataModel.IProject, resources: NamedResource[]) {
     return await this.runLoader(
       generateNamesLoad,
       toIdObject(project),
-      contractsByCompilation
+      resources
     );
   }
 
@@ -111,16 +109,16 @@ export class TruffleDB {
   ) {
     const project = await this.loadProject();
 
-    const { compilations, contractsByCompilation } = await this.runLoader(
+    const { compilations, contracts } = await this.runLoader(
       generateCompileLoad,
       result
     );
 
     if (options.names === true) {
-      await this.loadNames(project, contractsByCompilation);
+      await this.loadNames(project, contracts);
     }
 
-    return { compilations, contractsByCompilation };
+    return { compilations, contracts };
   }
 
   createContext(config: IConfig): IContext {

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -46,6 +46,13 @@ export class TruffleDB {
     return await execute(this.schema, document, null, this.context, variables);
   }
 
+  async getWorkspaceResponse(generatorRequest: WorkspaceRequest) {
+    const { request, variables }: WorkspaceRequest = generatorRequest;
+
+    const response: WorkspaceResponse = await this.query(request, variables);
+
+    return response;
+  }
   async loadNames(
     project: DataModel.IProject,
     contractsByCompilation: Array<DataModel.IContract[]>
@@ -57,15 +64,7 @@ export class TruffleDB {
     let curNames = namesLoader.next();
 
     while (!curNames.done) {
-      const {
-        request,
-        variables
-      }: WorkspaceRequest = curNames.value as WorkspaceRequest;
-      const namesResponse: WorkspaceResponse = await this.query(
-        request,
-        variables
-      );
-
+      const namesResponse = await this.getWorkspaceResponse(curNames.value);
       curNames = namesLoader.next(namesResponse);
     }
   }
@@ -75,12 +74,7 @@ export class TruffleDB {
       directory: this.context.workingDirectory
     }).next();
 
-    // this gets the response using that request, the project
-    const {
-      request,
-      variables
-    }: WorkspaceRequest = projectRequest.value as WorkspaceRequest;
-    const response = await this.query(request, variables);
+    const response = await this.getWorkspaceResponse(projectRequest.value);
     const projectResponse = response.data.workspace.projectsAdd.projects[0];
 
     return projectResponse;
@@ -99,12 +93,7 @@ export class TruffleDB {
       // HACK not sure why this is necessary; TS knows we're not done, so
       // cur.value should only be WorkspaceRequest (first Generator param),
       // not the return value (second Generator param)
-      const {
-        request,
-        variables
-      }: WorkspaceRequest = cur.value as WorkspaceRequest;
-      const response = await this.query(request, variables);
-
+      const response = await this.getWorkspaceResponse(cur.value);
       cur = saga.next(response);
     }
 

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -1,10 +1,17 @@
 import { GraphQLSchema, DocumentNode, parse, execute } from "graphql";
 import { schema } from "@truffle/db/data";
 import { generateCompileLoad } from "@truffle/db/loaders/commands";
-import { WorkspaceRequest } from "@truffle/db/loaders/types";
+import {
+  WorkspaceRequest,
+  WorkspaceResponse,
+  toIdObject
+} from "@truffle/db/loaders/types";
 import { WorkflowCompileResult } from "@truffle/compile-common";
 import { Workspace } from "@truffle/db/workspace";
-import { projectLoadGenerate } from "@truffle/db/loaders/commands";
+import {
+  projectLoadGenerate,
+  generateNamesLoad
+} from "@truffle/db/loaders/commands";
 
 interface IConfig {
   contracts_build_directory: string;

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -9,7 +9,7 @@ import {
 import { WorkflowCompileResult } from "@truffle/compile-common";
 import { Workspace } from "@truffle/db/workspace";
 import {
-  projectLoadGenerate,
+  generateInitializeLoad,
   generateNamesLoad
 } from "@truffle/db/loaders/commands";
 
@@ -77,7 +77,7 @@ export class TruffleDB {
   }
 
   async loadProject(): Promise<DataModel.IProject> {
-    const projectRequest = projectLoadGenerate({
+    const projectRequest = generateInitializeLoad({
       directory: this.context.workingDirectory
     }).next();
 

--- a/packages/db/src/loaders/commands/compile.ts
+++ b/packages/db/src/loaders/commands/compile.ts
@@ -72,6 +72,7 @@ export function* generateCompileLoad(
   //
   // again going one compilation at a time (for impl. convenience; HACK)
   // (@cds-amal reminds that "premature optimization is the root of all evil")
+  let contractsByCompilation = [];
   for (const [compilationIndex, compilation] of compilations.entries()) {
     const resultCompilation = resultCompilations[compilationIndex];
     const bytecodes = compilationBytecodes[compilationIndex];
@@ -92,17 +93,10 @@ export function* generateCompileLoad(
     }
 
     const contracts = yield* generateContractsLoad(loadableContracts);
-
-    const nameRecords = yield* generateNameRecordsLoad(
-      contracts,
-      "Contract",
-      getCurrent
-    );
-
-    yield* generateProjectNamesAssign(toIdObject(project), nameRecords);
+    contractsByCompilation.push(contracts);
   }
 
-  return { project, compilations };
+  return { project, compilations, contractsByCompilation };
 }
 
 function processResultCompilations(

--- a/packages/db/src/loaders/commands/compile.ts
+++ b/packages/db/src/loaders/commands/compile.ts
@@ -77,11 +77,13 @@ export function* generateCompileLoad(
       }
     }
 
-    const contracts = yield* generateContractsLoad(loadableContracts);
-    contractsByCompilation.push(contracts);
+    const loadedContracts = yield* generateContractsLoad(loadableContracts);
+    contractsByCompilation.push(loadedContracts);
   }
 
-  return { compilations, contractsByCompilation };
+  const contracts = contractsByCompilation.flat();
+
+  return { compilations, contracts };
 }
 
 function processResultCompilations(

--- a/packages/db/src/loaders/commands/compile.ts
+++ b/packages/db/src/loaders/commands/compile.ts
@@ -1,6 +1,5 @@
 import {
   CompilationData,
-  toIdObject,
   WorkspaceRequest,
   WorkspaceResponse
 } from "@truffle/db/loaders/types";
@@ -14,12 +13,6 @@ import { generateBytecodesLoad } from "@truffle/db/loaders/resources/bytecodes";
 import { generateCompilationsLoad } from "@truffle/db/loaders/resources/compilations";
 import { generateContractsLoad } from "@truffle/db/loaders/resources/contracts";
 import { generateSourcesLoad } from "@truffle/db/loaders/resources/sources";
-import {
-  generateProjectLoad,
-  generateProjectNameResolve,
-  generateProjectNamesAssign
-} from "@truffle/db/loaders/resources/projects";
-import { generateNameRecordsLoad } from "@truffle/db/loaders/resources/nameRecords";
 
 /**
  * For a compilation result from @truffle/workflow-compile/new, generate a
@@ -30,16 +23,8 @@ import { generateNameRecordsLoad } from "@truffle/db/loaders/resources/nameRecor
  * and ultimately returns nothing when complete.
  */
 export function* generateCompileLoad(
-  result: WorkflowCompileResult,
-  { directory }: { directory: string }
+  result: WorkflowCompileResult
 ): Generator<WorkspaceRequest, any, WorkspaceResponse<string>> {
-  // start by adding loading the project resource
-  const project = yield* generateProjectLoad(directory);
-
-  const getCurrent = function* (name, type) {
-    return yield* generateProjectNameResolve(toIdObject(project), name, type);
-  };
-
   const resultCompilations = processResultCompilations(result);
 
   // for each compilation returned by workflow-compile:
@@ -96,7 +81,7 @@ export function* generateCompileLoad(
     contractsByCompilation.push(contracts);
   }
 
-  return { project, compilations, contractsByCompilation };
+  return { compilations, contractsByCompilation };
 }
 
 function processResultCompilations(

--- a/packages/db/src/loaders/commands/index.ts
+++ b/packages/db/src/loaders/commands/index.ts
@@ -1,3 +1,3 @@
 export { generateCompileLoad } from "./compile";
 export { generateNamesLoad } from "./names";
-export { projectLoadGenerate } from "./projects";
+export { generateInitializeLoad } from "./initialize";

--- a/packages/db/src/loaders/commands/index.ts
+++ b/packages/db/src/loaders/commands/index.ts
@@ -1,2 +1,3 @@
 export { generateCompileLoad } from "./compile";
 export { generateNamesLoad } from "./names";
+export { projectLoadGenerate } from "./projects";

--- a/packages/db/src/loaders/commands/index.ts
+++ b/packages/db/src/loaders/commands/index.ts
@@ -1,1 +1,2 @@
 export { generateCompileLoad } from "./compile";
+export { generateNamesLoad } from "./names";

--- a/packages/db/src/loaders/commands/initialize.ts
+++ b/packages/db/src/loaders/commands/initialize.ts
@@ -1,7 +1,7 @@
 import { generateProjectLoad } from "@truffle/db/loaders/resources/projects";
 import { WorkspaceRequest, WorkspaceResponse } from "@truffle/db/loaders/types";
 
-export function* projectLoadGenerate({
+export function* generateInitializeLoad({
   directory
 }: {
   directory: string;

--- a/packages/db/src/loaders/commands/names.ts
+++ b/packages/db/src/loaders/commands/names.ts
@@ -9,7 +9,6 @@ import {
   WorkspaceRequest,
   WorkspaceResponse
 } from "@truffle/db/loaders/types";
-import { projectLoadGenerate } from "./projects";
 
 /**
  * generator function to load nameRecords and project names into Truffle DB

--- a/packages/db/src/loaders/commands/names.ts
+++ b/packages/db/src/loaders/commands/names.ts
@@ -5,20 +5,20 @@ import {
 
 import { generateNameRecordsLoad } from "@truffle/db/loaders/resources/nameRecords";
 import {
-  toIdObject,
   WorkspaceRequest,
-  WorkspaceResponse
+  WorkspaceResponse,
+  IdObject
 } from "@truffle/db/loaders/types";
 
 /**
  * generator function to load nameRecords and project names into Truffle DB
  */
 export function* generateNamesLoad(
-  project: DataModel.IProject,
+  project: IdObject<DataModel.IProject>,
   contractsByCompilation: Array<DataModel.IContract[]>
 ): Generator<WorkspaceRequest, any, WorkspaceResponse<string>> {
   let getCurrent = function* (name, type) {
-    return yield* generateProjectNameResolve(toIdObject(project), name, type);
+    return yield* generateProjectNameResolve(project, name, type);
   };
 
   for (const contracts of contractsByCompilation) {
@@ -28,6 +28,6 @@ export function* generateNamesLoad(
       getCurrent
     );
 
-    yield* generateProjectNamesAssign(toIdObject(project), nameRecords);
+    yield* generateProjectNamesAssign(project, nameRecords);
   }
 }

--- a/packages/db/src/loaders/commands/names.ts
+++ b/packages/db/src/loaders/commands/names.ts
@@ -9,6 +9,7 @@ import {
   WorkspaceRequest,
   WorkspaceResponse
 } from "@truffle/db/loaders/types";
+import { projectLoadGenerate } from "./projects";
 
 /**
  * generator function to load nameRecords and project names into Truffle DB

--- a/packages/db/src/loaders/commands/names.ts
+++ b/packages/db/src/loaders/commands/names.ts
@@ -7,7 +7,8 @@ import { generateNameRecordsLoad } from "@truffle/db/loaders/resources/nameRecor
 import {
   WorkspaceRequest,
   WorkspaceResponse,
-  IdObject
+  IdObject,
+  NamedResource
 } from "@truffle/db/loaders/types";
 
 /**
@@ -15,19 +16,17 @@ import {
  */
 export function* generateNamesLoad(
   project: IdObject<DataModel.IProject>,
-  contractsByCompilation: Array<DataModel.IContract[]>
+  contracts: NamedResource[]
 ): Generator<WorkspaceRequest, any, WorkspaceResponse<string>> {
   let getCurrent = function* (name, type) {
     return yield* generateProjectNameResolve(project, name, type);
   };
 
-  for (const contracts of contractsByCompilation) {
-    const nameRecords = yield* generateNameRecordsLoad(
-      contracts,
-      "Contract",
-      getCurrent
-    );
+  const nameRecords = yield* generateNameRecordsLoad(
+    contracts,
+    "Contract",
+    getCurrent
+  );
 
-    yield* generateProjectNamesAssign(project, nameRecords);
-  }
+  yield* generateProjectNamesAssign(project, nameRecords);
 }

--- a/packages/db/src/loaders/commands/names.ts
+++ b/packages/db/src/loaders/commands/names.ts
@@ -1,0 +1,33 @@
+import {
+  generateProjectNameResolve,
+  generateProjectNamesAssign
+} from "@truffle/db/loaders/resources/projects";
+
+import { generateNameRecordsLoad } from "@truffle/db/loaders/resources/nameRecords";
+import {
+  toIdObject,
+  WorkspaceRequest,
+  WorkspaceResponse
+} from "@truffle/db/loaders/types";
+
+/**
+ * generator function to load nameRecords and project names into Truffle DB
+ */
+export function* generateNamesLoad(
+  project: DataModel.IProject,
+  contractsByCompilation: Array<DataModel.IContract[]>
+): Generator<WorkspaceRequest, any, WorkspaceResponse<string>> {
+  let getCurrent = function* (name, type) {
+    return yield* generateProjectNameResolve(toIdObject(project), name, type);
+  };
+
+  for (const contracts of contractsByCompilation) {
+    const nameRecords = yield* generateNameRecordsLoad(
+      contracts,
+      "Contract",
+      getCurrent
+    );
+
+    yield* generateProjectNamesAssign(toIdObject(project), nameRecords);
+  }
+}

--- a/packages/db/src/loaders/commands/projects.ts
+++ b/packages/db/src/loaders/commands/projects.ts
@@ -7,7 +7,7 @@ export function* projectLoadGenerate({
   directory: string;
 }): Generator<
   WorkspaceRequest,
-  DataModel.IProject,
+  any,
   WorkspaceResponse<"projectsAdd", DataModel.IProjectsAddPayload>
 > {
   const project = yield* generateProjectLoad(directory);

--- a/packages/db/src/loaders/commands/projects.ts
+++ b/packages/db/src/loaders/commands/projects.ts
@@ -1,0 +1,15 @@
+import { generateProjectLoad } from "@truffle/db/loaders/resources/projects";
+import { WorkspaceRequest, WorkspaceResponse } from "@truffle/db/loaders/types";
+
+export function* projectLoadGenerate({
+  directory
+}: {
+  directory: string;
+}): Generator<
+  WorkspaceRequest,
+  DataModel.IProject,
+  WorkspaceResponse<"projectsAdd", DataModel.IProjectsAddPayload>
+> {
+  const project = yield* generateProjectLoad(directory);
+  return project;
+}

--- a/packages/db/src/loaders/resources/nameRecords/index.ts
+++ b/packages/db/src/loaders/resources/nameRecords/index.ts
@@ -34,7 +34,6 @@ export function* generateNameRecordsLoad(
   const nameRecords = [];
   for (const resource of resources) {
     const { name } = resource;
-
     const current: DataModel.INameRecord = yield* getCurrent(name, type);
 
     if (current) {

--- a/packages/db/src/loaders/schema/artifactsLoader.ts
+++ b/packages/db/src/loaders/schema/artifactsLoader.ts
@@ -53,11 +53,6 @@ type BytecodeInfo = {
   bytes?: string;
 };
 
-type BytecodesObject = {
-  bytecodes: Array<BytecodeInfo>;
-  callBytecodes: Array<BytecodeInfo>;
-};
-
 type IdObject = {
   id: string;
 };
@@ -95,11 +90,9 @@ export class ArtifactsLoader {
 
     // third parameter in loadCompilation is for whether or not we need
     // to update nameRecords (i.e. is this happening in test)
-    const { compilations } = await this.db.loadCompilations(
-      project,
-      result,
-      true
-    );
+    const { compilations } = await this.db.loadCompilations(project, result, {
+      names: true
+    });
 
     //map contracts and contract instances to compiler
     await Promise.all(
@@ -157,7 +150,7 @@ export class ArtifactsLoader {
     );
 
     //set new projectNameHeads based on name records added
-    const projectNamesResult = await this.db.query(AssignProjectNames, {
+    await this.db.query(AssignProjectNames, {
       projectNames
     });
   }

--- a/packages/db/src/loaders/schema/artifactsLoader.ts
+++ b/packages/db/src/loaders/schema/artifactsLoader.ts
@@ -90,7 +90,7 @@ export class ArtifactsLoader {
 
     // third parameter in loadCompilation is for whether or not we need
     // to update nameRecords (i.e. is this happening in test)
-    const { compilations } = await this.db.loadCompilations(project, result, {
+    const { compilations } = await this.db.loadCompilations(result, {
       names: true
     });
 

--- a/packages/db/src/loaders/schema/artifactsLoader.ts
+++ b/packages/db/src/loaders/schema/artifactsLoader.ts
@@ -91,7 +91,12 @@ export class ArtifactsLoader {
       this.config
     );
 
-    const { project, compilations } = await this.db.loadCompilations(result);
+    // second parameter in loadCompilation is for whether or not we need
+    // to update nameRecords (i.e. is this happening in test)
+    const { project, compilations } = await this.db.loadCompilations(
+      result,
+      true
+    );
 
     //map contracts and contract instances to compiler
     await Promise.all(

--- a/packages/db/src/loaders/schema/artifactsLoader.ts
+++ b/packages/db/src/loaders/schema/artifactsLoader.ts
@@ -91,9 +91,12 @@ export class ArtifactsLoader {
       this.config
     );
 
-    // second parameter in loadCompilation is for whether or not we need
+    const project = await this.db.loadProject();
+
+    // third parameter in loadCompilation is for whether or not we need
     // to update nameRecords (i.e. is this happening in test)
-    const { project, compilations } = await this.db.loadCompilations(
+    const { compilations } = await this.db.loadCompilations(
+      project,
       result,
       true
     );

--- a/packages/db/src/loaders/types.ts
+++ b/packages/db/src/loaders/types.ts
@@ -56,3 +56,8 @@ export type WorkspaceResponse<N extends string = string, R = any> = {
     workspace: { [RequestName in N]: R };
   };
 };
+
+export interface NamedResource {
+  id: string;
+  name: string;
+}


### PR DESCRIPTION
This PR pulls out adding name records, putting that functionality behind a boolean so that we can ensure that when Truffle DB is integrated with the rest of Truffle that we do not update names when `test` is being run. In the course of this work, I also pulled out the logic for adding projects, so that it is now done before we load compilations and everything else.