### PR TITLE
Fix short-circuit check that Vyper's unneeded

### DIFF
--- a/packages/compile-vyper/index.js
+++ b/packages/compile-vyper/index.js
@@ -119,7 +119,7 @@ const Compile = {
     const vyperFiles = sources.filter(path => minimatch(path, VYPER_PATTERN));
 
     // no vyper files found, no need to check vyper
-    if (sources.length === 0) {
+    if (vyperFiles.length === 0) {
       return { compilations: [] };
     }
 


### PR DESCRIPTION
Looks like this variable name was wrong