### PR TITLE
Internal improvement: Fix debugger test debug module names

### DIFF
--- a/packages/debugger/test/ast.js
+++ b/packages/debugger/test/ast.js
@@ -1,11 +1,11 @@
 import debugModule from "debug";
-const debug = debugModule("test:ast");
+const debug = debugModule("debugger:test:ast");
 
-import { assert } from "chai";
+import {assert} from "chai";
 
 import Ganache from "ganache-core";
 
-import { prepareContracts } from "./helpers";
+import {prepareContracts} from "./helpers";
 import Debugger from "lib/debugger";
 
 import solidity from "lib/solidity/selectors";
@@ -53,7 +53,7 @@ describe("AST", function () {
   var compilations;
 
   before("Create Provider", async function () {
-    provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
+    provider = Ganache.provider({seed: "debugger", gasLimit: 7000000});
   });
 
   before("Prepare contracts and artifacts", async function () {
@@ -78,7 +78,7 @@ describe("AST", function () {
       });
 
       do {
-        let { start, length } = bugger.view(solidity.current.sourceRange);
+        let {start, length} = bugger.view(solidity.current.sourceRange);
         let end = start + length;
 
         let node = bugger.view(solidity.current.node);

--- a/packages/debugger/test/context.js
+++ b/packages/debugger/test/context.js
@@ -1,11 +1,11 @@
 import debugModule from "debug";
-const debug = debugModule("test:context");
+const debug = debugModule("debugger:test:context");
 
-import { assert } from "chai";
+import {assert} from "chai";
 
 import Ganache from "ganache-core";
 
-import { prepareContracts } from "./helpers";
+import {prepareContracts} from "./helpers";
 import Debugger from "lib/debugger";
 
 import sessionSelector from "lib/session/selectors";
@@ -115,7 +115,7 @@ describe("Contexts", function () {
   var compilations;
 
   before("Create Provider", async function () {
-    provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
+    provider = Ganache.provider({seed: "debugger", gasLimit: 7000000});
   });
 
   before("Prepare contracts and artifacts", async function () {

--- a/packages/debugger/test/data/calldata.js
+++ b/packages/debugger/test/data/calldata.js
@@ -1,11 +1,11 @@
 import debugModule from "debug";
-const debug = debugModule("test:data:calldata");
+const debug = debugModule("debugger:test:data:calldata");
 
-import { assert } from "chai";
+import {assert} from "chai";
 
 import Ganache from "ganache-core";
 
-import { prepareContracts, lineOf } from "../helpers";
+import {prepareContracts, lineOf} from "../helpers";
 import Debugger from "lib/debugger";
 
 import * as Codec from "@truffle/codec";
@@ -112,7 +112,7 @@ describe("Calldata Decoding", function () {
   var compilations;
 
   before("Create Provider", async function () {
-    provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
+    provider = Ganache.provider({seed: "debugger", gasLimit: 7000000});
   });
 
   before("Prepare contracts and artifacts", async function () {
@@ -129,7 +129,7 @@ describe("Calldata Decoding", function () {
     let receipt = await instance.multiTester();
     let txHash = receipt.tx;
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     let sourceId = bugger.view(solidity.current.source).id;
     let source = bugger.view(solidity.current.source).source;
@@ -147,7 +147,7 @@ describe("Calldata Decoding", function () {
     const expectedResult = {
       hello: "hello",
       someInts: [41, 42],
-      pair: { x: 321, y: 2049 }
+      pair: {x: 321, y: 2049}
     };
 
     assert.deepInclude(variables, expectedResult);
@@ -159,7 +159,7 @@ describe("Calldata Decoding", function () {
     let receipt = await instance.simpleTest("hello world");
     let txHash = receipt.tx;
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     let sourceId = bugger.view(solidity.current.source).id;
     let source = bugger.view(solidity.current.source).source;
@@ -184,10 +184,10 @@ describe("Calldata Decoding", function () {
   it("Decodes dynamic structs correctly", async function () {
     this.timeout(6000);
     let instance = await abstractions.CalldataTest.deployed();
-    let receipt = await instance.stringBoxTest({ it: "hello world" });
+    let receipt = await instance.stringBoxTest({it: "hello world"});
     let txHash = receipt.tx;
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     let sourceId = bugger.view(solidity.current.source).id;
     let source = bugger.view(solidity.current.source).source;

--- a/packages/debugger/test/data/codex.js
+++ b/packages/debugger/test/data/codex.js
@@ -1,12 +1,12 @@
 import debugModule from "debug";
-const debug = debugModule("test:data:codex");
+const debug = debugModule("debugger:test:data:codex");
 
-import { assert } from "chai";
+import {assert} from "chai";
 import * as Codec from "@truffle/codec";
 
 import Ganache from "ganache-core";
 
-import { prepareContracts } from "../helpers";
+import {prepareContracts} from "../helpers";
 import Debugger from "lib/debugger";
 
 const __LIBTEST = `
@@ -96,7 +96,7 @@ describe("Codex", function () {
   var compilations;
 
   before("Create Provider", async function () {
-    provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
+    provider = Ganache.provider({seed: "debugger", gasLimit: 7000000});
   });
 
   before("Prepare contracts and artifacts", async function () {
@@ -113,7 +113,7 @@ describe("Codex", function () {
     let receipt = await instance.run();
     let txHash = receipt.tx;
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     debug("starting stepping");
     await bugger.continueUntilBreakpoint(); //run till end
@@ -132,7 +132,7 @@ describe("Codex", function () {
     let receipt = await instance.run();
     let txHash = receipt.tx;
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     await bugger.continueUntilBreakpoint(); //run till end
 
@@ -147,7 +147,7 @@ describe("Codex", function () {
     let receipt = await instance.run();
     let txHash = receipt.tx;
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     await bugger.continueUntilBreakpoint(); //run till end
 

--- a/packages/debugger/test/data/decoding.js
+++ b/packages/debugger/test/data/decoding.js
@@ -1,11 +1,11 @@
 import debugModule from "debug";
-const debug = debugModule("test:data:decode");
+const debug = debugModule("debugger:test:data:decode");
 
 import faker from "faker";
 
 import evm from "lib/evm/selectors";
 
-import { generateUints, describeDecoding } from "./helpers";
+import {generateUints, describeDecoding} from "./helpers";
 
 const uints = generateUints();
 
@@ -56,7 +56,7 @@ const mappingFixtures = [
     value: {
       ...Object.assign(
         {},
-        ...generateArray(5).map((value, idx) => ({ [idx]: value }))
+        ...generateArray(5).map((value, idx) => ({[idx]: value}))
       )
     }
   },
@@ -111,11 +111,11 @@ contract ${contractName} {
   event Done();
 
   // declarations
-  ${fixtures.map(({ type, name }) => `${type} ${name};`).join("\n  ")}
+  ${fixtures.map(({type, name}) => `${type} ${name};`).join("\n  ")}
 
   function run() public {
     ${fixtures
-      .map(({ name, value }) => `${name} = ${JSON.stringify(value)};`)
+      .map(({name, value}) => `${name} = ${JSON.stringify(value)};`)
       .join("\n    ")}
 
     emit Done();
@@ -138,14 +138,12 @@ contract ${contractName} {
 
   // declarations
   ${fixtures
-    .map(
-      ({ name, type: { from, to } }) => `mapping (${from} => ${to}) ${name};`
-    )
+    .map(({name, type: {from, to}}) => `mapping (${from} => ${to}) ${name};`)
     .join("\n  ")}
 
   function run() public {
     ${fixtures
-      .map(({ name, type: { from }, value }) =>
+      .map(({name, type: {from}, value}) =>
         Object.entries(value)
           .map(([k, v]) =>
             from === "string"
@@ -174,7 +172,7 @@ contract ${contractName} {
     (contractName, fixtures) => {
       const separator = ";\n    ";
 
-      function declareAssign({ name, type, value }) {
+      function declareAssign({name, type, value}) {
         if (type.indexOf("[]") != -1) {
           // array, must `new`
           let declare = `${type} memory ${name} = new ${type}(${value.length})`;

--- a/packages/debugger/test/data/function-decoding.js
+++ b/packages/debugger/test/data/function-decoding.js
@@ -1,11 +1,11 @@
 import debugModule from "debug";
-const debug = debugModule("test:data:function-decoding");
+const debug = debugModule("debugger:test:data:function-decoding");
 
-import { assert } from "chai";
+import {assert} from "chai";
 
 import Ganache from "ganache-core";
 
-import { prepareContracts, lineOf } from "../helpers";
+import {prepareContracts, lineOf} from "../helpers";
 import Debugger from "lib/debugger";
 import * as Codec from "@truffle/codec";
 
@@ -139,7 +139,7 @@ describe("Function Pointer Decoding", function () {
   var compilations;
 
   before("Create Provider", async function () {
-    provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
+    provider = Ganache.provider({seed: "debugger", gasLimit: 7000000});
   });
 
   before("Prepare contracts and artifacts", async function () {
@@ -157,7 +157,7 @@ describe("Function Pointer Decoding", function () {
     let receipt = await instance.run();
     let txHash = receipt.tx;
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     let sourceId = bugger.view(solidity.current.source).id;
     let source = bugger.view(solidity.current.source).source;
@@ -195,7 +195,7 @@ describe("Function Pointer Decoding", function () {
     let receipt = await instance.run();
     let txHash = receipt.tx;
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     let sourceId = bugger.view(solidity.current.source).id;
     let source = bugger.view(solidity.current.source).source;
@@ -230,7 +230,7 @@ describe("Function Pointer Decoding", function () {
     let receipt = await abstractions.InternalsTest.new();
     let txHash = receipt.transactionHash;
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     let sourceId = bugger.view(solidity.current.source).id;
     let source = bugger.view(solidity.current.source).source;

--- a/packages/debugger/test/data/global-const.js
+++ b/packages/debugger/test/data/global-const.js
@@ -1,5 +1,5 @@
 import debugModule from "debug";
-const debug = debugModule("test:data:global");
+const debug = debugModule("debugger:test:data:global");
 
 import {assert} from "chai";
 

--- a/packages/debugger/test/data/global.js
+++ b/packages/debugger/test/data/global.js
@@ -1,11 +1,11 @@
 import debugModule from "debug";
-const debug = debugModule("test:data:global");
+const debug = debugModule("debugger:test:data:global");
 
-import { assert } from "chai";
+import {assert} from "chai";
 
 import Ganache from "ganache-core";
 
-import { prepareContracts, lineOf } from "../helpers";
+import {prepareContracts, lineOf} from "../helpers";
 import Debugger from "lib/debugger";
 
 import * as Codec from "@truffle/codec";
@@ -156,7 +156,7 @@ describe("Globally-available variables", function () {
   var compilations;
 
   before("Create Provider", async function () {
-    provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
+    provider = Ganache.provider({seed: "debugger", gasLimit: 7000000});
   });
 
   before("Prepare contracts and artifacts", async function () {
@@ -170,10 +170,10 @@ describe("Globally-available variables", function () {
   it("Gets globals correctly in simple call", async function () {
     this.timeout(8000);
     let instance = await abstractions.GlobalTest.deployed();
-    let receipt = await instance.run(9, { value: 100 });
+    let receipt = await instance.run(9, {value: 100});
     let txHash = receipt.tx;
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     await bugger.continueUntilBreakpoint(); //run till end
 
@@ -190,10 +190,10 @@ describe("Globally-available variables", function () {
   it("Gets globals correctly in nested call", async function () {
     this.timeout(12000);
     let instance = await abstractions.GlobalTest.deployed();
-    let receipt = await instance.runRun(9, { value: 100 });
+    let receipt = await instance.runRun(9, {value: 100});
     let txHash = receipt.tx;
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     let sourceId = bugger.view(solidity.current.source).id;
     let source = bugger.view(solidity.current.source).source;
@@ -219,7 +219,7 @@ describe("Globally-available variables", function () {
     let receipt = await instance.runStatic(9);
     let txHash = receipt.tx;
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     let sourceId = bugger.view(solidity.current.source).id;
     let source = bugger.view(solidity.current.source).source;
@@ -242,10 +242,10 @@ describe("Globally-available variables", function () {
   it("Gets globals correctly in library call", async function () {
     this.timeout(8000);
     let instance = await abstractions.GlobalTest.deployed();
-    let receipt = await instance.runLib(9, { value: 100 });
+    let receipt = await instance.runLib(9, {value: 100});
     let txHash = receipt.tx;
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     let sourceId = bugger.view(solidity.current.source).id;
     let source = bugger.view(solidity.current.source).source;
@@ -266,10 +266,10 @@ describe("Globally-available variables", function () {
 
   it("Gets globals correctly in simple creation", async function () {
     this.timeout(12000);
-    let contract = await abstractions.CreationTest.new(9, { value: 100 });
+    let contract = await abstractions.CreationTest.new(9, {value: 100});
     let txHash = contract.transactionHash;
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     await bugger.continueUntilBreakpoint(); //run till end
 
@@ -286,10 +286,10 @@ describe("Globally-available variables", function () {
   it("Gets globals correctly in nested creation", async function () {
     this.timeout(12000);
     let instance = await abstractions.GlobalTest.deployed();
-    let receipt = await instance.runCreate(9, { value: 100 });
+    let receipt = await instance.runCreate(9, {value: 100});
     let txHash = receipt.tx;
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     let sourceId = bugger.view(solidity.current.source).id;
     let source = bugger.view(solidity.current.source).source;
@@ -312,10 +312,10 @@ describe("Globally-available variables", function () {
   it("Gets globals correctly in failed CREATE2", async function () {
     this.timeout(12000);
     let instance = await abstractions.GlobalTest.deployed();
-    let receipt = await instance.runFailedCreate2(9, { value: 100 });
+    let receipt = await instance.runFailedCreate2(9, {value: 100});
     let txHash = receipt.tx;
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     let sourceId = bugger.view(solidity.current.source).id;
     let source = bugger.view(solidity.current.source).source;

--- a/packages/debugger/test/data/helpers.js
+++ b/packages/debugger/test/data/helpers.js
@@ -1,12 +1,12 @@
 import debugModule from "debug";
-const debug = debugModule("test:data:decode");
+const debug = debugModule("debugger:test:data:decode");
 
 import Ganache from "ganache-core";
-import { assert } from "chai";
+import {assert} from "chai";
 import changeCase from "change-case";
 import * as Codec from "@truffle/codec";
 
-import { prepareContracts } from "test/helpers";
+import {prepareContracts} from "test/helpers";
 
 import Debugger from "lib/debugger";
 
@@ -29,7 +29,7 @@ function fileName(testName) {
 }
 
 function generateTests(fixtures) {
-  for (let { name, value: expected } of fixtures) {
+  for (let {name, value: expected} of fixtures) {
     it(`correctly decodes ${name}`, async () => {
       const response = await this.decode(name);
       assert.deepEqual(response, expected);
@@ -48,18 +48,15 @@ function lastStatementLine(source) {
 }
 
 async function prepareDebugger(testName, sources) {
-  const provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
+  const provider = Ganache.provider({seed: "debugger", gasLimit: 7000000});
 
-  let { abstractions, compilations } = await prepareContracts(
-    provider,
-    sources
-  );
+  let {abstractions, compilations} = await prepareContracts(provider, sources);
 
   let instance = await abstractions[contractName(testName)].deployed();
   let receipt = await instance.run();
   let txHash = receipt.tx;
 
-  let bugger = await Debugger.forTx(txHash, { provider, compilations });
+  let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
   let source = sources[fileName(testName)];
 

--- a/packages/debugger/test/data/ids.js
+++ b/packages/debugger/test/data/ids.js
@@ -1,11 +1,11 @@
 import debugModule from "debug";
-const debug = debugModule("test:data:ids");
+const debug = debugModule("debugger:test:data:ids");
 
-import { assert } from "chai";
+import {assert} from "chai";
 
 import Ganache from "ganache-core";
 
-import { prepareContracts, lineOf } from "../helpers";
+import {prepareContracts, lineOf} from "../helpers";
 import Debugger from "lib/debugger";
 
 import trace from "lib/trace/selectors";
@@ -187,7 +187,7 @@ describe("Variable IDs", function () {
   var compilations;
 
   before("Create Provider", async function () {
-    provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
+    provider = Ganache.provider({seed: "debugger", gasLimit: 7000000});
   });
 
   before("Prepare contracts and artifacts", async function () {
@@ -204,7 +204,7 @@ describe("Variable IDs", function () {
     let receipt = await instance.factorial(3);
     let txHash = receipt.tx;
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     debug("sourceId %d", bugger.view(solidity.current.source).id);
 
@@ -238,7 +238,7 @@ describe("Variable IDs", function () {
     let receipt = await instance.run();
     let txHash = receipt.tx;
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     debug("sourceId %d", bugger.view(solidity.current.source).id);
 
@@ -277,7 +277,7 @@ describe("Variable IDs", function () {
     let receipt = await instance.run();
     let txHash = receipt.tx;
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     debug("sourceId %d", bugger.view(solidity.current.source).id);
 
@@ -297,7 +297,7 @@ describe("Variable IDs", function () {
     let receipt = await instance.runLib();
     let txHash = receipt.tx;
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     debug("sourceId %d", bugger.view(solidity.current.source).id);
 

--- a/packages/debugger/test/data/immutable.js
+++ b/packages/debugger/test/data/immutable.js
@@ -1,11 +1,11 @@
 import debugModule from "debug";
-const debug = debugModule("test:data:immutable");
+const debug = debugModule("debugger:test:data:immutable");
 
-import { assert } from "chai";
+import {assert} from "chai";
 
 import Ganache from "ganache-core";
 
-import { prepareContracts, lineOf } from "../helpers";
+import {prepareContracts, lineOf} from "../helpers";
 import Debugger from "lib/debugger";
 
 import * as Codec from "@truffle/codec";
@@ -69,7 +69,7 @@ describe("Immutable state variables", function () {
   var compilations;
 
   before("Create Provider", async function () {
-    provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
+    provider = Ganache.provider({seed: "debugger", gasLimit: 7000000});
   });
 
   before("Prepare contracts and artifacts", async function () {
@@ -87,7 +87,7 @@ describe("Immutable state variables", function () {
     let receipt = await instance.run();
     let txHash = receipt.tx;
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     let sourceId = bugger.view(solidity.current.source).id;
     let source = bugger.view(solidity.current.source).source;
@@ -123,7 +123,7 @@ describe("Immutable state variables", function () {
     let address = instance.address;
     let txHash = instance.transactionHash;
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     let sourceId = bugger.view(solidity.current.source).id;
     let source = bugger.view(solidity.current.source).source;

--- a/packages/debugger/test/data/more-decoding.js
+++ b/packages/debugger/test/data/more-decoding.js
@@ -1,12 +1,12 @@
 import debugModule from "debug";
-const debug = debugModule("test:data:more-decoding");
+const debug = debugModule("debugger:test:data:more-decoding");
 
-import { assert } from "chai";
+import {assert} from "chai";
 import Web3 from "web3"; //just using for utils
 
 import Ganache from "ganache-core";
 
-import { prepareContracts, lineOf } from "../helpers";
+import {prepareContracts, lineOf} from "../helpers";
 import Debugger from "lib/debugger";
 
 import solidity from "lib/solidity/selectors";
@@ -307,7 +307,7 @@ describe("Further Decoding", function () {
   var compilations;
 
   before("Create Provider", async function () {
-    provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
+    provider = Ganache.provider({seed: "debugger", gasLimit: 7000000});
   });
 
   before("Prepare contracts and artifacts", async function () {
@@ -325,7 +325,7 @@ describe("Further Decoding", function () {
     let receipt = await instance.run();
     let txHash = receipt.tx;
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     let sourceId = bugger.view(solidity.current.source).id;
     let source = bugger.view(solidity.current.source).source;
@@ -343,11 +343,11 @@ describe("Further Decoding", function () {
     const expectedResult = {
       memoryStaticArray: [107],
       localStorage: [107, 214],
-      storageStructArray: [{ x: 107 }],
+      storageStructArray: [{x: 107}],
       storageArrayArray: [[2, 3]],
-      structMapping: { hello: { x: 107 } },
-      arrayMapping: { hello: [2, 3] },
-      signedMapping: { hello: -1 },
+      structMapping: {hello: {x: 107}},
+      arrayMapping: {hello: [2, 3]},
+      signedMapping: {hello: -1},
       pointedAt: [107, 214]
     };
 
@@ -362,7 +362,7 @@ describe("Further Decoding", function () {
     let txHash = receipt.tx;
     let address = instance.address;
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     let sourceId = bugger.view(solidity.current.source).id;
     let source = bugger.view(solidity.current.source).source;
@@ -379,15 +379,15 @@ describe("Further Decoding", function () {
     debug("variables %O", variables);
 
     const expectedResult = {
-      boolMap: { true: true },
-      byteMap: { "0x01": "0x01" },
-      bytesMap: { "0x01": "0x01" },
-      uintMap: { "1": 1, "2": 2 },
-      intMap: { "-1": -1 },
-      stringMap: { "0xdeadbeef": "0xdeadbeef", "12345": "12345" },
-      addressMap: { [address]: address },
-      contractMap: { [address]: address },
-      enumMap: { "ElementaryTest.Ternary.Blue": "ElementaryTest.Ternary.Blue" },
+      boolMap: {true: true},
+      byteMap: {"0x01": "0x01"},
+      bytesMap: {"0x01": "0x01"},
+      uintMap: {"1": 1, "2": 2},
+      intMap: {"-1": -1},
+      stringMap: {"0xdeadbeef": "0xdeadbeef", "12345": "12345"},
+      addressMap: {[address]: address},
+      contractMap: {[address]: address},
+      enumMap: {"ElementaryTest.Ternary.Blue": "ElementaryTest.Ternary.Blue"},
       oneByte: "0xff",
       severalBytes: ["0xff"]
     };
@@ -402,7 +402,7 @@ describe("Further Decoding", function () {
     let receipt = await instance.run();
     let txHash = receipt.tx;
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     let sourceId = bugger.view(solidity.current.source).id;
     let source = bugger.view(solidity.current.source).source;
@@ -418,10 +418,10 @@ describe("Further Decoding", function () {
     );
 
     const expectedResult = {
-      map: { key1: "value1", key2: "value2" },
+      map: {key1: "value1", key2: "value2"},
       pointedAt: "key2",
       arrayArray: [[82]],
-      arrayStruct: { x: [82] },
+      arrayStruct: {x: [82]},
       key1: "key1",
       key2: "key2",
       pointedAt: "key2"
@@ -437,7 +437,7 @@ describe("Further Decoding", function () {
     let receipt = await instance.run();
     let txHash = receipt.tx;
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     //we're only testing storage so run till end
     await bugger.continueUntilBreakpoint();
@@ -447,13 +447,13 @@ describe("Further Decoding", function () {
     );
 
     const expectedResult = {
-      mapArrayStatic: [{ a: "0a" }],
-      mapMap: { a: { c: "ac" } },
+      mapArrayStatic: [{a: "0a"}],
+      mapMap: {a: {c: "ac"}},
       mapStruct0: {
-        map: { a: "00a" }
+        map: {a: "00a"}
       },
       mapStruct1: {
-        map: { e: "10e" }
+        map: {e: "10e"}
       }
     };
 
@@ -469,7 +469,7 @@ describe("Further Decoding", function () {
     //converting to numbers for convenience
     const startingOffsets = Object.values(
       bugger.view(data.current.allocations.state)[contractId].members
-    ).map(({ pointer }) => pointer.range.from.slot.offset);
+    ).map(({pointer}) => pointer.range.from.slot.offset);
 
     const mappingKeys = bugger.view(data.views.mappingKeys);
     for (let slot of mappingKeys) {
@@ -489,14 +489,14 @@ describe("Further Decoding", function () {
     let signature = "run(bool)";
     //manually set up the selector; 10 is for initial 0x + 8 more hex digits
     let selector = Web3.utils
-      .soliditySha3({ type: "string", value: signature })
+      .soliditySha3({type: "string", value: signature})
       .slice(0, 10);
     let argument =
       "0000000000000000000000000000000000000000000000000000000000000002";
-    let receipt = await instance.sendTransaction({ data: selector + argument });
+    let receipt = await instance.sendTransaction({data: selector + argument});
     let txHash = receipt.tx;
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     await bugger.continueUntilBreakpoint(); //run till end
 
@@ -506,7 +506,7 @@ describe("Further Decoding", function () {
     debug("variables %O", variables);
 
     const expectedResult = {
-      boolMap: { true: 1 }
+      boolMap: {true: 1}
     };
 
     assert.deepInclude(variables, expectedResult);
@@ -519,7 +519,7 @@ describe("Further Decoding", function () {
     let receipt = await instance.run();
     let txHash = receipt.tx;
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     await bugger.continueUntilBreakpoint(); //run till end
 
@@ -529,7 +529,7 @@ describe("Further Decoding", function () {
     debug("variables %O", variables);
 
     const expectedResult = {
-      globalStruct: { x: 2, y: 3 },
+      globalStruct: {x: 2, y: 3},
       globalEnum: "GlobalEnum.Yes"
     };
 
@@ -543,7 +543,7 @@ describe("Further Decoding", function () {
     let receipt = await instance.run();
     let txHash = receipt.tx;
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     let sourceId = bugger.view(solidity.current.source).id;
     let source = bugger.view(solidity.current.source).source;
@@ -570,7 +570,7 @@ describe("Further Decoding", function () {
       let receipt = await instance.unsignedTest();
       let txHash = receipt.tx;
 
-      let bugger = await Debugger.forTx(txHash, { provider, compilations });
+      let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
       let sourceId = bugger.view(solidity.current.source).id;
       let source = bugger.view(solidity.current.source).source;
@@ -600,7 +600,7 @@ describe("Further Decoding", function () {
       let receipt = await instance.signedTest();
       let txHash = receipt.tx;
 
-      let bugger = await Debugger.forTx(txHash, { provider, compilations });
+      let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
       let sourceId = bugger.view(solidity.current.source).id;
       let source = bugger.view(solidity.current.source).source;
@@ -630,7 +630,7 @@ describe("Further Decoding", function () {
       let receipt = await instance.rawTest();
       let txHash = receipt.tx;
 
-      let bugger = await Debugger.forTx(txHash, { provider, compilations });
+      let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
       let sourceId = bugger.view(solidity.current.source).id;
       let source = bugger.view(solidity.current.source).source;

--- a/packages/debugger/test/data/returnvalue.js
+++ b/packages/debugger/test/data/returnvalue.js
@@ -1,11 +1,11 @@
 import debugModule from "debug";
-const debug = debugModule("test:data:returnvalue");
+const debug = debugModule("debugger:test:data:returnvalue");
 
-import { assert } from "chai";
+import {assert} from "chai";
 
 import Ganache from "ganache-core";
 
-import { prepareContracts } from "../helpers";
+import {prepareContracts} from "../helpers";
 import Debugger from "lib/debugger";
 
 import * as Codec from "@truffle/codec";
@@ -75,7 +75,7 @@ describe("Return value decoding", function () {
   var compilations;
 
   before("Create Provider", async function () {
-    provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
+    provider = Ganache.provider({seed: "debugger", gasLimit: 7000000});
   });
 
   before("Prepare contracts and artifacts", async function () {
@@ -93,7 +93,7 @@ describe("Return value decoding", function () {
     let receipt = await instance.pair();
     let txHash = receipt.tx;
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     await bugger.continueUntilBreakpoint(); //run till end
 
@@ -105,7 +105,7 @@ describe("Return value decoding", function () {
     assert.lengthOf(outputs, 2);
     assert.strictEqual(outputs[0].name, "x");
     assert.isUndefined(outputs[1].name);
-    const values = outputs.map(({ value }) =>
+    const values = outputs.map(({value}) =>
       Codec.Format.Utils.Inspect.nativize(value)
     );
     assert.deepEqual(values, [-1, -2]);
@@ -118,7 +118,7 @@ describe("Return value decoding", function () {
     let txHash = instance.transactionHash;
     debug("txHash: %s", txHash);
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     debug("about to run!");
     await bugger.continueUntilBreakpoint(); //run till end
@@ -146,7 +146,7 @@ describe("Return value decoding", function () {
     let txHash = instance.transactionHash;
     debug("txHash: %s", txHash);
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     debug("about to run!");
     await bugger.continueUntilBreakpoint(); //run till end
@@ -167,7 +167,7 @@ describe("Return value decoding", function () {
     let txHash = instance.transactionHash;
     debug("txHash: %s", txHash);
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     debug("about to run!");
     await bugger.continueUntilBreakpoint(); //run till end
@@ -202,7 +202,7 @@ describe("Return value decoding", function () {
       txHash = error.hashes[0]; //it's the only hash involved
     }
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     await bugger.continueUntilBreakpoint(); //run till end
 
@@ -226,7 +226,7 @@ describe("Return value decoding", function () {
       txHash = error.hashes[0]; //it's the only hash involved
     }
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     await bugger.continueUntilBreakpoint(); //run till end
 

--- a/packages/debugger/test/data/yul.js
+++ b/packages/debugger/test/data/yul.js
@@ -1,11 +1,11 @@
 import debugModule from "debug";
-const debug = debugModule("test:data:more-decoding");
+const debug = debugModule("debugger:test:data:yul");
 
-import { assert } from "chai";
+import {assert} from "chai";
 
 import Ganache from "ganache-core";
 
-import { prepareContracts, lineOf } from "../helpers";
+import {prepareContracts, lineOf} from "../helpers";
 import Debugger from "lib/debugger";
 
 import solidity from "lib/solidity/selectors";
@@ -57,7 +57,7 @@ describe("Assembly decoding", function () {
   var compilations;
 
   before("Create Provider", async function () {
-    provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
+    provider = Ganache.provider({seed: "debugger", gasLimit: 7000000});
   });
 
   before("Prepare contracts and artifacts", async function () {
@@ -75,7 +75,7 @@ describe("Assembly decoding", function () {
     let receipt = await instance.run();
     let txHash = receipt.tx;
 
-    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+    let bugger = await Debugger.forTx(txHash, {provider, compilations});
 
     let sourceId = bugger.view(solidity.current.source).id;
     let source = bugger.view(solidity.current.source).source;
@@ -97,7 +97,7 @@ describe("Assembly decoding", function () {
     const numberize = obj =>
       Object.assign(
         {},
-        ...Object.entries(obj).map(([key, value]) => ({ [key]: Number(value) }))
+        ...Object.entries(obj).map(([key, value]) => ({[key]: Number(value)}))
       );
 
     let variables = numberize(

--- a/packages/debugger/test/endstate.js
+++ b/packages/debugger/test/endstate.js
@@ -1,11 +1,11 @@
 import debugModule from "debug";
-const debug = debugModule("test:endstate"); // eslint-disable-line no-unused-vars
+const debug = debugModule("debugger:test:endstate");
 
-import { assert } from "chai";
+import {assert} from "chai";
 
 import Ganache from "ganache-core";
 
-import { prepareContracts } from "./helpers";
+import {prepareContracts} from "./helpers";
 import Debugger from "lib/debugger";
 
 import evm from "lib/evm/selectors";
@@ -45,7 +45,7 @@ describe("End State", function () {
   var compilations;
 
   before("Create Provider", async function () {
-    provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
+    provider = Ganache.provider({seed: "debugger", gasLimit: 7000000});
   });
 
   before("Prepare contracts and artifacts", async function () {
@@ -93,6 +93,6 @@ describe("End State", function () {
     const variables = Codec.Format.Utils.Inspect.nativizeVariables(
       await bugger.variables()
     );
-    assert.include(variables, { x: 107 });
+    assert.include(variables, {x: 107});
   });
 });

--- a/packages/debugger/test/evm.js
+++ b/packages/debugger/test/evm.js
@@ -1,11 +1,11 @@
 import debugModule from "debug";
-const debug = debugModule("test:evm"); // eslint-disable-line no-unused-vars
+const debug = debugModule("debugger:test:evm");
 
-import { assert } from "chai";
+import {assert} from "chai";
 
 import Ganache from "ganache-core";
 
-import { prepareContracts } from "./helpers";
+import {prepareContracts} from "./helpers";
 import Debugger from "lib/debugger";
 
 import evm from "lib/evm/selectors";
@@ -70,7 +70,7 @@ describe("EVM Debugging", function () {
   var compilations;
 
   before("Create Provider", async function () {
-    provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
+    provider = Ganache.provider({seed: "debugger", gasLimit: 7000000});
   });
 
   before("Prepare contracts and artifacts", async function () {

--- a/packages/debugger/test/helpers.js
+++ b/packages/debugger/test/helpers.js
@@ -1,5 +1,5 @@
 import debugModule from "debug";
-const debug = debugModule("test:helpers");
+const debug = debugModule("debugger:test:helpers");
 
 import path from "path";
 import fs from "fs-extra";
@@ -27,14 +27,14 @@ export async function prepareContracts(provider, sources = {}, migrations) {
     solc: {
       version: "0.7.4",
       settings: {
-        optimizer: { enabled: false, runs: 200 },
+        optimizer: {enabled: false, runs: 200},
         evmVersion: "constantinople"
       }
     }
   };
 
   await addContracts(config, sources);
-  let { contractNames, files } = await compile(config);
+  let {contractNames, files} = await compile(config);
 
   if (!migrations) {
     migrations = await defaultMigrations(contractNames);
@@ -134,7 +134,7 @@ export async function defaultMigrations(contractNames) {
 }
 
 export async function compile(config) {
-  const { compilations } = await WorkflowCompile.compileAndSave(
+  const {compilations} = await WorkflowCompile.compileAndSave(
     config.with({
       all: true,
       quiet: true
@@ -150,7 +150,7 @@ export async function compile(config) {
       }
       return a;
     },
-    { contractNames: [], sourceIndexes: [] }
+    {contractNames: [], sourceIndexes: []}
   );
   const sourceIndexes = collectedCompilationOutput.sourceIndexes.filter(
     (item, index) => {

--- a/packages/debugger/test/load.js
+++ b/packages/debugger/test/load.js
@@ -1,11 +1,11 @@
 import debugModule from "debug";
-const debug = debugModule("test:load"); // eslint-disable-line no-unused-vars
+const debug = debugModule("debugger:test:load");
 
-import { assert } from "chai";
+import {assert} from "chai";
 
 import Ganache from "ganache-core";
 
-import { prepareContracts } from "./helpers";
+import {prepareContracts} from "./helpers";
 import * as Codec from "@truffle/codec";
 import Debugger from "lib/debugger";
 
@@ -41,7 +41,7 @@ describe("Loading and unloading transactions", function () {
   var compilations;
 
   before("Create Provider", async function () {
-    provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
+    provider = Ganache.provider({seed: "debugger", gasLimit: 7000000});
   });
 
   before("Prepare contracts and artifacts", async function () {
@@ -69,7 +69,7 @@ describe("Loading and unloading transactions", function () {
     const variables = Codec.Format.Utils.Inspect.nativizeVariables(
       await bugger.variables()
     );
-    const expected = { x: 1 };
+    const expected = {x: 1};
     assert.deepInclude(variables, expected);
   });
 
@@ -92,7 +92,7 @@ describe("Loading and unloading transactions", function () {
     let variables = Codec.Format.Utils.Inspect.nativizeVariables(
       await bugger.variables()
     );
-    let expected = { x: 1 };
+    let expected = {x: 1};
     assert.deepInclude(variables, expected);
     await bugger.unload();
     assert.isFalse(bugger.view(trace.loaded));
@@ -102,7 +102,7 @@ describe("Loading and unloading transactions", function () {
     variables = Codec.Format.Utils.Inspect.nativizeVariables(
       await bugger.variables()
     );
-    expected = { y: 2 };
+    expected = {y: 2};
     assert.deepInclude(variables, expected);
   });
 

--- a/packages/debugger/test/precompiles.js
+++ b/packages/debugger/test/precompiles.js
@@ -1,11 +1,11 @@
 import debugModule from "debug";
-const debug = debugModule("test:precompiles"); // eslint-disable-line no-unused-vars
+const debug = debugModule("debugger:test:precompiles");
 
-import { assert } from "chai";
+import {assert} from "chai";
 
 import Ganache from "ganache-core";
 
-import { prepareContracts } from "./helpers";
+import {prepareContracts} from "./helpers";
 import Debugger from "lib/debugger";
 
 import evm from "lib/evm/selectors";
@@ -55,7 +55,7 @@ describe("Precompiled Contracts", function () {
   let results = {};
 
   before("Create Provider", async function () {
-    provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
+    provider = Ganache.provider({seed: "debugger", gasLimit: 7000000});
   });
 
   before("Prepare contracts and artifacts", async function () {
@@ -68,7 +68,7 @@ describe("Precompiled Contracts", function () {
 
   before("Initialize results", function () {
     // initialize results as mapping of selector to step results list
-    for (let { name } of TEST_CASES) {
+    for (let {name} of TEST_CASES) {
       results[name] = [];
     }
   });
@@ -87,13 +87,13 @@ describe("Precompiled Contracts", function () {
     var finished; // is the trace finished?
 
     do {
-      for (let { name, selector } of TEST_CASES) {
+      for (let {name, selector} of TEST_CASES) {
         let stepResult;
 
         try {
-          stepResult = { value: bugger.view(selector) };
+          stepResult = {value: bugger.view(selector)};
         } catch (e) {
-          stepResult = { error: e };
+          stepResult = {error: e};
         }
 
         results[name].push(stepResult);
@@ -106,7 +106,7 @@ describe("Precompiled Contracts", function () {
 
   before("remove final step results", function () {
     // since these include one step past end of trace
-    for (let { name } of TEST_CASES) {
+    for (let {name} of TEST_CASES) {
       results[name].pop();
     }
   });

--- a/packages/debugger/test/reset.js
+++ b/packages/debugger/test/reset.js
@@ -1,11 +1,11 @@
 import debugModule from "debug";
-const debug = debugModule("test:reset"); // eslint-disable-line no-unused-vars
+const debug = debugModule("debugger:test:reset");
 
-import { assert } from "chai";
+import {assert} from "chai";
 
 import Ganache from "ganache-core";
 
-import { prepareContracts, lineOf } from "./helpers";
+import {prepareContracts, lineOf} from "./helpers";
 import * as Codec from "@truffle/codec";
 import Debugger from "lib/debugger";
 
@@ -39,7 +39,7 @@ describe("Reset Button", function () {
   var compilations;
 
   before("Create Provider", async function () {
-    provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
+    provider = Ganache.provider({seed: "debugger", gasLimit: 7000000});
   });
 
   before("Prepare contracts and artifacts", async function () {

--- a/packages/debugger/test/solidity.js
+++ b/packages/debugger/test/solidity.js
@@ -1,11 +1,11 @@
 import debugModule from "debug";
-const debug = debugModule("test:solidity"); // eslint-disable-line no-unused-vars
+const debug = debugModule("debugger:test:solidity");
 
-import { assert } from "chai";
+import {assert} from "chai";
 
 import Ganache from "ganache-core";
 
-import { prepareContracts, lineOf } from "./helpers";
+import {prepareContracts, lineOf} from "./helpers";
 import Debugger from "lib/debugger";
 
 import solidity from "lib/solidity/selectors";
@@ -152,7 +152,7 @@ describe("Solidity Debugging", function () {
   var compilations;
 
   before("Create Provider", async function () {
-    provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
+    provider = Ganache.provider({seed: "debugger", gasLimit: 7000000});
   });
 
   before("Prepare contracts and artifacts", async function () {
@@ -210,7 +210,7 @@ describe("Solidity Debugging", function () {
     // at `second();`
     let source = bugger.view(solidity.current.source);
     let breakLine = lineOf("BREAK", source.source);
-    let breakpoint = { sourceId: source.id, line: breakLine };
+    let breakpoint = {sourceId: source.id, line: breakLine};
 
     do {
       await bugger.continueUntilBreakpoint([breakpoint]);

--- a/packages/debugger/test/stacktrace.js
+++ b/packages/debugger/test/stacktrace.js
@@ -1,11 +1,11 @@
 import debugModule from "debug";
-const debug = debugModule("test:stacktrace"); // eslint-disable-line no-unused-vars
+const debug = debugModule("debugger:test:stacktrace");
 
-import { assert } from "chai";
+import {assert} from "chai";
 
 import Ganache from "ganache-core";
 
-import { prepareContracts, lineOf } from "./helpers";
+import {prepareContracts, lineOf} from "./helpers";
 import Debugger from "lib/debugger";
 
 import solidity from "lib/solidity/selectors";
@@ -105,7 +105,7 @@ describe("Stack tracing", function () {
   var compilations;
 
   before("Create Provider", async function () {
-    provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
+    provider = Ganache.provider({seed: "debugger", gasLimit: 7000000});
   });
 
   before("Prepare contracts and artifacts", async function () {
@@ -142,7 +142,7 @@ describe("Stack tracing", function () {
     await bugger.continueUntilBreakpoint(); //run till end
 
     let report = bugger.view(stacktrace.current.finalReport);
-    let functionNames = report.map(({ functionName }) => functionName);
+    let functionNames = report.map(({functionName}) => functionName);
     assert.deepEqual(functionNames, [
       undefined,
       "run",
@@ -153,9 +153,9 @@ describe("Stack tracing", function () {
       "run1",
       "runRequire"
     ]);
-    let contractNames = report.map(({ contractName }) => contractName);
+    let contractNames = report.map(({contractName}) => contractName);
     assert(contractNames.every(name => name === "StacktraceTest"));
-    let addresses = report.map(({ address }) => address);
+    let addresses = report.map(({address}) => address);
     assert(addresses.every(address => address === instance.address));
     let status = report[report.length - 1].status;
     assert.isFalse(status);
@@ -195,7 +195,7 @@ describe("Stack tracing", function () {
     await bugger.continueUntilBreakpoint(); //run till EMIT
 
     let report = bugger.view(stacktrace.current.report);
-    let functionNames = report.map(({ functionName }) => functionName);
+    let functionNames = report.map(({functionName}) => functionName);
     assert.deepEqual(functionNames, [
       undefined,
       "run",
@@ -205,9 +205,9 @@ describe("Stack tracing", function () {
       "run1",
       "runRequire"
     ]);
-    let contractNames = report.map(({ contractName }) => contractName);
+    let contractNames = report.map(({contractName}) => contractName);
     assert(contractNames.every(name => name === "StacktraceTest"));
-    let addresses = report.map(({ address }) => address);
+    let addresses = report.map(({address}) => address);
     assert(addresses.every(address => address === instance.address));
     let status = report[report.length - 1].status;
     assert.isUndefined(status);
@@ -219,7 +219,7 @@ describe("Stack tracing", function () {
     await bugger.continueUntilBreakpoint(); //run till EMIT again
 
     report = bugger.view(stacktrace.current.report);
-    functionNames = report.map(({ functionName }) => functionName);
+    functionNames = report.map(({functionName}) => functionName);
     assert.deepEqual(functionNames, [
       undefined,
       "run",
@@ -230,9 +230,9 @@ describe("Stack tracing", function () {
       "run1",
       "runRequire"
     ]);
-    contractNames = report.map(({ contractName }) => contractName);
+    contractNames = report.map(({contractName}) => contractName);
     assert(contractNames.every(name => name === "StacktraceTest"));
-    addresses = report.map(({ address }) => address);
+    addresses = report.map(({address}) => address);
     assert(addresses.every(address => address === instance.address));
     status = report[report.length - 1].status;
     assert.isUndefined(status);
@@ -268,7 +268,7 @@ describe("Stack tracing", function () {
     await bugger.continueUntilBreakpoint(); //run till end
 
     let report = bugger.view(stacktrace.current.finalReport);
-    let functionNames = report.map(({ functionName }) => functionName);
+    let functionNames = report.map(({functionName}) => functionName);
     assert.deepEqual(functionNames, [
       undefined,
       "run",
@@ -280,9 +280,9 @@ describe("Stack tracing", function () {
       "runPay",
       undefined
     ]);
-    let contractNames = report.map(({ contractName }) => contractName);
+    let contractNames = report.map(({contractName}) => contractName);
     assert(contractNames.every(name => name === "StacktraceTest"));
-    let addresses = report.map(({ address }) => address);
+    let addresses = report.map(({address}) => address);
     assert(addresses.every(address => address === instance.address));
     let status = report[report.length - 1].status;
     assert.isFalse(status);
@@ -318,7 +318,7 @@ describe("Stack tracing", function () {
     await bugger.continueUntilBreakpoint(); //run till end
 
     let report = bugger.view(stacktrace.current.finalReport);
-    let functionNames = report.map(({ functionName }) => functionName);
+    let functionNames = report.map(({functionName}) => functionName);
     assert.deepEqual(functionNames, [
       undefined,
       "run",
@@ -330,11 +330,11 @@ describe("Stack tracing", function () {
       "runInternal",
       undefined
     ]);
-    let contractNames = report.map(({ contractName }) => contractName);
+    let contractNames = report.map(({contractName}) => contractName);
     assert.isUndefined(contractNames[contractNames.length - 1]);
     contractNames.pop();
     assert(contractNames.every(name => name === "StacktraceTest"));
-    let addresses = report.map(({ address }) => address);
+    let addresses = report.map(({address}) => address);
     assert(addresses.every(address => address === instance.address));
     let status = report[report.length - 1].status;
     assert.isFalse(status);
@@ -371,7 +371,7 @@ describe("Stack tracing", function () {
     await bugger.continueUntilBreakpoint(); //run till end
 
     let report = bugger.view(stacktrace.current.finalReport);
-    let functionNames = report.map(({ functionName }) => functionName);
+    let functionNames = report.map(({functionName}) => functionName);
     assert.deepEqual(functionNames, [
       undefined,
       "run",
@@ -384,13 +384,13 @@ describe("Stack tracing", function () {
       undefined,
       "boom"
     ]);
-    let contractNames = report.map(({ contractName }) => contractName);
+    let contractNames = report.map(({contractName}) => contractName);
     assert.strictEqual(contractNames[contractNames.length - 1], "Boom");
     contractNames.pop(); //top frame
     assert.strictEqual(contractNames[contractNames.length - 1], "Boom");
     contractNames.pop(); //second-top frame
     assert(contractNames.every(name => name === "StacktraceTest"));
-    let addresses = report.map(({ address }) => address);
+    let addresses = report.map(({address}) => address);
     assert.strictEqual(
       addresses[addresses.length - 1],
       addresses[addresses.length - 2]

--- a/packages/debugger/test/txlog.js
+++ b/packages/debugger/test/txlog.js
@@ -1,5 +1,5 @@
 import debugModule from "debug";
-const debug = debugModule("test:txlog"); // eslint-disable-line no-unused-vars
+const debug = debugModule("debugger:test:txlog");
 
 import {assert} from "chai";
 


### PR DESCRIPTION
The debug module names in the debugger test didn't begin with `debugger`, and it was bugging me, so I changed it.

...also the one in `yul.js` was misnamed.