### PR TITLE
Turn on source maps in Vyper w/o an option

### DIFF
--- a/packages/compile-vyper/index.js
+++ b/packages/compile-vyper/index.js
@@ -29,13 +29,7 @@ function checkVyper() {
 
 // Execute vyper for single source file
 function execVyper(options, sourcePath, callback) {
-  const formats = ["abi", "bytecode", "bytecode_runtime"];
-  if (
-    options.compilers.vyper.settings &&
-    options.compilers.vyper.settings.sourceMap
-  ) {
-    formats.push("source_map");
-  }
+  const formats = ["abi", "bytecode", "bytecode_runtime", "source_map"];
   let evmVersionOption = "";
   if (
     options.compilers.vyper.settings &&

--- a/packages/compile-vyper/test/test_compiler.js
+++ b/packages/compile-vyper/test/test_compiler.js
@@ -85,7 +85,7 @@ describe("vyper compiler", function () {
     contracts.forEach((contract, index) => {
       assert(
         contract.deployedSourceMap,
-        `source map have to not be empty. ${index + 1}`
+        `source map has to not be empty. ${index + 1}`
       );
     });
   });

--- a/packages/compile-vyper/test/test_compiler.js
+++ b/packages/compile-vyper/test/test_compiler.js
@@ -79,17 +79,19 @@ describe("vyper compiler", function () {
     assert(noSolidityContract, "Compiled contracts have no SolidityContract");
   });
 
-  describe("with external options set", function () {
-    const configWithSourceMap = new Config().merge(defaultSettings).merge({
-      compilers: {
-        vyper: {
-          settings: {
-            sourceMap: true
-          }
-        }
-      }
+  it("outputs source maps", async () => {
+    const { compilations } = await Compile.all(config);
+    const { contracts } = compilations[0];
+    contracts.forEach((contract, index) => {
+      assert(
+        contract.deployedSourceMap,
+        `source map have to not be empty. ${index + 1}`
+      );
     });
+  });
 
+
+  describe("with external options set", function () {
     const configWithPetersburg = new Config().merge(defaultSettings).merge({
       compilers: {
         vyper: {
@@ -108,17 +110,6 @@ describe("vyper compiler", function () {
           }
         }
       }
-    });
-
-    it("compiles when sourceMap option set true", async () => {
-      const { compilations } = await Compile.all(configWithSourceMap);
-      const { contracts } = compilations[0];
-      contracts.forEach((contract, index) => {
-        assert(
-          contract.deployedSourceMap,
-          `source map have to not be empty. ${index + 1}`
-        );
-      });
     });
 
     it("compiles with specified EVM version (petersburg)", async () => {


### PR DESCRIPTION
As requested by @gnidan.  Gets rid of the sourceMap option for compiling Vyper contracts, in favor of just always getting the source map.  Tests have also been adjusted appropriately.