### PR TITLE
Enhancement: Add rudimentary Etherscan Vyper support to source-fetcher

### DIFF
--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -209,7 +209,8 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
       },
       options: {
         language: "Vyper",
-        version: result.CompilerVersion.replace(/^vyper:/, "")
+        version: result.CompilerVersion.replace(/^vyper:/, ""),
+        settings: this.extractVyperSettings(result)
       }
     };
   }
@@ -242,6 +243,18 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
       return {
         optimizer
       };
+    }
+  }
+
+  private static extractVyperSettings(
+    result: EtherscanResult
+  ): Types.VyperSettings {
+    const evmVersion: string =
+      result.EVMVersion === "Default" ? undefined : result.EVMVersion;
+    if (evmVersion !== undefined) {
+      return {evmVersion};
+    } else {
+      return {};
     }
   }
 };

--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -1,14 +1,9 @@
 import debugModule from "debug";
 const debug = debugModule("source-fetcher:etherscan");
 
-import { Fetcher, FetcherConstructor } from "./types";
+import {Fetcher, FetcherConstructor} from "./types";
 import * as Types from "./types";
-import {
-  networksById,
-  makeFilename,
-  makeTimer,
-  removeLibraries
-} from "./common";
+import {networksById, makeFilename, makeTimer, removeLibraries} from "./common";
 import request from "request-promise-native";
 
 //this looks awkward but the TS docs actually suggest this :P
@@ -123,15 +118,8 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
       return null;
     }
     //case 2: it's a Vyper contract
-    if (result.CompilerVersion.startsWith("vyper")) {
-      //return nothing useful, just something saying it's
-      //vyper so we can't do anything
-      return {
-        sources: {}, //not even going to bother processing the single source
-        options: {
-          language: "Vyper"
-        }
-      };
+    if (result.CompilerVersion.startsWith("vyper:")) {
+      return this.processVyperResult(result);
     }
     let multifileJson: Types.SolcSources;
     try {
@@ -212,12 +200,26 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
     };
   }
 
+  private static processVyperResult(result: EtherscanResult): Types.SourceInfo {
+    const filename = makeFilename(result.ContractName, ".vy");
+    //note: this means filename will always be Vyper_contract.vy
+    return {
+      sources: {
+        [filename]: result.SourceCode
+      },
+      options: {
+        language: "Vyper",
+        version: result.CompilerVersion.replace(/^vyper:/, "")
+      }
+    };
+  }
+
   private static processSources(
     sources: Types.SolcSources
   ): Types.SourcesByPath {
     return Object.assign(
       {},
-      ...Object.entries(sources).map(([path, { content: source }]) => ({
+      ...Object.entries(sources).map(([path, {content: source}]) => ({
         [makeFilename(path)]: source
       }))
     );

--- a/packages/source-fetcher/lib/types.ts
+++ b/packages/source-fetcher/lib/types.ts
@@ -41,6 +41,7 @@ export interface SolcOptions {
 export interface VyperOptions {
   language: "Vyper";
   version: string;
+  settings: VyperSettings;
 }
 
 //only including settings that would alter compiled result
@@ -51,6 +52,10 @@ export interface SolcSettings {
   debug?: DebugSettings;
   metadata?: MetadataSettings;
   libraries?: LibrarySettings; //note: we don't actually want to pass this!
+}
+
+export interface VyperSettings {
+  evmVersion?: string; //not gonna enumerate these
 }
 
 export interface SolcSources {

--- a/packages/source-fetcher/lib/types.ts
+++ b/packages/source-fetcher/lib/types.ts
@@ -40,6 +40,7 @@ export interface SolcOptions {
 
 export interface VyperOptions {
   language: "Vyper";
+  version: string;
 }
 
 //only including settings that would alter compiled result


### PR DESCRIPTION
This PR adds rudimentary support for Vyper contracts on Etherscan to source-fetcher.  Because these have no associated settings, it's pretty straightforward; the source code is just the given source code (no need to process that), and for the compiler version, we just strip off the initial `vyper:`, which I'm taking to be a prefix added by Etherscan, rather than a legitimate part of the version string.