### PR TITLE
Internal improvement: Capitalize names of languages (Solidity, Yul, Vyper)

### DIFF
--- a/packages/codec/lib/compilations/utils.ts
+++ b/packages/codec/lib/compilations/utils.ts
@@ -262,7 +262,7 @@ export function getContractNode(
     if (foundNode || !source) {
       return foundNode;
     }
-    if (!source.ast || source.language !== "solidity") {
+    if (!source.ast || source.language !== "Solidity") {
       //ignore non-Solidity ASTs for now, we don't support them yet
       return undefined;
     }
@@ -333,20 +333,20 @@ function inferLanguage(
 ): string | undefined {
   if (ast) {
     if (ast.nodeType === "SourceUnit") {
-      return "solidity";
+      return "Solidity";
     } else if (ast.nodeType && ast.nodeType.startsWith("Yul")) {
       //Every Yul source I've seen has YulBlock as the root, but
       //I'm not sure that that's *always* the case
-      return "yul";
+      return "Yul";
     } else if (ast.ast_type === "Module") {
-      return "vyper";
+      return "Vyper";
     }
   } else if (compiler) {
     if (compiler.name === "vyper") {
-      return "vyper";
+      return "Vyper";
     } else if (compiler.name === "solc") {
       //if it's solc but no AST, just assume it's Solidity
-      return "solidity";
+      return "Solidity";
     } else {
       return undefined;
     }

--- a/packages/compile-solidity/run.js
+++ b/packages/compile-solidity/run.js
@@ -278,7 +278,7 @@ function processAllSources({ sources, compilerOutput, originalSourcePaths }) {
       contents: sources[sourcePath],
       ast,
       legacyAST,
-      language: "solidity"
+      language: "Solidity"
     };
   }
   return outputSources;

--- a/packages/compile-vyper/index.js
+++ b/packages/compile-vyper/index.js
@@ -156,7 +156,7 @@ async function compileAllNoJson({ sources, options, version }) {
               {
                 sourcePath,
                 contents: sourceContents,
-                language: "vyper"
+                language: "Vyper"
               }
             ],
             contracts: [contractDefinition],

--- a/packages/compile-vyper/test/test_compiler.js
+++ b/packages/compile-vyper/test/test_compiler.js
@@ -171,7 +171,7 @@ describe("vyper compiler", function () {
             .readFileSync(path.join(__dirname, "sources/VyperContract1.vy"))
             .toString()
       );
-      assert(sources[0].language === "vyper");
+      assert(sources[0].language === "Vyper");
     });
   });
 });

--- a/packages/compile-vyper/vyper-json.js
+++ b/packages/compile-vyper/vyper-json.js
@@ -227,7 +227,7 @@ function processAllSources({ sources, compilerOutput, originalSourcePaths }) {
       sourcePath: originalSourcePaths[sourcePath],
       contents: sources[sourcePath],
       ast,
-      language: "vyper"
+      language: "Vyper"
     };
   }
   return outputSources;

--- a/packages/core/lib/debug/interpreter.js
+++ b/packages/core/lib/debug/interpreter.js
@@ -449,7 +449,7 @@ class DebugInterpreter {
       } else {
         //case if transaction succeeded
         this.printer.print("Transaction completed successfully.");
-        if (this.session.view(solidity.current.source).language !== "vyper") {
+        if (this.session.view(solidity.current.source).language !== "Vyper") {
           //HACK: not supported for vyper yet
           await this.printer.printReturnValue();
         }
@@ -478,7 +478,7 @@ class DebugInterpreter {
         this.printer.printGeneratedSourcesState();
         break;
       case "v":
-        if (this.session.view(solidity.current.source).language === "vyper") {
+        if (this.session.view(solidity.current.source).language === "Vyper") {
           this.printer.print("Decoding of variables is not currently supported for Vyper.");
           break;
         }

--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -76,6 +76,71 @@ const truffleColors = {
 
 const DEFAULT_TAB_WIDTH = 8;
 
+const trufflePalette = {
+  /* base (chromafi special, not hljs) */
+  "base": chalk,
+  "lineNumbers": chalk,
+  "trailingSpace": chalk,
+  /* classes hljs-solidity actually uses */
+  "keyword": truffleColors.mint,
+  "number": truffleColors.red,
+  "string": truffleColors.green,
+  "params": truffleColors.pink,
+  "builtIn": truffleColors.watermelon,
+  "built_in": truffleColors.watermelon, //just to be sure
+  "literal": truffleColors.watermelon,
+  "function": truffleColors.orange,
+  "title": truffleColors.orange,
+  "class": truffleColors.orange,
+  "comment": truffleColors.comment,
+  "doctag": truffleColors.comment,
+  /* classes it might soon use! */
+  "meta": truffleColors.pink,
+  "metaString": truffleColors.green,
+  "meta-string": truffleColors.green, //similar
+  /* classes it doesn't currently use but notionally could */
+  "type": truffleColors.orange,
+  "symbol": truffleColors.orange,
+  "metaKeyword": truffleColors.mint,
+  "meta-keyword": truffleColors.mint, //again, to be sure
+  /* classes that don't make sense for Solidity */
+  "regexp": chalk, //solidity does not have regexps
+  "subst": chalk, //or string interpolation
+  "name": chalk, //or s-expressions
+  "builtInName": chalk, //or s-expressions, again
+  "builtin-name": chalk, //just to be sure
+  /* classes for config, markup, CSS, templates, diffs (not programming) */
+  "section": chalk,
+  "tag": chalk,
+  "attr": chalk,
+  "attribute": chalk,
+  "variable": chalk,
+  "bullet": chalk,
+  "code": chalk,
+  "emphasis": chalk,
+  "strong": chalk,
+  "formula": chalk,
+  "link": chalk,
+  "quote": chalk,
+  "selectorAttr": chalk, //lotta redundancy follows
+  "selector-attr": chalk,
+  "selectorClass": chalk,
+  "selector-class": chalk,
+  "selectorId": chalk,
+  "selector-id": chalk,
+  "selectorPseudo": chalk,
+  "selector-pseudo": chalk,
+  "selectorTag": chalk,
+  "selector-tag": chalk,
+  "templateTag": chalk,
+  "template-tag": chalk,
+  "templateVariable": chalk,
+  "template-variable": chalk,
+  "addition": chalk,
+  "deletion": chalk
+};
+
+
 var DebugUtils = {
   truffleColors, //make these externally available
 
@@ -641,73 +706,6 @@ var DebugUtils = {
   },
 
   colorize: function (code, language = "Solidity") {
-    //I'd put these outside the function
-    //but then it gives me errors, because
-    //you can't just define self-referential objects like that...
-
-    const trufflePalette = {
-      /* base (chromafi special, not hljs) */
-      "base": chalk,
-      "lineNumbers": chalk,
-      "trailingSpace": chalk,
-      /* classes hljs-solidity actually uses */
-      "keyword": truffleColors.mint,
-      "number": truffleColors.red,
-      "string": truffleColors.green,
-      "params": truffleColors.pink,
-      "builtIn": truffleColors.watermelon,
-      "built_in": truffleColors.watermelon, //just to be sure
-      "literal": truffleColors.watermelon,
-      "function": truffleColors.orange,
-      "title": truffleColors.orange,
-      "class": truffleColors.orange,
-      "comment": truffleColors.comment,
-      "doctag": truffleColors.comment,
-      /* classes it might soon use! */
-      "meta": truffleColors.pink,
-      "metaString": truffleColors.green,
-      "meta-string": truffleColors.green, //similar
-      /* classes it doesn't currently use but notionally could */
-      "type": truffleColors.orange,
-      "symbol": truffleColors.orange,
-      "metaKeyword": truffleColors.mint,
-      "meta-keyword": truffleColors.mint, //again, to be sure
-      /* classes that don't make sense for Solidity */
-      "regexp": chalk, //solidity does not have regexps
-      "subst": chalk, //or string interpolation
-      "name": chalk, //or s-expressions
-      "builtInName": chalk, //or s-expressions, again
-      "builtin-name": chalk, //just to be sure
-      /* classes for config, markup, CSS, templates, diffs (not programming) */
-      "section": chalk,
-      "tag": chalk,
-      "attr": chalk,
-      "attribute": chalk,
-      "variable": chalk,
-      "bullet": chalk,
-      "code": chalk,
-      "emphasis": chalk,
-      "strong": chalk,
-      "formula": chalk,
-      "link": chalk,
-      "quote": chalk,
-      "selectorAttr": chalk, //lotta redundancy follows
-      "selector-attr": chalk,
-      "selectorClass": chalk,
-      "selector-class": chalk,
-      "selectorId": chalk,
-      "selector-id": chalk,
-      "selectorPseudo": chalk,
-      "selector-pseudo": chalk,
-      "selectorTag": chalk,
-      "selector-tag": chalk,
-      "templateTag": chalk,
-      "template-tag": chalk,
-      "templateVariable": chalk,
-      "template-variable": chalk,
-      "addition": chalk,
-      "deletion": chalk
-    };
 
     const options = {
       lang: "solidity",
@@ -723,24 +721,24 @@ var DebugUtils = {
       //NOTE: you might think you should pass highlight: true,
       //but you'd be wrong!  I don't understand this either
     };
-    if (language === "Solidity") {
-      //normal case: solidity
-      return chromafi(code, options);
-    } else if (language === "Yul") {
-      //HACK: stick the code in an assembly block since we don't
-      //have a separate Yul language for HLJS at the moment,
-      //colorize it there, then extract it after colorization
-      const wrappedCode = "assembly {\n" + code + "\n}";
-      const colorizedWrapped = chromafi(wrappedCode, options);
-      const firstNewLine = colorizedWrapped.indexOf("\n");
-      const lastNewLine = colorizedWrapped.lastIndexOf("\n");
-      return colorizedWrapped.slice(firstNewLine + 1, lastNewLine);
-    } else if (language === "Vyper") {
-      options.lang = "python"; //HACK -- close enough for now!
-      return chromafi(code, options);
-    } else {
-      //otherwise, don't highlight
-      return code;
+    switch (language) {
+      case "Solidity":
+        return chromafi(code, options);
+      case "Yul":
+        //HACK: stick the code in an assembly block since we don't
+        //have a separate Yul language for HLJS at the moment,
+        //colorize it there, then extract it after colorization
+        const wrappedCode = "assembly {\n" + code + "\n}";
+        const colorizedWrapped = chromafi(wrappedCode, options);
+        const firstNewLine = colorizedWrapped.indexOf("\n");
+        const lastNewLine = colorizedWrapped.lastIndexOf("\n");
+        return colorizedWrapped.slice(firstNewLine + 1, lastNewLine);
+      case "Vyper":
+        options.lang = "python"; //HACK -- close enough for now!
+        return chromafi(code, options);
+      default:
+        //don't highlight
+        return code;
     }
   },
 

--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -640,7 +640,7 @@ var DebugUtils = {
     return indented.join(OS.EOL);
   },
 
-  colorize: function (code, language = "solidity") {
+  colorize: function (code, language = "Solidity") {
     //I'd put these outside the function
     //but then it gives me errors, because
     //you can't just define self-referential objects like that...
@@ -723,10 +723,10 @@ var DebugUtils = {
       //NOTE: you might think you should pass highlight: true,
       //but you'd be wrong!  I don't understand this either
     };
-    if (language === "solidity") {
+    if (language === "Solidity") {
       //normal case: solidity
       return chromafi(code, options);
-    } else if (language === "yul") {
+    } else if (language === "Yul") {
       //HACK: stick the code in an assembly block since we don't
       //have a separate Yul language for HLJS at the moment,
       //colorize it there, then extract it after colorization
@@ -735,7 +735,7 @@ var DebugUtils = {
       const firstNewLine = colorizedWrapped.indexOf("\n");
       const lastNewLine = colorizedWrapped.lastIndexOf("\n");
       return colorizedWrapped.slice(firstNewLine + 1, lastNewLine);
-    } else if (language === "vyper") {
+    } else if (language === "Vyper") {
       options.lang = "python"; //HACK -- close enough for now!
       return chromafi(code, options);
     } else {

--- a/packages/debugger/lib/data/selectors/index.js
+++ b/packages/debugger/lib/data/selectors/index.js
@@ -1159,7 +1159,7 @@ const data = createSelectorTree({
           };
 
           if (
-            language !== "solidity" ||
+            language !== "Solidity" ||
             (scope &&
               (scope.nodeType.startsWith("Yul") ||
                 scope.nodeType === "InlineAssembly"))

--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -187,7 +187,7 @@ export class WireDecoder {
           continue; //remember, sources could be empty if shimmed!
         }
         const { ast, compiler, language } = source;
-        if (language === "solidity" && ast) {
+        if (language === "Solidity" && ast) {
           //don't check Yul or Vyper sources!
           for (const node of ast.nodes) {
             if (


### PR DESCRIPTION
Per earlier discussion, language names will now be capitalized.  Compiler names will not be -- so `"Vyper"` is the language, `"vyper"` is the compiler. :)  Anyway this PR does that.

This PR might be a breaking change to some packages?  Not sure.  I'll call it a **breaking change to debug-utils**, but we can probably get away with not calling it a breaking change to any others...

(Also as long as I was touching the syntax-highlighting code in `debug-utils` I also cleaned it up some, even though that's not the main point of this PR.)