### PR TITLE
Bug fix: Make forTx and session.load throw on failure (breaking change!)

### DIFF
--- a/packages/core/lib/debug/cli.js
+++ b/packages/core/lib/debug/cli.js
@@ -112,17 +112,21 @@ class CLIDebugger {
     //and only wake up to full mode later!
     //note: if we are in external mode, txHash had better be defined!
     //(this is ensured by commands/debug.js, so we don't check it ourselves)
-    const bugger =
-      this.txHash !== undefined
-        ? await Debugger.forTx(this.txHash, {
-            provider: this.config.provider,
-            compilations,
-            lightMode: this.config.fetchExternal
-          })
-        : await Debugger.forProject({
-            provider: this.config.provider,
-            compilations
-          });
+    const bugger = await Debugger.forProject({
+      provider: this.config.provider,
+      compilations,
+      lightMode: this.config.fetchExternal
+    });
+    if (this.txHash !== undefined) {
+      try {
+        debug("loading %s", this.txHash);
+        await bugger.load(this.txHash);
+      } catch (_) {
+        debug("loading error");
+        //on failure, stay unloaded
+        //(note we handle failing the spinner below rather than here)
+      }
+    }
 
     debug("debugger started");
 

--- a/packages/core/lib/debug/interpreter.js
+++ b/packages/core/lib/debug/interpreter.js
@@ -264,10 +264,13 @@ class DebugInterpreter {
     }
 
     if (this.session.view(session.status.loaded)) {
+      debug("loaded");
       this.printer.printSessionLoaded();
     } else if (this.session.view(session.status.isError)) {
+      debug("error!");
       this.printer.printSessionError();
     } else {
+      debug("didn't attempt a load");
       this.printer.printHelp();
     }
 
@@ -388,13 +391,11 @@ class DebugInterpreter {
           let txSpinner = ora(
             DebugUtils.formatTransactionStartMessage()
           ).start();
-          await this.session.load(cmdArgs);
-          //if load succeeded
-          if (this.session.view(selectors.session.status.success)) {
+          try {
+            await this.session.load(cmdArgs);
             txSpinner.succeed();
-            //if successful, change prompt
             this.repl.setPrompt(DebugUtils.formatPrompt(this.network, cmdArgs));
-          } else {
+          } catch (_) {
             txSpinner.fail();
             loadFailed = true;
           }

--- a/packages/debugger/lib/debugger.js
+++ b/packages/debugger/lib/debugger.js
@@ -19,6 +19,8 @@ import { Compilations } from "@truffle/codec";
 const Debugger = {
   /**
    * Instantiates a Debugger for a given transaction hash.
+   * Throws on failure.  If you want a more failure-tolerant method,
+   * use forProject and then do a session.load inside a try.
    *
    * @param {String} txHash - transaction hash with leading "0x"
    * @param {{contracts: Array<Artifact>, files: Array<String>, provider: Web3Provider, compilations: Array<Compilation>}} options -
@@ -31,13 +33,7 @@ const Debugger = {
     }
     let session = new Session(compilations, provider, { lightMode }, txHash);
 
-    try {
-      await session.ready();
-      debug("session ready");
-    } catch (e) {
-      debug("error occurred, unloaded");
-      session.unload();
-    }
+    await session.ready();
 
     return session;
   },

--- a/packages/debugger/lib/session/index.js
+++ b/packages/debugger/lib/session/index.js
@@ -302,17 +302,12 @@ export default class Session {
     });
   }
 
-  //returns true on success, false on already loaded, error object on failure
+  //returns true on success, false on already loaded; throws on failure
   async load(txHash) {
     if (this.view(session.status.loaded)) {
       return false;
     }
-    try {
-      return await this.readyAgainAfterLoading(actions.loadTransaction(txHash));
-    } catch (e) {
-      this._runSaga(sagas.unload);
-      return e;
-    }
+    return await this.readyAgainAfterLoading(actions.loadTransaction(txHash));
   }
 
   //returns true on success, false on already unloaded

--- a/packages/debugger/lib/session/selectors/index.js
+++ b/packages/debugger/lib/session/selectors/index.js
@@ -107,16 +107,16 @@ const session = createSelectorTree({
     block: createLeaf(["/state"], state => state.block)
   },
 
-  /*
+  /**
    * session.status (namespace)
    */
   status: {
-    /*
+    /**
      * session.status.readyOrError
      */
     readyOrError: createLeaf(["/state"], state => state.ready),
 
-    /*
+    /**
      * session.status.ready
      */
     ready: createLeaf(
@@ -124,27 +124,27 @@ const session = createSelectorTree({
       (readyOrError, error) => readyOrError && !error
     ),
 
-    /*
+    /**
      * session.status.waiting
      */
     waiting: createLeaf(["/state"], state => !state.ready),
 
-    /*
+    /**
      * session.status.error
      */
     error: createLeaf(["/state"], state => state.lastLoadingError),
 
-    /*
+    /**
      * session.status.isError
      */
     isError: createLeaf(["./error"], error => error !== null),
 
-    /*
+    /**
      * session.status.success
      */
     success: createLeaf(["./error"], error => error === null),
 
-    /*
+    /**
      * session.status.errored
      */
     errored: createLeaf(
@@ -152,7 +152,7 @@ const session = createSelectorTree({
       (readyOrError, error) => readyOrError && error
     ),
 
-    /*
+    /**
      * session.status.loaded
      */
     loaded: createLeaf([trace.loaded], loaded => loaded),


### PR DESCRIPTION
**This PR is a breaking change to `@truffle/debugger`.**

As requested by @seesemichaelj, this PR makes it so that when a debugger method fails to load a transaction, it will throw an error, rather than succeeding and then exposing that error via another mechanism.  (That other mechanism is still there, though, and we still use it in the CLI to avoid having to change too much.)

So, now the debugger's `load()` method will throw an error if it fails to load a transaction, rather than having no effect (other than setting the error), and `Debugger.forTx()` will throw if it fails to load the transaction, rather than returning a debugger with no transaction loaded.