### PR TITLE
Internal improvement: Add failure message to yarncheck job to increase clarity

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-node@v1
       - run: npm install -g yarn
       - run: yarn bootstrap
-      - run: test -z "$(git diff)"
+      - run: test -z "$(git diff)" || (echo 'Please run yarn and commit all changes to yarn.lock'; false)
 
 
   build:


### PR DESCRIPTION
Two people have asked recently what the yarncheck job does, because, well, the yarncheck job doesn't say anywhere what it does!  This PR adds a message saying `"Please run yarn and commit all changes to yarn.lock"` when it fails so people will be able to see what it is they need to do. :)