### PR TITLE
Internal improvement: Remove unused selector

### DIFF
--- a/packages/debugger/lib/data/selectors/index.js
+++ b/packages/debugger/lib/data/selectors/index.js
@@ -469,16 +469,6 @@ const data = createSelectorTree({
      * data.proc.mappedPaths
      */
     mappedPaths: createLeaf(["/state"], state => state.proc.mappedPaths),
-
-    /**
-     * data.proc.decodingKeys
-     *
-     * number of keys that are still decoding
-     */
-    decodingKeys: createLeaf(
-      ["./mappedPaths"],
-      mappedPaths => mappedPaths.decodingStarted
-    )
   },
 
   /**


### PR DESCRIPTION
This selector is completely unused and refers to a piece of state that no longer exists; it will only ever return `undefined`.  It's from back when one had to wait for decoding to be ready.  That's no longer the case, and this should have been tossed long ago.