### PR TITLE
Bug fix: Prevent confusing breakpoint behavior with internal sources (and fix node-based breakpoints)

### DIFF
--- a/packages/debugger/lib/controller/sagas/index.js
+++ b/packages/debugger/lib/controller/sagas/index.js
@@ -246,6 +246,7 @@ function* continueUntilBreakpoint(action) {
     //few lines down.  but at this point these are still the previous
     //values.
     let previousLine = currentLine;
+    let previousNode = currentNode;
     let previousSourceId = currentSourceId;
     if (!currentLocation.source.internal) {
       lastUserSourceId = currentSourceId;
@@ -273,6 +274,8 @@ function* continueUntilBreakpoint(action) {
           return (
             sourceId === currentSourceId &&
             node === currentNode &&
+            (currentSourceId !== previousSourceId ||
+              currentNode !== previousNode) &&
             //if we started in a user source (& allow internal is off),
             //we need to make sure we've moved from a user-source POV
             (!startedInUserSource ||

--- a/packages/debugger/lib/controller/sagas/index.js
+++ b/packages/debugger/lib/controller/sagas/index.js
@@ -1,9 +1,9 @@
 import debugModule from "debug";
 const debug = debugModule("debugger:controller:sagas");
 
-import { put, call, race, take, select } from "redux-saga/effects";
+import {put, call, race, take, select} from "redux-saga/effects";
 
-import { prefixName, isDeliberatelySkippedNodeType } from "lib/helpers";
+import {prefixName, isDeliberatelySkippedNodeType} from "lib/helpers";
 
 import * as trace from "lib/trace/sagas";
 import * as data from "lib/data/sagas";
@@ -45,7 +45,7 @@ export function* saga() {
 
 export default prefixName("controller", saga);
 
-/*
+/**
  * Advance the state by the given number of instructions (but not past the end)
  * (if no count given, advance 1)
  */
@@ -224,8 +224,19 @@ function* continueUntilBreakpoint(action) {
   let breakpointHit = false;
 
   let currentLocation = yield select(controller.current.location);
-  let currentLine = currentLocation.sourceRange.lines.start.line;
   let currentSourceId = currentLocation.source.id;
+  let currentLine = currentLocation.sourceRange.lines.start.line;
+  let currentNode = currentLocation.astRef;
+  //note that if allow internal is on, we don't turn on the special treatment
+  //of user sources even if we started in one
+  const startedInUserSource =
+    !(yield select(controller.stepIntoInternalSources)) &&
+    currentLocation.source.id !== undefined &&
+    !currentLocation.source.internal;
+  //the following are set regardless, but only used if startedInUserSource
+  let lastUserSourceId = currentSourceId;
+  let lastUserLine = currentLine;
+  let lastUserNode = currentNode;
 
   do {
     yield* advance(); //note: this avoids using stepNext in order to
@@ -236,6 +247,11 @@ function* continueUntilBreakpoint(action) {
     //values.
     let previousLine = currentLine;
     let previousSourceId = currentSourceId;
+    if (!currentLocation.source.internal) {
+      lastUserSourceId = currentSourceId;
+      lastUserLine = currentLine;
+      lastUserNode = currentNode;
+    }
 
     currentLocation = yield select(controller.current.location);
     let finished = yield select(controller.current.trace.finished);
@@ -247,20 +263,35 @@ function* continueUntilBreakpoint(action) {
     if (currentSourceId === undefined) {
       continue; //never stop on an unmapped instruction
     }
-    let currentNode = currentLocation.astRef;
     currentLine = currentLocation.sourceRange.lines.start.line;
+    currentNode = currentLocation.astRef;
 
     breakpointHit =
-      breakpoints.filter(({ sourceId, line, node }) => {
+      breakpoints.filter(({sourceId, line, node}) => {
         if (node !== undefined) {
-          return sourceId === currentSourceId && node === currentNode;
+          //node-based breakpoint
+          return (
+            sourceId === currentSourceId &&
+            node === currentNode &&
+            //if we started in a user source (& allow internal is off),
+            //we need to make sure we've moved from a user-source POV
+            (!startedInUserSource ||
+              currentSourceId !== lastUserSourceId ||
+              currentNode !== lastUserNode)
+          );
         }
         //otherwise, we have a line-style breakpoint; we want to stop at the
         //*first* point on the line
         return (
           sourceId === currentSourceId &&
           line === currentLine &&
-          (currentSourceId !== previousSourceId || currentLine !== previousLine) //can skip context check as don't need to worry about external calls to internal sources
+          (currentSourceId !== previousSourceId ||
+            currentLine !== previousLine) &&
+          //again, if started in a user source w/ allow internal off,
+          //need to make sure we've moved from a *user*-source POV
+          (!startedInUserSource ||
+            currentSourceId !== lastUserSourceId ||
+            currentLine !== lastUserLine)
         );
       }).length > 0;
   } while (!breakpointHit);

--- a/packages/debugger/test/data/global-const.js
+++ b/packages/debugger/test/data/global-const.js
@@ -1,16 +1,14 @@
 import debugModule from "debug";
 const debug = debugModule("test:data:global");
 
-import { assert } from "chai";
+import {assert} from "chai";
 
 import Ganache from "ganache-core";
 
-import { prepareContracts, lineOf } from "../helpers";
+import {prepareContracts} from "../helpers";
 import Debugger from "lib/debugger";
 
 import * as Codec from "@truffle/codec";
-
-import solidity from "lib/solidity/selectors";
 
 const __TESTER = `
 //SPDX-License-Identifier: MIT
@@ -41,17 +39,17 @@ let sources = {
   "Constants.sol": __CONSTANTS
 };
 
-describe("Globally-defined constants", function() {
+describe("Globally-defined constants", function () {
   var provider;
 
   var abstractions;
   var compilations;
 
-  before("Create Provider", async function() {
-    provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
+  before("Create Provider", async function () {
+    provider = Ganache.provider({seed: "debugger", gasLimit: 7000000});
   });
 
-  before("Prepare contracts and artifacts", async function() {
+  before("Prepare contracts and artifacts", async function () {
     this.timeout(30000);
 
     let prepared = await prepareContracts(provider, sources);
@@ -59,13 +57,13 @@ describe("Globally-defined constants", function() {
     compilations = prepared.compilations;
   });
 
-  it("Gets globally-defined constants, including imports", async function() {
+  it("Gets globally-defined constants, including imports", async function () {
     this.timeout(8000);
     let instance = await abstractions.ConstTest.deployed();
     let receipt = await instance.run();
     let txHash = receipt.tx;
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     //file-level constants should be available right away
     const variables = Codec.Format.Utils.Inspect.nativizeVariables(


### PR DESCRIPTION
This PR fixes an issue where breakpoints in user sources could behave in a confusing way when generated sources are present.  It also fixes a second issue where node-based breakpoints could be hit multiple times without leaving the node.

Let's say you place a breakpoint on a line; hit `c` to get to that line; and then hit `c` again.  You would expect that the debugger doesn't stop on that line again until it's left it at least once.  However, if generated sources are present, then the debugger might appear to do just that -- the reason is that it *has* left it, by entering a generated source; but from the user's point of view, this looks wrong.

So, I added an additional check, to both node-based and line-based breakpoints.  If you started in a user source, and generated sources are turned off, then line-based breakpoints won't only stop on a change of line, they'll also only stop on a change of line from a user perspective.  And similarly with node-based breakpoints.

Actually, with node-based breakpoints I also added a check for if the location has changed at all.  This wasn't relevant back when `continueUntilBreakpoint` used `stepNext`, but now that it uses `advance`, this is relevant and I'm kind of horrified I missed this earlier!  Oh well, I assume people mostly use line-based breakpoints...

Note that I made it so that this new check (the one about user-source-POV position changes) is disabled if generated sources are turned on.  Because if they're turned on, presumably the user does not want to ignore them!

This change is particularly relevant for the upcoming Solidity 0.8.x, which is going to make generated sources a whole lot more common!  (Because they're used for checked arithmetic and all arithmetic will be checked by default.)

...also, while I was at it, I removed some unused imports from a debugger test that Husky didn't catch while it was broken.