### PR TITLE
Support pre-stateMutability ABIs in schema

### DIFF
--- a/packages/contract-schema/spec/abi.spec.json
+++ b/packages/contract-schema/spec/abi.spec.json
@@ -64,7 +64,7 @@
           "$ref": "#/definitions/StateMutability"
         },
         "constant": { "type": "boolean" },
-        "payable": { "type": "boolean", "default": false }
+        "payable": { "type": "boolean" }
       },
       "required": ["name", "inputs", "stateMutability"],
       "additionalProperties": false
@@ -85,7 +85,7 @@
           "$ref": "#/definitions/StateMutability"
         },
         "constant": { "type": "boolean" },
-        "payable": { "type": "boolean", "default": false }
+        "payable": { "type": "boolean" }
       },
       "required": ["type", "inputs", "stateMutability"],
       "additionalProperties": false
@@ -102,7 +102,7 @@
           "$ref": "#/definitions/StateMutability"
         },
         "constant": { "type": "boolean" },
-        "payable": { "type": "boolean", "default": false }
+        "payable": { "type": "boolean" }
       },
       "required": ["type", "stateMutability"],
       "additionalProperties": false

--- a/packages/contract-schema/spec/abi.spec.json
+++ b/packages/contract-schema/spec/abi.spec.json
@@ -66,7 +66,10 @@
         "constant": { "type": "boolean" },
         "payable": { "type": "boolean" }
       },
-      "required": ["name", "inputs", "stateMutability"],
+      "anyOf": [
+        { "required": ["name", "inputs", "stateMutability"] },
+        { "required": ["name", "inputs", "constant", "payable"] }
+      ],
       "additionalProperties": false
     },
 
@@ -87,7 +90,10 @@
         "constant": { "type": "boolean" },
         "payable": { "type": "boolean" }
       },
-      "required": ["type", "inputs", "stateMutability"],
+      "anyOf": [
+        { "required": ["type", "inputs", "stateMutability"] },
+        { "required": ["type", "inputs", "payable"] }
+      ],
       "additionalProperties": false
     },
 
@@ -105,6 +111,10 @@
         "payable": { "type": "boolean" }
       },
       "required": ["type", "stateMutability"],
+      "anyOf": [
+        { "required": ["type", "stateMutability"] },
+        { "required": ["type", "payable"] }
+      ],
       "additionalProperties": false
     },
 

--- a/packages/db/src/artifacts/json/schema.ts
+++ b/packages/db/src/artifacts/json/schema.ts
@@ -170,8 +170,24 @@ const translations = [
                   }
                 },
 
+                // remove this and just compress into `required`
+                anyOf: undefined,
+
                 // ensure `type` is in array of required property names
-                required: Array.from(new Set([...itemType.required, "type"]))
+                required: Array.from(
+                  new Set([
+                    ...// required may be defined in `"anyOf"` - just take what's
+                    // in common amongst all the anyOf and make sure it has
+                    // `"type"`
+                    (itemType.required ||
+                      itemType.anyOf
+                        .map(option => new Set(option.required))
+                        .reduce((a, b) =>
+                          !a ? b : [...a].filter(x => b.has(x))
+                        )),
+                    "type"
+                  ])
+                )
               }
             }))
         )
@@ -261,7 +277,10 @@ const translations = [
   ),
 
   // find all `^x-` patternProperties and remove
-  searchReplace(key => key === "^x-", () => ({})),
+  searchReplace(
+    key => key === "^x-",
+    () => ({})
+  ),
 
   // manually fix network object references to event
   searchReplace(


### PR DESCRIPTION
Older versions of solc didn't emit `stateMutability` in ABI output.

This PR makes either `stateMutability` required **or** `payable` and/or `constant` (depending on the kind of function)