### PR TITLE
Use fs-extra in Truffle DB

### DIFF
--- a/packages/db/bin/server.js
+++ b/packages/db/bin/server.js
@@ -19,8 +19,6 @@ const server = new ApolloServer({
   context
 });
 
-// This `listen` method launches a web-server.  Existing apps
-// can utilize middleware options, which we'll discuss later.
 server.listen({ port }).then(({ url }) => {
   console.log(`🚀  Server ready at ${url}`);
 });

--- a/packages/db/src/artifacts/json/resolvers.ts
+++ b/packages/db/src/artifacts/json/resolvers.ts
@@ -1,4 +1,4 @@
-import fs from "fs";
+import * as fse from "fs-extra";
 import { shimBytecode } from "@truffle/workflow-compile/shims";
 
 const TruffleResolver = require("@truffle/resolver");
@@ -67,7 +67,7 @@ export const resolvers = {
     },
     contractNames: {
       resolve(_, {}, context: IContext): string[] {
-        const contents = fs.readdirSync(context.artifactsDirectory);
+        const contents = fse.readdirSync(context.artifactsDirectory);
 
         return contents
           .filter(filename => filename.endsWith(".json"))

--- a/packages/db/src/artifacts/test/index.ts
+++ b/packages/db/src/artifacts/test/index.ts
@@ -1,4 +1,3 @@
-import fs from "fs";
 import path from "path";
 import { TruffleDB } from "@truffle/db";
 import { shimBytecode } from "@truffle/workflow-compile/shims";

--- a/packages/db/src/loaders/commands/compile.ts
+++ b/packages/db/src/loaders/commands/compile.ts
@@ -1,4 +1,3 @@
-import { TruffleDB } from "@truffle/db/db";
 import {
   WorkflowCompileResult,
   CompilationData,
@@ -117,13 +116,15 @@ function processResultCompilation({
 }: WorkflowCompileResult["compilations"][string]): CompilationData {
   const contractsBySourcePath: {
     [sourcePath: string]: CompiledContract[];
-  } = contracts.map(contract => [contract.sourcePath, contract]).reduce(
-    (obj, [sourcePath, contract]: [string, CompiledContract]) => ({
-      ...obj,
-      [sourcePath]: [...(obj[sourcePath] || []), contract]
-    }),
-    {}
-  );
+  } = contracts
+    .map(contract => [contract.sourcePath, contract])
+    .reduce(
+      (obj, [sourcePath, contract]: [string, CompiledContract]) => ({
+        ...obj,
+        [sourcePath]: [...(obj[sourcePath] || []), contract]
+      }),
+      {}
+    );
 
   return {
     // PRECONDITION: all contracts in the same compilation **must** have the

--- a/packages/db/src/loaders/schema/artifactsLoader.ts
+++ b/packages/db/src/loaders/schema/artifactsLoader.ts
@@ -1,4 +1,3 @@
-import gql from "graphql-tag";
 import { TruffleDB } from "@truffle/db/db";
 import * as Contracts from "@truffle/workflow-compile/new";
 import { ContractObject } from "@truffle/contract-schema/spec";
@@ -111,9 +110,10 @@ export class ArtifactsLoader {
           .map(processedSource => processedSource.contracts)
           .flat();
 
-        const contracts = result.compilations[compiler.name].contracts.map(
-          ({ contractName }) =>
-            processedSourceContracts.find(({ name }) => name === contractName)
+        const contracts = result.compilations[
+          compiler.name
+        ].contracts.map(({ contractName }) =>
+          processedSourceContracts.find(({ name }) => name === contractName)
         );
 
         if (networks[0].length) {

--- a/packages/db/src/loaders/schema/index.ts
+++ b/packages/db/src/loaders/schema/index.ts
@@ -1,8 +1,5 @@
-import { TruffleDB } from "@truffle/db";
 import { ArtifactsLoader } from "./artifactsLoader";
 export { ArtifactsLoader };
-import { schema as rootSchema } from "@truffle/db/schema";
-import { Workspace, schema } from "@truffle/db/workspace";
 const tmp = require("tmp");
 import { makeExecutableSchema } from "@gnd/graphql-tools";
 import { gql } from "apollo-server";

--- a/packages/db/src/loaders/schema/test/index.ts
+++ b/packages/db/src/loaders/schema/test/index.ts
@@ -1,4 +1,3 @@
-import fs from "fs";
 import path from "path";
 import gql from "graphql-tag";
 import { TruffleDB } from "@truffle/db";

--- a/packages/db/src/loaders/test/index.ts
+++ b/packages/db/src/loaders/test/index.ts
@@ -1,9 +1,6 @@
-import fs from "fs";
 import path from "path";
 import gql from "graphql-tag";
 import { TruffleDB } from "@truffle/db";
-import * as Contracts from "@truffle/workflow-compile/new";
-import Ganache from "ganache-core";
 import tmp from "tmp";
 
 jest.mock("@truffle/workflow-compile/new", () => ({

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,11 +1,11 @@
-import fs from "fs";
+import * as fse from "fs-extra";
 import path from "path";
 
 import { makeExecutableSchema } from "@gnd/graphql-tools";
 
 export function readSchema() {
   const schemaFile = path.join(__dirname, "schema.graphql");
-  const typeDefs = fs.readFileSync(schemaFile).toString();
+  const typeDefs = fse.readFileSync(schemaFile).toString();
 
   return makeExecutableSchema({
     typeDefs,

--- a/packages/db/src/workspace/test/utils.ts
+++ b/packages/db/src/workspace/test/utils.ts
@@ -7,7 +7,6 @@ import { Workspace, schema } from "@truffle/db/workspace";
 export { generateId } from "@truffle/db/helpers";
 
 import tmp from "tmp";
-import * as fse from "fs-extra";
 
 export const fixturesDirectory = path.join(
   __dirname, // db/src/db/test


### PR DESCRIPTION
This PR removes a comment from the `server.js` file and removes unneeded imports. It also replaces `fs` with `fse` everywhere it is used in the Truffle DB project. Making a separate PR just to be sure nothing wonky is going on and nobody has concerns before merging into our longstanding truffle-db branch. 