### PR TITLE
Bug fix: Restrict data.current.identifiers.sections to variables with definitions

### DIFF
--- a/packages/debugger/lib/data/selectors/index.js
+++ b/packages/debugger/lib/data/selectors/index.js
@@ -1202,30 +1202,32 @@ const data = createSelectorTree({
 
       /**
        * data.current.identifiers.sections
-       * intended for use by Teams Debugger
+       * used for printing out the variables in sections
        */
-      sections: createLeaf(["./refs"], refs => {
+      sections: createLeaf(["./definitions", "./refs"], (definitions, refs) => {
         let sections = {
           builtin: [],
           contract: [],
           local: []
         };
         for (const [identifier, ref] of Object.entries(refs)) {
-          switch (ref.location) {
-            case "special":
-              sections.builtin.push(identifier);
-              break;
-            case "stack":
-              sections.local.push(identifier);
-              break;
-            case "storage":
-            case "code":
-            case "nowhere":
-            case "memory":
-            case "definition":
-              sections.contract.push(identifier);
-              break;
-            //other cases shouldn't happen
+          if (identifier in definitions) {
+            switch (ref.location) {
+              case "special":
+                sections.builtin.push(identifier);
+                break;
+              case "stack":
+                sections.local.push(identifier);
+                break;
+              case "storage":
+              case "code":
+              case "nowhere":
+              case "memory":
+              case "definition":
+                sections.contract.push(identifier);
+                break;
+              //other cases shouldn't happen
+            }
           }
         }
         return sections;


### PR DESCRIPTION
In response to #3440.

The problem is that the CLI debugger's `v` command could cause errors if there were variables with an allocation but no definition, e.g. the `this` builtin if you weren't in a known contract.

This used to not cause problems because the CLI debugger used to print out variables in whatever order it got them from `variables()`, and such variables simply wouldn't appear there.  However, now it uses `data.current.identifiers.sections` to group the variables into sections.  And I didn't think to exclude variables without definitions from the latter.  So sometimes it might get a variable name from that selector, look up that variable in the output of `variables()`, find nothing, and then get stuck when it tries to format `undefined` instead of the variable's decoded value.

This PR fixes the problem by making sure to only put variables with definitions in `data.current.identifiers.sections`.