### PR TITLE
Bug fix: Fix overwriting of legacyAST by AST

### DIFF
--- a/packages/contract-schema/index.js
+++ b/packages/contract-schema/index.js
@@ -121,13 +121,10 @@ var properties = {
   ast: {},
   legacyAST: {
     transform: function (value, obj) {
-      var schemaVersion = obj.schemaVersion || "0.0.0";
-
-      // legacyAST introduced in v2.0.0
-      if (schemaVersion[0] < 2) {
-        return obj.ast;
-      } else {
+      if (value) {
         return value;
+      } else {
+        return obj.ast;
       }
     }
   },


### PR DESCRIPTION
So `contract-schema` had a mechanism for copying AST to legacyAST when the latter doesn't exist.  Problem is, the check didn't work -- it would check the `schemaVersion` on the dirty object, despite dirty objects typically not having this set -- and so AST was getting copied over legacyAST even when the latter existed.  I've replaced it with a simpler check: Now, AST is copied to legacyAST precisely when there is no legacyAST; `schemaVersion` is not checked.