### PR TITLE
Remove @truffle/resolver dependency in @truffle/compile-common

### DIFF
--- a/packages/compile-common/package.json
+++ b/packages/compile-common/package.json
@@ -19,7 +19,6 @@
   },
   "dependencies": {
     "@truffle/contract-schema": "^3.2.5",
-    "@truffle/resolver": "^6.0.19",
     "fs-extra": "^8.1.0",
     "mocha": "8.0.1",
     "ts-node": "8.10.2"

--- a/packages/compile-common/src/profiler/getImports.ts
+++ b/packages/compile-common/src/profiler/getImports.ts
@@ -1,10 +1,11 @@
-import { ResolverSource } from "@truffle/resolver";
 import { isExplicitlyRelative } from "./isExplicitlyRelative";
 
 export interface ResolvedSource {
   filePath: string;
   body: string;
-  source: ResolverSource;
+  source: {
+    resolveDependencyPath(importPath: string, dependencyPath: string): string;
+  };
 }
 
 export interface GetImportsOptions {
@@ -24,10 +25,9 @@ export async function getImports({
   const imports = await parseImports(body);
 
   // Convert explicitly relative dependencies of modules back into module paths.
-  return imports.map(
-    dependencyPath =>
-      isExplicitlyRelative(dependencyPath)
-        ? source.resolveDependencyPath(filePath, dependencyPath)
-        : dependencyPath
+  return imports.map(dependencyPath =>
+    isExplicitlyRelative(dependencyPath)
+      ? source.resolveDependencyPath(filePath, dependencyPath)
+      : dependencyPath
   );
 }

--- a/packages/compile-common/src/profiler/requiredSources.ts
+++ b/packages/compile-common/src/profiler/requiredSources.ts
@@ -1,5 +1,3 @@
-import { Resolver } from "@truffle/resolver";
-
 import {
   resolveAllSources,
   ResolveAllSourcesOptions

--- a/packages/compile-common/src/profiler/resolveAllSources.ts
+++ b/packages/compile-common/src/profiler/resolveAllSources.ts
@@ -1,5 +1,3 @@
-import { Resolver, ResolverSource } from "@truffle/resolver";
-
 import { getImports, ResolvedSource } from "./getImports";
 
 export interface ResolveAllSourcesOptions {
@@ -24,7 +22,7 @@ export async function resolveAllSources({
   resolve,
   paths,
   shouldIncludePath,
-  parseImports,
+  parseImports
 }: ResolveAllSourcesOptions): Promise<ResolvedSourcesMapping> {
   const mapping: ResolvedSourcesMapping = {};
   const allPaths: (UnresolvedSource | string)[] = paths.slice();


### PR DESCRIPTION
- Remove a bunch of unused imports
- Replace imported `ResolverSource` type with an interface that contains only the relevant part.
- Get rid of the dependency