### PR TITLE
Include SPDX-License on AssertBytes32.sol

### DIFF
--- a/packages/core/lib/testing/AssertBytes32.sol
+++ b/packages/core/lib/testing/AssertBytes32.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: MIT
+
 pragma solidity >= 0.4.15 < 0.8.0;
 
 library AssertBytes32 {


### PR DESCRIPTION
Getting a warning message when using the most recent compiler

"  truffle/AssertBytes32.sol: Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source codeontaining "SPDX-License-Identifier: <SPDX-License>" to each so. Please see https://spdx.org for more information."