### PR TITLE
Bug fix: Fix debugger crash on calls with insufficient gas

### DIFF
--- a/packages/debugger/lib/trace/selectors/index.js
+++ b/packages/debugger/lib/trace/selectors/index.js
@@ -80,10 +80,8 @@ let trace = createSelectorTree({
    * HACK: if at the end,
    * we will return a spoofed "past end" step
    */
-  next: createLeaf(
-    ["./steps", "./index"],
-    (steps, index) =>
-      index < steps.length - 1 ? steps[index + 1] : PAST_END_OF_TRACE
+  next: createLeaf(["./steps", "./index"], (steps, index) =>
+    index < steps.length - 1 ? steps[index + 1] : PAST_END_OF_TRACE
   ),
 
   /*
@@ -91,10 +89,25 @@ let trace = createSelectorTree({
    * next trace step that's at the same depth as this one
    * NOTE: if there is none, will return undefined
    * (should not be used in such cases)
+   * NOTE: for additional correctness, will stop searching once
+   * it hits something of *lower* depth (yes that makes the name
+   * a little misleading, but the idea is to find the return step
+   * for a given call step)
    */
   nextOfSameDepth: createLeaf(["./steps", "./index"], (steps, index) => {
     let depth = steps[index].depth;
-    return steps.slice(index + 1).find(step => step.depth === depth);
+    for (let step of steps.slice(index + 1)) {
+      //start searching after current step
+      //using a manual for loop here instead of .find in order to
+      //cut off the search early if needed
+      if (step.depth === depth) {
+        return step;
+      }
+      if (step.depth < depth) {
+        return undefined;
+      }
+    }
+    return undefined;
   }),
 
   /**


### PR DESCRIPTION
This PR fixes a crash in the debugger that could happen if a `CALL` instruction (or similar) failed due to insufficient gas.  (There are technically other ways it could happen, but this is the most likely.)

Whenever there's a call or creation, the debugger looks ahead to the call's return to determine its return status or address returned.  To do this, it searches for the next step of the same depth.  But, what if there is no such step?  That's what can happen if the `CALL` never actually happens due to there not being enough gas.  Other parts of the debugger weren't prepared to handle this, and it caused a crash.  So, I made the other parts of the debugger that used this robust against the possibility of `undefined` here.

While I was at it, I also changed the logic there so that it will stop searching once it hits a step of *lower* depth, to avoid false positives.  (Imagine that A calls B, B attempts to call C and fails due to out of gas, and then A makes another call; this would cause the old logic to think that B's attempt to call C returned when A made that second call.)  So, now that logic is actually correct.  Note I did *not* bother changing the logic used in `addressesAffected`, which still does things the old way, because, eh, didn't see a particular need to change it there.  But thought the actual debugger part should make a point of getting this right.

Anyway, now it doesn't crash, hooray!