### PR TITLE
Remove I prefix from autogenerated @truffle/db DataModel types

### DIFF
--- a/packages/db/bin/codegen.js
+++ b/packages/db/bin/codegen.js
@@ -4,8 +4,16 @@ const { generateNamespace } = require("@gql2ts/from-schema");
 
 const { schema } = require("@truffle/db/dist/src/schema");
 
-const dataModel = generateNamespace("DataModel", schema, {
-  ignoreTypeNameDeclaration: true
-});
+const dataModel = generateNamespace(
+  "DataModel",
+  schema,
+  {
+    ignoreTypeNameDeclaration: true,
+    ignoredTypes: ["Resource", "Named"]
+  },
+  {
+    generateInterfaceName: name => name
+  }
+);
 
 fs.writeFileSync(path.join(__dirname, "..", "types", "schema.d.ts"), dataModel);

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -74,7 +74,7 @@ export class TruffleDB {
     return current.value;
   }
 
-  async loadNames(project: DataModel.IProject, resources: NamedResource[]) {
+  async loadNames(project: DataModel.Project, resources: NamedResource[]) {
     return await this.runLoader(
       generateNamesLoad,
       toIdObject(project),
@@ -82,7 +82,7 @@ export class TruffleDB {
     );
   }
 
-  async loadProject(): Promise<DataModel.IProject> {
+  async loadProject(): Promise<DataModel.Project> {
     return await this.runLoader(generateInitializeLoad, {
       directory: this.context.workingDirectory
     });

--- a/packages/db/src/definitions/types.ts
+++ b/packages/db/src/definitions/types.ts
@@ -4,42 +4,42 @@ import * as GraphQl from "../graphql";
 
 export type Collections = {
   sources: {
-    resource: DataModel.ISource;
-    input: DataModel.ISourceInput;
+    resource: DataModel.Source;
+    input: DataModel.SourceInput;
   };
   bytecodes: {
-    resource: DataModel.IBytecode;
-    input: DataModel.IBytecodeInput;
+    resource: DataModel.Bytecode;
+    input: DataModel.BytecodeInput;
   };
   compilations: {
-    resource: DataModel.ICompilation;
-    input: DataModel.ICompilationInput;
+    resource: DataModel.Compilation;
+    input: DataModel.CompilationInput;
   };
   contractInstances: {
-    resource: DataModel.IContractInstance;
-    input: DataModel.IContractInstanceInput;
+    resource: DataModel.ContractInstance;
+    input: DataModel.ContractInstanceInput;
   };
   contracts: {
-    resource: DataModel.IContract;
-    input: DataModel.IContractInput;
+    resource: DataModel.Contract;
+    input: DataModel.ContractInput;
     named: true;
   };
   nameRecords: {
-    resource: DataModel.INameRecord;
-    input: DataModel.INameRecordInput;
+    resource: DataModel.NameRecord;
+    input: DataModel.NameRecordInput;
   };
   networks: {
-    resource: DataModel.INetwork;
-    input: DataModel.INetworkInput;
+    resource: DataModel.Network;
+    input: DataModel.NetworkInput;
     named: true;
   };
   projects: {
-    resource: DataModel.IProject;
-    input: DataModel.IProjectInput;
+    resource: DataModel.Project;
+    input: DataModel.ProjectInput;
   };
   projectNames: {
-    resource: DataModel.IProjectName;
-    input: DataModel.IProjectNameInput;
+    resource: DataModel.ProjectName;
+    input: DataModel.ProjectNameInput;
     mutable: true;
   };
 };

--- a/packages/db/src/loaders/commands/initialize.ts
+++ b/packages/db/src/loaders/commands/initialize.ts
@@ -8,7 +8,7 @@ export function* generateInitializeLoad({
 }): Generator<
   WorkspaceRequest,
   any,
-  WorkspaceResponse<"projectsAdd", DataModel.IProjectsAddPayload>
+  WorkspaceResponse<"projectsAdd", DataModel.ProjectsAddPayload>
 > {
   const project = yield* generateProjectLoad(directory);
   return project;

--- a/packages/db/src/loaders/commands/names.ts
+++ b/packages/db/src/loaders/commands/names.ts
@@ -11,10 +11,10 @@ import { IdObject, NamedResource } from "@truffle/db/meta";
  * generator function to load nameRecords and project names into Truffle DB
  */
 export function* generateNamesLoad(
-  project: IdObject<DataModel.IProject>,
+  project: IdObject<DataModel.Project>,
   contracts: NamedResource[]
 ): Generator<WorkspaceRequest, any, WorkspaceResponse<string>> {
-  let getCurrent = function* (name, type) {
+  let getCurrent = function*(name, type) {
     return yield* generateProjectNameResolve(project, name, type);
   };
 

--- a/packages/db/src/loaders/resources/bytecodes/index.ts
+++ b/packages/db/src/loaders/resources/bytecodes/index.ts
@@ -17,7 +17,7 @@ export function* generateBytecodesLoad(
 ): Generator<
   WorkspaceRequest,
   LoadedBytecodes,
-  WorkspaceResponse<"bytecodesAdd", DataModel.IBytecodesAddPayload>
+  WorkspaceResponse<"bytecodesAdd", DataModel.BytecodesAddPayload>
 > {
   // we're flattening in order to send all bytecodes in one big list
   // (it's okay, we're gonna recreate the structure before we return)

--- a/packages/db/src/loaders/resources/compilations/index.ts
+++ b/packages/db/src/loaders/resources/compilations/index.ts
@@ -13,13 +13,13 @@ export { GetCompilation } from "./get.graphql";
 const compilationSourceInputs = ({
   compilation,
   sources
-}: LoadableCompilation): DataModel.IResourceReferenceInput[] =>
+}: LoadableCompilation): DataModel.ResourceReferenceInput[] =>
   compilation.sources.map(({ input: { sourcePath } }) => sources[sourcePath]);
 
 const compilationProcessedSourceInputs = ({
   compilation,
   sources
-}: LoadableCompilation): DataModel.IProcessedSourceInput[] =>
+}: LoadableCompilation): DataModel.ProcessedSourceInput[] =>
   compilation.sources.map(({ input: { sourcePath }, contracts }) => ({
     source: sources[sourcePath],
     // PRECONDITION: all contracts in the same compilation with the same
@@ -31,7 +31,7 @@ const compilationProcessedSourceInputs = ({
 
 const compilationSourceMapInputs = ({
   compilation
-}: LoadableCompilation): DataModel.ISourceMapInput[] => {
+}: LoadableCompilation): DataModel.SourceMapInput[] => {
   const contracts = compilation.sources
     .map(({ contracts }) => contracts)
     .flat();
@@ -48,7 +48,7 @@ const compilationSourceMapInputs = ({
 
 const compilationInput = (
   data: LoadableCompilation
-): DataModel.ICompilationInput => ({
+): DataModel.CompilationInput => ({
   compiler: data.compilation.compiler,
   processedSources: compilationProcessedSourceInputs(data),
   sources: compilationSourceInputs(data),
@@ -64,8 +64,8 @@ export function* generateCompilationsLoad(
   loadableCompilations: LoadableCompilation[]
 ): Generator<
   WorkspaceRequest,
-  DataModel.ICompilation[],
-  WorkspaceResponse<"compilationsAdd", DataModel.ICompilationsAddPayload>
+  DataModel.Compilation[],
+  WorkspaceResponse<"compilationsAdd", DataModel.CompilationsAddPayload>
 > {
   const compilations = loadableCompilations.map(compilationInput);
 

--- a/packages/db/src/loaders/resources/contracts/index.ts
+++ b/packages/db/src/loaders/resources/contracts/index.ts
@@ -13,15 +13,15 @@ export interface LoadableContract {
   contract: CompiledContract;
   path: { sourceIndex: number; contractIndex: number };
   bytecodes: LoadedBytecodes;
-  compilation: IdObject<DataModel.ICompilation>;
+  compilation: IdObject<DataModel.Compilation>;
 }
 
 export function* generateContractsLoad(
   loadableContracts: LoadableContract[]
 ): Generator<
   WorkspaceRequest,
-  DataModel.IContract[],
-  WorkspaceResponse<"contractsAdd", DataModel.IContractsAddPayload>
+  DataModel.Contract[],
+  WorkspaceResponse<"contractsAdd", DataModel.ContractsAddPayload>
 > {
   const contracts = loadableContracts.map(loadableContract => {
     const {

--- a/packages/db/src/loaders/resources/nameRecords/index.ts
+++ b/packages/db/src/loaders/resources/nameRecords/index.ts
@@ -14,7 +14,7 @@ type ResolveFunc = (
   type: string
 ) => Generator<
   WorkspaceRequest,
-  DataModel.INameRecord | null,
+  DataModel.NameRecord | null,
   WorkspaceResponse
 >;
 
@@ -24,13 +24,13 @@ export function* generateNameRecordsLoad(
   getCurrent: ResolveFunc
 ): Generator<
   WorkspaceRequest,
-  DataModel.INameRecord[],
-  WorkspaceResponse<"nameRecordsAdd", DataModel.INameRecordsAddPayload>
+  DataModel.NameRecord[],
+  WorkspaceResponse<"nameRecordsAdd", DataModel.NameRecordsAddPayload>
 > {
   const nameRecords = [];
   for (const resource of resources) {
     const { name } = resource;
-    const current: DataModel.INameRecord = yield* getCurrent(name, type);
+    const current: DataModel.NameRecord = yield* getCurrent(name, type);
 
     if (current) {
       nameRecords.push({

--- a/packages/db/src/loaders/resources/projects/index.ts
+++ b/packages/db/src/loaders/resources/projects/index.ts
@@ -10,8 +10,8 @@ export function* generateProjectLoad(
   directory: string
 ): Generator<
   WorkspaceRequest,
-  DataModel.IProject,
-  WorkspaceResponse<"projectsAdd", DataModel.IProjectsAddPayload>
+  DataModel.Project,
+  WorkspaceResponse<"projectsAdd", DataModel.ProjectsAddPayload>
 > {
   const result = yield {
     request: AddProjects,
@@ -24,13 +24,13 @@ export function* generateProjectLoad(
 }
 
 export function* generateProjectNameResolve(
-  project: IdObject<DataModel.IProject>,
+  project: IdObject<DataModel.Project>,
   name: string,
   type: string
 ): Generator<
   WorkspaceRequest,
-  DataModel.INameRecord,
-  WorkspaceResponse<"project", { resolve: DataModel.IProject["resolve"] }>
+  DataModel.NameRecord,
+  WorkspaceResponse<"project", { resolve: DataModel.Project["resolve"] }>
 > {
   const result = yield {
     request: ResolveProjectName,
@@ -45,12 +45,12 @@ export function* generateProjectNameResolve(
 }
 
 export function* generateProjectNamesAssign(
-  project: IdObject<DataModel.IProject>,
-  nameRecords: DataModel.INameRecord[]
+  project: IdObject<DataModel.Project>,
+  nameRecords: DataModel.NameRecord[]
 ): Generator<
   WorkspaceRequest,
   void,
-  WorkspaceResponse<"projectNamesAssign", DataModel.IProjectNamesAssignPayload>
+  WorkspaceResponse<"projectNamesAssign", DataModel.ProjectNamesAssignPayload>
 > {
   const projectNames = nameRecords.map(({ id, name, type }) => ({
     project,

--- a/packages/db/src/loaders/resources/sources/index.ts
+++ b/packages/db/src/loaders/resources/sources/index.ts
@@ -16,7 +16,7 @@ export function* generateSourcesLoad(
 ): Generator<
   WorkspaceRequest,
   LoadedSources,
-  WorkspaceResponse<"sourcesAdd", DataModel.ISourcesAddPayload>
+  WorkspaceResponse<"sourcesAdd", DataModel.SourcesAddPayload>
 > {
   // for each compilation, we need to load sources for each of the contracts
   const inputs = compilation.sources.map(({ input }) => input);

--- a/packages/db/src/loaders/schema/artifactsLoader.ts
+++ b/packages/db/src/loaders/schema/artifactsLoader.ts
@@ -283,7 +283,7 @@ export class ArtifactsLoader {
   }
 
   async loadContractInstances(
-    contracts: Array<DataModel.IContract>,
+    contracts: Array<DataModel.Contract>,
     networksArray: Array<Array<LoaderNetworkObject>>
   ) {
     // networksArray is an array of arrays of networks for each contract;

--- a/packages/db/src/loaders/types.ts
+++ b/packages/db/src/loaders/types.ts
@@ -13,12 +13,12 @@ export interface CompilationData {
 
 export interface SourceData {
   index: number;
-  input: DataModel.ISourceInput;
+  input: DataModel.SourceInput;
   contracts: CompiledContract[];
 }
 
 export interface LoadedSources {
-  [sourcePath: string]: IdObject<DataModel.ISource>;
+  [sourcePath: string]: IdObject<DataModel.Source>;
 }
 
 // we track loaded bytecodes using the same structure as CompilationData:
@@ -28,8 +28,8 @@ export interface LoadedSources {
 export interface LoadedBytecodes {
   sources: {
     contracts: {
-      createBytecode: IdObject<DataModel.IBytecode>;
-      callBytecode: IdObject<DataModel.IBytecode>;
+      createBytecode: IdObject<DataModel.Bytecode>;
+      callBytecode: IdObject<DataModel.Bytecode>;
     }[];
   }[];
 }

--- a/packages/db/types/stub.d.ts
+++ b/packages/db/types/stub.d.ts
@@ -2,59 +2,47 @@
 // graphql typescript definitions
 
 declare namespace DataModel {
-  type IResourceReferenceInput = any;
-  type IBytecode = any;
-  type IBytecodeInput = any;
-  type IBytecodesAddInput = any;
-  type IBytecodesAddPayload = any;
-  type ICompilation = any;
-  type ICompilationInput = any;
-  type IProcessedSourceInput = any;
-  type ISourceMapInput = any;
-  type ICompilationsAddInput = any;
-  type ICompilationsAddPayload = any;
-  type ICompiler = any;
-  type ICompilerInput = any;
-  type IContract = any;
-  type IContractInput = any;
-  type IContractInstance = any;
-  type IContractInstanceInput = any;
-  type IContractInstancesAddInput = any;
-  type IContractInstancesAddPayload = any;
-  type IContractsAddInput = any;
-  type IContractsAddPayload = any;
-  type IInstruction = any;
-  type INameRecord = any;
-  type INameRecordInput = any;
-  type INameRecordsAddInput = any;
-  type INameRecordsAddPayload = any;
-  type INetwork = any;
-  type INetworkInput = any;
-  type INetworksAddInput = any;
-  type IProject = any;
-  type IProjectInput = any;
-  type IProjectsAddInput = any;
-  type IProjectsAddPayload = any;
-  type IProjectName = any;
-  type IProjectNameInput = any;
-  type IProjectNamesAssignPayload = any;
-  type ISource = any;
-  type ISourceInput = any;
-  type ISourceRange = any;
-  type ISourcesAddInput = any;
-  type ISourcesAddPayload = any;
-
-  interface IWorkspaceQuery {
-    [key: string]: any;
-  }
-
-  interface IWorkspaceMutation {
-    [key: string]: any;
-  }
-
-  interface INamed {
-    name: string;
-  }
+  type ResourceReferenceInput = any;
+  type Bytecode = any;
+  type BytecodeInput = any;
+  type BytecodesAddInput = any;
+  type BytecodesAddPayload = any;
+  type Compilation = any;
+  type CompilationInput = any;
+  type ProcessedSourceInput = any;
+  type SourceMapInput = any;
+  type CompilationsAddInput = any;
+  type CompilationsAddPayload = any;
+  type Compiler = any;
+  type CompilerInput = any;
+  type Contract = any;
+  type ContractInput = any;
+  type ContractInstance = any;
+  type ContractInstanceInput = any;
+  type ContractInstancesAddInput = any;
+  type ContractInstancesAddPayload = any;
+  type ContractsAddInput = any;
+  type ContractsAddPayload = any;
+  type Instruction = any;
+  type NameRecord = any;
+  type NameRecordInput = any;
+  type NameRecordsAddInput = any;
+  type NameRecordsAddPayload = any;
+  type Network = any;
+  type NetworkInput = any;
+  type NetworksAddInput = any;
+  type Project = any;
+  type ProjectInput = any;
+  type ProjectsAddInput = any;
+  type ProjectsAddPayload = any;
+  type ProjectName = any;
+  type ProjectNameInput = any;
+  type ProjectNamesAssignPayload = any;
+  type Source = any;
+  type SourceInput = any;
+  type SourceRange = any;
+  type SourcesAddInput = any;
+  type SourcesAddPayload = any;
 }
 
 // tslint:enable


### PR DESCRIPTION
This would result in `interface Resource { id }` as well as `type Resource = Source | ...`, but I figure we don't need those; I'm just ignoring those from the output.