### PR TITLE
Replace custom config type in @truffle/db with @truffle/config

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@truffle/compile-common": "^0.4.1",
+    "@truffle/config": "^1.2.31",
     "@truffle/workflow-compile": "^3.0.5",
     "apollo-server": "^2.18.2",
     "fse": "^4.0.1",

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -1,4 +1,5 @@
 import { GraphQLSchema, DocumentNode, parse, execute } from "graphql";
+import type TruffleConfig from "@truffle/config";
 import { generateCompileLoad } from "@truffle/db/loaders/commands";
 import { WorkspaceRequest, WorkspaceResponse } from "@truffle/db/loaders/types";
 import { WorkflowCompileResult } from "@truffle/compile-common";
@@ -11,18 +12,6 @@ import {
 } from "@truffle/db/loaders/commands";
 import { toIdObject, NamedResource } from "@truffle/db/meta";
 
-interface IConfig {
-  contracts_build_directory: string;
-  contracts_directory: string;
-  working_directory?: string;
-  db?: {
-    adapter?: {
-      name: string;
-      settings?: any;
-    };
-  };
-}
-
 type LoaderOptions = {
   names: boolean;
 };
@@ -31,7 +20,7 @@ export class TruffleDB {
   schema: GraphQLSchema;
   private context: Context;
 
-  constructor(config: IConfig) {
+  constructor(config: TruffleConfig) {
     this.schema = schema;
     this.context = this.createContext(config);
   }
@@ -106,7 +95,7 @@ export class TruffleDB {
     return { compilations, contracts };
   }
 
-  private createContext(config: IConfig): Context {
+  private createContext(config: TruffleConfig): Context {
     return {
       workspace: connect({
         workingDirectory: config.working_directory,


### PR DESCRIPTION
... importing as type only, to keep it as a devDep

Note: this causes a problem with our git hooks, so I had to do `--no-verify`. Looks like this is a problem with us being very behind for our `husky` dependency.