### PR TITLE
Bug fix: Cause debugger CLI to error on invalid tx with --fetch-external

### DIFF
--- a/packages/core/lib/debug/cli.js
+++ b/packages/core/lib/debug/cli.js
@@ -101,54 +101,48 @@ class CLIDebugger {
     const startMessage = DebugUtils.formatStartMessage(
       this.txHash !== undefined
     );
-    debug("starting debugger");
-    let startSpinner;
+    let bugger;
     if (!this.config.fetchExternal) {
-      //in external mode spinner is handled below
+      //ordinary case, not doing fetch-external
+      let startSpinner;
       startSpinner = ora(startMessage).start();
-    }
-
-    //note that in external mode we start in light mode
-    //and only wake up to full mode later!
-    //note: if we are in external mode, txHash had better be defined!
-    //(this is ensured by commands/debug.js, so we don't check it ourselves)
-    const bugger = await Debugger.forProject({
-      provider: this.config.provider,
-      compilations,
-      lightMode: this.config.fetchExternal
-    });
-    if (this.txHash !== undefined) {
-      try {
-        debug("loading %s", this.txHash);
-        await bugger.load(this.txHash);
-      } catch (_) {
-        debug("loading error");
-        //on failure, stay unloaded
-        //(note we handle failing the spinner below rather than here)
-      }
-    }
-
-    debug("debugger started");
-
-    if (!this.config.fetchExternal) {
-      // check for error
-      if (bugger.view(Debugger.selectors.session.status.isError)) {
-        startSpinner.fail();
+      bugger = await Debugger.forProject({
+        provider: this.config.provider,
+        compilations
+      });
+      if (this.txHash !== undefined) {
+        try {
+          debug("loading %s", this.txHash);
+          await bugger.load(this.txHash);
+          startSpinner.succeed();
+        } catch (_) {
+          debug("loading error");
+          startSpinner.fail();
+          //just start up unloaded
+        }
       } else {
         startSpinner.succeed();
       }
     } else {
-      debug("about to fetch external sources");
+      //fetch-external case
+      //note that in this case we start in light mode
+      //and only wake up to full mode later!
+      //also, in this case, we can be sure that txHash is defined
+      bugger = await Debugger.forTx(
+        this.txHash,
+        {
+          provider: this.config.provider,
+          compilations,
+          lightMode: this.config.fetchExternal
+        }
+      ); //note: may throw!
       await this.fetchExternalSources(bugger); //note: mutates bugger!
-      startSpinner = ora(startMessage).start();
+      let startSpinner = ora(startMessage).start();
       await bugger.startFullMode();
-      if (bugger.view(Debugger.selectors.session.status.isError)) {
-        startSpinner.fail();
-      } else {
-        startSpinner.succeed();
-      }
+      //I'm removing the failure check here because I don't think that can
+      //actually happen
+      startSpinner.succeed();
     }
-
     return bugger;
   }
 

--- a/packages/core/lib/debug/interpreter.js
+++ b/packages/core/lib/debug/interpreter.js
@@ -346,7 +346,7 @@ class DebugInterpreter {
         case ";":
           //are we "finished" because we've reached the end, or because
           //nothing is loaded?
-          if (this.session.view(selectors.session.status.loaded)) {
+          if (this.session.view(session.status.loaded)) {
             this.printer.print("Transaction has halted; cannot advance.");
             this.printer.print("");
           } else {
@@ -358,7 +358,7 @@ class DebugInterpreter {
     if (cmd === "r") {
       //reset if given the reset command
       //(but not if nothing is loaded)
-      if (this.session.view(selectors.session.status.loaded)) {
+      if (this.session.view(session.status.loaded)) {
         await this.session.reset();
       } else {
         this.printer.print("No transaction loaded.");
@@ -367,7 +367,7 @@ class DebugInterpreter {
     }
     if (cmd === "t") {
       if (!this.fetchExternal) {
-        if (!this.session.view(selectors.session.status.loaded)) {
+        if (!this.session.view(session.status.loaded)) {
           let txSpinner = ora(
             DebugUtils.formatTransactionStartMessage()
           ).start();
@@ -394,7 +394,7 @@ class DebugInterpreter {
     }
     if (cmd === "T") {
       if (!this.fetchExternal) {
-        if (this.session.view(selectors.session.status.loaded)) {
+        if (this.session.view(session.status.loaded)) {
           await this.session.unload();
           this.printer.print("Transaction unloaded.");
           this.repl.setPrompt(DebugUtils.formatPrompt(this.network));
@@ -506,7 +506,7 @@ class DebugInterpreter {
           debug("location: %s", location);
           temporaryPrintouts.add(location);
         }
-        if (this.session.view(selectors.session.status.loaded)) {
+        if (this.session.view(session.status.loaded)) {
           if (this.session.view(trace.steps).length > 0) {
             this.printer.printInstruction(temporaryPrintouts);
             this.printer.printFile();
@@ -522,7 +522,7 @@ class DebugInterpreter {
         );
         break;
       case "l":
-        if (this.session.view(selectors.session.status.loaded)) {
+        if (this.session.view(session.status.loaded)) {
           this.printer.printFile();
           this.printer.printState(LINES_BEFORE_LONG, LINES_AFTER_LONG);
         }
@@ -538,7 +538,7 @@ class DebugInterpreter {
         );
         break;
       case "s":
-        if (this.session.view(selectors.session.status.loaded)) {
+        if (this.session.view(session.status.loaded)) {
           //print final report if finished & failed, intermediate if not
           if (
             this.session.view(trace.finished) &&
@@ -583,7 +583,7 @@ class DebugInterpreter {
         );
         break;
       case "r":
-        if (this.session.view(selectors.session.status.loaded)) {
+        if (this.session.view(session.status.loaded)) {
           this.printer.printAddressesAffected();
           this.printer.warnIfNoSteps();
           this.printer.printFile();
@@ -596,8 +596,8 @@ class DebugInterpreter {
           this.printer.warnIfNoSteps();
           this.printer.printFile();
           this.printer.printState();
-        } else if (this.session.view(selectors.session.status.isError)) {
-          let loadError = this.session.view(selectors.session.status.error);
+        } else if (this.session.view(session.status.isError)) {
+          let loadError = this.session.view(session.status.error);
           this.printer.print(loadError);
         }
         break;


### PR DESCRIPTION
This one's pretty simple.  Debugger CLI wouldn't error out if you tried to load an invalid transaction with `--fetch-external`.  Redid the startup so now it does.  Note I got rid of the reliance on the `session.status.isError` selector, although we still use that elsewhere.  Oh well.  Maybe we can redo that more thoroughly later.

Also, unrelated, but while I was at it I added a second commit changing `selectors.session` to just `session` everywhere in `interpreter.js` since that longhand version hasn't been necessary for a while.