### PR TITLE
Bug fix: Fix handling of -1s in source maps

### DIFF
--- a/packages/solidity-utils/index.js
+++ b/packages/solidity-utils/index.js
@@ -49,21 +49,16 @@ var SolidityUtils = {
       //at least that many fields, and that that particular field
       //is nonempty
 
-      if (splitInstruction[0] && splitInstruction[0] !== "-1") {
+      if (splitInstruction[0]) {
         processedInstruction.start = parseInt(splitInstruction[0]);
       }
 
-      if (splitInstruction[1] && splitInstruction[1] !== "-1") {
+      if (splitInstruction[1]) {
         processedInstruction.length = parseInt(splitInstruction[1]);
       }
 
       if (splitInstruction[2]) {
-        if (splitInstruction[0] === "-1" && splitInstruction[1] === "-1") {
-          //convert Vyper-style -1:-1:0 to Solidity-style -1:-1:-1
-          processedInstruction.file = -1;
-        } else {
-          processedInstruction.file = parseInt(splitInstruction[2]);
-        }
+        processedInstruction.file = parseInt(splitInstruction[2]);
       }
 
       if (splitInstruction[3]) {
@@ -166,6 +161,10 @@ var SolidityUtils = {
           file: instruction.file = primaryFile,
           modifierDepth: instruction.modifierDepth = 0
         } = instructionSourceMap);
+        if (instruction.start === -1 && instruction.length === -1) {
+          instruction.start = 0;
+          instruction.length = 0;
+        }
         const lineAndColumnMapping =
           lineAndColumnMappings[instruction.file] || {};
         instruction.range = {

--- a/packages/solidity-utils/index.js
+++ b/packages/solidity-utils/index.js
@@ -99,10 +99,6 @@ var SolidityUtils = {
     let numInstructions;
     if (sourceMap) {
       numInstructions = sourceMap.length;
-    } else {
-      //HACK
-      numInstructions = (binary.length - 2) / 2;
-      //this is actually an overestimate, but that's OK
     }
 
     //because we might be dealing with a constructor with arguments, we do


### PR DESCRIPTION
Fixing up a mistake I made in #3571.

See, translating `-1:-1:0` to `-1:-1:-1` doesn't actually work because, uh, then other things after it will also be recorded as being in file `-1`.  Oops.  So, I undid that.  And then I went further and got rid of the pre-existing special cases around -1 there, because why were those even there?

Instead, I made it so that later during processing, having start and length both equal to -1 gets translated to them both being 0 instead, because negative start and length seems potentially problematic.  But again, I didn't do this during the initial processing.  Hm, I guess I could have, but honestly I like this better I think.

Anyway, this should all basically work properly now.

Also while I was it, I took out that unnecessary `numInstructions` estimation in favor of just letting `parseCode` do its thing.