### PR TITLE
Instrument @truffle/db with some initial logging

### DIFF
--- a/packages/db/.madgerc
+++ b/packages/db/.madgerc
@@ -1,5 +1,5 @@
 {
-  "excludeRegExp": ["\\.\\.", "test"],
+  "excludeRegExp": ["\\.\\.", "test", "logger.ts"],
   "fileExtensions": ["ts"],
   "tsConfig": "./tsconfig.base.json"
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -21,10 +21,9 @@
     "dist": "dist"
   },
   "scripts": {
-    "build": "./bin/build",
+    "build": "yarn build:types && yarn build:dist",
     "clean": "rm -rf ./dist ./types/schema.d.ts",
     "prepare": "yarn build",
-    "build": "yarn build:types && yarn build:dist",
     "build:stubbed": "ttsc --project tsconfig.codegen.json",
     "build:types": "yarn build:stubbed && node ./bin/codegen.js",
     "build:dist": "ttsc",
@@ -40,6 +39,7 @@
     "@truffle/config": "^1.2.31",
     "@truffle/workflow-compile": "^3.0.5",
     "apollo-server": "^2.18.2",
+    "debug": "^4.2.0",
     "fse": "^4.0.1",
     "graphql": "^15.3.0",
     "graphql-tag": "^2.11.0",
@@ -60,6 +60,7 @@
   },
   "devDependencies": {
     "@gql2ts/from-schema": "^2.0.0-4",
+    "@types/debug": "^4.1.5",
     "@types/express": "^4.16.0",
     "@types/graphql": "^14.5.0",
     "@types/jest": "^23.3.11",

--- a/packages/db/src/connect.ts
+++ b/packages/db/src/connect.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:connect");
+
 import { definitions } from "./definitions";
 import { forDefinitions } from "./pouch";
 

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:db");
+
 import { GraphQLSchema, DocumentNode, parse, execute } from "graphql";
 import type TruffleConfig from "@truffle/config";
 import { generateCompileLoad } from "@truffle/db/loaders/commands";

--- a/packages/db/src/definitions/bytecodes.ts
+++ b/packages/db/src/definitions/bytecodes.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:definitions:bytecodes");
+
 import gql from "graphql-tag";
 
 import { Definition } from "./types";

--- a/packages/db/src/definitions/compilations.ts
+++ b/packages/db/src/definitions/compilations.ts
@@ -69,32 +69,58 @@ export const compilations: Definition<"compilations"> = {
   resolvers: {
     Compilation: {
       sources: {
-        resolve: ({ sources }, _, { workspace }) =>
-          Promise.all(sources.map(({ id }) => workspace.get("sources", id)))
+        resolve: async ({ sources }, _, { workspace }) => {
+          debug("Resolving Compilation.sources...");
+
+          const result = await Promise.all(
+            sources.map(({ id }) => workspace.get("sources", id))
+          );
+
+          debug("Resolved Compilation.sources.");
+          return result;
+        }
       },
       processedSources: {
-        resolve: ({ id, processedSources }, _, {}) =>
-          processedSources.map((processedSource, index) => ({
+        resolve: ({ id, processedSources }, _, {}) => {
+          debug("Resolving Compilation.processedSources...");
+
+          const result = processedSources.map((processedSource, index) => ({
             ...processedSource,
             compilation: { id },
             index
-          }))
+          }));
+
+          debug("Resolved Compilation.processedSources.");
+          return result;
+        }
       }
     },
 
     ProcessedSource: {
       source: {
-        resolve: ({ source: { id } }, _, { workspace }) =>
-          workspace.get("sources", id)
+        resolve: async ({ source: { id } }, _, { workspace }) => {
+          debug("Resolving ProcessedSource.source...");
+
+          const result = await workspace.get("sources", id);
+
+          debug("Resolved ProcessedSource.source.");
+          return result;
+        }
       },
       contracts: {
-        resolve: ({ compilation, index }, _, { workspace }) =>
-          workspace.find("contracts", {
+        resolve: async ({ compilation, index }, _, { workspace }) => {
+          debug("Resolving ProcessedSource.compilation...");
+
+          const result = await workspace.find("contracts", {
             selector: {
               "compilation.id": compilation.id,
               "processedSource.index": index
             }
-          })
+          });
+
+          debug("Resolved ProcessedSource.compilation.");
+          return result;
+        }
       }
     }
   }

--- a/packages/db/src/definitions/compilations.ts
+++ b/packages/db/src/definitions/compilations.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:definitions:compilations");
+
 import gql from "graphql-tag";
 
 import { Definition } from "./types";

--- a/packages/db/src/definitions/contractInstances.ts
+++ b/packages/db/src/definitions/contractInstances.ts
@@ -79,15 +79,28 @@ export const contractInstances: Definition<"contractInstances"> = {
   resolvers: {
     ContractInstance: {
       network: {
-        resolve: ({ network: { id } }, _, { workspace }) =>
-          workspace.get("networks", id)
+        resolve: async ({ network: { id } }, _, { workspace }) => {
+          debug("Resolving ContractInstance.network...");
+
+          const result = await workspace.get("networks", id);
+
+          debug("Resolved ContractInstance.network.");
+          return result;
+        }
       },
       contract: {
-        resolve: ({ contract: { id } }, _, { workspace }) =>
-          workspace.get("contracts", id)
+        resolve: async ({ contract: { id } }, _, { workspace }) => {
+          debug("Resolving ContractInstance.contract...");
+          const result = await workspace.get("contracts", id);
+
+          debug("Resolved ContractInstance.contract.");
+          return result;
+        }
       },
       callBytecode: {
         resolve: async ({ callBytecode }, _, { workspace }) => {
+          debug("Resolving ContractInstance.callBytecode...");
+
           const bytecode = await workspace.get(
             "bytecodes",
             callBytecode.bytecode.id
@@ -100,6 +113,8 @@ export const contractInstances: Definition<"contractInstances"> = {
               };
             }
           );
+
+          debug("Resolved ContractInstance.callBytecode.");
           return {
             bytecode: bytecode,
             linkValues: linkValues
@@ -108,6 +123,8 @@ export const contractInstances: Definition<"contractInstances"> = {
       },
       creation: {
         resolve: async (input, _, { workspace }) => {
+          debug("Resolving ContractInstance.creation...");
+
           let bytecode = await workspace.get(
             "bytecodes",
             input.creation.constructor.createBytecode.bytecode.id
@@ -121,6 +138,8 @@ export const contractInstances: Definition<"contractInstances"> = {
               };
             }
           );
+
+          debug("Resolved ContractInstance.creation.");
           return {
             transactionHash: transactionHash,
             constructor: {

--- a/packages/db/src/definitions/contractInstances.ts
+++ b/packages/db/src/definitions/contractInstances.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:definitions:contractInstances");
+
 import gql from "graphql-tag";
 
 import { Definition } from "./types";

--- a/packages/db/src/definitions/contracts.ts
+++ b/packages/db/src/definitions/contracts.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:definitions:contracts");
+
 import gql from "graphql-tag";
 
 import { Definition } from "./types";

--- a/packages/db/src/definitions/contracts.ts
+++ b/packages/db/src/definitions/contracts.ts
@@ -48,8 +48,14 @@ export const contracts: Definition<"contracts"> = {
   resolvers: {
     Contract: {
       compilation: {
-        resolve: ({ compilation: { id } }, _, { workspace }) =>
-          workspace.get("compilations", id)
+        resolve: async ({ compilation: { id } }, _, { workspace }) => {
+          debug("Resolving Contract.compilation...");
+
+          const result = workspace.get("compilations", id);
+
+          debug("Resolved Contract.compilation.");
+          return result;
+        }
       },
       processedSource: {
         fragment: `... on Contract { compilation { id } }`,
@@ -58,18 +64,33 @@ export const contracts: Definition<"contracts"> = {
           _,
           { workspace }
         ) => {
+          debug("Resolving Contract.processedSource...");
+
           const { processedSources } = await workspace.get("compilations", id);
 
+          debug("Resolved Contract.processedSource.");
           return processedSources[processedSource.index];
         }
       },
       createBytecode: {
-        resolve: ({ createBytecode: { id } }, _, { workspace }) =>
-          workspace.get("bytecodes", id)
+        resolve: async ({ createBytecode: { id } }, _, { workspace }) => {
+          debug("Resolving Contract.createBytecode...");
+
+          const result = await workspace.get("bytecodes", id);
+
+          debug("Resolved Contract.createBytecode.");
+          return result;
+        }
       },
       callBytecode: {
-        resolve: ({ callBytecode: { id } }, _, { workspace }) =>
-          workspace.get("bytecodes", id)
+        resolve: async ({ callBytecode: { id } }, _, { workspace }) => {
+          debug("Resolving Contract.callBytecode...");
+
+          const result = await workspace.get("bytecodes", id);
+
+          debug("Resolved Contract.callBytecode.");
+          return result;
+        }
       }
     }
   }

--- a/packages/db/src/definitions/index.ts
+++ b/packages/db/src/definitions/index.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:definitions");
+
 import { Definitions } from "./types";
 export * from "./types";
 

--- a/packages/db/src/definitions/nameRecords.ts
+++ b/packages/db/src/definitions/nameRecords.ts
@@ -31,13 +31,25 @@ export const nameRecords: Definition<"nameRecords"> = {
     NameRecord: {
       resource: {
         resolve: async ({ type, resource: { id } }, _, { workspace }) => {
+          debug("Resolving NameRecord.resource...");
+
           const collectionName = camelCase(plural(type)) as CollectionName;
 
-          return await workspace.get(collectionName, id);
+          const result = await workspace.get(collectionName, id);
+
+          debug("Resolved NameRecord.resource.");
+          return result;
         }
       },
       previous: {
-        resolve: ({ id }, _, { workspace }) => workspace.get("nameRecords", id)
+        resolve: async ({ id }, _, { workspace }) => {
+          debug("Resolving NameRecord.previous...");
+
+          const result = await workspace.get("nameRecords", id);
+
+          debug("Resolved NameRecord.previous.");
+          return result;
+        }
       }
     }
   }

--- a/packages/db/src/definitions/nameRecords.ts
+++ b/packages/db/src/definitions/nameRecords.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:definitions:nameRecords");
+
 import gql from "graphql-tag";
 import camelCase from "camel-case";
 import { plural } from "pluralize";

--- a/packages/db/src/definitions/networks.ts
+++ b/packages/db/src/definitions/networks.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:definitions:networks");
+
 import gql from "graphql-tag";
 
 import { Definition } from "./types";

--- a/packages/db/src/definitions/projectNames.ts
+++ b/packages/db/src/definitions/projectNames.ts
@@ -38,12 +38,24 @@ export const projectNames: Definition<"projectNames"> = {
   resolvers: {
     ProjectName: {
       project: {
-        resolve: ({ project: { id } }, _, { workspace }) =>
-          workspace.get("projects", id)
+        resolve: async ({ project: { id } }, _, { workspace }) => {
+          debug("Resolving ProjectName.project...");
+
+          const result = await workspace.get("projects", id);
+
+          debug("Resolved ProjectName.project.");
+          return result;
+        }
       },
       nameRecord: {
-        resolve: ({ nameRecord: { id } }, _, { workspace }) =>
-          workspace.get("nameRecords", id)
+        resolve: async ({ nameRecord: { id } }, _, { workspace }) => {
+          debug("Resolving ProjectName.nameRecord...");
+
+          const result = await workspace.get("nameRecords", id);
+
+          debug("Resolved ProjectName.nameRecord.");
+          return result;
+        }
       }
     }
   }

--- a/packages/db/src/definitions/projectNames.ts
+++ b/packages/db/src/definitions/projectNames.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:definitions:projectNames");
+
 import gql from "graphql-tag";
 
 import { Definition } from "./types";

--- a/packages/db/src/definitions/projects.ts
+++ b/packages/db/src/definitions/projects.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:definitions:projects");
+
 import gql from "graphql-tag";
 
 import { Definition } from "./types";

--- a/packages/db/src/definitions/projects.ts
+++ b/packages/db/src/definitions/projects.ts
@@ -27,19 +27,28 @@ export const projects: Definition<"projects"> = {
     Project: {
       resolve: {
         resolve: async ({ id }, { name, type }, { workspace }) => {
+          debug("Resolving Project.resolve...");
+
           const results = await workspace.find("projectNames", {
             selector: { "project.id": id, name, type }
           });
+
           const nameRecordIds = results.map(({ nameRecord: { id } }) => id);
-          return await workspace.find("nameRecords", {
+
+          const result = await workspace.find("nameRecords", {
             selector: {
               id: { $in: nameRecordIds }
             }
           });
+
+          debug("Resolved Project.resolve.");
+          return result;
         }
       },
       network: {
         resolve: async ({ id }, { name }, { workspace }) => {
+          debug("Resolving Project.network...");
+
           const results = await workspace.find("projectNames", {
             selector: { "project.id": id, name, "type": "Network" }
           });
@@ -55,11 +64,16 @@ export const projects: Definition<"projects"> = {
           }
           const { resource } = nameRecords[0];
 
-          return await workspace.get("networks", resource.id);
+          const result = await workspace.get("networks", resource.id);
+
+          debug("Resolved Project.network.");
+          return result;
         }
       },
       contract: {
         resolve: async ({ id }, { name }, { workspace }) => {
+          debug("Resolving Project.contract...");
+
           const results = await workspace.find("projectNames", {
             selector: { "project.id": id, name, "type": "Contract" }
           });
@@ -74,7 +88,11 @@ export const projects: Definition<"projects"> = {
             return;
           }
           const { resource } = nameRecords[0];
-          return await workspace.get("contracts", resource.id);
+
+          const result = await workspace.get("contracts", resource.id);
+
+          debug("Resolved Project.contract.");
+          return result;
         }
       }
     }

--- a/packages/db/src/definitions/sources.ts
+++ b/packages/db/src/definitions/sources.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:definitions:sources");
+
 import gql from "graphql-tag";
 
 import { Definition } from "./types";

--- a/packages/db/src/definitions/types.ts
+++ b/packages/db/src/definitions/types.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:definitions:types");
+
 import * as Meta from "@truffle/db/meta";
 import * as Pouch from "../pouch";
 import * as GraphQl from "../graphql";

--- a/packages/db/src/graphql/index.ts
+++ b/packages/db/src/graphql/index.ts
@@ -1,2 +1,5 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:graphql");
+
 export * from "./types";
 export * from "./schema";

--- a/packages/db/src/graphql/schema.ts
+++ b/packages/db/src/graphql/schema.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:graphql:schema");
+
 import gql from "graphql-tag";
 import * as graphql from "graphql";
 import { makeExecutableSchema, IResolvers } from "graphql-tools";

--- a/packages/db/src/graphql/schema.ts
+++ b/packages/db/src/graphql/schema.ts
@@ -36,6 +36,9 @@ class DefinitionsSchema<C extends Collections> {
   }
 
   get typeDefs(): graphql.DocumentNode[] {
+    const log = debug.extend("typeDefs");
+    log("Generating...");
+
     const common = gql`
       interface Resource {
         id: ID!
@@ -54,12 +57,18 @@ class DefinitionsSchema<C extends Collections> {
       type Mutation
     `;
 
-    return Object.values(this.collections)
+    const result = Object.values(this.collections)
       .map(schema => schema.typeDefs)
       .reduce((a, b) => [...a, ...b], [common]);
+
+    log("Generated.");
+    return result;
   }
 
   get resolvers() {
+    const log = debug.extend("resolvers");
+    log("Generating...");
+
     const common = {
       Query: {},
 
@@ -79,7 +88,7 @@ class DefinitionsSchema<C extends Collections> {
       }
     };
 
-    return Object.values(this.collections).reduce(
+    const result = Object.values(this.collections).reduce(
       (a, { resolvers: b }) => ({
         ...a,
         ...b,
@@ -94,23 +103,34 @@ class DefinitionsSchema<C extends Collections> {
       }),
       common
     );
+
+    log("Generated.");
+    return result;
   }
 
   private createSchema(
     resource: CollectionName<C>
   ): DefinitionSchema<C, CollectionName<C>> {
+    debug("Creating DefinitonSchema for %s...", resource);
+
     const definition = this.definitions[resource];
     if (definition.mutable) {
-      return new MutableDefinitionSchema({
+      const result = new MutableDefinitionSchema({
         resource: resource as MutableCollectionName<C>,
         definition
       });
+
+      debug("Created MutableDefinitonSchema for %s.", resource);
+      return result;
     }
 
-    return new ImmutableDefinitionSchema({
+    const result = new ImmutableDefinitionSchema({
       resource,
       definition
     });
+
+    debug("Created ImmutableDefinitionSchema for %s.", resource);
+    return result;
   }
 }
 
@@ -136,6 +156,9 @@ abstract class DefinitionSchema<
   }
 
   get typeDefs() {
+    const log = debug.extend(`${this.resource}:typeDefs`);
+    log("Generating...");
+
     const { typeDefs } = this.definition;
 
     const {
@@ -146,7 +169,7 @@ abstract class DefinitionSchema<
       ResourcesMutate
     } = this.names;
 
-    return [
+    const result = [
       gql`
       ${typeDefs}
 
@@ -170,25 +193,52 @@ abstract class DefinitionSchema<
       }
     `
     ];
+
+    log("Generated.");
+    return result;
   }
 
   get resolvers(): IResolvers<any, Context<C>> {
+    const log = debug.extend(`${this.resource}:resolvers`);
+    log("Generating...");
+
+    // setup loggers for specific resolvers
+    const logGet = log.extend("get");
+    const logAll = log.extend("all");
+
     const { resource, resources } = this.names;
 
     const { resolvers = {} } = this.definition;
 
-    return {
+    const result = {
       ...resolvers,
 
       Query: {
         [resource]: {
-          resolve: (_, { id }, { workspace }) => workspace.get(resources, id)
+          resolve: async (_, { id }, { workspace }) => {
+            logGet("Getting id: %s...", id);
+
+            const result = await workspace.get(resources, id);
+
+            logGet("Got id: %s.", id);
+            return result;
+          }
         },
         [resources]: {
-          resolve: (_, {}, { workspace }) => workspace.all(resources)
+          resolve: async (_, {}, { workspace }) => {
+            logAll("Fetching all...");
+
+            const result = await workspace.all(resources);
+
+            logAll("Fetched all.");
+            return result;
+          }
         }
       }
     };
+
+    log("Generated.");
+    return result;
   }
 }
 
@@ -218,16 +268,30 @@ class ImmutableDefinitionSchema<
   }
 
   get resolvers() {
+    const log = debug.extend(`${this.resource}:resolvers`);
+    log("Generating...");
+
+    const logMutate = log.extend("add");
+
     const { resources, resourcesMutate } = this.names;
 
-    return {
+    const result = {
       ...super.resolvers,
 
       Mutation: {
-        [resourcesMutate]: (_, { input }, { workspace }) =>
-          workspace.add(resources, input)
+        [resourcesMutate]: async (_, { input }, { workspace }) => {
+          logMutate("Mutating...");
+
+          const result = await workspace.add(resources, input);
+
+          logMutate("Mutated.");
+          return result;
+        }
       }
     };
+
+    log("Generated.");
+    return result;
   }
 }
 
@@ -257,16 +321,30 @@ class MutableDefinitionSchema<
   }
 
   get resolvers() {
+    const log = debug.extend(`${this.resource}:resolvers`);
+    log("Generating...");
+
+    const logMutate = log.extend("assign");
+
     const { resources, resourcesMutate } = this.names;
 
-    return {
+    const result = {
       ...super.resolvers,
 
       Mutation: {
-        [resourcesMutate]: (_, { input }, { workspace }) =>
-          workspace.update(resources, input)
+        [resourcesMutate]: async (_, { input }, { workspace }) => {
+          logMutate("Mutating...");
+
+          const result = await workspace.update(resources, input);
+
+          logMutate("Mutated.");
+          return result;
+        }
       }
     };
+
+    log("Generated.");
+    return result;
   }
 }
 

--- a/packages/db/src/graphql/types.ts
+++ b/packages/db/src/graphql/types.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:graphql:types");
+
 import * as graphql from "graphql";
 import { IResolvers } from "graphql-tools";
 

--- a/packages/db/src/helpers/generateId.ts
+++ b/packages/db/src/helpers/generateId.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:helpers:generateId");
+
 import { soliditySha3 } from "web3-utils";
 const jsonStableStringify = require("json-stable-stringify");
 

--- a/packages/db/src/helpers/index.ts
+++ b/packages/db/src/helpers/index.ts
@@ -1,1 +1,4 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:helpers");
+
 export { generateId } from "./generateId";

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,3 +1,5 @@
+const debug = require("debug")("db");
+
 require("source-map-support/register");
 
 const { TruffleDB } = require("./db");

--- a/packages/db/src/loaders/commands/compile.ts
+++ b/packages/db/src/loaders/commands/compile.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:loaders:commands:compile");
+
 import { CompilationData, Load } from "@truffle/db/loaders/types";
 import {
   WorkflowCompileResult,

--- a/packages/db/src/loaders/commands/index.ts
+++ b/packages/db/src/loaders/commands/index.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:loaders:commands");
+
 export { generateCompileLoad } from "./compile";
 export { generateNamesLoad } from "./names";
 export { generateInitializeLoad } from "./initialize";

--- a/packages/db/src/loaders/commands/initialize.ts
+++ b/packages/db/src/loaders/commands/initialize.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:loaders:commands:initialize");
+
 import { IdObject, toIdObject } from "@truffle/db/meta";
 
 import { generateProjectLoad } from "@truffle/db/loaders/resources/projects";

--- a/packages/db/src/loaders/commands/names.ts
+++ b/packages/db/src/loaders/commands/names.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:loaders:commands:names");
+
 import {
   generateProjectNameResolve,
   generateProjectNamesAssign
@@ -14,7 +17,7 @@ export function* generateNamesLoad(
   project: IdObject<DataModel.Project>,
   contracts: NamedResource[]
 ): Load<void> {
-  let getCurrent = function*(name, type) {
+  let getCurrent = function* (name, type) {
     return yield* generateProjectNameResolve(project, name, type);
   };
 

--- a/packages/db/src/loaders/resources/bytecodes/index.ts
+++ b/packages/db/src/loaders/resources/bytecodes/index.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:loaders:resources:bytecodes");
+
 import {
   CompilationData,
   LoadedBytecodes,

--- a/packages/db/src/loaders/resources/compilations/index.ts
+++ b/packages/db/src/loaders/resources/compilations/index.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:loaders:resources:compilations");
+
 import {
   CompilationData,
   LoadedSources,

--- a/packages/db/src/loaders/resources/contractInstances/index.ts
+++ b/packages/db/src/loaders/resources/contractInstances/index.ts
@@ -1,1 +1,4 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:loaders:resources:contractInstances");
+
 export { AddContractInstances } from "./add.graphql";

--- a/packages/db/src/loaders/resources/contracts/index.ts
+++ b/packages/db/src/loaders/resources/contracts/index.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:loaders:resources:contracts");
+
 import { LoadedBytecodes, Load } from "@truffle/db/loaders/types";
 import { IdObject } from "@truffle/db/meta";
 import { CompiledContract } from "@truffle/compile-common";

--- a/packages/db/src/loaders/resources/nameRecords/index.ts
+++ b/packages/db/src/loaders/resources/nameRecords/index.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:loaders:resources:nameRecords");
+
 import { Load } from "@truffle/db/loaders/types";
 import { toIdObject } from "@truffle/db/meta";
 

--- a/packages/db/src/loaders/resources/networks/index.ts
+++ b/packages/db/src/loaders/resources/networks/index.ts
@@ -1,1 +1,4 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:loaders:resources:networks");
+
 export { AddNetworks } from "./add.graphql";

--- a/packages/db/src/loaders/resources/projects/index.ts
+++ b/packages/db/src/loaders/resources/projects/index.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:loaders:resources:projects");
+
 import { Load } from "@truffle/db/loaders/types";
 import { IdObject } from "@truffle/db/meta";
 

--- a/packages/db/src/loaders/resources/sources/index.ts
+++ b/packages/db/src/loaders/resources/sources/index.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:loaders:resources:sources");
+
 import { toIdObject } from "@truffle/db/meta";
 
 import {

--- a/packages/db/src/loaders/run.ts
+++ b/packages/db/src/loaders/run.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:loaders:run");
+
 import { Loader, LoadRequest, RequestName } from "./types";
 
 export type LoaderRunner = <

--- a/packages/db/src/loaders/schema/artifactsLoader.ts
+++ b/packages/db/src/loaders/schema/artifactsLoader.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:loaders:schema:artifactsLoader");
+
 import { TruffleDB } from "@truffle/db/db";
 import * as fse from "fs-extra";
 import path from "path";

--- a/packages/db/src/loaders/types.ts
+++ b/packages/db/src/loaders/types.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:loaders:types");
+
 import * as graphql from "graphql";
 
 import { CompiledContract } from "@truffle/compile-common";

--- a/packages/db/src/logger.ts
+++ b/packages/db/src/logger.ts
@@ -1,0 +1,4 @@
+import debugModule from "debug";
+const debug = debugModule("db:logger"); // this could maybe dogfood
+
+export const logger = (namespace: string) => debugModule(namespace);

--- a/packages/db/src/meta/index.ts
+++ b/packages/db/src/meta/index.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:meta");
+
 export type Collections = {
   [collectionName: string]:
     | {

--- a/packages/db/src/pouch/databases.ts
+++ b/packages/db/src/pouch/databases.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:pouch:databases");
+
 import PouchDB from "pouchdb";
 import PouchDBDebug from "pouchdb-debug";
 import PouchDBFind from "pouchdb-find";

--- a/packages/db/src/pouch/fs.ts
+++ b/packages/db/src/pouch/fs.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:pouch:fs");
+
 import path from "path";
 import PouchDB from "pouchdb";
 import * as jsondown from "jsondown";

--- a/packages/db/src/pouch/index.ts
+++ b/packages/db/src/pouch/index.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:pouch");
+
 import path from "path";
 
 export * from "./types";

--- a/packages/db/src/pouch/memory.ts
+++ b/packages/db/src/pouch/memory.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:pouch:memory");
+
 import PouchDB from "pouchdb";
 import PouchDBMemoryAdapter from "pouchdb-adapter-memory";
 

--- a/packages/db/src/pouch/sqlite.ts
+++ b/packages/db/src/pouch/sqlite.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:pouch:sqlite");
+
 import path from "path";
 import fse from "fs-extra";
 import PouchDB from "pouchdb";

--- a/packages/db/src/pouch/types.ts
+++ b/packages/db/src/pouch/types.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:pouch:types");
+
 import PouchDB from "pouchdb";
 
 import {

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:schema");
+
 import { definitions } from "./definitions";
 import { forDefinitions } from "./graphql";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7520,6 +7520,13 @@ debug@4.1.1, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
+debug@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.2.0.tgz#7f150f93920e94c58f5574c2fd01a3110effe7f1"
+  integrity sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==
+  dependencies:
+    ms "2.1.2"
+
 debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"


### PR DESCRIPTION
This PR adds [debug](https://www.npmjs.com/package/debug) in an internal `@truffle/db/logger` module, for use throughout the @truffle/db codebase.

This defines logger instances in all existing TS modules, as well as adds some initial logging in key areas.