### PR TITLE
Internal improvement: Separate multiple compilations in testing & factor doing so

### DIFF
--- a/packages/compile-common/src/types.ts
+++ b/packages/compile-common/src/types.ts
@@ -1,7 +1,7 @@
 import { Abi, ImmutableReferences } from "@truffle/contract-schema/spec";
 
 export type Compilation = {
-  sourceIndexes: string[];
+  sourceIndexes: string[]; //note: doesnot include internal sources
   contracts: CompiledContract[];
   compiler: {
     name: string | undefined;

--- a/packages/core/lib/debug/cli.js
+++ b/packages/core/lib/debug/cli.js
@@ -94,15 +94,7 @@ class CLIDebugger {
 
     compileSpinner.succeed();
 
-    return [].concat(
-      ...compilationResult.map((compilation, index) =>
-        Codec.Compilations.Utils.shimArtifacts(
-          compilation.contracts,
-          compilation.sourceIndexes,
-          `shimmedCompilationNumber(${index})`
-        )
-      )
-    );
+    return Codec.Compilations.Utils.shimCompilations(compilationResult);
   }
 
   async startDebugger(compilations) {

--- a/packages/core/lib/debug/external.js
+++ b/packages/core/lib/debug/external.js
@@ -112,19 +112,13 @@ class DebugExternalHandler {
           sources
         );
         //shim the result
-        const compilationIdBase = `externalFor(${address})Via(${fetcher.fetcherName})`;
-        const newCompilations = [].concat(
-          ...compilations.map((compilation, index) =>
-            Codec.Compilations.Utils.shimArtifacts(
-              compilation.contracts,
-              compilation.sourceIndexes,
-              `${compilationIdBase}Number(${index})`,
-              true //mark compilation as external Solidity
-            )
-          )
+        const shimmedCompilations = Codec.Compilations.Utils.shimCompilations(
+          compilations,
+          `externalFor(${address})Via(${fetcher.fetcherName})`,
+          true //mark compilations as external Solidity
         );
         //add it!
-        await this.bugger.addExternalCompilations(newCompilations);
+        await this.bugger.addExternalCompilations(shimmedCompilations);
         //check: did this actually help?
         debug("checking result");
         if (!getUnknownAddresses(this.bugger).includes(address)) {

--- a/packages/core/lib/test.js
+++ b/packages/core/lib/test.js
@@ -116,9 +116,11 @@ const Test = {
 
     await this.performInitialDeploy(config, testResolver);
 
-    const sourcePaths = [].concat(
-      ...compilations.map(compilation => compilation.sourceIndexes) //we don't need the indices here, just the paths
-    );
+    const sourcePaths = []
+      .concat(
+        ...compilations.map(compilation => compilation.sourceIndexes) //we don't need the indices here, just the paths
+      )
+      .filter(path => path); //make sure we don't pass in any undefined
 
     await this.defineSolidityTests(mocha, testContracts, sourcePaths, runner);
 


### PR DESCRIPTION
(Possibly a pre-emptive bug fix although nothing's been reported!)

I noticed that, since the compile changes, `test.js` also does the thing that `debug/compiler.js` had been altered to do -- namely, to squash multiple different compilations together, rather than keeping them separate.  I'd already fixed this in `debug`, but now I wanted to do it in `test` as well.

In order to do this though I started by making a change to `Codec`.  The function `shimArtifacts` always returned a `Compilation[]` rather than a `Compilation`, and so to do what I wanted with it in `debug` was a little awkward.

So, I factored it.  Now `shimArtifacts` is just a wrapper around `shimContracts`, which returns a `Compilation`; and for actual use, I added another wrapper around it, `shimCompilations`, which directly shims the new compiler output format, so we don't have to do any more work there.

I then changed what I did in `debug/compiler.js` and `debug/external.js` to now use this new wrapper.  And finally I did what I'd originally set out to do -- use this new wrapper in `test.js` as well.

One thing worth noting though is that the squashed-together compilation was also being used for a second purpose in `test.js`, namely, for getting all the source files to pass to `defineSolidityTests`.  So, I made a separate thing where we concatenate together all of the lists of source files, separate from where we shim the compilations.

And that's it.  And then also `prettier` made a few changes...