### PR TITLE
Bug fix: Remove end-of-line padding in debugger CLI

### DIFF
--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -689,7 +689,10 @@ var DebugUtils = {
       //handling padding & numbering manually
       lineNumbers: false,
       stripIndent: false,
-      codePad: 0
+      codePad: 0,
+      tabsToSpaces: false, //we handle this ourself and don't
+      //want chromafi's padding
+      lineEndPad: false
       //NOTE: you might think you should pass highlight: true,
       //but you'd be wrong!  I don't understand this either
     };

--- a/packages/debug-utils/package.json
+++ b/packages/debug-utils/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@truffle/codec": "^0.6.1",
-    "@trufflesuite/chromafi": "^2.1.2",
+    "@trufflesuite/chromafi": "^2.2.0",
     "chalk": "^2.4.2",
     "debug": "^4.1.0",
     "highlight.js": "^9.15.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1137,10 +1137,10 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@trufflesuite/chromafi@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@trufflesuite/chromafi/-/chromafi-2.1.2.tgz#50715070093c5543a406a2cc85fa70fc8d1a36ab"
-  integrity sha512-KcfjcH3B8+lHfSTfugFPBpMZmppLNCnM6/PP8ByrQLSACyjh9UOMUWHAW3FDHKEt1cOCzIFXrx2f4AFFrQFxSg==
+"@trufflesuite/chromafi@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@trufflesuite/chromafi/-/chromafi-2.2.0.tgz#18cceacbb44f1e22ec956dd7ad21a2ed414b09c7"
+  integrity sha512-km4Px34wZ015PDjAK0wfYBx+zoCE4qR3AY9NWLUvtjnnzhCUkaRFCpZdvwDEyB75EzFBoLwV9iiqboz+mMXwBA==
   dependencies:
     ansi-mark "^1.0.0"
     ansi-regex "^3.0.0"


### PR DESCRIPTION
I didn't realize that `chromafi` was adding lots of end of padding to the end of each line.  Unfortunately chromafi has no option to turn this off.  So, I updated our fork to add such an option.  Now we pass that option.  I also made it so we pass the `tabsToSpaces: false` option (though it hasn't seemed to affect anything), since we handle the tabs-to-spaces conversion ourselves already.