### PR TITLE
Allow querying @truffle/db for compilation contracts

### DIFF
--- a/packages/db/src/definitions/compilations.ts
+++ b/packages/db/src/definitions/compilations.ts
@@ -15,6 +15,7 @@ export const compilations: Definition<"compilations"> = {
       sources: [Source]!
       processedSources: [ProcessedSource]!
       sourceMaps: [SourceMap]
+      contracts: [Contract]!
     }
 
     type Compiler {
@@ -91,6 +92,20 @@ export const compilations: Definition<"compilations"> = {
           }));
 
           debug("Resolved Compilation.processedSources.");
+          return result;
+        }
+      },
+      contracts: {
+        resolve: async ({ id }, _, { workspace }) => {
+          debug("Resolving Compilation.contracts...");
+
+          const result = await workspace.find("contracts", {
+            selector: {
+              "compilation.id": id
+            }
+          });
+
+          debug("Resolved Compilation.contracts.");
           return result;
         }
       }

--- a/packages/db/src/definitions/contracts.ts
+++ b/packages/db/src/definitions/contracts.ts
@@ -8,6 +8,9 @@ import { Definition } from "./types";
 export const contracts: Definition<"contracts"> = {
   createIndexes: [
     {
+      fields: ["compilation.id"]
+    },
+    {
       fields: ["compilation.id", "processedSource.index"]
     }
   ],

--- a/packages/db/src/test/compilation.graphql.ts
+++ b/packages/db/src/test/compilation.graphql.ts
@@ -72,18 +72,19 @@ export const GetCompilation = gql`
   }
 `;
 
-export const GetCompilationWithContracts = gql`
+export const GetCompilationContracts = gql`
   query GetCompilation($id: ID!) {
     compilation(id: $id) {
-      id
-      compiler {
-        name
-        version
-      }
-      sources {
+      contracts {
         id
-        contents
+        name
       }
+    }
+  }
+`;
+export const GetCompilationProcessedSources = gql`
+  query GetCompilation($id: ID!) {
+    compilation(id: $id) {
       processedSources {
         contracts {
           id


### PR DESCRIPTION
This PR adds a lookup to Compilation to query all known contracts that specify that compilation ID.