### PR TITLE
Internal improvement: Remove use of Truffle Test in decoder tests

### DIFF
--- a/packages/debugger/test/helpers.js
+++ b/packages/debugger/test/helpers.js
@@ -15,7 +15,7 @@ import flatten from "lodash.flatten";
 export async function prepareContracts(provider, sources = {}, migrations) {
   let config = await createSandbox();
 
-  let accounts = await getAccounts(provider);
+  const accounts = await new Web3(provider).eth.getAccounts();
 
   config.networks["debugger"] = {
     provider: provider,
@@ -56,16 +56,6 @@ export async function prepareContracts(provider, sources = {}, migrations) {
     compilations,
     config
   };
-}
-
-export function getAccounts(provider) {
-  let web3 = new Web3(provider);
-  return new Promise(function (accept, reject) {
-    web3.eth.getAccounts(function (err, accounts) {
-      if (err) return reject(err);
-      accept(accounts);
-    });
-  });
 }
 
 export async function createSandbox() {

--- a/packages/decoder/package.json
+++ b/packages/decoder/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@truffle/abi-utils": "^0.1.1",
     "@truffle/codec": "^0.9.1",
-    "@truffle/compile-solidity": "^5.1.2",
+    "@truffle/compile-common": "^0.5.0",
     "@truffle/source-map-utils": "^1.3.29",
     "bn.js": "^4.11.8",
     "debug": "^4.1.0",

--- a/packages/decoder/package.json
+++ b/packages/decoder/package.json
@@ -17,7 +17,7 @@
     "build": "tsc",
     "prepare": "yarn build",
     "start": "tsc --watch",
-    "test": "cd test/current && npx truffle test && cd ../legacy && npx truffle test"
+    "test": "mocha ./test/current/test/* ./test/legacy/test/*"
   },
   "types": "dist/index.d.ts",
   "dependencies": {
@@ -30,19 +30,21 @@
     "source-map-support": "^0.5.19",
     "web3": "1.2.9"
   },
-  "peerDependencies": {
-    "truffle": "^5.0.14"
-  },
   "devDependencies": {
     "@truffle/config": "^1.2.33",
     "@truffle/contract-schema": "^3.3.2",
+    "@truffle/migrate": "^3.2.4",
     "@truffle/provider": "^0.2.25",
+    "@truffle/workflow-compile": "^3.1.2",
     "@types/big.js": "^4.0.5",
     "@types/bn.js": "^4.11.2",
     "@types/debug": "^0.0.31",
     "@types/web3": "1.0.19",
     "chai": "^4.2.0",
+    "ganache-core": "^2.13.1",
     "lodash.clonedeep": "^4.5.0",
+    "lodash.flatten": "^4.4.0",
+    "tmp": "^0.2.1",
     "typescript": "3.9.6"
   },
   "keywords": [

--- a/packages/decoder/test/current/test/receive-test.js
+++ b/packages/decoder/test/current/test/receive-test.js
@@ -1,25 +1,49 @@
 const debug = require("debug")("decoder:test:receive-test");
 const assert = require("chai").assert;
+const Ganache = require("ganache-core");
+const path = require("path");
+const Web3 = require("web3");
 
 const Decoder = require("../../..");
 
-const ReceiveTest = artifacts.require("ReceiveTest");
-const FallbackTest = artifacts.require("FallbackTest");
+const { prepareContracts } = require("../../helpers");
 
-contract("ReceiveTest", function(accounts) {
+describe("Non-function transactions", function() {
+
+  let provider;
+  let abstractions;
+  let compilations;
+  let web3;
+
+  let Contracts;
+
+  before("Create Provider", async function () {
+    provider = Ganache.provider({seed: "decoder", gasLimit: 7000000});
+    web3 = new Web3(provider);
+  });
+
+  before("Prepare contracts and artifacts", async function () {
+    this.timeout(30000);
+
+    const prepared = await prepareContracts(provider, path.resolve(__dirname, ".."));
+    abstractions = prepared.abstractions;
+    compilations = prepared.compilations;
+
+    Contracts = [
+      abstractions.ReceiveTest,
+      abstractions.FallbackTest,
+    ];
+  });
+
   it("should decode transactions that invoke fallback or receive", async function() {
-    let receiveTest = await ReceiveTest.deployed();
-    let fallbackTest = await FallbackTest.deployed();
+    let receiveTest = await abstractions.ReceiveTest.deployed();
+    let fallbackTest = await abstractions.FallbackTest.deployed();
 
-    const decoder = await Decoder.forProject(web3.currentProvider, [
-      FallbackTest,
-      ReceiveTest
-    ]);
+    const decoder = await Decoder.forProject(web3.currentProvider, Contracts);
 
     let receiveHash = (await receiveTest.send(1)).tx;
     let fallbackNoDataHash = (await fallbackTest.send(1)).tx;
     let fallbackDataHash = (await receiveTest.sendTransaction({
-      from: accounts[0],
       to: receiveTest.address,
       data: "0xdeadbeef"
     })).tx;

--- a/packages/decoder/test/helpers.js
+++ b/packages/decoder/test/helpers.js
@@ -1,0 +1,86 @@
+const debugModule = require("debug");
+const debug = debugModule("decoder:test:helpers");
+
+const fs = require("fs");
+const WorkflowCompile = require("@truffle/workflow-compile");
+const Web3 = require("web3");
+const Migrate = require("@truffle/migrate");
+const Codec = require("@truffle/codec");
+const Config = require("@truffle/config");
+const { Environment } = require("@truffle/environment");
+const flatten = require("lodash.flatten");
+const tmp = require("tmp");
+tmp.setGracefulCleanup();
+
+async function prepareContracts(provider, projectDir) {
+
+  const temporaryDirectory = tmp.dirSync({
+    unsafeCleanup: true,
+    prefix: "test-"
+  }).name;
+
+  let config = Config.detect({ working_directory: projectDir }).merge(
+    {
+      contracts_build_directory: temporaryDirectory,
+      networks: {
+        decoder: {
+          provider,
+          network_id: "*"
+        }
+      },
+      network: "decoder"
+    }
+  );
+
+  await Environment.detect(config);
+
+  let { contractNames, compilations: rawCompilations } = await compile(config);
+
+  await migrate(config);
+
+  let abstractions = {};
+  for (const name of contractNames) {
+    abstractions[name] = config.resolver.require(name);
+  }
+
+  const compilations = Codec.Compilations.Utils.shimCompilations(rawCompilations);
+
+  return {
+    abstractions,
+    compilations,
+    config
+  };
+}
+
+async function compile(config) {
+  const { compilations } = await WorkflowCompile.compileAndSave(
+    config.with({
+      all: true,
+      quiet: true
+    })
+  );
+  const contractNames = flatten(
+    compilations.map(compilation =>
+      compilation.contracts.map(contract => contract.contractName)
+    )
+  );
+  return { compilations, contractNames };
+}
+
+async function migrate(config) {
+  return new Promise(function (accept, reject) {
+    Migrate.run(
+      config.with({
+        quiet: true
+      }),
+      function (err, contracts) {
+        if (err) return reject(err);
+        accept(contracts);
+      }
+    );
+  });
+}
+
+module.exports = {
+  prepareContracts
+}

--- a/packages/decoder/test/legacy/test/shadow-test.js
+++ b/packages/decoder/test/legacy/test/shadow-test.js
@@ -1,17 +1,35 @@
 const debug = require("debug")("decoder:test:shadow-test");
 const assert = require("chai").assert;
+const Ganache = require("ganache-core");
+const path = require("path");
 
 const Decoder = require("../../..");
 const Codec = require("@truffle/codec");
 
-const ShadowBase = artifacts.require("ShadowBase");
-const ShadowDerived = artifacts.require("ShadowDerived");
+const { prepareContracts } = require("../../helpers");
 
-contract("ShadowDerived", function(_accounts) {
+describe("Shadowed storage variables", function() {
+
+  let provider;
+  let abstractions;
+  let compilations;
+
+  before("Create Provider", async function () {
+    provider = Ganache.provider({seed: "decoder", gasLimit: 7000000});
+  });
+
+  before("Prepare contracts and artifacts", async function () {
+    this.timeout(30000);
+
+    const prepared = await prepareContracts(provider, path.resolve(__dirname, ".."));
+    abstractions = prepared.abstractions;
+    compilations = prepared.compilations;
+  });
+
   it("Includes shadowed storage variables in variables", async function() {
-    let deployedContract = await ShadowDerived.deployed();
+    let deployedContract = await abstractions.ShadowDerived.deployed();
     let decoder = await Decoder.forContractInstance(deployedContract, [
-      ShadowBase
+      abstractions.ShadowBase
     ]);
 
     let variables = await decoder.variables();
@@ -23,9 +41,9 @@ contract("ShadowDerived", function(_accounts) {
   });
 
   it("Fetches variables by name or qualified name", async function() {
-    let deployedContract = await ShadowDerived.deployed();
+    let deployedContract = await abstractions.ShadowDerived.deployed();
     let decoder = await Decoder.forContractInstance(deployedContract, [
-      ShadowBase
+      abstractions.ShadowBase
     ]);
 
     const expectedBaseX = 1;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9222,6 +9222,18 @@ eth-sig-util@^1.4.2:
     ethereumjs-abi "git+https://github.com/ethereumjs/ethereumjs-abi.git"
     ethereumjs-util "^5.1.1"
 
+eth-sig-util@^2.0.0:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/eth-sig-util/-/eth-sig-util-2.5.3.tgz#6938308b38226e0b3085435474900b03036abcbe"
+  integrity sha512-KpXbCKmmBUNUTGh9MRKmNkIPietfhzBqqYqysDavLseIiMUGl95k6UcPEkALAZlj41e9E6yioYXc1PC333RKqw==
+  dependencies:
+    buffer "^5.2.1"
+    elliptic "^6.4.0"
+    ethereumjs-abi "0.6.5"
+    ethereumjs-util "^5.1.1"
+    tweetnacl "^1.0.0"
+    tweetnacl-util "^0.15.0"
+
 eth-tx-summary@^3.1.2:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/eth-tx-summary/-/eth-tx-summary-3.2.4.tgz#e10eb95eb57cdfe549bf29f97f1e4f1db679035c"
@@ -9319,7 +9331,7 @@ ethereumjs-abi@0.6.7:
     bn.js "^4.11.8"
     ethereumjs-util "^6.0.0"
 
-ethereumjs-abi@^0.6.8, "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git":
+ethereumjs-abi@0.6.8, ethereumjs-abi@^0.6.8, "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git":
   version "0.6.8"
   resolved "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b"
   dependencies:
@@ -10746,6 +10758,43 @@ ganache-core@2.13.0:
     encoding-down "5.0.4"
     eth-sig-util "2.3.0"
     ethereumjs-abi "0.6.7"
+    ethereumjs-account "3.0.0"
+    ethereumjs-block "2.2.2"
+    ethereumjs-common "1.5.0"
+    ethereumjs-tx "2.1.2"
+    ethereumjs-util "6.2.1"
+    ethereumjs-vm "4.2.0"
+    heap "0.2.6"
+    keccak "3.0.1"
+    level-sublevel "6.6.4"
+    levelup "3.1.1"
+    lodash "4.17.20"
+    lru-cache "5.1.1"
+    merkle-patricia-tree "3.0.0"
+    patch-package "6.2.2"
+    seedrandom "3.0.1"
+    source-map-support "0.5.12"
+    tmp "0.1.0"
+    web3-provider-engine "14.2.1"
+    websocket "1.0.32"
+  optionalDependencies:
+    ethereumjs-wallet "0.6.5"
+    web3 "1.2.11"
+
+ganache-core@^2.13.1:
+  version "2.13.1"
+  resolved "https://registry.yarnpkg.com/ganache-core/-/ganache-core-2.13.1.tgz#bf60399a2dd084e1090db91cbbc7ed3885dc01e4"
+  integrity sha512-Ewg+kNcDqXtOohe7jCcP+ZUv9EMzOx2MoqOYYP3BCfxrDh3KjBXXaKK+Let7li0TghAs9lxmBgevZku35j5YzA==
+  dependencies:
+    abstract-leveldown "3.0.0"
+    async "2.6.2"
+    bip39 "2.5.0"
+    cachedown "1.0.0"
+    clone "2.1.2"
+    debug "3.2.6"
+    encoding-down "5.0.4"
+    eth-sig-util "^2.0.0"
+    ethereumjs-abi "0.6.8"
     ethereumjs-account "3.0.0"
     ethereumjs-block "2.2.2"
     ethereumjs-common "1.5.0"


### PR DESCRIPTION
Addresses #3310.  This PR gets rid of the use of Truffle Test in the decoder tests, hopefully finally ending the headache they've posed and defusing any potential future problems they might pose with `lerna`.

To do this I reconstituted them along the lines of the debugger tests.  However I didn't want to remove the existing structure, so I kept the existing structure as two truffle projects in place and added `helpers.js`, much like exists in the debugger, to set things up.  However unlike in the debugger, we already have the structure of a Truffle project here, so we don't need to set up a sandbox, but rather just use `Config.detect` and `Environment.detect`.  We do use a temporary directory for the contracts build directory, but that's it.

The tests are a fair bit slower now due to their use of `Ganache.provider()`, but whatever.  Also I used `web3` and `abstractions` as global variables in one test, but, oh well, I think it's fine.