### PR TITLE
Bug fix: Fix variable error

### DIFF
--- a/packages/core/lib/testing/TestRunner.js
+++ b/packages/core/lib/testing/TestRunner.js
@@ -41,7 +41,7 @@ class TestRunner {
 
   async initialize() {
     debug("initializing");
-    this.config.resolver = new Resolver(config, true);
+    this.config.resolver = new Resolver(this.config, true);
 
     if (this.first_snapshot) {
       debug("taking first snapshot");


### PR DESCRIPTION
Recently while updating `TestRunner.js`, a variable error was made. This corrects the mistake which fixes redeploys during testing.

Fixes https://github.com/trufflesuite/truffle/issues/3437