### PR TITLE
Internal improvement: Update doc comment about externalSolidity flag

### DIFF
--- a/packages/codec/lib/compilations/types.ts
+++ b/packages/codec/lib/compilations/types.ts
@@ -45,8 +45,10 @@ export interface Compilation {
   /**
    * A flag intended for internal use to indicate that this compilation is not
    * part of the user's Truffle project but rather is compiled from
-   * temporarily-downloaded external Solidity sources.  Again, this should only
-   * be used for Solidity compilations; it may cause irregularities otherwise.
+   * temporarily-downloaded external sources.  This flag was only originally
+   * intended to be used for Solidity or Yul, hence the name; but it should be
+   * OK to set this for externally-downloaded sources regardless of their
+   * language.
    */
   externalSolidity?: boolean;
 }


### PR DESCRIPTION
The `externalSolidity` flag on codec's `Compilation` type used to be for Solidity only (OK or notionally also Yul), but due to #3212 it should now be safe to use with any language.  I never updated the comment, though, and it's part of our codec documentation so I really should.  So, did that here.

I could have changed the name of the flag, but that seemed more trouble than it was worth, so I left it alone.  Can change that though if people think that should really be done.  Obviously then I'd have to change it where it's used as well.