### PR TITLE
Bug fix: Check for missing AST in orderABI to prevent crash

### DIFF
--- a/packages/compile-solidity/run.js
+++ b/packages/compile-solidity/run.js
@@ -74,6 +74,9 @@ async function run(rawSources, options) {
 function orderABI({ abi, contractName, ast }) {
   // AST can have multiple contract definitions, make sure we have the
   // one that matches our contract
+  if (!ast || !ast.nodes) {
+    return abi;
+  }
   const contractDefinition = ast.nodes.find(
     ({ nodeType, name }) =>
       nodeType === "ContractDefinition" && name === contractName


### PR DESCRIPTION
A crash of this form was pointed out by @interfect on Gitter.  Dunno why there's no AST, but looking at that can come later, I think; first I figure I'll just prevent the crash.