### PR TITLE
Add support for web3 requests in @truffle/db loaders

### DIFF
--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -27,7 +27,10 @@ export class TruffleDB {
   constructor(config: TruffleConfig) {
     this.schema = schema;
     this.context = this.createContext(config);
-    this.runLoader = forDb(this);
+
+    const { run } = forDb(this);
+
+    this.runLoader = run;
   }
 
   async query(query: DocumentNode | string, variables: any = {}): Promise<any> {

--- a/packages/db/src/loaders/resources/bytecodes/index.ts
+++ b/packages/db/src/loaders/resources/bytecodes/index.ts
@@ -16,7 +16,7 @@ export { AddBytecodes };
  */
 export function* generateBytecodesLoad(
   compilation: CompilationData
-): Load<LoadedBytecodes, "bytecodesAdd"> {
+): Load<LoadedBytecodes, { graphql: "bytecodesAdd" }> {
   // we're flattening in order to send all bytecodes in one big list
   // (it's okay, we're gonna recreate the structure before we return)
   const flattenedContracts: CompiledContract[] = compilation.sources
@@ -38,6 +38,7 @@ export function* generateBytecodesLoad(
 
   // submit
   const result = yield {
+    type: "graphql",
     request: AddBytecodes,
     variables: { bytecodes }
   };

--- a/packages/db/src/loaders/resources/compilations/index.ts
+++ b/packages/db/src/loaders/resources/compilations/index.ts
@@ -64,10 +64,11 @@ type LoadableCompilation = {
 
 export function* generateCompilationsLoad(
   loadableCompilations: LoadableCompilation[]
-): Load<DataModel.Compilation[], "compilationsAdd"> {
+): Load<DataModel.Compilation[], { graphql: "compilationsAdd" }> {
   const compilations = loadableCompilations.map(compilationInput);
 
   const result = yield {
+    type: "graphql",
     request: AddCompilations,
     variables: { compilations }
   };

--- a/packages/db/src/loaders/resources/contracts/index.ts
+++ b/packages/db/src/loaders/resources/contracts/index.ts
@@ -17,7 +17,7 @@ export interface LoadableContract {
 
 export function* generateContractsLoad(
   loadableContracts: LoadableContract[]
-): Load<DataModel.Contract[], "contractsAdd"> {
+): Load<DataModel.Contract[], { graphql: "contractsAdd" }> {
   const contracts = loadableContracts.map(loadableContract => {
     const {
       contract: { contractName: name, abi: abiObject },
@@ -43,6 +43,7 @@ export function* generateContractsLoad(
   });
 
   const result = yield {
+    type: "graphql",
     request: AddContracts,
     variables: { contracts }
   };

--- a/packages/db/src/loaders/resources/nameRecords/index.ts
+++ b/packages/db/src/loaders/resources/nameRecords/index.ts
@@ -21,7 +21,7 @@ export function* generateNameRecordsLoad(
   resources: Resource[],
   type: string,
   getCurrent: ResolveFunc
-): Load<DataModel.NameRecord[], "nameRecordsAdd"> {
+): Load<DataModel.NameRecord[]> {
   const nameRecords = [];
   for (const resource of resources) {
     const { name } = resource;
@@ -44,6 +44,7 @@ export function* generateNameRecordsLoad(
   }
 
   const result = yield {
+    type: "graphql",
     request: AddNameRecords,
     variables: { nameRecords }
   };

--- a/packages/db/src/loaders/resources/projects/index.ts
+++ b/packages/db/src/loaders/resources/projects/index.ts
@@ -11,8 +11,9 @@ export { AddProjects, AssignProjectNames, ResolveProjectName };
 
 export function* generateProjectLoad(
   directory: string
-): Load<DataModel.Project, "projectsAdd"> {
+): Load<DataModel.Project, { graphql: "projectsAdd" }> {
   const result = yield {
+    type: "graphql",
     request: AddProjects,
     variables: {
       projects: [{ directory }]
@@ -26,8 +27,9 @@ export function* generateProjectNameResolve(
   project: IdObject<DataModel.Project>,
   name: string,
   type: string
-): Load<DataModel.NameRecord, "project"> {
+): Load<DataModel.NameRecord, { graphql: "project" }> {
   const result = yield {
+    type: "graphql",
     request: ResolveProjectName,
     variables: {
       projectId: project.id,
@@ -44,7 +46,7 @@ export function* generateProjectNameResolve(
 export function* generateProjectNamesAssign(
   project: IdObject<DataModel.Project>,
   nameRecords: DataModel.NameRecord[]
-): Load<void, "projectNamesAssign"> {
+): Load<void, { graphql: "projectNamesAssign" }> {
   const projectNames = nameRecords.map(({ id, name, type }) => ({
     project,
     nameRecord: { id },
@@ -53,6 +55,7 @@ export function* generateProjectNamesAssign(
   }));
 
   yield {
+    type: "graphql",
     request: AssignProjectNames,
     variables: { projectNames }
   };

--- a/packages/db/src/loaders/resources/sources/index.ts
+++ b/packages/db/src/loaders/resources/sources/index.ts
@@ -15,11 +15,12 @@ export { AddSources };
 // returns list of IDs
 export function* generateSourcesLoad(
   compilation: CompilationData
-): Load<LoadedSources, "sourcesAdd"> {
+): Load<LoadedSources, { graphql: "sourcesAdd" }> {
   // for each compilation, we need to load sources for each of the contracts
   const inputs = compilation.sources.map(({ input }) => input);
 
   const result = yield {
+    type: "graphql",
     request: AddSources,
     variables: { sources: inputs }
   };

--- a/packages/db/src/loaders/types.ts
+++ b/packages/db/src/loaders/types.ts
@@ -37,12 +37,6 @@ export interface LoadedBytecodes {
   }[];
 }
 
-export interface LoadRequest<_N extends RequestName | string> {
-  request: string | graphql.DocumentNode; // GraphQL request
-  variables: {
-    [name: string]: any;
-  };
-}
 
 type Data<O, N extends string | keyof O> = string extends N
   ? Partial<O>
@@ -59,24 +53,77 @@ export type MutationData<N extends string | MutationName> = Data<
   N
 >;
 
-export type RequestName = QueryName | MutationName;
-export type RequestData<N extends RequestName | string> = string extends N
-  ? Data<DataModel.Query & DataModel.Mutation, N>
-  : Data<DataModel.Query, N> | Data<DataModel.Mutation, N>;
+// eventually it might be a good idea to type the known requests+response types
+// for now this can just be opaquely a string
+type MethodName = string;
 
-export interface LoadResponse<N extends RequestName | string> {
-  data: RequestData<N>;
+export interface GraphQlRequestType<
+  N extends QueryName | MutationName | string = string
+> {
+  graphql: N;
 }
+
+export interface Web3RequestType<
+  N extends MethodName | string = string
+>{
+  web3: MethodName | string;
+}
+
+export type RequestType =
+  | GraphQlRequestType
+  | Web3RequestType;
+
+export type RequestData<R extends RequestType> =
+  R extends { graphql: infer N }
+    ? N extends string
+      ? string extends N
+        ? Data<DataModel.Query & DataModel.Mutation, N>
+        : Data<DataModel.Query, N> | Data<DataModel.Mutation, N>
+      : never // shouldn't happen
+    : any;
+
+export interface GraphQlRequest {
+  type: "graphql";
+  request: string | graphql.DocumentNode; // GraphQL request
+  variables: {
+    [name: string]: any;
+  };
+}
+
+export interface Web3Request {
+  type: "web3";
+  method: string;
+  params?: any[];
+}
+
+export type LoadRequest<R extends RequestType | undefined> =
+  "graphql" extends keyof R
+    ? GraphQlRequest
+    : "web3" extends keyof R
+      ? Web3Request
+      : GraphQlRequest | Web3Request;
+
+
+export type LoadResponse<R extends RequestType> =
+  R extends { graphql: string }
+    ? {
+        data: RequestData<R>;
+      }
+    : {
+        id: number;
+        jsonrpc: "2.0";
+        result: RequestData<R>;
+      };
 
 export type Load<
   T = any,
-  N extends RequestName | string = string
-> = string extends N
-  ? Generator<any, T, any> // HACK to get TS to play nice, sorry
-  : Generator<LoadRequest<N>, T, LoadResponse<N>>;
+  R extends RequestType | undefined = undefined
+> = R extends undefined
+  ? Generator<LoadRequest<R>, T, any> // HACK to get TS to play nice, sorry
+  : Generator<LoadRequest<R>, T, LoadResponse<R>>;
 
 export type Loader<
   A extends unknown[],
   T = any,
-  N extends RequestName | string = string
-> = (...args: A) => Load<T, N>;
+  R extends RequestType | undefined = undefined
+> = (...args: A) => Load<T, R>;


### PR DESCRIPTION
In addition to existing graphql requests, this PR allows the various loader generator functions to issue requests to either the DB schema or to a web3 provider.