### PR TITLE
Move core resource type definitions to @truffle/db/meta

### DIFF
--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -1,18 +1,14 @@
 import { GraphQLSchema, DocumentNode, parse, execute } from "graphql";
 import { schema } from "@truffle/db/data";
 import { generateCompileLoad } from "@truffle/db/loaders/commands";
-import {
-  WorkspaceRequest,
-  WorkspaceResponse,
-  toIdObject,
-  NamedResource
-} from "@truffle/db/loaders/types";
+import { WorkspaceRequest, WorkspaceResponse } from "@truffle/db/loaders/types";
 import { WorkflowCompileResult } from "@truffle/compile-common";
 import { Workspace } from "@truffle/db/workspace";
 import {
   generateInitializeLoad,
   generateNamesLoad
 } from "@truffle/db/loaders/commands";
+import { toIdObject, NamedResource } from "@truffle/db/meta";
 
 interface IConfig {
   contracts_build_directory: string;

--- a/packages/db/src/loaders/commands/names.ts
+++ b/packages/db/src/loaders/commands/names.ts
@@ -4,12 +4,8 @@ import {
 } from "@truffle/db/loaders/resources/projects";
 
 import { generateNameRecordsLoad } from "@truffle/db/loaders/resources/nameRecords";
-import {
-  WorkspaceRequest,
-  WorkspaceResponse,
-  IdObject,
-  NamedResource
-} from "@truffle/db/loaders/types";
+import { WorkspaceRequest, WorkspaceResponse } from "@truffle/db/loaders/types";
+import { IdObject, NamedResource } from "@truffle/db/meta";
 
 /**
  * generator function to load nameRecords and project names into Truffle DB

--- a/packages/db/src/loaders/resources/bytecodes/index.ts
+++ b/packages/db/src/loaders/resources/bytecodes/index.ts
@@ -1,10 +1,10 @@
 import {
   CompilationData,
-  toIdObject,
   LoadedBytecodes,
   WorkspaceRequest,
   WorkspaceResponse
 } from "@truffle/db/loaders/types";
+import { toIdObject } from "@truffle/db/meta";
 import { CompiledContract } from "@truffle/compile-common";
 import { AddBytecodes } from "./add.graphql";
 export { AddBytecodes };

--- a/packages/db/src/loaders/resources/compilations/index.ts
+++ b/packages/db/src/loaders/resources/compilations/index.ts
@@ -1,7 +1,6 @@
 import {
   CompilationData,
   LoadedSources,
-  IdObject,
   WorkspaceRequest,
   WorkspaceResponse
 } from "@truffle/db/loaders/types";
@@ -31,8 +30,7 @@ const compilationProcessedSourceInputs = ({
   }));
 
 const compilationSourceMapInputs = ({
-  compilation,
-  sources
+  compilation
 }: LoadableCompilation): DataModel.ICompilationSourceMapInput[] => {
   const contracts = compilation.sources
     .map(({ contracts }) => contracts)

--- a/packages/db/src/loaders/resources/contracts/index.ts
+++ b/packages/db/src/loaders/resources/contracts/index.ts
@@ -1,9 +1,9 @@
 import {
   LoadedBytecodes,
-  IdObject,
   WorkspaceRequest,
   WorkspaceResponse
 } from "@truffle/db/loaders/types";
+import { IdObject } from "@truffle/db/meta";
 import { CompiledContract } from "@truffle/compile-common";
 
 import { AddContracts } from "./add.graphql";

--- a/packages/db/src/loaders/resources/nameRecords/index.ts
+++ b/packages/db/src/loaders/resources/nameRecords/index.ts
@@ -1,9 +1,5 @@
-import {
-  WorkspaceRequest,
-  IdObject,
-  toIdObject,
-  WorkspaceResponse
-} from "@truffle/db/loaders/types";
+import { WorkspaceRequest, WorkspaceResponse } from "@truffle/db/loaders/types";
+import { toIdObject } from "@truffle/db/meta";
 
 import { AddNameRecords } from "./add.graphql";
 export { AddNameRecords };

--- a/packages/db/src/loaders/resources/projects/index.ts
+++ b/packages/db/src/loaders/resources/projects/index.ts
@@ -1,8 +1,5 @@
-import {
-  IdObject,
-  WorkspaceRequest,
-  WorkspaceResponse
-} from "@truffle/db/loaders/types";
+import { WorkspaceRequest, WorkspaceResponse } from "@truffle/db/loaders/types";
+import { IdObject } from "@truffle/db/meta";
 
 import { AddProjects } from "./add.graphql";
 import { AssignProjectNames } from "./assign.graphql";

--- a/packages/db/src/loaders/resources/sources/index.ts
+++ b/packages/db/src/loaders/resources/sources/index.ts
@@ -1,7 +1,8 @@
+import { toIdObject } from "@truffle/db/meta";
+
 import {
   CompilationData,
   LoadedSources,
-  toIdObject,
   WorkspaceRequest,
   WorkspaceResponse
 } from "@truffle/db/loaders/types";

--- a/packages/db/src/loaders/types.ts
+++ b/packages/db/src/loaders/types.ts
@@ -1,4 +1,5 @@
 import { CompiledContract } from "@truffle/compile-common";
+import { IdObject } from "@truffle/db/meta";
 
 export interface CompilationData {
   compiler: {
@@ -31,19 +32,6 @@ export interface LoadedBytecodes {
   }[];
 }
 
-type Resource = {
-  id: string;
-};
-
-export type IdObject<R extends Resource = Resource> = {
-  [N in keyof R]: N extends "id" ? string : never;
-};
-
-export const toIdObject = <R extends Resource>({ id }: R): IdObject<R> =>
-  ({
-    id
-  } as IdObject<R>);
-
 export interface WorkspaceRequest {
   request: string; // GraphQL request
   variables: {
@@ -56,8 +44,3 @@ export type WorkspaceResponse<N extends string = string, R = any> = {
     workspace: { [RequestName in N]: R };
   };
 };
-
-export interface NamedResource {
-  id: string;
-  name: string;
-}

--- a/packages/db/src/meta/index.ts
+++ b/packages/db/src/meta/index.ts
@@ -4,7 +4,7 @@ export type Collections = {
         resource: {
           id: string;
         };
-        input: any;
+        input: object;
         mutable?: boolean;
         named?: false;
       }
@@ -14,7 +14,7 @@ export type Collections = {
           id: string;
           name: string;
         };
-        input: any;
+        input: object;
         mutable?: boolean;
         named: true;
       };
@@ -93,10 +93,9 @@ export type NamedCollectionName<C extends Collections> = FilteredCollectionName<
   { is: "named" }
 >;
 
-export type Input<
-  C extends Collections,
-  N extends CollectionName<C>
-> = CollectionProperty<"input", C, N>;
+export type Input<C extends Collections, N extends CollectionName<C>> = {
+  [K in N]: CollectionProperty<"input", C, N>[];
+};
 
 export type Payload<C extends Collections, N extends CollectionName<C>> = {
   [K in N]: Resource<C, N>[];

--- a/packages/db/src/meta/index.ts
+++ b/packages/db/src/meta/index.ts
@@ -70,6 +70,11 @@ export type Resource<
     : Extract<Collection<C, N>, { [K in F["is"]]: true }>["resource"]
   : CollectionProperty<"resource", C, N>;
 
+export type Input<
+  C extends Collections = Collections,
+  N extends CollectionName<C> = CollectionName<C>
+> = CollectionProperty<"input", C, N>;
+
 export type FilteredCollectionName<C extends Collections, F = undefined> = {
   [K in CollectionName<C>]: Resource<C, K, F> extends never ? never : K;
 }[CollectionName<C>];
@@ -93,11 +98,17 @@ export type NamedCollectionName<C extends Collections> = FilteredCollectionName<
   { is: "named" }
 >;
 
-export type Input<C extends Collections, N extends CollectionName<C>> = {
-  [K in N]: CollectionProperty<"input", C, N>[];
+export type MutationInput<
+  C extends Collections,
+  N extends CollectionName<C>
+> = {
+  [K in N]: Input<C, N>[];
 };
 
-export type Payload<C extends Collections, N extends CollectionName<C>> = {
+export type MutationPayload<
+  C extends Collections,
+  N extends CollectionName<C>
+> = {
   [K in N]: Resource<C, N>[];
 };
 

--- a/packages/db/src/meta/index.ts
+++ b/packages/db/src/meta/index.ts
@@ -1,0 +1,112 @@
+export type Collections = {
+  [collectionName: string]:
+    | {
+        resource: {
+          id: string;
+        };
+        input: any;
+        mutable?: boolean;
+        named?: false;
+      }
+    // definitely named, must define name property
+    | {
+        resource: {
+          id: string;
+          name: string;
+        };
+        input: any;
+        mutable?: boolean;
+        named: true;
+      };
+};
+
+export type CollectionName<C extends Collections> = string & keyof C;
+
+export type Collection<
+  C extends Collections = Collections,
+  N extends CollectionName<C> = CollectionName<C>
+> = {
+  [K in N]: C[K];
+}[N];
+
+export type CollectionPropertyFilter = {
+  extends: any;
+};
+
+export type CollectionPropertyName<
+  F extends CollectionPropertyFilter = CollectionPropertyFilter
+> = {
+  [P in string &
+    keyof Collection<Collections>]: F["extends"] extends CollectionProperty<
+    P,
+    Collections
+  >
+    ? P
+    : never;
+}[string & keyof Collection<Collections>];
+
+export type CollectionProperty<
+  P extends CollectionPropertyName,
+  C extends Collections = Collections,
+  N extends CollectionName<C> = CollectionName<C>
+> = Collection<C, N>[P];
+
+export type CollectionResult<
+  C extends Collections,
+  N extends CollectionName<C>
+> = Resource<C, N>[];
+
+export type ResourceFilter = {
+  is: CollectionPropertyName<{ extends: boolean }>;
+};
+
+export type Resource<
+  C extends Collections = Collections,
+  N extends CollectionName<C> = CollectionName<C>,
+  F = undefined
+> = F extends ResourceFilter
+  ? Extract<Collection<C, N>, { [K in F["is"]]: true }> extends never
+    ? never
+    : Extract<Collection<C, N>, { [K in F["is"]]: true }>["resource"]
+  : CollectionProperty<"resource", C, N>;
+
+export type FilteredCollectionName<C extends Collections, F = undefined> = {
+  [K in CollectionName<C>]: Resource<C, K, F> extends never ? never : K;
+}[CollectionName<C>];
+
+export type MutableResource<
+  C extends Collections,
+  N extends CollectionName<C> = CollectionName<C>
+> = Resource<C, N, { is: "mutable" }>;
+
+export type MutableCollectionName<
+  C extends Collections
+> = FilteredCollectionName<C, { is: "mutable" }>;
+
+export type NamedResource<
+  C extends Collections = Collections,
+  N extends CollectionName<C> = CollectionName<C>
+> = Resource<C, N, { is: "named" }>;
+
+export type NamedCollectionName<C extends Collections> = FilteredCollectionName<
+  C,
+  { is: "named" }
+>;
+
+export type Input<
+  C extends Collections,
+  N extends CollectionName<C>
+> = CollectionProperty<"input", C, N>;
+
+export type Payload<C extends Collections, N extends CollectionName<C>> = {
+  [K in N]: Resource<C, N>[];
+};
+
+export type IdObject<R extends Resource = Resource> = {
+  [N in keyof R]: N extends "id" ? string : never;
+};
+
+export const toIdObject = <R extends Resource>({ id }: R): IdObject<R> =>
+  ({
+    id
+  } as IdObject<R>);

--- a/packages/db/src/workspace/definitions.ts
+++ b/packages/db/src/workspace/definitions.ts
@@ -1,6 +1,6 @@
-import { Definitions } from "./pouch";
+import * as Pouch from "./pouch";
 
-export type WorkspaceCollections = {
+export type Collections = {
   bytecodes: {
     resource: DataModel.IBytecode;
     input: DataModel.IBytecodesAddInput;
@@ -40,7 +40,23 @@ export type WorkspaceCollections = {
   };
 };
 
-export const definitions: Definitions<WorkspaceCollections> = {
+export type Definitions = Pouch.Definitions<Collections>;
+
+export type CollectionName<
+  F extends Pouch.CollectionFilter<Collections> | undefined = undefined
+> = Pouch.CollectionName<Collections, F>;
+
+export type MutableCollectionName = Pouch.MutableCollectionName<Collections>;
+
+export type Resource<
+  N extends CollectionName = CollectionName
+> = Pouch.Resource<Collections, N>;
+
+export type MutableResource<
+  N extends MutableCollectionName = MutableCollectionName
+> = Pouch.MutableResource<Collections, N>;
+
+export const definitions: Definitions = {
   contracts: {
     createIndexes: [
       {

--- a/packages/db/src/workspace/definitions.ts
+++ b/packages/db/src/workspace/definitions.ts
@@ -16,6 +16,7 @@ export type Collections = {
   contracts: {
     resource: DataModel.IContract;
     input: DataModel.IContractsAddInput;
+    named: true;
   };
   nameRecords: {
     resource: DataModel.INameRecord;
@@ -24,6 +25,7 @@ export type Collections = {
   networks: {
     resource: DataModel.INetwork;
     input: DataModel.INetworksAddInput;
+    named: true;
   };
   sources: {
     resource: DataModel.ISource;
@@ -48,6 +50,8 @@ export type CollectionName<
 
 export type MutableCollectionName = Pouch.MutableCollectionName<Collections>;
 
+export type NamedCollectionName = Pouch.NamedCollectionName<Collections>;
+
 export type Resource<
   N extends CollectionName = CollectionName
 > = Pouch.Resource<Collections, N>;
@@ -55,6 +59,10 @@ export type Resource<
 export type MutableResource<
   N extends MutableCollectionName = MutableCollectionName
 > = Pouch.MutableResource<Collections, N>;
+
+export type NamedResource<
+  N extends NamedCollectionName = NamedCollectionName
+> = Pouch.NamedResource<Collections, N>;
 
 export const definitions: Definitions = {
   contracts: {

--- a/packages/db/src/workspace/definitions.ts
+++ b/packages/db/src/workspace/definitions.ts
@@ -1,3 +1,4 @@
+import * as Meta from "@truffle/db/meta";
 import * as Pouch from "./pouch";
 
 export type Collections = {
@@ -44,23 +45,20 @@ export type Collections = {
 
 export type Definitions = Pouch.Definitions<Collections>;
 
-export type CollectionName = Pouch.CollectionName<Collections>;
+export type CollectionName = Meta.CollectionName<Collections>;
 
-export type MutableCollectionName = Pouch.MutableCollectionName<Collections>;
-
-export type NamedCollectionName = Pouch.NamedCollectionName<Collections>;
-
-export type Resource<
-  N extends CollectionName = CollectionName
-> = Pouch.Resource<Collections, N>;
+export type Resource<N extends CollectionName = CollectionName> = Meta.Resource<
+  Collections,
+  N
+>;
 
 export type MutableResource<
-  N extends MutableCollectionName = MutableCollectionName
-> = Pouch.MutableResource<Collections, N>;
+  N extends CollectionName = CollectionName
+> = Meta.MutableResource<Collections, N>;
 
 export type NamedResource<
-  N extends NamedCollectionName = NamedCollectionName
-> = Pouch.NamedResource<Collections, N>;
+  N extends CollectionName = CollectionName
+> = Meta.NamedResource<Collections, N>;
 
 export const definitions: Definitions = {
   contracts: {

--- a/packages/db/src/workspace/definitions.ts
+++ b/packages/db/src/workspace/definitions.ts
@@ -44,9 +44,7 @@ export type Collections = {
 
 export type Definitions = Pouch.Definitions<Collections>;
 
-export type CollectionName<
-  F extends Pouch.CollectionFilter<Collections> | undefined = undefined
-> = Pouch.CollectionName<Collections, F>;
+export type CollectionName = Pouch.CollectionName<Collections>;
 
 export type MutableCollectionName = Pouch.MutableCollectionName<Collections>;
 

--- a/packages/db/src/workspace/definitions.ts
+++ b/packages/db/src/workspace/definitions.ts
@@ -4,37 +4,37 @@ import * as Pouch from "./pouch";
 export type Collections = {
   bytecodes: {
     resource: DataModel.IBytecode;
-    input: DataModel.IBytecodesAddInput;
+    input: DataModel.IBytecodeInput;
   };
   compilations: {
     resource: DataModel.ICompilation;
-    input: DataModel.ICompilationsAddInput;
+    input: DataModel.ICompilationInput;
   };
   contractInstances: {
     resource: DataModel.IContractInstance;
-    input: DataModel.IContractInstancesAddInput;
+    input: DataModel.IContractInstanceInput;
   };
   contracts: {
     resource: DataModel.IContract;
-    input: DataModel.IContractsAddInput;
+    input: DataModel.IContractInput;
     named: true;
   };
   nameRecords: {
     resource: DataModel.INameRecord;
-    input: DataModel.INameRecordsAddInput;
+    input: DataModel.INameRecordInput;
   };
   networks: {
     resource: DataModel.INetwork;
-    input: DataModel.INetworksAddInput;
+    input: DataModel.INetworkInput;
     named: true;
   };
   sources: {
     resource: DataModel.ISource;
-    input: DataModel.ISourcesAddInput;
+    input: DataModel.ISourceInput;
   };
   projects: {
     resource: DataModel.IProject;
-    input: DataModel.IProjectsAddInput;
+    input: DataModel.IProjectInput;
   };
   projectNames: {
     resource: DataModel.IProjectName;

--- a/packages/db/src/workspace/index.ts
+++ b/packages/db/src/workspace/index.ts
@@ -7,7 +7,7 @@ import {
   MemoryDatabases,
   SqliteDatabases
 } from "./pouch";
-import { WorkspaceCollections, definitions } from "./definitions";
+import { Collections, definitions } from "./definitions";
 
 export interface WorkspaceConfig {
   workingDirectory?: string;
@@ -18,7 +18,7 @@ export interface WorkspaceConfig {
 }
 
 export class Workspace {
-  public databases: Databases<WorkspaceCollections>;
+  public databases: Databases<Collections>;
 
   constructor({
     workingDirectory,

--- a/packages/db/src/workspace/pouch/databases.ts
+++ b/packages/db/src/workspace/pouch/databases.ts
@@ -4,17 +4,16 @@ import PouchDBFind from "pouchdb-find";
 import { generateId } from "@truffle/db/helpers";
 
 import {
-  CollectionDatabases,
   CollectionName,
   CollectionResult,
   Collections,
-  Definition,
-  Definitions,
   Input,
   Payload,
   MutableCollectionName,
   Resource
-} from "./types";
+} from "@truffle/db/meta";
+
+import { CollectionDatabases, Definition, Definitions } from "./types";
 
 export interface DatabasesOptions<C extends Collections> {
   settings: any;

--- a/packages/db/src/workspace/pouch/databases.ts
+++ b/packages/db/src/workspace/pouch/databases.ts
@@ -145,7 +145,7 @@ export abstract class Databases<C extends Collections> {
           return resource;
         }
 
-        const resourceAdded = await this.collections[collectionName].put({
+        await this.collections[collectionName].put({
           ...resourceInput,
           _id: id
         });
@@ -174,13 +174,9 @@ export abstract class Databases<C extends Collections> {
 
         // check for existing
         const resource = await this.get(collectionName, id);
-        const {
-          _rev
-        }: {
-          _rev: PouchDB.Core.RevisionId;
-        } = resource ? resource : {};
+        const { _rev }: any = resource ? resource : {};
 
-        const resourceAdded = await this.collections[collectionName].put({
+        await this.collections[collectionName].put({
           ...resourceInput,
           _rev,
           _id: id
@@ -209,11 +205,7 @@ export abstract class Databases<C extends Collections> {
         const id = this.generateId(collectionName, resourceInput);
 
         const resource = await this.get(collectionName, id);
-        const {
-          _rev
-        }: {
-          _rev: PouchDB.Core.RevisionId;
-        } = resource ? resource : {};
+        const { _rev }: any = resource ? resource : {};
 
         if (_rev) {
           await this.collections[collectionName].put({

--- a/packages/db/src/workspace/pouch/databases.ts
+++ b/packages/db/src/workspace/pouch/databases.ts
@@ -7,8 +7,8 @@ import {
   CollectionName,
   CollectionResult,
   Collections,
-  Input,
-  Payload,
+  MutationInput,
+  MutationPayload,
   MutableCollectionName,
   Resource
 } from "@truffle/db/meta";
@@ -130,8 +130,8 @@ export abstract class Databases<C extends Collections> {
 
   public async add<N extends CollectionName<C>>(
     collectionName: N,
-    input: Input<C, N>
-  ): Promise<Payload<C, N>> {
+    input: MutationInput<C, N>
+  ): Promise<MutationPayload<C, N>> {
     await this.ready;
 
     const resources = await Promise.all(
@@ -158,13 +158,13 @@ export abstract class Databases<C extends Collections> {
 
     return ({
       [collectionName]: resources
-    } as unknown) as Payload<C, N>;
+    } as unknown) as MutationPayload<C, N>;
   }
 
   public async update<M extends MutableCollectionName<C>>(
     collectionName: M,
-    input: Input<C, M>
-  ): Promise<Payload<C, M>> {
+    input: MutationInput<C, M>
+  ): Promise<MutationPayload<C, M>> {
     await this.ready;
 
     const resources = await Promise.all(
@@ -190,12 +190,12 @@ export abstract class Databases<C extends Collections> {
 
     return ({
       [collectionName]: resources
-    } as unknown) as Payload<C, M>;
+    } as unknown) as MutationPayload<C, M>;
   }
 
   public async remove<M extends MutableCollectionName<C>>(
     collectionName: M,
-    input: Input<C, M>
+    input: MutationInput<C, M>
   ): Promise<void> {
     await this.ready;
 
@@ -219,7 +219,7 @@ export abstract class Databases<C extends Collections> {
 
   private generateId<N extends CollectionName<C>>(
     collectionName: N,
-    input: Input<C, N>[N][number]
+    input: MutationInput<C, N>[N][number]
   ): string {
     const { idFields } = this.definitions[collectionName];
 

--- a/packages/db/src/workspace/pouch/fs.ts
+++ b/packages/db/src/workspace/pouch/fs.ts
@@ -4,7 +4,7 @@ import * as jsondown from "jsondown";
 import * as PouchDBUtils from "pouchdb-utils";
 import CoreLevelPouch from "pouchdb-adapter-leveldb-core";
 
-import { Collections } from "./types";
+import { Collections } from "@truffle/db/meta";
 import { Databases } from "./databases";
 
 export class FSDatabases<C extends Collections> extends Databases<C> {

--- a/packages/db/src/workspace/pouch/memory.ts
+++ b/packages/db/src/workspace/pouch/memory.ts
@@ -1,8 +1,8 @@
 import PouchDB from "pouchdb";
 import PouchDBMemoryAdapter from "pouchdb-adapter-memory";
 
+import { Collections } from "@truffle/db/meta";
 import { Databases } from "./databases";
-import { Collections } from "./types";
 
 export class MemoryDatabases<C extends Collections> extends Databases<C> {
   static counter: number = 0;

--- a/packages/db/src/workspace/pouch/sqlite.ts
+++ b/packages/db/src/workspace/pouch/sqlite.ts
@@ -3,8 +3,8 @@ import fse from "fs-extra";
 import PouchDB from "pouchdb";
 import PouchDBNodeWebSQLAdapter from "pouchdb-adapter-node-websql";
 
+import { Collections } from "@truffle/db/meta";
 import { Databases } from "./databases";
-import { Collections } from "./types";
 
 export class SqliteDatabases<C extends Collections> extends Databases<C> {
   private directory: string;

--- a/packages/db/src/workspace/pouch/types.ts
+++ b/packages/db/src/workspace/pouch/types.ts
@@ -1,26 +1,6 @@
 import PouchDB from "pouchdb";
 
-export type Collections = {
-  [collectionName: string]:
-    | {
-        resource: {
-          id: string;
-        };
-        input: any;
-        mutable?: boolean;
-        named?: false;
-      }
-    // definitely named, must define name property
-    | {
-        resource: {
-          id: string;
-          name: string;
-        };
-        input: any;
-        mutable?: boolean;
-        named: true;
-      };
-};
+import { Collections, CollectionName } from "@truffle/db/meta";
 
 export type Definitions<C extends Collections> = {
   [N in CollectionName<C>]: {
@@ -31,88 +11,6 @@ export type Definitions<C extends Collections> = {
 
 export type CollectionDatabases<C extends Collections> = {
   [N in CollectionName<C>]: PouchDB.Database;
-};
-
-export type CollectionName<C extends Collections> = string & keyof C;
-
-export type Collection<
-  C extends Collections = Collections,
-  N extends CollectionName<C> = CollectionName<C>
-> = {
-  [K in N]: C[K];
-}[N];
-
-export type CollectionPropertyFilter = {
-  extends: any;
-};
-
-export type CollectionPropertyName<
-  F extends CollectionPropertyFilter = CollectionPropertyFilter
-> = {
-  [P in string &
-    keyof Collection<Collections>]: F["extends"] extends CollectionProperty<
-    P,
-    Collections
-  >
-    ? P
-    : never;
-}[string & keyof Collection<Collections>];
-
-export type CollectionProperty<
-  P extends CollectionPropertyName,
-  C extends Collections = Collections,
-  N extends CollectionName<C> = CollectionName<C>
-> = Collection<C, N>[P];
-
-export type CollectionResult<
-  C extends Collections,
-  N extends CollectionName<C>
-> = Resource<C, N>[];
-
-export type ResourceFilter = {
-  is: CollectionPropertyName<{ extends: boolean }>;
-};
-
-export type Resource<
-  C extends Collections = Collections,
-  N extends CollectionName<C> = CollectionName<C>,
-  F = undefined
-> = F extends ResourceFilter
-  ? Extract<Collection<C, N>, { [K in F["is"]]: true }> extends never
-    ? never
-    : Extract<Collection<C, N>, { [K in F["is"]]: true }>["resource"]
-  : CollectionProperty<"resource", C, N>;
-
-export type FilteredCollectionName<C extends Collections, F = undefined> = {
-  [K in CollectionName<C>]: Resource<C, K, F> extends never ? never : K;
-}[CollectionName<C>];
-
-export type MutableResource<
-  C extends Collections,
-  N extends CollectionName<C> = CollectionName<C>
-> = Resource<C, N, { is: "mutable" }>;
-
-export type MutableCollectionName<
-  C extends Collections
-> = FilteredCollectionName<C, { is: "mutable" }>;
-
-export type NamedResource<
-  C extends Collections,
-  N extends CollectionName<C> = CollectionName<C>
-> = Resource<C, N, { is: "named" }>;
-
-export type NamedCollectionName<
-  C extends Collections
-> = FilteredCollectionName<C, { is: "named" }>;
-
-
-export type Input<
-  C extends Collections,
-  N extends CollectionName<C>
-> = CollectionProperty<"input", C, N>;
-
-export type Payload<C extends Collections, N extends CollectionName<C>> = {
-  [K in N]: Resource<C, N>[];
 };
 
 export type Definition<

--- a/packages/db/src/workspace/pouch/types.ts
+++ b/packages/db/src/workspace/pouch/types.ts
@@ -21,20 +21,71 @@ export type CollectionDatabases<C extends Collections> = {
 
 export type CollectionName<C extends Collections> = string & keyof C;
 
+export type Collection<
+  C extends Collections = Collections,
+  N extends CollectionName<C> = CollectionName<C>
+> = {
+  [K in N]: C[K];
+}[N];
+
+export type CollectionPropertyFilter = {
+  extends: any;
+};
+
+export type CollectionPropertyName<
+  F extends CollectionPropertyFilter = CollectionPropertyFilter
+> = {
+  [P in string &
+    keyof Collection<Collections>]: F["extends"] extends CollectionProperty<
+    P,
+    Collections
+  >
+    ? P
+    : never;
+}[string & keyof Collection<Collections>];
+
+export type CollectionProperty<
+  P extends CollectionPropertyName,
+  C extends Collections = Collections,
+  N extends CollectionName<C> = CollectionName<C>
+> = Collection<C, N>[P];
+
 export type CollectionResult<
   C extends Collections,
   N extends CollectionName<C>
 > = Resource<C, N>[];
 
+export type ResourceFilter = {
+  is: CollectionPropertyName<{ extends: boolean }>;
+};
+
 export type Resource<
+  C extends Collections = Collections,
+  N extends CollectionName<C> = CollectionName<C>,
+  F = undefined
+> = F extends ResourceFilter
+  ? Extract<Collection<C, N>, { [K in F["is"]]: true }> extends never
+    ? never
+    : Extract<Collection<C, N>, { [K in F["is"]]: true }>["resource"]
+  : CollectionProperty<"resource", C, N>;
+
+export type FilteredCollectionName<C extends Collections, F = undefined> = {
+  [K in CollectionName<C>]: Resource<C, K, F> extends never ? never : K;
+}[CollectionName<C>];
+
+export type MutableResource<
   C extends Collections,
-  N extends CollectionName<C>
-> = C[N]["resource"];
+  N extends CollectionName<C> = CollectionName<C>
+> = Resource<C, N, { is: "mutable" }>;
+
+export type MutableCollectionName<
+  C extends Collections
+> = FilteredCollectionName<C, { is: "mutable" }>;
 
 export type Input<
   C extends Collections,
   N extends CollectionName<C>
-> = C[N]["input"];
+> = CollectionProperty<"input", C, N>;
 
 export type Payload<C extends Collections, N extends CollectionName<C>> = {
   [K in N]: Resource<C, N>[];
@@ -44,7 +95,3 @@ export type Definition<
   C extends Collections,
   N extends CollectionName<C>
 > = Definitions<C>[N];
-
-export type MutableCollectionName<C extends Collections> = {
-  [K in CollectionName<C>]: C[K]["mutable"] extends true ? K : never;
-}[CollectionName<C>];

--- a/packages/db/src/workspace/pouch/types.ts
+++ b/packages/db/src/workspace/pouch/types.ts
@@ -5,6 +5,7 @@ export type Collections = {
     resource: any;
     input: any;
     mutable?: boolean;
+    named?: boolean;
   };
 };
 
@@ -20,6 +21,11 @@ export type CollectionDatabases<C extends Collections> = {
 };
 
 export type CollectionName<C extends Collections> = string & keyof C;
+
+export type NamedCollectionName<C extends Collections> = CollectionName<
+  C,
+  { is: "named" }
+>;
 
 export type Collection<
   C extends Collections = Collections,
@@ -81,6 +87,11 @@ export type MutableResource<
 export type MutableCollectionName<
   C extends Collections
 > = FilteredCollectionName<C, { is: "mutable" }>;
+
+export type NamedResource<
+  C extends Collections,
+  N extends NamedCollectionName<C> = NamedCollectionName<C>
+> = Resource<C, N>;
 
 export type Input<
   C extends Collections,

--- a/packages/db/src/workspace/pouch/types.ts
+++ b/packages/db/src/workspace/pouch/types.ts
@@ -1,12 +1,25 @@
 import PouchDB from "pouchdb";
 
 export type Collections = {
-  [collectionName: string]: {
-    resource: any;
-    input: any;
-    mutable?: boolean;
-    named?: boolean;
-  };
+  [collectionName: string]:
+    | {
+        resource: {
+          id: string;
+        };
+        input: any;
+        mutable?: boolean;
+        named?: false;
+      }
+    // definitely named, must define name property
+    | {
+        resource: {
+          id: string;
+          name: string;
+        };
+        input: any;
+        mutable?: boolean;
+        named: true;
+      };
 };
 
 export type Definitions<C extends Collections> = {
@@ -21,11 +34,6 @@ export type CollectionDatabases<C extends Collections> = {
 };
 
 export type CollectionName<C extends Collections> = string & keyof C;
-
-export type NamedCollectionName<C extends Collections> = CollectionName<
-  C,
-  { is: "named" }
->;
 
 export type Collection<
   C extends Collections = Collections,
@@ -90,8 +98,13 @@ export type MutableCollectionName<
 
 export type NamedResource<
   C extends Collections,
-  N extends NamedCollectionName<C> = NamedCollectionName<C>
-> = Resource<C, N>;
+  N extends CollectionName<C> = CollectionName<C>
+> = Resource<C, N, { is: "named" }>;
+
+export type NamedCollectionName<
+  C extends Collections
+> = FilteredCollectionName<C, { is: "named" }>;
+
 
 export type Input<
   C extends Collections,

--- a/packages/db/types/stub.d.ts
+++ b/packages/db/types/stub.d.ts
@@ -25,12 +25,14 @@ declare namespace DataModel {
   type IContractsAddPayload = any;
   type IInstruction = any;
   type INameRecord = any;
+  type INameRecordInput = any;
   type INameRecordsAddInput = any;
   type INameRecordsAddPayload = any;
   type INetwork = any;
   type INetworkInput = any;
   type INetworksAddInput = any;
   type IProject = any;
+  type IProjectInput = any;
   type IProjectsAddInput = any;
   type IProjectsAddPayload = any;
   type IProjectName = any;


### PR DESCRIPTION
This stuff lived in a pouch-specific module, but it's more widely useful than that, so this PR moves this boilerplate logic into a more cohesive place, along with some additional changes along the way.

In particular:

- Define types for filtering resources based on mutability or namedness (`MutableResource`, etc.)
- Include in this new module the `IdObject` and `NamedResource` types from loaders
- Redefine each resource's input type as the actual resource input, not the input to the mutation.
- Define additional types for mutation input and mutation payload
- Tighten up the base collection type to use less `any`
- Make actual workspace Databases implementation more typesafe