### PR TITLE
Bug fix: Add generatedSources and deployedGeneratedSources to shims

### DIFF
--- a/packages/compile-common/src/shims/NewToLegacy.ts
+++ b/packages/compile-common/src/shims/NewToLegacy.ts
@@ -16,7 +16,9 @@ export function forContract(contract: CompiledContract): any {
     compiler,
     devdoc,
     userdoc,
-    immutableReferences
+    immutableReferences,
+    generatedSources,
+    deployedGeneratedSources
   } = contract;
 
   return {
@@ -35,7 +37,9 @@ export function forContract(contract: CompiledContract): any {
     compiler,
     devdoc,
     userdoc,
-    immutableReferences
+    immutableReferences,
+    generatedSources,
+    deployedGeneratedSources
   };
 }
 


### PR DESCRIPTION
These were missing from the shim, so these weren't getting saved in the artifacts, so the debugger wasn't getting them when running off of artifacts.  Added now.