### PR TITLE
Bug fix: Better handle deployed addresses library compilation

### DIFF
--- a/packages/compile-solidity/compilerSupplier/rangeUtils.js
+++ b/packages/compile-solidity/compilerSupplier/rangeUtils.js
@@ -9,7 +9,7 @@ const RangeUtils = {
   //takes a version string which may be native or local, and resolves
   //it to one which is (presumably) either a version or a version range
   resolveToRange: function (version) {
-    if (!version) {
+    if (!version || version === "pragma") {
       return CompilerSupplier.getDefaultVersion();
     }
     //if version was native or local, must determine what version that

--- a/packages/compile-solidity/compilerSupplier/rangeUtils.js
+++ b/packages/compile-solidity/compilerSupplier/rangeUtils.js
@@ -9,6 +9,8 @@ const RangeUtils = {
   //takes a version string which may be native or local, and resolves
   //it to one which is (presumably) either a version or a version range
   resolveToRange: function (version) {
+    // if version is "pragma", we can just use the solc default since
+    // there is no explicit version specified
     if (!version || version === "pragma") {
       return CompilerSupplier.getDefaultVersion();
     }

--- a/packages/resolver/lib/sources/truffle/Deployed.ts
+++ b/packages/resolver/lib/sources/truffle/Deployed.ts
@@ -1,5 +1,5 @@
 const web3Utils = require("web3-utils");
-import RangeUtils from "@truffle/compile-solidity/compilerSupplier/rangeUtils";
+const RangeUtils = require("@truffle/compile-solidity/compilerSupplier/rangeUtils");
 
 type solcOptionsArg = {
   solc: { version: string };

--- a/packages/resolver/test/Deployed.ts
+++ b/packages/resolver/test/Deployed.ts
@@ -1,0 +1,38 @@
+import assert from "assert";
+import { Deployed } from "../lib/sources/truffle/Deployed";
+import { describe, it } from "mocha";
+let address, version;
+
+describe("Deployed", () => {
+  describe("makeSolidityDeployedAddressesLibrary", () => {
+    it("creates the deployed addresses library", () => {
+      address = "0x1234567890123456789012345678901234567890";
+      version = "0.6.0";
+      const result = Deployed.makeSolidityDeployedAddressesLibrary(
+        {
+          HamburgerContract: address
+        },
+        {
+          solc: { version }
+        }
+      );
+      assert(result.includes(address));
+      assert(result.includes("HamburgerContract"));
+    });
+
+    it("can deal with 'pragma' specified as version", () => {
+      version = "pragma";
+      address = "0x1234567890123456789012345678901234567890";
+      const result = Deployed.makeSolidityDeployedAddressesLibrary(
+        {
+          CheeseburgerContract: address
+        },
+        {
+          solc: { version }
+        }
+      );
+      assert(result.includes(address));
+      assert(result.includes("CheeseburgerContract"))
+    });
+  });
+});


### PR DESCRIPTION
When testing while using "pragma" as the version, Truffle would crash when attempting to create the `DeployedAddresses` library as there was no infrastructure to handle this. This PR updates the `rangeUtils` to return the default solc version in the case where "pragma" is specified.