### PR TITLE
Internal improvement: Clean up debugger dependencies

### DIFF
--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -22,8 +22,6 @@
   "dependencies": {
     "@truffle/abi-utils": "^0.1.1",
     "@truffle/codec": "^0.9.1",
-    "@truffle/compile-solidity": "^5.1.2",
-    "@truffle/expect": "^0.0.15",
     "@truffle/solidity-utils": "^1.3.29",
     "bn.js": "^4.11.8",
     "debug": "^4.1.0",


### PR DESCRIPTION
Just some stuff I missed in #3598, `@truffle/debugger` had some unused dependencies listed, namely `@truffle/compile-solidity` and `@truffle/expect`, so those are gone now.