### PR TITLE
Internal improvement: Make source-fetcher throw on invalid network

### DIFF
--- a/packages/core/lib/debug/external.js
+++ b/packages/core/lib/debug/external.js
@@ -5,6 +5,7 @@ const Web3 = require("web3");
 
 const Codec = require("@truffle/codec");
 const Fetchers = require("@truffle/source-fetcher").default;
+const {InvalidNetworkError} = require("@truffle/source-fetcher");
 
 const {DebugCompiler} = require("./compiler");
 
@@ -48,8 +49,7 @@ class DebugExternalHandler {
               this.config[Fetcher.fetcherName]
             );
           } catch (error) {
-            if (error.name !== "InvalidNetworkError") {
-              //HACK?
+            if (!(error instanceof InvalidNetworkError)) {
               //if it's *not* just an invalid network, log the error.
               badFetchers.push(fetcher.fetcherName);
             }

--- a/packages/core/lib/debug/external.js
+++ b/packages/core/lib/debug/external.js
@@ -24,7 +24,7 @@ class DebugExternalHandler {
     let sortedFetchers = [];
     if (userFetcherNames) {
       for (let name of userFetcherNames) {
-        let Fetcher = allFetchers.find(Fetcher => Fetcher.fetcherName === name);
+        let Fetcher = Fetchers.find(Fetcher => Fetcher.fetcherName === name);
         if (Fetcher) {
           sortedFetchers.push(Fetcher);
         } else {
@@ -49,7 +49,7 @@ class DebugExternalHandler {
           } catch (error) {
             if (!(error instanceof InvalidNetworkError)) {
               //if it's *not* just an invalid network, log the error.
-              badFetchers.push(fetcher.fetcherName);
+              badFetchers.push(Fetcher.fetcherName);
             }
             //either way, filter this fetcher out
             return null;

--- a/packages/core/lib/debug/external.js
+++ b/packages/core/lib/debug/external.js
@@ -1,8 +1,6 @@
 const debugModule = require("debug");
 const debug = debugModule("lib:debug:external");
 
-const Web3 = require("web3");
-
 const Codec = require("@truffle/codec");
 const Fetchers = require("@truffle/source-fetcher").default;
 const {InvalidNetworkError} = require("@truffle/source-fetcher");
@@ -36,7 +34,7 @@ class DebugExternalHandler {
     } else {
       sortedFetchers = Fetchers;
     }
-    const networkId = await new Web3(this.config.provider).eth.net.getId(); //note: this is a number
+    const networkId = this.config.network_id; //note: this is a number
     //make fetcher instances. we'll filter out ones that don't support this
     //network (and note ones that yielded errors)
     debug("Fetchers: %o", Fetchers);

--- a/packages/core/lib/debug/external.js
+++ b/packages/core/lib/debug/external.js
@@ -6,7 +6,7 @@ const Web3 = require("web3");
 const Codec = require("@truffle/codec");
 const Fetchers = require("@truffle/source-fetcher").default;
 
-const { DebugCompiler } = require("./compiler");
+const {DebugCompiler} = require("./compiler");
 
 class DebugExternalHandler {
   constructor(bugger, config) {
@@ -20,18 +20,6 @@ class DebugExternalHandler {
     let addressesToSkip = new Set(); //addresses we know we can't get source for
     //note: this should always be a subset of unknownAddresses! [see below]
     //get the network id
-    const networkId = await new Web3(this.config.provider).eth.net.getId(); //note: this is a number
-    //make fetcher instances
-    debug("Fetchers: %o", Fetchers);
-    const allFetchers = await Promise.all(
-      Fetchers.map(
-        async Fetcher =>
-          await Fetcher.forNetworkId(
-            networkId,
-            this.config[Fetcher.fetcherName]
-          )
-      )
-    );
     const userFetcherNames = this.config.sourceFetchers;
     //sort/filter fetchers by user's order, if given; otherwise use default order
     let sortedFetchers = [];
@@ -45,27 +33,32 @@ class DebugExternalHandler {
         }
       }
     } else {
-      sortedFetchers = allFetchers;
+      sortedFetchers = Fetchers;
     }
-    //to get the final list, we'll filter out ones that don't support this
+    const networkId = await new Web3(this.config.provider).eth.net.getId(); //note: this is a number
+    //make fetcher instances. we'll filter out ones that don't support this
     //network (and note ones that yielded errors)
-    let fetchers = [];
-    for (const fetcher of sortedFetchers) {
-      let isValid;
-      let failure = false;
-      try {
-        isValid = await fetcher.isNetworkValid();
-      } catch (_) {
-        isValid = false;
-        failure = true;
-      }
-      if (isValid) {
-        fetchers.push(fetcher);
-      }
-      if (failure) {
-        badFetchers.push(fetcher.fetcherName);
-      }
-    }
+    debug("Fetchers: %o", Fetchers);
+    const fetchers = (
+      await Promise.all(
+        Fetchers.map(async Fetcher => {
+          try {
+            return await Fetcher.forNetworkId(
+              networkId,
+              this.config[Fetcher.fetcherName]
+            );
+          } catch (error) {
+            if (error.name !== "InvalidNetworkError") {
+              //HACK?
+              //if it's *not* just an invalid network, log the error.
+              badFetchers.push(fetcher.fetcherName);
+            }
+            //either way, filter this fetcher out
+            return null;
+          }
+        })
+      )
+    ).filter(fetcher => fetcher !== null);
     //now: the main loop!
     let address;
     while (
@@ -94,7 +87,7 @@ class DebugExternalHandler {
         }
         //if we do have it, extract sources & options
         debug("got sources!");
-        const { sources, options } = result;
+        const {sources, options} = result;
         if (options.language !== "Solidity") {
           //if it's not Solidity, bail out now
           debug("not Solidity, bailing out!");
@@ -142,7 +135,7 @@ class DebugExternalHandler {
         }
       }
     }
-    return { badAddresses, badFetchers }; //main result is that we've mutated bugger,
+    return {badAddresses, badFetchers}; //main result is that we've mutated bugger,
     //not the return value!
   }
 }
@@ -154,7 +147,7 @@ function getUnknownAddresses(bugger) {
   );
   debug("got instances");
   return Object.entries(instances)
-    .filter(([_, { contractName }]) => contractName === undefined)
+    .filter(([_, {contractName}]) => contractName === undefined)
     .map(([address, _]) => address);
 }
 

--- a/packages/source-fetcher/lib/common.ts
+++ b/packages/source-fetcher/lib/common.ts
@@ -1,9 +1,9 @@
 //these imports aren't actually necessary, but why not :)
 import util from "util";
-import { setTimeout } from "timers";
+import {setTimeout} from "timers";
 import * as Types from "./types";
 
-export const networksById: { [id: number]: string } = {
+export const networksById: {[id: number]: string} = {
   1: "mainnet",
   3: "ropsten",
   4: "rinkeby",
@@ -29,7 +29,16 @@ export const makeTimer: (
 export function removeLibraries(
   settings: Types.SolcSettings
 ): Types.SolcSettings {
-  let copySettings: Types.SolcSettings = { ...settings };
+  let copySettings: Types.SolcSettings = {...settings};
   delete copySettings.libraries;
   return copySettings;
+}
+
+export class InvalidNetworkError extends Error {
+  public networkId: number;
+  constructor(networkId: number) {
+    super(`Invalid network ID ${networkId}`);
+    this.networkId = networkId;
+    this.name = "InvalidNetworkError";
+  }
 }

--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -1,13 +1,14 @@
 import debugModule from "debug";
 const debug = debugModule("source-fetcher:etherscan");
 
-import { Fetcher, FetcherConstructor } from "./types";
+import {Fetcher, FetcherConstructor} from "./types";
 import * as Types from "./types";
 import {
   networksById,
   makeFilename,
   makeTimer,
-  removeLibraries
+  removeLibraries,
+  InvalidNetworkError
 } from "./common";
 import request from "request-promise-native";
 
@@ -45,11 +46,9 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
       "goerli"
     ];
     if (networkName === undefined || !supportedNetworks.includes(networkName)) {
-      this.validNetwork = false;
-    } else {
-      this.validNetwork = true;
-      this.suffix = networkName === "mainnet" ? "" : `-${networkName}`;
+      throw new InvalidNetworkError(networkId);
     }
+    this.suffix = networkName === "mainnet" ? "" : `-${networkName}`;
     debug("apiKey: %s", apiKey);
     this.apiKey = apiKey;
     const baseDelay = this.apiKey ? 200 : 3000; //etherscan permits 5 requests/sec w/a key, 1/3sec w/o
@@ -58,12 +57,7 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
     this.ready = makeTimer(0); //at start, it's ready to go immediately
   }
 
-  private readonly validNetwork: boolean;
   private readonly suffix: string;
-
-  async isNetworkValid(): Promise<boolean> {
-    return this.validNetwork;
-  }
 
   async fetchSourcesForAddress(
     address: string
@@ -217,7 +211,7 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
   ): Types.SourcesByPath {
     return Object.assign(
       {},
-      ...Object.entries(sources).map(([path, { content: source }]) => ({
+      ...Object.entries(sources).map(([path, {content: source}]) => ({
         [makeFilename(path)]: source
       }))
     );

--- a/packages/source-fetcher/lib/index.ts
+++ b/packages/source-fetcher/lib/index.ts
@@ -1,7 +1,8 @@
 import "source-map-support/register";
 
-import { Fetcher, FetcherConstructor } from "./types";
-export { Fetcher, FetcherConstructor };
+import {Fetcher, FetcherConstructor} from "./types";
+import {InvalidNetworkError} from "./common";
+export {Fetcher, FetcherConstructor, InvalidNetworkError};
 
 import EtherscanFetcher from "./etherscan";
 import SourcifyFetcher from "./sourcify";

--- a/packages/source-fetcher/lib/types.ts
+++ b/packages/source-fetcher/lib/types.ts
@@ -8,7 +8,6 @@ export interface Fetcher {
    * should have same name as the static version
    */
   readonly fetcherName: string;
-  isNetworkValid(): Promise<boolean>;
   /**
    * returns null if no Solidity sources for address
    * (address not in system, sources are Vyper, whatever)


### PR DESCRIPTION
**Note: This PR is a breaking change to `@truffle/source-fetcher`**.

I realized that source-fetcher probably ought to throw if you give it an invalid network ID.  So now it does.  The `isNetworkValid` method is gone, because it's now unnecessary.  Note obviously this required appropriate modifications to `external.js`.