### PR TITLE
Bug fix: Fix URL construction in the CompilerSupplier

### DIFF
--- a/packages/compile-solidity/compilerSupplier/loadingStrategies/VersionRange.js
+++ b/packages/compile-solidity/compilerSupplier/loadingStrategies/VersionRange.js
@@ -97,7 +97,7 @@ class VersionRange extends LoadingStrategy {
     const url = this.config.compilerRoots[index] + fileName;
     const { events } = this.config;
     events.emit("downloadCompiler:start", {
-      attemptNumber: index + 1,
+      attemptNumber: index + 1
     });
     try {
       const response = await request.get(url, { gzip: true, timeout: 30000 });
@@ -142,10 +142,9 @@ class VersionRange extends LoadingStrategy {
       throw this.errors("noUrl");
     }
     const { compilerRoots } = this.config;
-    const url =
-      compilerRoots[compilerRoots.length] === "/"
-        ? `${compilerRoots[index]}list.json`
-        : `${compilerRoots[index]}/list.json`;
+
+    // trim trailing slashes from compilerRoot
+    const url = `${compilerRoots[index].replace(/\/+$/, "")}/list.json`;
     return request(url, { gzip: true, timeout: 30000 })
       .then(list => {
         events.emit("fetchSolcList:succeed");


### PR DESCRIPTION
Truffle is currently constructing bad URLs for fetching the Solidity compiler version list. It is adding an extra trailing "/" to the base of the URL. This PR strips off trailing commas from the base part of the URL before adding "/list.json".