### PR TITLE
Define project-based abstraction for loading Truffle stuff to @truffle/db

### DIFF
--- a/packages/db/.madgerc
+++ b/packages/db/.madgerc
@@ -1,5 +1,10 @@
 {
-  "excludeRegExp": ["\\.\\.", "test", "logger.ts"],
+  "excludeRegExp": [
+    "\\.\\.",
+    "test",
+    "meta/index.ts",
+    "logger.ts"
+  ],
   "fileExtensions": ["ts"],
   "tsConfig": "./tsconfig.base.json"
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -31,7 +31,7 @@
     "start:debug": "DEBUG=pouchdb:api ts-node-dev -r tsconfig-paths/register ./bin/server",
     "start:drizzle": "ts-node-dev -r tsconfig-paths/register ./bin/server ./test/truffle-projects/drizzle-box",
     "start:drizzle:debug": "DEBUG=pouchdb:api ts-node-dev -r tsconfig-paths/register ./bin/server ./test/truffle-projects/drizzle-box",
-    "madge": "madge ./src/db.ts",
+    "madge": "madge ./src/db.ts ./src/loaders/index.ts",
     "test": "jest --verbose --detectOpenHandles"
   },
   "dependencies": {

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -3,34 +3,17 @@ const debug = logger("db:db");
 
 import { GraphQLSchema, DocumentNode, parse, execute } from "graphql";
 import type TruffleConfig from "@truffle/config";
-import { generateCompileLoad } from "@truffle/db/loaders/commands";
-import { LoaderRunner, forDb } from "@truffle/db/loaders/run";
-import { WorkflowCompileResult } from "@truffle/compile-common";
 import { schema } from "./schema";
 import { connect } from "./connect";
 import { Context } from "./definitions";
-import {
-  generateInitializeLoad,
-  generateNamesLoad
-} from "@truffle/db/loaders/commands";
-import { toIdObject, NamedResource } from "@truffle/db/meta";
-
-type LoaderOptions = {
-  names: boolean;
-};
 
 export class TruffleDB {
   schema: GraphQLSchema;
   private context: Context;
-  private runLoader: LoaderRunner;
 
   constructor(config: TruffleConfig) {
     this.schema = schema;
     this.context = this.createContext(config);
-
-    const { run } = forDb(this);
-
-    this.runLoader = run;
   }
 
   async query(query: DocumentNode | string, variables: any = {}): Promise<any> {
@@ -38,38 +21,6 @@ export class TruffleDB {
       typeof query !== "string" ? query : parse(query);
 
     return await execute(this.schema, document, null, this.context, variables);
-  }
-
-  async loadNames(project: DataModel.Project, resources: NamedResource[]) {
-    return await this.runLoader(
-      generateNamesLoad,
-      toIdObject(project),
-      resources
-    );
-  }
-
-  async loadProject(): Promise<DataModel.Project> {
-    return await this.runLoader(generateInitializeLoad, {
-      directory: this.context.workingDirectory
-    });
-  }
-
-  async loadCompilations(
-    result: WorkflowCompileResult,
-    options: LoaderOptions
-  ) {
-    const project = await this.loadProject();
-
-    const { compilations, contracts } = await this.runLoader(
-      generateCompileLoad,
-      result
-    );
-
-    if (options.names === true) {
-      await this.loadNames(project, contracts);
-    }
-
-    return { compilations, contracts };
   }
 
   private createContext(config: TruffleConfig): Context {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -4,6 +4,7 @@ require("source-map-support/register");
 
 const { TruffleDB } = require("./db");
 const { ApolloServer } = require("apollo-server");
+const { Project } = require("./loaders");
 
 const playgroundServer = config => {
   const { context, schema } = new TruffleDB(config);
@@ -15,4 +16,4 @@ const playgroundServer = config => {
   });
 };
 
-export { TruffleDB, playgroundServer };
+export { TruffleDB, Project, playgroundServer };

--- a/packages/db/src/loaders/commands/index.ts
+++ b/packages/db/src/loaders/commands/index.ts
@@ -4,3 +4,4 @@ const debug = logger("db:loaders:commands");
 export { generateCompileLoad } from "./compile";
 export { generateNamesLoad } from "./names";
 export { generateInitializeLoad } from "./initialize";
+export { generateMigrateLoad } from "./migrate";

--- a/packages/db/src/loaders/commands/migrate.ts
+++ b/packages/db/src/loaders/commands/migrate.ts
@@ -1,0 +1,131 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:loaders:commands:migrate");
+
+import { ContractObject } from "@truffle/contract-schema/spec";
+import { toIdObject, IdObject } from "@truffle/db/meta";
+import { Load } from "@truffle/db/loaders/types";
+
+import { generateContractGet } from "@truffle/db/loaders/resources/contracts";
+import {
+  generateTranasctionNetworkLoad,
+  generateNetworkIdFetch,
+  generateNetworkGet
+} from "@truffle/db/loaders/resources/networks";
+import {
+  LoadableContractInstance,
+  generateContractInstancesLoad
+} from "@truffle/db/loaders/resources/contractInstances";
+
+export interface GenerateMigrateLoadOptions {
+  // we'll need everything for this input other than what's calculated here
+  network: Omit<DataModel.NetworkInput, "networkId" | "historicBlock">;
+  artifacts: ContractObject[];
+}
+
+export function* generateMigrateLoad(
+  options: GenerateMigrateLoadOptions
+): Load<{
+  network: IdObject<DataModel.Network>;
+  contractInstances: IdObject<DataModel.ContractInstance>[];
+}> {
+  // for each artifact, first add a Network resource for the historic block
+  // when the contract was deployed
+  //
+  // one of these networks will be the latest, so that's what we'll return
+  // (for purposes of namekeeping, e.g.)
+
+  // first, get the networkId from the blockchain
+  const networkId = yield* generateNetworkIdFetch();
+
+  // start enumerating over the artifacts
+  let latestNetwork: DataModel.Network | undefined;
+  const contractNetworks: ContractNetwork[] = [];
+  for (const artifact of options.artifacts) {
+    if (!artifact.networks[networkId]) {
+      // skip over artifacts that don't contain this network
+      continue;
+    }
+
+    const { transactionHash } = artifact.networks[networkId];
+
+    // load the historical network
+    const network = yield* generateTranasctionNetworkLoad({
+      transactionHash,
+      network: {
+        name: options.network.name,
+        networkId
+      }
+    });
+
+    if (
+      latestNetwork &&
+      latestNetwork.historicBlock.height < network.historicBlock.height
+    ) {
+      latestNetwork = network;
+    }
+
+    // keep track of this new network alongside the artifact
+    contractNetworks.push({
+      network: toIdObject(network),
+      artifact
+    });
+  }
+
+  // now, let's get ready to add the contract instances
+  const loadableContractInstances = yield* processContractNetworks(
+    contractNetworks
+  );
+
+  // and do it
+  const contractInstances = yield* generateContractInstancesLoad(
+    loadableContractInstances
+  );
+
+  return {
+    network: toIdObject(latestNetwork),
+    contractInstances: contractInstances.map(toIdObject)
+  };
+}
+
+interface ContractNetwork {
+  network: IdObject<DataModel.Network>;
+  artifact: ContractObject;
+}
+
+function* processContractNetworks(
+  contractNetworks: ContractNetwork[]
+): Load<LoadableContractInstance[]> {
+  const loadableContractInstances = [];
+  for (const { network, artifact } of contractNetworks) {
+    // @ts-ignore
+    const { contract }: IdObject<DataModel.Contract> = artifact.db;
+    const { createBytecode, callBytecode } = yield* generateContractGet(
+      contract
+    );
+
+    const { networkId } = yield* generateNetworkGet(network);
+
+    const networkObject = artifact.networks[networkId];
+    if (!networkObject) {
+      continue;
+    }
+
+    loadableContractInstances.push({
+      contract,
+      network,
+      networkObject,
+      bytecodes: {
+        call: {
+          bytecode: toIdObject(callBytecode),
+          linkReferences: callBytecode.linkReferences
+        },
+        create: {
+          bytecode: toIdObject(createBytecode),
+          linkReferences: createBytecode.linkReferences
+        }
+      }
+    });
+  }
+
+  return loadableContractInstances;
+}

--- a/packages/db/src/loaders/commands/migrate.ts
+++ b/packages/db/src/loaders/commands/migrate.ts
@@ -7,7 +7,7 @@ import { Load } from "@truffle/db/loaders/types";
 
 import { generateContractGet } from "@truffle/db/loaders/resources/contracts";
 import {
-  generateTranasctionNetworkLoad,
+  generateTransactionNetworkLoad,
   generateNetworkIdFetch,
   generateNetworkGet
 } from "@truffle/db/loaders/resources/networks";
@@ -49,7 +49,7 @@ export function* generateMigrateLoad(
     const { transactionHash } = artifact.networks[networkId];
 
     // load the historical network
-    const network = yield* generateTranasctionNetworkLoad({
+    const network = yield* generateTransactionNetworkLoad({
       transactionHash,
       network: {
         name: options.network.name,

--- a/packages/db/src/loaders/commands/names.ts
+++ b/packages/db/src/loaders/commands/names.ts
@@ -1,31 +1,44 @@
-import { logger } from "@truffle/db/logger";
+import {logger} from "@truffle/db/logger";
 const debug = logger("db:loaders:commands:names");
+
+import {singular} from "pluralize";
+import pascalCase from "pascal-case";
 
 import {
   generateProjectNameResolve,
   generateProjectNamesAssign
 } from "@truffle/db/loaders/resources/projects";
 
-import { generateNameRecordsLoad } from "@truffle/db/loaders/resources/nameRecords";
-import { Load } from "@truffle/db/loaders/types";
-import { IdObject, NamedResource } from "@truffle/db/meta";
+import {generateNameRecordsLoad} from "@truffle/db/loaders/resources/nameRecords";
+import {Load} from "@truffle/db/loaders/types";
+import {IdObject} from "@truffle/db/meta";
 
 /**
  * generator function to load nameRecords and project names into Truffle DB
  */
 export function* generateNamesLoad(
   project: IdObject<DataModel.Project>,
-  contracts: NamedResource[]
-): Load<void> {
+  assignments: {
+    [collectionName: string]: IdObject[];
+  }
+): Load<DataModel.NameRecord[]> {
   let getCurrent = function* (name, type) {
     return yield* generateProjectNameResolve(project, name, type);
   };
 
-  const nameRecords = yield* generateNameRecordsLoad(
-    contracts,
-    "Contract",
-    getCurrent
-  );
+  const loadedNameRecords = [];
+  for (const [collectionName, resources] of Object.entries(assignments)) {
+    const type = singular(pascalCase(collectionName));
 
-  yield* generateProjectNamesAssign(project, nameRecords);
+    const nameRecords = yield* generateNameRecordsLoad(
+      resources,
+      type,
+      getCurrent
+    );
+
+    loadedNameRecords.push(...nameRecords);
+    yield* generateProjectNamesAssign(project, nameRecords);
+  }
+
+  return loadedNameRecords;
 }

--- a/packages/db/src/loaders/index.ts
+++ b/packages/db/src/loaders/index.ts
@@ -1,0 +1,1 @@
+export { Project } from "./project";

--- a/packages/db/src/loaders/project.ts
+++ b/packages/db/src/loaders/project.ts
@@ -55,18 +55,13 @@ export class Project {
   async loadCompilations(options: {
     result: WorkflowCompileResult;
   }): Promise<{
-    compilations: IdObject<DataModel.Compilation>[];
     contracts: IdObject<DataModel.Contract>[];
   }> {
     const {result} = options;
 
-    const {compilations, contracts} = await this.run(
-      generateCompileLoad,
-      result
-    );
+    const {contracts} = await this.run(generateCompileLoad, result);
 
     return {
-      compilations: compilations.map(toIdObject),
       contracts: contracts.map(toIdObject)
     };
   }

--- a/packages/db/src/loaders/project.ts
+++ b/packages/db/src/loaders/project.ts
@@ -1,13 +1,18 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:loaders:project");
+
 import {DocumentNode} from "graphql";
 import type {Provider} from "web3/providers";
 import {WorkflowCompileResult} from "@truffle/compile-common";
+import {ContractObject} from "@truffle/contract-schema/spec";
 
 import {toIdObject, IdObject} from "@truffle/db/meta";
 
 import {
   generateCompileLoad,
   generateInitializeLoad,
-  generateNamesLoad
+  generateNamesLoad,
+  generateMigrateLoad
 } from "./commands";
 
 import {LoaderRunner, forDb} from "./run";
@@ -97,5 +102,18 @@ export class Project {
 }
 
 export class LiveProject extends Project {
+  async loadMigration(options: {
+    network: Omit<DataModel.NetworkInput, "networkId" | "historicBlock">;
+    artifacts: ContractObject[];
+  }): Promise<{
+    network: IdObject<DataModel.Network>,
+    contractInstances: IdObject<DataModel.ContractInstance>[]
+  }> {
+    const {
+      network,
+      contractInstances
+    } = await this.run(generateMigrateLoad, options);
 
+    return { network, contractInstances };
+  }
 }

--- a/packages/db/src/loaders/project.ts
+++ b/packages/db/src/loaders/project.ts
@@ -1,0 +1,80 @@
+import {DocumentNode} from "graphql";
+import {WorkflowCompileResult} from "@truffle/compile-common";
+
+import {toIdObject, IdObject} from "@truffle/db/meta";
+
+import {
+  generateCompileLoad,
+  generateInitializeLoad,
+  generateNamesLoad
+} from "./commands";
+
+import {LoaderRunner, forDb} from "./run";
+
+interface ITruffleDB {
+  query: (query: DocumentNode | string, variables: any) => Promise<any>;
+}
+
+export interface InitializeOptions {
+  project: DataModel.ProjectInput;
+  db: ITruffleDB;
+}
+
+export class Project {
+  private run: LoaderRunner;
+  private project: IdObject<DataModel.Project>;
+
+  static async initialize(options: InitializeOptions): Promise<Project> {
+    const {db, project: input} = options;
+
+    const { run } = forDb(db);
+
+    const project = await run(generateInitializeLoad, input);
+
+    return new Project({run, project});
+  }
+
+  async loadCompilations(options: {
+    result: WorkflowCompileResult;
+  }): Promise<{
+    compilations: IdObject<DataModel.Compilation>[];
+    contracts: IdObject<DataModel.Contract>[];
+  }> {
+    const {result} = options;
+
+    const {compilations, contracts} = await this.run(
+      generateCompileLoad,
+      result
+    );
+
+    return {
+      compilations: compilations.map(toIdObject),
+      contracts: contracts.map(toIdObject)
+    };
+  }
+
+  async loadNames(options: {
+    assignments: {
+      [collectionName: string]: IdObject[];
+    };
+  }): Promise<{
+    nameRecords: IdObject<DataModel.NameRecord>[];
+  }> {
+    const nameRecords = await this.run(
+      generateNamesLoad,
+      this.project,
+      options.assignments
+    );
+    return {
+      nameRecords: nameRecords.map(toIdObject)
+    };
+  }
+
+  private constructor(options: {
+    project: IdObject<DataModel.Project>;
+    run: LoaderRunner;
+  }) {
+    this.project = options.project;
+    this.run = options.run;
+  }
+}

--- a/packages/db/src/loaders/resources/compilations/find.graphql.ts
+++ b/packages/db/src/loaders/resources/compilations/find.graphql.ts
@@ -1,0 +1,11 @@
+import gql from "graphql-tag";
+
+export const FindCompilationContracts = gql`
+  query FindCompilations($ids: [ID!]!) {
+    compilations(filter: { ids: $ids }) {
+      contracts {
+        id
+      }
+    }
+  }
+`;

--- a/packages/db/src/loaders/resources/compilations/get.graphql.ts
+++ b/packages/db/src/loaders/resources/compilations/get.graphql.ts
@@ -10,27 +10,21 @@ export const GetCompilation = gql`
       sourceMaps {
         json
       }
-      processedSources {
-        source {
-          sourcePath
-        }
-
-        contracts {
+      contracts {
+        id
+        name
+        createBytecode {
           id
-          name
-          createBytecode {
-            id
-            bytes
-            linkReferences {
-              name
-            }
+          bytes
+          linkReferences {
+            name
           }
-          callBytecode {
-            id
-            bytes
-            linkReferences {
-              name
-            }
+        }
+        callBytecode {
+          id
+          bytes
+          linkReferences {
+            name
           }
         }
       }

--- a/packages/db/src/loaders/resources/compilations/index.ts
+++ b/packages/db/src/loaders/resources/compilations/index.ts
@@ -1,6 +1,7 @@
 import { logger } from "@truffle/db/logger";
 const debug = logger("db:loaders:resources:compilations");
 
+import { toIdObject, IdObject } from "@truffle/db/meta";
 import {
   CompilationData,
   LoadedSources,
@@ -10,6 +11,7 @@ import {
 import { AddCompilations } from "./add.graphql";
 export { AddCompilations };
 
+import { FindCompilationContracts } from "./find.graphql";
 export { GetCompilation } from "./get.graphql";
 
 const compilationSourceInputs = ({
@@ -74,4 +76,22 @@ export function* generateCompilationsLoad(
   };
 
   return result.data.compilationsAdd.compilations;
+}
+
+export function* generateCompilationsContracts(
+  compilations: IdObject<DataModel.Compilation>[]
+): Load<IdObject<DataModel.Contract>[], { graphql: "compilations" }> {
+  const result = yield {
+    type: "graphql",
+    request: FindCompilationContracts,
+    variables: {
+      ids: compilations.map(({ id }) => id)
+    }
+  };
+
+  const contracts = result.data.compilations
+    .map(({ contracts }) => contracts)
+    .flat();
+
+  return contracts.map(toIdObject);
 }

--- a/packages/db/src/loaders/resources/contractInstances/index.ts
+++ b/packages/db/src/loaders/resources/contractInstances/index.ts
@@ -1,4 +1,88 @@
 import { logger } from "@truffle/db/logger";
 const debug = logger("db:loaders:resources:contractInstances");
 
-export { AddContractInstances } from "./add.graphql";
+import { NetworkObject } from "@truffle/contract-schema/spec";
+import { IdObject } from "@truffle/db/meta";
+import { Load } from "@truffle/db/loaders/types";
+
+import { AddContractInstances } from "./add.graphql";
+
+export interface LoadableContractInstanceBytecode {
+  bytecode: IdObject<DataModel.Bytecode>;
+  linkReferences?: DataModel.LinkReference[]
+}
+
+export interface LoadableContractInstance {
+  contract: IdObject<DataModel.Contract>;
+  network: IdObject<DataModel.Network>;
+  networkObject: NetworkObject;
+  bytecodes: {
+    call: LoadableContractInstanceBytecode;
+    create: LoadableContractInstanceBytecode;
+  };
+}
+
+export function* generateContractInstancesLoad(
+  loadableContractInstances: LoadableContractInstance[]
+): Load<DataModel.ContractInstance[], { graphql: "contractInstancesAdd" }> {
+  const contractInstances = loadableContractInstances.map(({
+    contract,
+    network,
+    networkObject: {
+      address,
+      transactionHash,
+    },
+    bytecodes: {
+      call: callBytecode,
+      create: createBytecode
+    }
+  }) => ({
+    address,
+    network,
+    creation: {
+      transactionHash,
+      constructor: {
+        createBytecode: link(createBytecode)
+      }
+    },
+    contract,
+    callBytecode: link(callBytecode)
+  }));
+
+  const result = yield {
+    type: "graphql",
+    request: AddContractInstances,
+    variables: { contractInstances }
+  };
+
+  return result.data.contractInstancesAdd.contractInstances;
+}
+
+function link(
+  loadableBytecode: LoadableContractInstanceBytecode,
+  links?: NetworkObject["links"]
+): DataModel.LinkedBytecodeInput {
+  const { bytecode, linkReferences } = loadableBytecode;
+  if (!links) {
+    return {
+      bytecode,
+      linkValues: []
+    }
+  }
+
+  const linkValues = Object.entries(links).map(([ name, value ]) => ({
+    value,
+    linkReference: {
+      bytecode,
+      index: linkReferences.findIndex(
+        linkReference => name === linkReference.name
+      )
+    }
+  }));
+
+  return {
+    bytecode,
+    linkValues
+  };
+
+}

--- a/packages/db/src/loaders/resources/contracts/find.graphql.ts
+++ b/packages/db/src/loaders/resources/contracts/find.graphql.ts
@@ -1,0 +1,24 @@
+import gql from "graphql-tag";
+
+export const FindContracts = gql`
+  query FindContracts($ids: [ID!]!) {
+    contracts(filter: { ids: $ids }) {
+      id
+      name
+      createBytecode {
+        id
+        bytes
+        linkReferences {
+          name
+        }
+      }
+      callBytecode {
+        id
+        bytes
+        linkReferences {
+          name
+        }
+      }
+    }
+  }
+`;

--- a/packages/db/src/loaders/resources/contracts/get.graphql.ts
+++ b/packages/db/src/loaders/resources/contracts/get.graphql.ts
@@ -1,0 +1,24 @@
+import gql from "graphql-tag";
+
+export const GetContract = gql`
+  query GetContract($id: ID!) {
+    contract(id: $id) {
+      id
+      name
+      createBytecode {
+        id
+        bytes
+        linkReferences {
+          name
+        }
+      }
+      callBytecode {
+        id
+        bytes
+        linkReferences {
+          name
+        }
+      }
+    }
+  }
+`;

--- a/packages/db/src/loaders/resources/contracts/index.ts
+++ b/packages/db/src/loaders/resources/contracts/index.ts
@@ -5,9 +5,31 @@ import { LoadedBytecodes, Load } from "@truffle/db/loaders/types";
 import { IdObject } from "@truffle/db/meta";
 import { CompiledContract } from "@truffle/compile-common";
 
+import { GetContract } from "./get.graphql";
+
+export { FindContracts } from "./find.graphql";
+
 import { AddContracts } from "./add.graphql";
 export { AddContracts };
 
+export function* generateContractGet(
+  { id }: IdObject<DataModel.Contract>
+): Load<DataModel.Contract | undefined, { graphql: "contract" }> {
+  debug("Generating contract get...");
+
+  const response = yield {
+    type: "graphql",
+    request: GetContract,
+    variables: {
+      id
+    }
+  }
+
+  const contract = response.data.contract;
+
+  debug("Generated contract get.");
+  return contract;
+}
 export interface LoadableContract {
   contract: CompiledContract;
   path: { sourceIndex: number; contractIndex: number };

--- a/packages/db/src/loaders/resources/nameRecords/get.graphql.ts
+++ b/packages/db/src/loaders/resources/nameRecords/get.graphql.ts
@@ -1,0 +1,11 @@
+import gql from "graphql-tag";
+import camelCase from "camel-case";
+
+export const forType = (type: string) => gql`
+  query GetResourceName($id: ID!) {
+    ${camelCase(type)}(id: $id) {
+      id
+      name
+    }
+  }
+`;

--- a/packages/db/src/loaders/resources/nameRecords/index.ts
+++ b/packages/db/src/loaders/resources/nameRecords/index.ts
@@ -1,44 +1,58 @@
 import { logger } from "@truffle/db/logger";
 const debug = logger("db:loaders:resources:nameRecords");
 
+import camelCase from "camel-case";
+import { IdObject, toIdObject } from "@truffle/db/meta";
+
 import { Load } from "@truffle/db/loaders/types";
-import { toIdObject } from "@truffle/db/meta";
 
 import { AddNameRecords } from "./add.graphql";
+import { forType } from "./get.graphql";
 export { AddNameRecords };
-
-interface Resource {
-  id: string;
-  name: string;
-}
 
 type ResolveFunc = (
   name: string,
   type: string
 ) => Load<DataModel.NameRecord | null>;
 
+function* getResourceName(
+  { id }: IdObject,
+  type: string
+): Load<{ name: string }> {
+  const GetResourceName = forType(type);
+
+  const result = yield {
+    type: "graphql",
+    request: GetResourceName,
+    variables: { id }
+  };
+
+  return result.data[camelCase(type)];
+}
+
 export function* generateNameRecordsLoad(
-  resources: Resource[],
+  resources: IdObject[],
   type: string,
   getCurrent: ResolveFunc
 ): Load<DataModel.NameRecord[]> {
   const nameRecords = [];
   for (const resource of resources) {
-    const { name } = resource;
+    const { name } = yield* getResourceName(resource, type);
+
     const current: DataModel.NameRecord = yield* getCurrent(name, type);
 
     if (current) {
       nameRecords.push({
         name,
         type,
-        resource: toIdObject(resource),
+        resource,
         previous: toIdObject(current)
       });
     } else {
       nameRecords.push({
         name,
         type,
-        resource: toIdObject(resource)
+        resource
       });
     }
   }

--- a/packages/db/src/loaders/resources/networks/add.graphql.ts
+++ b/packages/db/src/loaders/resources/networks/add.graphql.ts
@@ -5,6 +5,7 @@ export const AddNetworks = gql`
     networksAdd(input: { networks: $networks }) {
       networks {
         id
+        name
         networkId
         historicBlock {
           height

--- a/packages/db/src/loaders/resources/networks/get.graphql.ts
+++ b/packages/db/src/loaders/resources/networks/get.graphql.ts
@@ -1,0 +1,11 @@
+import gql from "graphql-tag";
+
+export const GetNetwork = gql`
+  query GetNetwork($id: ID!) {
+    network(id: $id) {
+      id
+      name
+      networkId
+    }
+  }
+`;

--- a/packages/db/src/loaders/resources/networks/index.ts
+++ b/packages/db/src/loaders/resources/networks/index.ts
@@ -1,4 +1,116 @@
 import { logger } from "@truffle/db/logger";
 const debug = logger("db:loaders:resources:networks");
 
-export { AddNetworks } from "./add.graphql";
+import { IdObject } from "@truffle/db/meta";
+import { Load } from "@truffle/db/loaders/types";
+
+import { GetNetwork } from "./get.graphql";
+import { AddNetworks } from "./add.graphql";
+
+type TransactionHash = any;
+type NetworkId = any;
+
+export function* generateNetworkGet(
+  { id }: IdObject<DataModel.Network>
+): Load<DataModel.Network | undefined, { graphql: "network" }> {
+  debug("Generating network get...");
+
+  const response = yield {
+    type: "graphql",
+    request: GetNetwork,
+    variables: {
+      id
+    }
+  }
+
+  const network = response.data.network;
+
+  debug("Generated network get.");
+  return network;
+}
+
+export interface GenerateTransactionNetworkLoadOptions {
+  transactionHash: TransactionHash;
+  network: Pick<DataModel.NetworkInput, "name" | "networkId">;
+}
+
+export function* generateTranasctionNetworkLoad({
+  transactionHash,
+  network: {
+    name,
+    networkId
+  }
+}: GenerateTransactionNetworkLoadOptions): Load<DataModel.Network> {
+  debug("Generating transaction network load...");
+  const historicBlock = yield* generateHistoricBlockFetch(transactionHash);
+
+  const result = yield* generateNetworkLoad({
+    name,
+    networkId,
+    historicBlock
+  });
+
+  debug("Generated transaction network load.");
+  return result;
+}
+
+export function* generateNetworkIdFetch(): Load<any, { web3: "net_version" }> {
+  debug("Generating networkId fetch...");
+
+  const response = yield {
+    type: "web3",
+    method: "net_version"
+  };
+
+  const { result } = response;
+
+  const networkId = parseInt(result);
+
+  debug("Generated networkId fetch.");
+  return networkId;
+}
+
+function* generateHistoricBlockFetch(
+  transactionHash: TransactionHash
+): Load<DataModel.Block, { web3: "eth_getTransactionByHash" }> {
+  debug("Generating historic block fetch...");
+
+  const response = yield {
+    type: "web3",
+    method: "eth_getTransactionByHash",
+    params: [transactionHash]
+  };
+
+  const {
+    result: {
+      blockNumber,
+      blockHash: hash
+    }
+  } = response;
+
+  const height = parseInt(blockNumber);
+
+  const historicBlock = { height, hash };
+
+  debug("Generated historic block fetch.");
+  return historicBlock;
+}
+
+function* generateNetworkLoad(
+  input: DataModel.NetworkInput
+): Load<DataModel.Network, { graphql: "networksAdd" }> {
+  debug("Generating network load...");
+  const response = yield {
+    type: "graphql",
+    request: AddNetworks,
+    variables: {
+      networks: [input]
+    }
+  }
+
+  const network = response.data.networksAdd.networks[0];
+
+  debug("Generated network load.");
+  return network;
+}
+

--- a/packages/db/src/loaders/resources/networks/index.ts
+++ b/packages/db/src/loaders/resources/networks/index.ts
@@ -34,7 +34,7 @@ export interface GenerateTransactionNetworkLoadOptions {
   network: Pick<DataModel.NetworkInput, "name" | "networkId">;
 }
 
-export function* generateTranasctionNetworkLoad({
+export function* generateTransactionNetworkLoad({
   transactionHash,
   network: {
     name,
@@ -113,4 +113,3 @@ function* generateNetworkLoad(
   debug("Generated network load.");
   return network;
 }
-

--- a/packages/db/src/loaders/run.ts
+++ b/packages/db/src/loaders/run.ts
@@ -2,7 +2,7 @@ import { logger } from "@truffle/db/logger";
 const debug = logger("db:loaders:run");
 
 import { promisify } from "util";
-import type Web3 from "web3";
+import type {Provider} from "web3/providers";
 import {DocumentNode} from "graphql";
 
 import { Loader, LoadRequest, GraphQlRequest, Web3Request, RequestType } from "./types";
@@ -21,7 +21,7 @@ export type LoaderRunner = <
 ) => Promise<T>;
 
 export const forDb = (db): {
-  forProvider(provider: Web3["currentProvider"]): {
+  forProvider(provider: Provider): {
     run: LoaderRunner
   };
   run: LoaderRunner;
@@ -53,7 +53,7 @@ const run = async <
   Return,
   R extends RequestType | undefined
 >(
-  connections: { db: ITruffleDB, provider?: Web3["currentProvider"] },
+  connections: { db: ITruffleDB, provider?: Provider },
   loader: Loader<Args, Return, R>,
   ...args: Args
 ) => {

--- a/packages/db/src/loaders/run.ts
+++ b/packages/db/src/loaders/run.ts
@@ -7,12 +7,7 @@ import {DocumentNode} from "graphql";
 
 import { Loader, LoadRequest, GraphQlRequest, Web3Request, RequestType } from "./types";
 
-interface ITruffleDB {
-  query: (query: DocumentNode | string, variables: any) => Promise<any>;
-}
-
-export type LoaderRunner = <
-  A extends unknown[],
+export type LoaderRunner = < A extends unknown[],
   T = any,
   R extends RequestType | undefined = undefined
 >(
@@ -20,7 +15,11 @@ export type LoaderRunner = <
   ...args: A
 ) => Promise<T>;
 
-export const forDb = (db): {
+export interface Db {
+  query: (query: DocumentNode | string, variables: any) => Promise<any>;
+}
+
+export const forDb = (db: Db): {
   forProvider(provider: Provider): {
     run: LoaderRunner
   };
@@ -53,7 +52,7 @@ const run = async <
   Return,
   R extends RequestType | undefined
 >(
-  connections: { db: ITruffleDB, provider?: Provider },
+  connections: { db: Db, provider?: Provider },
   loader: Loader<Args, Return, R>,
   ...args: Args
 ) => {

--- a/packages/db/src/loaders/schema/artifactsLoader.ts
+++ b/packages/db/src/loaders/schema/artifactsLoader.ts
@@ -2,275 +2,124 @@ import { logger } from "@truffle/db/logger";
 const debug = logger("db:loaders:schema:artifactsLoader");
 
 import { TruffleDB } from "@truffle/db/db";
-import * as fse from "fs-extra";
-import path from "path";
+import { IdObject, toIdObject } from "@truffle/db/meta";
 import Config from "@truffle/config";
+import TruffleResolver from "@truffle/resolver";
+import type { Resolver } from "@truffle/resolver";
 import { Environment } from "@truffle/environment";
-import Web3 from "web3";
+import { ContractObject } from "@truffle/contract-schema/spec";
 
-import { Project } from "@truffle/db/loaders";
-import { GetCompilation } from "@truffle/db/loaders/resources/compilations";
-import { AddContractInstances } from "@truffle/db/loaders/resources/contractInstances";
-import { AddNetworks } from "@truffle/db/loaders/resources/networks";
-import {
-  WorkflowCompileResult,
-  CompiledContract
-} from "@truffle/compile-common/src/types";
+import { Project } from "@truffle/db/loaders/project";
+import { FindContracts } from "@truffle/db/loaders/resources/contracts";
+import { WorkflowCompileResult } from "@truffle/compile-common/src/types";
 import WorkflowCompile from "@truffle/workflow-compile";
-
-type NetworkLinkObject = {
-  [name: string]: string;
-};
-
-type LinkValueLinkReferenceObject = {
-  bytecode: { id: string };
-  index: number;
-};
-
-type LinkValueObject = {
-  value: string;
-  linkReference: LinkValueLinkReferenceObject;
-};
-
-type LoaderNetworkObject = {
-  contract: string;
-  id: string;
-  address: string;
-  transactionHash: string;
-  links?: NetworkLinkObject;
-};
-
-type LinkReferenceObject = {
-  offsets: Array<number>;
-  name: string;
-  length: number;
-};
-
-type BytecodeInfo = {
-  id: string;
-  linkReferences: Array<LinkReferenceObject>;
-  bytes?: string;
-};
-
-type CompilationConfigObject = {
-  contracts_directory?: string;
-  contracts_build_directory?: string;
-  artifacts_directory?: string;
-  working_directory?: string;
-  all?: boolean;
-};
 
 export class ArtifactsLoader {
   private db: TruffleDB;
-  private config: CompilationConfigObject;
+  private compilationConfig: Partial<Config>;
+  private resolver: Resolver;
 
-  constructor(db: TruffleDB, config?: CompilationConfigObject) {
+  constructor(db: TruffleDB, config?: Partial<Config>) {
     this.db = db;
-    this.config = config;
+    this.compilationConfig = config;
+    // @ts-ignore
+    this.resolver = new TruffleResolver(config);
   }
 
   async load(): Promise<void> {
+    debug("Compiling...");
     const result: WorkflowCompileResult = await WorkflowCompile.compile(
-      this.config
+      this.compilationConfig
     );
+    debug("Compiled.");
 
+    debug("Initializing project...");
     const project = await Project.initialize({
       project: {
-        directory: this.config.working_directory
+        directory: this.compilationConfig.working_directory
       },
       db: this.db
     });
+    debug("Initialized project.");
 
-    // third parameter in loadCompilation is for whether or not we need
-    // to update nameRecords (i.e. is this happening in test)
-    const { compilations, contracts } = await project.loadCompilations({
-      result
-    });
+    debug("Loading compilations...");
+    const { contracts } = await project.loadCompilations({ result });
+    debug("Loaded compilations.");
 
+    debug("Assigning contract names...");
     await project.loadNames({ assignments: { contracts } });
+    debug("Assigned contract names.");
 
-    //map contracts and contract instances to compiler
-    await Promise.all(
-      compilations.map(async ({ id }, index) => {
-        const {
-          data: {
-            compilation: { processedSources }
-          }
-        } = await this.db.query(GetCompilation, { id });
-
-        const networksByContract = await this.loadNetworks(
-          result.compilations[index].contracts,
-          this.config["artifacts_directory"],
-          this.config["contracts_directory"]
-        );
-
-        // assign names for networks we just added
-        const networks = [
-          ...new Set(networksByContract.flat().map(({ id }) => id))
-        ].map(id => ({ id }));
-
-        await project.loadNames({ assignments: { networks } });
-
-        const processedSourceContracts = processedSources
-          .map(processedSource => processedSource.contracts)
-          .flat();
-
-        let contracts = [];
-        result.compilations[index].contracts.map(({ contractName }) =>
-          contracts.push(
-            processedSourceContracts.find(({ name }) => name === contractName)
-          )
-        );
-
-        if (networksByContract[0].length) {
-          await this.loadContractInstances(contracts, networksByContract);
-        }
-      })
+    const artifacts = await this.correlateContractsToArtifacts(
+      contracts
     );
-  }
 
-  async loadNetworks(
-    contracts: Array<CompiledContract>,
-    artifacts: string,
-    workingDirectory: string
-  ) {
-    const networksByContract = await Promise.all(
-      contracts.map(async ({ contractName, bytecode }) => {
-        const name = contractName.toString().concat(".json");
-        const artifactsNetworksPath = fse.readFileSync(
-          path.join(artifacts, name)
-        );
-        const artifactsNetworks = JSON.parse(artifactsNetworksPath.toString())
-          .networks;
-        let configNetworks = [];
-        if (Object.keys(artifactsNetworks).length) {
-          const config = Config.detect({ workingDirectory: workingDirectory });
-          for (let network of Object.keys(config.networks)) {
-            config.network = network;
-            await Environment.detect(config);
-            let networkId;
-            let web3;
-            try {
-              web3 = new Web3(config.provider);
-              networkId = await web3.eth.net.getId();
-            } catch (err) {}
-
-            if (networkId) {
-              let filteredNetwork = Object.entries(artifactsNetworks).filter(
-                network => network[0] == networkId
-              );
-              //assume length of filteredNetwork is 1 -- shouldn't have multiple networks with same id in one contract
-              if (filteredNetwork.length > 0) {
-                const transaction = await web3.eth.getTransaction(
-                  filteredNetwork[0][1]["transactionHash"]
-                );
-                const historicBlock = {
-                  height: transaction.blockNumber,
-                  hash: transaction.blockHash
-                };
-
-                const networksAdd = await this.db.query(AddNetworks, {
-                  networks: [
-                    {
-                      name: network,
-                      networkId: networkId,
-                      historicBlock: historicBlock
-                    }
-                  ]
-                });
-
-                const id = networksAdd.data.networksAdd.networks[0].id;
-                configNetworks.push({
-                  contract: contractName,
-                  id: id,
-                  address: filteredNetwork[0][1]["address"],
-                  transactionHash: filteredNetwork[0][1]["transactionHash"],
-                  bytecode: bytecode,
-                  links: filteredNetwork[0][1]["links"],
-                  name: network
-                });
-              }
-            }
-          }
-        }
-
-        return configNetworks;
-      })
-    );
-    return networksByContract;
-  }
-
-  getNetworkLinks(network: LoaderNetworkObject, bytecode: BytecodeInfo) {
-    let networkLink: Array<LinkValueObject> = [];
-    if (network.links) {
-      networkLink = Object.entries(network.links).map(link => {
-        let linkReferenceIndexByName = bytecode.linkReferences.findIndex(
-          ({ name }) => name === link[0]
-        );
-
-        let linkValue = {
-          value: link[1],
-          linkReference: {
-            bytecode: { id: bytecode.id },
-            index: linkReferenceIndexByName
-          }
-        };
-
-        return linkValue;
-      });
-    }
-
-    return networkLink;
-  }
-
-  async loadContractInstances(
-    contracts: Array<DataModel.Contract>,
-    networksArray: Array<Array<LoaderNetworkObject>>
-  ) {
-    // networksArray is an array of arrays of networks for each contract;
-    // this first mapping maps to each contract
-    const instances = networksArray.map((networks, index) => {
-      // this second mapping maps each network in a contract
-      const contractInstancesByNetwork = networks.map(network => {
-        let createBytecodeLinkValues = this.getNetworkLinks(
-          network,
-          contracts[index].createBytecode
-        );
-        let callBytecodeLinkValues = this.getNetworkLinks(
-          network,
-          contracts[index].callBytecode
-        );
-
-        let instance = {
-          address: network.address,
-          contract: {
-            id: contracts[index].id
-          },
-          network: {
-            id: network.id
-          },
-          creation: {
-            transactionHash: network.transactionHash,
-            constructor: {
-              createBytecode: {
-                bytecode: { id: contracts[index].createBytecode.id },
-                linkValues: createBytecodeLinkValues
-              }
-            }
-          },
-          callBytecode: {
-            bytecode: { id: contracts[index].callBytecode.id },
-            linkValues: callBytecodeLinkValues
-          }
-        };
-        return instance;
-      });
-
-      return contractInstancesByNetwork;
+    const config = Config.detect({
+      working_directory: this.compilationConfig["contracts_directory"]
     });
 
-    await this.db.query(AddContractInstances, {
-      contractInstances: instances.flat()
+    debug("Loading networks...");
+    const networks = [];
+    for (const name of Object.keys(config.networks)) {
+      try {
+        debug("Connecting to network name: %s", name);
+        config.network = name;
+        await Environment.detect(config);
+
+        const liveProject = await project.connect({
+          provider: config.provider
+        });
+
+        const result = await liveProject.loadMigration({
+          network: { name },
+          artifacts
+        });
+
+        networks.push(result.network);
+      } catch (error) {
+        debug("error %o", error);
+        continue;
+      }
+    }
+    debug("Loaded networks.");
+
+    debug("Assigning network names...");
+    await project.loadNames({ assignments: { networks } });
+    debug("Assigned network names.");
+  }
+
+  async correlateContractsToArtifacts(
+    contractIdObjects: IdObject<DataModel.Contract>[]
+  ): Promise<ContractObject[]> {
+    // get full representation
+    debug(
+      "Retrieving contracts, ids: %o...",
+      contractIdObjects.map(({ id }) => id)
+    );
+    const {
+      data: { contracts }
+    } = await this.db.query(FindContracts, {
+      ids: contractIdObjects.map(({ id }) => id)
+    });
+    debug(
+      "Retrieved contracts, ids: %o.",
+      contractIdObjects.map(({ id }) => id)
+    );
+
+    // and resolve artifact
+    return contracts.map((contract: DataModel.Contract) => {
+      const { name } = contract;
+
+      debug("Requiring artifact for %s...", name);
+      // @ts-ignore
+      const artifact: ContractObject = this.resolver.require(name)._json;
+      debug("Required artifact for %s.", name);
+
+      artifact.db = {
+        contract: toIdObject(contract)
+      };
+
+      return artifact;
     });
   }
 }

--- a/packages/db/src/loaders/test/index.ts
+++ b/packages/db/src/loaders/test/index.ts
@@ -35,7 +35,7 @@ afterAll(async done => {
 // mocking the truffle-workflow-compile to avoid jest timing issues
 // and also to keep from adding more time to Travis testing
 jest.mock("@truffle/workflow-compile", () => ({
-  compile: function () {
+  compile: function() {
     return require(path.join(
       __dirname,
       "workflowCompileOutputMock",

--- a/packages/db/src/loaders/test/index.ts
+++ b/packages/db/src/loaders/test/index.ts
@@ -72,12 +72,6 @@ const compilationConfig = {
     "build",
     "contracts"
   ),
-  artifacts_directory: path.join(
-    __dirname,
-    "compilationSources",
-    "build",
-    "contracts"
-  ),
   working_directory: tempDir.name,
   all: true
 };

--- a/packages/db/src/meta/index.ts
+++ b/packages/db/src/meta/index.ts
@@ -100,11 +100,6 @@ export type NamedResource<
   N extends CollectionName<C> = CollectionName<C>
 > = Resource<C, N, { is: "named" }>;
 
-export type NamedCollectionName<C extends Collections> = FilteredCollectionName<
-  C,
-  { is: "named" }
->;
-
 export type MutationInput<
   C extends Collections,
   N extends CollectionName<C>

--- a/packages/db/types/stub.d.ts
+++ b/packages/db/types/stub.d.ts
@@ -3,6 +3,7 @@
 
 declare namespace DataModel {
   type ResourceReferenceInput = any;
+  type Block = any;
   type Bytecode = any;
   type BytecodeInput = any;
   type BytecodesAddInput = any;
@@ -24,6 +25,8 @@ declare namespace DataModel {
   type ContractsAddInput = any;
   type ContractsAddPayload = any;
   type Instruction = any;
+  type LinkReference = any;
+  type LinkedBytecodeInput = any;
   type NameRecord = any;
   type NameRecordInput = any;
   type NameRecordsAddInput = any;


### PR DESCRIPTION
To bridge the gap between @truffle/db and Truffle at large.

This adds a top-level `const { Project } = require("@truffle/db")` that exposes methods corresponding to existing Truffle workflows.