### PR TITLE
Add support for viaIR and modelCheckerSettings

### DIFF
--- a/packages/compile-solidity/run.js
+++ b/packages/compile-solidity/run.js
@@ -23,7 +23,8 @@ async function run(rawSources, options) {
   const compilerInput = prepareCompilerInput({
     sources,
     targets,
-    settings: options.compilers.solc.settings
+    settings: options.compilers.solc.settings,
+    modelCheckerSettings: options.compilers.solc.modelCheckerSettings
   });
 
   // perform compilation
@@ -183,7 +184,7 @@ function getPortableSourcePath(sourcePath) {
  * @param setings - subset of Solidity settings
  * @return solc compiler input JSON
  */
-function prepareCompilerInput({sources, targets, settings}) {
+function prepareCompilerInput({sources, targets, settings, modelCheckerSettings}) {
   return {
     language: "Solidity",
     sources: prepareSources({sources}),
@@ -194,10 +195,12 @@ function prepareCompilerInput({sources, targets, settings}) {
       debug: settings.debug,
       metadata: settings.metadata,
       libraries: settings.libraries,
+      viaIR: settings.viaIR,
       // Specify compilation targets. Each target uses defaultSelectors,
       // defaulting to single target `*` if targets are unspecified
       outputSelection: prepareOutputSelection({targets})
-    }
+    },
+    modelCheckerSettings
   };
 }
 


### PR DESCRIPTION
Solidity version 0.7.5 adds the `viaIR` compilation setting, so I've added support for that.

Solidity version 0.7.4 adds `modelCheckerSettings`, so I've added support for that.  Note that I've made this separate from `settings` because that's how Solidity does it, but if we think it should be part of `settings` we could do it that way as well.

Also Solidity version 0.7.3 added the `stopAfter` option, but I decided not to add support for that now because uhhh that seems a bit dicey, we'll have to figure out later what to do about that.

Edit: After trying out `stopAfter` myself, it seems that supporting it would require us to modify `outputSelection`, so yeah, we'll figure that out later, I guess?