### PR TITLE
Bug fix: Better handling of Vyper source maps (including putting them in the right place in the artifact!)

### DIFF
--- a/packages/compile-vyper/index.js
+++ b/packages/compile-vyper/index.js
@@ -38,7 +38,7 @@ function execVyper(options, sourcePath, callback) {
   }
   const command = `vyper -f ${formats.join(",")} ${sourcePath}`;
 
-  exec(command, {maxBuffer: 600 * 1024}, function (err, stdout, stderr) {
+  exec(command, { maxBuffer: 600 * 1024 }, function (err, stdout, stderr) {
     if (err)
       return callback(
         `${stderr}\n${colors.red(
@@ -49,7 +49,7 @@ function execVyper(options, sourcePath, callback) {
     var outputs = stdout.split(/\r?\n/);
 
     const compiledContract = outputs.reduce((contract, output, index) => {
-      return Object.assign(contract, {[formats[index]]: output});
+      return Object.assign(contract, { [formats[index]]: output });
     }, {});
 
     callback(null, compiledContract);
@@ -84,7 +84,7 @@ function processAllSources(sources) {
 }
 
 // compile all sources
-async function compileAll({sources, options}) {
+async function compileAll({ sources, options }) {
   options.logger = options.logger || console;
 
   Compile.display(sources, options);
@@ -115,7 +115,7 @@ async function compileAll({sources, options}) {
             abi: compiledContract.abi,
             bytecode: compiledContract.bytecode,
             deployedBytecode: compiledContract.bytecode_runtime,
-            sourceMap: compiledContract.source_map,
+            deployedSourceMap: compiledContract.source_map, //there is no constructor source map
             compiler
           };
 
@@ -126,7 +126,7 @@ async function compileAll({sources, options}) {
   });
   const contracts = await Promise.all(promises);
 
-  const compilerInfo = {name: "vyper", version: compiler.version};
+  const compilerInfo = { name: "vyper", version: compiler.version };
   return {
     compilations: [
       {
@@ -141,13 +141,13 @@ async function compileAll({sources, options}) {
 
 const Compile = {
   // Check that vyper is available then forward to internal compile function
-  async sources({sources = [], options}) {
+  async sources({ sources = [], options }) {
     // filter out non-vyper paths
     const vyperFiles = sources.filter(path => minimatch(path, VYPER_PATTERN));
 
     // no vyper files found, no need to check vyper
     if (vyperFiles.length === 0) {
-      return {compilations: []};
+      return { compilations: [] };
     }
 
     await checkVyper();
@@ -157,7 +157,7 @@ const Compile = {
     });
   },
 
-  async sourcesWithDependencies({paths = [], options}) {
+  async sourcesWithDependencies({ paths = [], options }) {
     return await Compile.sources({
       sources: paths,
       options
@@ -190,7 +190,7 @@ const Compile = {
     const updated = await Profiler.updated(options);
 
     if (updated.length === 0 && options.quiet !== true) {
-      return {compilations: []};
+      return { compilations: [] };
     }
 
     // filter out only Vyper files
@@ -218,7 +218,7 @@ const Compile = {
 
       return contract;
     });
-    options.events.emit("compile:sourcesToCompile", {sourceFileNames});
+    options.events.emit("compile:sourcesToCompile", { sourceFileNames });
   }
 };
 

--- a/packages/compile-vyper/test/test_compiler.js
+++ b/packages/compile-vyper/test/test_compiler.js
@@ -1,7 +1,7 @@
 const path = require("path");
 const assert = require("assert");
 const Config = require("@truffle/config");
-const {Compile} = require("../index");
+const { Compile } = require("../index");
 const fs = require("fs");
 
 describe("vyper compiler", function () {
@@ -15,8 +15,8 @@ describe("vyper compiler", function () {
   const config = new Config().merge(defaultSettings);
 
   it("compiles vyper contracts", async function () {
-    const {compilations} = await Compile.all(config);
-    const {contracts, sourceIndexes} = compilations[0];
+    const { compilations } = await Compile.all(config);
+    const { contracts, sourceIndexes } = compilations[0];
     sourceIndexes.forEach(path => {
       assert(
         [".vy", ".v.py", ".vyper.py"].some(
@@ -64,8 +64,8 @@ describe("vyper compiler", function () {
   });
 
   it("skips solidity contracts", async function () {
-    const {compilations} = await Compile.all(config);
-    const {contracts, sourceIndexes} = compilations[0];
+    const { compilations } = await Compile.all(config);
+    const { contracts, sourceIndexes } = compilations[0];
 
     sourceIndexes.forEach(path => {
       assert.equal(path.indexOf(".sol"), -1, "Paths have no .sol files");
@@ -88,11 +88,11 @@ describe("vyper compiler", function () {
     });
 
     it("compiles when sourceMap option set true", async () => {
-      const {compilations} = await Compile.all(configWithSourceMap);
-      const {contracts} = compilations[0];
+      const { compilations } = await Compile.all(configWithSourceMap);
+      const { contracts } = compilations[0];
       contracts.forEach((contract, index) => {
         assert(
-          contract.sourceMap,
+          contract.deployedSourceMap,
           `source map have to not be empty. ${index + 1}`
         );
       });
@@ -101,8 +101,8 @@ describe("vyper compiler", function () {
 
   describe("compilation sources array", async () => {
     it("returns an array of sources reflecting sources in project", async () => {
-      const {compilations} = await Compile.all(config);
-      const {sources} = compilations[0];
+      const { compilations } = await Compile.all(config);
+      const { sources } = compilations[0];
 
       assert(sources.length === 3);
       assert(

--- a/packages/debugger/lib/session/index.js
+++ b/packages/debugger/lib/session/index.js
@@ -211,6 +211,18 @@ export default class Session {
         debug("compiler %o", compiler);
         debug("abi %o", abi);
 
+        //convert Vyper source maps to solidity ones
+        //(note we won't bother handling the case where the compressed
+        //version doesn't exist)
+        try {
+          let vyperSourceMap = JSON.parse(sourceMap);
+          sourceMap = vyperSourceMap.pc_pos_map_compressed;
+        } catch (_) {}
+        try {
+          let vyperDeployedSourceMap = JSON.parse(deployedSourceMap);
+          deployedSourceMap = vyperDeployedSourceMap.pc_pos_map_compressed;
+        } catch (_) {}
+
         if (binary && binary != "0x") {
           //NOTE: we take hash as *string*, not as bytes, because the binary may
           //contain link references!

--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -23,9 +23,9 @@ import {
 import * as Utils from "./utils";
 import * as DecoderTypes from "./types";
 import Web3 from "web3";
-import {ContractObject as Artifact} from "@truffle/contract-schema/spec";
+import { ContractObject as Artifact } from "@truffle/contract-schema/spec";
 import BN from "bn.js";
-import {Provider} from "web3/providers";
+import { Provider } from "web3/providers";
 import {
   ContractBeingDecodedHasNoNodeError,
   ContractAllocationFailedError,
@@ -34,7 +34,7 @@ import {
   VariableNotFoundError
 } from "./errors";
 //sorry for the untyped imports, but...
-const {Shims} = require("@truffle/compile-common");
+const { Shims } = require("@truffle/compile-common");
 const SolidityUtils = require("@truffle/solidity-utils");
 
 /**
@@ -51,7 +51,7 @@ export class WireDecoder {
   private deployedContexts: Contexts.Contexts = {};
   private contractsAndContexts: DecoderTypes.ContractAndContexts[] = [];
 
-  private referenceDeclarations: {[compilationId: string]: Ast.AstNodes};
+  private referenceDeclarations: { [compilationId: string]: Ast.AstNodes };
   private userDefinedTypes: Format.Types.TypesById;
   private allocations: Evm.AllocationInfo;
 
@@ -105,7 +105,7 @@ export class WireDecoder {
     this.deployedContexts = Object.assign(
       {},
       ...Object.values(this.contexts).map(context =>
-        !context.isConstructor ? {[context.context]: context} : {}
+        !context.isConstructor ? { [context.context]: context } : {}
       )
     );
 
@@ -130,7 +130,7 @@ export class WireDecoder {
 
     const allocationInfo: AbiData.Allocate.ContractAllocationInfo[] = this.contractsAndContexts.map(
       ({
-        contract: {abi, compiler, immutableReferences},
+        contract: { abi, compiler, immutableReferences },
         compilationId,
         node,
         deployedContext,
@@ -175,10 +175,10 @@ export class WireDecoder {
   }
 
   private collectUserDefinedTypes(): {
-    definitions: {[compilationId: string]: Ast.AstNodes};
+    definitions: { [compilationId: string]: Ast.AstNodes };
     types: Format.Types.TypesById;
   } {
-    let references: {[compilationId: string]: Ast.AstNodes} = {};
+    let references: { [compilationId: string]: Ast.AstNodes } = {};
     let types: Format.Types.TypesById = {};
     for (const compilation of this.compilations) {
       references[compilation.id] = {};
@@ -186,7 +186,7 @@ export class WireDecoder {
         if (!source) {
           continue; //remember, sources could be empty if shimmed!
         }
-        const {ast, compiler, language} = source;
+        const { ast, compiler, language } = source;
         if (language === "solidity" && ast) {
           //don't check Yul sources!
           for (const node of ast.nodes) {
@@ -228,7 +228,7 @@ export class WireDecoder {
         }
       }
     }
-    return {definitions: references, types};
+    return { definitions: references, types };
   }
 
   /**
@@ -315,7 +315,7 @@ export class WireDecoder {
       },
       userDefinedTypes: this.userDefinedTypes,
       allocations: this.allocations,
-      contexts: {...this.deployedContexts, ...additionalContexts},
+      contexts: { ...this.deployedContexts, ...additionalContexts },
       currentContext: context
     };
     const decoder = decodeCalldata(info, isConstructor);
@@ -388,7 +388,7 @@ export class WireDecoder {
       },
       userDefinedTypes: this.userDefinedTypes,
       allocations: this.allocations,
-      contexts: {...this.deployedContexts, ...additionalContexts}
+      contexts: { ...this.deployedContexts, ...additionalContexts }
     };
     const decoder = decodeEvent(info, log.address, options.name);
 
@@ -436,7 +436,7 @@ export class WireDecoder {
     options: DecoderTypes.EventOptions = {},
     additionalContexts: Contexts.Contexts = {}
   ): Promise<DecoderTypes.DecodedLog[]> {
-    let {address, name, fromBlock, toBlock} = options;
+    let { address, name, fromBlock, toBlock } = options;
     if (fromBlock === undefined) {
       fromBlock = "latest";
     }
@@ -515,7 +515,7 @@ export class WireDecoder {
       code = constructorBinary;
     }
     //if neither of these hold... we have a problem
-    let contexts = {...this.contexts, ...additionalContexts};
+    let contexts = { ...this.contexts, ...additionalContexts };
     return Contexts.Utils.findContext(contexts, code);
   }
 
@@ -540,7 +540,7 @@ export class WireDecoder {
     );
     const bytecode = Shims.NewToLegacy.forBytecode(artifact.bytecode);
 
-    const {compilation, contract} = this.compilations.reduce(
+    const { compilation, contract } = this.compilations.reduce(
       (foundSoFar: DecoderTypes.CompilationAndContract, compilation) => {
         if (foundSoFar) {
           return foundSoFar;
@@ -570,7 +570,7 @@ export class WireDecoder {
           }
         });
         if (contractFound) {
-          return {compilation, contract: contractFound};
+          return { compilation, contract: contractFound };
         } else {
           return undefined;
         }
@@ -646,7 +646,7 @@ export class WireDecoder {
       await this.getCode(address, blockNumber)
     );
     const contractAndContexts = this.contractsAndContexts.find(
-      ({deployedContext}) =>
+      ({ deployedContext }) =>
         deployedContext &&
         Contexts.Utils.matchContext(deployedContext, deployedBytecode)
     );
@@ -658,7 +658,7 @@ export class WireDecoder {
         address
       );
     }
-    const {contract, compilationId} = contractAndContexts;
+    const { contract, compilationId } = contractAndContexts;
     const compilation = this.compilations.find(
       compilation => compilation.id === compilationId
     );
@@ -674,7 +674,7 @@ export class WireDecoder {
   /**
    * @protected
    */
-  public getReferenceDeclarations(): {[compilationId: string]: Ast.AstNodes} {
+  public getReferenceDeclarations(): { [compilationId: string]: Ast.AstNodes } {
     return this.referenceDeclarations;
   }
 
@@ -919,7 +919,7 @@ export class ContractDecoder {
       },
       userDefinedTypes: this.userDefinedTypes,
       allocations: this.allocations,
-      contexts: {...this.contexts, ...additionalContexts}
+      contexts: { ...this.contexts, ...additionalContexts }
     };
 
     const decoder = decodeReturndata(info, allocation, status);
@@ -1086,7 +1086,7 @@ export class ContractInstanceDecoder {
   private contexts: Contexts.Contexts = {}; //deployed contexts only
   private additionalContexts: Contexts.Contexts = {}; //for passing to wire decoder when contract has no deployedBytecode
 
-  private referenceDeclarations: {[compilationId: string]: Ast.AstNodes};
+  private referenceDeclarations: { [compilationId: string]: Ast.AstNodes };
   private userDefinedTypes: Format.Types.TypesById;
   private allocations: Codec.Evm.AllocationInfo;
 
@@ -1174,7 +1174,7 @@ export class ContractInstanceDecoder {
         this.compilation
       );
       this.contextHash = extraContext.context;
-      this.additionalContexts = {[extraContext.context]: extraContext};
+      this.additionalContexts = { [extraContext.context]: extraContext };
       //the following line only has any effect if we're dealing with a library,
       //since the code we pulled from the blockchain obviously does not have unresolved link references!
       //(it's not strictly necessary even then, but, hey, why not?)
@@ -1183,7 +1183,7 @@ export class ContractInstanceDecoder {
       );
       //again, since the code did not have unresolved link references, it is safe to just
       //mash these together like I'm about to
-      this.contexts = {...this.contexts, ...this.additionalContexts};
+      this.contexts = { ...this.contexts, ...this.additionalContexts };
     }
 
     //finally: set up internal functions table (only if source order is reliable;
@@ -1191,9 +1191,12 @@ export class ContractInstanceDecoder {
     //unlike the debugger, we don't *demand* an answer, so we won't set up
     //some sort of fake table if we don't have a source map, or if any ASTs are missing
     //(if a whole *source* is missing, we'll consider that OK)
+    //note: we don't attempt to handle Vyper source maps!
+    const compiler = this.compilation.compiler || this.contract.compiler;
     if (
       !this.compilation.unreliableSourceOrder &&
       this.contract.deployedSourceMap &&
+      compiler.name === "solc" &&
       this.compilation.sources.every(source => !source || source.ast)
     ) {
       //WARNING: untyped code in this block!
@@ -1413,7 +1416,7 @@ export class ContractInstanceDecoder {
     //case 1: an ID was input
     if (typeof nameOrId === "number" || nameOrId.match(/[0-9]+/)) {
       return this.stateVariableReferences.find(
-        ({definition}) => definition.id === nameOrId
+        ({ definition }) => definition.id === nameOrId
       );
       //there should be exactly one; returns undefined if none
     }
@@ -1424,7 +1427,7 @@ export class ContractInstanceDecoder {
       return this.stateVariableReferences
         .slice()
         .reverse()
-        .find(({definition}) => definition.name === nameOrId);
+        .find(({ definition }) => definition.name === nameOrId);
     }
     //case 3: a qualified name was input
     else {
@@ -1434,7 +1437,7 @@ export class ContractInstanceDecoder {
         .slice()
         .reverse()
         .find(
-          ({definition, definedIn}) =>
+          ({ definition, definedIn }) =>
             definition.name === variableName && definedIn.name === className
         );
     }
@@ -1690,7 +1693,7 @@ export class ContractInstanceDecoder {
     options: DecoderTypes.EventOptions = {}
   ): Promise<DecoderTypes.DecodedLog[]> {
     return await this.wireDecoder.eventsWithAdditionalContexts(
-      {address: this.contractAddress, ...options},
+      { address: this.contractAddress, ...options },
       this.additionalContexts
     );
   }
@@ -1786,7 +1789,7 @@ export class ContractInstanceDecoder {
         //we don't need to use fullType or what have you
         let allocation: Storage.Allocate.StorageMemberAllocation = this.allocations.storage[
           parentType.id
-        ].members.find(({name}) => name === rawIndex); //there should be exactly one
+        ].members.find(({ name }) => name === rawIndex); //there should be exactly one
         slot = {
           path: parentSlot,
           //need type coercion here -- we know structs don't contain constants but the compiler doesn't

--- a/packages/solidity-utils/index.js
+++ b/packages/solidity-utils/index.js
@@ -58,7 +58,12 @@ var SolidityUtils = {
       }
 
       if (splitInstruction[2]) {
-        processedInstruction.file = parseInt(splitInstruction[2]);
+        if (splitInstruction[0] === "-1" && splitInstruction[1] === "-1") {
+          //convert Vyper-style -1:-1:0 to Solidity-style -1:-1:-1
+          processedInstruction.file = -1;
+        } else {
+          processedInstruction.file = parseInt(splitInstruction[2]);
+        }
       }
 
       if (splitInstruction[3]) {


### PR DESCRIPTION
This might be a breaking change to `compile-vyper`?  Or to something? (Edit: We've agreed it's not since it never worked properly in the first place!)

So this has several parts to it:

1. Biggest change -- Vyper source maps will now go under `deployedSourceMap` in the artifact, not `sourceMap`, because they're source maps for the deployed bytecode!  (As best I can tell, Vyper doesn't support source maps for constructors, for whatever reason.)  Note that Vyper source maps are a different format from Solidity's, so I'm unsure this is *really* the right place, but, um, it's an improvement at least I guess...?

2. The decoder now checks that any source maps it's attempting to use are Solidity source maps, not Vyper source maps.

3. The debugger now attempts to convert Vyper source maps to Solidity ones.  Note that I'm doing this the lazy way -- just using the field which contains the Solidity-equivalent source map, which is missing on older versions; I'm not doing any actual conversion.

4. Finally, Vyper seems to indicate unmapped instructions with `-1:-1:0` instead of Solidity's `-1:-1:-1`, so I had `solidity-utils` do a conversion here, where if start and length are both `-1` then it'll put `-1` for the file, instead of whatever's present.

Also `prettier` made a bunch of changes which is annoying. :-/