### PR TITLE
Enable querying @truffle/db ABIs for individual entries

### DIFF
--- a/packages/db/bin/codegen.js
+++ b/packages/db/bin/codegen.js
@@ -9,7 +9,7 @@ const dataModel = generateNamespace(
   schema,
   {
     ignoreTypeNameDeclaration: true,
-    ignoredTypes: ["Resource", "Named"]
+    ignoredTypes: ["Resource", "Named", "Entry"]
   },
   {
     generateInterfaceName: name => name

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -35,6 +35,7 @@
     "test": "jest --verbose --detectOpenHandles"
   },
   "dependencies": {
+    "@truffle/abi-utils": "^0.1.1",
     "@truffle/code-utils": "^1.2.22",
     "@truffle/compile-common": "^0.4.3",
     "@truffle/config": "^1.2.33",


### PR DESCRIPTION
Use @truffle/abi-utils to normalize the ABI JSON and define corresponding types for querying in @truffle/db