### PR TITLE
Internal improvement: Add workaround to mocha-webpack problem to debugger test script

### DIFF
--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -15,7 +15,7 @@
     "docs": "esdoc",
     "prepare": "yarn build",
     "start": "node ./webpack/dev-server.js",
-    "test": "mocha-webpack --webpack-config webpack/webpack.config-test.js --recursive && yarn build",
+    "test": "mocha-webpack --webpack-config webpack/webpack.config-test.js --recursive && rm -r dist && yarn build",
     "test:coverage": "nyc mocha-webpack --webpack-config webpack/webpack.config-test.js --recursive",
     "test:debug": "NODE_ENV=testing node --inspect ./node_modules/.bin/mocha-webpack --webpack-config webpack/webpack.config-test.js --recursive"
   },


### PR DESCRIPTION
This is what I need to do locally to keep things from breaking.  Intended so coverage can work in #3548.