### PR TITLE
Enhancement: The visualizer (v1: Function calls and such)

### DIFF
--- a/packages/codec/lib/core.ts
+++ b/packages/codec/lib/core.ts
@@ -79,7 +79,9 @@ export function* decodeCalldata(
   let selector: string;
   //first: is this a creation call?
   if (isConstructor) {
-    allocation = allocations.constructorAllocations[contextHash].input;
+    allocation = (
+      allocations.constructorAllocations[contextHash] || { input: undefined }
+    ).input;
   } else {
     //skipping any error-handling on this read, as a calldata read can't throw anyway
     let rawSelector = yield* read(
@@ -92,7 +94,7 @@ export function* decodeCalldata(
     );
     selector = Conversion.toHexString(rawSelector);
     allocation = (
-      allocations.functionAllocations[contextHash][selector] || {
+      (allocations.functionAllocations[contextHash] || {})[selector] || {
         input: undefined
       }
     ).input;

--- a/packages/debugger/lib/controller/sagas/index.js
+++ b/packages/debugger/lib/controller/sagas/index.js
@@ -7,6 +7,7 @@ import { prefixName, isDeliberatelySkippedNodeType } from "lib/helpers";
 
 import * as trace from "lib/trace/sagas";
 import * as data from "lib/data/sagas";
+import * as txlog from "lib/txlog/sagas";
 import * as evm from "lib/evm/sagas";
 import * as solidity from "lib/solidity/sagas";
 import * as stacktrace from "lib/stacktrace/sagas";
@@ -276,4 +277,5 @@ export function* reset() {
   yield* solidity.reset();
   yield* trace.reset();
   yield* stacktrace.reset();
+  yield* txlog.reset();
 }

--- a/packages/debugger/lib/data/sagas/index.js
+++ b/packages/debugger/lib/data/sagas/index.js
@@ -131,6 +131,7 @@ export function* decodeReturnValue() {
   const contexts = yield select(data.views.contexts);
   const status = yield select(data.current.returnStatus); //may be undefined
   const returnAllocation = yield select(data.current.returnAllocation); //may be null
+  debug("returnAllocation: %O", returnAllocation);
 
   const decoder = Codec.decodeReturndata(
     {
@@ -141,6 +142,70 @@ export function* decodeReturnValue() {
     },
     returnAllocation,
     status
+  );
+
+  debug("beginning decoding");
+  let result = decoder.next();
+  while (!result.done) {
+    debug("request received");
+    let request = result.value;
+    let response;
+    switch (request.type) {
+      //skip storage case, it won't happen here
+      case "code":
+        response = yield* requestCode(request.address);
+        break;
+      default:
+        debug("unrecognized request type!");
+    }
+    debug("sending response");
+    result = decoder.next(response);
+  }
+  //at this point, result.value holds the final value
+  debug("done decoding");
+  return result.value;
+}
+
+//by default, decodes the call being made at the current step;
+//if the flag is passed, instead decodes the call you're currently in
+export function* decodeCall(decodeCurrent = false) {
+  const isCall = yield select(data.current.isCall);
+  const isCreate = yield select(data.current.isCreate);
+  if (!isCall && !isCreate && !decodeCurrent) {
+    return null;
+  }
+  const currentCallIsCreate = yield select(data.current.currentCallIsCreate);
+  const userDefinedTypes = yield select(data.views.userDefinedTypes);
+  let state = decodeCurrent
+    ? yield select(data.current.state)
+    : yield select(data.next.state);
+  if (decodeCurrent && currentCallIsCreate) {
+    //if we want to decode the *current* call, but the current call
+    //is a creation, we had better pass in the code, not the calldata
+    state = {
+      ...state,
+      calldata: yield select(data.current.state.code)
+    };
+  }
+  const allocations = yield select(data.info.allocations);
+  debug("allocations: %O", allocations);
+  const contexts = yield select(data.views.contexts);
+  const context = decodeCurrent
+    ? yield select(data.current.context)
+    : yield select(data.current.callContext);
+  const isConstructor = decodeCurrent
+    ? yield select(data.current.currentCallIsCreate)
+    : isCreate;
+
+  const decoder = Codec.decodeCalldata(
+    {
+      state,
+      userDefinedTypes,
+      allocations,
+      contexts,
+      currentContext: context
+    },
+    isConstructor
   );
 
   debug("beginning decoding");

--- a/packages/debugger/lib/data/sagas/index.js
+++ b/packages/debugger/lib/data/sagas/index.js
@@ -184,7 +184,7 @@ export function* decodeCall(decodeCurrent = false) {
     //is a creation, we had better pass in the code, not the calldata
     state = {
       ...state,
-      calldata: yield select(data.current.state.code)
+      calldata: state.code
     };
   }
   const allocations = yield select(data.info.allocations);

--- a/packages/debugger/lib/data/selectors/index.js
+++ b/packages/debugger/lib/data/selectors/index.js
@@ -107,6 +107,10 @@ function debuggerContextToDecoderContext(context) {
     contractKind,
     isConstructor,
     abi: Codec.AbiData.Utils.computeSelectors(abi),
+    fallbackAbi: {
+      fallback: (abi || []).find(item => item.type === "fallback") || null,
+      receive: (abi || []).find(item => item.type === "receive") || null
+    },
     payable,
     compiler,
     compilationId
@@ -895,7 +899,7 @@ const data = createSelectorTree({
       }
     ),
 
-    /*
+    /**
      * data.current.inModifier
      */
     inModifier: createLeaf(
@@ -903,7 +907,7 @@ const data = createSelectorTree({
       node => node && node.nodeType === "ModifierDefinition"
     ),
 
-    /*
+    /**
      * data.current.inFunctionOrModifier
      */
     inFunctionOrModifier: createLeaf(
@@ -1414,6 +1418,33 @@ const data = createSelectorTree({
           return allocation.output;
         }
       }
+    ),
+
+    /**
+     * data.current.isCall
+     */
+    isCall: createLeaf([evm.current.step.isCall], identity),
+
+    /**
+     * data.current.isCreate
+     */
+    isCreate: createLeaf([evm.current.step.isCreate], identity),
+
+    /**
+     * data.current.currentCallIsCreate
+     */
+    currentCallIsCreate: createLeaf(
+      [evm.current.call],
+      call => call.binary !== undefined
+    ),
+
+    /**
+     * data.current.callContext
+     * note that we convert to decoder context!
+     */
+    callContext: createLeaf(
+      [evm.current.step.callContext],
+      debuggerContextToDecoderContext
     )
   },
 
@@ -1438,12 +1469,32 @@ const data = createSelectorTree({
 
       /**
        * data.next.state.returndata
-       * NOTE: this is only for use by returnValue(); this is *not*
+       * NOTE: this is only for use by decodeReturnValue(); this is *not*
        * an accurate reflection of the current contents of returndata!
        * we don't track that at the moment
        */
       returndata: createLeaf([evm.current.step.returnValue], data =>
         Codec.Conversion.toBytes(data)
+      ),
+
+      /**
+       * data.next.state.calldata
+       * NOTE: this is only for use by decodeCall(); this is *not*
+       * necessarily the actual next contents of calldata!
+       */
+      calldata: createLeaf(
+        [
+          evm.current.step.isCall,
+          evm.current.step.isCreate,
+          evm.current.step.callData,
+          evm.current.step.createBinary
+        ],
+        (isCall, isCreate, data, binary) => {
+          if (!isCall && !isCreate) {
+            return null;
+          }
+          return Codec.Conversion.toBytes(isCall ? data : binary);
+        }
       )
     },
 
@@ -1485,7 +1536,7 @@ const data = createSelectorTree({
       }
     ),
 
-    /*
+    /**
      * data.next.modifierBeingInvoked
      */
     modifierBeingInvoked: createLeaf(

--- a/packages/debugger/lib/debugger.js
+++ b/packages/debugger/lib/debugger.js
@@ -6,6 +6,7 @@ import Session from "./session";
 import { createNestedSelector } from "reselect-tree";
 
 import dataSelector from "./data/selectors";
+import txlogSelector from "./txlog/selectors";
 import astSelector from "./ast/selectors";
 import traceSelector from "./trace/selectors";
 import evmSelector from "./evm/selectors";
@@ -26,7 +27,7 @@ const Debugger = {
    * @param {{contracts: Array<Artifact>, files: Array<String>, provider: Web3Provider, compilations: Array<Compilation>}} options -
    * @return {Debugger} instance
    */
-  forTx: async function(txHash, options = {}) {
+  forTx: async function (txHash, options = {}) {
     let { contracts, files, provider, compilations, lightMode } = options;
     if (!compilations) {
       compilations = Compilations.Utils.shimArtifacts(contracts, files);
@@ -44,7 +45,7 @@ const Debugger = {
    * @param {{contracts: Array<Artifact>, files: Array<String>, provider: Web3Provider, compilations: Array<Compilation>}} options -
    * @return {Debugger} instance
    */
-  forProject: async function(options = {}) {
+  forProject: async function (options = {}) {
     let { contracts, files, provider, compilations, lightMode } = options;
     if (!compilations) {
       compilations = Compilations.Utils.shimArtifacts(contracts, files);
@@ -74,6 +75,7 @@ const Debugger = {
     return createNestedSelector({
       ast: astSelector,
       data: dataSelector,
+      txlog: txlogSelector,
       trace: traceSelector,
       evm: evmSelector,
       solidity: soliditySelector,

--- a/packages/debugger/lib/evm/selectors/index.js
+++ b/packages/debugger/lib/evm/selectors/index.js
@@ -563,7 +563,7 @@ const evm = createSelectorTree({
       ),
 
       /**
-       * evm.current.step.isInstantCallOrReturn
+       * evm.current.step.isInstantCallOrCreate
        *
        * are we doing a call or create for which there are no trace steps?
        * This can happen if:
@@ -618,19 +618,20 @@ const evm = createSelectorTree({
 
       /**
        * evm.current.step.returnStatus
-       * checks the return status of the *current* halting instruction
-       * returns null if not halting
+       * checks the return status of the *current* halting instruction or insta-call
+       * returns null if not halting & not an insta-call
        * (returns a boolean -- true for success, false for failure)
        */
       returnStatus: createLeaf(
         [
           "./isHalting",
+          "./isInstantCallOrCreate",
           "/next/state",
           trace.stepsRemaining,
           "/transaction/status"
         ],
-        (isHalting, { stack }, remaining, finalStatus) => {
-          if (!isHalting) {
+        (isHalting, isInstaCall, { stack }, remaining, finalStatus) => {
+          if (!isHalting && !isInstaCall) {
             return null; //not clear this'll do much good since this may get
             //read as false, but, oh well, may as well
           }

--- a/packages/debugger/lib/evm/selectors/index.js
+++ b/packages/debugger/lib/evm/selectors/index.js
@@ -14,7 +14,8 @@ import {
   isShortCallMnemonic,
   isDelegateCallMnemonicBroad,
   isDelegateCallMnemonicStrict,
-  isStaticCallMnemonic
+  isStaticCallMnemonic,
+  isSelfDestructMnemonic
 } from "lib/helpers";
 
 const ZERO_WORD = "00".repeat(Codec.Evm.Utils.WORD_SIZE);
@@ -125,6 +126,13 @@ function createStepSelectors(step, state = null) {
      * (includes CREATE2)
      */
     isCreate: createLeaf(["./trace"], step => isCreateMnemonic(step.op)),
+
+    /**
+     * .isSelfDestruct
+     */
+    isSelfDestruct: createLeaf(["./trace"], step =>
+      isSelfDestructMnemonic(step.op)
+    ),
 
     /**
      * .isCreate2
@@ -316,6 +324,21 @@ function createStepSelectors(step, state = null) {
           }
 
           return stack[stack.length - 1];
+        }
+      ),
+
+      /**
+       * .salt
+       */
+      salt: createLeaf(
+        ["./isCreate2", state],
+
+        (isCreate2, { stack }) => {
+          if (!isCreate2) {
+            return null;
+          }
+
+          return "0x" + stack[stack.length - 4];
         }
       ),
 
@@ -564,7 +587,7 @@ const evm = createSelectorTree({
       ),
 
       /**
-       * .isNormalHalting
+       * evm.current.step.isNormalHalting
        */
       isNormalHalting: createLeaf(
         ["./isHalting", "./returnStatus"],
@@ -572,7 +595,7 @@ const evm = createSelectorTree({
       ),
 
       /**
-       * .isHalting
+       * evm.current.step.isHalting
        *
        * whether the instruction halts or returns from a calling context
        * HACK: the check for stepsRemainining === 0 is a hack to cover
@@ -669,6 +692,24 @@ const evm = createSelectorTree({
             return null;
           }
           return stack[stack.length - 1];
+        }
+      ),
+
+      /**
+       * evm.current.step.beneficiary
+       * NOTE: for a value-destroying selfdestruct, returns null
+       */
+      beneficiary: createLeaf(
+        ["./isSelfDestruct", "../state", "../call"],
+
+        (isSelfDestruct, { stack }, { storageAddress: currentAddress }) => {
+          if (!isSelfDestruct) {
+            return null;
+          }
+          const beneficiary = Codec.Evm.Utils.toAddress(
+            stack[stack.length - 1]
+          );
+          return beneficiary !== currentAddress ? beneficiary : null;
         }
       )
     },

--- a/packages/debugger/lib/session/index.js
+++ b/packages/debugger/lib/session/index.js
@@ -10,6 +10,7 @@ import configureStore from "lib/store";
 import * as controller from "lib/controller/actions";
 import * as actions from "./actions";
 import data from "lib/data/selectors";
+import txlog from "lib/txlog/selectors";
 import stacktrace from "lib/stacktrace/selectors";
 import session from "lib/session/selectors";
 import * as dataSagas from "lib/data/sagas";
@@ -513,6 +514,7 @@ export default class Session {
     return createNestedSelector({
       ast,
       data,
+      txlog,
       trace,
       evm,
       solidity,

--- a/packages/debugger/lib/session/reducers.js
+++ b/packages/debugger/lib/session/reducers.js
@@ -9,6 +9,7 @@ import solidity from "lib/solidity/reducers";
 import trace from "lib/trace/reducers";
 import controller from "lib/controller/reducers";
 import stacktrace from "lib/stacktrace/reducers";
+import txlog from "lib/txlog/reducers";
 
 import * as actions from "./actions";
 
@@ -96,6 +97,7 @@ const session = combineReducers({
 const reduceState = combineReducers({
   session,
   data,
+  txlog,
   evm,
   solidity,
   stacktrace,

--- a/packages/debugger/lib/session/selectors/index.js
+++ b/packages/debugger/lib/session/selectors/index.js
@@ -64,7 +64,7 @@ const session = createSelectorTree({
               let constructorArgs;
               if (creationBinary !== undefined) {
                 let creationContext = contexts[creationContextId];
-                if (creationContext !== null) {
+                if (creationContext) {
                   //slice off the bytecode part of the constructor to leave the arguments
                   constructorArgs = creationBinary.slice(
                     creationContext.binary.length

--- a/packages/debugger/lib/solidity/selectors/index.js
+++ b/packages/debugger/lib/solidity/selectors/index.js
@@ -265,11 +265,12 @@ let solidity = createSelectorTree({
       [
         "./instructionAtProgramCounter",
         evm.current.step.programCounter,
-        evm.next.step.programCounter
+        evm.next.step.programCounter,
+        evm.current.step.isContextChange
       ],
 
-      (map, current, next) => {
-        if (!map[next]) {
+      (map, current, next, changesContext) => {
+        if (changesContext || !map[next]) {
           return true;
         }
 

--- a/packages/debugger/lib/trace/sagas/index.js
+++ b/packages/debugger/lib/trace/sagas/index.js
@@ -19,9 +19,9 @@ export function* setSubmoduleCount(count) {
   yield put(actions.setSubmoduleCount(count));
 }
 
-export function* addSubmoduleToCount() {
+export function* addSubmoduleToCount(increment = 1) {
   let count = yield select(trace.application.submoduleCount);
-  yield put(actions.setSubmoduleCount(count + 1));
+  yield put(actions.setSubmoduleCount(count + increment));
 }
 
 export function* advance() {

--- a/packages/debugger/lib/txlog/actions/index.js
+++ b/packages/debugger/lib/txlog/actions/index.js
@@ -154,12 +154,12 @@ export function selfdestruct(pointer, newPointer, beneficiary) {
 }
 
 export const REVERT = "TXLOG_REVERT";
-export function revert(pointer, newPointer, message) {
+export function revert(pointer, newPointer, error) {
   return {
     type: REVERT,
     pointer,
     newPointer,
-    message
+    error
   };
 }
 

--- a/packages/debugger/lib/txlog/actions/index.js
+++ b/packages/debugger/lib/txlog/actions/index.js
@@ -1,20 +1,34 @@
 export const INTERNAL_CALL = "TXLOG_INTERNAL_CALL";
-export function internalCall() {
+export function internalCall(pointer, newPointer) {
   return {
-    type: INTERNAL_CALL
+    type: INTERNAL_CALL,
+    pointer,
+    newPointer
+  };
+}
+
+export const ABSORBED_CALL = "TXLOG_ABSORBED_CALL";
+export function absorbedCall(pointer) {
+  return {
+    type: ABSORBED_CALL,
+    pointer
   };
 }
 
 export const INTERNAL_RETURN = "TXLOG_INTERNAL_RETURN";
-export function internalReturn(variables) {
+export function internalReturn(pointer, newPointer, variables) {
   return {
     type: INTERNAL_RETURN,
+    pointer,
+    newPointer,
     variables
   };
 }
 
 export const EXTERNAL_CALL = "TXLOG_EXTERNAL_CALL";
 export function externalCall(
+  pointer,
+  newPointer,
   address,
   context,
   value,
@@ -26,6 +40,8 @@ export function externalCall(
 ) {
   return {
     type: EXTERNAL_CALL,
+    pointer,
+    newPointer,
     address,
     context,
     value,
@@ -39,6 +55,8 @@ export function externalCall(
 
 export const INSTANT_EXTERNAL_CALL = "TXLOG_INSTANT_EXTERNAL_CALL";
 export function instantExternalCall(
+  pointer,
+  newPointer, //does not actually affect the current pointer!
   address,
   context,
   value,
@@ -51,6 +69,8 @@ export function instantExternalCall(
 ) {
   return {
     type: INSTANT_EXTERNAL_CALL,
+    pointer,
+    newPointer,
     address,
     context,
     value,
@@ -64,9 +84,20 @@ export function instantExternalCall(
 }
 
 export const CREATE = "TXLOG_CREATE";
-export function create(address, context, value, salt, decoding, binary) {
+export function create(
+  pointer,
+  newPointer,
+  address,
+  context,
+  value,
+  salt,
+  decoding,
+  binary
+) {
   return {
     type: CREATE,
+    pointer,
+    newPointer,
     address,
     context,
     value,
@@ -78,6 +109,8 @@ export function create(address, context, value, salt, decoding, binary) {
 
 export const INSTANT_CREATE = "TXLOG_INSTANT_CREATE";
 export function instantCreate(
+  pointer,
+  newPointer, //does not actually affect the current pointer!
   address,
   context,
   value,
@@ -88,6 +121,8 @@ export function instantCreate(
 ) {
   return {
     type: INSTANT_CREATE,
+    pointer,
+    newPointer,
     address,
     context,
     value,
@@ -99,33 +134,45 @@ export function instantCreate(
 }
 
 export const EXTERNAL_RETURN = "TXLOG_EXTERNAL_RETURN";
-export function externalReturn(decodings) {
+export function externalReturn(pointer, newPointer, decodings) {
   return {
     type: EXTERNAL_RETURN,
+    pointer,
+    newPointer,
     decodings
   };
 }
 
 export const SELFDESTRUCT = "TXLOG_SELFDESTRUCT";
-export function selfdestruct(beneficiary) {
+export function selfdestruct(pointer, newPointer, beneficiary) {
   return {
     type: SELFDESTRUCT,
+    pointer,
+    newPointer,
     beneficiary
   };
 }
 
 export const REVERT = "TXLOG_REVERT";
-export function revert(message) {
+export function revert(pointer, newPointer, message) {
   return {
     type: REVERT,
+    pointer,
+    newPointer,
     message
   };
 }
 
 export const IDENTIFY_FUNCTION_CALL = "TXLOG_IDENTIFY_FUNCTION_CALL";
-export function identifyFunctionCall(functionNode, contractNode, variables) {
+export function identifyFunctionCall(
+  pointer,
+  functionNode,
+  contractNode,
+  variables
+) {
   return {
     type: IDENTIFY_FUNCTION_CALL,
+    pointer,
     functionNode,
     contractNode,
     variables
@@ -133,9 +180,10 @@ export function identifyFunctionCall(functionNode, contractNode, variables) {
 }
 
 export const RECORD_ORIGIN = "TXLOG_RECORD_ORIGIN";
-export function recordOrigin(address) {
+export function recordOrigin(pointer, address) {
   return {
     type: RECORD_ORIGIN,
+    pointer,
     address
   };
 }

--- a/packages/debugger/lib/txlog/actions/index.js
+++ b/packages/debugger/lib/txlog/actions/index.js
@@ -21,7 +21,8 @@ export function externalCall(
   isDelegate,
   kind,
   decoding,
-  calldata
+  calldata,
+  absorbNextInternalCall
 ) {
   return {
     type: EXTERNAL_CALL,
@@ -31,7 +32,8 @@ export function externalCall(
     isDelegate,
     kind,
     decoding,
-    calldata
+    calldata,
+    absorbNextInternalCall
   };
 }
 
@@ -44,6 +46,7 @@ export function instantExternalCall(
   kind,
   decoding,
   calldata,
+  absorbNextInternalCall,
   status
 ) {
   return {
@@ -55,6 +58,7 @@ export function instantExternalCall(
     kind,
     decoding,
     calldata,
+    absorbNextInternalCall,
     status
   };
 }

--- a/packages/debugger/lib/txlog/actions/index.js
+++ b/packages/debugger/lib/txlog/actions/index.js
@@ -1,0 +1,151 @@
+export const INTERNAL_CALL = "TXLOG_INTERNAL_CALL";
+export function internalCall() {
+  return {
+    type: INTERNAL_CALL
+  };
+}
+
+export const INTERNAL_RETURN = "TXLOG_INTERNAL_RETURN";
+export function internalReturn(variables) {
+  return {
+    type: INTERNAL_RETURN,
+    variables
+  };
+}
+
+export const EXTERNAL_CALL = "TXLOG_EXTERNAL_CALL";
+export function externalCall(
+  address,
+  context,
+  value,
+  isDelegate,
+  kind,
+  decoding,
+  calldata
+) {
+  return {
+    type: EXTERNAL_CALL,
+    address,
+    context,
+    value,
+    isDelegate,
+    kind,
+    decoding,
+    calldata
+  };
+}
+
+export const INSTANT_EXTERNAL_CALL = "TXLOG_INSTANT_EXTERNAL_CALL";
+export function instantExternalCall(
+  address,
+  context,
+  value,
+  isDelegate,
+  kind,
+  decoding,
+  calldata,
+  status
+) {
+  return {
+    type: INSTANT_EXTERNAL_CALL,
+    address,
+    context,
+    value,
+    isDelegate,
+    kind,
+    decoding,
+    calldata,
+    status
+  };
+}
+
+export const CREATE = "TXLOG_CREATE";
+export function create(address, context, value, salt, decoding, binary) {
+  return {
+    type: CREATE,
+    address,
+    context,
+    value,
+    salt,
+    decoding,
+    binary
+  };
+}
+
+export const INSTANT_CREATE = "TXLOG_INSTANT_CREATE";
+export function instantCreate(
+  address,
+  context,
+  value,
+  salt,
+  decoding,
+  binary,
+  status
+) {
+  return {
+    type: INSTANT_CREATE,
+    address,
+    context,
+    value,
+    salt,
+    decoding,
+    binary,
+    status
+  };
+}
+
+export const EXTERNAL_RETURN = "TXLOG_EXTERNAL_RETURN";
+export function externalReturn(decodings) {
+  return {
+    type: EXTERNAL_RETURN,
+    decodings
+  };
+}
+
+export const SELFDESTRUCT = "TXLOG_SELFDESTRUCT";
+export function selfdestruct(beneficiary) {
+  return {
+    type: SELFDESTRUCT,
+    beneficiary
+  };
+}
+
+export const REVERT = "TXLOG_REVERT";
+export function revert(message) {
+  return {
+    type: REVERT,
+    message
+  };
+}
+
+export const IDENTIFY_FUNCTION_CALL = "TXLOG_IDENTIFY_FUNCTION_CALL";
+export function identifyFunctionCall(functionNode, contractNode, variables) {
+  return {
+    type: IDENTIFY_FUNCTION_CALL,
+    functionNode,
+    contractNode,
+    variables
+  };
+}
+
+export const RECORD_ORIGIN = "TXLOG_RECORD_ORIGIN";
+export function recordOrigin(address) {
+  return {
+    type: RECORD_ORIGIN,
+    address
+  };
+}
+
+export const RESET = "TXLOG_RESET";
+export function reset() {
+  return {
+    type: RESET
+  };
+}
+
+export const UNLOAD_TRANSACTION = "TXLOG_UNLOAD_TRANSACTION";
+export function unloadTransaction() {
+  return {
+    type: UNLOAD_TRANSACTION
+  };
+}

--- a/packages/debugger/lib/txlog/reducers.js
+++ b/packages/debugger/lib/txlog/reducers.js
@@ -31,6 +31,7 @@ function transactionLog(state = [], action) {
         kind,
         decoding,
         calldata,
+        absorbNextInternalCall,
         status
       } = action;
       const contractName = context ? context.contractName : undefined;
@@ -57,6 +58,11 @@ function transactionLog(state = [], action) {
         //one we hit would instead be a function *called* from the fallback
         //function, which is not what we want.
         waitingForFunctionDefinition: kind !== "message",
+        //if kind is message or constructor, we don't want to absorb.
+        //but, for constructors absorb will already be false, so we don't need to
+        //explicitly disallow that.
+        //(so: absorb for function & library only)
+        absorbNextInternalCall: absorbNextInternalCall && kind !== "message",
         instant: action.type === actions.INSTANT_EXTERNAL_CALL,
         status //will be undefined if not instant!
       };
@@ -89,6 +95,7 @@ function transactionLog(state = [], action) {
         variables,
         binary,
         waitingForFunctionDefinition: true,
+        absorbNextInternalCall: false,
         instant: action.type === actions.INSTANT_CREATE,
         status //will be undefined if not instant!
       };

--- a/packages/debugger/lib/txlog/reducers.js
+++ b/packages/debugger/lib/txlog/reducers.js
@@ -1,0 +1,198 @@
+import debugModule from "debug";
+const debug = debugModule("debugger:txlog:reducers");
+
+import { combineReducers } from "redux";
+
+import * as actions from "./actions";
+
+function transactionLog(state = [], action) {
+  //The first few cases just append to the log (or, occasionally, don't).
+  //Most cases primarily append to the log, but also, if the previous
+  //entry was a callexternal of kind library, will modify it to be of kind
+  //message.
+  //The final case, identify function call, *only* modifies the last entry
+  //and appends nothing.
+  //(...and then there's also reset and unload transaction)
+  switch (action.type) {
+    case actions.INTERNAL_CALL: {
+      const lastAction = state[state.length - 1];
+      if (
+        lastAction.type === "callexternal" &&
+        lastAction.kind !== "constructor" &&
+        lastAction.waitingForFunctionDefinition
+      ) {
+        //this is for handling post-0.5.1 initial jump-ins; don't add
+        //a separate internal call if we're sitting on an external call
+        //waiting to be identified
+        //However, note that we don't do this for constructors, because
+        //for constructors, an initializer could run first.  Fortunately
+        //constructors don't have a jump in, so it works out OK!
+        return state;
+      } else {
+        return [
+          ...state,
+          { type: "callinternal", waitingForFunctionDefinition: true }
+        ];
+      }
+    }
+    case actions.INTERNAL_RETURN:
+      return [
+        ...state,
+        { type: "returninternal", variables: action.variables }
+      ];
+    case actions.RECORD_ORIGIN:
+      return [...state, { type: "origin", address: action.address }];
+    case actions.INSTANT_EXTERNAL_CALL:
+    case actions.EXTERNAL_CALL: {
+      const {
+        address,
+        context,
+        value,
+        isDelegate,
+        kind,
+        decoding,
+        calldata,
+        status
+      } = action;
+      const contractName = context ? context.contractName : undefined;
+      let functionName, variables;
+      if (decoding.kind === "function") {
+        //note: in this case we should also have kind === "function"
+        functionName = decoding.abi.name;
+        variables = decoding.arguments;
+      }
+      const newEntry = {
+        type: "callexternal",
+        address,
+        context,
+        contractName,
+        value,
+        isDelegate,
+        kind,
+        functionName,
+        variables,
+        calldata,
+        //If kind === "message", set waiting to false.
+        //Why?  Well, because fallback functions and receive functions
+        //typically have their function definitions skipped over, so the next
+        //one we hit would instead be a function *called* from the fallback
+        //function, which is not what we want.
+        waitingForFunctionDefinition: kind !== "message",
+        instant: action.type === actions.INSTANT_EXTERNAL_CALL,
+        status //will be undefined if not instant!
+      };
+      const modifiedLog = setLastEntryAsMessageIfLibrary(state);
+      return [...modifiedLog, newEntry];
+    }
+    case actions.INSTANT_CREATE:
+    case actions.CREATE: {
+      const {
+        address,
+        binary,
+        context,
+        value,
+        salt,
+        decoding,
+        status
+      } = action;
+      const contractName = context ? context.contractName : undefined;
+      let variables;
+      if (decoding.kind === "constructor") {
+        variables = decoding.arguments;
+      }
+      let newEntry = {
+        type: "callexternal",
+        kind: context ? "constructor" : "unknowncreate",
+        address,
+        context,
+        contractName,
+        value,
+        salt,
+        variables,
+        binary,
+        waitingForFunctionDefinition: true,
+        instant: action.type === actions.INSTANT_CREATE,
+        status //will be undefined if not instant!
+      };
+      const modifiedLog = setLastEntryAsMessageIfLibrary(state);
+      return [...modifiedLog, newEntry];
+    }
+    case actions.EXTERNAL_RETURN: {
+      const newEntry = { type: "returnexternal", decodings: action.decodings };
+      const modifiedLog = setLastEntryAsMessageIfLibrary(state);
+      return [...modifiedLog, newEntry];
+    }
+    case actions.REVERT: {
+      const newEntry = { type: "revert", message: action.message };
+      const modifiedLog = setLastEntryAsMessageIfLibrary(state);
+      return [...modifiedLog, newEntry];
+    }
+    case actions.SELFDESTRUCT: {
+      const newEntry = {
+        type: "selfdestruct",
+        beneficiary: action.beneficiary
+      };
+      const modifiedLog = setLastEntryAsMessageIfLibrary(state);
+      return [...modifiedLog, newEntry];
+    }
+    case actions.IDENTIFY_FUNCTION_CALL: {
+      //This case is special.  Most other cases primarily append to the log;
+      //this case instead just modifies the last entry with nothing appended.
+      const { functionNode, contractNode, variables } = action;
+      const lastCall = state[state.length - 1];
+      let modifiedCall = { ...lastCall, waitingForFunctionDefinition: false };
+      //note: I don't handle the following with { stuff, ...lastCall, moreStuff } because
+      //I want lastCall take precedence over the following even if what it has is undefined or null,
+      //*not* just if it's not present at all
+      if (!modifiedCall.functionName) {
+        //we don't bother checking if functionNode is null because this action should only
+        //happen when it's not
+        modifiedCall.functionName = functionNode.name
+          ? functionNode.name
+          : undefined; //replace "" with undefined
+      }
+      if (!modifiedCall.contractName) {
+        modifiedCall.contractName =
+          contractNode && contractNode.nodeType === "ContractDefinition"
+            ? contractNode.name
+            : null;
+      }
+      if (!modifiedCall.variables) {
+        modifiedCall.variables = variables;
+      }
+      //now: resolve the kind if it was library
+      if (
+        modifiedCall.type === "callexternal" &&
+        modifiedCall.kind === "library"
+      ) {
+        modifiedCall.kind = "function";
+      }
+      return [...state.slice(0, -1), modifiedCall];
+    }
+    case actions.RESET:
+      return state.slice(0, 2); //keep origin and initial call
+    case actions.UNLOAD_TRANSACTION:
+      return [];
+    default:
+      return state;
+  }
+}
+
+function setLastEntryAsMessageIfLibrary(log) {
+  const lastEntry = log[log.length - 1];
+  if (lastEntry.type === "callexternal" && lastEntry.kind === "library") {
+    return [...log.slice(0, -1), { ...lastEntry, kind: "message" }];
+  } else {
+    return log;
+  }
+}
+
+const proc = combineReducers({
+  transactionLog
+});
+
+const reducer = combineReducers({
+  proc
+});
+
+export default reducer;

--- a/packages/debugger/lib/txlog/reducers.js
+++ b/packages/debugger/lib/txlog/reducers.js
@@ -5,131 +5,352 @@ import { combineReducers } from "redux";
 
 import * as actions from "./actions";
 
-function transactionLog(state = [], action) {
-  //note that aside from resetting or unloading, we only ever append to
-  //the log; processing into tree form happens in the selectors
+//NOTE: even though we refer to nodes by JSON pointer,
+//these pointers are "fake" in that we don't actually
+//use them *as* JSON pointers; it's just a convenient
+//method of IDing them that also has a nice intuitive
+//meaning (you'll notice we don't actually import
+//json-pointer here or anywhere else in this submodule)
+const DEFAULT_TX_LOG = {
+  byPointer: {
+    "": { // "" is the root node
+      type: "origin",
+      actions: []
+    }
+  }
+};
+
+function transactionLog(state = DEFAULT_TX_LOG, action) {
+  const { pointer, newPointer } = action;
+  const node = state.byPointer[pointer];
   switch (action.type) {
-    case actions.INTERNAL_CALL:
-      return [
-        ...state,
-        { type: "callinternal", waitingForFunctionDefinition: true }
-      ];
-    case actions.INTERNAL_RETURN:
-      return [
-        ...state,
-        { type: "returninternal", variables: action.variables }
-      ];
     case actions.RECORD_ORIGIN:
-      return [...state, { type: "origin", address: action.address }];
+      if (node.type === "origin") {
+        return {
+          byPointer: {
+            ...state.byPointer,
+            [pointer]: {
+              ...node,
+              address: action.address
+            }
+          }
+        };
+      } else {
+        debug("attempt to set origin of bad node type!");
+        return state;
+      }
+    case actions.INTERNAL_CALL:
+      return {
+        byPointer: {
+          ...state.byPointer,
+          [pointer]: {
+            ...node,
+            actions: [...node.actions, newPointer]
+          },
+          [newPointer]: {
+            type: "callinternal",
+            actions: [],
+            waitingForFunctionDefinition: true
+          }
+        }
+      };
+    case actions.ABSORBED_CALL:
+      return {
+        byPointer: {
+          ...state.byPointer,
+          [pointer]: {
+            ...node,
+            absorbNextInternalCall: false
+          }
+        }
+      };
+    case actions.INTERNAL_RETURN:
+      //pop the top call from the stack if it's internal (and set its return values)
+      //if the top call is instead external, just set its return values if appropriate.
+      //(this is how we handle internal/external return absorption)
+      const modifiedNode = { ...node };
+      if (modifiedNode.type === "callinternal") {
+        modifiedNode.returnKind = "return";
+        modifiedNode.returnValues = action.variables;
+        delete modifiedNode.waitingForFunctionDefinition;
+      } else if (modifiedNode.type === "callexternal") {
+        if (modifiedNode.kind === "function") {
+          //don't set return variables for non-function external calls
+          modifiedNode.returnValues = action.variables;
+        }
+      } else {
+        debug("returninternal once tx done!");
+      }
+      return {
+        byPointer: {
+          ...state.byPointer,
+          [pointer]: modifiedNode
+        }
+      };
     case actions.INSTANT_EXTERNAL_CALL:
-    case actions.EXTERNAL_CALL: {
+    case actions.EXTERNAL_CALL:
+    case actions.INSTANT_CREATE:
+    case actions.CREATE: {
+      const instant =
+        action.type === actions.INSTANT_EXTERNAL_CALL ||
+        action.type === actions.INSTANT_CREATE;
+      let modifiedNode = {
+        ...node,
+        actions: [...node.actions, newPointer]
+      };
+      if (
+        modifiedNode.type === "callexternal" &&
+        modifiedNode.kind === "library"
+      ) {
+        //didn't identify it as function, so set it to message
+        modifiedNode.kind = "message";
+      }
       const {
         address,
+        binary, //only for creates
         context,
         value,
+        salt, //only for creates
         isDelegate,
-        kind,
         decoding,
         calldata,
-        absorbNextInternalCall,
         status
       } = action;
+      let kind;
+      if (
+        action.type === actions.CREATE ||
+        action.type === actions.INSTANT_CREATE
+      ) {
+        //these don't have kind in the action, so we instead determine
+        //it this way
+        kind = context ? "constructor" : "unknowncreate";
+      } else {
+        kind = action.kind;
+      }
       const contractName = context ? context.contractName : undefined;
       let functionName, variables;
-      if (decoding.kind === "function") {
-        //note: in this case we should also have kind === "function"
+      if (decoding.kind === "function" || decoding.kind === "constructor") {
         functionName = decoding.abi.name;
         variables = decoding.arguments;
       }
-      const newEntry = {
+      let call = {
         type: "callexternal",
         address,
-        context,
-        contractName,
+        contextHash: context.context || null,
         value,
-        isDelegate,
         kind,
+        isDelegate,
         functionName,
-        variables,
-        calldata,
+        contractName,
+        arguments: variables,
+        actions: []
+      };
+      if (kind === "message" || kind === "library") {
+        call.data = calldata;
+      } else if (kind === "unknowncreate") {
+        call.binary = binary;
+      }
+      if (kind === "constructor" || kind === "unknowncreate") {
+        call.salt = salt;
+      }
+      if (instant) {
+        call.returnKind = status ? "return" : "revert";
+      } else {
         //If kind === "message", set waiting to false.
         //Why?  Well, because fallback functions and receive functions
         //typically have their function definitions skipped over, so the next
         //one we hit would instead be a function *called* from the fallback
         //function, which is not what we want.
-        waitingForFunctionDefinition: kind !== "message",
+        call.waitingForFunctionDefinition = kind !== "message";
         //if kind is message or constructor, we don't want to absorb.
-        //but, for constructors absorb will already be false, so we don't need to
-        //explicitly disallow that.
-        //(so: absorb for function & library only)
-        absorbNextInternalCall: absorbNextInternalCall && kind !== "message",
-        instant: action.type === actions.INSTANT_EXTERNAL_CALL,
-        status //will be undefined if not instant!
+        call.absorbNextInternalCall =
+          (kind === "function" || kind === "library") &&
+          action.absorbNextInternalCall
       };
-      return [...state, newEntry];
-    }
-    case actions.INSTANT_CREATE:
-    case actions.CREATE: {
-      const {
-        address,
-        binary,
-        context,
-        value,
-        salt,
-        decoding,
-        status
-      } = action;
-      const contractName = context ? context.contractName : undefined;
-      let variables;
-      if (decoding.kind === "constructor") {
-        variables = decoding.arguments;
-      }
-      let newEntry = {
-        type: "callexternal",
-        kind: context ? "constructor" : "unknowncreate",
-        address,
-        context,
-        contractName,
-        value,
-        salt,
-        variables,
-        binary,
-        waitingForFunctionDefinition: true,
-        absorbNextInternalCall: false,
-        instant: action.type === actions.INSTANT_CREATE,
-        status //will be undefined if not instant!
+      return {
+        byPointer: {
+          ...state.byPointer,
+          [pointer]: modifiedNode,
+          [newPointer]: call
+        }
       };
-      return [...state, newEntry];
     }
-    case actions.EXTERNAL_RETURN: {
-      const newEntry = { type: "returnexternal", decodings: action.decodings };
-      return [...state, newEntry];
-    }
-    case actions.REVERT: {
-      const newEntry = { type: "revert", message: action.message };
-      return [...state, newEntry];
-    }
+    case actions.EXTERNAL_RETURN:
+    case actions.REVERT:
     case actions.SELFDESTRUCT: {
-      const newEntry = {
-        type: "selfdestruct",
-        beneficiary: action.beneficiary
+      //first: set the returnKind and other info
+      let modifiedNode = { ...node };
+      if (
+        modifiedNode.type === "callexternal" &&
+        modifiedNode.kind === "library"
+      ) {
+        //didn't identify it as function, so set it to message
+        modifiedNode.kind = "message";
+      }
+      switch (action.type) {
+        case actions.EXTERNAL_RETURN:
+          if (!modifiedNode.returnKind) {
+            modifiedNode.returnKind = "return";
+          }
+          break;
+        case actions.REVERT:
+          modifiedNode.returnKind = "revert";
+          modifiedNode.message = action.message;
+          break;
+        case actions.SELFDESTRUCT:
+          modifiedNode.returnKind = "selfdestruct";
+          modifiedNode.beneficiary = action.beneficiary;
+          break;
+      }
+      let newState = {
+        byPointer: {
+          ...state.byPointer,
+          [pointer]: modifiedNode
+        }
       };
-      return [...state, newEntry];
+      //now: pop all calls from stack until we pop an external call.
+      //we don't handle return values here since those are handled
+      //in returninternal (yay absorption)
+      let currentPointer;
+      for (
+        currentPointer = pointer;
+        currentPointer.replace(/\/actions\/\d+$/, "") !== newPointer; //stop *before* the stop pointer
+        currentPointer = currentPointer.replace(/\/actions\/\d+$/, "") //cut off end
+      ) {
+        debug("currentNode!");
+        let currentNode = { ...newState.byPointer[currentPointer] }; //clone
+        if (!currentNode.returnKind) {
+          //set the return kind on any nodes popped along the way that don't have
+          //one already to note that they failed to return due to a call they made
+          //reverting
+          currentNode.returnKind = "unwind";
+        }
+        delete currentNode.waitingForFunctionDefinition;
+        debug("set currentNode!");
+        newState.byPointer[currentPointer] = currentNode;
+      }
+      //now handle the external call.
+      //note that currentPointer now points to it.
+      debug("finalNode!");
+      let finalNode = { ...newState.byPointer[currentPointer] }; //clone
+      //first let's set the returnKind if there isn't one already
+      //(in which case we can infer it was unwound).
+      if (!finalNode.returnKind) {
+        finalNode.returnKind = "unwind";
+      }
+      //now let's set its return variables if applicable.
+      if (
+        finalNode.kind === "function" &&
+        action.type === actions.EXTERNAL_RETURN &&
+        action.decodings
+      ) {
+        const decoding = action.decodings.find(
+          decoding => decoding.kind === "return"
+        );
+        if (decoding) {
+          //we'll trust this method over the method resulting from an internal return,
+          //*if* it produces a valid return-value decoding.  if it doesn't, we ignore it.
+          finalNode.returnValues = decoding.arguments;
+        }
+      }
+      //also, set immutables if applicable -- note that we do *not* attempt to set
+      //these the internal way, as we don't have a reliable way of doing that
+      if (
+        finalNode.kind === "constructor" &&
+        action.type === actions.EXTERNAL_RETURN &&
+        action.decodings
+      ) {
+        const decoding = action.decodings.find(
+          decoding => decoding.kind === "bytecode"
+        );
+        if (decoding && decoding.immutables) {
+          finalNode.returnImmutables = decoding.immutables;
+        }
+      }
+      //finally, delete internal info
+      delete finalNode.waitingForFunctionDefinition;
+      delete finalNode.absorbNextInternalCall;
+      debug("set finalNode!");
+      newState.byPointer[currentPointer] = finalNode;
+      return newState;
     }
     case actions.IDENTIFY_FUNCTION_CALL: {
       const { functionNode, contractNode, variables } = action;
-      const newEntry = {
-        type: "identify",
-        variables,
-        functionName: functionNode.name || undefined, //replace "" with undefined
-        contractName: contractNode && contractNode.nodeType === "ContractDefinition"
+      const functionName = functionNode.name || undefined; //replace "" with undefined
+      const contractName =
+        contractNode && contractNode.nodeType === "ContractDefinition"
           ? contractNode.name
-          : null
+          : null;
+      let modifiedNode = {
+        ...node,
+        waitingForFunctionDefinition: false
       };
-      return [...state, newEntry];
+      //note: I don't handle the following in the object spread above
+      //because I don't want undefined or null counting against it
+      if (!modifiedNode.functionName) {
+        modifiedNode.functionName = functionName;
+      }
+      if (!modifiedNode.contractName) {
+        modifiedNode.contractName = contractName;
+      }
+      if (!modifiedNode.arguments) {
+        modifiedNode.arguments = variables;
+      }
+      if (
+        modifiedNode.type === "callexternal" &&
+        modifiedNode.kind === "library"
+      ) {
+        modifiedNode.kind = "function";
+        delete modifiedNode.data;
+      }
+      return {
+        byPointer: {
+          ...state.byPointer,
+          [pointer]: modifiedNode
+        }
+      };
     }
+    case actions.UNLOAD_TRANSACTION:
+      return DEFAULT_TX_LOG;
+    default:
+      return state;
+  }
+}
+
+function currentNodePointer(state = "", action) {
+  switch (action.type) {
+    case actions.INTERNAL_CALL:
+    case actions.EXTERNAL_CALL:
+    case actions.CREATE:
+    case actions.INTERNAL_RETURN:
+    case actions.EXTERNAL_RETURN:
+    case actions.REVERT:
+    case actions.SELFDESTRUCT:
+      //note that instant calls/creates are not included!
+      return action.newPointer;
     case actions.RESET:
-      return state.slice(0, 2); //keep origin and initial call
+      return "/actions/0"; //reset to status after initial call
+    case actions.UNLOAD_TRANSACTION:
+      return "";
+    default:
+      return state;
+  }
+}
+
+//this is a stack of the pointers to external calls.
+//note: not to the frames below them!
+function pointerStack(state = [], action) {
+  switch (action.type) {
+    case actions.EXTERNAL_CALL:
+    case actions.CREATE:
+      //note that instant calls & creates are not included!
+      return [...state, action.newPointer];
+    case actions.EXTERNAL_RETURN:
+    case actions.REVERT:
+    case actions.SELFDESTRUCT:
+      return state.slice(0, -1);
+    case actions.RESET:
+      return ["/actions/0"]; //reset to status after initial call
     case actions.UNLOAD_TRANSACTION:
       return [];
     default:
@@ -138,7 +359,9 @@ function transactionLog(state = [], action) {
 }
 
 const proc = combineReducers({
-  transactionLog
+  transactionLog,
+  currentNodePointer,
+  pointerStack
 });
 
 const reducer = combineReducers({

--- a/packages/debugger/lib/txlog/reducers.js
+++ b/packages/debugger/lib/txlog/reducers.js
@@ -195,7 +195,7 @@ function transactionLog(state = DEFAULT_TX_LOG, action) {
           break;
         case actions.REVERT:
           modifiedNode.returnKind = "revert";
-          modifiedNode.message = action.message;
+          modifiedNode.error = action.error;
           break;
         case actions.SELFDESTRUCT:
           modifiedNode.returnKind = "selfdestruct";

--- a/packages/debugger/lib/txlog/reducers.js
+++ b/packages/debugger/lib/txlog/reducers.js
@@ -1,7 +1,7 @@
 import debugModule from "debug";
 const debug = debugModule("debugger:txlog:reducers");
 
-import { combineReducers } from "redux";
+import {combineReducers} from "redux";
 
 import * as actions from "./actions";
 
@@ -13,25 +13,26 @@ import * as actions from "./actions";
 //json-pointer here or anywhere else in this submodule)
 const DEFAULT_TX_LOG = {
   byPointer: {
-    "": { // "" is the root node
-      type: "origin",
+    "": {
+      // "" is the root node
+      type: "transaction",
       actions: []
     }
   }
 };
 
 function transactionLog(state = DEFAULT_TX_LOG, action) {
-  const { pointer, newPointer } = action;
+  const {pointer, newPointer} = action;
   const node = state.byPointer[pointer];
   switch (action.type) {
     case actions.RECORD_ORIGIN:
-      if (node.type === "origin") {
+      if (node.type === "transaction") {
         return {
           byPointer: {
             ...state.byPointer,
             [pointer]: {
               ...node,
-              address: action.address
+              origin: action.address
             }
           }
         };
@@ -68,7 +69,7 @@ function transactionLog(state = DEFAULT_TX_LOG, action) {
       //pop the top call from the stack if it's internal (and set its return values)
       //if the top call is instead external, just set its return values if appropriate.
       //(this is how we handle internal/external return absorption)
-      const modifiedNode = { ...node };
+      const modifiedNode = {...node};
       if (modifiedNode.type === "callinternal") {
         modifiedNode.returnKind = "return";
         modifiedNode.returnValues = action.variables;
@@ -165,8 +166,8 @@ function transactionLog(state = DEFAULT_TX_LOG, action) {
         //if kind is message or constructor, we don't want to absorb.
         call.absorbNextInternalCall =
           (kind === "function" || kind === "library") &&
-          action.absorbNextInternalCall
-      };
+          action.absorbNextInternalCall;
+      }
       return {
         byPointer: {
           ...state.byPointer,
@@ -179,7 +180,7 @@ function transactionLog(state = DEFAULT_TX_LOG, action) {
     case actions.REVERT:
     case actions.SELFDESTRUCT: {
       //first: set the returnKind and other info
-      let modifiedNode = { ...node };
+      let modifiedNode = {...node};
       if (
         modifiedNode.type === "callexternal" &&
         modifiedNode.kind === "library"
@@ -218,7 +219,7 @@ function transactionLog(state = DEFAULT_TX_LOG, action) {
         currentPointer = currentPointer.replace(/\/actions\/\d+$/, "") //cut off end
       ) {
         debug("currentNode!");
-        let currentNode = { ...newState.byPointer[currentPointer] }; //clone
+        let currentNode = {...newState.byPointer[currentPointer]}; //clone
         if (!currentNode.returnKind) {
           //set the return kind on any nodes popped along the way that don't have
           //one already to note that they failed to return due to a call they made
@@ -232,7 +233,7 @@ function transactionLog(state = DEFAULT_TX_LOG, action) {
       //now handle the external call.
       //note that currentPointer now points to it.
       debug("finalNode!");
-      let finalNode = { ...newState.byPointer[currentPointer] }; //clone
+      let finalNode = {...newState.byPointer[currentPointer]}; //clone
       //first let's set the returnKind if there isn't one already
       //(in which case we can infer it was unwound).
       if (!finalNode.returnKind) {
@@ -275,7 +276,7 @@ function transactionLog(state = DEFAULT_TX_LOG, action) {
       return newState;
     }
     case actions.IDENTIFY_FUNCTION_CALL: {
-      const { functionNode, contractNode, variables } = action;
+      const {functionNode, contractNode, variables} = action;
       const functionName = functionNode.name || undefined; //replace "" with undefined
       const contractName =
         contractNode && contractNode.nodeType === "ContractDefinition"

--- a/packages/debugger/lib/txlog/reducers.js
+++ b/packages/debugger/lib/txlog/reducers.js
@@ -6,35 +6,14 @@ import { combineReducers } from "redux";
 import * as actions from "./actions";
 
 function transactionLog(state = [], action) {
-  //The first few cases just append to the log (or, occasionally, don't).
-  //Most cases primarily append to the log, but also, if the previous
-  //entry was a callexternal of kind library, will modify it to be of kind
-  //message.
-  //The final case, identify function call, *only* modifies the last entry
-  //and appends nothing.
-  //(...and then there's also reset and unload transaction)
+  //note that aside from resetting or unloading, we only ever append to
+  //the log; processing into tree form happens in the selectors
   switch (action.type) {
-    case actions.INTERNAL_CALL: {
-      const lastAction = state[state.length - 1];
-      if (
-        lastAction.type === "callexternal" &&
-        lastAction.kind !== "constructor" &&
-        lastAction.waitingForFunctionDefinition
-      ) {
-        //this is for handling post-0.5.1 initial jump-ins; don't add
-        //a separate internal call if we're sitting on an external call
-        //waiting to be identified
-        //However, note that we don't do this for constructors, because
-        //for constructors, an initializer could run first.  Fortunately
-        //constructors don't have a jump in, so it works out OK!
-        return state;
-      } else {
-        return [
-          ...state,
-          { type: "callinternal", waitingForFunctionDefinition: true }
-        ];
-      }
-    }
+    case actions.INTERNAL_CALL:
+      return [
+        ...state,
+        { type: "callinternal", waitingForFunctionDefinition: true }
+      ];
     case actions.INTERNAL_RETURN:
       return [
         ...state,
@@ -81,8 +60,7 @@ function transactionLog(state = [], action) {
         instant: action.type === actions.INSTANT_EXTERNAL_CALL,
         status //will be undefined if not instant!
       };
-      const modifiedLog = setLastEntryAsMessageIfLibrary(state);
-      return [...modifiedLog, newEntry];
+      return [...state, newEntry];
     }
     case actions.INSTANT_CREATE:
     case actions.CREATE: {
@@ -114,60 +92,34 @@ function transactionLog(state = [], action) {
         instant: action.type === actions.INSTANT_CREATE,
         status //will be undefined if not instant!
       };
-      const modifiedLog = setLastEntryAsMessageIfLibrary(state);
-      return [...modifiedLog, newEntry];
+      return [...state, newEntry];
     }
     case actions.EXTERNAL_RETURN: {
       const newEntry = { type: "returnexternal", decodings: action.decodings };
-      const modifiedLog = setLastEntryAsMessageIfLibrary(state);
-      return [...modifiedLog, newEntry];
+      return [...state, newEntry];
     }
     case actions.REVERT: {
       const newEntry = { type: "revert", message: action.message };
-      const modifiedLog = setLastEntryAsMessageIfLibrary(state);
-      return [...modifiedLog, newEntry];
+      return [...state, newEntry];
     }
     case actions.SELFDESTRUCT: {
       const newEntry = {
         type: "selfdestruct",
         beneficiary: action.beneficiary
       };
-      const modifiedLog = setLastEntryAsMessageIfLibrary(state);
-      return [...modifiedLog, newEntry];
+      return [...state, newEntry];
     }
     case actions.IDENTIFY_FUNCTION_CALL: {
-      //This case is special.  Most other cases primarily append to the log;
-      //this case instead just modifies the last entry with nothing appended.
       const { functionNode, contractNode, variables } = action;
-      const lastCall = state[state.length - 1];
-      let modifiedCall = { ...lastCall, waitingForFunctionDefinition: false };
-      //note: I don't handle the following with { stuff, ...lastCall, moreStuff } because
-      //I want lastCall take precedence over the following even if what it has is undefined or null,
-      //*not* just if it's not present at all
-      if (!modifiedCall.functionName) {
-        //we don't bother checking if functionNode is null because this action should only
-        //happen when it's not
-        modifiedCall.functionName = functionNode.name
-          ? functionNode.name
-          : undefined; //replace "" with undefined
-      }
-      if (!modifiedCall.contractName) {
-        modifiedCall.contractName =
-          contractNode && contractNode.nodeType === "ContractDefinition"
-            ? contractNode.name
-            : null;
-      }
-      if (!modifiedCall.variables) {
-        modifiedCall.variables = variables;
-      }
-      //now: resolve the kind if it was library
-      if (
-        modifiedCall.type === "callexternal" &&
-        modifiedCall.kind === "library"
-      ) {
-        modifiedCall.kind = "function";
-      }
-      return [...state.slice(0, -1), modifiedCall];
+      const newEntry = {
+        type: "identify",
+        variables,
+        functionName: functionNode.name || undefined, //replace "" with undefined
+        contractName: contractNode && contractNode.nodeType === "ContractDefinition"
+          ? contractNode.name
+          : null
+      };
+      return [...state, newEntry];
     }
     case actions.RESET:
       return state.slice(0, 2); //keep origin and initial call
@@ -175,15 +127,6 @@ function transactionLog(state = [], action) {
       return [];
     default:
       return state;
-  }
-}
-
-function setLastEntryAsMessageIfLibrary(log) {
-  const lastEntry = log[log.length - 1];
-  if (lastEntry.type === "callexternal" && lastEntry.kind === "library") {
-    return [...log.slice(0, -1), { ...lastEntry, kind: "message" }];
-  } else {
-    return log;
   }
 }
 

--- a/packages/debugger/lib/txlog/sagas/index.js
+++ b/packages/debugger/lib/txlog/sagas/index.js
@@ -1,0 +1,227 @@
+import debugModule from "debug";
+const debug = debugModule("debugger:txlog:sagas");
+
+import { put, takeEvery, select } from "redux-saga/effects";
+import { prefixName } from "lib/helpers";
+import * as Codec from "@truffle/codec";
+
+import * as actions from "../actions";
+import { TICK } from "lib/trace/actions";
+import * as trace from "lib/trace/sagas";
+import * as data from "lib/data/sagas";
+
+import txlog from "../selectors";
+
+function* tickSaga() {
+  yield* updateTransactionLogSaga();
+  yield* trace.signalTickSagaCompletion();
+}
+
+function* updateTransactionLogSaga() {
+  if (yield select(txlog.current.isHalting)) {
+    //note that we process this case first so that it overrides the others!
+    const status = yield select(txlog.current.returnStatus);
+    if (status) {
+      if (yield select(txlog.current.isSelfDestruct)) {
+        const beneficiary = yield select(txlog.current.beneficiary);
+        //note: this selector returns null for a value-destroying selfdestruct
+        yield put(actions.selfdestruct(beneficiary));
+      } else {
+        const decodings = yield* data.decodeReturnValue();
+        yield put(actions.externalReturn(decodings));
+      }
+    } else {
+      const message = yield* data.decodeReturnValue();
+      yield put(actions.revert(message));
+    }
+  } else if (yield select(txlog.current.isJump)) {
+    const jumpDirection = yield select(txlog.current.jumpDirection);
+    if (jumpDirection === "i") {
+      const internal = yield select(txlog.next.inInternalSourceOrYul); //don't log jumps into internal sources or Yul
+      if (!internal) {
+        //we don't do any decoding/fn identification here because that's handled by
+        //the function definition case
+        yield put(actions.internalCall());
+      }
+    } else if (jumpDirection === "o") {
+      const internal = yield select(txlog.current.inInternalSourceOrYul); //don't log jumps out of internal sources or Yul
+      if (!internal) {
+        //in this case, we have to do decoding & fn identification
+        const outputAllocations = yield select(
+          txlog.current.outputParameterAllocations
+        );
+        if (outputAllocations) {
+          const compilationId = yield select(txlog.current.compilationId);
+          //can't do a yield* inside a map, have to do this loop manually
+          let variables = [];
+          for (let { name, definition, pointer } of outputAllocations) {
+            name = name ? name : undefined; //replace "" with undefined
+            const decodedValue = yield* data.decode(
+              definition,
+              pointer,
+              compilationId
+            );
+            variables.push({ name, value: decodedValue });
+          }
+          yield put(actions.internalReturn(variables));
+        } else {
+          yield put(actions.internalReturn(null));
+        }
+      }
+    }
+  } else if (yield select(txlog.current.isCall)) {
+    const address = yield select(txlog.current.callAddress);
+    const value = yield select(txlog.current.callValue);
+    //distinguishing DELEGATECALL vs CALLCODE seems unnecessary here
+    const isDelegate = yield select(txlog.current.isDelegateCallBroad);
+    //we need to determine what kind of call this is.
+    //we'll sort them into: function, constructor, message, library
+    //(library is a placeholder to be replaced later)
+    const context = yield select(txlog.current.callContext);
+    const calldata = yield select(txlog.current.callData);
+    const instant = yield select(txlog.current.isInstantCallOrCreate);
+    const kind = callKind(context, calldata, instant);
+    const decoding = yield* data.decodeCall();
+    if (instant) {
+      const status = yield select(txlog.current.returnStatus);
+      yield put(
+        actions.instantExternalCall(
+          address,
+          context,
+          value,
+          isDelegate,
+          kind,
+          decoding,
+          calldata,
+          status
+        )
+      );
+    } else {
+      yield put(
+        actions.externalCall(
+          address,
+          context,
+          value,
+          isDelegate,
+          kind,
+          decoding,
+          calldata
+        )
+      );
+    }
+  } else if (yield select(txlog.current.isCreate)) {
+    const address = yield select(txlog.current.createdAddress);
+    const context = yield select(txlog.current.callContext);
+    const value = yield select(txlog.current.createValue);
+    const salt = yield select(txlog.current.salt); //is null for an ordinary create
+    const instant = yield select(txlog.current.isInstantCallOrCreate);
+    const binary = yield select(txlog.current.createBinary);
+    const decoding = yield* data.decodeCall();
+    if (instant) {
+      const status = yield select(txlog.current.returnStatus);
+      yield put(
+        actions.instantCreate(
+          address,
+          context,
+          value,
+          salt,
+          decoding,
+          binary,
+          status
+        )
+      );
+    } else {
+      yield put(
+        actions.create(address, context, value, salt, decoding, binary)
+      );
+    }
+  }
+  //we process this last in case jump & function def on same step
+  if (yield select(txlog.current.onFunctionDefinition)) {
+    if (yield select(txlog.current.waitingForFunctionDefinition)) {
+      debug("identifying");
+      const inputAllocations = yield select(
+        txlog.current.inputParameterAllocations
+      );
+      debug("inputAllocations: %O", inputAllocations);
+      if (inputAllocations) {
+        const functionNode = yield select(txlog.current.node);
+        const contractNode = yield select(txlog.current.contract);
+        const compilationId = yield select(txlog.current.compilationId);
+        //can't do a yield* inside a map, have to do this loop manually
+        let variables = [];
+        for (let { name, definition, pointer } of inputAllocations) {
+          const decodedValue = yield* data.decode(
+            definition,
+            pointer,
+            compilationId
+          );
+          variables.push({ name, value: decodedValue });
+        }
+        yield put(
+          actions.identifyFunctionCall(functionNode, contractNode, variables)
+        );
+      }
+    }
+  }
+}
+
+function callKind(context, calldata, instant) {
+  if (context) {
+    if (context.contractKind === "library") {
+      return instant ? "message" : "library";
+      //for an instant return, just get it out of the way and set it to
+      //message rather than leaving it open (it'll get resolved in favor
+      //of message by our criteria)
+    } else {
+      const abi = context.abi;
+      debug("abi: %O", abi);
+      const selector = calldata
+        .slice(0, 2 + 2 * Codec.Evm.Utils.SELECTOR_SIZE)
+        .padEnd("00", 2 + 2 * Codec.Evm.Utils.SELECTOR_SIZE);
+      debug("selector: %s", selector);
+      if (abi && selector in abi) {
+        return "function";
+      }
+    }
+  }
+  return "message";
+}
+
+export function* reset() {
+  yield put(actions.reset());
+}
+
+export function* unload() {
+  yield put(actions.unloadTransaction());
+}
+
+export function* begin() {
+  const origin = yield select(txlog.transaction.origin);
+  debug("origin: %s", origin);
+  yield put(actions.recordOrigin(origin));
+  const { address, storageAddress, value, data: calldata } = yield select(
+    txlog.current.call
+  );
+  const context = yield select(txlog.current.context);
+  //note: there was an instant check here (based on checking if there are no
+  //trace steps) but I took it out, because even though having no trace steps
+  //is essentially an insta-call, the debugger doesn't treat it that way (it
+  //will see the return later), so we shouldn't here either
+  const decoding = yield* data.decodeCall(true); //pass flag to decode *current* call
+  debug("decoding: %O", decoding);
+  if (address) {
+    const kind = callKind(context, calldata, false); //no insta-calls here!
+    yield put(
+      actions.externalCall(address, context, value, false, kind, decoding)
+    ); //initial call is never delegate
+  } else {
+    yield put(actions.create(storageAddress, context, value, null, decoding)); //initial create never has salt
+  }
+}
+
+export function* saga() {
+  yield takeEvery(TICK, tickSaga);
+}
+
+export default prefixName("txlog", saga);

--- a/packages/debugger/lib/txlog/sagas/index.js
+++ b/packages/debugger/lib/txlog/sagas/index.js
@@ -35,9 +35,9 @@ function* updateTransactionLogSaga() {
         yield put(actions.externalReturn(pointer, newPointer, decodings));
       }
     } else {
-      const message = yield* data.decodeReturnValue();
+      const error = (yield* data.decodeReturnValue())[0]; //NOTE: we will do this a better way in the future!
       debug("revert: %o %o", pointer, newPointer);
-      yield put(actions.revert(pointer, newPointer, message));
+      yield put(actions.revert(pointer, newPointer, error));
     }
   } else if (yield select(txlog.current.isJump)) {
     const jumpDirection = yield select(txlog.current.jumpDirection);

--- a/packages/debugger/lib/txlog/selectors/index.js
+++ b/packages/debugger/lib/txlog/selectors/index.js
@@ -1,0 +1,500 @@
+import debugModule from "debug";
+const debug = debugModule("debugger:txlog:selectors");
+
+import { createSelectorTree, createLeaf } from "reselect-tree";
+
+import data from "lib/data/selectors";
+import evm from "lib/evm/selectors";
+import solidity from "lib/solidity/selectors";
+
+import * as Codec from "@truffle/codec";
+
+const identity = x => x;
+
+function createMultistepSelectors(stepSelector) {
+  return {
+    /**
+     * .source
+     * HACK: see notes in solidity selectors about cases
+     * where this won't work
+     */
+    source: createLeaf([stepSelector.source], identity),
+
+    /**
+     * .node
+     * HACK: see notes in solidity selectors about cases
+     * where this won't work
+     */
+    node: createLeaf([stepSelector.node], identity),
+
+    /**
+     * .inInternalSourceOrYul
+     */
+    inInternalSourceOrYul: createLeaf(
+      ["./source", "./node"],
+      //note: the first of these won't actually happen atm, as source id
+      //of -1 would instead result in source.id === undefined, but I figure
+      //I'll include that condition in case I end up changing this later
+      (source, node) =>
+        !node || source.internal || node.nodeType.startsWith("Yul")
+    )
+  };
+}
+
+let txlog = createSelectorTree({
+  /**
+   * txlog.state
+   */
+  state: state => state.txlog,
+
+  /**
+   * txlog.transaction
+   */
+  transaction: {
+    /**
+     * txlog.transaction.origin
+     */
+    origin: createLeaf([evm.transaction.globals.tx], tx => tx.origin)
+  },
+
+  /**
+   * txlog.current
+   */
+  current: {
+    ...createMultistepSelectors(solidity.current),
+
+    /**
+     * txlog.current.state
+     */
+    state: createLeaf([evm.current.state], identity),
+
+    /**
+     * txlog.current.transactionLog
+     */
+    transactionLog: createLeaf(["/state"], state => state.proc.transactionLog),
+
+    /**
+     * txlog.current.transactionTree
+     */
+    transactionTree: createLeaf(["./transactionLog"], logToTree),
+
+    /**
+     * txlog.current.lastAction
+     */
+    lastAction: createLeaf(["./transactionLog"], log => log[log.length - 1]),
+
+    /**
+     * txlog.current.waitingForFunctionDefinition
+     * This selector indicates whether there's a call (internal or external)
+     * that is waiting to have its function definition identified when we hit
+     * a function definition node.
+     */
+    waitingForFunctionDefinition: createLeaf(
+      ["./lastAction"],
+      lastAction =>
+        (lastAction.type === "callinternal" ||
+          lastAction.type === "callexternal") &&
+        lastAction.waitingForFunctionDefinition
+    ),
+
+    /**
+     * txlog.current.context
+     * Note we use data context, not evm context
+     * (i.e. decoder context, not debugger context)
+     */
+    context: createLeaf([data.current.context], identity),
+
+    /**
+     * txlog.current.call
+     */
+    call: createLeaf([evm.current.call], identity),
+
+    /**
+     * txlog.current.contract
+     */
+    contract: createLeaf([data.current.contract], identity),
+
+    /**
+     * txlog.current.isSourceRangeFinal
+     */
+    isSourceRangeFinal: createLeaf(
+      [solidity.current.isSourceRangeFinal],
+      identity
+    ),
+
+    /**
+     * txlog.current.onFunctionDefinition
+     */
+    onFunctionDefinition: createLeaf(
+      ["./node", "./isSourceRangeFinal"],
+      (node, ready) => ready && node && node.nodeType === "FunctionDefinition"
+    ),
+
+    /**
+     * txlog.current.compilationId
+     */
+    compilationId: createLeaf([data.current.compilationId], identity),
+
+    /**
+     * txlog.current.isJump
+     */
+    isJump: createLeaf([evm.current.step.isJump], identity),
+
+    /**
+     * txlog.current.jumpDirection
+     */
+    jumpDirection: createLeaf([solidity.current.jumpDirection], identity),
+
+    /**
+     * txlog.current.isCall
+     */
+    isCall: createLeaf([evm.current.step.isCall], identity),
+
+    /**
+     * txlog.current.isDelegateCallBroad
+     */
+    isDelegateCallBroad: createLeaf(
+      [evm.current.step.isDelegateCallBroad],
+      identity
+    ),
+
+    /**
+     * txlog.current.isCreate
+     */
+    isCreate: createLeaf([evm.current.step.isCreate], identity),
+
+    /**
+     * txlog.current.isInstantCallOrCreate
+     */
+    isInstantCallOrCreate: createLeaf(
+      [evm.current.step.isInstantCallOrCreate],
+      identity
+    ),
+
+    /**
+     * txlog.current.isHalting
+     */
+    isHalting: createLeaf([evm.current.step.isHalting], identity),
+
+    /**
+     * txlog.current.returnStatus
+     */
+    returnStatus: createLeaf([evm.current.step.returnStatus], identity),
+
+    /**
+     * txlog.current.callValue
+     */
+    callValue: createLeaf([evm.current.step.callValue], identity),
+
+    /**
+     * txlog.current.callAddress
+     */
+    callAddress: createLeaf([evm.current.step.callAddress], identity),
+
+    /**
+     * txlog.current.callContext
+     * note we make sure to use data, not evm, context!
+     * (i.e. decoder context, not debugger context)
+     */
+    callContext: createLeaf([data.current.callContext], identity),
+
+    /**
+     * txlog.current.callData
+     */
+    callData: createLeaf([evm.current.step.callData], identity),
+
+    /**
+     * txlog.current.createBinary
+     */
+    createBinary: createLeaf([evm.current.step.createBinary], identity),
+
+    /**
+     * txlog.current.createValue
+     */
+    createValue: createLeaf([evm.current.step.createValue], identity),
+
+    /**
+     * txlog.current.createdAddress
+     */
+    createdAddress: createLeaf([evm.current.step.createdAddress], identity),
+
+    /**
+     * txlog.current.salt
+     */
+    salt: createLeaf([evm.current.step.salt], identity),
+
+    /**
+     * txlog.current.isSelfDestruct
+     */
+    isSelfDestruct: createLeaf([evm.current.step.isSelfDestruct], identity),
+
+    /**
+     * txlog.current.beneficiary
+     */
+    beneficiary: createLeaf([evm.current.step.beneficiary], identity),
+
+    /**
+     * txlog.current.inputParameterAllocations
+     */
+    inputParameterAllocations: createLeaf(
+      ["./node", "./state"],
+      (functionDefinition, { stack }) => {
+        if (
+          !functionDefinition ||
+          functionDefinition.nodeType !== "FunctionDefinition"
+        ) {
+          return null;
+        }
+        return locateParameters(
+          functionDefinition.parameters.parameters,
+          stack.length - 1
+        );
+      }
+    ),
+
+    /**
+     * txlog.current.outputParameterAllocations
+     */
+    outputParameterAllocations: createLeaf(
+      ["./node", "./state"],
+      (functionDefinition, { stack }) => {
+        if (
+          !functionDefinition ||
+          functionDefinition.nodeType !== "FunctionDefinition"
+        ) {
+          return null;
+        }
+        //when this selector is invoked, we're on the jump out step, so the
+        //top element of the stack is the return address; we need to skip past that
+        return locateParameters(
+          functionDefinition.returnParameters.parameters,
+          stack.length - 2
+        );
+      }
+    )
+  },
+
+  /**
+   * txlog.next
+   */
+  next: {
+    ...createMultistepSelectors(solidity.next)
+  }
+});
+
+function locateParameters(parameters, top) {
+  const reverseParameters = parameters.slice().reverse();
+  //note we clone before reversing because reverse() is in place
+
+  let results = [];
+  let currentPosition = top;
+  for (let parameter of reverseParameters) {
+    const words = Codec.Ast.Utils.stackSize(parameter);
+    const pointer = {
+      location: "stack",
+      from: currentPosition - words + 1,
+      to: currentPosition
+    };
+
+    results.unshift({
+      name: parameter.name ? parameter.name : undefined, //replace "" with undefined
+      definition: parameter,
+      pointer
+    });
+    currentPosition -= words;
+  }
+  return results;
+}
+
+//this function turns the log array into a tree object.
+function logToTree(log) {
+  let tree = { type: "origin", actions: [] };
+  let currentNode = tree; //this variable will act as a pointer; we will make writes through it
+  let nodeStack = [tree]; //the entries here should similarly be thought of as pointers
+  for (let action of log) {
+    debug(
+      "stack info: %o",
+      nodeStack.map(node => ({ type: node.type, name: node.functionName }))
+    );
+    debug("currentNode: %o", {
+      type: currentNode.type,
+      name: currentNode.functionName
+    });
+    if (currentNode !== nodeStack[nodeStack.length - 1]) {
+      debug("node stack desynchronized!!");
+    }
+    switch (action.type) {
+      case "origin":
+        debug("setting origin");
+        debug("address: %s", action.address);
+        if (currentNode.type === "origin") {
+          currentNode.address = action.address;
+        } else {
+          debug("attempt to set origin of bad node type!");
+        }
+        break;
+      case "callexternal": {
+        debug("external call");
+        const {
+          type,
+          address,
+          context,
+          value,
+          kind,
+          isDelegate,
+          functionName,
+          contractName,
+          variables,
+          instant,
+          calldata,
+          binary
+        } = action;
+        let call = {
+          type,
+          address,
+          contextHash: context.context,
+          value,
+          kind,
+          isDelegate,
+          functionName,
+          contractName,
+          arguments: variables,
+          actions: []
+        };
+        if (kind === "message") {
+          call.data = calldata;
+        } else if (kind === "unknowncreate") {
+          call.binary = binary;
+        }
+        if (instant) {
+          call.returnKind = action.status ? "return" : "revert";
+          currentNode.actions.push(call);
+        } else {
+          currentNode.actions.push(call);
+          currentNode = call;
+          nodeStack.push(call);
+        }
+        break;
+      }
+      case "callinternal": {
+        debug("internal call");
+        const { type, functionName, contractName, variables } = action;
+        const call = {
+          type,
+          functionName,
+          contractName,
+          arguments: variables,
+          actions: []
+        };
+        currentNode.actions.push(call);
+        currentNode = call;
+        nodeStack.push(call);
+        break;
+      }
+      case "returninternal":
+        debug("internal return");
+        //pop the top call from the stack if it's internal (and set its return values)
+        //if the top call is instead external, just set its return values if appropriate.
+        //(this is how we handle internal/external return absorption)
+        if (currentNode.type === "callinternal") {
+          currentNode.returnKind = "return";
+          currentNode.returnValues = action.variables;
+          nodeStack.pop();
+          currentNode = nodeStack[nodeStack.length - 1];
+        } else if (currentNode.type === "callexternal") {
+          if (currentNode.kind === "function") {
+            //don't set return variables for non-function external calls
+            currentNode.returnValues = action.variables;
+          }
+        } else {
+          debug("returninternal once tx done!");
+        }
+        break;
+      case "returnexternal":
+      case "revert":
+      case "selfdestruct":
+        switch (action.type) {
+          case "returnexternal":
+            debug("external return");
+            if (!currentNode.returnKind) {
+              currentNode.returnKind = "return";
+            }
+            break;
+          case "revert":
+            debug("revert");
+            currentNode.returnKind = "revert";
+            currentNode.message = action.message;
+            break;
+          case "selfdestruct":
+            debug("selfdestruct");
+            currentNode.returnKind = "selfdestruct";
+            currentNode.beneficiary = action.beneficiary;
+            break;
+        }
+        //pop all calls from stack until we pop an external call.
+        //we don't handle return values here since those are handled
+        //in returninternal (yay absorption)
+        debug("currentNode: %o", currentNode);
+        while (currentNode.type !== "callexternal") {
+          if (nodeStack.length === 0 || currentNode.type !== "callinternal") {
+            debug("problem handling external return");
+          }
+          if (!currentNode.returnKind) {
+            //set the return kind on any nodes popped along the way that don't have
+            //one already to note that they failed to return due to a call they made
+            //reverting
+            currentNode.returnKind = "unwind";
+          }
+          debug("preliminary popping");
+          nodeStack.pop();
+          currentNode = nodeStack[nodeStack.length - 1];
+        }
+        //now handle the external call.  first let's set the returnKind if there
+        //isn't one already (in which case we can infer it was unwound).
+        if (!currentNode.returnKind) {
+          currentNode.returnKind = "unwind";
+        }
+        //now let's set its return variables if applicable.
+        if (
+          currentNode.kind === "function" &&
+          action.type === "returnexternal" &&
+          action.decodings
+        ) {
+          const decoding = action.decodings.find(
+            decoding => decoding.kind === "return"
+          );
+          if (decoding) {
+            //we'll trust this method over the method resulting from an internal return,
+            //*if* it produces a valid return-value decoding.  if it doesn't, we ignore it.
+            currentNode.returnValues = decoding.arguments;
+          }
+        }
+        //also, set immutables if applicable -- note that we do *not* attempt to set
+        //these the internal way, as we don't have a reliable way of doing that
+        if (
+          currentNode.kind === "constructor" &&
+          action.type === "returnexternal" &&
+          action.decodings
+        ) {
+          const decoding = action.decodings.find(
+            decoding => decoding.kind === "bytecode"
+          );
+          if (decoding && decoding.immutables) {
+            currentNode.returnImmutables = decoding.immutables;
+          }
+        }
+        //finally, pop it from the stack.
+        nodeStack.pop();
+        currentNode = nodeStack[nodeStack.length - 1];
+        break;
+      default:
+        //nothing goes here at the moment, but this will possibly
+        //handle other generic actions in the future
+        debug("generic action");
+        currentNode.actions.push(action);
+    }
+  }
+  return tree;
+}
+
+export default txlog;

--- a/packages/debugger/test/txlog.js
+++ b/packages/debugger/test/txlog.js
@@ -1,0 +1,417 @@
+import debugModule from "debug";
+const debug = debugModule("test:txlog"); // eslint-disable-line no-unused-vars
+
+import { assert } from "chai";
+
+import Ganache from "ganache-core";
+
+import { prepareContracts, lineOf } from "./helpers";
+import Debugger from "lib/debugger";
+import * as Codec from "@truffle/codec";
+
+import txlog from "lib/txlog/selectors";
+
+const __TXLOG = `
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.7.0;
+
+contract VizTest {
+
+  event Dummy();
+
+  function testCall(uint x) public returns (uint y) {
+    return called(x);
+  }
+
+  function called(uint x) public returns (uint y) {
+    emit Dummy();
+    return x + 1;
+  }
+
+  function testLibrary() public {
+    VizLibrary.loudIncrement(1);
+  }
+
+  function testTransfer() public {
+    tx.origin.transfer(1);
+  }
+
+  fallback() external {
+    called(msg.data.length);
+  }
+
+  function testRevert() public {
+    callReverter();
+  }
+
+  function callReverter() public {
+    revert("Oops!");
+  }
+
+  constructor() payable {
+  }
+}
+
+contract Secondary {
+
+  event Dummy();
+
+  uint immutable x = another();
+  uint immutable w;
+
+  constructor(uint y) {
+    w = y;
+  }
+
+  function another() public returns (uint z) {
+    emit Dummy();
+    return 2;
+  }
+
+  function secret() public returns (uint) {
+    return x + w; //just here so x & w are used
+  }
+}
+
+library VizLibrary {
+  event Noise();
+
+  function loudIncrement(uint x) external returns (uint y) {
+    emit Noise();
+    return x + 1;
+  }
+}
+`;
+
+let sources = {
+  "VizTest.sol": __TXLOG
+};
+
+const __MIGRATION = `
+let VizTest = artifacts.require("VizTest");
+let VizLibrary = artifacts.require("VizLibrary");
+
+module.exports = function(deployer) {
+  deployer.deploy(VizLibrary);
+  deployer.link(VizLibrary, VizTest);
+  deployer.deploy(VizTest, { value: 100 });
+};
+`;
+
+let migrations = {
+  "2_deploy_contracts.js": __MIGRATION
+};
+
+function byName(variables) {
+  return Object.assign(
+    {},
+    ...variables.map(
+      variable => ({
+        [variable.name]: variable.value
+      })
+    )
+  );
+}
+
+describe("Transaction log (visualizer)", function () {
+  var provider;
+
+  var abstractions;
+  var compilations;
+
+  before("Create Provider", async function () {
+    provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
+  });
+
+  before("Prepare contracts and artifacts", async function () {
+    this.timeout(30000);
+
+    let prepared = await prepareContracts(provider, sources, migrations);
+    abstractions = prepared.abstractions;
+    compilations = prepared.compilations;
+  });
+
+  it("Correctly logs a simple call", async function () {
+    this.timeout(12000);
+    let instance = await abstractions.VizTest.deployed();
+    let receipt = await instance.testCall(108);
+    let txHash = receipt.tx;
+
+    let bugger = await Debugger.forTx(txHash, {
+      provider,
+      compilations
+    });
+
+    await bugger.continueUntilBreakpoint(); //run till end
+
+    const root = bugger.view(txlog.current.transactionTree);
+    assert.equal(root.type, "origin");
+    assert.lengthOf(root.actions, 1);
+    let call = root.actions[0];
+    assert.equal(call.type, "callexternal");
+    assert.equal(call.kind, "function");
+    assert.equal(call.address, instance.address);
+    assert.equal(call.functionName, "testCall");
+    assert.equal(call.contractName, "VizTest");
+    assert.equal(call.returnKind, "return");
+    debug("arguments: %O", call.arguments);
+    let inputs = Codec.Format.Utils.Inspect.nativizeVariables(
+      byName(call.arguments)
+    );
+    debug("nativized: %O", inputs);
+    assert.deepEqual(inputs, {
+      x: 108
+    });
+    let outputs = Codec.Format.Utils.Inspect.nativizeVariables(
+      byName(call.returnValues)
+    );
+    assert.deepEqual(outputs, {
+      y: 109
+    });
+    assert.lengthOf(call.actions, 1);
+    call = call.actions[0];
+    assert.equal(call.type, "callinternal");
+    assert.equal(call.functionName, "called");
+    assert.equal(call.contractName, "VizTest");
+    assert.equal(call.returnKind, "return");
+    inputs = Codec.Format.Utils.Inspect.nativizeVariables(
+      byName(call.arguments)
+    );
+    assert.deepEqual(inputs, {
+      x: 108
+    });
+    outputs = Codec.Format.Utils.Inspect.nativizeVariables(
+      byName(call.returnValues)
+    );
+    assert.deepEqual(outputs, {
+      y: 109
+    });
+  });
+
+  it("Correctly logs a creation", async function () {
+    this.timeout(12000);
+    let instance = await abstractions.Secondary.new(108);
+    let txHash = instance.transactionHash;
+
+    let bugger = await Debugger.forTx(txHash, {
+      provider,
+      compilations
+    });
+
+    await bugger.continueUntilBreakpoint(); //run till end
+
+    const root = bugger.view(txlog.current.transactionTree);
+    assert.equal(root.type, "origin");
+    assert.lengthOf(root.actions, 1);
+    let call = root.actions[0];
+    assert.equal(call.type, "callexternal");
+    assert.equal(call.kind, "constructor");
+    assert.equal(call.address, instance.address);
+    assert.isUndefined(call.functionName);
+    assert.equal(call.contractName, "Secondary");
+    assert.equal(call.returnKind, "return");
+    let inputs = Codec.Format.Utils.Inspect.nativizeVariables(
+      byName(call.arguments)
+    );
+    assert.deepEqual(inputs, {
+      y: 108
+    });
+    debug("immuts: %O", call.returnImmutables);
+    let outputs = Codec.Format.Utils.Inspect.nativizeVariables(
+      byName(call.returnImmutables)
+    );
+    assert.deepEqual(outputs, {
+      x: 2,
+      w: 108
+    });
+    assert.lengthOf(call.actions, 1);
+    call = call.actions[0];
+    assert.equal(call.type, "callinternal");
+    assert.equal(call.functionName, "another");
+    assert.equal(call.contractName, "Secondary");
+    assert.equal(call.returnKind, "return");
+    assert.lengthOf(call.arguments, 0);
+    outputs = Codec.Format.Utils.Inspect.nativizeVariables(
+      byName(call.returnValues)
+    );
+    assert.include(outputs, {
+      z: 2
+    });
+  });
+
+  it("Correctly logs a library call", async function () {
+    this.timeout(12000);
+    let instance = await abstractions.VizTest.deployed();
+    let library = await abstractions.VizLibrary.deployed();
+    let receipt = await instance.testLibrary();
+    let txHash = receipt.tx;
+
+    let bugger = await Debugger.forTx(txHash, {
+      provider,
+      compilations
+    });
+
+    await bugger.continueUntilBreakpoint(); //run till end
+
+    const root = bugger.view(txlog.current.transactionTree);
+    assert.equal(root.type, "origin");
+    assert.lengthOf(root.actions, 1);
+    let call = root.actions[0];
+    assert.equal(call.type, "callexternal");
+    assert.equal(call.kind, "function");
+    assert.equal(call.address, instance.address);
+    assert.equal(call.functionName, "testLibrary");
+    assert.equal(call.contractName, "VizTest");
+    assert.equal(call.returnKind, "return");
+    assert.lengthOf(call.arguments, 0);
+    assert.lengthOf(call.returnValues, 0);
+    assert.lengthOf(call.actions, 1);
+    call = call.actions[0];
+    assert.equal(call.type, "callexternal");
+    assert.equal(call.kind, "function");
+    assert.equal(call.address, library.address);
+    assert.isTrue(call.isDelegate);
+    assert.equal(call.functionName, "loudIncrement");
+    assert.equal(call.contractName, "VizLibrary");
+    assert.equal(call.returnKind, "return");
+    let inputs = Codec.Format.Utils.Inspect.nativizeVariables(
+      byName(call.arguments)
+    );
+    assert.deepEqual(inputs, {
+      x: 1
+    });
+    let outputs = Codec.Format.Utils.Inspect.nativizeVariables(
+      byName(call.returnValues)
+    );
+    assert.deepEqual(outputs, {
+      y: 2
+    });
+  });
+
+  it("Correctly logs an ether transfer", async function () {
+    this.timeout(12000);
+    let instance = await abstractions.VizTest.deployed();
+    let receipt = await instance.testTransfer();
+    let txHash = receipt.tx;
+
+    let bugger = await Debugger.forTx(txHash, {
+      provider,
+      compilations
+    });
+
+    await bugger.continueUntilBreakpoint(); //run till end
+
+    const root = bugger.view(txlog.current.transactionTree);
+    assert.equal(root.type, "origin");
+    let origin = root.address;
+    assert.lengthOf(root.actions, 1);
+    let call = root.actions[0];
+    assert.equal(call.type, "callexternal");
+    assert.equal(call.kind, "function");
+    assert.equal(call.address, instance.address);
+    assert.equal(call.functionName, "testTransfer");
+    assert.equal(call.contractName, "VizTest");
+    assert.equal(call.returnKind, "return");
+    assert.lengthOf(call.arguments, 0);
+    assert.lengthOf(call.returnValues, 0);
+    assert.lengthOf(call.actions, 1);
+    call = call.actions[0];
+    assert.equal(call.type, "callexternal");
+    assert.equal(call.kind, "message");
+    assert.equal(call.address, origin);
+    assert.equal(call.value.toNumber(), 1);
+    assert.equal(call.returnKind, "return");
+  });
+
+  it("Correctly logs a fallback call", async function () {
+    this.timeout(12000);
+    let instance = await abstractions.VizTest.deployed();
+    let receipt = await instance.sendTransaction({data: "0xdeadbeef"});
+    let txHash = receipt.tx;
+
+    let bugger = await Debugger.forTx(txHash, {
+      provider,
+      compilations
+    });
+
+    await bugger.continueUntilBreakpoint(); //run till end
+
+    const root = bugger.view(txlog.current.transactionTree);
+    assert.equal(root.type, "origin");
+    assert.lengthOf(root.actions, 1);
+    let call = root.actions[0];
+    assert.equal(call.type, "callexternal");
+    assert.equal(call.kind, "message");
+    assert.equal(call.address, instance.address);
+    assert.equal(call.contractName, "VizTest");
+    assert.equal(call.data, "0xdeadbeef");
+    assert.equal(call.returnKind, "return");
+    assert.lengthOf(call.actions, 1);
+    call = call.actions[0];
+    assert.equal(call.type, "callinternal");
+    assert.equal(call.functionName, "called");
+    assert.equal(call.contractName, "VizTest");
+    assert.equal(call.returnKind, "return");
+    let inputs = Codec.Format.Utils.Inspect.nativizeVariables(
+      byName(call.arguments)
+    );
+    assert.deepEqual(inputs, {
+      x: 4
+    });
+    let outputs = Codec.Format.Utils.Inspect.nativizeVariables(
+      byName(call.returnValues)
+    );
+    assert.deepEqual(outputs, {
+      y: 5
+    });
+  });
+
+  it("Correctly logs a revert", async function () {
+    this.timeout(12000);
+    let instance = await abstractions.VizTest.deployed();
+    //HACK: because this transaction fails, we have to extract the hash from
+    //the resulting exception (there is supposed to be a non-hacky way but it
+    //does not presently work)
+    let txHash;
+    try {
+      await instance.testRevert(); //this will throw because of the revert
+    } catch (error) {
+      txHash = error.hashes[0]; //it's the only hash involved
+    }
+
+    let bugger = await Debugger.forTx(txHash, {
+      provider,
+      compilations
+    });
+
+    await bugger.continueUntilBreakpoint(); //run till end
+
+    const root = bugger.view(txlog.current.transactionTree);
+    assert.equal(root.type, "origin");
+    assert.lengthOf(root.actions, 1);
+    let call = root.actions[0];
+    assert.equal(call.type, "callexternal");
+    assert.equal(call.kind, "function");
+    assert.equal(call.address, instance.address);
+    assert.equal(call.functionName, "testRevert");
+    assert.equal(call.contractName, "VizTest");
+    assert.equal(call.returnKind, "unwind");
+    assert.lengthOf(call.arguments, 0);
+    assert.lengthOf(call.actions, 1);
+    call = call.actions[0];
+    assert.equal(call.type, "callinternal");
+    assert.equal(call.functionName, "callReverter");
+    assert.equal(call.contractName, "VizTest");
+    assert.equal(call.returnKind, "revert");
+    assert.lengthOf(call.arguments, 0);
+    assert.lengthOf(call.message, 1);
+    const message = call.message[0];
+    assert.equal(message.kind, "revert");
+    assert.lengthOf(message.arguments, 1);
+    assert.equal(
+      Codec.Format.Utils.Inspect.nativize(message.arguments[0].value),
+      "Oops!"
+    );
+  });
+
+});

--- a/packages/debugger/test/txlog.js
+++ b/packages/debugger/test/txlog.js
@@ -1,11 +1,11 @@
 import debugModule from "debug";
 const debug = debugModule("test:txlog"); // eslint-disable-line no-unused-vars
 
-import { assert } from "chai";
+import {assert} from "chai";
 
 import Ganache from "ganache-core";
 
-import { prepareContracts, lineOf } from "./helpers";
+import {prepareContracts} from "./helpers";
 import Debugger from "lib/debugger";
 import * as Codec from "@truffle/codec";
 
@@ -105,11 +105,9 @@ let migrations = {
 function byName(variables) {
   return Object.assign(
     {},
-    ...variables.map(
-      variable => ({
-        [variable.name]: variable.value
-      })
-    )
+    ...variables.map(variable => ({
+      [variable.name]: variable.value
+    }))
   );
 }
 
@@ -120,7 +118,7 @@ describe("Transaction log (visualizer)", function () {
   var compilations;
 
   before("Create Provider", async function () {
-    provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
+    provider = Ganache.provider({seed: "debugger", gasLimit: 7000000});
   });
 
   before("Prepare contracts and artifacts", async function () {
@@ -145,7 +143,7 @@ describe("Transaction log (visualizer)", function () {
     await bugger.continueUntilBreakpoint(); //run till end
 
     const root = bugger.view(txlog.views.transactionLog);
-    assert.equal(root.type, "origin");
+    assert.equal(root.type, "transaction");
     assert.lengthOf(root.actions, 1);
     let call = root.actions[0];
     assert.equal(call.type, "callexternal");
@@ -201,7 +199,7 @@ describe("Transaction log (visualizer)", function () {
     await bugger.continueUntilBreakpoint(); //run till end
 
     const root = bugger.view(txlog.views.transactionLog);
-    assert.equal(root.type, "origin");
+    assert.equal(root.type, "transaction");
     assert.lengthOf(root.actions, 1);
     let call = root.actions[0];
     assert.equal(call.type, "callexternal");
@@ -254,7 +252,7 @@ describe("Transaction log (visualizer)", function () {
     await bugger.continueUntilBreakpoint(); //run till end
 
     const root = bugger.view(txlog.views.transactionLog);
-    assert.equal(root.type, "origin");
+    assert.equal(root.type, "transaction");
     assert.lengthOf(root.actions, 1);
     let call = root.actions[0];
     assert.equal(call.type, "callexternal");
@@ -302,8 +300,8 @@ describe("Transaction log (visualizer)", function () {
     await bugger.continueUntilBreakpoint(); //run till end
 
     const root = bugger.view(txlog.views.transactionLog);
-    assert.equal(root.type, "origin");
-    let origin = root.address;
+    assert.equal(root.type, "transaction");
+    let origin = root.origin;
     assert.lengthOf(root.actions, 1);
     let call = root.actions[0];
     assert.equal(call.type, "callexternal");
@@ -337,7 +335,7 @@ describe("Transaction log (visualizer)", function () {
     await bugger.continueUntilBreakpoint(); //run till end
 
     const root = bugger.view(txlog.views.transactionLog);
-    assert.equal(root.type, "origin");
+    assert.equal(root.type, "transaction");
     assert.lengthOf(root.actions, 1);
     let call = root.actions[0];
     assert.equal(call.type, "callexternal");
@@ -387,7 +385,7 @@ describe("Transaction log (visualizer)", function () {
     await bugger.continueUntilBreakpoint(); //run till end
 
     const root = bugger.view(txlog.views.transactionLog);
-    assert.equal(root.type, "origin");
+    assert.equal(root.type, "transaction");
     assert.lengthOf(root.actions, 1);
     let call = root.actions[0];
     assert.equal(call.type, "callexternal");
@@ -411,5 +409,4 @@ describe("Transaction log (visualizer)", function () {
       "Oops!"
     );
   });
-
 });

--- a/packages/debugger/test/txlog.js
+++ b/packages/debugger/test/txlog.js
@@ -144,7 +144,7 @@ describe("Transaction log (visualizer)", function () {
 
     await bugger.continueUntilBreakpoint(); //run till end
 
-    const root = bugger.view(txlog.current.transactionTree);
+    const root = bugger.view(txlog.views.transactionLog);
     assert.equal(root.type, "origin");
     assert.lengthOf(root.actions, 1);
     let call = root.actions[0];
@@ -200,7 +200,7 @@ describe("Transaction log (visualizer)", function () {
 
     await bugger.continueUntilBreakpoint(); //run till end
 
-    const root = bugger.view(txlog.current.transactionTree);
+    const root = bugger.view(txlog.views.transactionLog);
     assert.equal(root.type, "origin");
     assert.lengthOf(root.actions, 1);
     let call = root.actions[0];
@@ -253,7 +253,7 @@ describe("Transaction log (visualizer)", function () {
 
     await bugger.continueUntilBreakpoint(); //run till end
 
-    const root = bugger.view(txlog.current.transactionTree);
+    const root = bugger.view(txlog.views.transactionLog);
     assert.equal(root.type, "origin");
     assert.lengthOf(root.actions, 1);
     let call = root.actions[0];
@@ -301,7 +301,7 @@ describe("Transaction log (visualizer)", function () {
 
     await bugger.continueUntilBreakpoint(); //run till end
 
-    const root = bugger.view(txlog.current.transactionTree);
+    const root = bugger.view(txlog.views.transactionLog);
     assert.equal(root.type, "origin");
     let origin = root.address;
     assert.lengthOf(root.actions, 1);
@@ -336,7 +336,7 @@ describe("Transaction log (visualizer)", function () {
 
     await bugger.continueUntilBreakpoint(); //run till end
 
-    const root = bugger.view(txlog.current.transactionTree);
+    const root = bugger.view(txlog.views.transactionLog);
     assert.equal(root.type, "origin");
     assert.lengthOf(root.actions, 1);
     let call = root.actions[0];
@@ -386,7 +386,7 @@ describe("Transaction log (visualizer)", function () {
 
     await bugger.continueUntilBreakpoint(); //run till end
 
-    const root = bugger.view(txlog.current.transactionTree);
+    const root = bugger.view(txlog.views.transactionLog);
     assert.equal(root.type, "origin");
     assert.lengthOf(root.actions, 1);
     let call = root.actions[0];

--- a/packages/debugger/test/txlog.js
+++ b/packages/debugger/test/txlog.js
@@ -404,12 +404,10 @@ describe("Transaction log (visualizer)", function () {
     assert.equal(call.contractName, "VizTest");
     assert.equal(call.returnKind, "revert");
     assert.lengthOf(call.arguments, 0);
-    assert.lengthOf(call.message, 1);
-    const message = call.message[0];
-    assert.equal(message.kind, "revert");
-    assert.lengthOf(message.arguments, 1);
+    assert.equal(call.error.kind, "revert");
+    assert.lengthOf(call.error.arguments, 1);
     assert.equal(
-      Codec.Format.Utils.Inspect.nativize(message.arguments[0].value),
+      Codec.Format.Utils.Inspect.nativize(call.error.arguments[0].value),
       "Oops!"
     );
   });


### PR DESCRIPTION
OK, here's the initial version of the visualizer!  Or rather the new debugger subsystem that generates a JS tree object that will be used as input to some sort of visualizer.  (Note: The form of this object will really need to be documented somewhere.  I suppose this PR writeup will serve as the initial place, but it should really live somewhere else later!)

This initial version contains decoding for function calls, return values, and related information.  It does not include gas information.  It also does not include events or storage writes.  Those will come in future versions of the visualizer.  (Storage writes in particular is going to take a while...)

You can get the transaction tree object by running the debugger to the end (not in light mode!) and viewing the selector `txlog.views.transactionLog`.

So, what is the form of this object?  I'll cover that first, and then describe how the system for generating it works later.

The object is structured as a tree; each node has a `type` field, which is a string.  The root node (the object itself) always has type `"transaction"`.  It also has an `origin` field, and an `actions` field.  The `origin` is the address of the transaction's origin.

The `action` field is something that a number of nodes will have, and is an array representing the sub-actions of a given node; this is where the tree structure comes in.  Right now, these are always function calls.  However, in the future, they may include events, storage writes, and transaction fees.  Note that because of that, right now all nodes have an `actions` field.  However, when leaf actions such as events, storage writes, or transaction fees are added, they will not include an `actions` field.

For the root (transaction) node, right now the `actions` array always consists of a single action, which will be of type `"callexternal"`.  However, in the future, a transaction fee action might be added afterwards.

So right now, aside from `"transaction"`, there are only two types of actions: `"callexternal"` and `"callinternal"`.  Since both represent function calls, they have some structure in common.  So let's start with the fields common to both.

* `functionName`: The name of the function being called.  Will be `undefined` for constructors, fallback functions, or calls that aren't to functions at all.
* `contractName`: The name of the contract being called.
* `arguments`: An array of arguments passed to the function.  Each argument is given as a `{ name: ..., value: ...}` pair, where `name` is a string (if the argument is named) or `undefined` (if it's unnamed); and each `value` uses the decoder output format.
* `returnKind`: This can be one of `"return"`, `"revert"`, `"selfdestruct"`, or `"unwind"`.  If it's `"return"`, that means the call returned normally.  If it's `"revert"`, that means it reverted, and `"selfdestruct"` means it selfdestructed.  **Note that these returnKinds are only used in the actual innermost call where the revert or selfdestruct happened.**  The other calls below it in the same EVM stackframe, that got unwound as a result, will get returnKind `"unwind"`.  **If the revert or selfdestruct happened in an internal call, that means the external call action that started the EVM stackframe will be marked `"unwind"` as well -- not `"revert"` or `"selfdestruct"`.  Also note that `"unwind"` is only used back to an EVM call boundary.  If the function that made the EVM call reverts as a result, it will be marked `"revert"`, not unwind.**
* `returnValues`: An array of return values, formatted similarly to `arguments`.  Only included if `returnKind === "return"`.  For external calls, only included if `kind === "function"` (see below).  **Note: Not guaranteed to be included, as decoding may fail!**
* `returnImmutables`: If it's an external call with `kind === "constructor"` (see below), this will be present instead of `returnValues`, with an array of the returned contract's immutables, again formatted in the same way.  Note that any immutables which go unused in the deployed contract will be omitted.  (Note: Obviously this field can only go on a `"callexternal"`, not a `"callinternal"`, but I've included it here for ease of exposition.)  (Won't be included if decoding fails, although that shouldn't happen...?)
* `error`: If the returnKind is equal to `"revert"`, this will be included instead of `returnValues`.  It contains the decoded revert message (or lack of message); it takes the form of a Codec `ReturndataDecoding`, so it may be of kind `failure` to indicate no message or kind `revert` to indicate a message.  **Won't be included if decoding fails.**
* `beneficiary`: If the returnKind is equal to `selfDestruct`, this will be included instead of `returnValues`.  It contains the address that the ether was sent to in the self-destruct.  If the contract performed an ether-destroying self-destruct, this field will be `null`.

In addition, the `"callexternal"` type has several additional fields that do not appear on `"callinternal"`:
* `kind`: This can be one of `"function"`, `"constructor"`, or `"message"`.  Kind `"function"` means it's a function call.  Kind `"constructor"` means it's a constructor call.  And kind `"message"` means it's something else.  There's also the rare fourth kind `"unknowncreate"`, for an unrecognized constructor call.
* `address`: The contract address being called.
* `contextHash`: This is kind of an internal thing but I included it anyway; it's a hash for disambiguating contracts with the same name (although a contract's constructor bytecode and deployed bytecode will get different hashes).  It's `null` for unrecognized contracts.
* `value`: The number of wei sent, as a `BN`.
* `isDelegate`: Set to `true` for calls made with `DELEGATECALL` or `CALLCODE`; set to `false` otherwise.  I didn't bother distinguishing any further than that.
* `data`: The calldata sent.  Only included when `kind === "message"`.
* `binary`: The constructor bytecode being run.  Only included when `kind === "unknowncreate"`.

So, that's the format as it currently stands.  Again, this should really be documented somewhere better, but here's a start.

Some additional notes:

1. Absorption -- When an external function call is made, it will show up as *one* node in the tree, not two, regardless of Solidity version.  An external call to `C.f()` will show up *only* as a `callexternal` node, not both a `callexternal` node and then again as a `callinternal` subnode.
2. Yul function calls are not tracked; only Solidity function calls and EVM calls.  Calls to generated sources are *definitely* not tracked.  (As in, perhaps a future version might add in Yul function calls if people want that, but my intent is that calls to generated sources should never be included.)
3. Oops I just realized this: Currently there's no `returnData` field for when an external call of kind `message` and returnKind `return` returns some raw data.  That said, not sure if this is worth adding.  Like it wouldn't work for calls to precompiles, which strike me as the main use case.

Some limitations:

1. I can't guarantee how well this will work with optimized Solidity.  That said, the EVM-based stuff and ABI-based stuff should obviously work regardless.  The rest... well, we can hope.
2. The debugger can't handle the case where multiple EVM stackframes return simultaneously, so neither can this.  That said, that case requires contrived (and non-Solidity) setup and should never occur in practice.

OK, so that's what it produces.  How does it all *work*?

Well, again we have a new submodule.  This had to be hooked up like any new submodule; and since it's a new full-mode submodule, that had to be accounted for too.

I'm not going to go over the workings of the saga in too much detail because in a lot of ways it's pretty similar to the `solidity` saga or the `stacktrace` saga, keeping track of external and internal calls and instacalls, external and internal returns, reverts, and selfdestructs.  However, what is quite different is the form of the state.

The state has three parts: `transactionLog`, `currentNodePointer`, and `pointerStack`.

The `transactionLog` state is the main part of the state; it's what contains the actual tree.  However, it doesn't contain it as a tree!  Rather, it has a single field, `byPointer` (as per state normalization), and then it has the various nodes of the tree indexed by what JSON pointer they *would* have if this were an actual tree.  Except, the nodes here don't contain actual pointers to the other nodes in their `actions` arrays; rather, they contain JSON pointers.

This state (which can be accessed via the selector `txlog.proc.transactionLog`) is then processed into an actual tree in `txlog.views.transactionLog`, which resolves the JSON pointers and processes it all into an actual tree.

(Note that the JSON pointers are kind of fake -- this submodule doesn't even import `json-pointer`!  But they make for a convenient and manipulable way of referring to the nodes.)

The second part of the state is `currentNodePointer`.  This keeps track of which node in the tree is the active one.  The third part is `pointerStack`.  This is a stack of pointers that correspond to external calls; it's used for implementing external returns, so that it knows where to return to.  (Internal returns are just handled by chopping off the end of the current pointer.)

As a result of this structure, most actions take a `pointer` argument, which tell the `transactionLog` reducer which node to operate on.  Actions that change the currently active node also take a `newPointer` argument, which tells the `currentNodePointer` reducer what to switch the pointer to.  There is one exception to this -- the actions `instantExternalCall` and `instantCreate`, which represent a call or create that returns instantly, still take the `newPointer` argument; however, they do not actually change the active node.  Instead, the `newPointer` argument is used purely to tell `transactionLog` where to create the new node.

Here are a few other particular things I want to point out:

Firstly: Redundancy.  A number of things involving external calls are done in two redundant ways -- one based on the EVM info, the ABI, and Truffle Codec's functionality for decoding function calls and returns; and one based on the sourcemaps, the ASTs, and Truffle Debugger's variable-decoding functionality.  The EVM-based way takes priority to keep optimized code from screwing things up too much, but both routes are there.  It's not pure redundancy, to be clear; there are cases involving libraries where the EVM-based way can't work.  So they're both there to help cover all the cases.

Secondly: The identify system.  The AST-based way of handling external calls is that when a `FunctionDefinition` node is hit after one, there's an `identify` action, which is what adds the extra info to the externalcall node.  This is there to make sure we can handle pre-0.5.1 stuff, in particular pre-0.5.1 library calls, which I don't think can really be handled any other way.  But, we also use this system for internal calls, even though it's not really necessary there, just for consistency and to prevent extra effort in the internal case.  Originally the identify system was also used for handling absorptions, but that ended up not working like I thought, so I had to add a separate thing for handling absporptions.  It's a bit inelegant, but, oh well...

Thirdly: Internal flags and the `"library"` kind.  While the tree is being built, some nodes may have internal flags not listed above; these will be deleted by the end though.  Specifically, the flags `absorbNextInternalCall` and `waitingForFunctionDefinition`.  Also, an `externalcall` node can temporarily get the `"library"` kind when it's a call to a library, because with those we don't always know what's going on right away.  However they should always be resolved to `"function"` or `"message"` by the end.

Fourthly: I had to add a new decoding saga to `data` to decode EVM function calls, because the debugger hasn't had to do that before; that was purely a Truffle Decoder feature previously.  Note that normally this saga decodes the call the debugger is about to make, but there's a flag you can pass to instead make it decode the one it's currently in; this is used for decoding the initial call.

Fifthly: There's a new EVM selector for getting the beneficiary of a self-destruct.  If the beneficiary is equal to the self-destructing address -- so that the ether will be destroyed -- it returns `null` rather than the address.  I could have done that processing in `txlog`, but I thought it was easier to do it here.

Sixthly: There are two selectors in `txlog`, `txlog.current.inputParameterAllocations` and `txlog.current.outputParameterAllocations`, for getting the input & output stack allocations for a given function.  Note that each is only built to be used at particular times!  They won't give correct if used at other times.  Also you'll notice they both make use of a `locateParameters` function.  Of course, it's still basically the same way the `data` saga does it, but I didn't go *that* far in factoring it because that seemed unnecessary and inconvenient.

And finally of course I added some tests.  Note that the tests aren't *too* extensive, because, well, we don't want the tests to be too slow, and also writing tests is tedious.  But I tested more stuff manually.  And of course I can add more tests if you think it's warranted.

OK, I think that's it!  Visualizer v1, here it is!