### PR TITLE
Bug fix: Put IDs in shimmed sources when inputSources is passed

### DIFF
--- a/packages/codec/lib/compilations/utils.ts
+++ b/packages/codec/lib/compilations/utils.ts
@@ -133,10 +133,10 @@ export function shimContracts(
         : files.indexOf(sourcePath);
       if (!inputSources) {
         //if inputSources was passed, we'll handle this separately below
+        sourceObject.id = index.toString(); //HACK
         sources[index] = sourceObject;
       }
-      sourceObject.id = index.toString(); //HACK
-      contractObject.primarySourceId = index.toString();
+      contractObject.primarySourceId = index.toString(); //HACK
     } else {
       //if neither was passed, attempt to determine it from the ast
       let index = sourceIndexForAst(sourceObject.ast); //sourceObject.ast for typing reasons
@@ -148,10 +148,8 @@ export function shimContracts(
       ));
       if (index !== null) {
         //if we're in this case, inputSources was not passed
-        sources[index] = {
-          ...sourceObject,
-          id: index.toString()
-        };
+        sourceObject.id = index.toString(); //HACK
+        sources[index] = sourceObject;
         contractObject.primarySourceId = index.toString();
       }
     }
@@ -162,11 +160,12 @@ export function shimContracts(
   if (inputSources) {
     //if input sources was passed, set up the sources object directly :)
     sources = inputSources.map(
-      ({sourcePath, contents: source, ast, language}) => ({
+      ({sourcePath, contents: source, ast, language}, index) => ({
         sourcePath,
         source,
         ast: <Ast.AstNode>ast,
-        language
+        language,
+        id: index.toString() //HACK
         //we'll omit compiler, as if inputSources was passed, presumably
         //we're using shimCompilation(), which sets that up separately
       })

--- a/packages/debugger/lib/session/index.js
+++ b/packages/debugger/lib/session/index.js
@@ -171,6 +171,7 @@ export default class Session {
           generatedSources,
           deployedGeneratedSources
         } = contract;
+        debug("contractName: %s", contractName);
 
         //hopefully we can get rid of this step eventually, but not yet
         if (typeof binary === "object") {


### PR DESCRIPTION
Fixes a bug I accidentally introduced in #3565: If `inputSources` was passed, the shimmed output sources didn't get IDs.  Now they do, with ID equal to `index.toString()` (which is kind of hacky but what we do elsewhere and works well enough).