### PR TITLE
Allow Compilations to have missing sources in @truffle/db

### DIFF
--- a/packages/db/src/project/compile/compilations.ts
+++ b/packages/db/src/project/compile/compilations.ts
@@ -41,6 +41,7 @@ export const generateCompilationsLoad = Batch.Compilations.generate<{
   },
 
   *process({ entries }) {
+    debug("entries %o", entries);
     return yield* resources.load("compilations", entries);
   },
 

--- a/packages/db/src/resources/compilations.ts
+++ b/packages/db/src/resources/compilations.ts
@@ -43,8 +43,8 @@ export const compilations: Definition<"compilations"> = {
 
     input CompilationInput {
       compiler: CompilerInput!
-      processedSources: [ProcessedSourceInput!]
-      sources: [ResourceReferenceInput!]!
+      processedSources: [ProcessedSourceInput]
+      sources: [ResourceReferenceInput]!
       sourceMaps: [SourceMapInput]
     }
 
@@ -76,7 +76,7 @@ export const compilations: Definition<"compilations"> = {
           debug("Resolving Compilation.sources...");
 
           const result = await Promise.all(
-            sources.map(({id}) => workspace.get("sources", id))
+            sources.map(source => source && workspace.get("sources", source.id))
           );
 
           debug("Resolved Compilation.sources.");
@@ -87,11 +87,14 @@ export const compilations: Definition<"compilations"> = {
         resolve: ({id, processedSources}, _, {}) => {
           debug("Resolving Compilation.processedSources...");
 
-          const result = processedSources.map((processedSource, index) => ({
-            ...processedSource,
-            compilation: {id},
-            index
-          }));
+          const result = processedSources.map(
+            (processedSource, index) =>
+              processedSource && {
+                ...processedSource,
+                compilation: {id},
+                index
+              }
+          );
 
           debug("Resolved Compilation.processedSources.");
           return result;


### PR DESCRIPTION
This removes the non-nullability requirement for source and processed source inputs, as well as fixes the resolvers to handle the case where these are null.

This addresses the situation where @truffle/workflow-compile reports `null` paths for particular source indexes