### PR TITLE
Properly mark abstract getter as such

### DIFF
--- a/packages/db/src/graphql/schema.ts
+++ b/packages/db/src/graphql/schema.ts
@@ -145,7 +145,7 @@ abstract class DefinitionSchema<
   protected resource: N;
   protected definition: Definition<C, N>;
 
-  protected names: {
+  protected abstract get names(): {
     resource: string;
     Resource: string;
     resources: N; // sure why not


### PR DESCRIPTION
Rather than specifying that it's just a regular property