### PR TITLE
Bug fix: Fix compilation during testing

### DIFF
--- a/packages/core/lib/commands/test/compileContractsIfNecessary.js
+++ b/packages/core/lib/commands/test/compileContractsIfNecessary.js
@@ -17,7 +17,6 @@ const compileContractsIfNecessary = async config => {
     quiet: config.runnerOutputOnly || config.quiet
   });
 
-  // Compile project contracts and test contracts
   await WorkflowCompile.compileAndSave(compileConfig);
 };
 

--- a/packages/core/lib/commands/test/compileContractsIfNecessary.js
+++ b/packages/core/lib/commands/test/compileContractsIfNecessary.js
@@ -1,0 +1,26 @@
+const Profiler = require("@truffle/compile-solidity/profiler");
+const WorkflowCompile = require("@truffle/workflow-compile");
+
+const compileContractsIfNecessary = async config => {
+  const updated = (await Profiler.updated(config)) || [];
+  if (updated.length === 0) {
+    return;
+  }
+
+  const compiler =
+    config.compileNone || config["--compile-none"] ? "none" : config.compiler;
+
+  let compileConfig = config.with({
+    all: config.compileAll === true,
+    compiler,
+    files: updated,
+    quiet: config.runnerOutputOnly || config.quiet
+  });
+
+  // Compile project contracts and test contracts
+  await WorkflowCompile.compileAndSave(compileConfig);
+};
+
+module.exports = {
+  compileContractsIfNecessary
+};

--- a/packages/core/lib/commands/test/index.js
+++ b/packages/core/lib/commands/test/index.js
@@ -128,6 +128,9 @@ const command = {
     const { copyArtifactsToTempDir } = require("./copyArtifactsToTempDir");
     const { determineTestFilesToRun } = require("./determineTestFilesToRun");
     const { prepareConfigAndRunTests } = require("./prepareConfigAndRunTests");
+    const {
+      compileContractsIfNecessary
+    } = require("./compileContractsIfNecessary");
 
     const config = Config.detect(options);
 
@@ -166,6 +169,7 @@ const command = {
 
     if (config.networks[config.network]) {
       Environment.detect(config)
+        .then(() => compileContractsIfNecessary(config))
         .then(() => copyArtifactsToTempDir(config))
         .then(({ config, temporaryDirectory }) => {
           return prepareConfigAndRunTests({
@@ -202,6 +206,7 @@ const command = {
           ipcDisconnect = disconnect;
           return Environment.develop(config, ganacheOptions);
         })
+        .then(() => compileContractsIfNecessary(config))
         .then(() => copyArtifactsToTempDir(config))
         .then(({ config, temporaryDirectory }) => {
           return prepareConfigAndRunTests({

--- a/packages/core/lib/testing/Test.js
+++ b/packages/core/lib/testing/Test.js
@@ -13,7 +13,6 @@ const SolidityTest = require("./SolidityTest");
 const RangeUtils = require("@truffle/compile-solidity/compilerSupplier/rangeUtils");
 const expect = require("@truffle/expect");
 const Migrate = require("@truffle/migrate");
-const Profiler = require("@truffle/compile-solidity/profiler");
 const originalrequire = require("original-require");
 const Codec = require("@truffle/codec");
 const debug = require("debug")("lib:test");
@@ -92,7 +91,7 @@ const Test = {
 
     const testResolver = new Resolver(config, true);
 
-    const { compilations } = await this.compileContractsWithTestFilesIfNeeded(
+    const { compilations } = await this.compileTestFiles(
       solTests,
       config,
       testResolver
@@ -184,21 +183,14 @@ const Test = {
     return interfaceAdapter.getAccounts();
   },
 
-  compileContractsWithTestFilesIfNeeded: async function (
-    solidityTestFiles,
-    config,
-    testResolver
-  ) {
-    const updated =
-      (await Profiler.updated(config.with({ resolver: testResolver }))) || [];
-
+  compileTestFiles: async function (solidityTestFiles, config, testResolver) {
     const compiler =
       config.compileNone || config["--compile-none"] ? "none" : config.compiler;
 
     let compileConfig = config.with({
       all: config.compileAll === true,
       compiler,
-      files: updated.concat(solidityTestFiles),
+      files: solidityTestFiles,
       resolver: testResolver,
       quiet: config.runnerOutputOnly || config.quiet,
       quietWrite: true

--- a/packages/core/lib/testing/Test.js
+++ b/packages/core/lib/testing/Test.js
@@ -13,7 +13,6 @@ const SolidityTest = require("./SolidityTest");
 const RangeUtils = require("@truffle/compile-solidity/compilerSupplier/rangeUtils");
 const expect = require("@truffle/expect");
 const Migrate = require("@truffle/migrate");
-const Profiler = require("@truffle/compile-solidity/profiler");
 const originalrequire = require("original-require");
 const Codec = require("@truffle/codec");
 const debug = require("debug")("lib:test");
@@ -92,7 +91,7 @@ const Test = {
 
     const testResolver = new Resolver(config, true);
 
-    const { compilations } = await this.compileContractsWithTestFilesIfNeeded(
+    const { compilations } = await this.compileSolidityTestFiles(
       solTests,
       config,
       testResolver
@@ -184,21 +183,18 @@ const Test = {
     return interfaceAdapter.getAccounts();
   },
 
-  compileContractsWithTestFilesIfNeeded: async function (
+  compileSolidityTestFiles: async function (
     solidityTestFiles,
     config,
     testResolver
   ) {
-    const updated =
-      (await Profiler.updated(config.with({ resolver: testResolver }))) || [];
-
     const compiler =
       config.compileNone || config["--compile-none"] ? "none" : config.compiler;
 
     let compileConfig = config.with({
       all: config.compileAll === true,
       compiler,
-      files: updated.concat(solidityTestFiles),
+      files: solidityTestFiles,
       resolver: testResolver,
       quiet: config.runnerOutputOnly || config.quiet,
       quietWrite: true

--- a/packages/core/lib/testing/Test.js
+++ b/packages/core/lib/testing/Test.js
@@ -188,12 +188,8 @@ const Test = {
     config,
     testResolver
   ) {
-    const compiler =
-      config.compileNone || config["--compile-none"] ? "none" : config.compiler;
-
     let compileConfig = config.with({
-      all: config.compileAll === true,
-      compiler,
+      compiler: config.compiler,
       files: solidityTestFiles,
       resolver: testResolver,
       quiet: config.runnerOutputOnly || config.quiet,

--- a/packages/truffle/scripts/test.sh
+++ b/packages/truffle/scripts/test.sh
@@ -7,9 +7,9 @@ if [ "$GETH" == true ]; then
 elif [ "$FABRICEVM" == true ]; then
   mocha --timeout 50000 --grep @fabric-evm --colors $@
 elif [ "$COVERAGE" == true ]; then
-  NO_BUILD=true mocha --no-warnings --timeout 7000 --grep @geth --invert --colors $@
+  NO_BUILD=true mocha --no-warnings --timeout 50000 --grep @geth --invert --colors $@
 elif [ "$INTEGRATION" == true ]; then
-  mocha --no-warnings --timeout 7000 --grep @geth --invert --colors $@
+  mocha --no-warnings --timeout 50000 --grep @geth --invert --colors $@
 else
-  yarn build && mocha --no-warnings --timeout 7000 --grep @geth --invert --colors $@
+  yarn build && mocha --no-warnings --timeout 50000 --grep @geth --invert --colors $@
 fi

--- a/packages/truffle/test/scenarios/commands/test.js
+++ b/packages/truffle/test/scenarios/commands/test.js
@@ -1,0 +1,44 @@
+const CommandRunner = require("../commandrunner");
+const sandbox = require("../sandbox");
+const path = require("path");
+const assert = require("assert");
+const fse = require("fs-extra");
+
+const updateFile = (filename, config) => {
+  const fileToUpdate = path.resolve(
+    path.join(config.contracts_directory, filename)
+  );
+
+  // Update the modification time to simulate an edit.
+  const newTime = new Date().getTime();
+  fse.utimesSync(fileToUpdate, newTime, newTime);
+};
+
+describe("Test", () => {
+  let config;
+
+  beforeEach("set up config for logger", async () => {
+    config = await sandbox.create(path.resolve("test", "sources", "test"));
+  });
+
+  it("will run on a simple sample project", async () => {
+    await CommandRunner.run("truffle test", config);
+  });
+
+  it("compiles/creates artifacts for out of sync sources", async () => {
+    await CommandRunner.run("truffle compile", config);
+    const timeModified = fse.statSync(
+      path.join(config.contracts_build_directory, "MetaCoin.json")
+    ).mtime;
+    updateFile("MetaCoin.sol", config);
+    await CommandRunner.run("truffle test", config);
+    const newTimeModified = fse.statSync(
+      path.join(config.contracts_build_directory, "MetaCoin.json")
+    ).mtime;
+    assert.notEqual(
+      timeModified,
+      newTimeModified,
+      "the artifact wasn't updated"
+    );
+  });
+});

--- a/packages/truffle/test/scenarios/library/api.js
+++ b/packages/truffle/test/scenarios/library/api.js
@@ -66,7 +66,7 @@ describe("Truffle Library APIs [ @standalone ]", () => {
     assert(truffle.test.createMocha, "test.createMocha undefined");
     assert(truffle.test.getAccounts, "test.getAccounts undefined");
     assert(
-      truffle.test.compileContractsWithTestFilesIfNeeded,
+      truffle.test.compileSolidityTestFiles,
       "test.withTestFiles undefined"
     );
     assert(

--- a/packages/truffle/test/sources/test/.gitattributes
+++ b/packages/truffle/test/sources/test/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity

--- a/packages/truffle/test/sources/test/LICENSE
+++ b/packages/truffle/test/sources/test/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2018 Truffle
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/packages/truffle/test/sources/test/contracts/ConvertLib.sol
+++ b/packages/truffle/test/sources/test/contracts/ConvertLib.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.4.25 <0.7.0;
+
+library ConvertLib{
+	function convert(uint amount,uint conversionRate) public pure returns (uint convertedAmount)
+	{
+		return amount * conversionRate;
+	}
+}

--- a/packages/truffle/test/sources/test/contracts/MetaCoin.sol
+++ b/packages/truffle/test/sources/test/contracts/MetaCoin.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.4.25 <0.7.0;
+
+import "./ConvertLib.sol";
+
+// This is just a simple example of a coin-like contract.
+// It is not standards compatible and cannot be expected to talk to other
+// coin/token contracts. If you want to create a standards-compliant
+// token, see: https://github.com/ConsenSys/Tokens. Cheers!
+
+contract MetaCoin {
+	mapping (address => uint) balances;
+
+	event Transfer(address indexed _from, address indexed _to, uint256 _value);
+
+	constructor() public {
+		balances[tx.origin] = 10000;
+	}
+
+	function sendCoin(address receiver, uint amount) public returns(bool sufficient) {
+		if (balances[msg.sender] < amount) return false;
+		balances[msg.sender] -= amount;
+		balances[receiver] += amount;
+		emit Transfer(msg.sender, receiver, amount);
+		return true;
+	}
+
+	function getBalanceInEth(address addr) public view returns(uint){
+		return ConvertLib.convert(getBalance(addr),2);
+	}
+
+	function getBalance(address addr) public view returns(uint) {
+		return balances[addr];
+	}
+}

--- a/packages/truffle/test/sources/test/contracts/Migrations.sol
+++ b/packages/truffle/test/sources/test/contracts/Migrations.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.4.25 <0.7.0;
+
+contract Migrations {
+  address public owner;
+  uint public last_completed_migration;
+
+  modifier restricted() {
+    if (msg.sender == owner) _;
+  }
+
+  constructor() public {
+    owner = msg.sender;
+  }
+
+  function setCompleted(uint completed) public restricted {
+    last_completed_migration = completed;
+  }
+}

--- a/packages/truffle/test/sources/test/migrations/1_initial_migration.js
+++ b/packages/truffle/test/sources/test/migrations/1_initial_migration.js
@@ -1,0 +1,5 @@
+const Migrations = artifacts.require("Migrations");
+
+module.exports = function (deployer) {
+  deployer.deploy(Migrations);
+};

--- a/packages/truffle/test/sources/test/migrations/2_deploy_contracts.js
+++ b/packages/truffle/test/sources/test/migrations/2_deploy_contracts.js
@@ -1,0 +1,8 @@
+const ConvertLib = artifacts.require("ConvertLib");
+const MetaCoin = artifacts.require("MetaCoin");
+
+module.exports = function (deployer) {
+  deployer.deploy(ConvertLib);
+  deployer.link(ConvertLib, MetaCoin);
+  deployer.deploy(MetaCoin);
+};

--- a/packages/truffle/test/sources/test/test/TestMetaCoin.sol
+++ b/packages/truffle/test/sources/test/test/TestMetaCoin.sol
@@ -1,0 +1,25 @@
+pragma solidity >=0.4.25 <0.7.0;
+
+import "truffle/Assert.sol";
+import "truffle/DeployedAddresses.sol";
+import "../contracts/MetaCoin.sol";
+
+contract TestMetaCoin {
+
+  function testInitialBalanceUsingDeployedContract() public {
+    MetaCoin meta = MetaCoin(DeployedAddresses.MetaCoin());
+
+    uint expected = 10000;
+
+    Assert.equal(meta.getBalance(tx.origin), expected, "Owner should have 10000 MetaCoin initially");
+  }
+
+  function testInitialBalanceWithNewMetaCoin() public {
+    MetaCoin meta = new MetaCoin();
+
+    uint expected = 10000;
+
+    Assert.equal(meta.getBalance(tx.origin), expected, "Owner should have 10000 MetaCoin initially");
+  }
+
+}

--- a/packages/truffle/test/sources/test/test/metacoin.js
+++ b/packages/truffle/test/sources/test/test/metacoin.js
@@ -1,0 +1,63 @@
+const MetaCoin = artifacts.require("MetaCoin");
+
+contract("MetaCoin", accounts => {
+  it("should put 10000 MetaCoin in the first account", async () => {
+    const metaCoinInstance = await MetaCoin.deployed();
+    const balance = await metaCoinInstance.getBalance.call(accounts[0]);
+
+    assert.equal(balance.valueOf(), 10000, "10000 wasn't in the first account");
+  });
+  it("should call a function that depends on a linked library", async () => {
+    const metaCoinInstance = await MetaCoin.deployed();
+    const metaCoinBalance = (
+      await metaCoinInstance.getBalance.call(accounts[0])
+    ).toNumber();
+    const metaCoinEthBalance = (
+      await metaCoinInstance.getBalanceInEth.call(accounts[0])
+    ).toNumber();
+
+    assert.equal(
+      metaCoinEthBalance,
+      2 * metaCoinBalance,
+      "Library function returned unexpected function, linkage may be broken"
+    );
+  });
+  it("should send coin correctly", async () => {
+    const metaCoinInstance = await MetaCoin.deployed();
+
+    // Setup 2 accounts.
+    const accountOne = accounts[0];
+    const accountTwo = accounts[1];
+
+    // Get initial balances of first and second account.
+    const accountOneStartingBalance = (
+      await metaCoinInstance.getBalance.call(accountOne)
+    ).toNumber();
+    const accountTwoStartingBalance = (
+      await metaCoinInstance.getBalance.call(accountTwo)
+    ).toNumber();
+
+    // Make transaction from first account to second.
+    const amount = 10;
+    await metaCoinInstance.sendCoin(accountTwo, amount, { from: accountOne });
+
+    // Get balances of first and second account after the transactions.
+    const accountOneEndingBalance = (
+      await metaCoinInstance.getBalance.call(accountOne)
+    ).toNumber();
+    const accountTwoEndingBalance = (
+      await metaCoinInstance.getBalance.call(accountTwo)
+    ).toNumber();
+
+    assert.equal(
+      accountOneEndingBalance,
+      accountOneStartingBalance - amount,
+      "Amount wasn't correctly taken from the sender"
+    );
+    assert.equal(
+      accountTwoEndingBalance,
+      accountTwoStartingBalance + amount,
+      "Amount wasn't correctly sent to the receiver"
+    );
+  });
+});

--- a/packages/truffle/test/sources/test/truffle-config.js
+++ b/packages/truffle/test/sources/test/truffle-config.js
@@ -1,0 +1,21 @@
+module.exports = {
+  // Uncommenting the defaults below
+  // provides for an easier quick-start with Ganache.
+  // You can also follow this format for other networks;
+  // see <http://truffleframework.com/docs/advanced/configuration>
+  // for more details on how to specify configuration options!
+  //
+  //networks: {
+  //  development: {
+  //    host: "127.0.0.1",
+  //    port: 7545,
+  //    network_id: "*"
+  //  },
+  //  test: {
+  //    host: "127.0.0.1",
+  //    port: 7545,
+  //    network_id: "*"
+  //  }
+  //}
+  //
+};


### PR DESCRIPTION
Compile contracts before creating and moving the built files to a temporary directory during testing.

Currently Truffle copies over the built artifacts to a temporary directory while testing. It then examines them to see whether they are in sync with the Solidity source files; if not, it compiles and saves them to the temporary directory. If you continuously run test, it will always compile the same files over and over again since they are never saved to the project's build directory and instead get deleted after the test run.

This PR checks to see if a compilation is necessary BEFORE copying the files to the temporary directory to ensure that the compilation gets saved properly. Thus on the second run, the files will be updated and it will no longer be necessary to compile those artifacts again. Tests written in Solidity, however, still need to be compiled each time.

Fixes https://github.com/trufflesuite/truffle/issues/3271