### PR TITLE
Dependency update: Update highlight.js to 10.x

### DIFF
--- a/packages/debug-utils/package.json
+++ b/packages/debug-utils/package.json
@@ -18,7 +18,7 @@
     "@trufflesuite/chromafi": "^2.2.1",
     "chalk": "^2.4.2",
     "debug": "^4.1.0",
-    "highlight.js": "^9.15.8",
+    "highlight.js": "^10.4.0",
     "highlightjs-solidity": "^1.0.19"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11690,6 +11690,11 @@ heap@0.2.6:
   resolved "https://registry.yarnpkg.com/heap/-/heap-0.2.6.tgz#087e1f10b046932fc8594dd9e6d378afc9d1e5ac"
   integrity sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw=
 
+highlight.js@^10.4.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.4.0.tgz#ef3ce475e5dfa7a48484260b49ea242ddab823a0"
+  integrity sha512-EfrUGcQ63oLJbj0J0RI9ebX6TAITbsDBLbsjr881L/X5fMO9+oadKzEF21C7R3ULKG6Gv3uoab2HiqVJa/4+oA==
+
 highlight.js@^9.12.0, highlight.js@^9.15.8:
   version "9.17.1"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.17.1.tgz#14a4eded23fd314b05886758bb906e39dd627f9a"


### PR DESCRIPTION
As best I can tell, none of the breaking changes in highlight.js 10.x are at all relevant to us.  Doing a quick test, it seems fine.  Addresses #3551.