### PR TITLE
Enhancement: Have debugger/decoder make use of sources info in compilations

### DIFF
--- a/packages/codec/lib/compilations/types.ts
+++ b/packages/codec/lib/compilations/types.ts
@@ -4,7 +4,7 @@ import {
   Abi as SchemaAbi,
   ImmutableReferences
 } from "@truffle/contract-schema/spec";
-import { Bytecode } from "@truffle/compile-common";
+import * as Common from "@truffle/compile-common";
 
 //Note to other people passing in compilations:
 //Please include all fields you can that aren't
@@ -92,13 +92,13 @@ export interface Contract {
    * in the old artifacts format, or as a bytecode object in the new
    * compilation format.
    */
-  bytecode?: string | Bytecode;
+  bytecode?: string | Common.Bytecode;
   /**
    * The contract's deployed bytecode; may be given either as a string
    * in the old artifacts format, or as a bytecode object in the new
    * compilation format.
    */
-  deployedBytecode?: string | Bytecode;
+  deployedBytecode?: string | Common.Bytecode;
   /**
    * The contract's constructor source map.
    */

--- a/packages/codec/lib/compilations/utils.ts
+++ b/packages/codec/lib/compilations/utils.ts
@@ -7,15 +7,11 @@ import {
   ContractObject as Artifact,
   GeneratedSources
 } from "@truffle/contract-schema/spec";
-import {
-  CompiledContract,
-  Compilation as CompilerCompilation,
-  Source as CompilerSource
-} from "@truffle/compile-common";
+import * as Common from "@truffle/compile-common";
 import {Compilation, Contract, Source} from "./types";
 
 export function shimCompilations(
-  inputCompilations: CompilerCompilation[],
+  inputCompilations: Common.Compilation[],
   shimmedCompilationIdPrefix = "shimmedcompilation"
 ): Compilation[] {
   return inputCompilations.map((compilation, compilationIndex) =>
@@ -27,7 +23,7 @@ export function shimCompilations(
 }
 
 export function shimCompilation(
-  inputCompilation: CompilerCompilation,
+  inputCompilation: Common.Compilation,
   shimmedCompilationId = "shimmedcompilation"
 ): Compilation {
   return {
@@ -47,7 +43,7 @@ export function shimCompilation(
  * shimArtifacts for compatibility)
  */
 export function shimArtifacts(
-  artifacts: (Artifact | CompiledContract)[],
+  artifacts: (Artifact | Common.CompiledContract)[],
   files?: string[],
   shimmedCompilationId = "shimmedcompilation"
 ): Compilation[] {
@@ -62,10 +58,10 @@ export function shimArtifacts(
  * shimCompilation().
  */
 export function shimContracts(
-  artifacts: (Artifact | CompiledContract)[],
+  artifacts: (Artifact | Common.CompiledContract)[],
   files?: string[],
   shimmedCompilationId: string = "shimmedcompilation",
-  inputSources?: CompilerSource[]
+  inputSources?: Common.Source[]
 ): Compilation {
   let contracts: Contract[] = [];
   let sources: Source[] = [];

--- a/packages/codec/lib/compilations/utils.ts
+++ b/packages/codec/lib/compilations/utils.ts
@@ -247,7 +247,7 @@ export function getContractNode(
     if (foundNode || !source) {
       return foundNode;
     }
-    if (!source.ast || source.language !== "Solidity") {
+    if (!source.ast || source.language !== "solidity") {
       //don't search Yul sources!
       return undefined;
     }
@@ -313,11 +313,11 @@ function inferLanguage(ast: Ast.AstNode | undefined): string | undefined {
   if (!ast || typeof ast.nodeType !== "string") {
     return undefined;
   } else if (ast.nodeType === "SourceUnit") {
-    return "Solidity";
+    return "solidity";
   } else if (ast.nodeType.startsWith("Yul")) {
     //Every Yul source I've seen has YulBlock as the root, but
     //I'm not sure that that's *always* the case
-    return "Yul";
+    return "yul";
   } else {
     return undefined;
   }

--- a/packages/codec/lib/compilations/utils.ts
+++ b/packages/codec/lib/compilations/utils.ts
@@ -27,18 +27,17 @@ export function shimCompilation(
   shimmedCompilationId = "shimmedcompilation"
 ): Compilation {
   return {
-    ...shimContracts(
-      inputCompilation.contracts,
-      inputCompilation.sourceIndexes,
-      shimmedCompilationId,
-      inputCompilation.sources
-    ),
+    ...shimContracts(inputCompilation.contracts, {
+      files: inputCompilation.sourceIndexes,
+      sources: inputCompilation.sources,
+      shimmedCompilationId
+    }),
     compiler: inputCompilation.compiler
   };
 }
 
 /**
- * wrapper around shimArtifactsToCompilation that just returns
+ * wrapper around shimContracts that just returns
  * the result in a one-element array (keeping the old name
  * shimArtifacts for compatibility)
  */
@@ -47,22 +46,30 @@ export function shimArtifacts(
   files?: string[],
   shimmedCompilationId = "shimmedcompilation"
 ): Compilation[] {
-  return [shimContracts(artifacts, files, shimmedCompilationId)];
+  return [shimContracts(artifacts, {files, shimmedCompilationId})];
+}
+
+interface CompilationOptions {
+  files?: string[];
+  sources?: Common.Source[];
+  shimmedCompilationId?: string;
 }
 
 /**
  * shims a bunch of contracts ("artifacts", though not necessarily)
  * to a compilation.  usually used via one of the above functions.
- * Note: if you pass in inputSources, sources will not have
+ * Note: if you pass in options.sources, options.files will be ignored.
+ * Note: if you pass in options.sources, sources will not have
  * compiler set, so you should set that up separately, as in
  * shimCompilation().
  */
 export function shimContracts(
   artifacts: (Artifact | Common.CompiledContract)[],
-  files?: string[],
-  shimmedCompilationId: string = "shimmedcompilation",
-  inputSources?: Common.Source[]
+  options: CompilationOptions = {}
 ): Compilation {
+  const {files, sources: inputSources} = options;
+  const shimmedCompilationId =
+    options.shimmedCompilationId || "shimmedcompilation";
   let contracts: Contract[] = [];
   let sources: Source[] = [];
   let unreliableSourceOrder: boolean = false;

--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -106,15 +106,15 @@ var DebugUtils = {
     const lowestInternalIndex = Math.min(
       ...compilation.contracts.map(contract => {
         //find first defined index
-        let lowestConstructor = contract.generatedSources.findIndex(
+        let lowestConstructor = (contract.generatedSources || []).findIndex(
           x => x !== undefined
         );
         if (lowestConstructor === -1) {
           lowestConstructor = Infinity;
         }
-        let lowestDeployed = contract.deployedGeneratedSources.findIndex(
-          x => x !== undefined
-        );
+        let lowestDeployed = (
+          contract.deployedGeneratedSources || []
+        ).findIndex(x => x !== undefined);
         if (lowestDeployed === -1) {
           lowestDeployed = Infinity;
         }
@@ -123,7 +123,7 @@ var DebugUtils = {
     );
     if (lowestInternalIndex !== Infinity) {
       //Infinity would mean there were none
-      if (lowestInternalIndex > compilation.sources.length) {
+      if (lowestInternalIndex !== compilation.sources.length) {
         //if it's a usable compilation, these should be equal,
         //as length = 1 + last user source
         return false;

--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -640,7 +640,7 @@ var DebugUtils = {
     return indented.join(OS.EOL);
   },
 
-  colorize: function (code, language = "Solidity") {
+  colorize: function (code, language = "solidity") {
     //I'd put these outside the function
     //but then it gives me errors, because
     //you can't just define self-referential objects like that...
@@ -723,10 +723,10 @@ var DebugUtils = {
       //NOTE: you might think you should pass highlight: true,
       //but you'd be wrong!  I don't understand this either
     };
-    if (language === "Solidity") {
+    if (language === "solidity") {
       //normal case: solidity
       return chromafi(code, options);
-    } else if (language === "Yul") {
+    } else if (language === "yul") {
       //HACK: stick the code in an assembly block since we don't
       //have a separate Yul language for HLJS at the moment,
       //colorize it there, then extract it after colorization

--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -9,55 +9,55 @@ hljsDefineSolidity(chromafi.hljs);
 var chalk = require("chalk");
 
 const commandReference = {
-  o: "step over",
-  i: "step into",
-  u: "step out",
-  n: "step next",
+  "o": "step over",
+  "i": "step into",
+  "u": "step out",
+  "n": "step next",
   ";": "step instruction (include number to step multiple)",
-  p: "print instruction & state (`p [mem|cal|sto]*`; see docs for more)",
-  l: "print additional source context",
-  h: "print this help",
-  v: "print variables and values",
+  "p": "print instruction & state (`p [mem|cal|sto]*`; see docs for more)",
+  "l": "print additional source context",
+  "h": "print this help",
+  "v": "print variables and values",
   ":": "evaluate expression - see `v`",
   "+": "add watch expression (`+:<expr>`)",
   "-": "remove watch expression (-:<expr>)",
   "?": "list existing watch expressions and breakpoints",
-  b: "add breakpoint (`b [[<source-file>:]<line-number>]`; see docs for more)",
-  B: "remove breakpoint (similar to adding, or `B all` to remove all)",
-  c: "continue until breakpoint",
-  q: "quit",
-  r: "reset",
-  t: "load new transaction",
-  T: "unload transaction",
-  s: "print stacktrace",
-  g: "turn on generated sources",
-  G: "turn off generated sources except via `;`"
+  "b": "add breakpoint (`b [[<source-file>:]<line-number>]`; see docs for more)",
+  "B": "remove breakpoint (similar to adding, or `B all` to remove all)",
+  "c": "continue until breakpoint",
+  "q": "quit",
+  "r": "reset",
+  "t": "load new transaction",
+  "T": "unload transaction",
+  "s": "print stacktrace",
+  "g": "turn on generated sources",
+  "G": "turn off generated sources except via `;`"
 };
 
 const shortCommandReference = {
-  o: "step over",
-  i: "step into",
-  u: "step out",
-  n: "step next",
+  "o": "step over",
+  "i": "step into",
+  "u": "step out",
+  "n": "step next",
   ";": "step instruction",
-  p: "print state",
-  l: "print context",
-  h: "print help",
-  v: "print variables",
+  "p": "print state",
+  "l": "print context",
+  "h": "print help",
+  "v": "print variables",
   ":": "evaluate",
   "+": "add watch",
   "-": "remove watch",
   "?": "list watches & breakpoints",
-  b: "add breakpoint",
-  B: "remove breakpoint",
-  c: "continue",
-  q: "quit",
-  r: "reset",
-  t: "load",
-  T: "unload",
-  s: "stacktrace",
-  g: "turn on generated sources",
-  G: "turn off generated sources"
+  "b": "add breakpoint",
+  "B": "remove breakpoint",
+  "c": "continue",
+  "q": "quit",
+  "r": "reset",
+  "t": "load",
+  "T": "unload",
+  "s": "stacktrace",
+  "g": "turn on generated sources",
+  "G": "turn off generated sources"
 };
 
 const truffleColors = {
@@ -91,7 +91,7 @@ var DebugUtils = {
       return false;
     }
 
-    //check #2: are source indices consecutive?
+    //check #2: are (user) source indices consecutive?
     //(while nonconsecutivity should not be a problem by itself, this probably
     //indicates a name collision of a sort that will be fatal for other
     //reasons)
@@ -103,7 +103,34 @@ var DebugUtils = {
       return false;
     }
 
-    //check #3: are there any AST ID collisions?
+    const lowestInternalIndex = Math.min(
+      ...compilation.contracts.map(contract => {
+        //find first defined index
+        let lowestConstructor = contract.generatedSources.findIndex(
+          x => x !== undefined
+        );
+        if (lowestConstructor === -1) {
+          lowestConstructor = Infinity;
+        }
+        let lowestDeployed = contract.deployedGeneratedSources.findIndex(
+          x => x !== undefined
+        );
+        if (lowestDeployed === -1) {
+          lowestDeployed = Infinity;
+        }
+        return Math.min(lowestConstructor, lowestDeployed);
+      })
+    );
+    if (lowestInternalIndex !== Infinity) {
+      //Infinity would mean there were none
+      if (lowestInternalIndex > compilation.sources.length) {
+        //if it's a usable compilation, these should be equal,
+        //as length = 1 + last user source
+        return false;
+      }
+    }
+
+    //check #4: are there any AST ID collisions?
     let astIds = new Set();
 
     let allIDsUnseenSoFar = node => {
@@ -563,7 +590,7 @@ var DebugUtils = {
     //reverse
     stacktrace = stacktrace.slice().reverse(); //reverse is in-place so clone first
     let lines = stacktrace.map(
-      ({ functionName, contractName, address, location }) => {
+      ({functionName, contractName, address, location}) => {
         let name;
         if (contractName && functionName) {
           name = `${contractName}.${functionName}`;
@@ -577,10 +604,10 @@ var DebugUtils = {
         let locationString;
         if (location) {
           let {
-            source: { sourcePath },
+            source: {sourcePath},
             sourceRange: {
               lines: {
-                start: { line, column }
+                start: {line, column}
               }
             }
           } = location;
@@ -620,66 +647,66 @@ var DebugUtils = {
 
     const trufflePalette = {
       /* base (chromafi special, not hljs) */
-      base: chalk,
-      lineNumbers: chalk,
-      trailingSpace: chalk,
+      "base": chalk,
+      "lineNumbers": chalk,
+      "trailingSpace": chalk,
       /* classes hljs-solidity actually uses */
-      keyword: truffleColors.mint,
-      number: truffleColors.red,
-      string: truffleColors.green,
-      params: truffleColors.pink,
-      builtIn: truffleColors.watermelon,
-      built_in: truffleColors.watermelon, //just to be sure
-      literal: truffleColors.watermelon,
-      function: truffleColors.orange,
-      title: truffleColors.orange,
-      class: truffleColors.orange,
-      comment: truffleColors.comment,
-      doctag: truffleColors.comment,
+      "keyword": truffleColors.mint,
+      "number": truffleColors.red,
+      "string": truffleColors.green,
+      "params": truffleColors.pink,
+      "builtIn": truffleColors.watermelon,
+      "built_in": truffleColors.watermelon, //just to be sure
+      "literal": truffleColors.watermelon,
+      "function": truffleColors.orange,
+      "title": truffleColors.orange,
+      "class": truffleColors.orange,
+      "comment": truffleColors.comment,
+      "doctag": truffleColors.comment,
       /* classes it might soon use! */
-      meta: truffleColors.pink,
-      metaString: truffleColors.green,
+      "meta": truffleColors.pink,
+      "metaString": truffleColors.green,
       "meta-string": truffleColors.green, //similar
       /* classes it doesn't currently use but notionally could */
-      type: truffleColors.orange,
-      symbol: truffleColors.orange,
-      metaKeyword: truffleColors.mint,
+      "type": truffleColors.orange,
+      "symbol": truffleColors.orange,
+      "metaKeyword": truffleColors.mint,
       "meta-keyword": truffleColors.mint, //again, to be sure
       /* classes that don't make sense for Solidity */
-      regexp: chalk, //solidity does not have regexps
-      subst: chalk, //or string interpolation
-      name: chalk, //or s-expressions
-      builtInName: chalk, //or s-expressions, again
+      "regexp": chalk, //solidity does not have regexps
+      "subst": chalk, //or string interpolation
+      "name": chalk, //or s-expressions
+      "builtInName": chalk, //or s-expressions, again
       "builtin-name": chalk, //just to be sure
       /* classes for config, markup, CSS, templates, diffs (not programming) */
-      section: chalk,
-      tag: chalk,
-      attr: chalk,
-      attribute: chalk,
-      variable: chalk,
-      bullet: chalk,
-      code: chalk,
-      emphasis: chalk,
-      strong: chalk,
-      formula: chalk,
-      link: chalk,
-      quote: chalk,
-      selectorAttr: chalk, //lotta redundancy follows
+      "section": chalk,
+      "tag": chalk,
+      "attr": chalk,
+      "attribute": chalk,
+      "variable": chalk,
+      "bullet": chalk,
+      "code": chalk,
+      "emphasis": chalk,
+      "strong": chalk,
+      "formula": chalk,
+      "link": chalk,
+      "quote": chalk,
+      "selectorAttr": chalk, //lotta redundancy follows
       "selector-attr": chalk,
-      selectorClass: chalk,
+      "selectorClass": chalk,
       "selector-class": chalk,
-      selectorId: chalk,
+      "selectorId": chalk,
       "selector-id": chalk,
-      selectorPseudo: chalk,
+      "selectorPseudo": chalk,
       "selector-pseudo": chalk,
-      selectorTag: chalk,
+      "selectorTag": chalk,
       "selector-tag": chalk,
-      templateTag: chalk,
+      "templateTag": chalk,
       "template-tag": chalk,
-      templateVariable: chalk,
+      "templateVariable": chalk,
       "template-variable": chalk,
-      addition: chalk,
-      deletion: chalk
+      "addition": chalk,
+      "deletion": chalk
     };
 
     const options = {
@@ -719,7 +746,7 @@ var DebugUtils = {
     return Object.assign(
       {},
       ...Object.entries(variables).map(([variable, value]) =>
-        variable === "this" ? { [replacement]: value } : { [variable]: value }
+        variable === "this" ? {[replacement]: value} : {[variable]: value}
       )
     );
   },
@@ -739,10 +766,10 @@ var DebugUtils = {
   getTransactionSourcesBeforeStarting: async function (bugger) {
     await bugger.reset();
     let sources = {};
-    const { controller } = bugger.selectors;
+    const {controller} = bugger.selectors;
     while (!bugger.view(controller.current.trace.finished)) {
       const source = bugger.view(controller.current.location.source);
-      const { compilationId, id, internal } = source;
+      const {compilationId, id, internal} = source;
       //stepInto should skip internal sources, but there still might be
       //one at the end
       if (!internal && compilationId !== undefined && id !== undefined) {

--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -23,9 +23,9 @@ import {
 import * as Utils from "./utils";
 import * as DecoderTypes from "./types";
 import Web3 from "web3";
-import { ContractObject as Artifact } from "@truffle/contract-schema/spec";
+import {ContractObject as Artifact} from "@truffle/contract-schema/spec";
 import BN from "bn.js";
-import { Provider } from "web3/providers";
+import {Provider} from "web3/providers";
 import {
   ContractBeingDecodedHasNoNodeError,
   ContractAllocationFailedError,
@@ -34,7 +34,7 @@ import {
   VariableNotFoundError
 } from "./errors";
 //sorry for the untyped imports, but...
-const { Shims } = require("@truffle/compile-common");
+const {Shims} = require("@truffle/compile-common");
 const SolidityUtils = require("@truffle/solidity-utils");
 
 /**
@@ -51,7 +51,7 @@ export class WireDecoder {
   private deployedContexts: Contexts.Contexts = {};
   private contractsAndContexts: DecoderTypes.ContractAndContexts[] = [];
 
-  private referenceDeclarations: { [compilationId: string]: Ast.AstNodes };
+  private referenceDeclarations: {[compilationId: string]: Ast.AstNodes};
   private userDefinedTypes: Format.Types.TypesById;
   private allocations: Evm.AllocationInfo;
 
@@ -105,7 +105,7 @@ export class WireDecoder {
     this.deployedContexts = Object.assign(
       {},
       ...Object.values(this.contexts).map(context =>
-        !context.isConstructor ? { [context.context]: context } : {}
+        !context.isConstructor ? {[context.context]: context} : {}
       )
     );
 
@@ -130,7 +130,7 @@ export class WireDecoder {
 
     const allocationInfo: AbiData.Allocate.ContractAllocationInfo[] = this.contractsAndContexts.map(
       ({
-        contract: { abi, compiler, immutableReferences },
+        contract: {abi, compiler, immutableReferences},
         compilationId,
         node,
         deployedContext,
@@ -175,10 +175,10 @@ export class WireDecoder {
   }
 
   private collectUserDefinedTypes(): {
-    definitions: { [compilationId: string]: Ast.AstNodes };
+    definitions: {[compilationId: string]: Ast.AstNodes};
     types: Format.Types.TypesById;
   } {
-    let references: { [compilationId: string]: Ast.AstNodes } = {};
+    let references: {[compilationId: string]: Ast.AstNodes} = {};
     let types: Format.Types.TypesById = {};
     for (const compilation of this.compilations) {
       references[compilation.id] = {};
@@ -186,8 +186,8 @@ export class WireDecoder {
         if (!source) {
           continue; //remember, sources could be empty if shimmed!
         }
-        const { ast, compiler, language } = source;
-        if (language === "Solidity" && ast) {
+        const {ast, compiler, language} = source;
+        if (language === "solidity" && ast) {
           //don't check Yul sources!
           for (const node of ast.nodes) {
             if (
@@ -228,7 +228,7 @@ export class WireDecoder {
         }
       }
     }
-    return { definitions: references, types };
+    return {definitions: references, types};
   }
 
   /**
@@ -315,7 +315,7 @@ export class WireDecoder {
       },
       userDefinedTypes: this.userDefinedTypes,
       allocations: this.allocations,
-      contexts: { ...this.deployedContexts, ...additionalContexts },
+      contexts: {...this.deployedContexts, ...additionalContexts},
       currentContext: context
     };
     const decoder = decodeCalldata(info, isConstructor);
@@ -388,7 +388,7 @@ export class WireDecoder {
       },
       userDefinedTypes: this.userDefinedTypes,
       allocations: this.allocations,
-      contexts: { ...this.deployedContexts, ...additionalContexts }
+      contexts: {...this.deployedContexts, ...additionalContexts}
     };
     const decoder = decodeEvent(info, log.address, options.name);
 
@@ -436,7 +436,7 @@ export class WireDecoder {
     options: DecoderTypes.EventOptions = {},
     additionalContexts: Contexts.Contexts = {}
   ): Promise<DecoderTypes.DecodedLog[]> {
-    let { address, name, fromBlock, toBlock } = options;
+    let {address, name, fromBlock, toBlock} = options;
     if (fromBlock === undefined) {
       fromBlock = "latest";
     }
@@ -515,7 +515,7 @@ export class WireDecoder {
       code = constructorBinary;
     }
     //if neither of these hold... we have a problem
-    let contexts = { ...this.contexts, ...additionalContexts };
+    let contexts = {...this.contexts, ...additionalContexts};
     return Contexts.Utils.findContext(contexts, code);
   }
 
@@ -540,7 +540,7 @@ export class WireDecoder {
     );
     const bytecode = Shims.NewToLegacy.forBytecode(artifact.bytecode);
 
-    const { compilation, contract } = this.compilations.reduce(
+    const {compilation, contract} = this.compilations.reduce(
       (foundSoFar: DecoderTypes.CompilationAndContract, compilation) => {
         if (foundSoFar) {
           return foundSoFar;
@@ -570,7 +570,7 @@ export class WireDecoder {
           }
         });
         if (contractFound) {
-          return { compilation, contract: contractFound };
+          return {compilation, contract: contractFound};
         } else {
           return undefined;
         }
@@ -646,7 +646,7 @@ export class WireDecoder {
       await this.getCode(address, blockNumber)
     );
     const contractAndContexts = this.contractsAndContexts.find(
-      ({ deployedContext }) =>
+      ({deployedContext}) =>
         deployedContext &&
         Contexts.Utils.matchContext(deployedContext, deployedBytecode)
     );
@@ -658,7 +658,7 @@ export class WireDecoder {
         address
       );
     }
-    const { contract, compilationId } = contractAndContexts;
+    const {contract, compilationId} = contractAndContexts;
     const compilation = this.compilations.find(
       compilation => compilation.id === compilationId
     );
@@ -674,7 +674,7 @@ export class WireDecoder {
   /**
    * @protected
    */
-  public getReferenceDeclarations(): { [compilationId: string]: Ast.AstNodes } {
+  public getReferenceDeclarations(): {[compilationId: string]: Ast.AstNodes} {
     return this.referenceDeclarations;
   }
 
@@ -919,7 +919,7 @@ export class ContractDecoder {
       },
       userDefinedTypes: this.userDefinedTypes,
       allocations: this.allocations,
-      contexts: { ...this.contexts, ...additionalContexts }
+      contexts: {...this.contexts, ...additionalContexts}
     };
 
     const decoder = decodeReturndata(info, allocation, status);
@@ -1086,7 +1086,7 @@ export class ContractInstanceDecoder {
   private contexts: Contexts.Contexts = {}; //deployed contexts only
   private additionalContexts: Contexts.Contexts = {}; //for passing to wire decoder when contract has no deployedBytecode
 
-  private referenceDeclarations: { [compilationId: string]: Ast.AstNodes };
+  private referenceDeclarations: {[compilationId: string]: Ast.AstNodes};
   private userDefinedTypes: Format.Types.TypesById;
   private allocations: Codec.Evm.AllocationInfo;
 
@@ -1174,14 +1174,16 @@ export class ContractInstanceDecoder {
         this.compilation
       );
       this.contextHash = extraContext.context;
-      this.additionalContexts = { [extraContext.context]: extraContext };
+      this.additionalContexts = {[extraContext.context]: extraContext};
       //the following line only has any effect if we're dealing with a library,
       //since the code we pulled from the blockchain obviously does not have unresolved link references!
       //(it's not strictly necessary even then, but, hey, why not?)
-      this.additionalContexts = Contexts.Utils.normalizeContexts(this.additionalContexts);
+      this.additionalContexts = Contexts.Utils.normalizeContexts(
+        this.additionalContexts
+      );
       //again, since the code did not have unresolved link references, it is safe to just
       //mash these together like I'm about to
-      this.contexts = { ...this.contexts, ...this.additionalContexts };
+      this.contexts = {...this.contexts, ...this.additionalContexts};
     }
 
     //finally: set up internal functions table (only if source order is reliable;
@@ -1411,7 +1413,7 @@ export class ContractInstanceDecoder {
     //case 1: an ID was input
     if (typeof nameOrId === "number" || nameOrId.match(/[0-9]+/)) {
       return this.stateVariableReferences.find(
-        ({ definition }) => definition.id === nameOrId
+        ({definition}) => definition.id === nameOrId
       );
       //there should be exactly one; returns undefined if none
     }
@@ -1422,7 +1424,7 @@ export class ContractInstanceDecoder {
       return this.stateVariableReferences
         .slice()
         .reverse()
-        .find(({ definition }) => definition.name === nameOrId);
+        .find(({definition}) => definition.name === nameOrId);
     }
     //case 3: a qualified name was input
     else {
@@ -1432,7 +1434,7 @@ export class ContractInstanceDecoder {
         .slice()
         .reverse()
         .find(
-          ({ definition, definedIn }) =>
+          ({definition, definedIn}) =>
             definition.name === variableName && definedIn.name === className
         );
     }
@@ -1688,7 +1690,7 @@ export class ContractInstanceDecoder {
     options: DecoderTypes.EventOptions = {}
   ): Promise<DecoderTypes.DecodedLog[]> {
     return await this.wireDecoder.eventsWithAdditionalContexts(
-      { address: this.contractAddress, ...options },
+      {address: this.contractAddress, ...options},
       this.additionalContexts
     );
   }
@@ -1784,7 +1786,7 @@ export class ContractInstanceDecoder {
         //we don't need to use fullType or what have you
         let allocation: Storage.Allocate.StorageMemberAllocation = this.allocations.storage[
           parentType.id
-        ].members.find(({ name }) => name === rawIndex); //there should be exactly one
+        ].members.find(({name}) => name === rawIndex); //there should be exactly one
         slot = {
           path: parentSlot,
           //need type coercion here -- we know structs don't contain constants but the compiler doesn't


### PR DESCRIPTION
Now that #3550 is merged, this is possible!  **Edit: This PR is now a breaking change to `@truffle/codec`.**

This PR does two things.  The first is that it makes it so that `shimCompilations` (and the new `shimCompilation`) make use of the `sources` information on a compilation, if it is present.  Note that on `shimContracts`, I've added this as an optional argument on the *end* in order to prevent a breaking change.  If `inputSources` is passed to that, it will use that for the sources information, instead of trying to dig it out of `contracts` and `files`.

The second thing is that in `debug-utils`, it adds one more check for whether the debugger CLI should recompile: If there's a gap between the index of the last user source and the first generated source, that will now trigger a recompile.  (If there are any generated sources, that is, obviously.  Otherwise this has no effect.)

Oh also I changed language tags in codec and debugger to lowercase so that they're compatible with the ones from compile, initially this PR accidentally broke syntax highlighting. :P