### PR TITLE
Internal improvement: Some adjustments for the new compile format

### DIFF
--- a/packages/codec/lib/compilations/types.ts
+++ b/packages/codec/lib/compilations/types.ts
@@ -4,6 +4,7 @@ import {
   Abi as SchemaAbi,
   ImmutableReferences
 } from "@truffle/contract-schema/spec";
+import { Bytecode } from "@truffle/compile-common";
 
 //Note to other people passing in compilations:
 //Please include all fields you can that aren't
@@ -132,14 +133,4 @@ export interface Contract {
    * The ID of the contract's primary source.
    */
   primarySourceId?: string;
-}
-
-//defining this ourselves for now, sorry!
-export interface Bytecode {
-  bytes: string;
-  linkReferences: {
-    offsets: number[];
-    name: string;
-    length: number;
-  }[];
 }

--- a/packages/codec/lib/compilations/utils.ts
+++ b/packages/codec/lib/compilations/utils.ts
@@ -4,10 +4,11 @@ const debug = debugModule("codec:compilations:utils");
 import * as Ast from "@truffle/codec/ast";
 import * as Compiler from "@truffle/codec/compiler";
 import { ContractObject as Artifact } from "@truffle/contract-schema/spec";
+import { CompiledContract } from "@truffle/compile-common";
 import { Compilation, Contract, Source } from "./types";
 
 export function shimArtifacts(
-  artifacts: Artifact[],
+  artifacts: (Artifact | CompiledContract)[],
   files?: string[],
   shimmedCompilationId = "shimmedcompilation",
   externalSolidity = false
@@ -20,7 +21,6 @@ export function shimArtifacts(
   for (let artifact of artifacts) {
     let {
       contractName,
-      contract_name,
       bytecode,
       sourceMap,
       deployedBytecode,
@@ -35,8 +35,11 @@ export function shimArtifacts(
       deployedGeneratedSources
     } = artifact;
 
-    contractName = contractName || <string>contract_name;
-    //dunno what's up w/ the type of contract_name, but it needs coercing
+    if ((<Artifact>artifact).contract_name) {
+      //just in case
+      contractName = <string>(<Artifact>artifact).contract_name;
+      //dunno what's up w/ the type of contract_name, but it needs coercing
+    }
 
     debug("contractName: %s", contractName);
 

--- a/packages/codec/package.json
+++ b/packages/codec/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "@gnd/typedoc": "0.15.0-0",
+    "@truffle/compile-common": "^0.3.10",
     "@truffle/contract-schema": "^3.2.5",
     "@trufflesuite/typedoc-default-themes": "^0.6.1",
     "@types/big.js": "^4.0.5",

--- a/packages/compile-common/src/types.ts
+++ b/packages/compile-common/src/types.ts
@@ -1,4 +1,4 @@
-import { ContractObject } from "@truffle/contract-schema/spec";
+import { Abi, ImmutableReferences } from "@truffle/contract-schema/spec";
 
 export type Compilation = {
   sourceIndexes: string[];
@@ -32,7 +32,7 @@ export type CompiledContract = {
   deployedSourceMap: string;
   legacyAST: object;
   ast: object;
-  abi: object[];
+  abi: Abi;
   metadata: string;
   bytecode: Bytecode;
   deployedBytecode: Bytecode;
@@ -42,7 +42,7 @@ export type CompiledContract = {
   };
   devdoc: object;
   userdoc: object;
-  immutableReferences: object;
+  immutableReferences: ImmutableReferences;
   generatedSources: any;
   deployedGeneratedSources: any;
 };

--- a/packages/core/lib/debug/cli.js
+++ b/packages/core/lib/debug/cli.js
@@ -83,8 +83,7 @@ class CLIDebugger {
       }
     }
     //if not, or if build directory doens't exist, we have to recompile
-    let { contracts, files } = await this.compileSources();
-    return Codec.Compilations.Utils.shimArtifacts(contracts, files);
+    return await this.compileSources();
   }
 
   async compileSources() {
@@ -95,10 +94,15 @@ class CLIDebugger {
 
     compileSpinner.succeed();
 
-    return {
-      contracts: compilationResult.contracts,
-      files: compilationResult.sourceIndexes
-    };
+    return [].concat(
+      ...compilationResult.map((compilation, index) =>
+        Codec.Compilations.Utils.shimArtifacts(
+          compilation.contracts,
+          compilation.sourceIndexes,
+          `shimmedCompilationNumber(${index})`
+        )
+      )
+    );
   }
 
   async startDebugger(compilations) {

--- a/packages/core/lib/debug/compiler.js
+++ b/packages/core/lib/debug/compiler.js
@@ -12,17 +12,7 @@ class DebugCompiler {
       ? await Compile.sources({ sources, options: compileConfig }) //used by external.js
       : await Compile.all(compileConfig);
 
-    return compilations.reduce(
-      (a, compilation) => {
-        a.contracts = a.contracts.concat(compilation.contracts);
-        a.sourceIndexes = a.sourceIndexes.concat(compilation.sourceIndexes);
-        return a;
-      },
-      {
-        contracts: [],
-        sourceIndexes: []
-      }
-    );
+    return compilations;
   }
 }
 

--- a/packages/core/lib/debug/external.js
+++ b/packages/core/lib/debug/external.js
@@ -108,18 +108,20 @@ class DebugExternalHandler {
             solc: options
           }
         });
-        const { contracts, sourceIndexes: files } = await new DebugCompiler(
-          externalConfig
-        ).compile(sources);
-        debug("contracts: %o", contracts);
-        debug("files: %O", files);
+        const compilations = await new DebugCompiler(externalConfig).compile(
+          sources
+        );
         //shim the result
-        const compilationId = `externalFor(${address})Via(${fetcher.fetcherName})`;
-        const newCompilations = Codec.Compilations.Utils.shimArtifacts(
-          contracts,
-          files,
-          compilationId,
-          true //mark compilation as external Solidity
+        const compilationIdBase = `externalFor(${address})Via(${fetcher.fetcherName})`;
+        const newCompilations = [].concat(
+          ...compilations.map((compilation, index) =>
+            Codec.Compilations.Utils.shimArtifacts(
+              compilation.contracts,
+              compilation.sourceIndexes,
+              `${compilationIdBase}Number(${index})`,
+              true //mark compilation as external Solidity
+            )
+          )
         );
         //add it!
         await this.bugger.addExternalCompilations(newCompilations);


### PR DESCRIPTION
This PR has two purposes.

The first commit redoes `core/lib/debug/compile.js`, and the other files in that directory that invoke it, so that it can actually return multiple compilations.  PR #3332 accounted for the new compile return format by mashing the different compilations together; here instead I've separated them into different compilations.

The second commit attempts to fix the types on `shimArtifacts` from `codec` to account for the fact that `bytecode` and `deployedBytecode` may be either strings or `Bytecode` objects.  To get it to compile I had to alter some of the types in compile-common, note.  This also makes `compile-common` a devDependency of codec (but not a run-time dependency).