### PR TITLE
Add specializations to source-fetcher

### DIFF
--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -1,7 +1,9 @@
 import debugModule from "debug";
 const debug = debugModule("source-fetcher:etherscan");
+// untyped import since no @types/web3-utils exists
+const Web3Utils = require("web3-utils");
 
-import {Fetcher, FetcherConstructor} from "./types";
+import { Fetcher, FetcherConstructor } from "./types";
 import * as Types from "./types";
 import {
   networksById,
@@ -234,7 +236,7 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
   ): Types.SourcesByPath {
     return Object.assign(
       {},
-      ...Object.entries(sources).map(([path, {content: source}]) => ({
+      ...Object.entries(sources).map(([path, { content: source }]) => ({
         [makeFilename(path)]: source
       }))
     );
@@ -258,21 +260,21 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
         optimizer
       };
     }
-
   }
 
-  private static processLibraries(librariesString: string): Types.LibrarySettings {
+  private static processLibraries(
+    librariesString: string
+  ): Types.LibrarySettings {
     let libraries: Types.Libraries;
     if (librariesString === "") {
       libraries = {};
     } else {
-      libraries = Object.assign({},
-        ...librariesString.split(";").map(
-          pair => {
-            const [name, address] = pair.split(":");
-            return { [name]: "0x" + address };
-          }
-        )
+      libraries = Object.assign(
+        {},
+        ...librariesString.split(";").map(pair => {
+          const [name, address] = pair.split(":");
+          return { [name]: Web3Utils.toChecksumAddress(address) };
+        })
       );
     }
     return { "": libraries }; //empty string as key means it applies to all contracts
@@ -284,7 +286,7 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
     const evmVersion: string =
       result.EVMVersion === "Default" ? undefined : result.EVMVersion;
     if (evmVersion !== undefined) {
-      return {evmVersion};
+      return { evmVersion };
     } else {
       return {};
     }

--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -80,7 +80,10 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
       options: {
         language: metadata.language,
         version: metadata.compiler.version,
-        settings: removeLibraries(metadata.settings)
+        settings: removeLibraries(metadata.settings),
+        specializations: {
+          libraries: metadata.settings.libraries
+        }
       }
     };
   }

--- a/packages/source-fetcher/lib/types.ts
+++ b/packages/source-fetcher/lib/types.ts
@@ -35,12 +35,14 @@ export interface SolcOptions {
   language: "Solidity" | "Yul"; //again, only Solidity really supported atm
   version: string;
   settings: SolcSettings;
+  specializations: SolcSpecializations;
 }
 
 export interface VyperOptions {
   language: "Vyper";
   version: string;
   settings: VyperSettings;
+  specializations: VyperSpecializations;
 }
 
 //only including settings that would alter compiled result
@@ -50,11 +52,20 @@ export interface SolcSettings {
   evmVersion?: string; //not gonna enumerate these
   debug?: DebugSettings;
   metadata?: MetadataSettings;
-  libraries?: LibrarySettings; //note: we don't actually want to pass this!
+  libraries?: LibrarySettings; //note: we don't actually want to return this!
 }
 
 export interface VyperSettings {
   evmVersion?: string; //not gonna enumerate these
+}
+
+export interface SolcSpecializations {
+  libraries?: LibrarySettings;
+  constructorArguments?: string; //encoded, as hex string, w/o 0x in front
+}
+
+export interface VyperSpecializations {
+  constructorArguments?: string; //encoded, as hex string, w/o 0x in front
 }
 
 export interface SolcSources {

--- a/packages/source-fetcher/package.json
+++ b/packages/source-fetcher/package.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "debug": "^4.1.1",
     "request-promise-native": "^1.0.8",
-    "source-map-support": "^0.5.19"
+    "source-map-support": "^0.5.19",
+    "web3-utils": "^1.3.0"
   },
   "devDependencies": {
     "@types/debug": "^4.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23171,7 +23171,7 @@ web3-utils@1.2.9:
     underscore "1.9.1"
     utf8 "3.0.0"
 
-web3-utils@1.3.0:
+web3-utils@1.3.0, web3-utils@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.3.0.tgz#5bac16e5e0ec9fe7bdcfadb621655e8aa3cf14e1"
   integrity sha512-2mS5axFCbkhicmoDRuJeuo0TVGQDgC2sPi/5dblfVC+PMtX0efrb8Xlttv/eGkq7X4E83Pds34FH98TP2WOUZA==


### PR DESCRIPTION
Adds a `specializations` field to the output of source-fetcher.  This contains the libraries information and (when retrieving from Etherscan only) the constructor arguments information.  When retrieving from Sourcify, constructor arguments will not be present.  Also obviously libraries info is omitted for Vyper.

Constructor arguments is given as a hex string, of course, but note that I did *not* put a `"0x"` in front, for consistency with how we do it in the debugger (and also easy concatenation).

Libraries are given in a form understandable to solc.  When dealing with JSON (from Etherscan or Sourcify), well, it's right in the JSON.  When dealing with non-JSON Etherscan, we have to parse the `Library` field.  Fortunately that's just a semicolon-delimited list, with the individual entries being `name:address` pairs (although oddly the addresses lack a `"0x"` in front and are not checksummed... we handle that though).  Then, having constructed a `libraries` object containing this information, we make our libraries settings `{"": libraries}`, because using the empty string as a key tells Solc to use these libraries settings for *all* contracts.

Note I didn't really test this PR.