### PR TITLE
Internal improvement: Remove git add from husky steps

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,13 +39,11 @@
   "lint-staged": {
     "*.js": [
       "prettier --write",
-      "eslint --fix",
-      "git add"
+      "eslint --fix"
     ],
     "*.ts": [
       "prettier --write",
-      "eslint --fix",
-      "git add"
+      "eslint --fix"
     ]
   }
 }


### PR DESCRIPTION
This new version of Husky warns us that we have `git add` in our Husky steps, which apparently is unnecessary (or at least unnecessary now).  Removing it to get rid of the warning.