### PR TITLE
When searching @truffle/db network relationships, return one CandidateSearchResult instead of list

### DIFF
--- a/packages/db/src/test/networkGenealogy.graphql.ts
+++ b/packages/db/src/test/networkGenealogy.graphql.ts
@@ -28,7 +28,7 @@ export const FindAncestors = gql`
   query findAncestorCandidates($id: ID!, $alreadyTried: [ID]!, $limit: Int) {
     network(id: $id) {
       possibleAncestors(alreadyTried: $alreadyTried, limit: $limit) {
-        network {
+        networks {
           id
           historicBlock {
             hash
@@ -48,7 +48,7 @@ export const FindDescendants = gql`
   query findDescendantCandidates($id: ID!, $alreadyTried: [ID]!, $limit: Int) {
     network(id: $id) {
       possibleDescendants(alreadyTried: $alreadyTried, limit: $limit) {
-        network {
+        networks {
           id
           historicBlock {
             hash


### PR DESCRIPTION
- Move list to `networks`, renamed from `network`
- Return only a single `alreadyTried`, rather than a separate `alreadyTried` for each candidate