### PR TITLE
Internal improvement: Turn on spaces in object literals in prettier

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,5 @@
 {
   "arrowParens": "avoid",
-  "trailingComma": "none"
+  "trailingComma": "none",
+  "bracketSpacing": true
 }


### PR DESCRIPTION
Since people seem to want this, thought I'd turn this on!