### PR TITLE
Internal improvement: Add GHA check that yarn.lock is not modified on bootstrapping

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,6 +13,13 @@ on:
       - "*"
 
 jobs:
+  yarncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - run: yarn bootstrap
+      - run: test -z "$(git diff)"
+
+
   build:
     strategy:
       matrix:
@@ -42,7 +49,7 @@ jobs:
       if: failure()
 
   slack_notification:
-    needs: build
+    needs: [yarncheck, build]
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,9 +8,6 @@ on:
     - develop
     - next
 
-    # other targets
-    - truffle-db
-
   pull_request:
     branches:
       - "*"

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,6 +16,8 @@ jobs:
   yarncheck:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
       - run: npm install -g yarn
       - run: yarn bootstrap
       - run: test -z "$(git diff)"

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,6 +16,7 @@ jobs:
   yarncheck:
     runs-on: ubuntu-latest
     steps:
+      - run: npm install -g yarn
       - run: yarn bootstrap
       - run: test -z "$(git diff)"
 


### PR DESCRIPTION
OK, I have very little idea if I've done this correctly.  People please look this over.

The idea -- as suggested by @gnidan a bit ago -- is that we should have a GHA job that checks that, if `yarn bootstrap` is run on the branch you're PRing, `yarn.lock` is not modified.  The idea being that if running `yarn bootstrap` modifies `yarn.lock`, you should have done that on your branch and committed the change.

That's what this PR attempts to do.  I have very little idea if I've done this correctly, as mentioned.  Hopefully at least the new job won't fail this very PR? :P  (Edit: It finally didn't! :) )

You can also see that I made the Slack notification depend on this new job in addition to the existing jobs.

Also, while I was at it, I removed the `push` trigger for the `truffle-db` branch, because that branch doesn't exist anymore.