### PR TITLE
Add debugger support for file-level constants

### DIFF
--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -479,6 +479,7 @@ class DebugPrinter {
 
     const sectionNames = {
       builtin: "Solidity built-ins",
+      global: "Global constants",
       contract: "Contract variables",
       local: "Local variables"
     };

--- a/packages/debugger/lib/data/selectors/index.js
+++ b/packages/debugger/lib/data/selectors/index.js
@@ -613,52 +613,75 @@ const data = createSelectorTree({
           {},
           ...Object.entries(scopes).map(([id, scope]) => {
             let definition = inlined[id].definition;
-            if (definition.nodeType !== "ContractDefinition") {
-              return { [id]: scope };
-            }
-            //if we've reached this point, we should be dealing with a
-            //contract, and specifically a contract -- not an interface or
-            //library (those don't get "variables" entries in their scopes)
-            debug("contract id %d", id);
-            let newScope = { ...scope };
-            //note that Solidity gives us the linearization in order from most
-            //derived to most base, but we want most base to most derived;
-            //annoyingly, reverse() is in-place, so we clone with slice() first
-            let linearizedBaseContractsFromBase = definition.linearizedBaseContracts
-              .slice()
-              .reverse();
-            linearizedBaseContractsFromBase.pop(); //remove the last element, i.e.,
-            //the contract itself, because we want to treat that one specially
-            //now, we put it all together
-            newScope.variables = []
-              .concat(
-                //concatenate the variables lists from the base classes
-                ...linearizedBaseContractsFromBase.map(
-                  contractId => scopes[contractId].variables || []
-                  //we need the || [] because contracts with no state variables
-                  //have variables undefined rather than empty like you'd expect
+            if (definition.nodeType === "ContractDefinition") {
+              //contract definition case: process inheritance
+              debug("contract id %d", id);
+              let newScope = { ...scope };
+              //note that Solidity gives us the linearization in order from most
+              //derived to most base, but we want most base to most derived;
+              //annoyingly, reverse() is in-place, so we clone with slice() first
+              const linearizedBaseContractsFromBase = definition.linearizedBaseContracts
+                .slice()
+                .reverse();
+              linearizedBaseContractsFromBase.pop(); //remove the last element, i.e.,
+              //the contract itself, because we want to treat that one specially
+              //now, we put it all together
+              newScope.variables = []
+                .concat(
+                  //concatenate the variables lists from the base classes
+                  ...linearizedBaseContractsFromBase.map(
+                    contractId => scopes[contractId].variables || []
+                    //we need the || [] because contracts with no state variables
+                    //have variables undefined rather than empty like you'd expect
+                  )
                 )
-              )
-              .filter(
-                variable =>
-                  inlined[variable.astRef].definition.visibility !== "private"
-                //filter out private variables from the base classes
-              )
-              //add in the variables for the contract itself -- note that here
-              //private variables are not filtered out!
-              .concat(scopes[id].variables || [])
-              .filter(variable => {
+                .filter(
+                  variable =>
+                    inlined[variable.astRef].definition.visibility !== "private"
+                  //filter out private variables from the base classes
+                )
+                //add in the variables for the contract itself -- note that here
+                //private variables are not filtered out!
+                .concat(scopes[id].variables || [])
+                .filter(variable => {
+                  //HACK: let's filter out those constants we don't know
+                  //how to read.  they'll just clutter things up.
+                  debug("variable %O", variable);
+                  const definition = inlined[variable.astRef].definition;
+                  return (
+                    !definition.constant ||
+                    Codec.Ast.Utils.isSimpleConstant(definition.value)
+                  );
+                });
+              return { [id]: newScope };
+            } else if (definition.nodeType === "SourceUnit") {
+              //source unit case: process imports
+              let newScope = { ...scope };
+              //in this case, handling imports in some sort of tree fashion would
+              //be too much work.  we'll do this the easy way: by checking exported
+              //symbols for constants.
+              newScope.variables = Object.values(definition.exportedSymbols).map(
+                array => array[0] //I don't know why these are arrays...?
+              ).filter(astRef => {
                 //HACK: let's filter out those constants we don't know
                 //how to read.  they'll just clutter things up.
-                debug("variable %O", variable);
-                let definition = inlined[variable.astRef].definition;
+                //(yeah, this is copypasted with modifications)
+                const definition = inlined[astRef].definition;
                 return (
                   !definition.constant ||
                   Codec.Ast.Utils.isSimpleConstant(definition.value)
                 );
-              });
-
-            return { [id]: newScope };
+              }).map(astRef => ({
+                //we'll have to reconstruct the rest from just the astRef
+                astRef,
+                name: inlined[astRef].definition.name,
+                sourceId: inlined[astRef].sourceId
+              }));
+              return { [id]: newScope };
+            } else {
+              //default case, nothing to process
+              return { [id]: scope };
+            }
           })
         )
       ),

--- a/packages/debugger/test/data/global-const.js
+++ b/packages/debugger/test/data/global-const.js
@@ -1,0 +1,82 @@
+import debugModule from "debug";
+const debug = debugModule("test:data:global");
+
+import { assert } from "chai";
+
+import Ganache from "ganache-core";
+
+import { prepareContracts, lineOf } from "../helpers";
+import Debugger from "lib/debugger";
+
+import * as Codec from "@truffle/codec";
+
+import solidity from "lib/solidity/selectors";
+
+const __TESTER = `
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.7.4;
+
+import "./Constants.sol";
+
+uint constant unity = 1;
+
+contract ConstTest {
+  function run() public {
+  }
+}
+`;
+
+const __CONSTANTS = `
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.7.4;
+
+uint constant secret = 77;
+
+contract Dummy { //just here for artifact purposes
+}
+`;
+
+let sources = {
+  "ConstTest.sol": __TESTER,
+  "Constants.sol": __CONSTANTS
+};
+
+describe("Globally-defined constants", function() {
+  var provider;
+
+  var abstractions;
+  var compilations;
+
+  before("Create Provider", async function() {
+    provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
+  });
+
+  before("Prepare contracts and artifacts", async function() {
+    this.timeout(30000);
+
+    let prepared = await prepareContracts(provider, sources);
+    abstractions = prepared.abstractions;
+    compilations = prepared.compilations;
+  });
+
+  it("Gets globally-definedd constants, including imports", async function() {
+    this.timeout(8000);
+    let instance = await abstractions.ConstTest.deployed();
+    let receipt = await instance.run();
+    let txHash = receipt.tx;
+
+    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+
+    //file-level constants should be available right away
+    const variables = Codec.Format.Utils.Inspect.nativizeVariables(
+      await bugger.variables()
+    );
+
+    const expectedResult = {
+      unity: 1,
+      secret: 77
+    };
+
+    assert.deepInclude(variables, expectedResult);
+  });
+});

--- a/packages/debugger/test/helpers.js
+++ b/packages/debugger/test/helpers.js
@@ -25,7 +25,7 @@ export async function prepareContracts(provider, sources = {}, migrations) {
 
   config.compilers = {
     solc: {
-      version: "0.7.1",
+      version: "0.7.4",
       settings: {
         optimizer: { enabled: false, runs: 200 },
         evmVersion: "constantinople"


### PR DESCRIPTION
Solidity 0.7.4 added the ability to declare file-level constants.  This PR adds support for them in the debugger.

There are several parts to this.  Firstly, we need these to show up in `data.current.identifiers.refs`.  They show up fine in `data.current.identifiers` and `data.current.identifiers.definitions` (their scope is the whole `SourceUnit` they're declared in), but they're not in `data.current.identifiers.refs` because they never get processed for assignment by the data sagas.

So, we need them to show up there somehow.  I didn't think there was a great way of handling this via the assignments system (would they be assigned when you entered the relevant source...?) so I did it in what is maybe a hackier way: In `data.current.identifiers.refs`, any variables we can't locate an assignment for, we check their definition to see if they're a file-level constant, and if so whip up a `ref` for them as appropriate.

They also needed a new section added in `data.current.identifiers.sections`, and of course `printer.js` needed to be modified to print out this new section.

Except, if I had stopped there, there would be a problem: This would handle file-level constants just fine if they were declared in the same file, but what if they were imported?  This requires some way of processing the imports.  Specifically, this has to be done in `data.current.scopes`.  Currently we do inheritance processing there for `ContractDefinition` scopes (and leave other scopes alone), but now we'll need to do import processing for `SourceUnit` scopes.

Now if we wanted to do this the hard way, we could do something similar to how we do inheritance processing: take the variables we already have for that source unit, add in the ones from the imports, add in the ones from the imports' imports, etc.  Thing is, there's an easier way (even if, once again, it's possibly a bit hacky), so we do that instead.  Because who wants to deal with recursive import checking?  So instead we just check that source unit's list of exported symbols, and restrict to the ones that are variable declarations.  Tada, that gets us all the file-level constants visible in that source unit, regardless of how far down the import tree they are.

So, that's basically it.  Maybe a bit hacky but nothing too complicated.  Also, I added a test of this.