### PR TITLE
Unify @truffle/db loaders infrastructure

### DIFF
--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -1,6 +1,7 @@
 import { GraphQLSchema, DocumentNode, parse, execute } from "graphql";
 import type TruffleConfig from "@truffle/config";
 import { generateCompileLoad } from "@truffle/db/loaders/commands";
+import { LoaderRunner, forDb } from "@truffle/db/loaders/run";
 import { WorkspaceRequest, WorkspaceResponse } from "@truffle/db/loaders/types";
 import { WorkflowCompileResult } from "@truffle/compile-common";
 import { schema } from "./schema";
@@ -19,10 +20,12 @@ type LoaderOptions = {
 export class TruffleDB {
   schema: GraphQLSchema;
   private context: Context;
+  private runLoader: LoaderRunner;
 
   constructor(config: TruffleConfig) {
     this.schema = schema;
     this.context = this.createContext(config);
+    this.runLoader = forDb(this);
   }
 
   async query(query: DocumentNode | string, variables: any = {}): Promise<any> {
@@ -38,29 +41,6 @@ export class TruffleDB {
     const response: WorkspaceResponse = await this.query(request, variables);
 
     return response;
-  }
-
-  private async runLoader<
-    Request extends WorkspaceRequest,
-    Response extends WorkspaceResponse,
-    Args extends unknown[],
-    Return
-  >(
-    loader: (...args: Args) => Generator<Request, Return, Response>,
-    ...args: Args
-  ): Promise<Return> {
-    const saga = loader(...args);
-    let current = saga.next();
-
-    while (!current.done) {
-      const { request, variables } = current.value as Request;
-
-      const response: Response = await this.query(request, variables);
-
-      current = saga.next(response);
-    }
-
-    return current.value;
   }
 
   async loadNames(project: DataModel.Project, resources: NamedResource[]) {

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -2,7 +2,6 @@ import { GraphQLSchema, DocumentNode, parse, execute } from "graphql";
 import type TruffleConfig from "@truffle/config";
 import { generateCompileLoad } from "@truffle/db/loaders/commands";
 import { LoaderRunner, forDb } from "@truffle/db/loaders/run";
-import { WorkspaceRequest, WorkspaceResponse } from "@truffle/db/loaders/types";
 import { WorkflowCompileResult } from "@truffle/compile-common";
 import { schema } from "./schema";
 import { connect } from "./connect";
@@ -33,14 +32,6 @@ export class TruffleDB {
       typeof query !== "string" ? query : parse(query);
 
     return await execute(this.schema, document, null, this.context, variables);
-  }
-
-  async getWorkspaceResponse(generatorRequest: WorkspaceRequest) {
-    const { request, variables }: WorkspaceRequest = generatorRequest;
-
-    const response: WorkspaceResponse = await this.query(request, variables);
-
-    return response;
   }
 
   async loadNames(project: DataModel.Project, resources: NamedResource[]) {

--- a/packages/db/src/loaders/commands/compile.ts
+++ b/packages/db/src/loaders/commands/compile.ts
@@ -1,8 +1,4 @@
-import {
-  CompilationData,
-  WorkspaceRequest,
-  WorkspaceResponse
-} from "@truffle/db/loaders/types";
+import { CompilationData, Load } from "@truffle/db/loaders/types";
 import {
   WorkflowCompileResult,
   Compilation,
@@ -24,7 +20,10 @@ import { generateSourcesLoad } from "@truffle/db/loaders/resources/sources";
  */
 export function* generateCompileLoad(
   result: WorkflowCompileResult
-): Generator<WorkspaceRequest, any, WorkspaceResponse<string>> {
+): Load<{
+  compilations: DataModel.Compilation[];
+  contracts: DataModel.Contract[];
+}> {
   const resultCompilations = processResultCompilations(result);
 
   // for each compilation returned by workflow-compile:

--- a/packages/db/src/loaders/commands/initialize.ts
+++ b/packages/db/src/loaders/commands/initialize.ts
@@ -1,15 +1,11 @@
+import { IdObject, toIdObject } from "@truffle/db/meta";
+
 import { generateProjectLoad } from "@truffle/db/loaders/resources/projects";
-import { WorkspaceRequest, WorkspaceResponse } from "@truffle/db/loaders/types";
+import { Load } from "@truffle/db/loaders/types";
 
 export function* generateInitializeLoad({
   directory
-}: {
-  directory: string;
-}): Generator<
-  WorkspaceRequest,
-  any,
-  WorkspaceResponse<"projectsAdd", DataModel.ProjectsAddPayload>
-> {
+}): Load<IdObject<DataModel.Project>> {
   const project = yield* generateProjectLoad(directory);
-  return project;
+  return toIdObject(project);
 }

--- a/packages/db/src/loaders/commands/names.ts
+++ b/packages/db/src/loaders/commands/names.ts
@@ -4,7 +4,7 @@ import {
 } from "@truffle/db/loaders/resources/projects";
 
 import { generateNameRecordsLoad } from "@truffle/db/loaders/resources/nameRecords";
-import { WorkspaceRequest, WorkspaceResponse } from "@truffle/db/loaders/types";
+import { Load } from "@truffle/db/loaders/types";
 import { IdObject, NamedResource } from "@truffle/db/meta";
 
 /**
@@ -13,7 +13,7 @@ import { IdObject, NamedResource } from "@truffle/db/meta";
 export function* generateNamesLoad(
   project: IdObject<DataModel.Project>,
   contracts: NamedResource[]
-): Generator<WorkspaceRequest, any, WorkspaceResponse<string>> {
+): Load<void> {
   let getCurrent = function*(name, type) {
     return yield* generateProjectNameResolve(project, name, type);
   };

--- a/packages/db/src/loaders/resources/bytecodes/index.ts
+++ b/packages/db/src/loaders/resources/bytecodes/index.ts
@@ -1,8 +1,7 @@
 import {
   CompilationData,
   LoadedBytecodes,
-  WorkspaceRequest,
-  WorkspaceResponse
+  Load
 } from "@truffle/db/loaders/types";
 import { toIdObject } from "@truffle/db/meta";
 import { CompiledContract } from "@truffle/compile-common";
@@ -14,11 +13,7 @@ export { AddBytecodes };
  */
 export function* generateBytecodesLoad(
   compilation: CompilationData
-): Generator<
-  WorkspaceRequest,
-  LoadedBytecodes,
-  WorkspaceResponse<"bytecodesAdd", DataModel.BytecodesAddPayload>
-> {
+): Load<LoadedBytecodes, "bytecodesAdd"> {
   // we're flattening in order to send all bytecodes in one big list
   // (it's okay, we're gonna recreate the structure before we return)
   const flattenedContracts: CompiledContract[] = compilation.sources

--- a/packages/db/src/loaders/resources/compilations/index.ts
+++ b/packages/db/src/loaders/resources/compilations/index.ts
@@ -1,8 +1,7 @@
 import {
   CompilationData,
   LoadedSources,
-  WorkspaceRequest,
-  WorkspaceResponse
+  Load
 } from "@truffle/db/loaders/types";
 
 import { AddCompilations } from "./add.graphql";
@@ -62,11 +61,7 @@ type LoadableCompilation = {
 
 export function* generateCompilationsLoad(
   loadableCompilations: LoadableCompilation[]
-): Generator<
-  WorkspaceRequest,
-  DataModel.Compilation[],
-  WorkspaceResponse<"compilationsAdd", DataModel.CompilationsAddPayload>
-> {
+): Load<DataModel.Compilation[], "compilationsAdd"> {
   const compilations = loadableCompilations.map(compilationInput);
 
   const result = yield {

--- a/packages/db/src/loaders/resources/contracts/index.ts
+++ b/packages/db/src/loaders/resources/contracts/index.ts
@@ -1,8 +1,4 @@
-import {
-  LoadedBytecodes,
-  WorkspaceRequest,
-  WorkspaceResponse
-} from "@truffle/db/loaders/types";
+import { LoadedBytecodes, Load } from "@truffle/db/loaders/types";
 import { IdObject } from "@truffle/db/meta";
 import { CompiledContract } from "@truffle/compile-common";
 
@@ -18,11 +14,7 @@ export interface LoadableContract {
 
 export function* generateContractsLoad(
   loadableContracts: LoadableContract[]
-): Generator<
-  WorkspaceRequest,
-  DataModel.Contract[],
-  WorkspaceResponse<"contractsAdd", DataModel.ContractsAddPayload>
-> {
+): Load<DataModel.Contract[], "contractsAdd"> {
   const contracts = loadableContracts.map(loadableContract => {
     const {
       contract: { contractName: name, abi: abiObject },

--- a/packages/db/src/loaders/resources/nameRecords/index.ts
+++ b/packages/db/src/loaders/resources/nameRecords/index.ts
@@ -1,4 +1,4 @@
-import { WorkspaceRequest, WorkspaceResponse } from "@truffle/db/loaders/types";
+import { Load } from "@truffle/db/loaders/types";
 import { toIdObject } from "@truffle/db/meta";
 
 import { AddNameRecords } from "./add.graphql";
@@ -12,21 +12,13 @@ interface Resource {
 type ResolveFunc = (
   name: string,
   type: string
-) => Generator<
-  WorkspaceRequest,
-  DataModel.NameRecord | null,
-  WorkspaceResponse
->;
+) => Load<DataModel.NameRecord | null>;
 
 export function* generateNameRecordsLoad(
   resources: Resource[],
   type: string,
   getCurrent: ResolveFunc
-): Generator<
-  WorkspaceRequest,
-  DataModel.NameRecord[],
-  WorkspaceResponse<"nameRecordsAdd", DataModel.NameRecordsAddPayload>
-> {
+): Load<DataModel.NameRecord[], "nameRecordsAdd"> {
   const nameRecords = [];
   for (const resource of resources) {
     const { name } = resource;

--- a/packages/db/src/loaders/resources/projects/index.ts
+++ b/packages/db/src/loaders/resources/projects/index.ts
@@ -1,4 +1,4 @@
-import { WorkspaceRequest, WorkspaceResponse } from "@truffle/db/loaders/types";
+import { Load } from "@truffle/db/loaders/types";
 import { IdObject } from "@truffle/db/meta";
 
 import { AddProjects } from "./add.graphql";
@@ -8,11 +8,7 @@ export { AddProjects, AssignProjectNames, ResolveProjectName };
 
 export function* generateProjectLoad(
   directory: string
-): Generator<
-  WorkspaceRequest,
-  DataModel.Project,
-  WorkspaceResponse<"projectsAdd", DataModel.ProjectsAddPayload>
-> {
+): Load<DataModel.Project, "projectsAdd"> {
   const result = yield {
     request: AddProjects,
     variables: {
@@ -27,11 +23,7 @@ export function* generateProjectNameResolve(
   project: IdObject<DataModel.Project>,
   name: string,
   type: string
-): Generator<
-  WorkspaceRequest,
-  DataModel.NameRecord,
-  WorkspaceResponse<"project", { resolve: DataModel.Project["resolve"] }>
-> {
+): Load<DataModel.NameRecord, "project"> {
   const result = yield {
     request: ResolveProjectName,
     variables: {
@@ -41,17 +33,15 @@ export function* generateProjectNameResolve(
     }
   };
 
-  return result.data.project.resolve[0];
+  const nameRecord = result.data.project.resolve[0];
+
+  return nameRecord;
 }
 
 export function* generateProjectNamesAssign(
   project: IdObject<DataModel.Project>,
   nameRecords: DataModel.NameRecord[]
-): Generator<
-  WorkspaceRequest,
-  void,
-  WorkspaceResponse<"projectNamesAssign", DataModel.ProjectNamesAssignPayload>
-> {
+): Load<void, "projectNamesAssign"> {
   const projectNames = nameRecords.map(({ id, name, type }) => ({
     project,
     nameRecord: { id },

--- a/packages/db/src/loaders/resources/sources/index.ts
+++ b/packages/db/src/loaders/resources/sources/index.ts
@@ -3,8 +3,7 @@ import { toIdObject } from "@truffle/db/meta";
 import {
   CompilationData,
   LoadedSources,
-  WorkspaceRequest,
-  WorkspaceResponse
+  Load
 } from "@truffle/db/loaders/types";
 
 import { AddSources } from "./add.graphql";
@@ -13,11 +12,7 @@ export { AddSources };
 // returns list of IDs
 export function* generateSourcesLoad(
   compilation: CompilationData
-): Generator<
-  WorkspaceRequest,
-  LoadedSources,
-  WorkspaceResponse<"sourcesAdd", DataModel.SourcesAddPayload>
-> {
+): Load<LoadedSources, "sourcesAdd"> {
   // for each compilation, we need to load sources for each of the contracts
   const inputs = compilation.sources.map(({ input }) => input);
 

--- a/packages/db/src/loaders/run.ts
+++ b/packages/db/src/loaders/run.ts
@@ -1,0 +1,34 @@
+import { WorkspaceRequest, WorkspaceResponse } from "./types";
+
+export type LoaderRunner = <
+  Request extends WorkspaceRequest,
+  Response extends WorkspaceResponse,
+  Args extends unknown[],
+  Return
+>(
+  loader: (...args: Args) => Generator<Request, Return, Response>,
+  ...args: Args
+) => Promise<Return>;
+
+export const forDb = (db): LoaderRunner => async <
+  Request extends WorkspaceRequest,
+  Response extends WorkspaceResponse,
+  Args extends unknown[],
+  Return
+>(
+  loader: (...args: Args) => Generator<Request, Return, Response>,
+  ...args: Args
+): Promise<Return> => {
+  const saga = loader(...args);
+  let current = saga.next();
+
+  while (!current.done) {
+    const { request, variables } = current.value as Request;
+
+    const response = await db.query(request, variables);
+
+    current = saga.next(response);
+  }
+
+  return current.value;
+};

--- a/packages/db/types/stub.d.ts
+++ b/packages/db/types/stub.d.ts
@@ -43,6 +43,9 @@ declare namespace DataModel {
   type SourceRange = any;
   type SourcesAddInput = any;
   type SourcesAddPayload = any;
+
+  type Query = any;
+  type Mutation = any;
 }
 
 // tslint:enable


### PR DESCRIPTION
This PR improves internals for @truffle/db loaders system by collecting existing patterns into first-class citizens. Mostly, this is two-part:

## Move `runLoader` to a module inside `@truffle/db/loaders/run`

Pretty straightforward - this PR defines a new type `LoaderRunner`, and provides a constructor for obtaining such an value given a Truffle DB instance.

## Define a `Load` type for use in loaders

... to serve in place of the existing `Generator</* ... ugly params ... */>`s everywhere.

This type is generic, accepting between 0..2 type parameters as arguments:
```typescript
type Load<T = any, N extends RequestName | string = string>
```

These arguments function as follows:
- `T` represents value ultimately returned by the loader. Think: `const result: T = yield *generateResourceLoad()`
- `N` represents a specific kind of query or mutation defined by the data model. For loaders that only issue one kind of GraphQL request, this can be specified to add additional type safety; e.g. `function* generateSourcesLoad(...): Load<LoadedSources, "sourcesAdd">` doesn't make any kind of request besides the `sourcesAdd` mutation.

To set up the type safety, this PR defines a bunch of helper types that make `Load` possible, to represent the allowable request names as well as the corresponding data that comes back for a given request.