### PR TITLE
Bug fix: Allow contract instances as an argument to the link method

### DIFF
--- a/packages/contract-tests/test/linking.js
+++ b/packages/contract-tests/test/linking.js
@@ -14,14 +14,14 @@ const { Shims } = require("@truffle/compile-common");
 // which happens to be the first.
 process.removeListener(
   "uncaughtException",
-  process.listeners("uncaughtException")[0] || function () {}
+  process.listeners("uncaughtException")[0] || (() => {})
 );
 
-var log = {
+const log = {
   log: debug
 };
 
-describe("Library linking", function () {
+describe("Library linking", () => {
   let LibraryExample;
   let provider = Ganache.provider({ logger: log });
   let networkId;
@@ -95,7 +95,7 @@ describe("Library linking", function () {
   });
 });
 
-describe("Library linking with contract objects", function () {
+describe("Library linking with contract objects", () => {
   let ExampleLibrary;
   let ExampleLibraryConsumer;
   let accounts;

--- a/packages/contract/lib/contract/constructorMethods.js
+++ b/packages/contract/lib/contract/constructorMethods.js
@@ -6,6 +6,7 @@ const utils = require("../utils");
 const execute = require("../execute");
 const bootstrap = require("./bootstrap");
 const debug = require("debug")("contract:contract:constructorMethods");
+const OS = require("os");
 
 module.exports = Contract => ({
   configureNetwork({ networkType, provider } = {}) {
@@ -192,20 +193,30 @@ module.exports = Contract => ({
         //   - Contract.link({<libraryName>: <address>, ... })
         //   - Contract.link(<instance>)
         const obj = name;
-        if (obj.constructor && obj.constructor.contractName && obj.address) {
+        if (
+          obj.constructor &&
+          typeof obj.constructor.contractName === "string" &&
+          obj.address
+        ) {
           // obj is a Truffle contract instance
           this.link(obj.constructor.contractName, obj.address);
         } else {
           // obj is of the form { <libraryName>: <address>, ... }
-          Object.keys(obj).forEach(name => {
-            const a = obj[name];
-            this.link(name, a);
-          });
+          Object.keys(obj).forEach(name => this.link(name, obj[name]));
         }
         return;
       default:
-        const message = "Input to the link method is in the incorrect format.";
-        throw new Error(message);
+        const invalidInput = `Input to the link method is in the incorrect` +
+          ` format. Input must be one of the following:${OS.EOL}` +
+          `    - a library name and address                 > ("MyLibrary", ` +
+            `"0x123456789...")${OS.EOL}` +
+          `    - a contract type                            > ` +
+            `(MyContract)${OS.EOL}` +
+          `    - a contract instance                        > ` +
+            `(myContract)${OS.EOL}` +
+          `    - an object with library names and addresses > ({ <libName>: ` +
+            `<address>, <libName2>: <address2>, ... })${OS.EOL}`;
+        throw new Error(invalidInput);
     }
   },
 

--- a/packages/contract/lib/contract/constructorMethods.js
+++ b/packages/contract/lib/contract/constructorMethods.js
@@ -194,7 +194,6 @@ module.exports = Contract => ({
         const obj = name;
         if (obj.constructor && obj.constructor.contractName && obj.address) {
           // obj is a Truffle contract instance
-          console.log('about to link %o -- %o', obj.constructor.contractName, obj.address);
           this.link(obj.constructor.contractName, obj.address);
         } else {
           // obj is of the form { <libraryName>: <address>, ... }

--- a/packages/contract/lib/contract/constructorMethods.js
+++ b/packages/contract/lib/contract/constructorMethods.js
@@ -155,7 +155,7 @@ module.exports = Contract => ({
   },
 
   link(name, address) {
-    // Case: Contract.link(instance)
+    // Case: Contract.link(<contractType>)
     if (typeof name === "function") {
       const contract = name;
 
@@ -169,17 +169,24 @@ module.exports = Contract => ({
       Object.keys(contract.events).forEach(topic => {
         this.network.events[topic] = contract.events[topic];
       });
-
       return;
     }
 
-    // Case: Contract.link({<libraryName>: <address>, ... })
+    // 2 Cases:
+    //   - Contract.link({<libraryName>: <address>, ... })
+    //   - Contract.link(<instance>)
     if (typeof name === "object") {
       const obj = name;
-      Object.keys(obj).forEach(name => {
-        const a = obj[name];
-        this.link(name, a);
-      });
+      if (obj._json && obj._json.contractName && obj.address) {
+        // obj is a Truffle contract instance
+        this.link(obj._json.contractName, obj.address);
+      } else {
+        // objc is of the form { <libraryName>: <address>, ... }
+        Object.keys(obj).forEach(name => {
+          const a = obj[name];
+          this.link(name, a);
+        });
+      }
       return;
     }
 


### PR DESCRIPTION
Currently on a `@truffle/contract` object (the type, i.e. `MetaCoin`) the `link` method only accepts another `@truffle/contract` object as an argument and will incorrectly link if you pass an instance. This PR adds support for passing a `@truffle/contract` instance (not the type, i.e. `await MetaCoin.deployed()`).

It also refactors the method into a big `switch` statement which more clearly conveys what is happening there.

~It is a little bit wonky to test for `contract._json.contractName` but I'm not sure if there is a better way to test that it is an instance. Ideas?~

related to https://github.com/trufflesuite/truffle/issues/3584