### PR TITLE
Bug fix: Have codec rethrow unexpected errors in decoding

### DIFF
--- a/packages/codec/lib/abi-data/decode/index.ts
+++ b/packages/codec/lib/abi-data/decode/index.ts
@@ -31,15 +31,19 @@ export function* decodeAbi(
     try {
       dynamic = abiSizeInfo(dataType, info.allocations.abi).dynamic;
     } catch (error) {
-      if (options.strictAbiMode) {
-        throw new StopDecodingError((<DecodingError>error).error);
+      if (error instanceof DecodingError) {
+        if (options.strictAbiMode) {
+          throw new StopDecodingError(error.error);
+        }
+        return <Format.Errors.ErrorResult>{
+          //dunno why TS is failing at this inference
+          type: dataType,
+          kind: "error" as const,
+          error: error.error
+        };
+      } else {
+        throw error;
       }
-      return <Format.Errors.ErrorResult>{
-        //dunno why TS is failing at this inference
-        type: dataType,
-        kind: "error" as const,
-        error: (<DecodingError>error).error
-      };
     }
     if (dynamic) {
       return yield* decodeAbiReferenceByAddress(
@@ -86,15 +90,19 @@ export function* decodeAbiReferenceByAddress(
   try {
     rawValue = yield* read(pointer, state);
   } catch (error) {
-    if (strict) {
-      throw new StopDecodingError((<DecodingError>error).error);
+    if (error instanceof DecodingError) {
+      if (strict) {
+        throw new StopDecodingError(error.error);
+      }
+      return <Format.Errors.ErrorResult>{
+        //dunno why TS is failing here
+        type: dataType,
+        kind: "error" as const,
+        error: error.error
+      };
+    } else {
+      throw error;
     }
-    return <Format.Errors.ErrorResult>{
-      //dunno why TS is failing here
-      type: dataType,
-      kind: "error" as const,
-      error: (<DecodingError>error).error
-    };
   }
 
   let rawValueAsBN = Conversion.toBN(rawValue);
@@ -126,15 +134,19 @@ export function* decodeAbiReferenceByAddress(
   try {
     ({ dynamic, size } = abiSizeInfo(dataType, allocations));
   } catch (error) {
-    if (strict) {
-      throw new StopDecodingError((<DecodingError>error).error);
+    if (error instanceof DecodingError) {
+      if (strict) {
+        throw new StopDecodingError(error.error);
+      }
+      return <Format.Errors.ErrorResult>{
+        //dunno why TS is failing here
+        type: dataType,
+        kind: "error" as const,
+        error: error.error
+      };
+    } else {
+      throw error;
     }
-    return <Format.Errors.ErrorResult>{
-      //dunno why TS is failing here
-      type: dataType,
-      kind: "error" as const,
-      error: (<DecodingError>error).error
-    };
   }
   if (!dynamic) {
     //this will only come up when called from stack.ts
@@ -173,15 +185,19 @@ export function* decodeAbiReferenceByAddress(
             state
           );
         } catch (error) {
-          if (strict) {
-            throw new StopDecodingError((<DecodingError>error).error);
+          if (error instanceof DecodingError) {
+            if (strict) {
+              throw new StopDecodingError(error.error);
+            }
+            return <Format.Errors.ErrorResult>{
+              //dunno why TS is failing here
+              type: dataType,
+              kind: "error" as const,
+              error: error.error
+            };
+          } else {
+            throw error;
           }
-          return <Format.Errors.ErrorResult>{
-            //dunno why TS is failing here
-            type: dataType,
-            kind: "error" as const,
-            error: (<DecodingError>error).error
-          };
         }
         lengthAsBN = Conversion.toBN(rawLength);
         startPosition += Evm.Utils.WORD_SIZE; //increment start position after reading length
@@ -255,14 +271,18 @@ export function* decodeAbiReferenceByAddress(
           );
         } catch (error) {
           //error: DecodingError
-          if (strict) {
-            throw new StopDecodingError((<DecodingError>error).error);
+          if (error instanceof DecodingError) {
+            if (strict) {
+              throw new StopDecodingError(error.error);
+            }
+            return {
+              type: dataType,
+              kind: "error" as const,
+              error: error.error
+            };
+          } else {
+            throw error;
           }
-          return {
-            type: dataType,
-            kind: "error" as const,
-            error: (<DecodingError>error).error
-          };
         }
         lengthAsBN = Conversion.toBN(rawLength);
         startPosition += Evm.Utils.WORD_SIZE; //increment startPosition
@@ -300,14 +320,18 @@ export function* decodeAbiReferenceByAddress(
       try {
         baseSize = abiSizeInfo(dataType.baseType, allocations).size;
       } catch (error) {
-        if (strict) {
-          throw new StopDecodingError((<DecodingError>error).error);
+        if (error instanceof DecodingError) {
+          if (strict) {
+            throw new StopDecodingError(error.error);
+          }
+          return {
+            type: dataType,
+            kind: "error" as const,
+            error: error.error
+          };
+        } else {
+          throw error;
         }
-        return {
-          type: dataType,
-          kind: "error" as const,
-          error: (<DecodingError>error).error
-        };
       }
 
       let decodedChildren: Format.Values.Result[] = [];
@@ -390,14 +414,18 @@ export function* decodeAbiReferenceStatic(
         baseSize = abiSizeInfo(dataType.baseType, info.allocations.abi).size;
       } catch (error) {
         //error: DecodingError
-        if (options.strictAbiMode) {
-          throw new StopDecodingError((<DecodingError>error).error);
+        if (error instanceof DecodingError) {
+          if (options.strictAbiMode) {
+            throw new StopDecodingError(error.error);
+          }
+          return {
+            type: dataType,
+            kind: "error" as const,
+            error: error.error
+          };
+        } else {
+          throw error;
         }
-        return {
-          type: dataType,
-          kind: "error" as const,
-          error: (<DecodingError>error).error
-        };
       }
 
       let decodedChildren: Format.Values.Result[] = [];

--- a/packages/codec/lib/ast-constant/decode/index.ts
+++ b/packages/codec/lib/ast-constant/decode/index.ts
@@ -30,11 +30,15 @@ export function* decodeConstant(
     try {
       word = yield* read(pointer, info.state);
     } catch (error) {
-      return {
-        type: dataType,
-        kind: "error" as const,
-        error: (<DecodingError>error).error
-      };
+      if (error instanceof DecodingError) {
+        return {
+          type: dataType,
+          kind: "error" as const,
+          error: error.error
+        };
+      } else {
+        throw error;
+      }
     }
     //not bothering to check padding; shouldn't be necessary
     let bytes = word.slice(Evm.Utils.WORD_SIZE - size);

--- a/packages/codec/lib/ast-constant/decode/index.ts
+++ b/packages/codec/lib/ast-constant/decode/index.ts
@@ -9,7 +9,7 @@ import * as Basic from "@truffle/codec/basic";
 import * as Bytes from "@truffle/codec/bytes";
 import { DecoderRequest } from "@truffle/codec/types";
 import * as Evm from "@truffle/codec/evm";
-import { DecodingError } from "@truffle/codec/errors";
+import { handleDecodingError } from "@truffle/codec/errors";
 
 export function* decodeConstant(
   dataType: Format.Types.Type,
@@ -30,15 +30,7 @@ export function* decodeConstant(
     try {
       word = yield* read(pointer, info.state);
     } catch (error) {
-      if (error instanceof DecodingError) {
-        return {
-          type: dataType,
-          kind: "error" as const,
-          error: error.error
-        };
-      } else {
-        throw error;
-      }
+      return handleDecodingError(dataType, error);
     }
     //not bothering to check padding; shouldn't be necessary
     let bytes = word.slice(Evm.Utils.WORD_SIZE - size);

--- a/packages/codec/lib/basic/decode/index.ts
+++ b/packages/codec/lib/basic/decode/index.ts
@@ -33,15 +33,19 @@ export function* decodeBasic(
   } catch (error) {
     //error: DecodingError
     debug("segfault, pointer %o, state: %O", pointer, state);
-    if (strict) {
-      throw new StopDecodingError((<DecodingError>error).error);
+    if (error instanceof DecodingError) {
+      if (strict) {
+        throw new StopDecodingError(error.error);
+      }
+      return <Format.Errors.ErrorResult>{
+        //no idea why TS is failing here
+        type: dataType,
+        kind: "error" as const,
+        error: error.error
+      };
+    } else {
+      throw error;
     }
-    return <Format.Errors.ErrorResult>{
-      //no idea why TS is failing here
-      type: dataType,
-      kind: "error" as const,
-      error: (<DecodingError>error).error
-    };
   }
   rawBytes = bytes;
 

--- a/packages/codec/lib/basic/decode/index.ts
+++ b/packages/codec/lib/basic/decode/index.ts
@@ -13,7 +13,7 @@ import {
   PaddingType
 } from "@truffle/codec/types";
 import * as Evm from "@truffle/codec/evm";
-import { DecodingError, StopDecodingError } from "@truffle/codec/errors";
+import { handleDecodingError, StopDecodingError } from "@truffle/codec/errors";
 import { byteLength } from "@truffle/codec/basic/allocate";
 
 export function* decodeBasic(
@@ -31,21 +31,8 @@ export function* decodeBasic(
   try {
     bytes = yield* read(pointer, state);
   } catch (error) {
-    //error: DecodingError
     debug("segfault, pointer %o, state: %O", pointer, state);
-    if (error instanceof DecodingError) {
-      if (strict) {
-        throw new StopDecodingError(error.error);
-      }
-      return <Format.Errors.ErrorResult>{
-        //no idea why TS is failing here
-        type: dataType,
-        kind: "error" as const,
-        error: error.error
-      };
-    } else {
-      throw error;
-    }
+    return handleDecodingError(dataType, error, strict);
   }
   rawBytes = bytes;
 

--- a/packages/codec/lib/bytes/decode/index.ts
+++ b/packages/codec/lib/bytes/decode/index.ts
@@ -25,15 +25,19 @@ export function* decodeBytes(
   } catch (error) {
     //error: DecodingError
     debug("segfault, pointer %o, state: %O", pointer, state);
-    if (strict) {
-      throw new StopDecodingError((<DecodingError>error).error);
+    if (error instanceof DecodingError) {
+      if (strict) {
+        throw new StopDecodingError(error.error);
+      }
+      return <Format.Errors.ErrorResult>{
+        //no idea why TS is failing here
+        type: dataType,
+        kind: "error" as const,
+        error: error.error
+      };
+    } else {
+      throw error;
     }
-    return <Format.Errors.ErrorResult>{
-      //no idea why TS is failing here
-      type: dataType,
-      kind: "error" as const,
-      error: (<DecodingError>error).error
-    };
   }
 
   debug("type %O", dataType);

--- a/packages/codec/lib/bytes/decode/index.ts
+++ b/packages/codec/lib/bytes/decode/index.ts
@@ -7,7 +7,7 @@ import * as Format from "@truffle/codec/format";
 import * as Pointer from "@truffle/codec/pointer";
 import { DecoderRequest, DecoderOptions } from "@truffle/codec/types";
 import * as Evm from "@truffle/codec/evm";
-import { DecodingError, StopDecodingError } from "@truffle/codec/errors";
+import { handleDecodingError } from "@truffle/codec/errors";
 import utf8 from "utf8";
 
 export function* decodeBytes(
@@ -23,21 +23,8 @@ export function* decodeBytes(
   try {
     bytes = yield* read(pointer, state);
   } catch (error) {
-    //error: DecodingError
     debug("segfault, pointer %o, state: %O", pointer, state);
-    if (error instanceof DecodingError) {
-      if (strict) {
-        throw new StopDecodingError(error.error);
-      }
-      return <Format.Errors.ErrorResult>{
-        //no idea why TS is failing here
-        type: dataType,
-        kind: "error" as const,
-        error: error.error
-      };
-    } else {
-      throw error;
-    }
+    return handleDecodingError(dataType, error, strict);
   }
 
   debug("type %O", dataType);
@@ -81,7 +68,7 @@ export function decodeString(bytes: Uint8Array): Format.Values.StringValueInfo {
       kind: "valid" as const,
       asString: correctlyEncodedString
     };
-  } catch (_) {
+  } catch {
     //we're going to ignore the precise error and just assume it's because
     //the string was malformed (what else could it be?)
     let hexString = Conversion.toHexString(bytes);

--- a/packages/codec/lib/errors.ts
+++ b/packages/codec/lib/errors.ts
@@ -36,3 +36,31 @@ export class StopDecodingError extends Error {
     this.allowRetry = Boolean(allowRetry);
   }
 }
+
+/**
+ * @hidden
+ */
+export function handleDecodingError(
+  dataType: Format.Types.Type,
+  error: any,
+  strict: boolean = false
+): Format.Errors.ErrorResult {
+  if (error instanceof DecodingError) {
+    //expected error
+    if (strict) {
+      //strict mode -- stop decoding on errors
+      throw new StopDecodingError(error.error);
+    } else {
+      //nonstrict mode -- return an error result
+      return <Format.Errors.ErrorResult>{
+        //I don't know why TS's inference is failing here and needs the coercion
+        type: dataType,
+        kind: "error" as const,
+        error: error.error
+      };
+    }
+  } else {
+    //if it's *not* an expected error, we better not swallow it -- rethrow!
+    throw error;
+  }
+}

--- a/packages/codec/lib/memory/decode/index.ts
+++ b/packages/codec/lib/memory/decode/index.ts
@@ -69,12 +69,16 @@ export function* decodeMemoryReferenceByAddress(
   try {
     rawValue = yield* read(pointer, state);
   } catch (error) {
-    return <Format.Errors.ErrorResult>{
-      //dunno why TS is failing here
-      type: dataType,
-      kind: "error" as const,
-      error: (<DecodingError>error).error
-    };
+    if (error instanceof DecodingError) {
+      return <Format.Errors.ErrorResult>{
+        //dunno why TS is failing here
+        type: dataType,
+        kind: "error" as const,
+        error: error.error
+      };
+    } else {
+      throw error;
+    }
   }
 
   let startPositionAsBN = Conversion.toBN(rawValue);
@@ -114,12 +118,16 @@ export function* decodeMemoryReferenceByAddress(
           state
         );
       } catch (error) {
-        return <Format.Errors.ErrorResult>{
-          //dunno why TS is failing here
-          type: dataType,
-          kind: "error" as const,
-          error: (<DecodingError>error).error
-        };
+        if (error instanceof DecodingError) {
+          return <Format.Errors.ErrorResult>{
+            //dunno why TS is failing here
+            type: dataType,
+            kind: "error" as const,
+            error: error.error
+          };
+        } else {
+          throw error;
+        }
       }
       lengthAsBN = Conversion.toBN(rawLength);
       try {
@@ -171,11 +179,15 @@ export function* decodeMemoryReferenceByAddress(
             state
           );
         } catch (error) {
-          return {
-            type: dataType,
-            kind: "error" as const,
-            error: (<DecodingError>error).error
-          };
+          if (error instanceof DecodingError) {
+            return {
+              type: dataType,
+              kind: "error" as const,
+              error: error.error
+            };
+          } else {
+            throw error;
+          }
         }
         lengthAsBN = Conversion.toBN(rawLength);
         startPosition += Evm.Utils.WORD_SIZE; //increment startPosition

--- a/packages/codec/lib/memory/decode/index.ts
+++ b/packages/codec/lib/memory/decode/index.ts
@@ -11,7 +11,7 @@ import * as Pointer from "@truffle/codec/pointer";
 import { DecoderRequest, DecoderOptions } from "@truffle/codec/types";
 import * as Evm from "@truffle/codec/evm";
 import { isSkippedInMemoryStructs } from "@truffle/codec/memory/allocate";
-import { DecodingError } from "@truffle/codec/errors";
+import { handleDecodingError } from "@truffle/codec/errors";
 
 export function* decodeMemory(
   dataType: Format.Types.Type,
@@ -69,23 +69,14 @@ export function* decodeMemoryReferenceByAddress(
   try {
     rawValue = yield* read(pointer, state);
   } catch (error) {
-    if (error instanceof DecodingError) {
-      return <Format.Errors.ErrorResult>{
-        //dunno why TS is failing here
-        type: dataType,
-        kind: "error" as const,
-        error: error.error
-      };
-    } else {
-      throw error;
-    }
+    return handleDecodingError(dataType, error);
   }
 
   let startPositionAsBN = Conversion.toBN(rawValue);
   let startPosition: number;
   try {
     startPosition = startPositionAsBN.toNumber();
-  } catch (_) {
+  } catch {
     return <Format.Errors.ErrorResult>{
       //again with the TS failures...
       type: dataType,
@@ -118,21 +109,12 @@ export function* decodeMemoryReferenceByAddress(
           state
         );
       } catch (error) {
-        if (error instanceof DecodingError) {
-          return <Format.Errors.ErrorResult>{
-            //dunno why TS is failing here
-            type: dataType,
-            kind: "error" as const,
-            error: error.error
-          };
-        } else {
-          throw error;
-        }
+        return handleDecodingError(dataType, error);
       }
       lengthAsBN = Conversion.toBN(rawLength);
       try {
         length = lengthAsBN.toNumber();
-      } catch (_) {
+      } catch {
         return <
           | Format.Errors.BytesDynamicErrorResult
           | Format.Errors.StringErrorResult
@@ -179,15 +161,7 @@ export function* decodeMemoryReferenceByAddress(
             state
           );
         } catch (error) {
-          if (error instanceof DecodingError) {
-            return {
-              type: dataType,
-              kind: "error" as const,
-              error: error.error
-            };
-          } else {
-            throw error;
-          }
+          return handleDecodingError(dataType, error);
         }
         lengthAsBN = Conversion.toBN(rawLength);
         startPosition += Evm.Utils.WORD_SIZE; //increment startPosition
@@ -197,7 +171,7 @@ export function* decodeMemoryReferenceByAddress(
       }
       try {
         length = lengthAsBN.toNumber();
-      } catch (_) {
+      } catch {
         return {
           type: dataType,
           kind: "error" as const,

--- a/packages/codec/lib/stack/decode/index.ts
+++ b/packages/codec/lib/stack/decode/index.ts
@@ -22,12 +22,16 @@ export function* decodeStack(
   try {
     rawValue = yield* read(pointer, info.state);
   } catch (error) {
-    return <Format.Errors.ErrorResult>{
-      //no idea why TS is failing here
-      type: dataType,
-      kind: "error" as const,
-      error: (<DecodingError>error).error
-    };
+    if (error instanceof DecodingError) {
+      return <Format.Errors.ErrorResult>{
+        //no idea why TS is failing here
+        type: dataType,
+        kind: "error" as const,
+        error: error.error
+      };
+    } else {
+      throw error;
+    }
   }
   const literalPointer: Pointer.StackLiteralPointer = {
     location: "stackliteral" as const,

--- a/packages/codec/lib/stack/decode/index.ts
+++ b/packages/codec/lib/stack/decode/index.ts
@@ -11,7 +11,7 @@ import * as Storage from "@truffle/codec/storage";
 import * as Pointer from "@truffle/codec/pointer";
 import { DecoderRequest } from "@truffle/codec/types";
 import * as Evm from "@truffle/codec/evm";
-import { DecodingError } from "@truffle/codec/errors";
+import { handleDecodingError } from "@truffle/codec/errors";
 
 export function* decodeStack(
   dataType: Format.Types.Type,
@@ -22,16 +22,7 @@ export function* decodeStack(
   try {
     rawValue = yield* read(pointer, info.state);
   } catch (error) {
-    if (error instanceof DecodingError) {
-      return <Format.Errors.ErrorResult>{
-        //no idea why TS is failing here
-        type: dataType,
-        kind: "error" as const,
-        error: error.error
-      };
-    } else {
-      throw error;
-    }
+    return handleDecodingError(dataType, error);
   }
   const literalPointer: Pointer.StackLiteralPointer = {
     location: "stackliteral" as const,

--- a/packages/codec/lib/storage/decode/index.ts
+++ b/packages/codec/lib/storage/decode/index.ts
@@ -41,12 +41,16 @@ export function* decodeStorageReferenceByAddress(
   try {
     rawValue = yield* read(pointer, info.state);
   } catch (error) {
-    return <Format.Errors.ErrorResult>{
-      //no idea why TS is failing here
-      type: dataType,
-      kind: "error" as const,
-      error: (<DecodingError>error).error
-    };
+    if (error instanceof DecodingError) {
+      return <Format.Errors.ErrorResult>{
+        //no idea why TS is failing here
+        type: dataType,
+        kind: "error" as const,
+        error: error.error
+      };
+    } else {
+      throw error;
+    }
   }
   const startOffset = Conversion.toBN(rawValue);
   let rawSize: Storage.StorageLength;
@@ -54,12 +58,16 @@ export function* decodeStorageReferenceByAddress(
     rawSize = storageSize(dataType, info.userDefinedTypes, allocations);
   } catch (error) {
     //error: DecodingError
-    return <Format.Errors.ErrorResult>{
-      //no idea why TS is failing here
-      type: dataType,
-      kind: "error" as const,
-      error: (<DecodingError>error).error
-    };
+    if (error instanceof DecodingError) {
+      return <Format.Errors.ErrorResult>{
+        //no idea why TS is failing here
+        type: dataType,
+        kind: "error" as const,
+        error: error.error
+      };
+    } else {
+      throw error;
+    }
   }
   //we *know* the type being decoded must be sized in words, because it's a
   //reference type, but TypeScript doesn't, so we'll have to use a type
@@ -109,12 +117,16 @@ export function* decodeStorageReference(
           try {
             data = yield* read(pointer, state);
           } catch (error) {
-            return <Format.Errors.ErrorResult>{
-              //no idea why TS is failing here
-              type: dataType,
-              kind: "error" as const,
-              error: (<DecodingError>error).error
-            };
+            if (error instanceof DecodingError) {
+              return <Format.Errors.ErrorResult>{
+                //no idea why TS is failing here
+                type: dataType,
+                kind: "error" as const,
+                error: error.error
+              };
+            } else {
+              throw error;
+            }
           }
           lengthAsBN = Conversion.toBN(data);
           break;
@@ -147,11 +159,15 @@ export function* decodeStorageReference(
         );
       } catch (error) {
         //error: DecodingError
-        return {
-          type: dataType,
-          kind: "error" as const,
-          error: (<DecodingError>error).error
-        };
+        if (error instanceof DecodingError) {
+          return {
+            type: dataType,
+            kind: "error" as const,
+            error: error.error
+          };
+        } else {
+          throw error;
+        }
       }
       debug("baseSize %o", baseSize);
 
@@ -254,12 +270,16 @@ export function* decodeStorageReference(
       try {
         data = yield* read(pointer, state);
       } catch (error) {
-        return <Format.Errors.ErrorResult>{
-          //no idea why TS is failing here
-          type: dataType,
-          kind: "error" as const,
-          error: (<DecodingError>error).error
-        };
+        if (error instanceof DecodingError) {
+          return <Format.Errors.ErrorResult>{
+            //no idea why TS is failing here
+            type: dataType,
+            kind: "error" as const,
+            error: (<DecodingError>error).error
+          };
+        } else {
+          throw error;
+        }
       }
 
       let lengthByte = data[Evm.Utils.WORD_SIZE - 1];
@@ -410,11 +430,15 @@ export function* decodeStorageReference(
       } catch (error) {
         //error: DecodingError
         debug("couldn't get value size! error: %o", error);
-        return {
-          type: dataType,
-          kind: "error" as const,
-          error: (<DecodingError>error).error
-        };
+        if (error instanceof DecodingError) {
+          return {
+            type: dataType,
+            kind: "error" as const,
+            error: (<DecodingError>error).error
+          };
+        } else {
+          throw error;
+        }
       }
 
       let decodedEntries: Format.Values.KeyValuePair[] = [];


### PR DESCRIPTION
So, I think Codec's error handling was causing some problems.  The decoding functions would just catch errors and *assume* they were expected errors we knew what to do with.  Seems they weren't always.  Now I've added a check for this, and the error will be rethrown if it's not a `DecodingError` (i.e., an expected error that we threw).

Kind of wondering if I should factor this, but not clear where the function would live?  This is probably OK for now.

(In more detail, the problem is that unexpected errors, instead of getting rethrown, were having their `error` field extracted -- which would be `undefined` since it wasn't a `DecodingError` -- and returned inside an error result.  This would then cause problems *later* when other code attempted to *use* that `undefined`, and we would have no useful stacktrace to the error's origin.  The solution, of course, is that unexpected errors should be rethrown, which means explicitly checking whether the error we got was expected or not.)