### PR TITLE
Allow using docker with --fetch-external

### DIFF
--- a/packages/core/lib/debug/external.js
+++ b/packages/core/lib/debug/external.js
@@ -98,6 +98,13 @@ class DebugExternalHandler {
           compilers: {
             solc: options
           }
+        }).merge({
+          //turn on docker if the original config has docker
+          compilers: {
+            solc: {
+              docker: ((this.config.compilers || {}).solc || {}).docker
+            }
+          }
         });
         const compilations = await new DebugCompiler(externalConfig).compile(
           sources


### PR DESCRIPTION
As suggested by @gnidan.  Now, if you have the `docker` turned option in your solc config, it will also be applied to sources compiled with `--fetch-external`.  Pretty simple, really.