### PR TITLE
Dependency update: Bump ancillary web3 packages to 1.2.9

### DIFF
--- a/packages/codec/package.json
+++ b/packages/codec/package.json
@@ -32,7 +32,7 @@
     "semver": "^6.3.0",
     "source-map-support": "^0.5.19",
     "utf8": "^3.0.0",
-    "web3-utils": "1.2.1"
+    "web3-utils": "1.2.9"
   },
   "devDependencies": {
     "@gnd/typedoc": "0.15.0-0",

--- a/packages/contract-tests/package.json
+++ b/packages/contract-tests/package.json
@@ -30,6 +30,6 @@
     "mocha": "8.0.1",
     "sinon": "9.0.2",
     "web3": "1.2.9",
-    "web3-core-promievent": "1.2.1"
+    "web3-core-promievent": "1.2.9"
   }
 }

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -29,7 +29,7 @@
     "web3": "1.2.9",
     "web3-core-helpers": "1.2.9",
     "web3-core-promievent": "1.2.9",
-    "web3-eth-abi": "1.2.1",
+    "web3-eth-abi": "1.2.9",
     "web3-utils": "1.2.9"
   },
   "devDependencies": {

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -30,7 +30,7 @@
     "web3-core-helpers": "1.2.1",
     "web3-core-promievent": "1.2.1",
     "web3-eth-abi": "1.2.1",
-    "web3-utils": "1.2.1"
+    "web3-utils": "1.2.9"
   },
   "devDependencies": {
     "browserify": "^14.0.0",

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -28,7 +28,7 @@
     "source-map-support": "^0.5.19",
     "web3": "1.2.9",
     "web3-core-helpers": "1.2.9",
-    "web3-core-promievent": "1.2.1",
+    "web3-core-promievent": "1.2.9",
     "web3-eth-abi": "1.2.1",
     "web3-utils": "1.2.9"
   },

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -27,7 +27,7 @@
     "ethers": "^4.0.0-beta.1",
     "source-map-support": "^0.5.19",
     "web3": "1.2.9",
-    "web3-core-helpers": "1.2.1",
+    "web3-core-helpers": "1.2.9",
     "web3-core-promievent": "1.2.1",
     "web3-eth-abi": "1.2.1",
     "web3-utils": "1.2.9"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -69,7 +69,7 @@
     "tmp": "^0.2.1",
     "universal-analytics": "^0.4.17",
     "web3": "1.2.9",
-    "web3-utils": "1.2.1",
+    "web3-utils": "1.2.9",
     "xregexp": "^4.2.4",
     "yargs": "^8.0.2"
   },

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -51,7 +51,7 @@
     "pouchdb-find": "^7.0.0",
     "source-map-support": "^0.5.9",
     "web3": "1.2.9",
-    "web3-utils": "1.2.2"
+    "web3-utils": "1.2.9"
   },
   "devDependencies": {
     "@gql2ts/from-schema": "^2.0.0-4",

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -40,7 +40,7 @@
     "semver": "^6.3.0",
     "source-map-support": "^0.5.19",
     "web3": "1.2.9",
-    "web3-eth-abi": "1.2.1"
+    "web3-eth-abi": "1.2.9"
   },
   "devDependencies": {
     "@truffle/artifactor": "^4.0.82",

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -22,7 +22,7 @@
     "emittery": "^0.4.0",
     "eth-ens-namehash": "^2.0.8",
     "ethereum-ens": "^0.8.0",
-    "web3-utils": "1.2.2"
+    "web3-utils": "1.2.9"
   },
   "devDependencies": {
     "@truffle/reporters": "^1.1.1",

--- a/packages/external-compile/package.json
+++ b/packages/external-compile/package.json
@@ -19,7 +19,7 @@
     "@truffle/expect": "^0.0.15",
     "debug": "^4.1.0",
     "glob": "^7.1.2",
-    "web3-utils": "1.2.1"
+    "web3-utils": "1.2.9"
   },
   "devDependencies": {
     "chai": "4.2.0",

--- a/packages/reporters/package.json
+++ b/packages/reporters/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "node-emoji": "^1.8.1",
     "ora": "^3.4.0",
-    "web3-utils": "1.2.1"
+    "web3-utils": "1.2.9"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -22779,20 +22779,6 @@ web3-utils@1.2.11:
     underscore "1.9.1"
     utf8 "3.0.0"
 
-web3-utils@1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.2.2.tgz#b53a08c40d2c3f31d3c4a28e7d749405df99c8c0"
-  integrity sha512-joF+s3243TY5cL7Z7y4h1JsJpUCf/kmFmj+eJar7Y2yNIGVcW961VyrAms75tjUysSuHaUQ3eQXjBEUJueT52A==
-  dependencies:
-    bn.js "4.11.8"
-    eth-lib "0.2.7"
-    ethereum-bloom-filters "^1.0.6"
-    ethjs-unit "0.1.6"
-    number-to-bn "1.7.0"
-    randombytes "^2.1.0"
-    underscore "1.9.1"
-    utf8 "3.0.0"
-
 web3-utils@1.2.4, web3-utils@^1.0.0-beta.31:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.2.4.tgz#96832a39a66b05bf8862a5b0bdad2799d709d951"


### PR DESCRIPTION
This work used to be in #3448 but was moved to this branch due to problems merging/rebasing that couldn't be resolved.

Update web3 ancillary packages to 1.2.9