### PR TITLE
Dependency update: Update reselect-tree version for better errors

### DIFF
--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -35,7 +35,7 @@
     "redux-cli-logger": "^2.0.1",
     "redux-saga": "1.0.0",
     "remote-redux-devtools": "^0.5.12",
-    "reselect-tree": "^1.3.3",
+    "reselect-tree": "^1.3.4",
     "semver": "^6.3.0",
     "source-map-support": "^0.5.19",
     "web3": "1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13572,10 +13572,10 @@ require-nocache@^1.0.0:
   resolved "https://registry.yarnpkg.com/require-nocache/-/require-nocache-1.0.0.tgz#a665d0b60a07e8249875790a4d350219d3c85fa3"
   integrity sha1-pmXQtgoH6CSYdXkKTTUCGdPIX6M=
 
-reselect-tree@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/reselect-tree/-/reselect-tree-1.3.3.tgz#999f5fd7167d0d2610d5e48dcf8a7c03b28d159a"
-  integrity sha512-sG5sRWghWuWx+E2GolRZIGTVVNkMMvJpjI36gQYSOEtwca11mHtfZre6A6HNztxQcZCYdIwOB6qXt7HrAHrx0w==
+reselect-tree@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/reselect-tree/-/reselect-tree-1.3.4.tgz#449629728e2dc79bf0602571ec8859ac34737089"
+  integrity sha512-1OgNq1IStyJFqIqOoD3k3Ge4SsYCMP9W88VQOfvgyLniVKLfvbYO1Vrl92SyEK5021MkoBX6tWb381VxTDyPBQ==
   dependencies:
     debug "^3.1.0"
     esdoc "^1.0.4"


### PR DESCRIPTION
Updating the reselect-tree version in debugger now that [this PR](https://github.com/trufflesuite/reselect-tree/pull/8) has been merged and released.  Now in the future when I accidentally mess up a selector, hopefully I'll get some more informative error messages.