### PR TITLE
Bug fix: Allow for `false` value in provider callback

### DIFF
--- a/packages/provider/wrapper.js
+++ b/packages/provider/wrapper.js
@@ -8,7 +8,7 @@ module.exports = {
    * Wraps an underlying web3 provider's RPC transport methods (send/sendAsync)
    * for Truffle-specific purposes, mainly for logging / request verbosity.
    */
-  wrap: function(provider, options) {
+  wrap: function (provider, options) {
     /* wrapping should be idempotent */
     if (provider._alreadyWrapped) return provider;
 
@@ -51,15 +51,12 @@ module.exports = {
    */
 
   // before send/sendAsync
-  preHook: function(options) {
-    return function(payload) {
+  preHook: function (options) {
+    return function (payload) {
       if (options.verbose) {
         // for request payload debugging
         options.logger.log(
-          "   > " +
-            JSON.stringify(payload, null, 2)
-              .split("\n")
-              .join("\n   > ")
+          "   > " + JSON.stringify(payload, null, 2).split("\n").join("\n   > ")
         );
       }
 
@@ -68,20 +65,18 @@ module.exports = {
   },
 
   // after send/sendAsync
-  postHook: function(options) {
-    return function(payload, error, result) {
-      if (error != null) {
-        // wrap errors in internal error class
+  postHook: function (options) {
+    return function (payload, error, result) {
+      // web3 websocket providers return false and web3 http providers
+      // return null when no error has occurred...kind of obnoxious
+      if (error != null && error !== false) {
         error = new ProviderError(error.message, options);
         return [payload, error, result];
       }
 
       if (options.verbose) {
         options.logger.log(
-          " <   " +
-            JSON.stringify(result, null, 2)
-              .split("\n")
-              .join("\n <   ")
+          " <   " + JSON.stringify(result, null, 2).split("\n").join("\n <   ")
         );
       }
 
@@ -99,11 +94,11 @@ module.exports = {
    *
    * Return the wrapped function matching the original function's signature.
    */
-  send: function(originalSend, preHook, postHook) {
-    return function(payload, callback) {
+  send: function (originalSend, preHook, postHook) {
+    return function (payload, callback) {
       payload = preHook(payload);
 
-      originalSend(payload, function(error, result) {
+      originalSend(payload, function (error, result) {
         var modified = postHook(payload, error, result);
         payload = modified[0];
         error = modified[1];

--- a/packages/provider/wrapper.js
+++ b/packages/provider/wrapper.js
@@ -69,7 +69,7 @@ module.exports = {
     return function (payload, error, result) {
       // web3 websocket providers return false and web3 http providers
       // return null when no error has occurred...kind of obnoxious
-      if (error != null && error !== false) {
+      if (error) {
         error = new ProviderError(error.message, options);
         return [payload, error, result];
       }


### PR DESCRIPTION
On web3 version 1.2.9, a websocket provider returns `false` as a value for `error` as noted in the issue below. On the previous version we used it returned `null`. This causes it to always throw in the post hook [here](https://github.com/trufflesuite/truffle/blob/47686d9dedc3174e3133b89b3da9f4cd1d2eae82/packages/provider/wrapper.js#L73). This allows for `error` to be `false` as well as `null`/`undefined`.

Fixes https://github.com/trufflesuite/truffle/issues/3464