### PR TITLE
Internal improvement: Update decoder tests to 0.7.3 and add a test

### DIFF
--- a/packages/decoder/test/current/contracts/DecodingSample.sol
+++ b/packages/decoder/test/current/contracts/DecodingSample.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.3;
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.7.0;
 
 contract DecodingSample {
   enum E {
@@ -61,7 +62,7 @@ contract DecodingSample {
     functionExternal = this.example;
   }
 
-  constructor() public {
+  constructor() {
     varUint = 1;
     varString = "two";
     varBool = true;

--- a/packages/decoder/test/current/contracts/DowngradeTest.sol
+++ b/packages/decoder/test/current/contracts/DowngradeTest.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.1;
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
 contract DowngradeTestParent {

--- a/packages/decoder/test/current/contracts/MessageTest.sol
+++ b/packages/decoder/test/current/contracts/MessageTest.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.1;
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.7.0;
 
 contract ReceiveTest {
 

--- a/packages/decoder/test/current/contracts/Migrations.sol
+++ b/packages/decoder/test/current/contracts/Migrations.sol
@@ -1,10 +1,11 @@
-pragma solidity ^0.6.1;
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.7.0;
 
 contract Migrations {
   address public owner;
   uint public last_completed_migration;
 
-  constructor() public {
+  constructor() {
     owner = msg.sender;
   }
 

--- a/packages/decoder/test/current/contracts/SliceTest.sol
+++ b/packages/decoder/test/current/contracts/SliceTest.sol
@@ -1,0 +1,14 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.7.3;
+
+//This contract is purely here to make sure that
+//internal sources are generated, to make sure that the decoder
+//doesn't choke on them
+
+contract SliceTest {
+
+  function slice(uint[] calldata arr) public pure returns (uint[] calldata) {
+    return arr[1:arr.length - 1];
+  }
+
+}

--- a/packages/decoder/test/current/contracts/WireTest.sol
+++ b/packages/decoder/test/current/contracts/WireTest.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.1;
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
 contract WireTestParent {
@@ -11,8 +12,6 @@ contract WireTestParent {
 
   //no constructor
 
-  event Overridden(uint);
-
   function inheritedReturn() public pure returns (uint) {
     return 1;
   }
@@ -20,8 +19,6 @@ contract WireTestParent {
 
 abstract contract WireTestAbstract {
   event AbstractEvent();
-
-  event AbstractOverridden(uint indexed);
 
   function danger() public virtual;
 
@@ -43,7 +40,7 @@ contract WireTest is WireTestParent, WireTestAbstract {
     emit Done();
   } //just a dummy function, not 
 
-  constructor(bool status, bytes memory info, Ternary whoknows) public {
+  constructor(bool status, bytes memory info, Ternary whoknows) {
     deepStruct["blornst"].push();
     deepStruct["blornst"].push();
     deepString.push();
@@ -169,17 +166,6 @@ contract WireTest is WireTestParent, WireTestAbstract {
 
   mapping(string => Triple[]) public deepStruct;
   mapping(string => string)[] public deepString;
-
-  event Overridden(uint indexed);
-  event AbstractOverridden(uint);
-
-  function interfaceAndOverrideTest() public {
-    emit AbstractEvent();
-    emit AbstractOverridden(107);
-    emit WireTestAbstract.AbstractOverridden(683);
-    emit Overridden(107);
-    emit WireTestParent.Overridden(683);
-  }
 
   function returnsStuff() public pure returns (Triple memory, Ternary) {
     return (Triple(-1, 0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef, hex"deadbeef"), Ternary.No);

--- a/packages/decoder/test/current/test/wire-test.js
+++ b/packages/decoder/test/current/test/wire-test.js
@@ -73,8 +73,6 @@ contract("WireTest", function (_accounts) {
     );
     let getterHash2 = getterTest2.tx;
 
-    let overrideTest = await deployedContract.interfaceAndOverrideTest();
-
     let constructorTx = await web3.eth.getTransaction(constructorHash);
     let emitStuffTx = await web3.eth.getTransaction(emitStuffHash);
     let moreStuffTx = await web3.eth.getTransaction(moreStuffHash);
@@ -231,7 +229,6 @@ contract("WireTest", function (_accounts) {
     let inheritedBlock = inherited.receipt.blockNumber;
     let indexTestBlock = indexTest.receipt.blockNumber;
     let libraryTestBlock = libraryTest.receipt.blockNumber;
-    let overrideBlock = overrideTest.receipt.blockNumber;
 
     try {
       //due to web3's having ethers's crappy decoder built in,
@@ -268,10 +265,6 @@ contract("WireTest", function (_accounts) {
     let libraryTestEvents = await decoder.events({
       fromBlock: libraryTestBlock,
       toBlock: libraryTestBlock
-    });
-    let overrideTestEvents = await decoder.events({
-      fromBlock: overrideBlock,
-      toBlock: overrideBlock
     });
     //HACK -- since danger was last, we can just ask for the
     //events from the latest block
@@ -488,112 +481,6 @@ contract("WireTest", function (_accounts) {
         dangerEventDecoding.arguments[0].value
       ),
       `WireTest(${address}).danger`
-    );
-
-    assert.lengthOf(overrideTestEvents, 5);
-
-    assert.lengthOf(overrideTestEvents[0].decodings, 1);
-    assert.strictEqual(overrideTestEvents[0].decodings[0].kind, "event");
-    assert.strictEqual(
-      overrideTestEvents[0].decodings[0].abi.name,
-      "AbstractEvent"
-    );
-    assert.strictEqual(
-      overrideTestEvents[0].decodings[0].class.typeName,
-      "WireTest"
-    );
-    assert.strictEqual(
-      overrideTestEvents[0].decodings[0].definedIn.typeName,
-      "WireTestAbstract"
-    );
-    assert.isEmpty(overrideTestEvents[0].decodings[0].arguments);
-
-    assert.lengthOf(overrideTestEvents[1].decodings, 1);
-    assert.strictEqual(overrideTestEvents[1].decodings[0].kind, "event");
-    assert.strictEqual(
-      overrideTestEvents[1].decodings[0].abi.name,
-      "AbstractOverridden"
-    );
-    assert.strictEqual(
-      overrideTestEvents[1].decodings[0].class.typeName,
-      "WireTest"
-    );
-    assert.strictEqual(
-      overrideTestEvents[1].decodings[0].definedIn.typeName,
-      "WireTest"
-    );
-    assert.lengthOf(overrideTestEvents[1].decodings[0].arguments, 1);
-    assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(
-        overrideTestEvents[1].decodings[0].arguments[0].value
-      ),
-      107
-    );
-
-    assert.lengthOf(overrideTestEvents[2].decodings, 1);
-    assert.strictEqual(overrideTestEvents[2].decodings[0].kind, "event");
-    assert.strictEqual(
-      overrideTestEvents[2].decodings[0].abi.name,
-      "AbstractOverridden"
-    );
-    assert.strictEqual(
-      overrideTestEvents[2].decodings[0].class.typeName,
-      "WireTest"
-    );
-    assert.strictEqual(
-      overrideTestEvents[2].decodings[0].definedIn.typeName,
-      "WireTestAbstract"
-    );
-    assert.lengthOf(overrideTestEvents[2].decodings[0].arguments, 1);
-    assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(
-        overrideTestEvents[2].decodings[0].arguments[0].value
-      ),
-      683
-    );
-
-    assert.lengthOf(overrideTestEvents[3].decodings, 1);
-    assert.strictEqual(overrideTestEvents[3].decodings[0].kind, "event");
-    assert.strictEqual(
-      overrideTestEvents[3].decodings[0].abi.name,
-      "Overridden"
-    );
-    assert.strictEqual(
-      overrideTestEvents[3].decodings[0].class.typeName,
-      "WireTest"
-    );
-    assert.strictEqual(
-      overrideTestEvents[3].decodings[0].definedIn.typeName,
-      "WireTest"
-    );
-    assert.lengthOf(overrideTestEvents[3].decodings[0].arguments, 1);
-    assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(
-        overrideTestEvents[3].decodings[0].arguments[0].value
-      ),
-      107
-    );
-
-    assert.lengthOf(overrideTestEvents[4].decodings, 1);
-    assert.strictEqual(overrideTestEvents[4].decodings[0].kind, "event");
-    assert.strictEqual(
-      overrideTestEvents[4].decodings[0].abi.name,
-      "Overridden"
-    );
-    assert.strictEqual(
-      overrideTestEvents[4].decodings[0].class.typeName,
-      "WireTest"
-    );
-    assert.strictEqual(
-      overrideTestEvents[4].decodings[0].definedIn.typeName,
-      "WireTestParent"
-    );
-    assert.lengthOf(overrideTestEvents[4].decodings[0].arguments, 1);
-    assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(
-        overrideTestEvents[4].decodings[0].arguments[0].value
-      ),
-      683
     );
   });
 

--- a/packages/decoder/test/current/truffle-config.js
+++ b/packages/decoder/test/current/truffle-config.js
@@ -57,7 +57,7 @@ module.exports = {
   // Configure your compilers
   compilers: {
     solc: {
-      version: "0.6.6" // Fetch exact version from solc-bin (default: truffle's version)
+      version: "0.7.3" // Fetch exact version from solc-bin (default: truffle's version)
       // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
       // settings: {          // See the solidity docs for advice about optimization and evmVersion
       //  optimizer: {

--- a/packages/decoder/test/legacy/contracts/WireTest.sol
+++ b/packages/decoder/test/legacy/contracts/WireTest.sol
@@ -1,0 +1,31 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.5.16;
+
+contract LegacyWireTestParent {
+
+  event Overridden(uint);
+
+}
+
+contract LegacyWireTestAbstract {
+  event AbstractEvent();
+
+  event AbstractOverridden(uint indexed);
+
+  function interfaceAndOverrideTest() public; //just here to make the contract abstract
+}
+
+contract LegacyWireTest is LegacyWireTestParent, LegacyWireTestAbstract {
+
+  event Overridden(uint indexed);
+  event AbstractOverridden(uint);
+
+  function interfaceAndOverrideTest() public {
+    emit AbstractEvent();
+    emit AbstractOverridden(107);
+    emit LegacyWireTestAbstract.AbstractOverridden(683);
+    emit Overridden(107);
+    emit LegacyWireTestParent.Overridden(683);
+  }
+
+}

--- a/packages/decoder/test/legacy/test/wire-test.js
+++ b/packages/decoder/test/legacy/test/wire-test.js
@@ -1,0 +1,136 @@
+const debug = require("debug")("decoder:test:wire-test");
+const assert = require("chai").assert;
+
+const Decoder = require("../../..");
+const Codec = require("@truffle/codec");
+
+const LegacyWireTest = artifacts.require("LegacyWireTest");
+const LegacyWireTestParent = artifacts.require("LegacyWireTestParent");
+const LegacyWireTestAbstract = artifacts.require("LegacyWireTestAbstract");
+
+contract("LegacyWireTest", function (_accounts) {
+  it("should decode overridden events & events inherited from abstract contracts", async function () {
+    const deployedContract = await LegacyWireTest.new();
+
+    const decoder = await Decoder.forProject(web3.currentProvider, [
+      LegacyWireTest,
+      LegacyWireTestParent,
+      LegacyWireTestAbstract
+    ]);
+
+    const overrideTest = await deployedContract.interfaceAndOverrideTest();
+
+    const overrideBlock = overrideTest.receipt.blockNumber;
+
+    const overrideTestEvents = await decoder.events({
+      fromBlock: overrideBlock,
+      toBlock: overrideBlock
+    });
+
+    assert.lengthOf(overrideTestEvents, 5);
+
+    assert.lengthOf(overrideTestEvents[0].decodings, 1);
+    assert.strictEqual(overrideTestEvents[0].decodings[0].kind, "event");
+    assert.strictEqual(
+      overrideTestEvents[0].decodings[0].abi.name,
+      "AbstractEvent"
+    );
+    assert.strictEqual(
+      overrideTestEvents[0].decodings[0].class.typeName,
+      "LegacyWireTest"
+    );
+    assert.strictEqual(
+      overrideTestEvents[0].decodings[0].definedIn.typeName,
+      "LegacyWireTestAbstract"
+    );
+    assert.isEmpty(overrideTestEvents[0].decodings[0].arguments);
+
+    assert.lengthOf(overrideTestEvents[1].decodings, 1);
+    assert.strictEqual(overrideTestEvents[1].decodings[0].kind, "event");
+    assert.strictEqual(
+      overrideTestEvents[1].decodings[0].abi.name,
+      "AbstractOverridden"
+    );
+    assert.strictEqual(
+      overrideTestEvents[1].decodings[0].class.typeName,
+      "LegacyWireTest"
+    );
+    assert.strictEqual(
+      overrideTestEvents[1].decodings[0].definedIn.typeName,
+      "LegacyWireTest"
+    );
+    assert.lengthOf(overrideTestEvents[1].decodings[0].arguments, 1);
+    assert.strictEqual(
+      Codec.Format.Utils.Inspect.nativize(
+        overrideTestEvents[1].decodings[0].arguments[0].value
+      ),
+      107
+    );
+
+    assert.lengthOf(overrideTestEvents[2].decodings, 1);
+    assert.strictEqual(overrideTestEvents[2].decodings[0].kind, "event");
+    assert.strictEqual(
+      overrideTestEvents[2].decodings[0].abi.name,
+      "AbstractOverridden"
+    );
+    assert.strictEqual(
+      overrideTestEvents[2].decodings[0].class.typeName,
+      "LegacyWireTest"
+    );
+    assert.strictEqual(
+      overrideTestEvents[2].decodings[0].definedIn.typeName,
+      "LegacyWireTestAbstract"
+    );
+    assert.lengthOf(overrideTestEvents[2].decodings[0].arguments, 1);
+    assert.strictEqual(
+      Codec.Format.Utils.Inspect.nativize(
+        overrideTestEvents[2].decodings[0].arguments[0].value
+      ),
+      683
+    );
+
+    assert.lengthOf(overrideTestEvents[3].decodings, 1);
+    assert.strictEqual(overrideTestEvents[3].decodings[0].kind, "event");
+    assert.strictEqual(
+      overrideTestEvents[3].decodings[0].abi.name,
+      "Overridden"
+    );
+    assert.strictEqual(
+      overrideTestEvents[3].decodings[0].class.typeName,
+      "LegacyWireTest"
+    );
+    assert.strictEqual(
+      overrideTestEvents[3].decodings[0].definedIn.typeName,
+      "LegacyWireTest"
+    );
+    assert.lengthOf(overrideTestEvents[3].decodings[0].arguments, 1);
+    assert.strictEqual(
+      Codec.Format.Utils.Inspect.nativize(
+        overrideTestEvents[3].decodings[0].arguments[0].value
+      ),
+      107
+    );
+
+    assert.lengthOf(overrideTestEvents[4].decodings, 1);
+    assert.strictEqual(overrideTestEvents[4].decodings[0].kind, "event");
+    assert.strictEqual(
+      overrideTestEvents[4].decodings[0].abi.name,
+      "Overridden"
+    );
+    assert.strictEqual(
+      overrideTestEvents[4].decodings[0].class.typeName,
+      "LegacyWireTest"
+    );
+    assert.strictEqual(
+      overrideTestEvents[4].decodings[0].definedIn.typeName,
+      "LegacyWireTestParent"
+    );
+    assert.lengthOf(overrideTestEvents[4].decodings[0].arguments, 1);
+    assert.strictEqual(
+      Codec.Format.Utils.Inspect.nativize(
+        overrideTestEvents[4].decodings[0].arguments[0].value
+      ),
+      683
+    );
+  });
+});

--- a/packages/decoder/test/legacy/truffle-config.js
+++ b/packages/decoder/test/legacy/truffle-config.js
@@ -57,7 +57,7 @@ module.exports = {
   // Configure your compilers
   compilers: {
     solc: {
-      version: "0.5.16" // Fetch exact version from solc-bin (default: truffle's version)
+      version: "0.5.17" // Fetch exact version from solc-bin (default: truffle's version)
       // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
       // settings: {          // See the solidity docs for advice about optimization and evmVersion
       //  optimizer: {


### PR DESCRIPTION
So I recently merged #3420, but I didn't add any tests, and it's been kind of bothering me that there are no tests for that.

So, I added one.  I added a dummy test to the decoder test called `SliceTest`; this contract doesn't actually do anything, it's never used, but it includes code to perform array slicing because that generates internal sources.  The point is just to have something present with internal sources to make sure this doesn't crash the decoder.

Of course, to do this, I had to update the decoder tests to 0.7.x.  This caused a problem that one of the things being tested is no longer legal, so that test got moved to the legacy section.  (*Part* of what it's testing is still legal, but I thought it was more trouble than it's worth to attempt to split the test into still-legal and now-illegal pieces.)

Anyway yeah, just some decoder test updates.