### PR TITLE
Internal improvement: Update URL construction in VersionRange strategy

### DIFF
--- a/packages/compile-solidity/compilerSupplier/loadingStrategies/VersionRange.js
+++ b/packages/compile-solidity/compilerSupplier/loadingStrategies/VersionRange.js
@@ -94,7 +94,10 @@ class VersionRange extends LoadingStrategy {
   }
 
   async getSolcByUrlAndCache(fileName, index = 0) {
-    const url = this.config.compilerRoots[index] + fileName;
+    const url = `${this.config.compilerRoots[index].replace(
+      /\/+$/,
+      ""
+    )}/${fileName}`;
     const { events } = this.config;
     events.emit("downloadCompiler:start", {
       attemptNumber: index + 1


### PR DESCRIPTION
There is another instance where the `VersionRange` loading strategy (for `CompilerSupplier`) constructs a URL. This should make this construction more flexible: especially when a user enters their own `compilerRoots`.