### PR TITLE
Add sources to compile result

### DIFF
--- a/packages/compile-common/src/types.ts
+++ b/packages/compile-common/src/types.ts
@@ -2,7 +2,7 @@ import {Abi, ImmutableReferences} from "@truffle/contract-schema/spec";
 
 export type Compilation = {
   sourceIndexes: string[]; //note: does not include internal sources
-  sources: [] | Source[];
+  sources: Source[];
   contracts: CompiledContract[];
   compiler: {
     name: string | undefined;

--- a/packages/compile-common/src/types.ts
+++ b/packages/compile-common/src/types.ts
@@ -2,7 +2,7 @@ import {Abi, ImmutableReferences} from "@truffle/contract-schema/spec";
 
 export type Compilation = {
   sourceIndexes: string[]; //note: does not include internal sources
-  sources: Source[];
+  sources: Source[]; //note: does not include internal sources
   contracts: CompiledContract[];
   compiler: {
     name: string | undefined;

--- a/packages/compile-common/src/types.ts
+++ b/packages/compile-common/src/types.ts
@@ -1,13 +1,22 @@
-import { Abi, ImmutableReferences } from "@truffle/contract-schema/spec";
+import {Abi, ImmutableReferences} from "@truffle/contract-schema/spec";
 
 export type Compilation = {
-  sourceIndexes: string[]; //note: doesnot include internal sources
+  sourceIndexes: string[]; //note: does not include internal sources
+  sources?: Source[];
   contracts: CompiledContract[];
   compiler: {
     name: string | undefined;
     version: string | undefined;
   };
   db?: {};
+};
+
+export type Source = {
+  sourcePath: string;
+  contents: string;
+  ast?: object;
+  legacyAST?: object;
+  language: string;
 };
 
 export interface CompilerResult {

--- a/packages/compile-common/src/types.ts
+++ b/packages/compile-common/src/types.ts
@@ -2,7 +2,7 @@ import {Abi, ImmutableReferences} from "@truffle/contract-schema/spec";
 
 export type Compilation = {
   sourceIndexes: string[]; //note: does not include internal sources
-  sources?: Source[];
+  sources: [] | Source[];
   contracts: CompiledContract[];
   compiler: {
     name: string | undefined;

--- a/packages/compile-solidity/index.js
+++ b/packages/compile-solidity/index.js
@@ -5,7 +5,7 @@ const findContracts = require("@truffle/contract-sources");
 const Config = require("@truffle/config");
 const Profiler = require("./profiler");
 const CompilerSupplier = require("./compilerSupplier");
-const { run } = require("./run");
+const {run} = require("./run");
 
 const normalizeOptions = options => {
   if (options.logger === undefined) options.logger = console;
@@ -40,11 +40,11 @@ const normalizeOptions = options => {
 const Compile = {
   // this takes an object with keys being the name and values being source
   // material as well as an options object
-  async sources({ sources, options }) {
+  async sources({sources, options}) {
     const compilation = await run(sources, normalizeOptions(options));
     return compilation.contracts.length > 0
-      ? { compilations: [compilation] }
-      : { compilations: [] };
+      ? {compilations: [compilation]}
+      : {compilations: []};
   },
 
   async all(options) {
@@ -73,7 +73,7 @@ const Compile = {
   },
 
   // this takes an array of paths and options
-  async sourcesWithDependencies({ paths, options }) {
+  async sourcesWithDependencies({paths, options}) {
     options.logger = options.logger || console;
     options.contracts_directory = options.contracts_directory || process.cwd();
 
@@ -84,7 +84,7 @@ const Compile = {
     ]);
 
     const config = Config.default().merge(options);
-    const { allSources, compilationTargets } = await Profiler.requiredSources(
+    const {allSources, compilationTargets} = await Profiler.requiredSources(
       config.with({
         paths,
         base_path: options.contracts_directory,
@@ -100,27 +100,28 @@ const Compile = {
 
     // when there are no sources, don't call run
     if (Object.keys(allSources).length === 0) {
-      return { compilations: [] };
+      return {compilations: []};
     }
 
     options.compilationTargets = compilationTargets;
-    const { sourceIndexes, contracts, compiler } = await run(
+    const {sourceIndexes, sources, contracts, compiler} = await run(
       allSources,
       normalizeOptions(options)
     );
-    const { name, version } = compiler;
+    const {name, version} = compiler;
     // returns CompilerResult - see @truffle/compile-common
     return contracts.length > 0
       ? {
           compilations: [
             {
               sourceIndexes,
+              sources,
               contracts,
-              compiler: { name, version }
+              compiler: {name, version}
             }
           ]
         }
-      : { compilations: [] };
+      : {compilations: []};
   },
 
   display(paths, options) {

--- a/packages/compile-solidity/run.js
+++ b/packages/compile-solidity/run.js
@@ -320,7 +320,7 @@ function detectErrors({
 
 /**
  * aggregate source information based on compiled output;
- * this can include sources that are not contracts
+ * this can include sources that do not define any contracts
  */
 function processAllSources({sources, compilerOutput}) {
   if (!compilerOutput.contracts) return [];

--- a/packages/compile-solidity/run.js
+++ b/packages/compile-solidity/run.js
@@ -330,7 +330,7 @@ function processAllSources({sources, compilerOutput}) {
       contents: sources[sourcePath],
       ast: ast,
       legacyAST: legacyAST,
-      language: sourcePath.split(".").pop()
+      language: "solidity"
     })
   );
 }

--- a/packages/compile-solidity/run.js
+++ b/packages/compile-solidity/run.js
@@ -14,7 +14,7 @@ async function run(rawSources, options) {
 
   // Ensure sources have operating system independent paths
   // i.e., convert backslashes to forward slashes; things like C: are left intact.
-  const { sources, targets, originalSourcePaths } = collectSources(
+  const {sources, targets, originalSourcePaths} = collectSources(
     rawSources,
     options.compilationTargets
   );
@@ -27,20 +27,20 @@ async function run(rawSources, options) {
   });
 
   // perform compilation
-  const { compilerOutput, solcVersion } = await invokeCompiler({
+  const {compilerOutput, solcVersion} = await invokeCompiler({
     compilerInput,
     options
   });
 
   // handle warnings as errors if options.strict
   // log if not options.quiet
-  const { warnings, errors } = detectErrors({
+  const {warnings, errors} = detectErrors({
     compilerOutput,
     options,
     solcVersion
   });
   if (warnings.length > 0) {
-    options.events.emit("compile:warnings", { warnings });
+    options.events.emit("compile:warnings", {warnings});
   }
 
   if (errors.length > 0) {
@@ -64,6 +64,10 @@ async function run(rawSources, options) {
       solcVersion,
       originalSourcePaths
     }),
+    sources: processAllSources({
+      sources,
+      compilerOutput
+    }),
     compiler: {
       name: "solc",
       version: solcVersion
@@ -71,14 +75,14 @@ async function run(rawSources, options) {
   };
 }
 
-function orderABI({ abi, contractName, ast }) {
+function orderABI({abi, contractName, ast}) {
   // AST can have multiple contract definitions, make sure we have the
   // one that matches our contract
   if (!ast || !ast.nodes) {
     return abi;
   }
   const contractDefinition = ast.nodes.find(
-    ({ nodeType, name }) =>
+    ({nodeType, name}) =>
       nodeType === "ContractDefinition" && name === contractName
   );
 
@@ -88,24 +92,22 @@ function orderABI({ abi, contractName, ast }) {
 
   // Find all function definitions
   const orderedFunctionNames = contractDefinition.nodes
-    .filter(({ nodeType }) => nodeType === "FunctionDefinition")
-    .map(({ name: functionName }) => functionName);
+    .filter(({nodeType}) => nodeType === "FunctionDefinition")
+    .map(({name: functionName}) => functionName);
 
   // Put function names in a hash with their order, lowest first, for speed.
   const functionIndexes = orderedFunctionNames
-    .map((functionName, index) => ({ [functionName]: index }))
+    .map((functionName, index) => ({[functionName]: index}))
     .reduce((a, b) => Object.assign({}, a, b), {});
 
   // Construct new ABI with functions at the end in source order
   return [
-    ...abi.filter(({ name }) => functionIndexes[name] === undefined),
+    ...abi.filter(({name}) => functionIndexes[name] === undefined),
 
     // followed by the functions in the source order
     ...abi
-      .filter(({ name }) => functionIndexes[name] !== undefined)
-      .sort(
-        ({ name: a }, { name: b }) => functionIndexes[a] - functionIndexes[b]
-      )
+      .filter(({name}) => functionIndexes[name] !== undefined)
+      .sort(({name: a}, {name: b}) => functionIndexes[a] - functionIndexes[b])
   ];
 }
 
@@ -124,7 +126,7 @@ function collectSources(originalSources, originalTargets = []) {
       contents,
       sourcePath: getPortableSourcePath(originalSourcePath)
     }))
-    .map(({ originalSourcePath, sourcePath, contents }) => ({
+    .map(({originalSourcePath, sourcePath, contents}) => ({
       sources: {
         [sourcePath]: contents
       },
@@ -181,10 +183,10 @@ function getPortableSourcePath(sourcePath) {
  * @param setings - subset of Solidity settings
  * @return solc compiler input JSON
  */
-function prepareCompilerInput({ sources, targets, settings }) {
+function prepareCompilerInput({sources, targets, settings}) {
   return {
     language: "Solidity",
-    sources: prepareSources({ sources }),
+    sources: prepareSources({sources}),
     settings: {
       evmVersion: settings.evmVersion,
       optimizer: settings.optimizer,
@@ -194,7 +196,7 @@ function prepareCompilerInput({ sources, targets, settings }) {
       libraries: settings.libraries,
       // Specify compilation targets. Each target uses defaultSelectors,
       // defaulting to single target `*` if targets are unspecified
-      outputSelection: prepareOutputSelection({ targets })
+      outputSelection: prepareOutputSelection({targets})
     }
   };
 }
@@ -204,9 +206,9 @@ function prepareCompilerInput({ sources, targets, settings }) {
  * @param sources - { [sourcePath]: string }
  * @return { [sourcePath]: { content: string } }
  */
-function prepareSources({ sources }) {
+function prepareSources({sources}) {
   return Object.entries(sources)
-    .map(([sourcePath, content]) => ({ [sourcePath]: { content } }))
+    .map(([sourcePath, content]) => ({[sourcePath]: {content}}))
     .reduce((a, b) => Object.assign({}, a, b), {});
 }
 
@@ -215,7 +217,7 @@ function prepareSources({ sources }) {
  * Otherwise, just use "*" selector
  * @param targets - sourcePath[] | undefined
  */
-function prepareOutputSelection({ targets = [] }) {
+function prepareOutputSelection({targets = []}) {
   const defaultSelectors = {
     "": ["legacyAST", "ast"],
     "*": [
@@ -242,21 +244,21 @@ function prepareOutputSelection({ targets = [] }) {
   }
 
   return targets
-    .map(target => ({ [target]: defaultSelectors }))
+    .map(target => ({[target]: defaultSelectors}))
     .reduce((a, b) => Object.assign({}, a, b), {});
 }
 
 /**
  * Load solc and perform compilation
  */
-async function invokeCompiler({ compilerInput, options }) {
+async function invokeCompiler({compilerInput, options}) {
   const supplierOptions = {
     parser: options.parser,
     events: options.events,
     solcConfig: options.compilers.solc
   };
   const supplier = new CompilerSupplier(supplierOptions);
-  const { solc } = await supplier.load();
+  const {solc} = await supplier.load();
   const solcVersion = solc.version();
 
   // perform compilation
@@ -275,22 +277,22 @@ async function invokeCompiler({ compilerInput, options }) {
  * @return { errors: string, warnings: string }
  */
 function detectErrors({
-  compilerOutput: { errors: outputErrors },
+  compilerOutput: {errors: outputErrors},
   options,
   solcVersion
 }) {
   outputErrors = outputErrors || [];
   const rawErrors = options.strict
     ? outputErrors
-    : outputErrors.filter(({ severity }) => severity !== "warning");
+    : outputErrors.filter(({severity}) => severity !== "warning");
 
   const rawWarnings = options.strict
     ? [] // none of those in strict mode
-    : outputErrors.filter(({ severity }) => severity === "warning");
+    : outputErrors.filter(({severity}) => severity === "warning");
 
   // extract messages
-  let errors = rawErrors.map(({ formattedMessage }) => formattedMessage).join();
-  const warnings = rawWarnings.map(({ formattedMessage }) => formattedMessage);
+  let errors = rawErrors.map(({formattedMessage}) => formattedMessage).join();
+  const warnings = rawWarnings.map(({formattedMessage}) => formattedMessage);
 
   if (errors.includes("requires different compiler version")) {
     const contractSolcVer = errors.match(/pragma solidity[^;]*/gm)[0];
@@ -313,17 +315,34 @@ function detectErrors({
     );
   }
 
-  return { warnings, errors };
+  return {warnings, errors};
+}
+
+/**
+ * aggregate source information based on compiled output;
+ * this can include sources that are not contracts
+ */
+function processAllSources({sources, compilerOutput}) {
+  if (!compilerOutput.contracts) return [];
+  return Object.entries(compilerOutput.sources).map(
+    ([sourcePath, {ast, legacyAST}]) => ({
+      sourcePath: sourcePath,
+      contents: sources[sourcePath],
+      ast: ast,
+      legacyAST: legacyAST,
+      language: sourcePath.split(".").pop()
+    })
+  );
 }
 
 /**
  * Aggregate list of sources based on reported source index
  * Returns list transformed to use original source paths
  */
-function processSources({ compilerOutput, originalSourcePaths }) {
+function processSources({compilerOutput, originalSourcePaths}) {
   let files = [];
 
-  for (let [sourcePath, { id }] of Object.entries(compilerOutput.sources)) {
+  for (let [sourcePath, {id}] of Object.entries(compilerOutput.sources)) {
     files[id] = originalSourcePaths[sourcePath];
   }
 
@@ -361,7 +380,7 @@ function processContracts({
 
       // All source will have a key, but only the compiled source will have
       // the evm output.
-      .filter(({ contract: { evm } }) => Object.keys(evm).length > 0)
+      .filter(({contract: {evm}}) => Object.keys(evm).length > 0)
 
       // convert to output format
       .map(
@@ -396,7 +415,7 @@ function processContracts({
           }
         }) => ({
           contractName,
-          abi: orderABI({ abi, contractName, ast }),
+          abi: orderABI({abi, contractName, ast}),
           metadata,
           devdoc,
           userdoc,
@@ -439,26 +458,26 @@ function formatLinkReferences(linkReferences) {
     .reduce((a, b) => [...a, ...b], []);
 
   // convert to { offsets, length, name } format
-  return libraryLinkReferences.map(({ name, links }) => ({
-    offsets: links.map(({ start }) => start),
+  return libraryLinkReferences.map(({name, links}) => ({
+    offsets: links.map(({start}) => start),
     length: links[0].length, // HACK just assume they're going to be the same
     name
   }));
 }
 
 // takes linkReferences in output format (not Solidity's format)
-function zeroLinkReferences({ bytes, linkReferences }) {
+function zeroLinkReferences({bytes, linkReferences}) {
   // inline link references - start by flattening the offsets
   const flattenedLinkReferences = linkReferences
     // map each link ref to array of link refs with only one offset
-    .map(({ offsets, length, name }) =>
-      offsets.map(offset => ({ offset, length, name }))
+    .map(({offsets, length, name}) =>
+      offsets.map(offset => ({offset, length, name}))
     )
     // flatten
     .reduce((a, b) => [...a, ...b], []);
 
   // then overwite bytes with zeroes
-  bytes = flattenedLinkReferences.reduce((bytes, { offset, length }) => {
+  bytes = flattenedLinkReferences.reduce((bytes, {offset, length}) => {
     // length is a byte offset
     const characterLength = length * 2;
     const start = offset * 2;
@@ -470,7 +489,7 @@ function zeroLinkReferences({ bytes, linkReferences }) {
     )}`;
   }, bytes);
 
-  return { bytes, linkReferences };
+  return {bytes, linkReferences};
 }
 
-module.exports = { run };
+module.exports = {run};

--- a/packages/compile-vyper/index.js
+++ b/packages/compile-vyper/index.js
@@ -70,7 +70,7 @@ function readSource(sourcePath) {
  * this can include sources that are not contracts
  */
 function processAllSources(sources) {
-  if (!sourcePaths.length) return [];
+  if (!sources.length) return [];
   return sources.map(sourcePath => ({
     sourcePath: sourcePath,
     contents: readSource(sourcePath),

--- a/packages/compile-vyper/index.js
+++ b/packages/compile-vyper/index.js
@@ -74,7 +74,7 @@ function processAllSources(sources) {
   return sources.map(sourcePath => ({
     sourcePath: sourcePath,
     contents: readSource(sourcePath),
-    language: sourcePath.split(".").pop()
+    language: sourcePath.substr(sourcePath.indexOf("."))
   }));
 }
 

--- a/packages/compile-vyper/index.js
+++ b/packages/compile-vyper/index.js
@@ -74,7 +74,7 @@ function processAllSources(sources) {
   return sources.map(sourcePath => ({
     sourcePath: sourcePath,
     contents: readSource(sourcePath),
-    language: sourcePath.substr(sourcePath.indexOf("."))
+    language: "vyper"
   }));
 }
 

--- a/packages/compile-vyper/index.js
+++ b/packages/compile-vyper/index.js
@@ -38,7 +38,7 @@ function execVyper(options, sourcePath, callback) {
   }
   const command = `vyper -f ${formats.join(",")} ${sourcePath}`;
 
-  exec(command, { maxBuffer: 600 * 1024 }, function (err, stdout, stderr) {
+  exec(command, {maxBuffer: 600 * 1024}, function (err, stdout, stderr) {
     if (err)
       return callback(
         `${stderr}\n${colors.red(
@@ -49,15 +49,37 @@ function execVyper(options, sourcePath, callback) {
     var outputs = stdout.split(/\r?\n/);
 
     const compiledContract = outputs.reduce((contract, output, index) => {
-      return Object.assign(contract, { [formats[index]]: output });
+      return Object.assign(contract, {[formats[index]]: output});
     }, {});
 
     callback(null, compiledContract);
   });
 }
 
+/**
+ *
+ * read source contents from sourcePath
+ */
+function readSource(sourcePath) {
+  const sourceBuffer = fs.readFileSync(sourcePath);
+  return sourceBuffer.toString();
+}
+
+/**
+ * aggregate source information based on compiled output;
+ * this can include sources that are not contracts
+ */
+function processAllSources(sources) {
+  if (!sourcePaths.length) return [];
+  return sources.map(sourcePath => ({
+    sourcePath: sourcePath,
+    contents: readSource(sourcePath),
+    language: sourcePath.split(".").pop()
+  }));
+}
+
 // compile all sources
-async function compileAll({ sources, options }) {
+async function compileAll({sources, options}) {
   options.logger = options.logger || console;
 
   Compile.display(sources, options);
@@ -79,8 +101,7 @@ async function compileAll({ sources, options }) {
               ? basename
               : path.basename(basename, path.extname(basename));
 
-          const sourceBuffer = fs.readFileSync(sourcePath);
-          const sourceContents = sourceBuffer.toString();
+          const sourceContents = readSource(sourcePath);
 
           const contractDefinition = {
             contractName: contractName,
@@ -100,8 +121,9 @@ async function compileAll({ sources, options }) {
   });
   const contracts = await Promise.all(promises);
 
-  const compilerInfo = { name: "vyper", version: compiler.version };
+  const compilerInfo = {name: "vyper", version: compiler.version};
   return {
+    sources: processAllSources(sources),
     compilations: [
       {
         compiler: compilerInfo,
@@ -114,13 +136,13 @@ async function compileAll({ sources, options }) {
 
 const Compile = {
   // Check that vyper is available then forward to internal compile function
-  async sources({ sources = [], options }) {
+  async sources({sources = [], options}) {
     // filter out non-vyper paths
     const vyperFiles = sources.filter(path => minimatch(path, VYPER_PATTERN));
 
     // no vyper files found, no need to check vyper
     if (vyperFiles.length === 0) {
-      return { compilations: [] };
+      return {compilations: []};
     }
 
     await checkVyper();
@@ -130,7 +152,7 @@ const Compile = {
     });
   },
 
-  async sourcesWithDependencies({ paths = [], options }) {
+  async sourcesWithDependencies({paths = [], options}) {
     return await Compile.sources({
       sources: paths,
       options
@@ -163,7 +185,7 @@ const Compile = {
     const updated = await Profiler.updated(options);
 
     if (updated.length === 0 && options.quiet !== true) {
-      return { compilations: [] };
+      return {compilations: []};
     }
 
     // filter out only Vyper files
@@ -191,7 +213,7 @@ const Compile = {
 
       return contract;
     });
-    options.events.emit("compile:sourcesToCompile", { sourceFileNames });
+    options.events.emit("compile:sourcesToCompile", {sourceFileNames});
   }
 };
 

--- a/packages/compile-vyper/index.js
+++ b/packages/compile-vyper/index.js
@@ -71,11 +71,16 @@ function readSource(sourcePath) {
  */
 function processAllSources(sources) {
   if (!sources.length) return [];
-  return sources.map(sourcePath => ({
-    sourcePath: sourcePath,
-    contents: readSource(sourcePath),
-    language: "vyper"
-  }));
+
+  return sources.map(sourcePath => {
+    let source = {
+      sourcePath: sourcePath,
+      contents: readSource(sourcePath),
+      language: "vyper"
+    };
+
+    return source;
+  });
 }
 
 // compile all sources
@@ -123,9 +128,9 @@ async function compileAll({sources, options}) {
 
   const compilerInfo = {name: "vyper", version: compiler.version};
   return {
-    sources: processAllSources(sources),
     compilations: [
       {
+        sources: processAllSources(sources),
         compiler: compilerInfo,
         contracts,
         sourceIndexes: sources

--- a/packages/compile-vyper/test/test_compiler.js
+++ b/packages/compile-vyper/test/test_compiler.js
@@ -1,7 +1,8 @@
 const path = require("path");
 const assert = require("assert");
 const Config = require("@truffle/config");
-const { Compile } = require("../index");
+const {Compile} = require("../index");
+const fs = require("fs");
 
 describe("vyper compiler", function () {
   this.timeout(20000);
@@ -14,8 +15,8 @@ describe("vyper compiler", function () {
   const config = new Config().merge(defaultSettings);
 
   it("compiles vyper contracts", async function () {
-    const { compilations } = await Compile.all(config);
-    const { contracts, sourceIndexes } = compilations[0];
+    const {compilations} = await Compile.all(config);
+    const {contracts, sourceIndexes} = compilations[0];
     sourceIndexes.forEach(path => {
       assert(
         [".vy", ".v.py", ".vyper.py"].some(
@@ -63,8 +64,8 @@ describe("vyper compiler", function () {
   });
 
   it("skips solidity contracts", async function () {
-    const { compilations } = await Compile.all(config);
-    const { contracts, sourceIndexes } = compilations[0];
+    const {compilations} = await Compile.all(config);
+    const {contracts, sourceIndexes} = compilations[0];
 
     sourceIndexes.forEach(path => {
       assert.equal(path.indexOf(".sol"), -1, "Paths have no .sol files");
@@ -87,14 +88,34 @@ describe("vyper compiler", function () {
     });
 
     it("compiles when sourceMap option set true", async () => {
-      const { compilations } = await Compile.all(configWithSourceMap);
-      const { contracts } = compilations[0];
+      const {compilations} = await Compile.all(configWithSourceMap);
+      const {contracts} = compilations[0];
       contracts.forEach((contract, index) => {
         assert(
           contract.sourceMap,
           `source map have to not be empty. ${index + 1}`
         );
       });
+    });
+  });
+
+  describe("compilation sources array", async () => {
+    it("returns an array of sources reflecting sources in project", async () => {
+      const {compilations} = await Compile.all(config);
+      const {sources} = compilations[0];
+
+      assert(sources.length === 3);
+      assert(
+        sources[0].sourcePath ===
+          path.join(__dirname, "sources/VyperContract1.vy")
+      );
+      assert(
+        sources[0].contents ===
+          fs
+            .readFileSync(path.join(__dirname, "sources/VyperContract1.vy"))
+            .toString()
+      );
+      assert(sources[0].language === "vyper");
     });
   });
 });

--- a/packages/external-compile/index.js
+++ b/packages/external-compile/index.js
@@ -1,15 +1,15 @@
 "use strict";
 
 const debug = require("debug")("external-compile");
-const { exec, execSync } = require("child_process");
+const {exec, execSync} = require("child_process");
 const resolve = require("path").resolve;
-const { promisify } = require("util");
+const {promisify} = require("util");
 const glob = promisify(require("glob"));
 const fs = require("fs");
 const expect = require("@truffle/expect");
 const Schema = require("@truffle/contract-schema");
 const web3Utils = require("web3-utils");
-const { Shims } = require("@truffle/compile-common");
+const {Shims} = require("@truffle/compile-common");
 
 const DEFAULT_ABI = [
   {
@@ -86,8 +86,8 @@ function* bufferLines() {
  * invokes callback when process exits, error on nonzero exit code.
  */
 const runCommand = promisify(function (command, options, callback) {
-  const { cwd, logger, input } = options;
-  const child = exec(command, { cwd, input });
+  const {cwd, logger, input} = options;
+  const child = exec(command, {cwd, input});
 
   // wrap buffer generator for easy use
   const buffer = func => {
@@ -96,7 +96,7 @@ const runCommand = promisify(function (command, options, callback) {
     return data => {
       gen.next();
 
-      let { value: lines } = gen.next(data);
+      let {value: lines} = gen.next(data);
       for (let line of lines) {
         func(line);
       }
@@ -179,9 +179,9 @@ async function processTarget(target, cwd, logger) {
 
   if (usesCommand && !usesPath) {
     // just run command
-    const output = execSync(target.command, { cwd });
+    const output = execSync(target.command, {cwd});
     const contract = JSON.parse(output);
-    return { [contract.contractName]: contract };
+    return {[contract.contractName]: contract};
   }
 
   if (usesPath && !glob.hasMagic(target.path)) {
@@ -191,23 +191,23 @@ async function processTarget(target, cwd, logger) {
     if (usesStdin) {
       input = fs.readFileSync(filename).toString();
       command = target.command;
-      execOptions = { cwd, input };
+      execOptions = {cwd, input};
     } else {
       command = `${target.command} ${filename}`;
-      execOptions = { cwd };
+      execOptions = {cwd};
     }
 
     const output = usesCommand ? execSync(command, execOptions) : input;
 
     const contract = JSON.parse(output);
-    return { [contract.contractName]: contract };
+    return {[contract.contractName]: contract};
   }
 
   if (usesPath && glob.hasMagic(target.path)) {
     // glob expression, recurse after expansion
-    let paths = await glob(target.path, { cwd, follow: true });
+    let paths = await glob(target.path, {cwd, follow: true});
     // copy target properties, overriding path with expanded form
-    let targets = paths.map(path => Object.assign({}, target, { path }));
+    let targets = paths.map(path => Object.assign({}, target, {path}));
     return await processTargets(targets, cwd, logger);
   }
 
@@ -238,7 +238,7 @@ async function processTarget(target, cwd, logger) {
       );
     }
 
-    return { [contract.contractName]: contract };
+    return {[contract.contractName]: contract};
   }
 }
 
@@ -261,7 +261,7 @@ const Compile = {
 
   // compile-common defines object argument to include `sources`, but this is
   // unused as the user is responsible for dealing with compiling their sources
-  async sources({ options }) {
+  async sources({options}) {
     if (options.logger == null) {
       options.logger = console;
     }
@@ -270,7 +270,7 @@ const Compile = {
     expect.options(options.compilers, ["external"]);
     expect.options(options.compilers.external, ["command", "targets"]);
 
-    const { command, targets } = options.compilers.external;
+    const {command, targets} = options.compilers.external;
     const cwd =
       options.compilers.external.workingDirectory ||
       options.compilers.external.working_directory || // just in case
@@ -278,7 +278,7 @@ const Compile = {
     const logger = options.logger;
 
     debug("running compile command: %s", command);
-    await runCommand(command, { cwd, logger });
+    await runCommand(command, {cwd, logger});
 
     const contracts = await processTargets(targets, cwd, logger);
     return {
@@ -288,6 +288,9 @@ const Compile = {
           // sourceIndexes is empty because we have no way of
           // knowing for certain the source paths for the contracts
           sourceIndexes: [],
+          // since we don't know the sourcePaths, we can't really provide
+          // the source info reliably
+          sources: [],
           compiler: {
             name: "external",
             version: undefined
@@ -297,8 +300,8 @@ const Compile = {
     };
   },
 
-  async sourcesWithDependencies({ options }) {
-    return await Compile.sources({ options });
+  async sourcesWithDependencies({options}) {
+    return await Compile.sources({options});
   }
 };
 

--- a/packages/workflow-compile/index.js
+++ b/packages/workflow-compile/index.js
@@ -1,7 +1,7 @@
 const debug = require("debug")("workflow-compile");
 const fse = require("fs-extra");
-const { prepareConfig } = require("./utils");
-const { Shims } = require("@truffle/compile-common");
+const {prepareConfig} = require("./utils");
+const {Shims} = require("@truffle/compile-common");
 const {
   reportCompilationStarted,
   reportNothingToCompile,
@@ -54,8 +54,12 @@ async function compile(config) {
     return a.concat(compilation.contracts);
   }, []);
 
+  const sources = compilations.reduce((a, compilation) => {
+    return a.concat(compilation.sources);
+  }, []);
+
   // return WorkflowCompileResult
-  return { contracts, compilations };
+  return {contracts, sources, compilations};
 }
 
 const WorkflowCompile = {
@@ -64,7 +68,7 @@ const WorkflowCompile = {
 
     if (config.events) config.events.emit("compile:start");
 
-    const { contracts, compilations } = await compile(config);
+    const {contracts, sources, compilations} = await compile(config);
 
     const compilers = compilations
       .reduce((a, compilation) => {
@@ -84,15 +88,17 @@ const WorkflowCompile = {
     }
     return {
       contracts,
+      sources,
       compilations
     };
   },
 
   async compileAndSave(options) {
-    const { contracts, compilations } = await this.compile(options);
-    await this.save(options, { contracts, compilations });
+    const {contracts, sources, compilations} = await this.compile(options);
+    await this.save(options, {contracts, compilations});
     return {
       contracts,
+      sources,
       compilations
     };
   },
@@ -101,7 +107,7 @@ const WorkflowCompile = {
   reportCompilationFinished,
   reportNothingToCompile,
 
-  async save(options, { contracts, _compilations }) {
+  async save(options, {contracts, _compilations}) {
     const config = prepareConfig(options);
 
     await fse.ensureDir(config.contracts_build_directory);

--- a/packages/workflow-compile/test/index.js
+++ b/packages/workflow-compile/test/index.js
@@ -1,7 +1,7 @@
 const Contracts = require("../");
 const assert = require("assert");
-const { existsSync, removeSync } = require("fs-extra");
-const { join } = require("path");
+const {existsSync, removeSync} = require("fs-extra");
+const {join} = require("path");
 
 let config;
 
@@ -37,7 +37,7 @@ describe("Contracts.compile", () => {
   describe("when config.all is true", () => {
     it("recompiles all contracts in contracts_directory", async () => {
       // initial compile
-      const { contracts } = await Contracts.compileAndSave(config);
+      const {contracts} = await Contracts.compileAndSave(config);
 
       let contractName = contracts[0].contractName;
       assert(
@@ -46,7 +46,7 @@ describe("Contracts.compile", () => {
 
       // compile again
       config.all = true;
-      const { compilations } = await Contracts.compileAndSave(config);
+      const {compilations} = await Contracts.compileAndSave(config);
 
       assert(
         compilations[0].sourceIndexes[0] ===
@@ -55,5 +55,13 @@ describe("Contracts.compile", () => {
           )
       );
     }).timeout(4000);
+
+    it("provides an array of sources in compilation result", async () => {
+      config.all = true;
+      const {sources} = await Contracts.compileAndSave(config);
+
+      assert(sources.length === 1);
+      assert(existsSync(sources[0].sourcePath));
+    });
   });
 });


### PR DESCRIPTION
This PR adds a `sources` object to the `workflow-compile` result, and makes necessary changes in the `compile-common`, `compile-solidity`, `compile-vyper` and `external-compile` packages.

Of note, the vyper compilation result does not include `ast` or `legacyAST`, and external compilations will return an empty array for sources since the user does their own source management when using an external compiler.