### PR TITLE
Bug fix: Check that asts are Solidity before scanning their nodes

### DIFF
--- a/packages/codec/lib/compilations/utils.ts
+++ b/packages/codec/lib/compilations/utils.ts
@@ -185,7 +185,8 @@ export function getContractNode(
     if (foundNode || !source) {
       return foundNode;
     }
-    if (!source.ast) {
+    if (!source.ast || source.ast.nodeType !== "SourceUnit") {
+      //don't search Yul sources!
       return undefined;
     }
     return source.ast.nodes.find(

--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -188,7 +188,8 @@ export class WireDecoder {
           continue; //remember, sources could be empty if shimmed!
         }
         const { ast, compiler } = source;
-        if (ast) {
+        if (ast && ast.nodeType === "SourceUnit") {
+          //don't check Yul sources!
           for (const node of ast.nodes) {
             if (
               node.nodeType === "StructDefinition" ||


### PR DESCRIPTION
In response to #3419.

When adding support for internal sources, I didn't think about how it would affect the parts of `decoder` and `codec` that scan ASTs for types or contracts.  So, I've put some guards around these -- now, instead of just checking that ASTs are present, we check that they have `nodeType` equal to `"SourceUnit"` (not `"YulBlock"`).  With the guards the issue goes away.