### PR TITLE
Improve CLI printouts regarding generated sources

### DIFF
--- a/packages/core/lib/debug/interpreter.js
+++ b/packages/core/lib/debug/interpreter.js
@@ -409,16 +409,24 @@ class DebugInterpreter {
       }
     }
     if (cmd === "g") {
-      this.session.setInternalStepping(true);
-      this.printer.print(
-        "All debugger commands can now step into generated sources."
-      );
+      if (!(this.session.view(controller.stepIntoInternalSources))) {
+        this.session.setInternalStepping(true);
+        this.printer.print(
+          "All debugger commands can now step into generated sources."
+        );
+      } else {
+        this.printer.print("Generated sources already activated.");
+      }
     }
     if (cmd === "G") {
-      this.session.setInternalStepping(false);
-      this.printer.print(
-        "Commands other than (;) and (c) will now skip over generated sources."
-      );
+      if (this.session.view(controller.stepIntoInternalSources)) {
+        this.session.setInternalStepping(false);
+        this.printer.print(
+          "Commands other than (;) and (c) will now skip over generated sources."
+        );
+      } else {
+        this.printer.print("Generated sources already off.");
+      }
     }
 
     // Check if execution has (just now) stopped.
@@ -464,6 +472,7 @@ class DebugInterpreter {
       case "?":
         this.printer.printWatchExpressions(this.enabledExpressions);
         this.printer.printBreakpoints();
+        this.printer.printGeneratedSourcesState();
         break;
       case "v":
         await this.printer.printVariables();

--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -254,6 +254,14 @@ class DebugPrinter {
     }
   }
 
+  printGeneratedSourcesState() {
+    if(this.session.view(controller.stepIntoInternalSources)) {
+      this.config.logger.log("Generated sources are turned on.");
+    } else {
+      this.config.logger.log("Generated sources are turned off.");
+    }
+  }
+
   //this doesn't really *need* to be async as we could use codec directly, but, eh
   async printRevertMessage() {
     this.config.logger.log(

--- a/packages/debugger/test/data/global-const.js
+++ b/packages/debugger/test/data/global-const.js
@@ -59,7 +59,7 @@ describe("Globally-defined constants", function() {
     compilations = prepared.compilations;
   });
 
-  it("Gets globally-definedd constants, including imports", async function() {
+  it("Gets globally-defined constants, including imports", async function() {
     this.timeout(8000);
     let instance = await abstractions.ConstTest.deployed();
     let receipt = await instance.run();


### PR DESCRIPTION
Just some simple improvements to the debugger CLI regarding the `g` and `G` commands.  These commands will now print a different message if you try to set the debugger to a state it's already in.  Also, the `?` command will now also print out whether generated sources are on or off.

...also while I was at it I fixed a typo in a test description. :P