### PR TITLE
Add `sourcesWithDependencies` to compile interface

### DIFF
--- a/packages/compile-common/src/types.ts
+++ b/packages/compile-common/src/types.ts
@@ -54,12 +54,22 @@ export interface WorkflowCompileResult {
 
 export interface Compiler {
   all: (options: object) => Promise<CompilerResult>;
+
   necessary: (options: object) => Promise<CompilerResult>;
+
   sources: ({
     sources,
     options
   }: {
     sources: object;
+    options: object;
+  }) => Promise<CompilerResult>;
+
+  sourcesWithDependencies: ({
+    paths,
+    options
+  }: {
+    paths: string[];
     options: object;
   }) => Promise<CompilerResult>;
 }

--- a/packages/compile-vyper/index.js
+++ b/packages/compile-vyper/index.js
@@ -130,6 +130,13 @@ const Compile = {
     });
   },
 
+  async sourcesWithDependencies({ paths = [], options }) {
+    return await Compile.sources({
+      sources: paths,
+      options
+    });
+  },
+
   // contracts_directory: String. Directory where contract files can be found.
   // quiet: Boolean. Suppress output. Defaults to false.
   // strict: Boolean. Return compiler warnings as errors. Defaults to false.

--- a/packages/external-compile/index.js
+++ b/packages/external-compile/index.js
@@ -259,9 +259,9 @@ const Compile = {
     });
   },
 
-  // the `sources` argument here is currently unused as the user is
-  // responsible for dealing with compiling their sources
-  async sources({ sources, options }) {
+  // compile-common defines object argument to include `sources`, but this is
+  // unused as the user is responsible for dealing with compiling their sources
+  async sources({ options }) {
     if (options.logger == null) {
       options.logger = console;
     }
@@ -295,6 +295,10 @@ const Compile = {
         }
       ]
     };
+  },
+
+  async sourcesWithDependencies({ options }) {
+    return await Compile.sources({ options });
   }
 };
 


### PR DESCRIPTION
- Add to compile-common types
- Implement as pass-through for compile-vyper and external-compile