### PR TITLE
Add @truffle/db contract correlation to artifacts

### DIFF
--- a/packages/compile-common/src/shims/LegacyToNew.ts
+++ b/packages/compile-common/src/shims/LegacyToNew.ts
@@ -24,7 +24,8 @@ export function forContract(contract: any): CompiledContract {
     userdoc,
     immutableReferences,
     generatedSources,
-    deployedGeneratedSources
+    deployedGeneratedSources,
+    db
   } = contract;
 
   return {
@@ -44,7 +45,8 @@ export function forContract(contract: any): CompiledContract {
     userdoc,
     immutableReferences,
     generatedSources,
-    deployedGeneratedSources
+    deployedGeneratedSources,
+    db
   };
 }
 

--- a/packages/compile-common/src/shims/NewToLegacy.ts
+++ b/packages/compile-common/src/shims/NewToLegacy.ts
@@ -18,7 +18,8 @@ export function forContract(contract: CompiledContract): any {
     userdoc,
     immutableReferences,
     generatedSources,
-    deployedGeneratedSources
+    deployedGeneratedSources,
+    db
   } = contract;
 
   return {
@@ -39,7 +40,8 @@ export function forContract(contract: CompiledContract): any {
     userdoc,
     immutableReferences,
     generatedSources,
-    deployedGeneratedSources
+    deployedGeneratedSources,
+    db
   };
 }
 

--- a/packages/compile-common/src/types.ts
+++ b/packages/compile-common/src/types.ts
@@ -45,6 +45,7 @@ export type CompiledContract = {
   immutableReferences: ImmutableReferences;
   generatedSources: any;
   deployedGeneratedSources: any;
+  db?: any;
 };
 
 export interface WorkflowCompileResult {

--- a/packages/contract-schema/index.js
+++ b/packages/contract-schema/index.js
@@ -176,7 +176,8 @@ var properties = {
   },
   networkType: {},
   devdoc: {},
-  userdoc: {}
+  userdoc: {},
+  "db:contract": {}
 };
 
 /**

--- a/packages/contract-schema/index.js
+++ b/packages/contract-schema/index.js
@@ -177,7 +177,7 @@ var properties = {
   networkType: {},
   devdoc: {},
   userdoc: {},
-  "db:contract": {}
+  db: {}
 };
 
 /**
@@ -245,7 +245,6 @@ var TruffleContractSchema = {
             params,
             message,
             data,
-            schema, // eslint-disable-line no-unused-vars
             parentSchema
           }) =>
             util.format(

--- a/packages/contract-schema/spec/contract-object.spec.json
+++ b/packages/contract-schema/spec/contract-object.spec.json
@@ -90,6 +90,15 @@
     },
     "deployedGeneratedSources": {
       "$ref": "#/definitions/GeneratedSources"
+    },
+    "db:contract": {
+      "type": "object",
+      "description": "Reference to @truffle/db canonical ID object for correlation purposes",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
     }
   },
   "required": [

--- a/packages/contract-schema/spec/contract-object.spec.json
+++ b/packages/contract-schema/spec/contract-object.spec.json
@@ -91,12 +91,17 @@
     "deployedGeneratedSources": {
       "$ref": "#/definitions/GeneratedSources"
     },
-    "db:contract": {
+    "db": {
       "type": "object",
-      "description": "Reference to @truffle/db canonical ID object for correlation purposes",
-      "properties": {
-        "id": {
-          "type": "string"
+      "patternProperties": {
+        "^[a-zA-Z0-9]+$": {
+          "type": "object",
+          "description": "Reference to @truffle/db canonical ID object for correlation purposes",
+          "properties": {
+            "id": {
+              "type": "string"
+            }
+          }
         }
       }
     }

--- a/packages/contract-schema/spec/network-object.spec.json
+++ b/packages/contract-schema/spec/network-object.spec.json
@@ -20,6 +20,20 @@
         "^[a-zA-Z_][a-zA-Z0-9_]*$": { "$ref": "#/definitions/Address" }
       },
       "additionalProperties": false
+    },
+    "db": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9]+$": {
+          "type": "object",
+          "description": "Reference to @truffle/db canonical ID object for correlation purposes",
+          "properties": {
+            "id": {
+              "type": "string"
+            }
+          }
+        }
+      }
     }
   },
   "additionalProperties": false,

--- a/packages/contract/lib/contract/properties.js
+++ b/packages/contract/lib/contract/properties.js
@@ -401,12 +401,12 @@ module.exports = {
       this._json.deployedGeneratedSources = sources;
     }
   },
-  "db:contract": {
+  db: {
     get: function () {
-      return this._json["db:contract"];
+      return this._json.db;
     },
-    set: function (contract) {
-      this._json["db:contract"] = contract;
+    set: function (db) {
+      this._json.db = db;
     }
   }
 };

--- a/packages/contract/lib/contract/properties.js
+++ b/packages/contract/lib/contract/properties.js
@@ -400,5 +400,13 @@ module.exports = {
     set: function (sources) {
       this._json.deployedGeneratedSources = sources;
     }
+  },
+  "db:contract": {
+    get: function () {
+      return this._json["db:contract"];
+    },
+    set: function (contract) {
+      this._json["db:contract"] = contract;
+    }
   }
 };


### PR DESCRIPTION
Define property `db` on the ContractObject schema and the NetworkObject schema, allowing artifacts to contain relevant information about @truffle/db resources.

For example, artifacts will be expected to contain information something like:

```javascript
{
  // ... rest of artifact ...
  "db": {
    "source": {
      "id": "0xb63608deefb65ab93e8beebe5fb0397417c14dc54cb6cee5748e590d16ca5986"
    },
    "createBytecode": {
      "id": "0x5ad957bd618157fd28fac3ffa61dd5275ff6de8494e32323029a31daef7ac56a"
    },
    "callBytecode": {
      "id": "0x5ec2ead4cd51f88805b33da49c5ec4c57388992ae1f6492f8b17c38c5045d3d6"
    },
    "compilation": {
      "id": "0x8534281c01751b9701e53e91fd97733f092ab2a1048f215fb4ced35f67b2644d"
    },
    "contract": {
      "id": "0xa3d6cdfe66ead5c6843c5297248b79ab7090e8230247b2f8a9637ea7fd04b8c6"
    }
  }
}
```