### PR TITLE
Improve @truffle/db project name-keeping by adding `type` field to all resources

### DIFF
--- a/packages/db/src/graphql/schema.ts
+++ b/packages/db/src/graphql/schema.ts
@@ -40,6 +40,7 @@ class DefinitionsSchema<C extends Collections> {
     const common = gql`
       interface Resource {
         id: ID!
+        kind: String!
       }
 
       interface Named {
@@ -168,6 +169,7 @@ abstract class DefinitionSchema<
 
       extend type ${Resource} {
         id: ID!
+        kind: String!
       }
 
       extend type Query {
@@ -204,12 +206,18 @@ abstract class DefinitionSchema<
     const logAll = log.extend("all");
     const logFilter = log.extend("filter");
 
-    const { resource, resources } = this.definition.names;
+    const { resource, resources, Resource } = this.definition.names;
 
     const { resolvers = {} } = this.definition;
 
     const result = {
       ...resolvers,
+
+      [Resource]: {
+        ...(resolvers[Resource] as any),
+
+        kind: () => Resource
+      },
 
       Query: {
         [resource]: {

--- a/packages/db/src/graphql/schema.ts
+++ b/packages/db/src/graphql/schema.ts
@@ -4,8 +4,6 @@ const debug = logger("db:graphql:schema");
 import gql from "graphql-tag";
 import * as graphql from "graphql";
 import { makeExecutableSchema, IResolvers } from "graphql-tools";
-import pascalCase from "pascal-case";
-import { singular } from "pluralize";
 
 import {
   Collections,
@@ -145,15 +143,6 @@ abstract class DefinitionSchema<
   protected resource: N;
   protected definition: Definition<C, N>;
 
-  protected abstract get names(): {
-    resource: string;
-    Resource: string;
-    resources: N; // sure why not
-    Resources: string;
-    resourcesMutate: string;
-    ResourcesMutate: string;
-  };
-
   constructor(options: { resource: N; definition: Definition<C, N> }) {
     this.resource = options.resource;
     this.definition = options.definition;
@@ -171,7 +160,7 @@ abstract class DefinitionSchema<
       Resource,
       resourcesMutate,
       ResourcesMutate
-    } = this.names;
+    } = this.definition.names;
 
     const result = [
       gql`
@@ -211,7 +200,7 @@ abstract class DefinitionSchema<
     const logAll = log.extend("all");
     const logFilter = log.extend("filter");
 
-    const { resource, resources } = this.names;
+    const { resource, resources } = this.definition.names;
 
     const { resolvers = {} } = this.definition;
 
@@ -270,34 +259,13 @@ class ImmutableDefinitionSchema<
   C extends Collections,
   N extends CollectionName<C>
 > extends DefinitionSchema<C, N> {
-  get names() {
-    const resources = this.resource;
-    const Resources = pascalCase(resources);
-
-    const resource = singular(resources);
-    const Resource = pascalCase(resource);
-
-    const resourcesMutate = `${resources}Add`;
-
-    const ResourcesMutate = pascalCase(resourcesMutate);
-
-    return {
-      resource,
-      resources,
-      Resource,
-      Resources,
-      resourcesMutate,
-      ResourcesMutate
-    };
-  }
-
   get resolvers() {
     const log = debug.extend(`${this.resource}:resolvers`);
     log("Generating...");
 
     const logMutate = log.extend("add");
 
-    const { resources, resourcesMutate } = this.names;
+    const { resources, resourcesMutate } = this.definition.names;
 
     const result = {
       ...super.resolvers,
@@ -323,34 +291,13 @@ class MutableDefinitionSchema<
   C extends Collections,
   M extends MutableCollectionName<C>
 > extends DefinitionSchema<C, M> {
-  get names() {
-    const resources = this.resource;
-    const Resources = pascalCase(resources);
-
-    const resource = singular(resources);
-    const Resource = pascalCase(resource);
-
-    const resourcesMutate = `${resources}Assign`;
-
-    const ResourcesMutate = pascalCase(resourcesMutate);
-
-    return {
-      resource,
-      resources,
-      Resource,
-      Resources,
-      resourcesMutate,
-      ResourcesMutate
-    };
-  }
-
   get resolvers() {
     const log = debug.extend(`${this.resource}:resolvers`);
     log("Generating...");
 
     const logMutate = log.extend("assign");
 
-    const { resources, resourcesMutate } = this.names;
+    const { resources, resourcesMutate } = this.definition.names;
 
     const result = {
       ...super.resolvers,

--- a/packages/db/src/graphql/schema.ts
+++ b/packages/db/src/graphql/schema.ts
@@ -40,16 +40,22 @@ class DefinitionsSchema<C extends Collections> {
     const common = gql`
       interface Resource {
         id: ID!
-        kind: String!
+        type: String!
       }
 
       interface Named {
         id: ID!
+        type: String!
         name: String!
       }
 
       input ResourceReferenceInput {
         id: ID!
+      }
+
+      input TypedResourceReferenceInput {
+        id: ID!
+        type: String!
       }
 
       input QueryFilter {
@@ -169,7 +175,7 @@ abstract class DefinitionSchema<
 
       extend type ${Resource} {
         id: ID!
-        kind: String!
+        type: String!
       }
 
       extend type Query {
@@ -216,7 +222,7 @@ abstract class DefinitionSchema<
       [Resource]: {
         ...(resolvers[Resource] as any),
 
-        kind: () => Resource
+        type: () => Resource
       },
 
       Query: {

--- a/packages/db/src/graphql/schema.ts
+++ b/packages/db/src/graphql/schema.ts
@@ -166,6 +166,10 @@ abstract class DefinitionSchema<
       gql`
       ${typeDefs}
 
+      extend type ${Resource} {
+        id: ID!
+      }
+
       extend type Query {
         ${resources}(filter: QueryFilter): [${Resource}]
         ${resource}(id: ID!): ${Resource}

--- a/packages/db/src/graphql/types.ts
+++ b/packages/db/src/graphql/types.ts
@@ -13,17 +13,12 @@ import {
 import { Workspace } from "../pouch";
 
 export type Definitions<C extends Collections> = {
-  [N in CollectionName<C>]: N extends MutableCollectionName<C>
-    ? {
-        mutable: true;
-        typeDefs: graphql.DocumentNode;
-        resolvers?: IResolvers<any, Context<C>>;
-      }
-    : {
-        mutable?: boolean;
-        typeDefs: graphql.DocumentNode;
-        resolvers?: IResolvers<any, Context<C>>;
-      };
+  [N in CollectionName<C>]: {
+    typeDefs: graphql.DocumentNode;
+    resolvers?: IResolvers<any, Context<C>>;
+  } & (N extends MutableCollectionName<C>
+    ? { mutable: true }
+    : { mutable?: false });
 };
 
 export interface Context<C extends Collections> {

--- a/packages/db/src/graphql/types.ts
+++ b/packages/db/src/graphql/types.ts
@@ -7,6 +7,8 @@ import { IResolvers } from "graphql-tools";
 import {
   Collections,
   CollectionName,
+  CollectionNameStyle,
+  CollectionNameStyledAs,
   MutableCollectionName
 } from "@truffle/db/meta";
 
@@ -16,6 +18,9 @@ export type Definitions<C extends Collections> = {
   [N in CollectionName<C>]: {
     typeDefs: graphql.DocumentNode;
     resolvers?: IResolvers<any, Context<C>>;
+    names: {
+      [S in CollectionNameStyle]: CollectionNameStyledAs<S, C, N>;
+    };
   } & (N extends MutableCollectionName<C>
     ? { mutable: true }
     : { mutable?: false });

--- a/packages/db/src/meta/index.ts
+++ b/packages/db/src/meta/index.ts
@@ -22,11 +22,7 @@ export type Collections = {
         mutable?: boolean;
         named?: false;
         names: {
-          resource: string;
-          Resource: string;
-          resources: string;
-          Resources: string;
-          resourcesMutate: string;
+          [S in CollectionNameStyle]: string;
         };
       }
     // definitely named, must define name property
@@ -39,11 +35,7 @@ export type Collections = {
         mutable?: boolean;
         named: true;
         names: {
-          resource: string;
-          Resource: string;
-          resources: string;
-          Resources: string;
-          resourcesMutate: string;
+          [S in CollectionNameStyle]: string;
         };
       };
 };
@@ -78,6 +70,19 @@ export type CollectionProperty<
   C extends Collections = Collections,
   N extends CollectionName<C> = CollectionName<C>
 > = Collection<C, N>[P];
+
+export type CollectionNameStyle =
+  | "resource"
+  | "Resource"
+  | "resources"
+  | "Resources"
+  | "resourcesMutate";
+
+export type CollectionNameStyledAs<
+  S extends CollectionNameStyle,
+  C extends Collections,
+  N extends CollectionName<C>
+> = CollectionProperty<"names", C, N>[S];
 
 export type ResourceFilter = {
   is: CollectionPropertyName<{ extends: boolean }>;

--- a/packages/db/src/meta/index.ts
+++ b/packages/db/src/meta/index.ts
@@ -76,7 +76,8 @@ export type CollectionNameStyle =
   | "Resource"
   | "resources"
   | "Resources"
-  | "resourcesMutate";
+  | "resourcesMutate"
+  | "ResourcesMutate";
 
 export type CollectionNameStyledAs<
   S extends CollectionNameStyle,

--- a/packages/db/src/project/index.ts
+++ b/packages/db/src/project/index.ts
@@ -35,6 +35,10 @@ export class Project {
     return new Project({ run, forProvider, project });
   }
 
+  get id() {
+    return this.project.id;
+  }
+
   /**
    * Accept a compilation result and process it to save all relevant resources
    * (Source, Bytecode, Compilation, Contract)

--- a/packages/db/src/project/names/nameRecords.ts
+++ b/packages/db/src/project/names/nameRecords.ts
@@ -8,7 +8,7 @@ export const generateNameRecordsLoad = Batch.generate<{
   assignment: {
     name: string;
     type: string;
-    current: IdObject<DataModel.NameRecord> | undefined;
+    current: DataModel.NameRecord | undefined;
   };
   properties: {
     nameRecord: IdObject<DataModel.NameRecord>;
@@ -16,8 +16,28 @@ export const generateNameRecordsLoad = Batch.generate<{
   entry: DataModel.NameRecordInput;
   result: IdObject<DataModel.NameRecord>;
 }>({
-  extract<_I>({ input: { resource, name, type, current } }) {
-    return { resource, name, type, previous: current };
+  extract<_I>({
+    input: {
+      resource: { id },
+      type,
+      current
+    }
+  }) {
+    if (!current) {
+      debug("no previous");
+      return { resource: { id, type } };
+    }
+
+    if (current.resource.id === id) {
+      debug("re-assigning same resource");
+      return { resource: { id, type }, previous: current.previous };
+    }
+
+    debug("including previous");
+    debug("previous id %o", current.resource.id);
+    debug("id %o", id);
+
+    return { resource: { id, type }, previous: { id: current.id } };
   },
 
   *process({ entries }) {

--- a/packages/db/src/project/names/projectNames.ts
+++ b/packages/db/src/project/names/projectNames.ts
@@ -17,7 +17,7 @@ export const generateProjectNamesLoad = Batch.generate<{
   result: IdObject<DataModel.ProjectName>;
 }>({
   extract<_I>({ input: { name, type, nameRecord }, inputs: { project } }) {
-    return { project, name, type, nameRecord };
+    return { project, key: { name, type }, nameRecord };
   },
 
   *process({ entries }) {

--- a/packages/db/src/project/test/artifacts/index.ts
+++ b/packages/db/src/project/test/artifacts/index.ts
@@ -101,7 +101,7 @@ export class ArtifactsLoader {
       "contracts",
       ids,
       gql`
-        fragment Contract on Contract {
+        fragment ContractNameAndBytecodes on Contract {
           id
           name
           callBytecode {

--- a/packages/db/src/project/test/assignNames.spec.ts
+++ b/packages/db/src/project/test/assignNames.spec.ts
@@ -1,0 +1,183 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:project:test:assignNames");
+
+import gql from "graphql-tag";
+
+import { Db, Project, connect } from "@truffle/db";
+
+const helpers = (db: Db, project: Project) => ({
+  async addContract(input: DataModel.ContractInput) {
+    const {
+      data: {
+        contractsAdd: {
+          contracts: [contract]
+        }
+      }
+    }: any = await db.execute(
+      gql`
+        mutation AddContract($input: ContractInput!) {
+          contractsAdd(input: { contracts: [$input] }) {
+            contracts {
+              id
+            }
+          }
+        }
+      `,
+      { input }
+    );
+
+    return contract;
+  },
+
+  async resolveContractNameRecord(name: string) {
+    const {
+      data: {
+        project: { resolve }
+      }
+    }: any = await db.execute(
+      gql`
+        query ResolveContractNameRecord($name: String!) {
+          project(id: "${project.id}") {
+            resolve(name: $name, type: "Contract") {
+              id
+              resource {
+                id
+              }
+              previous {
+                id
+                resource {
+                  id
+                }
+              }
+            }
+          }
+        }
+      `,
+      { name }
+    );
+
+    debug("resolve %O", resolve);
+    const [nameRecord] = resolve;
+
+    return nameRecord;
+  }
+});
+
+describe("Project.assignNames", () => {
+  let db, project;
+
+  beforeAll(async () => {
+    const config = {
+      working_directory: "/Project.assignNames",
+      db: {
+        adapter: {
+          name: "memory"
+        }
+      }
+    };
+
+    // @ts-ignore
+    db = await connect(config);
+
+    project = await Project.initialize({
+      db,
+      project: {
+        directory: config.working_directory
+      }
+    });
+  });
+
+  it("resolves to new contract with no prior contract", async () => {
+    const { addContract, resolveContractNameRecord } = helpers(db, project);
+
+    const contract = await addContract({
+      name: "A",
+      abi: {
+        json: "[]"
+      }
+    });
+    debug("contract %o", contract);
+
+    await project.assignNames({
+      assignments: {
+        contracts: [contract]
+      }
+    });
+
+    const nameRecord = await resolveContractNameRecord("A");
+    debug("nameRecord %o", nameRecord);
+    const { resource } = nameRecord;
+    debug("resource %o", resource);
+
+    expect(resource).toEqual(contract);
+  });
+
+  it("is idempotent", async () => {
+    const { addContract, resolveContractNameRecord } = helpers(db, project);
+
+    const contract = await addContract({
+      name: "B",
+      abi: {
+        json: "[]"
+      }
+    });
+
+    await project.assignNames({
+      assignments: {
+        contracts: [contract]
+      }
+    });
+
+    const first = await resolveContractNameRecord("B");
+
+    await project.assignNames({
+      assignments: {
+        contracts: [contract]
+      }
+    });
+
+    const second = await resolveContractNameRecord("B");
+
+    expect(second).toEqual(first);
+  });
+
+  it("resolves to new contract with prior contract", async () => {
+    const { addContract, resolveContractNameRecord } = helpers(db, project);
+
+    const first = await addContract({
+      name: "C",
+      abi: {
+        json: "[]"
+      }
+    });
+    debug("first %o", first);
+
+    await project.assignNames({
+      assignments: {
+        contracts: [first]
+      }
+    });
+
+    const second = await addContract({
+      name: "C",
+      abi: {
+        json: `[{ type: "constructor", inputs: [] }]`
+      }
+    });
+    debug("second %o", second);
+
+    await project.assignNames({
+      assignments: {
+        contracts: [second]
+      }
+    });
+
+    const { id, resource, previous } = await resolveContractNameRecord("C");
+    debug("nameRecord %o", id);
+    debug("resource %o", resource);
+    debug("previous.resource %o", previous.resource);
+
+    expect(resource).toEqual(second);
+    expect(previous.resource).toEqual(first);
+  });
+});

--- a/packages/db/src/project/test/integration.spec.ts
+++ b/packages/db/src/project/test/integration.spec.ts
@@ -161,14 +161,11 @@ const AddNameRecords = gql`
     nameRecordsAdd(input: { nameRecords: $nameRecords }) {
       nameRecords {
         id
-        name
-        type
         resource {
           name
         }
         previous {
           id
-          name
         }
       }
     }
@@ -179,8 +176,10 @@ const AssignProjectNames = gql`
   mutation AssignProjectNames($projectNames: [ProjectNameInput!]!) {
     projectNamesAssign(input: { projectNames: $projectNames }) {
       projectNames {
-        name
-        type
+        key {
+          name
+          type
+        }
         nameRecord {
           resource {
             id
@@ -575,10 +574,9 @@ describe("Compilation", () => {
     });
 
     previousContractNameRecord = {
-      name: "Migrations",
-      type: "Contract",
       resource: {
-        id: previousContractExpectedId
+        id: previousContractExpectedId,
+        type: "Contract"
       }
     };
 
@@ -595,8 +593,10 @@ describe("Compilation", () => {
       projectNames: [
         {
           project: { id: projectId },
-          name: "Migrations",
-          type: "Contract",
+          key: {
+            name: "Migrations",
+            type: "Contract"
+          },
           nameRecord: {
             id: contractNameRecordId
           }
@@ -734,26 +734,6 @@ describe("Compilation", () => {
               : expectedVyperCompilationId
         }
       });
-
-      contractNameRecordId =
-        artifacts[index].contractName === previousContractNameRecord.name
-          ? generateId({
-              name: artifacts[index].contractName,
-              type: "Contract",
-              resource: {
-                id: expectedId
-              },
-              previous: {
-                id: previousContractExpectedId
-              }
-            })
-          : generateId({
-              name: artifacts[index].contractName,
-              type: "Contract",
-              resource: {
-                id: expectedId
-              }
-            });
 
       contractIds.push({ id: expectedId });
 

--- a/packages/db/src/resources/bytecodes.ts
+++ b/packages/db/src/resources/bytecodes.ts
@@ -1,12 +1,19 @@
-import {logger} from "@truffle/db/logger";
+import { logger } from "@truffle/db/logger";
 const debug = logger("db:resources:bytecodes");
 
 import gql from "graphql-tag";
 import CodeUtils from "@truffle/code-utils";
 
-import {Definition} from "./types";
+import { Definition } from "./types";
 
 export const bytecodes: Definition<"bytecodes"> = {
+  names: {
+    resource: "bytecode",
+    Resource: "Bytecode",
+    resources: "bytecodes",
+    Resources: "Bytecodes",
+    resourcesMutate: "bytecodesAdd"
+  },
   createIndexes: [],
   idFields: ["bytes", "linkReferences"],
   typeDefs: gql`
@@ -47,14 +54,16 @@ export const bytecodes: Definition<"bytecodes"> = {
   resolvers: {
     Bytecode: {
       instructions: {
-        async resolve({bytes}, {count = null}) {
+        async resolve({ bytes }, { count = null }) {
           const parsed = CodeUtils.parseCode(`0x${bytes}`, count);
 
-          return parsed.map(({name: opcode, pc: programCounter, pushData}) => ({
-            opcode,
-            programCounter,
-            pushData
-          }));
+          return parsed.map(
+            ({ name: opcode, pc: programCounter, pushData }) => ({
+              opcode,
+              programCounter,
+              pushData
+            })
+          );
         }
       }
     }

--- a/packages/db/src/resources/bytecodes.ts
+++ b/packages/db/src/resources/bytecodes.ts
@@ -19,7 +19,6 @@ export const bytecodes: Definition<"bytecodes"> = {
   idFields: ["bytes", "linkReferences"],
   typeDefs: gql`
     type Bytecode implements Resource {
-      id: ID!
       bytes: Bytes!
       linkReferences: [LinkReference]
       instructions(count: Int): [Instruction!]

--- a/packages/db/src/resources/bytecodes.ts
+++ b/packages/db/src/resources/bytecodes.ts
@@ -12,7 +12,8 @@ export const bytecodes: Definition<"bytecodes"> = {
     Resource: "Bytecode",
     resources: "bytecodes",
     Resources: "Bytecodes",
-    resourcesMutate: "bytecodesAdd"
+    resourcesMutate: "bytecodesAdd",
+    ResourcesMutate: "BytecodesAdd"
   },
   createIndexes: [],
   idFields: ["bytes", "linkReferences"],

--- a/packages/db/src/resources/compilations.ts
+++ b/packages/db/src/resources/compilations.ts
@@ -1,11 +1,18 @@
-import {logger} from "@truffle/db/logger";
+import { logger } from "@truffle/db/logger";
 const debug = logger("db:resources:compilations");
 
 import gql from "graphql-tag";
 
-import {Definition} from "./types";
+import { Definition } from "./types";
 
 export const compilations: Definition<"compilations"> = {
+  names: {
+    resource: "compilation",
+    Resource: "Compilation",
+    resources: "compilations",
+    Resources: "Compilations",
+    resourcesMutate: "compilationsAdd"
+  },
   createIndexes: [],
   idFields: ["compiler", "sources"],
   typeDefs: gql`
@@ -72,7 +79,7 @@ export const compilations: Definition<"compilations"> = {
   resolvers: {
     Compilation: {
       sources: {
-        resolve: async ({sources}, _, {workspace}) => {
+        resolve: async ({ sources }, _, { workspace }) => {
           debug("Resolving Compilation.sources...");
 
           const result = await Promise.all(
@@ -84,24 +91,21 @@ export const compilations: Definition<"compilations"> = {
         }
       },
       processedSources: {
-        resolve: ({id, processedSources}, _, {}) => {
+        resolve: ({ id, processedSources }, _, {}) => {
           debug("Resolving Compilation.processedSources...");
 
-          const result = processedSources.map(
-            (processedSource, index) =>
-              processedSource && {
-                ...processedSource,
-                compilation: {id},
-                index
-              }
-          );
+          const result = processedSources.map((processedSource, index) => ({
+            ...processedSource,
+            compilation: { id },
+            index
+          }));
 
           debug("Resolved Compilation.processedSources.");
           return result;
         }
       },
       contracts: {
-        resolve: async ({id}, _, {workspace}) => {
+        resolve: async ({ id }, _, { workspace }) => {
           debug("Resolving Compilation.contracts...");
 
           const result = await workspace.find("contracts", {
@@ -118,7 +122,7 @@ export const compilations: Definition<"compilations"> = {
 
     SourceMap: {
       bytecode: {
-        async resolve({bytecode: {id}}, _, {workspace}) {
+        async resolve({ bytecode: { id } }, _, { workspace }) {
           debug("Resolving SourceMap.bytecode...");
 
           const result = await workspace.get("bytecodes", id);
@@ -131,7 +135,7 @@ export const compilations: Definition<"compilations"> = {
 
     ProcessedSource: {
       source: {
-        resolve: async ({source: {id}}, _, {workspace}) => {
+        resolve: async ({ source: { id } }, _, { workspace }) => {
           debug("Resolving ProcessedSource.source...");
 
           const result = await workspace.get("sources", id);
@@ -141,7 +145,7 @@ export const compilations: Definition<"compilations"> = {
         }
       },
       contracts: {
-        resolve: async ({compilation, index}, _, {workspace}) => {
+        resolve: async ({ compilation, index }, _, { workspace }) => {
           debug("Resolving ProcessedSource.compilation...");
 
           const result = await workspace.find("contracts", {

--- a/packages/db/src/resources/compilations.ts
+++ b/packages/db/src/resources/compilations.ts
@@ -18,7 +18,6 @@ export const compilations: Definition<"compilations"> = {
   idFields: ["compiler", "sources"],
   typeDefs: gql`
     type Compilation implements Resource {
-      id: ID!
       compiler: Compiler!
       sources: [Source]!
       processedSources: [ProcessedSource]!

--- a/packages/db/src/resources/compilations.ts
+++ b/packages/db/src/resources/compilations.ts
@@ -11,7 +11,8 @@ export const compilations: Definition<"compilations"> = {
     Resource: "Compilation",
     resources: "compilations",
     Resources: "Compilations",
-    resourcesMutate: "compilationsAdd"
+    resourcesMutate: "compilationsAdd",
+    ResourcesMutate: "CompilationsAdd"
   },
   createIndexes: [],
   idFields: ["compiler", "sources"],

--- a/packages/db/src/resources/contractInstances.ts
+++ b/packages/db/src/resources/contractInstances.ts
@@ -11,7 +11,8 @@ export const contractInstances: Definition<"contractInstances"> = {
     Resource: "ContractInstance",
     resources: "contractInstances",
     Resources: "ContractInstances",
-    resourcesMutate: "contractInstancesAdd"
+    resourcesMutate: "contractInstancesAdd",
+    ResourcesMutate: "ContractInstancesAdd"
   },
   createIndexes: [],
   idFields: ["address", "network"],

--- a/packages/db/src/resources/contractInstances.ts
+++ b/packages/db/src/resources/contractInstances.ts
@@ -1,11 +1,18 @@
-import {logger} from "@truffle/db/logger";
+import { logger } from "@truffle/db/logger";
 const debug = logger("db:resources:contractInstances");
 
 import gql from "graphql-tag";
 
-import {Definition} from "./types";
+import { Definition } from "./types";
 
 export const contractInstances: Definition<"contractInstances"> = {
+  names: {
+    resource: "contractInstance",
+    Resource: "ContractInstance",
+    resources: "contractInstances",
+    Resources: "ContractInstances",
+    resourcesMutate: "contractInstancesAdd"
+  },
   createIndexes: [],
   idFields: ["address", "network"],
   typeDefs: gql`
@@ -79,7 +86,7 @@ export const contractInstances: Definition<"contractInstances"> = {
   resolvers: {
     ContractInstance: {
       network: {
-        resolve: async ({network: {id}}, _, {workspace}) => {
+        resolve: async ({ network: { id } }, _, { workspace }) => {
           debug("Resolving ContractInstance.network...");
 
           const result = await workspace.get("networks", id);
@@ -89,7 +96,7 @@ export const contractInstances: Definition<"contractInstances"> = {
         }
       },
       contract: {
-        resolve: async ({contract: {id}}, _, {workspace}) => {
+        resolve: async ({ contract: { id } }, _, { workspace }) => {
           debug("Resolving ContractInstance.contract...");
           const result = await workspace.get("contracts", id);
 
@@ -98,7 +105,7 @@ export const contractInstances: Definition<"contractInstances"> = {
         }
       },
       callBytecode: {
-        resolve: async ({callBytecode}, _, {workspace}) => {
+        resolve: async ({ callBytecode }, _, { workspace }) => {
           debug("Resolving ContractInstance.callBytecode...");
 
           const bytecode = await workspace.get(
@@ -106,7 +113,7 @@ export const contractInstances: Definition<"contractInstances"> = {
             callBytecode.bytecode.id
           );
           const linkValues = callBytecode.linkValues.map(
-            ({value, linkReference}) => {
+            ({ value, linkReference }) => {
               return {
                 value: value,
                 linkReference: bytecode.linkReferences[linkReference.index]
@@ -122,7 +129,7 @@ export const contractInstances: Definition<"contractInstances"> = {
         }
       },
       creation: {
-        resolve: async (input, _, {workspace}) => {
+        resolve: async (input, _, { workspace }) => {
           debug("Resolving ContractInstance.creation...");
 
           let bytecode = await workspace.get(
@@ -131,7 +138,7 @@ export const contractInstances: Definition<"contractInstances"> = {
           );
           let transactionHash = input.creation.transactionHash;
           let linkValues = input.creation.constructor.createBytecode.linkValues.map(
-            ({value, linkReference}) => {
+            ({ value, linkReference }) => {
               return {
                 value: value,
                 linkReference: bytecode.linkReferences[linkReference.index]

--- a/packages/db/src/resources/contractInstances.ts
+++ b/packages/db/src/resources/contractInstances.ts
@@ -18,7 +18,6 @@ export const contractInstances: Definition<"contractInstances"> = {
   idFields: ["address", "network"],
   typeDefs: gql`
     type ContractInstance implements Resource {
-      id: ID!
       address: Address!
       network: Network!
       creation: ContractInstanceCreation

--- a/packages/db/src/resources/contracts.ts
+++ b/packages/db/src/resources/contracts.ts
@@ -13,7 +13,8 @@ export const contracts: Definition<"contracts"> = {
     Resource: "Contract",
     resources: "contracts",
     Resources: "Contracts",
-    resourcesMutate: "contractsAdd"
+    resourcesMutate: "contractsAdd",
+    ResourcesMutate: "ContractsAdd"
   },
   createIndexes: [
     {

--- a/packages/db/src/resources/contracts.ts
+++ b/packages/db/src/resources/contracts.ts
@@ -27,7 +27,6 @@ export const contracts: Definition<"contracts"> = {
   idFields: ["name", "abi", "processedSource", "compilation"],
   typeDefs: gql`
     type Contract implements Resource & Named {
-      id: ID!
       name: String!
       abi: ABI
       compilation: Compilation

--- a/packages/db/src/resources/contracts.ts
+++ b/packages/db/src/resources/contracts.ts
@@ -1,13 +1,20 @@
-import {logger} from "@truffle/db/logger";
+import { logger } from "@truffle/db/logger";
 const debug = logger("db:resources:contracts");
 
 import gql from "graphql-tag";
 import { pascalCase } from "change-case";
 import { normalize } from "@truffle/abi-utils";
 
-import {Definition} from "./types";
+import { Definition } from "./types";
 
 export const contracts: Definition<"contracts"> = {
+  names: {
+    resource: "contract",
+    Resource: "Contract",
+    resources: "contracts",
+    Resources: "Contracts",
+    resourcesMutate: "contractsAdd"
+  },
   createIndexes: [
     {
       fields: ["compilation.id"]
@@ -110,7 +117,7 @@ export const contracts: Definition<"contracts"> = {
   resolvers: {
     Contract: {
       compilation: {
-        resolve: async ({compilation: {id}}, _, {workspace}) => {
+        resolve: async ({ compilation: { id } }, _, { workspace }) => {
           debug("Resolving Contract.compilation...");
 
           const result = workspace.get("compilations", id);
@@ -122,27 +129,27 @@ export const contracts: Definition<"contracts"> = {
       processedSource: {
         fragment: `... on Contract { compilation { id } }`,
         resolve: async (
-          {processedSource, compilation: {id}},
+          { processedSource, compilation: { id } },
           _,
-          {workspace}
+          { workspace }
         ) => {
           debug("Resolving Contract.processedSource...");
 
-          const {processedSources} = await workspace.get("compilations", id);
+          const { processedSources } = await workspace.get("compilations", id);
 
           debug("Resolved Contract.processedSource.");
           return processedSources[processedSource.index];
         }
       },
       createBytecode: {
-        resolve: async ({createBytecode}, _, {workspace}) => {
+        resolve: async ({ createBytecode }, _, { workspace }) => {
           debug("Resolving Contract.createBytecode...");
 
           if (!createBytecode) {
             return;
           }
 
-          const {id} = createBytecode;
+          const { id } = createBytecode;
 
           const result = await workspace.get("bytecodes", id);
 
@@ -151,14 +158,14 @@ export const contracts: Definition<"contracts"> = {
         }
       },
       callBytecode: {
-        resolve: async ({callBytecode}, _, {workspace}) => {
+        resolve: async ({ callBytecode }, _, { workspace }) => {
           debug("Resolving Contract.callBytecode...");
 
           if (!callBytecode) {
             return;
           }
 
-          const {id} = callBytecode;
+          const { id } = callBytecode;
 
           const result = await workspace.get("bytecodes", id);
 

--- a/packages/db/src/resources/nameRecords.ts
+++ b/packages/db/src/resources/nameRecords.ts
@@ -17,19 +17,15 @@ export const nameRecords: Definition<"nameRecords"> = {
     ResourcesMutate: "NameRecordsAdd"
   },
   createIndexes: [],
-  idFields: ["name", "type", "resource", "previous"],
+  idFields: ["resource", "previous"],
   typeDefs: gql`
     type NameRecord implements Resource {
-      name: String!
-      type: String!
       resource: Named!
       previous: NameRecord
     }
 
     input NameRecordInput {
-      name: String!
-      type: String!
-      resource: ResourceReferenceInput!
+      resource: TypedResourceReferenceInput!
       previous: ResourceReferenceInput
     }
   `,
@@ -37,7 +33,7 @@ export const nameRecords: Definition<"nameRecords"> = {
   resolvers: {
     NameRecord: {
       resource: {
-        resolve: async ({ type, resource: { id } }, _, { workspace }) => {
+        resolve: async ({ resource: { id, type } }, _, { workspace }) => {
           debug("Resolving NameRecord.resource...");
 
           const collectionName = camelCase(plural(type)) as CollectionName;
@@ -49,8 +45,14 @@ export const nameRecords: Definition<"nameRecords"> = {
         }
       },
       previous: {
-        resolve: async ({ id }, _, { workspace }) => {
+        resolve: async ({ previous }, _, { workspace }) => {
           debug("Resolving NameRecord.previous...");
+
+          if (!previous) {
+            return;
+          }
+
+          const { id } = previous;
 
           const result = await workspace.get("nameRecords", id);
 

--- a/packages/db/src/resources/nameRecords.ts
+++ b/packages/db/src/resources/nameRecords.ts
@@ -20,7 +20,6 @@ export const nameRecords: Definition<"nameRecords"> = {
   idFields: ["name", "type", "resource", "previous"],
   typeDefs: gql`
     type NameRecord implements Resource {
-      id: ID!
       name: String!
       type: String!
       resource: Named!

--- a/packages/db/src/resources/nameRecords.ts
+++ b/packages/db/src/resources/nameRecords.ts
@@ -8,6 +8,13 @@ import { plural } from "pluralize";
 import { Definition, CollectionName } from "./types";
 
 export const nameRecords: Definition<"nameRecords"> = {
+  names: {
+    resource: "nameRecord",
+    Resource: "NameRecord",
+    resources: "nameRecords",
+    Resources: "NameRecords",
+    resourcesMutate: "nameRecordsAdd"
+  },
   createIndexes: [],
   idFields: ["name", "type", "resource", "previous"],
   typeDefs: gql`

--- a/packages/db/src/resources/nameRecords.ts
+++ b/packages/db/src/resources/nameRecords.ts
@@ -13,7 +13,8 @@ export const nameRecords: Definition<"nameRecords"> = {
     Resource: "NameRecord",
     resources: "nameRecords",
     Resources: "NameRecords",
-    resourcesMutate: "nameRecordsAdd"
+    resourcesMutate: "nameRecordsAdd",
+    ResourcesMutate: "NameRecordsAdd"
   },
   createIndexes: [],
   idFields: ["name", "type", "resource", "previous"],

--- a/packages/db/src/resources/networkGenealogies.ts
+++ b/packages/db/src/resources/networkGenealogies.ts
@@ -8,7 +8,8 @@ export const networkGenealogies: Definition<"networkGenealogies"> = {
     Resource: "NetworkGenealogy",
     resources: "networkGenealogies",
     Resources: "NetworkGenealogies",
-    resourcesMutate: "networkGenealogiesAdd"
+    resourcesMutate: "networkGenealogiesAdd",
+    ResourcesMutate: "NetworkGenealogiesAdd"
   },
   createIndexes: [],
   idFields: ["ancestor", "descendant"],

--- a/packages/db/src/resources/networkGenealogies.ts
+++ b/packages/db/src/resources/networkGenealogies.ts
@@ -1,8 +1,15 @@
 import gql from "graphql-tag";
 
-import {Definition} from "./types";
+import { Definition } from "./types";
 
 export const networkGenealogies: Definition<"networkGenealogies"> = {
+  names: {
+    resource: "networkGenealogy",
+    Resource: "NetworkGenealogy",
+    resources: "networkGenealogies",
+    Resources: "NetworkGenealogies",
+    resourcesMutate: "networkGenealogiesAdd"
+  },
   createIndexes: [],
   idFields: ["ancestor", "descendant"],
   typeDefs: gql`
@@ -20,13 +27,13 @@ export const networkGenealogies: Definition<"networkGenealogies"> = {
   resolvers: {
     NetworkGenealogy: {
       ancestor: {
-        resolve: async ({ancestor}, __, {workspace}) => {
+        resolve: async ({ ancestor }, __, { workspace }) => {
           const result = await workspace.get("networks", ancestor.id);
           return result;
         }
       },
       descendant: {
-        resolve: async ({descendant}, __, {workspace}) =>
+        resolve: async ({ descendant }, __, { workspace }) =>
           await workspace.get("networks", descendant.id)
       }
     }

--- a/packages/db/src/resources/networkGenealogies.ts
+++ b/packages/db/src/resources/networkGenealogies.ts
@@ -15,7 +15,6 @@ export const networkGenealogies: Definition<"networkGenealogies"> = {
   idFields: ["ancestor", "descendant"],
   typeDefs: gql`
     type NetworkGenealogy implements Resource {
-      id: ID!
       ancestor: Network
       descendant: Network
     }

--- a/packages/db/src/resources/networks.ts
+++ b/packages/db/src/resources/networks.ts
@@ -11,7 +11,8 @@ export const networks: Definition<"networks"> = {
     Resource: "Network",
     resources: "networks",
     Resources: "Networks",
-    resourcesMutate: "networksAdd"
+    resourcesMutate: "networksAdd",
+    ResourcesMutate: "NetworksAdd"
   },
   createIndexes: [{ fields: ["historicBlock.height"] }],
   idFields: ["networkId", "historicBlock"],

--- a/packages/db/src/resources/networks.ts
+++ b/packages/db/src/resources/networks.ts
@@ -1,12 +1,19 @@
-import {logger} from "@truffle/db/logger";
+import { logger } from "@truffle/db/logger";
 const debug = logger("db:definitions:networks");
 
 import gql from "graphql-tag";
 
-import {Definition} from "./types";
+import { Definition } from "./types";
 
 export const networks: Definition<"networks"> = {
-  createIndexes: [{fields: ["historicBlock.height"]}],
+  names: {
+    resource: "network",
+    Resource: "Network",
+    resources: "networks",
+    Resources: "Networks",
+    resourcesMutate: "networksAdd"
+  },
+  createIndexes: [{ fields: ["historicBlock.height"] }],
   idFields: ["networkId", "historicBlock"],
   typeDefs: gql`
     type Network implements Resource & Named {
@@ -51,7 +58,7 @@ export const networks: Definition<"networks"> = {
   resolvers: {
     Network: {
       possibleAncestors: {
-        resolve: async ({id}, {limit = 5, alreadyTried}, {workspace}) => {
+        resolve: async ({ id }, { limit = 5, alreadyTried }, { workspace }) => {
           const network = await workspace.get("networks", id);
           const result = await workspace.find("networks", {
             selector: {
@@ -64,7 +71,7 @@ export const networks: Definition<"networks"> = {
                 $nin: alreadyTried
               }
             },
-            sort: [{"historicBlock.height": "desc"}],
+            sort: [{ "historicBlock.height": "desc" }],
             limit
           });
 
@@ -79,7 +86,7 @@ export const networks: Definition<"networks"> = {
         }
       },
       possibleDescendants: {
-        resolve: async ({id}, {limit = 5, alreadyTried}, {workspace}) => {
+        resolve: async ({ id }, { limit = 5, alreadyTried }, { workspace }) => {
           const network = await workspace.get("networks", id);
           const result = await workspace.find("networks", {
             selector: {
@@ -92,7 +99,7 @@ export const networks: Definition<"networks"> = {
                 $nin: alreadyTried
               }
             },
-            sort: [{"historicBlock.height": "asc"}],
+            sort: [{ "historicBlock.height": "asc" }],
             limit
           });
 

--- a/packages/db/src/resources/networks.ts
+++ b/packages/db/src/resources/networks.ts
@@ -18,7 +18,6 @@ export const networks: Definition<"networks"> = {
   idFields: ["networkId", "historicBlock"],
   typeDefs: gql`
     type Network implements Resource & Named {
-      id: ID!
       name: String!
       networkId: NetworkId!
       historicBlock: Block!

--- a/packages/db/src/resources/projectNames.ts
+++ b/packages/db/src/resources/projectNames.ts
@@ -19,27 +19,35 @@ export const projectNames: Definition<"projectNames"> = {
       fields: ["project.id"]
     },
     {
-      fields: ["project.id", "type"]
+      fields: ["project.id", "key.type"]
     },
     {
-      fields: ["project.id", "name", "type"]
+      fields: ["project.id", "key.name", "key.type"]
     }
   ],
-  idFields: ["project", "name", "type"],
+  idFields: ["project", "key"],
   mutable: true,
   typeDefs: gql`
     type ProjectName implements Resource {
       project: Project!
+      key: ProjectNameKey!
+      nameRecord: NameRecord!
+    }
+
+    type ProjectNameKey {
       name: String!
       type: String!
-      nameRecord: NameRecord!
     }
 
     input ProjectNameInput {
       project: ResourceReferenceInput!
+      key: ProjectNameKeyInput!
+      nameRecord: ResourceReferenceInput!
+    }
+
+    input ProjectNameKeyInput {
       name: String!
       type: String!
-      nameRecord: ResourceReferenceInput!
     }
   `,
   resolvers: {

--- a/packages/db/src/resources/projectNames.ts
+++ b/packages/db/src/resources/projectNames.ts
@@ -11,7 +11,8 @@ export const projectNames: Definition<"projectNames"> = {
     Resource: "ProjectName",
     resources: "projectNames",
     Resources: "ProjectNames",
-    resourcesMutate: "projectNamesAssign"
+    resourcesMutate: "projectNamesAssign",
+    ResourcesMutate: "ProjectNamesAssign"
   },
   createIndexes: [
     {

--- a/packages/db/src/resources/projectNames.ts
+++ b/packages/db/src/resources/projectNames.ts
@@ -1,11 +1,18 @@
-import {logger} from "@truffle/db/logger";
+import { logger } from "@truffle/db/logger";
 const debug = logger("db:resources:projectNames");
 
 import gql from "graphql-tag";
 
-import {Definition} from "./types";
+import { Definition } from "./types";
 
 export const projectNames: Definition<"projectNames"> = {
+  names: {
+    resource: "projectName",
+    Resource: "ProjectName",
+    resources: "projectNames",
+    Resources: "ProjectNames",
+    resourcesMutate: "projectNamesAssign"
+  },
   createIndexes: [
     {
       fields: ["project.id"]
@@ -38,7 +45,7 @@ export const projectNames: Definition<"projectNames"> = {
   resolvers: {
     ProjectName: {
       project: {
-        resolve: async ({project: {id}}, _, {workspace}) => {
+        resolve: async ({ project: { id } }, _, { workspace }) => {
           debug("Resolving ProjectName.project...");
 
           const result = await workspace.get("projects", id);
@@ -48,7 +55,7 @@ export const projectNames: Definition<"projectNames"> = {
         }
       },
       nameRecord: {
-        resolve: async ({nameRecord: {id}}, _, {workspace}) => {
+        resolve: async ({ nameRecord: { id } }, _, { workspace }) => {
           debug("Resolving ProjectName.nameRecord...");
 
           const result = await workspace.get("nameRecords", id);

--- a/packages/db/src/resources/projectNames.ts
+++ b/packages/db/src/resources/projectNames.ts
@@ -29,7 +29,6 @@ export const projectNames: Definition<"projectNames"> = {
   mutable: true,
   typeDefs: gql`
     type ProjectName implements Resource {
-      id: ID!
       project: Project!
       name: String!
       type: String!

--- a/packages/db/src/resources/projects.ts
+++ b/packages/db/src/resources/projects.ts
@@ -1,11 +1,18 @@
-import {logger} from "@truffle/db/logger";
+import { logger } from "@truffle/db/logger";
 const debug = logger("db:resources:projects");
 
 import gql from "graphql-tag";
 
-import {Definition} from "./types";
+import { Definition } from "./types";
 
 export const projects: Definition<"projects"> = {
+  names: {
+    resource: "project",
+    Resource: "Project",
+    resources: "projects",
+    Resources: "Projects",
+    resourcesMutate: "projectsAdd"
+  },
   createIndexes: [],
   idFields: ["directory"],
   typeDefs: gql`
@@ -26,18 +33,18 @@ export const projects: Definition<"projects"> = {
   resolvers: {
     Project: {
       resolve: {
-        resolve: async ({id}, {name, type}, {workspace}) => {
+        resolve: async ({ id }, { name, type }, { workspace }) => {
           debug("Resolving Project.resolve...");
 
           const results = await workspace.find("projectNames", {
-            selector: {"project.id": id, name, type}
+            selector: { "project.id": id, name, type }
           });
 
-          const nameRecordIds = results.map(({nameRecord: {id}}) => id);
+          const nameRecordIds = results.map(({ nameRecord: { id } }) => id);
 
           const result = await workspace.find("nameRecords", {
             selector: {
-              id: {$in: nameRecordIds}
+              id: { $in: nameRecordIds }
             }
           });
 
@@ -46,23 +53,23 @@ export const projects: Definition<"projects"> = {
         }
       },
       network: {
-        resolve: async ({id}, {name}, {workspace}) => {
+        resolve: async ({ id }, { name }, { workspace }) => {
           debug("Resolving Project.network...");
 
           const results = await workspace.find("projectNames", {
-            selector: {"project.id": id, name, "type": "Network"}
+            selector: { "project.id": id, name, "type": "Network" }
           });
-          const nameRecordIds = results.map(({nameRecord: {id}}) => id);
+          const nameRecordIds = results.map(({ nameRecord: { id } }) => id);
           const nameRecords = await workspace.find("nameRecords", {
             selector: {
-              id: {$in: nameRecordIds}
+              id: { $in: nameRecordIds }
             }
           });
 
           if (nameRecords.length === 0) {
             return;
           }
-          const {resource} = nameRecords[0];
+          const { resource } = nameRecords[0];
 
           const result = await workspace.get("networks", resource.id);
 
@@ -71,23 +78,23 @@ export const projects: Definition<"projects"> = {
         }
       },
       contract: {
-        resolve: async ({id}, {name}, {workspace}) => {
+        resolve: async ({ id }, { name }, { workspace }) => {
           debug("Resolving Project.contract...");
 
           const results = await workspace.find("projectNames", {
-            selector: {"project.id": id, name, "type": "Contract"}
+            selector: { "project.id": id, name, "type": "Contract" }
           });
-          const nameRecordIds = results.map(({nameRecord: {id}}) => id);
+          const nameRecordIds = results.map(({ nameRecord: { id } }) => id);
           const nameRecords = await workspace.find("nameRecords", {
             selector: {
-              id: {$in: nameRecordIds}
+              id: { $in: nameRecordIds }
             }
           });
 
           if (nameRecords.length === 0) {
             return;
           }
-          const {resource} = nameRecords[0];
+          const { resource } = nameRecords[0];
 
           const result = await workspace.get("contracts", resource.id);
 

--- a/packages/db/src/resources/projects.ts
+++ b/packages/db/src/resources/projects.ts
@@ -36,7 +36,11 @@ export const projects: Definition<"projects"> = {
           debug("Resolving Project.resolve...");
 
           const results = await workspace.find("projectNames", {
-            selector: { "project.id": id, name, type }
+            selector: {
+              "project.id": id,
+              "key.name": name,
+              "key.type": type
+            }
           });
 
           const nameRecordIds = results.map(({ nameRecord: { id } }) => id);
@@ -54,10 +58,24 @@ export const projects: Definition<"projects"> = {
       network: {
         resolve: async ({ id }, { name }, { workspace }) => {
           debug("Resolving Project.network...");
+          debug("name %o", name);
+          debug("project id %o", id);
+
+          const testResults = await workspace.find("projectNames", {
+            selector: {
+              "project.id": id
+            }
+          });
+          debug("test results %O", testResults);
 
           const results = await workspace.find("projectNames", {
-            selector: { "project.id": id, name, "type": "Network" }
+            selector: {
+              "project.id": id,
+              "key.name": name,
+              "key.type": "Network"
+            }
           });
+          debug("network results %O", results);
           const nameRecordIds = results.map(({ nameRecord: { id } }) => id);
           const nameRecords = await workspace.find("nameRecords", {
             selector: {
@@ -81,7 +99,11 @@ export const projects: Definition<"projects"> = {
           debug("Resolving Project.contract...");
 
           const results = await workspace.find("projectNames", {
-            selector: { "project.id": id, name, "type": "Contract" }
+            selector: {
+              "project.id": id,
+              "key.name": name,
+              "key.type": "Contract"
+            }
           });
           const nameRecordIds = results.map(({ nameRecord: { id } }) => id);
           const nameRecords = await workspace.find("nameRecords", {

--- a/packages/db/src/resources/projects.ts
+++ b/packages/db/src/resources/projects.ts
@@ -11,7 +11,8 @@ export const projects: Definition<"projects"> = {
     Resource: "Project",
     resources: "projects",
     Resources: "Projects",
-    resourcesMutate: "projectsAdd"
+    resourcesMutate: "projectsAdd",
+    ResourcesMutate: "ProjectsAdd"
   },
   createIndexes: [],
   idFields: ["directory"],

--- a/packages/db/src/resources/projects.ts
+++ b/packages/db/src/resources/projects.ts
@@ -18,8 +18,6 @@ export const projects: Definition<"projects"> = {
   idFields: ["directory"],
   typeDefs: gql`
     type Project implements Resource {
-      id: ID!
-
       directory: String!
 
       contract(name: String!): Contract

--- a/packages/db/src/resources/sources.ts
+++ b/packages/db/src/resources/sources.ts
@@ -1,11 +1,18 @@
-import {logger} from "@truffle/db/logger";
+import { logger } from "@truffle/db/logger";
 const debug = logger("db:resources:sources");
 
 import gql from "graphql-tag";
 
-import {Definition} from "./types";
+import { Definition } from "./types";
 
 export const sources: Definition<"sources"> = {
+  names: {
+    resource: "source",
+    Resource: "Source",
+    resources: "sources",
+    Resources: "Sources",
+    resourcesMutate: "sourcesAdd"
+  },
   createIndexes: [],
   idFields: ["contents", "sourcePath"],
   typeDefs: gql`

--- a/packages/db/src/resources/sources.ts
+++ b/packages/db/src/resources/sources.ts
@@ -11,7 +11,8 @@ export const sources: Definition<"sources"> = {
     Resource: "Source",
     resources: "sources",
     Resources: "Sources",
-    resourcesMutate: "sourcesAdd"
+    resourcesMutate: "sourcesAdd",
+    ResourcesMutate: "SourcesAdd"
   },
   createIndexes: [],
   idFields: ["contents", "sourcePath"],

--- a/packages/db/src/resources/sources.ts
+++ b/packages/db/src/resources/sources.ts
@@ -18,7 +18,6 @@ export const sources: Definition<"sources"> = {
   idFields: ["contents", "sourcePath"],
   typeDefs: gql`
     type Source implements Resource {
-      id: ID!
       sourcePath: String
       contents: String!
     }

--- a/packages/db/src/resources/types.ts
+++ b/packages/db/src/resources/types.ts
@@ -1,11 +1,11 @@
-import {logger} from "@truffle/db/logger";
+import { logger } from "@truffle/db/logger";
 const debug = logger("db:resources:types");
 
 import * as Meta from "@truffle/db/meta";
 import * as Pouch from "@truffle/db/pouch";
 import * as GraphQl from "@truffle/db/graphql";
 
-export {Db, IdObject, toIdObject} from "@truffle/db/meta";
+export { Db, IdObject, toIdObject } from "@truffle/db/meta";
 
 export type Collections = {
   sources: {
@@ -17,6 +17,7 @@ export type Collections = {
       resources: "sources";
       Resources: "Sources";
       resourcesMutate: "sourcesAdd";
+      ResourcesMutate: "SourcesAdd";
     };
   };
   bytecodes: {
@@ -28,6 +29,7 @@ export type Collections = {
       resources: "bytecodes";
       Resources: "Bytecodes";
       resourcesMutate: "bytecodesAdd";
+      ResourcesMutate: "BytecodesAdd";
     };
   };
   compilations: {
@@ -39,6 +41,7 @@ export type Collections = {
       resources: "compilations";
       Resources: "Compilations";
       resourcesMutate: "compilationsAdd";
+      ResourcesMutate: "CompilationsAdd";
     };
   };
   contractInstances: {
@@ -50,6 +53,7 @@ export type Collections = {
       resources: "contractInstances";
       Resources: "ContractInstances";
       resourcesMutate: "contractInstancesAdd";
+      ResourcesMutate: "ContractInstancesAdd";
     };
   };
   contracts: {
@@ -62,6 +66,7 @@ export type Collections = {
       resources: "contracts";
       Resources: "Contracts";
       resourcesMutate: "contractsAdd";
+      ResourcesMutate: "ContractsAdd";
     };
   };
   nameRecords: {
@@ -73,6 +78,7 @@ export type Collections = {
       resources: "nameRecords";
       Resources: "NameRecords";
       resourcesMutate: "nameRecordsAdd";
+      ResourcesMutate: "NameRecordsAdd";
     };
   };
   networks: {
@@ -85,6 +91,7 @@ export type Collections = {
       resources: "networks";
       Resources: "Networks";
       resourcesMutate: "networksAdd";
+      ResourcesMutate: "NetworksAdd";
     };
   };
   projects: {
@@ -96,6 +103,7 @@ export type Collections = {
       resources: "projects";
       Resources: "Projects";
       resourcesMutate: "projectsAdd";
+      ResourcesMutate: "ProjectsAdd";
     };
   };
   projectNames: {
@@ -108,6 +116,7 @@ export type Collections = {
       resources: "projectNames";
       Resources: "ProjectNames";
       resourcesMutate: "projectNamesAssign";
+      ResourcesMutate: "ProjectNamesAssign";
     };
   };
   networkGenealogies: {
@@ -119,6 +128,7 @@ export type Collections = {
       resources: "networkGenealogies";
       Resources: "NetworkGenealogies";
       resourcesMutate: "networkGenealogiesAdd";
+      ResourcesMutate: "NetworkGenealogiesAdd";
     };
   };
 };

--- a/packages/db/src/test/nameRecord.graphql.ts
+++ b/packages/db/src/test/nameRecord.graphql.ts
@@ -32,17 +32,11 @@ export const GetAllNameRecords = gql`
 
 export const AddNameRecord = gql`
   mutation AddNameRecord(
-    $name: String!
-    $type: String!
-    $resource: ResourceReferenceInput!
+    $resource: TypedResourceReferenceInput!
     $previous: ResourceReferenceInput
   ) {
     nameRecordsAdd(
-      input: {
-        nameRecords: [
-          { name: $name, type: $type, resource: $resource, previous: $previous }
-        ]
-      }
+      input: { nameRecords: [{ resource: $resource, previous: $previous }] }
     ) {
       nameRecords {
         id

--- a/packages/db/src/test/nameRecord.spec.ts
+++ b/packages/db/src/test/nameRecord.spec.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:test:nameRecord");
+
 import { generateId, Migrations, WorkspaceClient } from "./utils";
 import {
   AddNameRecord,
@@ -24,10 +27,9 @@ describe("Name Record", () => {
     let addNetworkId = addNetworkResult.networksAdd.networks[0].id;
 
     variables = {
-      name: "ganache",
-      type: "Network",
       resource: {
-        id: addNetworkId
+        id: addNetworkId,
+        type: "Network"
       }
     };
 

--- a/packages/db/src/test/projects.graphql.ts
+++ b/packages/db/src/test/projects.graphql.ts
@@ -49,8 +49,7 @@ export const AssignProjectName = gql`
         projectNames: [
           {
             project: { id: $projectId }
-            name: $name
-            type: $type
+            key: { name: $name, type: $type }
             nameRecord: { id: $nameRecordId }
           }
         ]

--- a/packages/db/src/test/projects.spec.ts
+++ b/packages/db/src/test/projects.spec.ts
@@ -1,3 +1,6 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:test:projects");
+
 import { generateId, Migrations, WorkspaceClient } from "./utils";
 import {
   GetProject,
@@ -38,12 +41,16 @@ describe("Project", () => {
     addNetworkId = addNetworkResult.networksAdd.networks[0].id;
 
     let addNetworkNameRecordResult = await wsClient.execute(AddNameRecord, {
-      name: "ganache",
-      type: "Network",
       resource: {
-        id: addNetworkId
+        id: addNetworkId,
+        type: "Network"
       }
     });
+
+    debug(
+      "addNetworkNameRecordResult %O",
+      addNetworkNameRecordResult.nameRecordsAdd.nameRecords
+    );
 
     let addNetworkNameRecordId =
       addNetworkNameRecordResult.nameRecordsAdd.nameRecords[0].id;
@@ -61,6 +68,11 @@ describe("Project", () => {
       networkVariables
     );
 
+    debug(
+      "projectNamesAssignNetworkResult %O",
+      projectNamesAssignNetworkResult.projectNamesAssign
+    );
+
     // add contract and contract name record
     let addContractResult = await wsClient.execute(AddContracts, {
       contractName: "Migrations",
@@ -69,13 +81,14 @@ describe("Project", () => {
       abi: JSON.stringify(Migrations.abi)
     });
 
+    debug("addContractResult %O", addContractResult.contractsAdd.contracts);
+
     addContractId = addContractResult.contractsAdd.contracts[0].id;
 
     let addContractNameRecordResult = await wsClient.execute(AddNameRecord, {
-      name: "Migrations",
-      type: "Contract",
       resource: {
-        id: addContractId
+        id: addContractId,
+        type: "Contract"
       }
     });
 
@@ -163,6 +176,8 @@ describe("Project", () => {
 
     expect(executionResult).toHaveProperty("project");
     const { project } = executionResult;
+
+    debug("project %O", project);
 
     expect(project).toHaveProperty("network");
     expect(project).toHaveProperty("contract");


### PR DESCRIPTION
Externally, this does the following:
- Fix name-keeping logic (by correctly returning `previous`, and by handling duplicates in Project abstraction)
- Add NameRecord.history to track previous records. This accepts optional `limit` and `includeSelf` inputs, for convenience.
- Expose `type` field for all resources.
- Remove NameRecord's `name` and `type`; NameRecords need to know resource type, so also define `TypedResourceReferenceInput` for when adding NameRecords.
- Move ProjectName's `name` and `type` fields to ProjectName.key, since `type` will now always return `ProjectName`.
- Expose `id` property on Project abstraction instances.

Internally, this does a few things to support the above:
- Hook up `type` field in `src/graphl/schema` by defining it as a field resolver.
- Remove `id` from concrete resource type definitions. The idea here is: when you do `type R implements Resource` in `src/resources` files, omit whatever `Resource` itself defines (This may or may not be best-practice, but now that all `Resource`s must have `type` as well, it seems better this way.)
- Require explicit name styles in each resource definition, and remove the dynamic case-changing logic from `src/graphql/schema`. 
- Add tests for project name assignment
