### PR TITLE
Bug fix: Correct `is_tx_params` method

### DIFF
--- a/packages/contract-tests/test/errors.js
+++ b/packages/contract-tests/test/errors.js
@@ -236,9 +236,7 @@ describe("Client appends errors (vmErrorsOnRPCResponse)", function () {
       const example = await Example.new(1);
       try {
         const accounts = await Example.web3.eth.getAccounts();
-        // specifying a gasLimit as ganache-core @2.7.0 no longer limits gas
-        // estimations to the default block gas limit.
-        await example.runsOutOfGas({ from: accounts[0], gasLimit: "0x6691b7" });
+        await example.runsOutOfGas({ from: accounts[0], gas: "0x6691b7" });
         assert.fail();
       } catch (e) {
         assert(e.message.includes("out of gas"));

--- a/packages/contract-tests/test/lib/utils/ens.js
+++ b/packages/contract-tests/test/lib/utils/ens.js
@@ -1,0 +1,62 @@
+const ens = require("@truffle/contract/lib/utils/ens");
+const assert = require("assert");
+const sinon = require("sinon");
+const Web3 = require("web3");
+const methodABI = {
+  constant: true,
+  inputs: [
+    {
+      name: "firstInput",
+      type: "address"
+    },
+    {
+      name: "secondInput",
+      type: "uint256"
+    }
+  ],
+  name: "myMethod",
+  outputs: [
+    {
+      name: "",
+      type: "bool"
+    }
+  ],
+  payable: false,
+  stateMutability: "pure",
+  type: "function"
+};
+const args = ["my.ens.name", 555, { from: "the.other.name" }];
+
+describe("convertENSNames", () => {
+  beforeEach(() => {
+    const expectedInput1 = "my.ens.name";
+    const expectedInput2 = "the.other.name";
+    sinon.stub(ens, "getNewENSJS").returns({
+      resolver: input => {
+        if (input === expectedInput1) {
+          return { addr: () => Promise.resolve("0x123") };
+        }
+        if (input === expectedInput2) {
+          return { addr: () => Promise.resolve("0x987") };
+        }
+        return Promise.reject("The input was not what was expected");
+      }
+    });
+  });
+  afterEach(() => {
+    ens.getNewENSJS.restore();
+  });
+
+  it("converts ens names in address fields to addresses", async () => {
+    let result = await ens.convertENSNames(args, methodABI, Web3);
+    assert(result[0] === "0x123");
+  });
+  it("does not change non-address arguments", async () => {
+    let result = await ens.convertENSNames(args, methodABI, Web3);
+    assert(result[1] === 555);
+  });
+  it("converts ens names in the from field of the tx object", async () => {
+    let result = await ens.convertENSNames(args, methodABI, Web3);
+    assert(result[2].from === "0x987");
+  });
+});

--- a/packages/contract-tests/test/lib/utils/index.js
+++ b/packages/contract-tests/test/lib/utils/index.js
@@ -1,62 +1,30 @@
-const ens = require("@truffle/contract/lib/utils/ens");
+const Utils = require("@truffle/contract/lib/utils");
 const assert = require("assert");
-const sinon = require("sinon");
-const Web3 = require("web3");
-const methodABI = {
-  constant: true,
-  inputs: [
-    {
-      name: "firstInput",
-      type: "address"
-    },
-    {
-      name: "secondInput",
-      type: "uint256"
-    }
-  ],
-  name: "myMethod",
-  outputs: [
-    {
-      name: "",
-      type: "bool"
-    }
-  ],
-  payable: false,
-  stateMutability: "pure",
-  type: "function"
-};
-const args = ["my.ens.name", 555, { from: "the.other.name" }];
+const whitelist = [
+  "from",
+  "to",
+  "gas",
+  "gasPrice",
+  "value",
+  "data",
+  "nonce",
+  "privateFor",
+  "overwrite"
+];
 
-describe("convertENSNames", () => {
-  beforeEach(() => {
-    const expectedInput1 = "my.ens.name";
-    const expectedInput2 = "the.other.name";
-    sinon.stub(ens, "getNewENSJS").returns({
-      resolver: input => {
-        if (input === expectedInput1) {
-          return { addr: () => Promise.resolve("0x123") };
-        }
-        if (input === expectedInput2) {
-          return { addr: () => Promise.resolve("0x987") };
-        }
-        return Promise.reject("The input was not what was expected");
-      }
-    });
+describe("isTxParams(val)", () => {
+  it("returns false if the input is not an object", () => {
+    const result = Utils.isTxParams(666);
+    assert.equal(result, false);
   });
-  afterEach(() => {
-    ens.getNewENSJS.restore();
+  it("returns true if a key is in the tx param whitelist", () => {
+    assert.equal(
+      whitelist.every(key => Utils.isTxParams({ [key]: "arbitraryValue" })),
+      true
+    );
   });
-
-  it("converts ens names in address fields to addresses", async () => {
-    let result = await ens.convertENSNames(args, methodABI, Web3);
-    assert(result[0] === "0x123");
-  });
-  it("does not change non-address arguments", async () => {
-    let result = await ens.convertENSNames(args, methodABI, Web3);
-    assert(result[1] === 555);
-  });
-  it("converts ens names in the from field of the tx object", async () => {
-    let result = await ens.convertENSNames(args, methodABI, Web3);
-    assert(result[2].from === "0x987");
+  it("returns false if no key matches anything in the whitelist", () => {
+    const result = Utils.isTxParams({ shiny: true, ready: false });
+    assert.equal(result, false);
   });
 });

--- a/packages/contract/lib/utils/index.js
+++ b/packages/contract/lib/utils/index.js
@@ -37,15 +37,13 @@ const Utils = {
       "overwrite"
     ]);
 
-    // if an unrecognized parameter is present, then assume
-    // it is the last arg and not the tx params
     for (let fieldName of Object.keys(val)) {
-      if (!allowedFields.has(fieldName)) {
-        return false;
+      if (allowedFields.has(fieldName)) {
+        return true;
       }
     }
 
-    return true;
+    return false;
   },
 
   decodeLogs(_logs, isSingle) {

--- a/packages/contract/lib/utils/index.js
+++ b/packages/contract/lib/utils/index.js
@@ -25,22 +25,27 @@ const Utils = {
     if (!Utils.is_object(val)) return false;
     if (Utils.is_big_number(val)) return false;
 
-    const allowedFields = {
-      from: true,
-      to: true,
-      gas: true,
-      gasPrice: true,
-      value: true,
-      data: true,
-      nonce: true,
-      privateFor: true
-    };
+    const allowedFields = new Set([
+      "from",
+      "to",
+      "gas",
+      "gasPrice",
+      "value",
+      "data",
+      "nonce",
+      "privateFor",
+      "overwrite"
+    ]);
 
+    // if an unrecognized parameter is present, then assume
+    // it is the last arg and not the tx params
     for (let fieldName of Object.keys(val)) {
-      if (allowedFields[fieldName]) return true;
+      if (!allowedFields.has(fieldName)) {
+        return false;
+      }
     }
 
-    return false;
+    return true;
   },
 
   decodeLogs(_logs, isSingle) {

--- a/packages/contract/lib/utils/index.js
+++ b/packages/contract/lib/utils/index.js
@@ -36,14 +36,7 @@ const Utils = {
   isTxParams(val) {
     if (!Utils.is_object(val)) return false;
     if (Utils.is_big_number(val)) return false;
-
-    for (let fieldName of Object.keys(val)) {
-      if (allowedTxParams.has(fieldName)) {
-        return true;
-      }
-    }
-
-    return false;
+    return Object.keys(val).some(fieldName => allowedTxParams.has(fieldName));
   },
 
   decodeLogs(_logs, isSingle) {

--- a/packages/contract/lib/utils/index.js
+++ b/packages/contract/lib/utils/index.js
@@ -21,11 +21,11 @@ const Utils = {
     return web3Utils.isBN(val) || web3Utils.isBigNumber(val);
   },
 
-  is_tx_params(val) {
+  isTxParams(val) {
     if (!Utils.is_object(val)) return false;
     if (Utils.is_big_number(val)) return false;
 
-    const allowed_fields = {
+    const allowedFields = {
       from: true,
       to: true,
       gas: true,
@@ -36,8 +36,8 @@ const Utils = {
       privateFor: true
     };
 
-    for (let field_name of Object.keys(val)) {
-      if (allowed_fields[field_name]) return true;
+    for (let fieldName of Object.keys(val)) {
+      if (allowedFields[fieldName]) return true;
     }
 
     return false;
@@ -143,7 +143,7 @@ const Utils = {
 
     if (
       args.length === expected_arg_count + 1 &&
-      Utils.is_tx_params(last_arg)
+      Utils.isTxParams(last_arg)
     ) {
       tx_params = args.pop();
     }

--- a/packages/contract/lib/utils/index.js
+++ b/packages/contract/lib/utils/index.js
@@ -6,6 +6,18 @@ const BlockchainUtils = require("@truffle/blockchain-utils");
 const reformat = require("../reformat");
 const ens = require("./ens");
 
+const allowedTxParams = new Set([
+  "from",
+  "to",
+  "gas",
+  "gasPrice",
+  "value",
+  "data",
+  "nonce",
+  "privateFor",
+  "overwrite"
+]);
+
 const Utils = {
   is_object(val) {
     return typeof val === "object" && !Array.isArray(val);
@@ -25,20 +37,8 @@ const Utils = {
     if (!Utils.is_object(val)) return false;
     if (Utils.is_big_number(val)) return false;
 
-    const allowedFields = new Set([
-      "from",
-      "to",
-      "gas",
-      "gasPrice",
-      "value",
-      "data",
-      "nonce",
-      "privateFor",
-      "overwrite"
-    ]);
-
     for (let fieldName of Object.keys(val)) {
-      if (allowedFields.has(fieldName)) {
+      if (allowedTxParams.has(fieldName)) {
         return true;
       }
     }


### PR DESCRIPTION
Currently the `is_tx_params` method is used to determine whether an argument to a function is the tx params. This function checks the keys of the object provided and returns once it finds that one of them matches the whitelisted fields. This PR adds the `overwrite` key to the whitelist. ~and will also accept an empty object. Accepting an empty object does seem a bit strange to me. It seems like it would make user errors more likely or cause misunderstandings but I suppose it could be better UX. This fix causes `@truffle/contract` to check all of the keys and make sure they match some term from the whitelist.~

related to https://github.com/trufflesuite/truffle/issues/2843