### PR TITLE
Consistently use Config.default() when compiling

### DIFF
--- a/packages/compile-solidity/index.js
+++ b/packages/compile-solidity/index.js
@@ -1,11 +1,11 @@
-const debug = require("debug")("compile"); // eslint-disable-line no-unused-vars
+const debug = require("debug")("compile");
 const path = require("path");
 const expect = require("@truffle/expect");
 const findContracts = require("@truffle/contract-sources");
 const Config = require("@truffle/config");
 const Profiler = require("./profiler");
 const CompilerSupplier = require("./compilerSupplier");
-const {run} = require("./run");
+const { run } = require("./run");
 
 const normalizeOptions = options => {
   if (options.logger === undefined) options.logger = console;
@@ -40,11 +40,12 @@ const normalizeOptions = options => {
 const Compile = {
   // this takes an object with keys being the name and values being source
   // material as well as an options object
-  async sources({sources, options}) {
+  async sources({ sources, options }) {
+    options = Config.default().merge(options);
     const compilation = await run(sources, normalizeOptions(options));
     return compilation.contracts.length > 0
-      ? {compilations: [compilation]}
-      : {compilations: []};
+      ? { compilations: [compilation] }
+      : { compilations: [] };
   },
 
   async all(options) {
@@ -57,7 +58,7 @@ const Compile = {
 
     return await Compile.sourcesWithDependencies({
       paths,
-      options: Config.default().merge(options)
+      options
     });
   },
 
@@ -68,12 +69,12 @@ const Compile = {
 
     return await Compile.sourcesWithDependencies({
       paths,
-      options: Config.default().merge(options)
+      options
     });
   },
 
   // this takes an array of paths and options
-  async sourcesWithDependencies({paths, options}) {
+  async sourcesWithDependencies({ paths, options }) {
     options.logger = options.logger || console;
     options.contracts_directory = options.contracts_directory || process.cwd();
 
@@ -83,9 +84,9 @@ const Compile = {
       "resolver"
     ]);
 
-    const config = Config.default().merge(options);
-    const {allSources, compilationTargets} = await Profiler.requiredSources(
-      config.with({
+    options = Config.default().merge(options);
+    const { allSources, compilationTargets } = await Profiler.requiredSources(
+      options.with({
         paths,
         base_path: options.contracts_directory,
         resolver: options.resolver
@@ -100,15 +101,15 @@ const Compile = {
 
     // when there are no sources, don't call run
     if (Object.keys(allSources).length === 0) {
-      return {compilations: []};
+      return { compilations: [] };
     }
 
     options.compilationTargets = compilationTargets;
-    const {sourceIndexes, sources, contracts, compiler} = await run(
+    const { sourceIndexes, sources, contracts, compiler } = await run(
       allSources,
       normalizeOptions(options)
     );
-    const {name, version} = compiler;
+    const { name, version } = compiler;
     // returns CompilerResult - see @truffle/compile-common
     return contracts.length > 0
       ? {
@@ -117,11 +118,11 @@ const Compile = {
               sourceIndexes,
               sources,
               contracts,
-              compiler: {name, version}
+              compiler: { name, version }
             }
           ]
         }
-      : {compilations: []};
+      : { compilations: [] };
   },
 
   display(paths, options) {

--- a/packages/compile-vyper/index.js
+++ b/packages/compile-vyper/index.js
@@ -8,6 +8,7 @@ const semver = require("semver");
 
 const findContracts = require("@truffle/contract-sources");
 const Common = require("@truffle/compile-common");
+const Config = require("@truffle/config");
 
 const { compileAllJson } = require("./vyper-json");
 
@@ -177,6 +178,7 @@ async function compileAllNoJson({ sources, options, version }) {
 const Compile = {
   // Check that vyper is available then forward to internal compile function
   async sources({ sources = [], options }) {
+    options = Config.default().merge(options);
     // filter out non-vyper paths
     const vyperFiles = sources.filter(path => minimatch(path, VYPER_PATTERN));
 

--- a/packages/compile-vyper/package.json
+++ b/packages/compile-vyper/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@truffle/compile-common": "^0.5.0",
+    "@truffle/config": "^1.2.33",
     "colors": "^1.1.2",
     "debug": "^4.3.1",
     "eslint": "^5.5.0",

--- a/packages/config/src/configDefaults.ts
+++ b/packages/config/src/configDefaults.ts
@@ -46,6 +46,8 @@ export const getInitialConfig = ({
     compilers: {
       solc: {
         settings: {
+          //Note: The default solc version is *not* set here!
+          //It's set in compilerSupplier/index.js in compile-solidity
           optimizer: {
             enabled: false,
             runs: 200

--- a/packages/config/src/configDefaults.ts
+++ b/packages/config/src/configDefaults.ts
@@ -53,7 +53,9 @@ export const getInitialConfig = ({
           remappings: []
         }
       },
-      vyper: {}
+      vyper: {
+        settings: {}
+      }
     },
     logger: console
   };

--- a/packages/external-compile/index.js
+++ b/packages/external-compile/index.js
@@ -1,15 +1,16 @@
 "use strict";
 
 const debug = require("debug")("external-compile");
-const {exec, execSync} = require("child_process");
+const { exec, execSync } = require("child_process");
 const resolve = require("path").resolve;
-const {promisify} = require("util");
+const { promisify } = require("util");
 const glob = promisify(require("glob"));
 const fs = require("fs");
 const expect = require("@truffle/expect");
 const Schema = require("@truffle/contract-schema");
 const web3Utils = require("web3-utils");
-const {Shims} = require("@truffle/compile-common");
+const { Shims } = require("@truffle/compile-common");
+const Config = require("@truffle/config");
 
 const DEFAULT_ABI = [
   {
@@ -86,8 +87,8 @@ function* bufferLines() {
  * invokes callback when process exits, error on nonzero exit code.
  */
 const runCommand = promisify(function (command, options, callback) {
-  const {cwd, logger, input} = options;
-  const child = exec(command, {cwd, input});
+  const { cwd, logger, input } = options;
+  const child = exec(command, { cwd, input });
 
   // wrap buffer generator for easy use
   const buffer = func => {
@@ -96,7 +97,7 @@ const runCommand = promisify(function (command, options, callback) {
     return data => {
       gen.next();
 
-      let {value: lines} = gen.next(data);
+      let { value: lines } = gen.next(data);
       for (let line of lines) {
         func(line);
       }
@@ -179,9 +180,9 @@ async function processTarget(target, cwd, logger) {
 
   if (usesCommand && !usesPath) {
     // just run command
-    const output = execSync(target.command, {cwd});
+    const output = execSync(target.command, { cwd });
     const contract = JSON.parse(output);
-    return {[contract.contractName]: contract};
+    return { [contract.contractName]: contract };
   }
 
   if (usesPath && !glob.hasMagic(target.path)) {
@@ -191,23 +192,23 @@ async function processTarget(target, cwd, logger) {
     if (usesStdin) {
       input = fs.readFileSync(filename).toString();
       command = target.command;
-      execOptions = {cwd, input};
+      execOptions = { cwd, input };
     } else {
       command = `${target.command} ${filename}`;
-      execOptions = {cwd};
+      execOptions = { cwd };
     }
 
     const output = usesCommand ? execSync(command, execOptions) : input;
 
     const contract = JSON.parse(output);
-    return {[contract.contractName]: contract};
+    return { [contract.contractName]: contract };
   }
 
   if (usesPath && glob.hasMagic(target.path)) {
     // glob expression, recurse after expansion
-    let paths = await glob(target.path, {cwd, follow: true});
+    let paths = await glob(target.path, { cwd, follow: true });
     // copy target properties, overriding path with expanded form
-    let targets = paths.map(path => Object.assign({}, target, {path}));
+    let targets = paths.map(path => Object.assign({}, target, { path }));
     return await processTargets(targets, cwd, logger);
   }
 
@@ -238,7 +239,7 @@ async function processTarget(target, cwd, logger) {
       );
     }
 
-    return {[contract.contractName]: contract};
+    return { [contract.contractName]: contract };
   }
 }
 
@@ -261,7 +262,8 @@ const Compile = {
 
   // compile-common defines object argument to include `sources`, but this is
   // unused as the user is responsible for dealing with compiling their sources
-  async sources({options}) {
+  async sources({ options }) {
+    options = Config.default().merge(options);
     if (options.logger == null) {
       options.logger = console;
     }
@@ -270,7 +272,7 @@ const Compile = {
     expect.options(options.compilers, ["external"]);
     expect.options(options.compilers.external, ["command", "targets"]);
 
-    const {command, targets} = options.compilers.external;
+    const { command, targets } = options.compilers.external;
     const cwd =
       options.compilers.external.workingDirectory ||
       options.compilers.external.working_directory || // just in case
@@ -278,7 +280,7 @@ const Compile = {
     const logger = options.logger;
 
     debug("running compile command: %s", command);
-    await runCommand(command, {cwd, logger});
+    await runCommand(command, { cwd, logger });
 
     const contracts = await processTargets(targets, cwd, logger);
     return {
@@ -300,8 +302,8 @@ const Compile = {
     };
   },
 
-  async sourcesWithDependencies({options}) {
-    return await Compile.sources({options});
+  async sourcesWithDependencies({ options }) {
+    return await Compile.sources({ options });
   }
 };
 

--- a/packages/external-compile/package.json
+++ b/packages/external-compile/package.json
@@ -15,6 +15,7 @@
     "test": "mocha"
   },
   "dependencies": {
+    "@truffle/config": "^1.2.33",
     "@truffle/contract-schema": "^3.3.2",
     "@truffle/expect": "^0.0.15",
     "debug": "^4.1.0",


### PR DESCRIPTION
Sometimes when we compile, we take `Config.defaults()` and merge the given options into it.  Sometimes we don't.  I made it so we always do.  Note I didn't do it in each individual function, I just made sure each path eventually hits it.  I did this for all three compile packages.

Also, in the defaults, I added `settings` under `vyper`, and added a comment explaining where the default solc version is found (since you might expect it to be there, but it's not).  I originally also changed `vyper-json.js` in `compile-vyper` to not do `settings || {}`, since I figured that would be unnecessary now, but uh that didn't end up working, so, uh, I left it alone...?  Not sure if that means I did someting wrong elsewhere...