### PR TITLE
Internal improvement: Reclassify some dependencies as devDependencies

### DIFF
--- a/packages/abi-utils/package.json
+++ b/packages/abi-utils/package.json
@@ -30,6 +30,7 @@
     "url": "https://github.com/trufflesuite/truffle/issues"
   },
   "devDependencies": {
+    "@truffle/contract-schema": "^3.3.2",
     "@types/faker": "^5.1.2",
     "@types/jest": "^26.0.14",
     "@types/jest-json-schema": "^2.1.2",
@@ -42,7 +43,6 @@
     "typescript": "^4.0.3"
   },
   "dependencies": {
-    "@truffle/contract-schema": "^3.3.2",
     "change-case": "^4.1.1",
     "faker": "^5.1.0",
     "fast-check": "^2.4.0",

--- a/packages/compile-common/package.json
+++ b/packages/compile-common/package.json
@@ -13,12 +13,12 @@
     "watch": "tsc -w"
   },
   "devDependencies": {
+    "@truffle/contract-schema": "^3.3.2",
     "@types/fs-extra": "^8.1.0",
     "@types/mocha": "^5.2.7",
     "typescript": "3.9.6"
   },
   "dependencies": {
-    "@truffle/contract-schema": "^3.3.2",
     "@truffle/error": "^0.0.11",
     "colors": "^1.4.0",
     "fs-extra": "^8.1.0",

--- a/packages/source-fetcher/lib/types.ts
+++ b/packages/source-fetcher/lib/types.ts
@@ -9,8 +9,9 @@ export interface Fetcher {
    */
   readonly fetcherName: string;
   /**
-   * returns null if no Solidity sources for address
-   * (address not in system, sources are Vyper, whatever)
+   * returns null if no sources for address
+   * (also may return null if the sources fall under an unsupported
+   * case, although currently there are no such cases)
    */
   fetchSourcesForAddress(address: string): Promise<SourceInfo | null>;
 }


### PR DESCRIPTION
I noticed that `abi-utils` and `compile-common` both have `contract-schema` listed as a dependency.  However, both of these packages only use *types* from `contract-schema`, so this should be devDependency.  I've reclassified things appropriately.

Also, I updated an out-of-date comment in source-fetcher (as source-fetcher now supports Vyper sources on Etherscan, even though the CLI debugger won't actually make use of these).