### PR TITLE
feat: configurable polling interval

### DIFF
--- a/packages/hdwallet-provider/README.md
+++ b/packages/hdwallet-provider/README.md
@@ -35,6 +35,7 @@ Parameters:
 | `numberOfAddresses` | `number` | `1` | [ ] | If specified, will create `numberOfAddresses` addresses when instantiated |
 | `shareNonce` | `boolean` | `true` | [ ] | If `false`, a new WalletProvider will track its own nonce-state |
 | `derivationPath` | `string` | `"m/44'/60'/0'/0/"` | [ ] | If specified, will tell the wallet engine what derivation path should use to derive addresses. |
+| `pollingInterval` | `number` | `4000` | [ ] | If specified, will tell the wallet engine to use a custom interval when polling to track blocks. Specified in milliseconds. |
 
 Some examples can be found below:
 
@@ -63,6 +64,16 @@ provider = new HDWalletProvider({
   numberOfAddresses: 1,
   shareNonce: true,
   derivationPath: "m/44'/137'/0'/0/"
+});
+
+// To make HDWallet less "chatty" over JSON-RPC,
+// configure a higher value for the polling interval.
+provider = new HDWalletProvider({
+  mnemonic: {
+    phrase: mnemonicPhrase
+  },
+  providerOrUrl: "http://localhost:8545",
+  pollingInterval: 8000
 });
 
 // HDWalletProvider is compatible with Web3. Use it at Web3 constructor, just like any other Web3 Provider

--- a/packages/hdwallet-provider/src/constructor/Constructor.ts
+++ b/packages/hdwallet-provider/src/constructor/Constructor.ts
@@ -5,6 +5,7 @@ import {
   ProviderOrUrl,
   AddressIndex,
   NumberOfAddresses,
+  PollingInterval,
   ShareNonce,
   DerivationPath
 } from "./types";
@@ -40,6 +41,7 @@ export interface CommonOptions {
   numberOfAddresses?: NumberOfAddresses;
   shareNonce?: ShareNonce;
   derivationPath?: DerivationPath;
+  pollingInterval?: PollingInterval;
 }
 
 export type Options = SigningAuthority & CommonOptions;

--- a/packages/hdwallet-provider/src/constructor/types.ts
+++ b/packages/hdwallet-provider/src/constructor/types.ts
@@ -13,5 +13,6 @@ export type ProviderUrl = string;
 export type ProviderOrUrl = Provider | ProviderUrl;
 export type AddressIndex = number;
 export type NumberOfAddresses = number;
+export type PollingInterval = number;
 export type ShareNonce = boolean;
 export type DerivationPath = string;

--- a/packages/hdwallet-provider/src/index.ts
+++ b/packages/hdwallet-provider/src/index.ts
@@ -47,6 +47,7 @@ class HDWalletProvider {
       numberOfAddresses = 10,
       shareNonce = true,
       derivationPath = `m/44'/60'/0'/0/`,
+      pollingInterval = 4000,
 
       // what's left is either a mnemonic or a list of private keys
       ...signingAuthority
@@ -58,7 +59,9 @@ class HDWalletProvider {
     this.walletHdpath = derivationPath;
     this.wallets = {};
     this.addresses = [];
-    this.engine = new ProviderEngine();
+    this.engine = new ProviderEngine({
+      pollingInterval
+    });
 
     if (!HDWalletProvider.isValidProvider(providerOrUrl)) {
       throw new Error(

--- a/packages/hdwallet-provider/test/provider.test.ts
+++ b/packages/hdwallet-provider/test/provider.test.ts
@@ -222,6 +222,47 @@ describe("HD Wallet Provider", function () {
       }
     });
 
+    it("provides for a default polling interval", () => {
+      const mnemonicPhrase =
+        "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat";
+      provider = new HDWalletProvider({
+        mnemonic: {
+          phrase: mnemonicPhrase
+        },
+        providerOrUrl: `http://localhost:${port}`,
+        // polling interval is unspecified
+      });
+      assert.ok(provider.engine,
+        "Web3ProviderEngine instantiated");
+      assert.ok(provider.engine._blockTracker,
+        "PollingBlockTracker instantiated");
+      assert.deepEqual(
+        provider.engine._blockTracker._pollingInterval,
+        4000,
+        "PollingBlockTracker with expected pollingInterval");
+    });
+
+    it("provides for a custom polling interval", () => {
+      const mnemonicPhrase =
+        "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat";
+      provider = new HDWalletProvider({
+        mnemonic: {
+          phrase: mnemonicPhrase
+        },
+        providerOrUrl: `http://localhost:${port}`,
+        // double the default value, for less chatty JSON-RPC
+        pollingInterval: 8000,
+      });
+      assert.ok(provider.engine,
+        "Web3ProviderEngine instantiated");
+      assert.ok(provider.engine._blockTracker,
+        "PollingBlockTracker instantiated");
+      assert.deepEqual(
+        provider.engine._blockTracker._pollingInterval,
+        8000,
+        "PollingBlockTracker with expected pollingInterval");
+    });
+
     it("provides for an array of private keys", async () => {
       const privateKeys = [
         "3f841bf589fdf83a521e55d51afddc34fa65351161eead24f064855fc29c9580",


### PR DESCRIPTION
## What

- Implemented additional config option in constructor: `pollingInterval`
  - specified in ms
  - passed on to `Web3ProviderEngine` which uses the value for polling new blocks
- Added tests for both default and custom values
- Updated relevant section in docs for this

## Why

- Give developers a way to reduce "chattiness" over JSON-RPC
  - In particular, needed for `rskj`, but would be just as useful for `geth`

## Refs

- Partially resolves [#3948](https://github.com/trufflesuite/truffle/issues/3498)
- Related [stackoverflow question](https://stackoverflow.com/q/64656558/194982)

