### PR TITLE
Bug fix: Correctly build URLs for fetching the Solidity compiler

### DIFF
--- a/packages/compile-solidity/compilerSupplier/loadingStrategies/VersionRange.js
+++ b/packages/compile-solidity/compilerSupplier/loadingStrategies/VersionRange.js
@@ -97,7 +97,7 @@ class VersionRange extends LoadingStrategy {
     const url = this.config.compilerRoots[index] + fileName;
     const { events } = this.config;
     events.emit("downloadCompiler:start", {
-      attemptNumber: index + 1,
+      attemptNumber: index + 1
     });
     try {
       const response = await request.get(url, { gzip: true, timeout: 30000 });
@@ -143,7 +143,7 @@ class VersionRange extends LoadingStrategy {
     }
     const { compilerRoots } = this.config;
     const url =
-      compilerRoots[compilerRoots.length] === "/"
+      compilerRoots[index][compilerRoots[index].length - 1] === "/"
         ? `${compilerRoots[index]}list.json`
         : `${compilerRoots[index]}/list.json`;
     return request(url, { gzip: true, timeout: 30000 })


### PR DESCRIPTION
Truffle is currently adding an extra "/" in the URL for fetching the Solidity compiler which is failing on "https://solc-bin.ethereum.org/bin/*.json". This fixes the logic for building those URLs.