### PR TITLE
Enhancement: Add debugger commands to turn internal sources on/off

### DIFF
--- a/packages/core/lib/debug/interpreter.js
+++ b/packages/core/lib/debug/interpreter.js
@@ -408,6 +408,18 @@ class DebugInterpreter {
         );
       }
     }
+    if (cmd === "g") {
+      this.session.setInternalStepping(true);
+      this.printer.print(
+        "All debugger commands can now step into generated sources."
+      );
+    }
+    if (cmd === "G") {
+      this.session.setInternalStepping(false);
+      this.printer.print(
+        "Commands other than (;) and (c) will now skip over generated sources."
+      );
+    }
 
     // Check if execution has (just now) stopped.
     if (this.session.view(trace.finished) && !alreadyFinished) {
@@ -590,6 +602,8 @@ class DebugInterpreter {
         }
         break;
       case "T":
+      case "g":
+      case "G":
         //nothing to print
         break;
       default:
@@ -611,6 +625,8 @@ class DebugInterpreter {
       cmd !== "-" &&
       cmd !== "t" &&
       cmd !== "T" &&
+      cmd !== "g" &&
+      cmd !== "G" &&
       cmd !== "s"
     ) {
       this.lastCommand = cmd;

--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -29,7 +29,9 @@ const commandReference = {
   "r": "reset",
   "t": "load new transaction",
   "T": "unload transaction",
-  "s": "print stacktrace"
+  "s": "print stacktrace",
+  "g": "turn on generated sources",
+  "G": "turn off generated sources except via `;`"
 };
 
 const shortCommandReference = {
@@ -53,7 +55,9 @@ const shortCommandReference = {
   "r": "reset",
   "t": "load",
   "T": "unload",
-  "s": "stacktrace"
+  "s": "stacktrace",
+  "g": "turn on generated sources",
+  "G": "turn off generated sources"
 };
 
 const truffleColors = {
@@ -195,6 +199,7 @@ var DebugUtils = {
       ["o", "i", "u", "n"],
       ["c"],
       [";"],
+      ["g", "G"],
       ["p"],
       ["l", "s", "h"],
       ["q", "r", "t", "T"],

--- a/packages/debugger/lib/controller/actions/index.js
+++ b/packages/debugger/lib/controller/actions/index.js
@@ -65,6 +65,14 @@ export function removeAllBreakpoints() {
   };
 }
 
+export const SET_INTERNAL_STEPPING = "CONTROLLER_SET_INTERNAL_STEPPING";
+export function setInternalStepping(status) {
+  return {
+    type: SET_INTERNAL_STEPPING,
+    status
+  }
+}
+
 export const START_STEPPING = "CONTROLLER_START_STEPPING";
 export function startStepping() {
   return {

--- a/packages/debugger/lib/controller/reducers.js
+++ b/packages/debugger/lib/controller/reducers.js
@@ -55,8 +55,17 @@ function isStepping(state = false, action) {
   }
 }
 
+function stepIntoInternalSources(state = false, action) {
+  if (action.type === actions.SET_INTERNAL_STEPPING) {
+    return action.status;
+  } else {
+    return state;
+  }
+}
+
 const reducer = combineReducers({
   breakpoints,
+  stepIntoInternalSources,
   isStepping
 });
 

--- a/packages/debugger/lib/controller/sagas/index.js
+++ b/packages/debugger/lib/controller/sagas/index.js
@@ -76,6 +76,7 @@ function* advance(action) {
  */
 function* stepNext() {
   const starting = yield select(controller.current.location);
+  const allowInternal = yield select(controller.stepIntoInternalSources);
 
   let upcoming, finished;
 
@@ -92,7 +93,11 @@ function* stepNext() {
   } while (
     !finished &&
     (!upcoming ||
-      (upcoming.source.internal && !starting.source.internal) ||
+      //don't stop on an internal source unless allowInternal is on or
+      //we started in an internal source
+      (!allowInternal &&
+        upcoming.source.internal &&
+        !starting.source.internal) ||
       !upcoming.node ||
       isDeliberatelySkippedNodeType(upcoming.node) ||
       (upcoming.sourceRange.start === starting.sourceRange.start &&

--- a/packages/debugger/lib/controller/selectors/index.js
+++ b/packages/debugger/lib/controller/selectors/index.js
@@ -199,7 +199,12 @@ const controller = createSelectorTree({
   /**
    * controller.isStepping
    */
-  isStepping: createLeaf(["./state"], state => state.isStepping)
+  isStepping: createLeaf(["./state"], state => state.isStepping),
+
+  /**
+   * controller.stepIntoInternalSources
+   */
+  stepIntoInternalSources: createLeaf(["./state"], state => state.stepIntoInternalSources)
 });
 
 export default controller;

--- a/packages/debugger/lib/session/index.js
+++ b/packages/debugger/lib/session/index.js
@@ -419,6 +419,10 @@ export default class Session {
     return await this.dispatch(controller.removeAllBreakpoints());
   }
 
+  async setInternalStepping(active) {
+    return await this.dispatch(controller.setInternalStepping(active));
+  }
+
   //deprecated -- decode is now *always* ready!
   async decodeReady() {
     return true;


### PR DESCRIPTION
This PR adds two new commands to the debugger CLI, `g` and `G`.  (Not sure if these are the best letters to use but I couldn't think of anything better; they can be changed, anyhow.)

The `g` command makes it so that all debugger commands can now step into generated sources, even if not starting from inside one, instead of just `;` and `c`.  The `G` command restores the default behavior, where you can only step into a generated source if you're already inside one or use `;` (or `c` and happen to hit a breakpoint inside one).

In order to implement this, the controller now has an extra bit of state, `stepIntoInternalSources`, and there's a new session method to set this state, `setInternalStepping`.  The `stepNext` method checks this state and, if it's on, it ignores its conditions about not stopping inside an internal source unless it started one.  Since the other commands like `stepOver` and `stepInto` fundamentally rely on `stepNext`, only `stepNext` needed modifying.

And, that's really it.  Pretty simple.

I didn't add any tests in this PR; I just tested it manually.