### PR TITLE
Internal improvement: Resolve linting problems in various packages

### DIFF
--- a/packages/codec/lib/abi-data/allocate/index.ts
+++ b/packages/codec/lib/abi-data/allocate/index.ts
@@ -24,7 +24,6 @@ import {
   CalldataAllocations,
   CalldataAllocationTemporary,
   CalldataArgumentAllocation,
-  ReturndataArgumentAllocation,
   ContractAllocationInfo,
   EventAllocation,
   EventAllocations,
@@ -1037,9 +1036,6 @@ export function getEventAllocations(
       //we'll need *one* of these two at least
       continue;
     }
-    let contractKind = contractNode
-      ? contractNode.contractKind
-      : deployedContext.contractKind;
     let contractAllocations = getEventAllocationsForContract(
       abi,
       contractNode,

--- a/packages/codec/lib/abi-data/allocate/types.ts
+++ b/packages/codec/lib/abi-data/allocate/types.ts
@@ -129,10 +129,14 @@ export interface EventArgumentAllocation {
 }
 
 //now let's go back ands fill in returndata
-type ReturndataKind = FunctionReturndataKind | ConstructorReturndataKind;
+export type ReturndataKind = FunctionReturndataKind | ConstructorReturndataKind;
 
-type FunctionReturndataKind = "return" | "revert" | "failure" | "selfdestruct";
-type ConstructorReturndataKind = "bytecode";
+export type FunctionReturndataKind =
+  | "return"
+  | "revert"
+  | "failure"
+  | "selfdestruct";
+export type ConstructorReturndataKind = "bytecode";
 
 export type ReturndataAllocation =
   | FunctionReturndataAllocation

--- a/packages/codec/lib/abi-data/decode/index.ts
+++ b/packages/codec/lib/abi-data/decode/index.ts
@@ -38,7 +38,7 @@ export function* decodeAbi(
         //dunno why TS is failing at this inference
         type: dataType,
         kind: "error" as const,
-        error: (<DecodingError>error).error,
+        error: (<DecodingError>error).error
       };
     }
     if (dynamic) {
@@ -67,7 +67,7 @@ export function* decodeAbiReferenceByAddress(
   base = base || 0; //in case base was undefined
   const {
     allocations: { abi: allocations },
-    state,
+    state
   } = info;
   debug("pointer %o", pointer);
   //this variable holds the location we should look to *next*
@@ -93,7 +93,7 @@ export function* decodeAbiReferenceByAddress(
       //dunno why TS is failing here
       type: dataType,
       kind: "error" as const,
-      error: (<DecodingError>error).error,
+      error: (<DecodingError>error).error
     };
   }
 
@@ -106,7 +106,7 @@ export function* decodeAbiReferenceByAddress(
   } catch (_) {
     let error = {
       kind: "OverlargePointersNotImplementedError" as const,
-      pointerAsBN: rawValueAsBN,
+      pointerAsBN: rawValueAsBN
     };
     if (strict) {
       throw new StopDecodingError(error);
@@ -115,7 +115,7 @@ export function* decodeAbiReferenceByAddress(
       //again with the TS failures...
       type: dataType,
       kind: "error" as const,
-      error,
+      error
     };
   }
   let startPosition = rawValueAsNumber + base;
@@ -133,7 +133,7 @@ export function* decodeAbiReferenceByAddress(
       //dunno why TS is failing here
       type: dataType,
       kind: "error" as const,
-      error: (<DecodingError>error).error,
+      error: (<DecodingError>error).error
     };
   }
   if (!dynamic) {
@@ -141,7 +141,7 @@ export function* decodeAbiReferenceByAddress(
     let staticPointer = {
       location,
       start: startPosition,
-      length: size,
+      length: size
     };
     return yield* decodeAbiReferenceStatic(
       dataType,
@@ -168,7 +168,7 @@ export function* decodeAbiReferenceByAddress(
             {
               location,
               start: startPosition,
-              length: Evm.Utils.WORD_SIZE,
+              length: Evm.Utils.WORD_SIZE
             },
             state
           );
@@ -180,7 +180,7 @@ export function* decodeAbiReferenceByAddress(
             //dunno why TS is failing here
             type: dataType,
             kind: "error" as const,
-            error: (<DecodingError>error).error,
+            error: (<DecodingError>error).error
           };
         }
         lengthAsBN = Conversion.toBN(rawLength);
@@ -194,7 +194,7 @@ export function* decodeAbiReferenceByAddress(
         throw new StopDecodingError({
           kind: "OverlongArrayOrStringStrictModeError" as const,
           lengthAsBN,
-          dataLength: state[location].length,
+          dataLength: state[location].length
         });
       }
       try {
@@ -211,15 +211,15 @@ export function* decodeAbiReferenceByAddress(
           kind: "error" as const,
           error: {
             kind: "OverlongArraysAndStringsNotImplementedError" as const,
-            lengthAsBN,
-          },
+            lengthAsBN
+          }
         };
       }
 
       let childPointer: Pointer.AbiDataPointer = {
         location,
         start: startPosition,
-        length,
+        length
       };
 
       return yield* Bytes.Decode.decodeBytes(
@@ -249,7 +249,7 @@ export function* decodeAbiReferenceByAddress(
             {
               location,
               start: startPosition,
-              length: Evm.Utils.WORD_SIZE,
+              length: Evm.Utils.WORD_SIZE
             },
             state
           );
@@ -261,7 +261,7 @@ export function* decodeAbiReferenceByAddress(
           return {
             type: dataType,
             kind: "error" as const,
-            error: (<DecodingError>error).error,
+            error: (<DecodingError>error).error
           };
         }
         lengthAsBN = Conversion.toBN(rawLength);
@@ -275,7 +275,7 @@ export function* decodeAbiReferenceByAddress(
         throw new StopDecodingError({
           kind: "OverlongArraysAndStringsNotImplementedError" as const,
           lengthAsBN,
-          dataLength: state[location].length,
+          dataLength: state[location].length
         });
       }
       try {
@@ -287,8 +287,8 @@ export function* decodeAbiReferenceByAddress(
           kind: "error" as const,
           error: {
             kind: "OverlongArraysAndStringsNotImplementedError" as const,
-            lengthAsBN,
-          },
+            lengthAsBN
+          }
         };
       }
 
@@ -306,7 +306,7 @@ export function* decodeAbiReferenceByAddress(
         return {
           type: dataType,
           kind: "error" as const,
-          error: (<DecodingError>error).error,
+          error: (<DecodingError>error).error
         };
       }
 
@@ -318,7 +318,7 @@ export function* decodeAbiReferenceByAddress(
             {
               location,
               start: startPosition + index * baseSize,
-              length: baseSize,
+              length: baseSize
             },
             info,
             { ...options, abiPointerBase: startPosition }
@@ -328,7 +328,7 @@ export function* decodeAbiReferenceByAddress(
       return {
         type: dataType,
         kind: "value" as const,
-        value: decodedChildren,
+        value: decodedChildren
       };
 
     case "struct":
@@ -374,7 +374,7 @@ export function* decodeAbiReferenceStatic(
         //array, well, we'll just have to deal with it
         let error = {
           kind: "OverlongArraysAndStringsNotImplementedError" as const,
-          lengthAsBN,
+          lengthAsBN
         };
         if (options.strictAbiMode) {
           throw new StopDecodingError(error);
@@ -382,7 +382,7 @@ export function* decodeAbiReferenceStatic(
         return {
           type: dataType,
           kind: "error" as const,
-          error,
+          error
         };
       }
       let baseSize: number;
@@ -396,7 +396,7 @@ export function* decodeAbiReferenceStatic(
         return {
           type: dataType,
           kind: "error" as const,
-          error: (<DecodingError>error).error,
+          error: (<DecodingError>error).error
         };
       }
 
@@ -408,7 +408,7 @@ export function* decodeAbiReferenceStatic(
             {
               location,
               start: pointer.start + index * baseSize,
-              length: baseSize,
+              length: baseSize
             },
             info,
             options
@@ -418,7 +418,7 @@ export function* decodeAbiReferenceStatic(
       return {
         type: dataType,
         kind: "value" as const,
-        value: decodedChildren,
+        value: decodedChildren
       };
 
     case "struct":
@@ -449,8 +449,7 @@ function* decodeAbiStructByPosition(
   options: DecoderOptions = {}
 ): Generator<DecoderRequest, Format.Values.StructResult, Uint8Array> {
   const {
-    userDefinedTypes,
-    allocations: { abi: allocations },
+    allocations: { abi: allocations }
   } = info;
 
   const typeLocation = location === "calldata" ? "calldata" : null; //other abi locations are not valid type locations
@@ -460,7 +459,7 @@ function* decodeAbiStructByPosition(
   if (!structAllocation) {
     let error = {
       kind: "UserDefinedTypeNotFoundError" as const,
-      type: dataType,
+      type: dataType
     };
     if (options.strictAbiMode || options.allowRetry) {
       throw new StopDecodingError(error, true);
@@ -469,7 +468,7 @@ function* decodeAbiStructByPosition(
     return {
       type: dataType,
       kind: "error" as const,
-      error,
+      error
     };
   }
 
@@ -480,7 +479,7 @@ function* decodeAbiStructByPosition(
     const childPointer: Pointer.AbiDataPointer = {
       location,
       start: startPosition + memberPointer.start,
-      length: memberPointer.length,
+      length: memberPointer.length
     };
 
     let memberName = memberAllocation.name;
@@ -493,15 +492,15 @@ function* decodeAbiStructByPosition(
       name: memberName,
       value: yield* decodeAbi(memberType, childPointer, info, {
         ...options,
-        abiPointerBase: startPosition,
-      }),
+        abiPointerBase: startPosition
+      })
       //note that the base option is only needed in the dynamic case, but we're being indiscriminate
     });
   }
   return {
     type: dataType,
     kind: "value" as const,
-    value: decodedMembers,
+    value: decodedMembers
   };
 }
 
@@ -525,14 +524,14 @@ function* decodeAbiTupleByPosition(
     const childPointer: Pointer.AbiDataPointer = {
       location,
       start: position,
-      length: memberSize,
+      length: memberSize
     };
     decodedMembers.push({
       name,
       value: yield* decodeAbi(memberType, childPointer, info, {
         ...options,
-        abiPointerBase: startPosition,
-      }),
+        abiPointerBase: startPosition
+      })
       //note that the base option is only needed in the dynamic case, but we're being indiscriminate
     });
     position += memberSize;
@@ -540,6 +539,6 @@ function* decodeAbiTupleByPosition(
   return {
     type: dataType,
     kind: "value" as const,
-    value: decodedMembers,
+    value: decodedMembers
   };
 }

--- a/packages/codec/lib/abify.ts
+++ b/packages/codec/lib/abify.ts
@@ -8,7 +8,6 @@ import {
   LogDecoding,
   ReturndataDecoding
 } from "@truffle/codec/types";
-import BN from "bn.js";
 import * as Conversion from "@truffle/codec/conversion";
 
 /** @category ABIfication */
@@ -210,7 +209,6 @@ export function abifyResult(
       let uintType = <Format.Types.UintType>(
         abifyType(result.type, userDefinedTypes)
       ); //may throw exception
-      let numericValue: BN;
       switch (coercedResult.kind) {
         case "value":
           return {

--- a/packages/codec/lib/bytes/encode/index.ts
+++ b/packages/codec/lib/bytes/encode/index.ts
@@ -1,6 +1,5 @@
 import * as Format from "@truffle/codec/format";
 import * as Conversion from "@truffle/codec/conversion";
-import * as Evm from "@truffle/codec/evm";
 import utf8 from "utf8";
 
 //UGH -- it turns out TypeScript can't handle nested tagged unions
@@ -15,7 +14,6 @@ import utf8 from "utf8";
 export function encodeBytes(
   input: Format.Values.BytesDynamicValue | Format.Values.StringValue
 ): Uint8Array {
-  let bytes: Uint8Array;
   switch (input.type.typeClass) {
     case "bytes":
       return Conversion.toBytes((<Format.Values.BytesValue>input).value.asHex);

--- a/packages/codec/lib/contexts/utils.ts
+++ b/packages/codec/lib/contexts/utils.ts
@@ -2,7 +2,6 @@ import debugModule from "debug";
 const debug = debugModule("codec:contexts:utils");
 
 import * as Evm from "@truffle/codec/evm";
-import * as Format from "@truffle/codec/format";
 import {
   DecoderContexts,
   DecoderContext,

--- a/packages/codec/lib/core.ts
+++ b/packages/codec/lib/core.ts
@@ -4,7 +4,6 @@ const debug = debugModule("codec:core");
 import * as Ast from "@truffle/codec/ast";
 import * as AbiData from "@truffle/codec/abi-data";
 import * as Topic from "@truffle/codec/topic";
-import * as Bytes from "@truffle/codec/bytes";
 import * as Pointer from "@truffle/codec/pointer";
 import {
   DecoderRequest,
@@ -15,8 +14,7 @@ import {
   UnknownBytecodeDecoding,
   DecodingMode,
   AbiArgument,
-  LogDecoding,
-  DecoderOptions
+  LogDecoding
 } from "@truffle/codec/types";
 import { ConstructorReturndataAllocation } from "@truffle/codec/abi-data/allocate";
 import * as Evm from "@truffle/codec/evm";
@@ -72,7 +70,6 @@ export function* decodeCalldata(
       };
     }
   }
-  const compiler = context.compiler;
   const contextHash = context.context;
   const contractType = Contexts.Import.contextToType(context);
   isConstructor = context.isConstructor;

--- a/packages/codec/lib/decode.ts
+++ b/packages/codec/lib/decode.ts
@@ -6,7 +6,6 @@ import * as AbiData from "@truffle/codec/abi-data";
 import * as Format from "@truffle/codec/format";
 import * as Pointer from "@truffle/codec/pointer";
 import * as Basic from "@truffle/codec/basic";
-import * as Bytes from "@truffle/codec/bytes";
 import * as Evm from "@truffle/codec/evm";
 import { DecoderRequest, DecoderOptions } from "@truffle/codec/types";
 import * as Memory from "@truffle/codec/memory";

--- a/packages/codec/lib/format/utils/inspect.ts
+++ b/packages/codec/lib/format/utils/inspect.ts
@@ -387,10 +387,6 @@ function enumTypeName(enumType: Format.Types.EnumType) {
   );
 }
 
-function styleHexString(hex: string, options: InspectOptions): string {
-  return options.stylize(`hex'${hex.slice(2)}'`, "string");
-}
-
 //this function will be used in the future for displaying circular
 //structures
 function formatCircular(loopLength: number, options: InspectOptions): string {

--- a/packages/codec/lib/format/values.ts
+++ b/packages/codec/lib/format/values.ts
@@ -10,7 +10,6 @@ const debug = debugModule("codec:format:values");
 //just intended for the future.  More optional fields may be added in the
 //future.
 
-import BN from "bn.js";
 import * as Types from "./types";
 import * as Errors from "./errors";
 import {
@@ -26,7 +25,6 @@ import {
   UfixedValue,
   EnumValue,
   ContractValue,
-  ContractValueInfo,
   ContractValueInfoKnown,
   ContractValueInfoUnknown
 } from "./elementary";

--- a/packages/codec/lib/mapping-key/encode/index.ts
+++ b/packages/codec/lib/mapping-key/encode/index.ts
@@ -3,7 +3,6 @@ const debug = debugModule("codec:mapping-key:encode");
 
 import * as Format from "@truffle/codec/format";
 import * as Conversion from "@truffle/codec/conversion";
-import * as Evm from "@truffle/codec/evm";
 import * as BasicEncode from "@truffle/codec/basic/encode";
 import * as BytesEncode from "@truffle/codec/bytes/encode";
 
@@ -21,9 +20,9 @@ export function encodeMappingKey(
     input.type.typeClass === "string" ||
     (input.type.typeClass === "bytes" && input.type.kind === "dynamic")
   ) {
-    return BytesEncode.encodeBytes(<
-      Format.Values.StringValue | Format.Values.BytesDynamicValue
-    >input);
+    return BytesEncode.encodeBytes(
+      <Format.Values.StringValue | Format.Values.BytesDynamicValue>input
+    );
   } else {
     return BasicEncode.encodeBasic(input);
   }

--- a/packages/codec/lib/memory/decode/index.ts
+++ b/packages/codec/lib/memory/decode/index.ts
@@ -235,8 +235,7 @@ export function* decodeMemoryReferenceByAddress(
       }
       //otherwise, decode as normal
       const {
-        allocations: { memory: allocations },
-        userDefinedTypes
+        allocations: { memory: allocations }
       } = info;
 
       const typeId = dataType.id;

--- a/packages/codec/lib/stack/decode/index.ts
+++ b/packages/codec/lib/stack/decode/index.ts
@@ -6,7 +6,6 @@ import * as Conversion from "@truffle/codec/conversion";
 import * as Format from "@truffle/codec/format";
 import read from "@truffle/codec/read";
 import * as Basic from "@truffle/codec/basic";
-import * as Bytes from "@truffle/codec/bytes";
 import * as Memory from "@truffle/codec/memory";
 import * as Storage from "@truffle/codec/storage";
 import * as Pointer from "@truffle/codec/pointer";

--- a/packages/codec/lib/storage/allocate/index.ts
+++ b/packages/codec/lib/storage/allocate/index.ts
@@ -1,7 +1,6 @@
 import debugModule from "debug";
 const debug = debugModule("codec:storage:allocate");
 
-import { DecodingError } from "@truffle/codec/errors";
 import * as Compiler from "@truffle/codec/compiler";
 import * as Common from "@truffle/codec/common";
 import * as Basic from "@truffle/codec/basic";
@@ -412,8 +411,8 @@ function allocateContractState(
     let arrayToGrabFrom = isConstant(variable.definition)
       ? constantVariableAllocations
       : isImmutable(variable.definition)
-        ? immutableVariableAllocations
-        : storageVariableAllocations;
+      ? immutableVariableAllocations
+      : storageVariableAllocations;
     contractAllocation.push(arrayToGrabFrom.shift()); //note that push and shift both modify!
   }
 

--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -12,7 +12,6 @@ import {
   Contexts,
   Compilations,
   Compiler,
-  Pointer,
   CalldataDecoding,
   LogDecoding,
   ReturndataDecoding,
@@ -72,7 +71,6 @@ export class WireDecoder {
         );
         let deployedContext: Contexts.DecoderContext | undefined = undefined;
         let constructorContext: Contexts.DecoderContext | undefined = undefined;
-        const compiler = compilation.compiler || contract.compiler;
         const deployedBytecode = Shims.NewToLegacy.forBytecode(
           contract.deployedBytecode
         );
@@ -1414,7 +1412,6 @@ export class ContractInstanceDecoder {
   ): Storage.Allocate.StateVariableAllocation | undefined {
     //case 1: an ID was input
     if (typeof nameOrId === "number" || nameOrId.match(/[0-9]+/)) {
-      let id: number = Number(nameOrId);
       return this.stateVariableReferences.find(
         ({ definition }) => definition.id === nameOrId
       );
@@ -1746,7 +1743,6 @@ export class ContractInstanceDecoder {
     let index: any;
     let key: Format.Values.ElementaryValue;
     let slot: Storage.Slot;
-    let definition: Ast.AstNode;
     let dataType: Format.Types.Type;
     switch (parentType.typeClass) {
       case "array":

--- a/packages/decoder/lib/types.ts
+++ b/packages/decoder/lib/types.ts
@@ -6,7 +6,6 @@ import {
   Ast,
   Compilations,
   Contexts,
-  CalldataDecoding,
   LogDecoding,
   StateVariable
 } from "@truffle/codec";

--- a/packages/decoder/test/current/test/decoding-test.js
+++ b/packages/decoder/test/current/test/decoding-test.js
@@ -1,6 +1,5 @@
 const debug = require("debug")("decoder:test:decoding-test");
 const assert = require("assert");
-const util = require("util"); // eslint-disable-line no-unused-vars
 
 const Decoder = require("../../..");
 const { nativizeDecoderVariables } = require("../../../dist/utils");
@@ -29,7 +28,7 @@ function validateStructS2(s2, values) {
 }
 
 contract("DecodingSample", _accounts => {
-  it("should get the initial state properly", async function() {
+  it("should get the initial state properly", async function () {
     let deployedContract = await DecodingSample.deployed();
     let address = deployedContract.address;
     const decoder = await Decoder.forContractInstance(deployedContract);
@@ -145,7 +144,7 @@ contract("DecodingSample", _accounts => {
     assert.equal(variables.functionInternal, "DecodingSample.example");
   });
 
-  it("should spawn decoders based on address alone", async function() {
+  it("should spawn decoders based on address alone", async function () {
     const deployedContract = await DecodingSample.deployed();
     const address = deployedContract.address;
     const decoder = await Decoder.forAddress(

--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -18,7 +18,7 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
 
   static async forNetworkId(
     id: number,
-    options?: Types.FetcherOptions
+    _options?: Types.FetcherOptions
   ): Promise<SourcifyFetcher> {
     //in the future, we may add protocol and node options,
     //but these don't exist yet
@@ -92,9 +92,7 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
   ): Promise<Types.SolcMetadata | null> {
     try {
       return await this.requestWithRetries<Types.SolcMetadata>({
-        uri: `https://${this.domain}/contract/${
-          this.networkId
-        }/${address}/metadata.json`,
+        uri: `https://${this.domain}/contract/${this.networkId}/${address}/metadata.json`,
         json: true //turns on auto-parsing
       });
     } catch (error) {
@@ -112,9 +110,7 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     sourcePath: string
   ): Promise<string> {
     return await this.requestWithRetries<string>({
-      uri: `https://${this.domain}/contract/${
-        this.networkId
-      }/${address}/sources/${sourcePath}`
+      uri: `https://${this.domain}/contract/${this.networkId}/${address}/sources/${sourcePath}`
     });
   }
 


### PR DESCRIPTION
Figured I'd run the linter over my stuff now that we're linting TS.  This is what it turned up.  (Prettier also made a bunch of changes in the process, mostly in `codec/lib/abi-data/decode`...)

Almost all of this is removing unused variables; however, there was one case of a parameter that needed an initial `_`.  Also in one case I decided I didn't want to delete the unused types I was defining so instead I exported them. :)

Interesting case: One decoder test, written in JS, turned up with an unused import of `util`.  Why did this turn up now and not earlier?  Well, someone had stuck an `eslint-disable-line` for the `no-unused-vars` rule on it.  But we're no longer using `no-unused-vars`, but rather `@typescript-eslint/no-unused-vars`!  So this could potentially come up elsewhere.  Anyway I just deleted the line, it's an unused import.