### PR TITLE
Internal improvement: Remove callbacks from cli.js interface with the commands

### DIFF
--- a/packages/core/cli.js
+++ b/packages/core/cli.js
@@ -88,19 +88,19 @@ command
         // If a number is returned, exit with that number.
         process.exit(error);
       } else {
-        let error = error.stack || error.message || error.toString();
+        let errorData = error.stack || error.message || error.toString();
         //remove identifying information if error stack is passed to analytics
-        if (error === error.stack) {
+        if (errorData === error.stack) {
           const directory = __dirname;
           //making sure users' identifying information does not get sent to
           //analytics by cutting off everything before truffle. Will not properly catch the user's info
           //here if the user has truffle in their name.
           let identifyingInfo = String.raw`${directory.split("truffle")[0]}`;
           let removedInfo = new XRegExp(XRegExp.escape(identifyingInfo), "g");
-          error = error.replace(removedInfo, "");
+          errorData = errorData.replace(removedInfo, "");
         }
         analytics.send({
-          exception: "Other Error - " + error,
+          exception: "Other Error - " + errorData,
           version: versionInfo.bundle
             ? versionInfo.bundle
             : "(unbundled) " + versionInfo.core

--- a/packages/core/lib/command.js
+++ b/packages/core/lib/command.js
@@ -1,9 +1,9 @@
 const TaskError = require("./errors/taskerror");
 const yargs = require("yargs/yargs");
-const { bundled, core } = require("../lib/version").info();
+const {bundled, core} = require("../lib/version").info();
 const OS = require("os");
 const analytics = require("../lib/services/analytics");
-const { extractFlags } = require("./utils/utils"); // Contains utility methods
+const {extractFlags} = require("./utils/utils"); // Contains utility methods
 
 class Command {
   constructor(commands) {
@@ -72,14 +72,12 @@ class Command {
     };
   }
 
-  run(inputStrings, options, callback) {
+  async run(inputStrings, options) {
     const result = this.getCommand(inputStrings, options.noAliases);
 
     if (result == null) {
-      return callback(
-        new TaskError(
-          "Cannot find command based on input: " + JSON.stringify(inputStrings)
-        )
+      throw new TaskError(
+        "Cannot find command based on input: " + JSON.stringify(inputStrings)
       );
     }
 
@@ -101,48 +99,43 @@ class Command {
       }
     });
 
-    // Check unsupported command line flag according to the option list in help
-    try {
-      // while in `console` & `develop`, input is passed as a string, not as an array
-      if (!Array.isArray(inputStrings)) inputStrings = inputStrings.split(" ");
-      // Method `extractFlags(args)` : Extracts the `--option` flags from arguments
-      const inputOptions = extractFlags(inputStrings);
-      const validOptions = result.command.help.options
-        .map(item => {
-          let opt = item.option.split(" ")[0];
-          return opt.startsWith("--") ? opt : null;
-        })
-        .filter(item => {
-          return item != null;
-        });
-
-      let invalidOptions = inputOptions.filter(
-        opt => !validOptions.includes(opt)
-      );
-
-      // TODO: Remove exception for 'truffle run' when plugin options support added.
-      if (invalidOptions.length > 0 && result.name !== "run") {
-        if (options.logger) {
-          const log = options.logger.log || options.logger.debug;
-          log(
-            "> Warning: possible unsupported (undocumented in help) command line option: " +
-              invalidOptions
-          );
-        }
-      }
-
-      const newOptions = Object.assign({}, clone, argv);
-
-      result.command.run(newOptions, callback);
-
-      analytics.send({
-        command: result.name ? result.name : "other",
-        args: result.argv._,
-        version: bundled || "(unbundled) " + core
+    // while in `console` & `develop`, input is passed as a string, not as an array
+    if (!Array.isArray(inputStrings)) inputStrings = inputStrings.split(" ");
+    // Method `extractFlags(args)` : Extracts the `--option` flags from arguments
+    const inputOptions = extractFlags(inputStrings);
+    const validOptions = result.command.help.options
+      .map(item => {
+        let opt = item.option.split(" ")[0];
+        return opt.startsWith("--") ? opt : null;
+      })
+      .filter(item => {
+        return item != null;
       });
-    } catch (err) {
-      callback(err);
+
+    let invalidOptions = inputOptions.filter(
+      opt => !validOptions.includes(opt)
+    );
+
+    // TODO: Remove exception for 'truffle run' when plugin options support added.
+    if (invalidOptions.length > 0 && result.name !== "run") {
+      if (options.logger) {
+        const log = options.logger.log || options.logger.debug;
+        log(
+          "> Warning: possible unsupported (undocumented in help) command line option: " +
+            invalidOptions
+        );
+      }
     }
+
+    const newOptions = Object.assign({}, clone, argv);
+
+    analytics.send({
+      command: result.name ? result.name : "other",
+      args: result.argv._,
+      version: bundled || "(unbundled) " + core
+    });
+
+    return result.command.run(newOptions);
   }
 
   displayGeneralHelp() {

--- a/packages/core/lib/commands/build.js
+++ b/packages/core/lib/commands/build.js
@@ -6,7 +6,8 @@ const command = {
     usage: "truffle build",
     options: []
   },
-  run: function (options, done) {
+  run: async function (options) {
+    const { promisify } = require("util");
     const OS = require("os");
     const colors = require("colors");
     const deprecationMessage = colors.yellow(
@@ -20,7 +21,7 @@ const command = {
     const Build = require("../build");
     const config = Config.detect(options);
 
-    Build.build(config, done);
+    return promisify(Build.build)(config);
   }
 };
 

--- a/packages/core/lib/commands/build.js
+++ b/packages/core/lib/commands/build.js
@@ -7,7 +7,6 @@ const command = {
     options: []
   },
   run: async function (options) {
-    const { promisify } = require("util");
     const OS = require("os");
     const colors = require("colors");
     const deprecationMessage = colors.yellow(
@@ -21,7 +20,7 @@ const command = {
     const Build = require("../build");
     const config = Config.detect(options);
 
-    return promisify(Build.build)(config);
+    return await Build.build(config);
   }
 };
 

--- a/packages/core/lib/commands/config.js
+++ b/packages/core/lib/commands/config.js
@@ -33,9 +33,8 @@ const command = {
   /**
    * run config commands to get/set Truffle config options
    * @param {Object} options
-   * @param {Func} callback
    */
-  run: function(options, done) {
+  run: async function (options) {
     const googleAnalytics = require("../services/analytics/google.js");
     const Config = require("@truffle/config");
     const OS = require("os");
@@ -59,8 +58,7 @@ const command = {
     }
 
     if (command === null) {
-      const setAnalytics = googleAnalytics.setUserConfigViaPrompt();
-      setAnalytics.then(() => done()).catch(err => err);
+      return googleAnalytics.setUserConfigViaPrompt();
     } else if (command.userLevel) {
       switch (command.key) {
         case "analytics": {
@@ -73,29 +71,25 @@ const command = {
         }
       }
 
-      done();
+      return;
     } else {
-      Promise.resolve()
-        .then(() => {
-          const config = Config.detect(options);
+      const config = Config.detect(options);
 
-          if (command.set) {
-            options.logger.log(
-              "Setting project-level parameters is not supported yet."
-            );
-            // TODO: add support for writing project-level settings to the truffle config file
-            // config[command.key] = command.value;
-          } else {
-            options.logger.log(config[command.key]);
-          }
-        })
-        .then(done)
-        .catch(options.logger.log);
+      if (command.set) {
+        options.logger.log(
+          "Setting project-level parameters is not supported yet."
+        );
+        // TODO: add support for writing project-level settings to the truffle config file
+        // config[command.key] = command.value;
+      } else {
+        options.logger.log(config[command.key]);
+      }
+      return;
     }
   }
 };
 
-const parse = function(args) {
+const parse = function (args) {
   if (args.length === 0) {
     return null;
   }

--- a/packages/core/lib/commands/console.js
+++ b/packages/core/lib/commands/console.js
@@ -18,7 +18,8 @@ const command = {
       }
     ]
   },
-  run: function (options, done) {
+  run: async function (options) {
+    const { promisify } = require("util");
     const Config = require("@truffle/config");
     const Console = require("../console");
     const { Environment } = require("@truffle/environment");
@@ -31,21 +32,13 @@ const command = {
 
     const consoleCommands = Object.keys(commands).reduce((acc, name) => {
       return !excluded.has(name)
-        ? Object.assign(acc, { [name]: commands[name] })
+        ? Object.assign(acc, {[name]: commands[name]})
         : acc;
     }, {});
 
-    Environment.detect(config)
-      .then(() => {
-        const c = new Console(
-          consoleCommands,
-          config.with({ noAliases: true })
-        );
-        c.start(done);
-      })
-      .catch(error => {
-        done(error);
-      });
+    await Environment.detect(config);
+    const c = new Console(consoleCommands, config.with({noAliases: true}));
+    return promisify(c.start)();
   }
 };
 

--- a/packages/core/lib/commands/create/helpers.js
+++ b/packages/core/lib/commands/create/helpers.js
@@ -1,6 +1,7 @@
 const copy = require("../../copy");
 const path = require("path");
 const fs = require("fs");
+const {promisify} = require("util");
 
 const templates = {
   test: {
@@ -17,32 +18,16 @@ const templates = {
   }
 };
 
-var processFile = function (file_path, processfn, callback) {
-  fs.readFile(file_path, { encoding: "utf8" }, function (err, data) {
-    if (err != null) {
-      callback(err);
-      return;
-    }
-
-    var result = processfn(data);
-    fs.writeFile(file_path, result, { encoding: "utf8" }, callback);
-  });
+const replaceContents = function (file_path, find, replacement) {
+  const data = fs.readFileSync(file_path, {encoding: "utf8"});
+  if (typeof find === "string") {
+    find = new RegExp(find, "g");
+  }
+  const result = data.replace(find, replacement);
+  fs.writeFileSync(file_path, result, {encoding: "utf8"});
 };
 
-var replaceContents = function (file_path, find, replacement, callback) {
-  processFile(
-    file_path,
-    function (data) {
-      if (typeof find === "string") {
-        find = new RegExp(find, "g");
-      }
-      return data.replace(find, replacement);
-    },
-    callback
-  );
-};
-
-var toUnderscoreFromCamel = function (string) {
+const toUnderscoreFromCamel = function (string) {
   string = string.replace(/([A-Z])/g, function ($1) {
     return "_" + $1.toLowerCase();
   });
@@ -54,78 +39,52 @@ var toUnderscoreFromCamel = function (string) {
   return string;
 };
 
-var Create = {
-  contract: function (directory, name, options, callback) {
-    if (typeof options === "function") {
-      callback = options;
-    }
-
-    var from = templates.contract.filename;
-    var to = path.join(directory, name + ".sol");
+const Create = {
+  contract: async function (directory, name, options) {
+    const from = templates.contract.filename;
+    const to = path.join(directory, name + ".sol");
 
     if (!options.force && fs.existsSync(to)) {
-      return callback(
-        new Error("Can not create " + name + ".sol: file exists")
-      );
+      throw new Error("Can not create " + name + ".sol: file exists");
     }
 
-    copy.file(from, to, function (err) {
-      if (err) return callback(err);
+    await promisify(copy.file)(from, to);
 
-      replaceContents(to, templates.contract.name, name, callback);
-    });
+    replaceContents(to, templates.contract.name, name);
   },
 
-  test: function (directory, name, options, callback) {
-    if (typeof options === "function") {
-      callback = options;
-    }
-
-    var underscored = toUnderscoreFromCamel(name);
+  test: async function (directory, name, options) {
+    let underscored = toUnderscoreFromCamel(name);
     underscored = underscored.replace(/\./g, "_");
-    var from = templates.test.filename;
-    var to = path.join(directory, underscored + ".js");
+    const from = templates.test.filename;
+    const to = path.join(directory, underscored + ".js");
 
     if (!options.force && fs.existsSync(to)) {
-      return callback(
-        new Error("Can not create " + underscored + ".js: file exists")
-      );
+      throw new Error("Can not create " + underscored + ".js: file exists");
     }
 
-    copy.file(from, to, function (err) {
-      if (err) return callback(err);
-
-      replaceContents(to, templates.contract.name, name, function (err) {
-        if (err) return callback(err);
-        replaceContents(to, templates.contract.variable, underscored, callback);
-      });
-    });
+    await promisify(copy.file)(from, to);
+    replaceContents(to, templates.contract.name, name);
+    replaceContents(to, templates.contract.variable, underscored);
   },
 
-  migration: function (directory, name, options, callback) {
-    if (typeof options === "function") {
-      callback = options;
-    }
-
-    var underscored = toUnderscoreFromCamel(name || "");
+  migration: async function (directory, name, options) {
+    let underscored = toUnderscoreFromCamel(name || "");
     underscored = underscored.replace(/\./g, "_");
-    var from = templates.migration.filename;
-    var filename = (new Date().getTime() / 1000) | 0; // Only do seconds.
+    const from = templates.migration.filename;
+    let filename = (new Date().getTime() / 1000) | 0; // Only do seconds.
 
     if (name != null && name !== "") {
       filename += "_" + underscored;
     }
 
     filename += ".js";
-    var to = path.join(directory, filename);
+    const to = path.join(directory, filename);
 
     if (!options.force && fs.existsSync(to)) {
-      return callback(
-        new Error("Can not create " + filename + ": file exists")
-      );
+      throw new Error("Can not create " + filename + ": file exists");
     }
-
-    copy.file(from, to, callback);
+    return promisify(copy.file)(from, to);
   }
 };
 

--- a/packages/core/lib/commands/create/index.js
+++ b/packages/core/lib/commands/create/index.js
@@ -75,13 +75,13 @@ const command = {
 
     if (type === "all") {
       for (const key of Object.keys(destinations)) {
-        await promisify(create[type])(destinations[type], name, options);
+        await create[key](destinations[key], name, options);
       }
       return;
     } else if (fn == null) {
       throw new ConfigurationError(`Cannot find creation type: ${type}`);
     } else {
-      return promisify(create[type])(destinations[type], name, options);
+      return create[type](destinations[type], name, options);
     }
   }
 };

--- a/packages/core/lib/commands/create/index.js
+++ b/packages/core/lib/commands/create/index.js
@@ -28,7 +28,7 @@ const command = {
       }
     ]
   },
-  run: function (options, done) {
+  run: async function (options) {
     const Config = require("@truffle/config");
     const ConfigurationError = require("../../errors/configurationerror");
     const create = require("./helpers");
@@ -48,28 +48,20 @@ const command = {
     }
 
     if (type == null) {
-      return done(
-        new ConfigurationError(
-          "Please specify the type of item to create. Example: truffle create contract MyContract"
-        )
+      throw new ConfigurationError(
+        "Please specify the type of item to create. Example: truffle create contract MyContract"
       );
     }
 
     if (name == null) {
-      return done(
-        new ConfigurationError(
-          "Please specify the name of item to create. Example: truffle create contract MyContract"
-        )
+      throw new ConfigurationError(
+        "Please specify the name of item to create. Example: truffle create contract MyContract"
       );
     }
 
     if (!/^[a-zA-Z_$][a-zA-Z_$0-9]*$/.test(name)) {
-      return done(
-        new ConfigurationError(
-          "The name " +
-            name +
-            " is invalid. Please enter a valid name using alpha-numeric characters."
-        )
+      throw new ConfigurationError(
+        `The name ${name} is invalid. Please enter a valid name using alpha-numeric characters.`
       );
     }
 
@@ -81,13 +73,16 @@ const command = {
       test: config.test_directory
     };
 
-    if (type === "all")
-      Object.keys(destinations).forEach((type, _) =>
-        create[type](destinations[type], name, options, done)
-      );
-    else if (fn == null)
-      return done(new ConfigurationError("Cannot find creation type: " + type));
-    else create[type](destinations[type], name, options, done);
+    if (type === "all") {
+      for (const key of Object.keys(destinations)) {
+        await promisify(create[type])(destinations[type], name, options);
+      }
+      return;
+    } else if (fn == null) {
+      throw new ConfigurationError(`Cannot find creation type: ${type}`);
+    } else {
+      return promisify(create[type])(destinations[type], name, options);
+    }
   }
 };
 

--- a/packages/core/lib/commands/debug.js
+++ b/packages/core/lib/commands/debug.js
@@ -32,30 +32,27 @@ const command = {
       }
     ]
   },
-  run: function (options, done) {
+  run: async function (options) {
+    const { promisify } = require("util");
     const debugModule = require("debug");
     const debug = debugModule("lib:commands:debug");
 
-    const { Environment } = require("@truffle/environment");
+    const {Environment} = require("@truffle/environment");
     const Config = require("@truffle/config");
 
-    const { CLIDebugger } = require("../debug");
+    const {CLIDebugger} = require("../debug");
 
-    Promise.resolve()
-      .then(async () => {
-        const config = Config.detect(options);
-        await Environment.detect(config);
+    const config = Config.detect(options);
+    await Environment.detect(config);
 
-        const txHash = config._[0]; //may be undefined
-        if (config.fetchExternal && txHash === undefined) {
-          throw new Error(
-            "Fetch-external mode requires a specific transaction to debug"
-          );
-        }
-        return await new CLIDebugger(config, { txHash }).run();
-      })
-      .then(interpreter => interpreter.start(done))
-      .catch(done);
+    const txHash = config._[0]; //may be undefined
+    if (config.fetchExternal && txHash === undefined) {
+      throw new Error(
+        "Fetch-external mode requires a specific transaction to debug"
+      );
+    }
+    const interpreter = await new CLIDebugger(config, {txHash}).run();
+    return promisify(interpreter.start)();
   }
 };
 

--- a/packages/core/lib/commands/develop.js
+++ b/packages/core/lib/commands/develop.js
@@ -22,38 +22,32 @@ const command = {
       }
     ]
   },
-  runConsole: (config, ganacheOptions, done) => {
+  runConsole: async (config, ganacheOptions) => {
     const Console = require("../console");
-    const { Environment } = require("@truffle/environment");
+    const {Environment} = require("@truffle/environment");
 
     const commands = require("./index");
     const excluded = new Set(["console", "develop", "unbox", "init"]);
 
     const consoleCommands = Object.keys(commands).reduce((acc, name) => {
       return !excluded.has(name)
-        ? Object.assign(acc, { [name]: commands[name] })
+        ? Object.assign(acc, {[name]: commands[name]})
         : acc;
     }, {});
 
-    Environment.develop(config, ganacheOptions)
-      .then(() => {
-        const c = new Console(
-          consoleCommands,
-          config.with({ noAliases: true })
-        );
-        c.start(done);
-        c.on("exit", () => process.exit());
-      })
-      .catch(err => done(err));
+    await Environment.develop(config, ganacheOptions);
+    const c = new Console(consoleCommands, config.with({noAliases: true}));
+    c.on("exit", () => process.exit());
+    return c.start();
   },
-  run: (options, done) => {
-    const { Develop } = require("@truffle/environment");
+  run: async options => {
+    const {Develop} = require("@truffle/environment");
     const Config = require("@truffle/config");
 
     const config = Config.detect(options);
     const customConfig = config.networks.develop || {};
 
-    const { mnemonic, accounts, privateKeys } = mnemonicInfo.getAccountsInfo(
+    const {mnemonic, accounts, privateKeys} = mnemonicInfo.getAccountsInfo(
       customConfig.accounts || 10
     );
 
@@ -64,7 +58,7 @@ const command = {
       "This mnemonic was created for you by Truffle. It is not secure.\n" +
       "Ensure you do not use it on production blockchains, or else you risk losing funds.";
 
-    const ipcOptions = { log: options.log };
+    const ipcOptions = {log: options.log};
 
     const ganacheOptions = {
       host: customConfig.host || "127.0.0.1",
@@ -102,36 +96,35 @@ const command = {
 
     ganacheOptions.network_id = sanitizeNetworkID(ganacheOptions.network_id);
 
-    Develop.connectOrStart(ipcOptions, ganacheOptions).then(({ started }) => {
-      const url = `http://${ganacheOptions.host}:${ganacheOptions.port}/`;
+    const {started} = await Develop.connectOrStart(ipcOptions, ganacheOptions);
+    const url = `http://${ganacheOptions.host}:${ganacheOptions.port}/`;
 
-      if (started) {
-        config.logger.log(`Truffle Develop started at ${url}`);
-        config.logger.log();
+    if (started) {
+      config.logger.log(`Truffle Develop started at ${url}`);
+      config.logger.log();
 
-        config.logger.log(`Accounts:`);
-        accounts.forEach((acct, idx) => config.logger.log(`(${idx}) ${acct}`));
-        config.logger.log();
+      config.logger.log(`Accounts:`);
+      accounts.forEach((acct, idx) => config.logger.log(`(${idx}) ${acct}`));
+      config.logger.log();
 
-        config.logger.log(`Private Keys:`);
-        privateKeys.forEach((key, idx) => config.logger.log(`(${idx}) ${key}`));
-        config.logger.log();
+      config.logger.log(`Private Keys:`);
+      privateKeys.forEach((key, idx) => config.logger.log(`(${idx}) ${key}`));
+      config.logger.log();
 
-        config.logger.log(`Mnemonic: ${mnemonic}`);
-        config.logger.log();
-        config.logger.log(emoji.emojify(warning, onMissing));
-        config.logger.log();
-      } else {
-        config.logger.log(
-          `Connected to existing Truffle Develop session at ${url}`
-        );
-        config.logger.log();
-      }
+      config.logger.log(`Mnemonic: ${mnemonic}`);
+      config.logger.log();
+      config.logger.log(emoji.emojify(warning, onMissing));
+      config.logger.log();
+    } else {
+      config.logger.log(
+        `Connected to existing Truffle Develop session at ${url}`
+      );
+      config.logger.log();
+    }
 
-      if (!options.log) {
-        command.runConsole(config, ganacheOptions, done);
-      }
-    });
+    if (!options.log) {
+      return command.runConsole(config, ganacheOptions);
+    }
   }
 };
 

--- a/packages/core/lib/commands/exec.js
+++ b/packages/core/lib/commands/exec.js
@@ -35,15 +35,15 @@ const command = {
       }
     ]
   },
-  run: function (options, done) {
+  run: async function (options) {
     const Config = require("@truffle/config");
     const WorkflowCompile = require("@truffle/workflow-compile");
     const ConfigurationError = require("../errors/configurationerror");
     const Require = require("@truffle/require");
-    const { Environment } = require("@truffle/environment");
+    const {Environment} = require("@truffle/environment");
     const path = require("path");
     const OS = require("os");
-    const { promisify } = require("util");
+    const {promisify} = require("util");
 
     const config = Config.detect(options);
 
@@ -54,43 +54,30 @@ const command = {
     }
 
     if (file == null) {
-      done(
-        new ConfigurationError(
-          "Please specify a file, passing the path of the script you'd like the run. Note that all scripts *must* call process.exit() when finished."
-        )
+      throw new ConfigurationError(
+        "Please specify a file, passing the path of the script you'd like the run. Note that all scripts *must* call process.exit() when finished."
       );
-      return;
     }
 
     if (path.isAbsolute(file) === false) {
       file = path.join(process.cwd(), file);
     }
 
-    Environment.detect(config)
-      .then(() => {
-        if (config.networkHint !== false) {
-          config.logger.log("Using network '" + config.network + "'." + OS.EOL);
-        }
+    await Environment.detect(config);
+    if (config.networkHint !== false) {
+      config.logger.log("Using network '" + config.network + "'." + OS.EOL);
+    }
 
-        // `--compile`
-        if (options.c || options.compile) {
-          return WorkflowCompile.compile(config);
-        }
-        return;
-      })
-      .then(compilationOutput => {
-        // save artifacts if compilation took place
-        if (compilationOutput) {
-          return WorkflowCompile.save(config, compilationOutput);
-        }
-      })
-      .then(() => {
-        return promisify(Require.exec.bind(Require))(config.with({ file }));
-      })
-      .then(() => {
-        done();
-      })
-      .catch(done);
+    // `--compile`
+    let compilationOutput;
+    if (options.c || options.compile) {
+      compilationOutput = await WorkflowCompile.compile(config);
+    }
+    // save artifacts if compilation took place
+    if (compilationOutput) {
+      await WorkflowCompile.save(config, compilationOutput);
+    }
+    return promisify(Require.exec.bind(Require))(config.with({file}));
   }
 };
 

--- a/packages/core/lib/commands/help.js
+++ b/packages/core/lib/commands/help.js
@@ -1,4 +1,4 @@
-var command = {
+const command = {
   command: "help",
   description:
     "List all commands or provide information about a specific command",
@@ -12,17 +12,17 @@ var command = {
     ]
   },
   builder: {},
-  run: function (options, callback) {
-    var commands = require("./index");
+  run: async function (options) {
+    const commands = require("./index");
     if (options._.length === 0) {
       this.displayCommandHelp("help");
-      return callback();
+      return;
     }
-    var selectedCommand = options._[0];
+    const selectedCommand = options._[0];
 
     if (commands[selectedCommand]) {
       this.displayCommandHelp(selectedCommand);
-      return callback();
+      return;
     } else {
       console.log(`\n  Cannot find the given command '${selectedCommand}'`);
       console.log("  Please ensure your command is one of the following: ");
@@ -30,7 +30,7 @@ var command = {
         .sort()
         .forEach(command => console.log(`      ${command}`));
       console.log("");
-      return callback();
+      return;
     }
   },
   displayCommandHelp: function (selectedCommand) {

--- a/packages/core/lib/commands/init/index.js
+++ b/packages/core/lib/commands/init/index.js
@@ -14,8 +14,8 @@ const command = {
       }
     ]
   },
-  run: function (options, done) {
-    const { copyFiles } = require("./copyFiles");
+  run: async function (options) {
+    const {copyFiles} = require("./copyFiles");
     const fse = require("fs-extra");
     const Config = require("@truffle/config");
     const config = Config.default();
@@ -28,18 +28,17 @@ const command = {
       destinationPath = config.working_directory;
     }
 
-    const { events } = config;
+    const {events} = config;
     events.emit("init:start");
 
-    copyFiles(destinationPath, config)
-      .then(async () => {
-        await events.emit("init:succeed");
-        done();
-      })
-      .catch(async error => {
-        await events.emit("init:fail", { error });
-        done(error);
-      });
+    try {
+      await copyFiles(destinationPath, config);
+      await events.emit("init:succeed");
+    } catch (error) {
+      await events.emit("init:fail", {error});
+      throw error;
+    }
+    return;
   }
 };
 

--- a/packages/core/lib/commands/install.js
+++ b/packages/core/lib/commands/install.js
@@ -18,18 +18,14 @@ const command = {
       }
     ]
   },
-  run: function (options, done) {
+  run: async function (options) {
     const Config = require("@truffle/config");
     const Package = require("../package");
 
     if (options._ && options._.length > 0) options.packages = options._;
 
     const config = Config.detect(options);
-    Package.install(config)
-      .then(() => {
-        return done();
-      })
-      .catch(done);
+    return Package.install(config);
   }
 };
 

--- a/packages/core/lib/commands/networks.js
+++ b/packages/core/lib/commands/networks.js
@@ -19,21 +19,16 @@ var command = {
       }
     ]
   },
-  run: function(options, done) {
+  run: async function (options) {
     const Config = require("@truffle/config");
     const Networks = require("../networks");
 
     const config = Config.detect(options);
 
     if (options.clean) {
-      Networks.clean(config)
-        .then(() => done())
-        .catch(done);
-    } else {
-      Networks.display(config)
-        .then(() => done())
-        .catch(done);
+      return Networks.clean(config);
     }
+    return Networks.display(config);
   }
 };
 

--- a/packages/core/lib/commands/obtain.js
+++ b/packages/core/lib/commands/obtain.js
@@ -10,7 +10,7 @@ module.exports = {
       }
     ]
   },
-  run: function(options, done) {
+  run: async function (options) {
     const SUPPORTED_COMPILERS = ["--solc"];
     const Config = require("@truffle/config");
     const config = Config.default().with(options);
@@ -25,9 +25,7 @@ module.exports = {
     config.events.emit("obtain:start");
 
     if (options.solc) {
-      return this.downloadAndCacheSolc({ config, options, supplier })
-        .then(done)
-        .catch(done);
+      return this.downloadAndCacheSolc({config, options, supplier});
     }
 
     const message =
@@ -36,11 +34,11 @@ module.exports = {
       `compilers as well as a version as arguments: ` +
       `${SUPPORTED_COMPILERS.join(", ")}\nSee 'truffle help ` +
       `obtain' for more information and usage.`;
-    return done(new Error(message));
+    throw new Error(message);
   },
 
-  downloadAndCacheSolc: async ({ config, options, supplier }) => {
-    const { events } = config;
+  downloadAndCacheSolc: async ({config, options, supplier}) => {
+    const {events} = config;
     const version = options.solc;
     try {
       const solc = await supplier.downloadAndCacheSolc(version);

--- a/packages/core/lib/commands/opcode.js
+++ b/packages/core/lib/commands/opcode.js
@@ -17,55 +17,48 @@ const command = {
       }
     ]
   },
-  run: function (options, done) {
+  run: async function (options) {
     const Config = require("@truffle/config");
     const TruffleError = require("@truffle/error");
     const WorkflowCompile = require("@truffle/workflow-compile");
     const CodeUtils = require("@truffle/code-utils");
 
     if (options._.length === 0) {
-      return done(new TruffleError("Please specify a contract name."));
+      throw new TruffleError("Please specify a contract name.");
     }
 
-    var config = Config.detect(options);
-    WorkflowCompile.compileAndSave(config)
-      .then(() => {
-        const contractName = options._[0];
-        let Contract;
-        try {
-          Contract = config.resolver.require(contractName);
-        } catch (e) {
-          return done(
-            new TruffleError(
-              'Cannot find compiled contract with name "' + contractName + '"'
-            )
-          );
-        }
+    const config = Config.detect(options);
+    await WorkflowCompile.compileAndSave(config);
+    const contractName = options._[0];
+    let Contract;
+    try {
+      Contract = config.resolver.require(contractName);
+    } catch (e) {
+      throw new TruffleError(
+        'Cannot find compiled contract with name "' + contractName + '"'
+      );
+    }
 
-        let bytecode = Contract.deployedBytecode;
-        let numInstructions = Contract.deployedSourceMap.split(";").length;
+    let bytecode = Contract.deployedBytecode;
+    let numInstructions = Contract.deployedSourceMap.split(";").length;
 
-        if (options.creation) {
-          bytecode = Contract.bytecode;
-          numInstructions = Contract.sourceMap.split(";").length;
-        }
-        const opcodes = CodeUtils.parseCode(bytecode, numInstructions);
+    if (options.creation) {
+      bytecode = Contract.bytecode;
+      numInstructions = Contract.sourceMap.split(";").length;
+    }
+    const opcodes = CodeUtils.parseCode(bytecode, numInstructions);
 
-        const indexLength = (opcodes.length + "").length;
+    const indexLength = (opcodes.length + "").length;
 
-        opcodes.forEach((opcode, index) => {
-          let strIndex = index + ":";
+    opcodes.forEach((opcode, index) => {
+      let strIndex = index + ":";
 
-          while (strIndex.length < indexLength + 1) {
-            strIndex += " ";
-          }
+      while (strIndex.length < indexLength + 1) {
+        strIndex += " ";
+      }
 
-          console.log(
-            strIndex + " " + opcode.name + " " + (opcode.pushData || "")
-          );
-        });
-      })
-      .catch(done);
+      console.log(strIndex + " " + opcode.name + " " + (opcode.pushData || ""));
+    });
   }
 };
 

--- a/packages/core/lib/commands/publish.js
+++ b/packages/core/lib/commands/publish.js
@@ -1,4 +1,4 @@
-var command = {
+const command = {
   command: "publish",
   description: "Publish a package to the Ethereum Package Registry",
   builder: {},
@@ -6,16 +6,12 @@ var command = {
     usage: "truffle publish",
     options: []
   },
-  run: function (options, done) {
-    var Config = require("@truffle/config");
-    var Package = require("../package");
+  run: async function (options) {
+    const Config = require("@truffle/config");
+    const Package = require("../package");
 
-    var config = Config.detect(options);
-    Package.publish(config)
-      .then(() => {
-        return done();
-      })
-      .catch(done);
+    const config = Config.detect(options);
+    return Package.publish(config);
   }
 };
 

--- a/packages/core/lib/commands/run/index.js
+++ b/packages/core/lib/commands/run/index.js
@@ -28,7 +28,7 @@ const command = {
 
     if (config.plugins) {
       let pluginConfigs = Plugin.load(config);
-      return promisify(Run.run)(pluginConfigs, customCommand, config);
+      return promisify(Run.run).bind(Run)(pluginConfigs, customCommand, config);
     } else {
       console.error(
         "\nError: No plugins detected in the configuration file.\n"

--- a/packages/core/lib/commands/run/index.js
+++ b/packages/core/lib/commands/run/index.js
@@ -11,7 +11,8 @@ const command = {
       }
     ]
   },
-  run(options, done) {
+  async run(options) {
+    const {promisify} = require("util");
     const Config = require("@truffle/config");
     const Plugin = require("./plugin");
     const Run = require("./run");
@@ -20,19 +21,19 @@ const command = {
     if (options._.length === 0) {
       const help = require("../help");
       help.displayCommandHelp("run");
-      return done();
+      return;
     }
 
     const customCommand = options._[0];
 
     if (config.plugins) {
       let pluginConfigs = Plugin.load(config);
-      Run.run(pluginConfigs, customCommand, config, done);
+      return promisify(Run.run)(pluginConfigs, customCommand, config);
     } else {
       console.error(
         "\nError: No plugins detected in the configuration file.\n"
       );
-      done();
+      return;
     }
   }
 };

--- a/packages/core/lib/commands/test/copyArtifactsToTempDir.js
+++ b/packages/core/lib/commands/test/copyArtifactsToTempDir.js
@@ -1,5 +1,5 @@
 const copyArtifactsToTempDir = async config => {
-  const { promisify } = require("util");
+  const {promisify} = require("util");
   const copy = require("../../copy");
   const fs = require("fs");
   const OS = require("os");
@@ -16,14 +16,14 @@ const copyArtifactsToTempDir = async config => {
   try {
     fs.statSync(config.contracts_build_directory);
   } catch (_error) {
-    return { config, temporaryDirectory };
+    return {config, temporaryDirectory};
   }
 
   await promisify(copy)(config.contracts_build_directory, temporaryDirectory);
   if (config.runnerOutputOnly !== true) {
     config.logger.log("Using network '" + config.network + "'." + OS.EOL);
   }
-  return { config, temporaryDirectory };
+  return {updatedConfig: config, temporaryDirectory};
 };
 
 module.exports = {

--- a/packages/core/lib/commands/test/copyArtifactsToTempDir.js
+++ b/packages/core/lib/commands/test/copyArtifactsToTempDir.js
@@ -16,14 +16,14 @@ const copyArtifactsToTempDir = async config => {
   try {
     fs.statSync(config.contracts_build_directory);
   } catch (_error) {
-    return {config, temporaryDirectory};
+    return {temporaryDirectory};
   }
 
   await promisify(copy)(config.contracts_build_directory, temporaryDirectory);
   if (config.runnerOutputOnly !== true) {
     config.logger.log("Using network '" + config.network + "'." + OS.EOL);
   }
-  return {updatedConfig: config, temporaryDirectory};
+  return {temporaryDirectory};
 };
 
 module.exports = {

--- a/packages/core/lib/commands/test/index.js
+++ b/packages/core/lib/commands/test/index.js
@@ -13,7 +13,7 @@ const command = {
       type: "boolean",
       default: false
     },
-    debug: {
+    "debug": {
       describe: "Enable in-test debugging",
       type: "boolean",
       default: false
@@ -27,13 +27,13 @@ const command = {
       type: "boolean",
       default: false
     },
-    bail: {
+    "bail": {
       alias: "b",
       describe: "Bail after first test failure",
       type: "boolean",
       default: false
     },
-    stacktrace: {
+    "stacktrace": {
       alias: "t",
       describe: "Produce Solidity stacktraces",
       type: "boolean",
@@ -122,12 +122,12 @@ const command = {
       }
     ]
   },
-  run: function (options, done) {
+  run: async function (options) {
     const Config = require("@truffle/config");
-    const { Environment, Develop } = require("@truffle/environment");
-    const { copyArtifactsToTempDir } = require("./copyArtifactsToTempDir");
-    const { determineTestFilesToRun } = require("./determineTestFilesToRun");
-    const { prepareConfigAndRunTests } = require("./prepareConfigAndRunTests");
+    const {Environment, Develop} = require("@truffle/environment");
+    const {copyArtifactsToTempDir} = require("./copyArtifactsToTempDir");
+    const {determineTestFilesToRun} = require("./determineTestFilesToRun");
+    const {prepareConfigAndRunTests} = require("./prepareConfigAndRunTests");
 
     const config = Config.detect(options);
 
@@ -139,7 +139,7 @@ const command = {
     if (!config.network) {
       config.network = "test";
     } else {
-      Environment.detect(config).catch(done);
+      await Environment.detect(config);
     }
 
     if (config.stacktraceExtra) {
@@ -151,70 +151,54 @@ const command = {
       config.compileAll = true;
     }
 
-    let ipcDisconnect, files;
-    try {
-      const { file } = options;
-      const inputArgs = options._;
-      files = determineTestFilesToRun({
-        config,
-        inputArgs,
-        inputFile: file
-      });
-    } catch (error) {
-      return done(error);
-    }
+    const {file} = options;
+    const inputArgs = options._;
+    const files = determineTestFilesToRun({
+      config,
+      inputArgs,
+      inputFile: file
+    });
 
     if (config.networks[config.network]) {
-      Environment.detect(config)
-        .then(() => copyArtifactsToTempDir(config))
-        .then(({ config, temporaryDirectory }) => {
-          return prepareConfigAndRunTests({
-            config,
-            files,
-            temporaryDirectory
-          });
-        })
-        .then(numberOfFailures => {
-          done.call(null, numberOfFailures);
-        })
-        .catch(done);
+      await Environment.detect(config);
+      const {updatedConfig, temporaryDirectory} = await copyArtifactsToTempDir(
+        config
+      );
+      const numberOfFailures = await prepareConfigAndRunTests({
+        config: updatedConfig,
+        files,
+        temporaryDirectory
+      });
+      return numberOfFailures;
     } else {
-      const getPort = require("get-port");
-      const ipcOptions = { network: "test" };
+      const ipcOptions = {network: "test"};
+      const port = await require("get-port")();
 
-      let ganacheOptions;
-      getPort()
-        .then(port => {
-          ganacheOptions = {
-            host: "127.0.0.1",
-            port,
-            network_id: 4447,
-            mnemonic:
-              "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat",
-            gasLimit: config.gas,
-            time: config.genesis_time
-          };
-        })
-        .then(() => {
-          return Develop.connectOrStart(ipcOptions, ganacheOptions);
-        })
-        .then(({ disconnect }) => {
-          ipcDisconnect = disconnect;
-          return Environment.develop(config, ganacheOptions);
-        })
-        .then(() => copyArtifactsToTempDir(config))
-        .then(({ config, temporaryDirectory }) => {
-          return prepareConfigAndRunTests({
-            config,
-            files,
-            temporaryDirectory
-          });
-        })
-        .then(numberOfFailures => {
-          done.call(null, numberOfFailures);
-          ipcDisconnect();
-        })
-        .catch(done);
+      const ganacheOptions = {
+        host: "127.0.0.1",
+        port,
+        network_id: 4447,
+        mnemonic:
+          "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat",
+        gasLimit: config.gas,
+        time: config.genesis_time
+      };
+      const {disconnect} = await Develop.connectOrStart(
+        ipcOptions,
+        ganacheOptions
+      );
+      const ipcDisconnect = disconnect;
+      await Environment.develop(config, ganacheOptions);
+      const {updatedConfig, temporaryDirectory} = await copyArtifactsToTempDir(
+        config
+      );
+      const {numberOfFailures} = await prepareConfigAndRunTests({
+        config: updatedConfig,
+        files,
+        temporaryDirectory
+      });
+      ipcDisconnect();
+      return numberOfFailures;
     }
   }
 };

--- a/packages/core/lib/commands/test/index.js
+++ b/packages/core/lib/commands/test/index.js
@@ -161,11 +161,9 @@ const command = {
 
     if (config.networks[config.network]) {
       await Environment.detect(config);
-      const {updatedConfig, temporaryDirectory} = await copyArtifactsToTempDir(
-        config
-      );
+      const {temporaryDirectory} = await copyArtifactsToTempDir(config);
       const numberOfFailures = await prepareConfigAndRunTests({
-        config: updatedConfig,
+        config,
         files,
         temporaryDirectory
       });
@@ -189,11 +187,9 @@ const command = {
       );
       const ipcDisconnect = disconnect;
       await Environment.develop(config, ganacheOptions);
-      const {updatedConfig, temporaryDirectory} = await copyArtifactsToTempDir(
-        config
-      );
+      const {temporaryDirectory} = await copyArtifactsToTempDir(config);
       const {numberOfFailures} = await prepareConfigAndRunTests({
-        config: updatedConfig,
+        config,
         files,
         temporaryDirectory
       });

--- a/packages/core/lib/commands/unbox.js
+++ b/packages/core/lib/commands/unbox.js
@@ -36,12 +36,12 @@ const command = {
       }
     ]
   },
-  run(options, done) {
+  async run(options) {
     const Config = require("@truffle/config");
     const Box = require("@truffle/box");
     const fse = require("fs-extra");
 
-    const config = Config.default().with({ logger: console });
+    const config = Config.default().with({logger: console});
 
     let [url, destination] = options._;
 
@@ -52,16 +52,17 @@ const command = {
 
     fse.ensureDirSync(normalizedDestination);
 
-    const unboxOptions = Object.assign({}, options, { logger: config.logger });
+    const unboxOptions = Object.assign({}, options, {logger: config.logger});
 
     config.events.emit("unbox:start");
 
-    Box.unbox(url, normalizedDestination, unboxOptions, config)
-      .then(async boxConfig => {
-        await config.events.emit("unbox:succeed", { boxConfig });
-        done();
-      })
-      .catch(done);
+    const boxConfig = await Box.unbox(
+      url,
+      normalizedDestination,
+      unboxOptions,
+      config
+    );
+    await config.events.emit("unbox:succeed", {boxConfig});
   }
 };
 

--- a/packages/core/lib/commands/version.js
+++ b/packages/core/lib/commands/version.js
@@ -6,12 +6,12 @@ const command = {
     usage: "truffle version",
     options: []
   },
-  run: function(options, done) {
-    let config;
+  run: async function (options) {
     const version = require("../version");
-    const { logger } = options;
+    const {logger} = options;
     const Config = require("@truffle/config");
 
+    let config;
     try {
       config = Config.detect(options);
     } catch (error) {
@@ -19,12 +19,12 @@ const command = {
       if (error.message === "Could not find suitable configuration file.") {
         config = Config.default();
       } else {
-        return done(error);
+        throw error;
       }
     }
 
     version.logAll(logger, config);
-    done();
+    return;
   }
 };
 

--- a/packages/core/lib/commands/watch.js
+++ b/packages/core/lib/commands/watch.js
@@ -10,7 +10,7 @@ const command = {
     usage: "truffle watch",
     options: []
   },
-  run: function (options) {
+  run: async function (options) {
     const OS = require("os");
     const deprecationMessage = colors.yellow(
       `> The watch command is planned ` +

--- a/packages/core/lib/console-child.js
+++ b/packages/core/lib/console-child.js
@@ -9,7 +9,7 @@ const inputStrings = input[1];
 
 //detect config so we can get the provider and resolver without having to serialize
 //and deserialize them
-const detectedConfig = Config.detect({ network: yargs(input[0]).argv.network });
+const detectedConfig = Config.detect({network: yargs(input[0]).argv.network});
 const customConfig = detectedConfig.networks.develop || {};
 
 //need host and port for provider url
@@ -25,7 +25,7 @@ detectedConfig.networks.develop = {
   port: customConfig.port || 9545,
   network_id: customConfig.network_id || 5777,
   provider: function () {
-    return new Web3.providers.HttpProvider(url, { keepAlive: false });
+    return new Web3.providers.HttpProvider(url, {keepAlive: false});
   }
 };
 
@@ -36,8 +36,10 @@ const command =
     ? new Command(require("./commands.bundled.js"))
     : new Command(require("./commands"));
 
-command.run(inputStrings, detectedConfig, error => {
-  if (error) {
+command
+  .run(inputStrings, detectedConfig)
+  .then(() => process.exit(0))
+  .catch(error => {
     // Perform error handling ourselves.
     if (error instanceof TruffleError) {
       console.log(error.message);
@@ -46,6 +48,4 @@ command.run(inputStrings, detectedConfig, error => {
       console.log(error.stack || error.toString());
     }
     process.exit(1);
-  }
-  process.exit(0);
-});
+  });

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -76,6 +76,7 @@ class Console extends EventEmitter {
       this.repl.on("exit", () => {
         process.exit();
       });
+      return new Promise(() => {});
     } catch (error) {
       this.options.logger.log(
         "Unexpected error: Cannot provision contracts while instantiating the console."
@@ -138,7 +139,7 @@ class Console extends EventEmitter {
     });
   }
 
-  runSpawn(inputStrings, options, callback) {
+  runSpawn(inputStrings, options) {
     let childPath;
     if (typeof BUNDLE_CONSOLE_CHILD_FILENAME !== "undefined") {
       childPath = path.join(__dirname, BUNDLE_CONSOLE_CHILD_FILENAME);
@@ -149,53 +150,41 @@ class Console extends EventEmitter {
     // stderr is piped here because we don't need to repeatedly see the parent
     // errors/warnings in child process - specifically the error re: having
     // multiple config files
-    const spawnOptions = { stdio: ["inherit", "inherit", "pipe"] };
+    const spawnOptions = {stdio: ["inherit", "inherit", "pipe"]};
 
     const spawnInput = "--network " + options.network + " -- " + inputStrings;
-    try {
-      spawnSync(
-        "node",
-        ["--no-deprecation", childPath, spawnInput],
-        spawnOptions
-      );
+    spawnSync(
+      "node",
+      ["--no-deprecation", childPath, spawnInput],
+      spawnOptions
+    );
 
-      // re-provision to ensure any changes are available in the repl
-      this.provision();
-    } catch (err) {
-      callback(err);
-    }
+    // re-provision to ensure any changes are available in the repl
+    this.provision();
 
     //display prompt when child repl process is finished
     this.repl.displayPrompt();
   }
 
-  interpret(input, context, filename, callback) {
+  async interpret(input, context, filename) {
     const processedInput = processInput(input);
     if (
       this.command.getCommand(processedInput, this.options.noAliases) != null
     ) {
-      return this.runSpawn(processedInput, this.options, error => {
-        if (error) {
-          // Perform error handling ourselves.
-          if (error instanceof TruffleError) {
-            console.log(error.message);
-          } else {
-            // Bubble up all other unexpected errors.
-            console.log(error.stack || error.toString());
-          }
-          return callback();
+      try {
+        this.runSpawn(processedInput, this.options);
+        return;
+      } catch (error) {
+        // Perform error handling ourselves.
+        if (error instanceof TruffleError) {
+          console.log(error.message);
+        } else {
+          // Bubble up all other unexpected errors.
+          console.log(error.stack || error.toString());
         }
-
-        // Reprovision after each command as it may change contracts.
-        try {
-          this.provision();
-          callback();
-        } catch (error) {
-          // Don't pass abstractions to the callback if they're there or else
-          // they'll get printed in the repl.
-          callback(error);
-        }
-      });
+      }
+      // Reprovision after each command as it may change contracts.
+      this.provision();
     }
 
     // Much of the following code is from here, though spruced up:
@@ -251,29 +240,16 @@ class Console extends EventEmitter {
       return script.runInContext(context, options);
     };
 
-    let script;
-    try {
-      const options = { displayErrors: true, lineOffset: -1 };
-      script = vm.createScript(source, options);
-    } catch (error) {
-      // If syntax error, or similar, bail.
-      return callback(error);
-    }
+    const options = {displayErrors: true, lineOffset: -1};
+    const script = vm.createScript(source, options);
 
     // Ensure our script returns a promise whether we're using an
     // async function or not. If our script is an async function,
     // this will ensure the console waits until that await is finished.
-    Promise.resolve(runScript(script))
-      .then(value => {
-        // If there's an assignment to run, run that.
-        if (assignment) return runScript(vm.createScript(assignment));
-        return value;
-      })
-      .then(value => {
-        // All good? Return the value (e.g., eval'd script or assignment)
-        callback(null, value);
-      })
-      .catch(callback);
+    const value = await Promise.resolve(runScript(script));
+    // If there's an assignment to run, run that.
+    if (assignment) return runScript(vm.createScript(assignment));
+    return value;
   }
 }
 

--- a/packages/core/test/lib/commands/compile.js
+++ b/packages/core/test/lib/commands/compile.js
@@ -26,22 +26,18 @@ describe("compile", function () {
       }
     };
     config.network = "default";
-    config.logger = { log: val => val && memStream.write(val) };
+    config.logger = {log: val => val && memStream.write(val)};
   });
 
-  after("Cleanup tmp files", function (done) {
-    glob("tmp-*", (err, files) => {
-      if (err) done(err);
-      files.forEach(file => fs.removeSync(file));
-      done();
-    });
+  after("Cleanup tmp files", async () => {
+    const files = glob.sync("tmp-*");
+    files.forEach(file => fs.removeSync(file));
   });
 
   afterEach("Clear MemoryStream", () => (output = ""));
 
-  it("compiles all initial contracts", async function () {
-    this.timeout(10000);
-    const { contracts } = await WorkflowCompile.compileAndSave(
+  it("compiles all initial contracts", async () => {
+    const {contracts} = await WorkflowCompile.compileAndSave(
       config.with({
         all: false,
         quiet: true
@@ -54,9 +50,8 @@ describe("compile", function () {
     );
   });
 
-  it("compiles no contracts after no updates", async function () {
-    this.timeout(10000);
-    const { contracts } = await WorkflowCompile.compileAndSave(
+  it("compiles no contracts after no updates", async () => {
+    const {contracts} = await WorkflowCompile.compileAndSave(
       config.with({
         all: false,
         quiet: true
@@ -69,19 +64,17 @@ describe("compile", function () {
     );
   });
 
-  it("compiles updated contract and its ancestors", async function () {
-    this.timeout(10000);
-
-    var file_to_update = path.resolve(
+  it("compiles updated contract and its ancestors", async () => {
+    const fileToUpdate = path.resolve(
       path.join(config.contracts_directory, "ConvertLib.sol")
     );
-    var stat = fs.statSync(file_to_update);
+    const stat = fs.statSync(fileToUpdate);
 
     // Update the modification time to simulate an edit.
-    var newTime = new Date().getTime();
-    fs.utimesSync(file_to_update, newTime, newTime);
+    const newTime = new Date().getTime();
+    fs.utimesSync(fileToUpdate, newTime, newTime);
 
-    const { contracts } = await WorkflowCompile.compileAndSave(
+    const {contracts} = await WorkflowCompile.compileAndSave(
       config.with({
         all: false,
         quiet: true
@@ -94,11 +87,11 @@ describe("compile", function () {
     );
 
     // reset time
-    fs.utimesSync(file_to_update, stat.atime, stat.mtime);
+    fs.utimesSync(fileToUpdate, stat.atime, stat.mtime);
   });
 
   it("compiling shouldn't create any network artifacts", function () {
-    var contract = config.resolver.require("MetaCoin.sol");
+    const contract = config.resolver.require("MetaCoin.sol");
     assert.equal(
       Object.keys(contract.networks).length,
       0,
@@ -114,67 +107,46 @@ describe("compile", function () {
       });
     });
 
-    it("prints a truncated list of solcjs versions", function (done) {
-      this.timeout(5000);
-
+    it("prints a truncated list of solcjs versions", async () => {
       const options = {
         list: ""
       };
 
-      command.run(config.with(options), err => {
-        if (err) return done(err);
-
-        memStream.on("end", function () {
-          const arr = JSON.parse(output);
-          assert(arr.length === 11);
-          done();
-        });
-
-        memStream.end("");
+      await command.run(config.with(options));
+      memStream.on("end", () => {
+        const arr = JSON.parse(output);
+        assert(arr.length === 11);
       });
+      memStream.end("");
     });
 
-    it("prints a list of docker tags", function (done) {
-      this.timeout(20000);
-
+    it("prints a list of docker tags", async () => {
       const options = {
         list: "docker"
       };
 
-      command.run(config.with(options), err => {
-        if (err) return done(err);
-
-        memStream.on("end", function () {
-          const arr = JSON.parse(output);
-          assert(arr.length === 11);
-          assert(typeof arr[0] === "string");
-          done();
-        });
-
-        memStream.end("");
+      await command.run(config.with(options));
+      memStream.on("end", () => {
+        const arr = JSON.parse(output);
+        assert(arr.length === 11);
+        assert(typeof arr[0] === "string");
       });
+      memStream.end("");
     });
 
-    it("prints a full list of releases when --all is set", function (done) {
-      this.timeout(5000);
-
+    it("prints a full list of releases when --all is set", async () => {
       const options = {
         list: "releases",
         all: true
       };
 
-      command.run(config.with(options), err => {
-        if (err) return done(err);
-
-        memStream.on("end", function () {
-          const arr = JSON.parse(output);
-          assert(arr.length > 11);
-          assert(typeof arr[0] === "string");
-          done();
-        });
-
-        memStream.end("");
+      await command.run(config.with(options));
+      memStream.on("end", () => {
+        const arr = JSON.parse(output);
+        assert(arr.length > 11);
+        assert(typeof arr[0] === "string");
       });
+      memStream.end("");
     });
   });
-}).timeout(10000);
+});

--- a/packages/core/test/lib/commands/config.js
+++ b/packages/core/test/lib/commands/config.js
@@ -9,10 +9,10 @@ const fs = require("fs-extra");
 const glob = require("glob");
 const Config = require("@truffle/config");
 
-describe("config", function() {
-  var config;
-  var output = "";
-  var memStream;
+describe("config", function () {
+  let config;
+  let output = "";
+  let memStream;
 
   before("Create a sandbox", async () => {
     config = await Box.sandbox("default");
@@ -27,22 +27,19 @@ describe("config", function() {
       }
     };
     config.network = "default";
-    config.logger = { log: val => val && memStream.write(val) };
+    config.logger = {log: val => val && memStream.write(val)};
   });
 
   beforeEach(() => {
     memStream = new MemoryStream();
-    memStream.on("data", function(data) {
+    memStream.on("data", data => {
       output += data.toString();
     });
   });
 
-  after("Cleanup tmp files", function(done) {
-    glob("tmp-*", (err, files) => {
-      if (err) done(err);
-      files.forEach(file => fs.removeSync(file));
-      done();
-    });
+  after("Cleanup tmp files", async () => {
+    const files = glob.sync("tmp-*");
+    files.forEach(file => fs.removeSync(file));
   });
 
   afterEach("Clear MemoryStream", () => {
@@ -50,45 +47,32 @@ describe("config", function() {
     output = "";
   });
 
-  it("retrieves the default migrations directory", function(done) {
-    command.run(
-      {
-        working_directory: config.working_directory,
-        _: ["get", "migrations_directory"],
-        logger: config.logger
-      },
-      () => {
-        const expected = path.join(config.working_directory, "./migrations");
-        assert.equal(output, expected);
-        done();
-      }
-    );
+  it("retrieves the default migrations directory", async () => {
+    await command.run({
+      working_directory: config.working_directory,
+      _: ["get", "migrations_directory"],
+      logger: config.logger
+    });
+    const expected = path.join(config.working_directory, "./migrations");
+    assert.equal(output, expected);
   });
 
-  it("retrieves an adjusted migrations directory", function(done) {
+  it("retrieves an adjusted migrations directory", async () => {
     const configFile = Config.search({
       working_directory: config.working_directory
     });
     fs.writeFileSync(
       configFile,
       "module.exports = { migrations_directory: './a-different-dir' };",
-      { encoding: "utf8" }
+      {encoding: "utf8"}
     );
 
-    command.run(
-      {
-        working_directory: config.working_directory,
-        _: ["get", "migrations_directory"],
-        logger: config.logger
-      },
-      () => {
-        const expected = path.join(
-          config.working_directory,
-          "./a-different-dir"
-        );
-        assert.equal(output, expected);
-        done();
-      }
-    );
+    await command.run({
+      working_directory: config.working_directory,
+      _: ["get", "migrations_directory"],
+      logger: config.logger
+    });
+    const expected = path.join(config.working_directory, "./a-different-dir");
+    assert.equal(output, expected);
   });
 });

--- a/packages/core/test/lib/commands/obtain.js
+++ b/packages/core/test/lib/commands/obtain.js
@@ -2,14 +2,13 @@ const assert = require("chai").assert;
 const command = require("../../../lib/commands/obtain");
 const sinon = require("sinon");
 const CompilerSupplier = require("@truffle/compile-solidity").CompilerSupplier;
-let options, done, solc;
+let options, solc;
 
 describe("obtain", () => {
-  describe(".run(options, done)", () => {
+  describe(".run(options)", () => {
     beforeEach(() => {
-      options = { solc: "0.5.3" };
-      done = () => {};
-      solc = { version: () => "0.5.3" };
+      options = {solc: "0.5.3"};
+      solc = {version: () => "0.5.3"};
       sinon
         .stub(CompilerSupplier.prototype, "downloadAndCacheSolc")
         .returns(solc);
@@ -19,21 +18,28 @@ describe("obtain", () => {
     });
 
     it("calls downloadAndCacheSolc on the supplier with the version", async () => {
-      await command.run(options, done);
+      await command.run(options);
       assert(
         CompilerSupplier.prototype.downloadAndCacheSolc.calledWith("0.5.3")
       );
     });
 
-    describe("when options.solc is present", () => {
+    describe("when options.solc is not present", () => {
       beforeEach(() => {
         options.solc = undefined;
-        done = input => input;
       });
 
-      it("calls done with an error", async () => {
-        let returnValue = await command.run(options, done);
-        assert.instanceOf(returnValue, Error);
+      it("throws an error", async () => {
+        try {
+          await command.run(options);
+          assert.fail("The run command should have failed");
+        } catch (error) {
+          assert(
+            error.message.includes(
+              "You have specified a compiler that is unsupported"
+            )
+          );
+        }
       });
     });
   });

--- a/packages/core/test/lib/commands/unbox.js
+++ b/packages/core/test/lib/commands/unbox.js
@@ -26,13 +26,13 @@ describe("commands/unbox.js", () => {
         unsafeCleanup: true
       });
       mockConfig = Config.default().with({
-        logger: { log: () => {} },
+        logger: {log: () => {}},
         working_directory: tempDir.name
       });
       mockConfig.events = {
         emit: () => {}
       };
-      sinon.stub(Config, "default").returns({ with: () => mockConfig });
+      sinon.stub(Config, "default").returns({with: () => mockConfig});
     });
     afterEach(() => {
       Config.default.restore();
@@ -43,13 +43,10 @@ describe("commands/unbox.js", () => {
         const promises = [];
         for (const path of invalidBoxFormats) {
           promises.push(
-            new Promise(resolve => {
-              const callback = error => {
-                error ? assert(true) : assert(false);
-                resolve();
-              };
-              unbox.run({ _: [`${path}`] }, callback);
-            })
+            unbox
+              .run({_: [`${path}`]})
+              .then(() => assert.fail())
+              .catch(_error => assert(true))
           );
         }
         return Promise.all(promises);
@@ -57,16 +54,17 @@ describe("commands/unbox.js", () => {
     });
 
     describe("successful unboxes", () => {
-      it("runs when passed valid box input", done => {
+      it("runs when passed valid box input", async () => {
         let promises = [];
         validBoxInput.forEach(val => {
           promises.push(
-            new Promise(resolve => {
-              unbox.run({ _: [`${val}`], force: true }, () => resolve());
-            })
+            unbox
+              .run({_: [`${val}`], force: true})
+              .then(() => assert(true))
+              .catch(_error => assert.fail())
           );
         });
-        Promise.all(promises).then(() => done());
+        return Promise.all(promises);
       }).timeout(10000);
     });
   });

--- a/packages/core/test/lib/create.js
+++ b/packages/core/test/lib/create.js
@@ -16,136 +16,107 @@ describe("create", function () {
     config.artifactor = new Artifactor(config.contracts_build_directory);
   });
 
-  after("Cleanup tmp files", function (done) {
-    glob("tmp-*", (err, files) => {
-      if (err) done(err);
-      files.forEach(file => fse.removeSync(file));
-      done();
-    });
+  after("Cleanup tmp files", async () => {
+    const files = glob.sync("tmp-*");
+    files.forEach(file => fse.removeSync(file));
   });
 
-  it("creates a new contract", function (done) {
-    Create.contract(config.contracts_directory, "MyNewContract", function (
-      err
-    ) {
-      if (err) return done(err);
+  it("creates a new contract", async () => {
+    await Create.contract(config.contracts_directory, "MyNewContract", {});
 
-      const expectedFile = path.join(
-        config.contracts_directory,
-        "MyNewContract.sol"
-      );
-      assert.isTrue(
-        fse.existsSync(expectedFile),
-        `Contract to be created doesns't exist, ${expectedFile}`
-      );
+    const expectedFile = path.join(
+      config.contracts_directory,
+      "MyNewContract.sol"
+    );
+    assert.isTrue(
+      fse.existsSync(expectedFile),
+      `Contract to be created doesns't exist, ${expectedFile}`
+    );
 
-      const fileData = fse.readFileSync(expectedFile, { encoding: "utf8" });
-      assert.isNotNull(fileData, "File's data is null");
-      assert.notEqual(fileData, "", "File's data is blank");
-      assert.isTrue(
-        fileData.includes("pragma solidity >=0.4.22 <0.8.0;"),
-        "File's solidity version does not match >=0.4.22 <0.8.0"
-      );
-      done();
-    });
+    const fileData = fse.readFileSync(expectedFile, {encoding: "utf8"});
+    assert.isNotNull(fileData, "File's data is null");
+    assert.notEqual(fileData, "", "File's data is blank");
+    assert.isTrue(
+      fileData.includes("pragma solidity >=0.4.22 <0.8.0;"),
+      "File's solidity version does not match >=0.4.22 <0.8.0"
+    );
   });
 
-  it("will not overwrite an existing contract (by default)", function (done) {
-    Create.contract(config.contracts_directory, "MyNewContract2", function (
-      err
-    ) {
-      if (err) return done(err);
+  it("will not overwrite an existing contract (by default)", async () => {
+    await Create.contract(config.contracts_directory, "MyNewContract2", {});
 
-      const expectedFile = path.join(
-        config.contracts_directory,
-        "MyNewContract2.sol"
-      );
-      assert.isTrue(
-        fse.existsSync(expectedFile),
-        `Contract to be created doesns't exist, ${expectedFile}`
-      );
+    const expectedFile = path.join(
+      config.contracts_directory,
+      "MyNewContract2.sol"
+    );
+    assert.isTrue(
+      fse.existsSync(expectedFile),
+      `Contract to be created doesn't exist, ${expectedFile}`
+    );
 
-      Create.contract(config.contracts_directory, "MyNewContract2", function (
-        err
+    try {
+      await Create.contract(config.contracts_directory, "MyNewContract2", {});
+      assert.fail();
+    } catch (error) {
+      assert(error.message.includes("file exists"));
+    }
+  });
+
+  it("will overwrite an existing contract if the force option is enabled", async () => {
+    await Create.contract(config.contracts_directory, "MyNewContract3", {});
+
+    const expectedFile = path.join(
+      config.contracts_directory,
+      "MyNewContract3.sol"
+    );
+    assert.isTrue(
+      fse.existsSync(expectedFile),
+      `Contract to be created doesns't exist, ${expectedFile}`
+    );
+
+    const options = {force: true};
+    await Create.contract(
+      config.contracts_directory,
+      "MyNewContract3",
+      options
+    );
+  });
+
+  it("creates a new test", async () => {
+    await Create.test(config.test_directory, "MyNewTest", {});
+
+    const expectedFile = path.join(config.test_directory, "my_new_test.js");
+    assert.isTrue(
+      fse.existsSync(expectedFile),
+      `Test to be created doesns't exist, ${expectedFile}`
+    );
+
+    const fileData = fse.readFileSync(expectedFile, {encoding: "utf8"});
+    assert.isNotNull(fileData, "File's data is null");
+    assert.notEqual(fileData, "", "File's data is blank");
+  });
+
+  it("creates a new migration", async () => {
+    await Create.migration(config.migrations_directory, "MyNewMigration", {});
+    const files = glob.sync(`${config.migrations_directory}${path.sep}*`);
+
+    const found = false;
+    const expectedSuffix = "_my_new_migration.js";
+
+    for (let file of files) {
+      if (
+        file.indexOf(expectedSuffix) ===
+        file.length - expectedSuffix.length
       ) {
-        assert(err.message.includes("file exists"));
-        done();
-      });
-    });
-  });
-
-  it("will overwrite an existing contract if the force option is enabled", function (done) {
-    Create.contract(config.contracts_directory, "MyNewContract3", function (
-      err
-    ) {
-      if (err) return done(err);
-
-      const expectedFile = path.join(
-        config.contracts_directory,
-        "MyNewContract3.sol"
-      );
-      assert.isTrue(
-        fse.existsSync(expectedFile),
-        `Contract to be created doesns't exist, ${expectedFile}`
-      );
-
-      const options = { force: true };
-      Create.contract(
-        config.contracts_directory,
-        "MyNewContract3",
-        options,
-        function (err) {
-          assert(err === null);
-          done();
-        }
-      );
-    });
-  });
-
-  it("creates a new test", function (done) {
-    Create.test(config.test_directory, "MyNewTest", function (err) {
-      if (err) return done(err);
-
-      const expectedFile = path.join(config.test_directory, "my_new_test.js");
-      assert.isTrue(
-        fse.existsSync(expectedFile),
-        `Test to be created doesns't exist, ${expectedFile}`
-      );
-
-      const fileData = fse.readFileSync(expectedFile, { encoding: "utf8" });
-      assert.isNotNull(fileData, "File's data is null");
-      assert.notEqual(fileData, "", "File's data is blank");
-
-      done();
-    });
-  }); // it
-
-  it("creates a new migration", function (done) {
-    Create.migration(config.migrations_directory, "MyNewMigration", function (
-      err
-    ) {
-      if (err) return done(err);
-      const files = glob.sync(`${config.migrations_directory}${path.sep}*`);
-
-      const found = false;
-      const expectedSuffix = "_my_new_migration.js";
-
-      for (let file of files) {
-        if (
-          file.indexOf(expectedSuffix) ===
-          file.length - expectedSuffix.length
-        ) {
-          const fileData = fse.readFileSync(file, { encoding: "utf8" });
-          assert.isNotNull(fileData, "File's data is null");
-          assert.notEqual(fileData, "", "File's data is blank");
-
-          return done();
-        }
+        const fileData = fse.readFileSync(file, {encoding: "utf8"});
+        assert.isNotNull(fileData, "File's data is null");
+        assert.notEqual(fileData, "", "File's data is blank");
+        return;
       }
+    }
 
-      if (found === false) {
-        assert.fail("Could not find a file that matched expected name");
-      }
-    });
-  }); // it
+    if (found === false) {
+      assert.fail("Could not find a file that matched expected name");
+    }
+  });
 }).timeout(10000);

--- a/packages/truffle/scripts/test.sh
+++ b/packages/truffle/scripts/test.sh
@@ -7,9 +7,9 @@ if [ "$GETH" == true ]; then
 elif [ "$FABRICEVM" == true ]; then
   mocha --timeout 50000 --grep @fabric-evm --colors $@
 elif [ "$COVERAGE" == true ]; then
-  NO_BUILD=true mocha --no-warnings --timeout 7000 --grep @geth --invert --colors $@
+  NO_BUILD=true mocha --no-warnings --timeout 20000 --grep @geth --invert --colors $@
 elif [ "$INTEGRATION" == true ]; then
-  mocha --no-warnings --timeout 7000 --grep @geth --invert --colors $@
+  mocha --no-warnings --timeout 20000 --grep @geth --invert --colors $@
 else
-  yarn build && mocha --no-warnings --timeout 7000 --grep @geth --invert --colors $@
+  yarn build && mocha --no-warnings --timeout 20000 --grep @geth --invert --colors $@
 fi

--- a/packages/truffle/test/scenarios/commandrunner.js
+++ b/packages/truffle/test/scenarios/commandrunner.js
@@ -17,11 +17,11 @@ module.exports = {
           " " +
           command);
 
-    let child = exec(execString, {
-      cwd: config.working_directory
-    });
-
     return new Promise((resolve, reject) => {
+      let child = exec(execString, {
+        cwd: config.working_directory
+      });
+
       child.stdout.on("data", data => {
         data = data.toString().replace(/\n$/, "");
         config.logger.log(data);
@@ -33,15 +33,13 @@ module.exports = {
       child.on("close", code => {
         // If the command didn't exit properly, show the output and throw.
         if (code !== 0) {
-          const err = new Error("Unknown exit code: " + code);
-          reject(err);
+          reject(new Error("Unknown exit code: " + code));
         }
-
         resolve();
       });
 
       if (child.error) {
-        throw child.error;
+        reject(child.error);
       }
     });
   }

--- a/packages/truffle/test/scenarios/commands/build.js
+++ b/packages/truffle/test/scenarios/commands/build.js
@@ -9,8 +9,7 @@ describe("truffle build [ @standalone ]", () => {
   let config, project;
 
   describe("when there is no build script in config", () => {
-    beforeEach("set up sandbox", function () {
-      this.timeout(10000);
+    beforeEach("set up sandbox", () => {
       project = path.join(
         __dirname,
         "../../sources/build/projectWithoutBuildScript"
@@ -33,12 +32,11 @@ describe("truffle build [ @standalone ]", () => {
       await CommandRunner.run("build", config);
       const output = logger.contents();
       assert(output.includes("No build configuration found."));
-    }).timeout(20000);
+    });
   });
 
   describe("when there is a proper build config", () => {
-    beforeEach("set up sandbox", function () {
-      this.timeout(10000);
+    beforeEach("set up sandbox", () => {
       project = path.join(
         __dirname,
         "../../sources/build/projectWithBuildScript"
@@ -48,8 +46,7 @@ describe("truffle build [ @standalone ]", () => {
         config.logger = logger;
       });
     });
-    it("runs the build script", async function () {
-      this.timeout(10000);
+    it("runs the build script", async () => {
       await CommandRunner.run("build", config);
       const output = logger.contents();
       assert(output.includes("'this is the build script'"));
@@ -57,8 +54,7 @@ describe("truffle build [ @standalone ]", () => {
   });
 
   describe("when there is an object in the build config", () => {
-    beforeEach("set up sandbox", function () {
-      this.timeout(10000);
+    beforeEach("set up sandbox", () => {
       project = path.join(
         __dirname,
         "../../sources/build/projectWithObjectInBuildScript"
@@ -68,11 +64,9 @@ describe("truffle build [ @standalone ]", () => {
         config.logger = logger;
       });
     });
-    it("tells the user it shouldn't use an object", async function () {
-      this.timeout(12000);
+    it("tells the user it shouldn't use an object", async () => {
       try {
         await CommandRunner.run("build", config);
-        assert(false, "The process should have exited with code 1");
       } catch (error) {
         const output = logger.contents();
         assert(


### PR DESCRIPTION
This PR aims to get rid of the callback interface used by `packages/core/cli.js`. Currently it takes a callback as the last argument. The idea is that it would be much easier to reason about all this stuff if instead this returned a Promise. All of the command files' `run` methods are updated to return a Promise.