### PR TITLE
Fix some minor errors in @truffle/db implementation

### DIFF
--- a/packages/db/src/definitions/contracts.ts
+++ b/packages/db/src/definitions/contracts.ts
@@ -76,8 +76,14 @@ export const contracts: Definition<"contracts"> = {
         }
       },
       createBytecode: {
-        resolve: async ({ createBytecode: { id } }, _, { workspace }) => {
+        resolve: async ({ createBytecode }, _, { workspace }) => {
           debug("Resolving Contract.createBytecode...");
+
+          if (!createBytecode) {
+            return;
+          }
+
+          const { id } = createBytecode;
 
           const result = await workspace.get("bytecodes", id);
 
@@ -86,8 +92,14 @@ export const contracts: Definition<"contracts"> = {
         }
       },
       callBytecode: {
-        resolve: async ({ callBytecode: { id } }, _, { workspace }) => {
+        resolve: async ({ callBytecode }, _, { workspace }) => {
           debug("Resolving Contract.callBytecode...");
+
+          if (!callBytecode) {
+            return;
+          }
+
+          const { id } = callBytecode;
 
           const result = await workspace.get("bytecodes", id);
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -6,11 +6,7 @@ const { TruffleDB } = require("./db");
 const { ApolloServer } = require("apollo-server");
 
 const playgroundServer = config => {
-  const { context, schema } = new TruffleDB({
-    contracts_build_directory: config.contracts_build_directory,
-    contracts_directory: config.contracts_directory,
-    working_directory: config.working_directory
-  });
+  const { context, schema } = new TruffleDB(config);
 
   return new ApolloServer({
     tracing: true,

--- a/packages/db/src/pouch/databases.ts
+++ b/packages/db/src/pouch/databases.ts
@@ -56,11 +56,11 @@ export abstract class Databases<C extends Collections> implements Workspace<C> {
   ): PouchDB.Database;
 
   private async initialize() {
-    await Promise.all(
-      Object.entries(this.definitions).map(([collectionName, definition]) =>
-        this.initializeCollection(collectionName, definition)
-      )
-    );
+    for (const [collectionName, definition] of Object.entries(this.definitions)) {
+      await this.initializeCollection(collectionName, definition)
+    };
+
+    debug("Databases ready.");
   }
 
   private async initializeCollection<N extends CollectionName<C>>(
@@ -74,15 +74,16 @@ export abstract class Databases<C extends Collections> implements Workspace<C> {
     for (let index of createIndexes || []) {
       await collection.createIndex({ index });
     }
+
   }
 
   public async all<N extends CollectionName<C>>(
     collectionName: N
   ): Promise<SavedInput<C, N>[]> {
+    await this.ready;
+
     const log = debug.extend(`${collectionName}:all`);
     log("Fetching all...");
-
-    await this.ready;
 
     const result = await this.find<N>(collectionName, { selector: {} });
 
@@ -94,10 +95,10 @@ export abstract class Databases<C extends Collections> implements Workspace<C> {
     collectionName: N,
     options: PouchDB.Find.FindRequest<{}>
   ): Promise<SavedInput<C, N>[]> {
+    await this.ready;
+
     const log = debug.extend(`${collectionName}:all`);
     log("Finding...");
-
-    await this.ready;
 
     // allows searching with `id` instead of pouch's internal `_id`,
     // since we call the field `id` externally, and this approach avoids
@@ -131,10 +132,10 @@ export abstract class Databases<C extends Collections> implements Workspace<C> {
     collectionName: N,
     id: string
   ): Promise<Historical<SavedInput<C, N>> | null> {
+    await this.ready;
+
     const log = debug.extend(`${collectionName}:get`);
     log("Getting id: %s...", id);
-
-    await this.ready;
 
     try {
       const result = await this.collections[collectionName].get(id);
@@ -154,10 +155,11 @@ export abstract class Databases<C extends Collections> implements Workspace<C> {
     collectionName: N,
     input: MutationInput<C, N>
   ): Promise<MutationPayload<C, N>> {
+    await this.ready;
+
     const log = debug.extend(`${collectionName}:add`);
     log("Adding...");
 
-    await this.ready;
 
     const resourceInputById = input[collectionName]
       .map(resourceInput => ({
@@ -198,10 +200,10 @@ export abstract class Databases<C extends Collections> implements Workspace<C> {
     collectionName: M,
     input: MutationInput<C, M>
   ): Promise<MutationPayload<C, M>> {
+    await this.ready;
+
     const log = debug.extend(`${collectionName}:update`);
     log("Updating...");
-
-    await this.ready;
 
     const resourceInputById = input[collectionName]
       .map(resourceInput => ({
@@ -241,10 +243,10 @@ export abstract class Databases<C extends Collections> implements Workspace<C> {
     collectionName: M,
     input: MutationInput<C, M>
   ): Promise<void> {
+    await this.ready;
+
     const log = debug.extend(`${collectionName}:remove`);
     log("Removing...");
-
-    await this.ready;
 
     await Promise.all(
       input[collectionName].map(async resourceInput => {

--- a/packages/db/src/pouch/index.ts
+++ b/packages/db/src/pouch/index.ts
@@ -27,7 +27,10 @@ export const forDefinitions = <C extends Collections>(
 ) => (config: DatabasesConfig): Workspace<C> => {
   const { constructor, settings } = concretize<C>(config);
 
-  return new constructor({ definitions, settings });
+  debug("Initializing workspace...");
+  const workspace = new constructor({ definitions, settings });
+
+  return workspace;
 };
 
 const concretize = <C extends Collections>(
@@ -41,6 +44,7 @@ const concretize = <C extends Collections>(
     adapter: { name, settings } = { name: "fs" }
   } = config;
 
+  debug("Selecting %s adapter", name);
   switch (name) {
     case "fs": {
       return {

--- a/packages/db/src/pouch/sqlite.ts
+++ b/packages/db/src/pouch/sqlite.ts
@@ -14,7 +14,7 @@ export class SqliteDatabases<C extends Collections> extends Databases<C> {
 
   setup(options) {
     this.directory = options.settings.directory;
-    fse.ensureDir(this.directory);
+    fse.ensureDirSync(this.directory);
 
     PouchDB.plugin(PouchDBNodeWebSQLAdapter);
   }


### PR DESCRIPTION
This PR is a bit of a grab-bag to catch some things I noticed during a round of acceptance testing:

- Make a few resolvers more robust in the face of null dereference errors
- Make sure the pouch databases properly wait until everything's initialized before allowing use (this fixes some race conditions)
- Pass the entire config object to the @truffle/db server to ensure there won't be any missing fields