### PR TITLE
Add support for settings.modelChecker

### DIFF
--- a/packages/compile-solidity/run.js
+++ b/packages/compile-solidity/run.js
@@ -138,6 +138,7 @@ function prepareCompilerInput({
       metadata: settings.metadata,
       libraries: settings.libraries,
       viaIR: settings.viaIR,
+      modelChecker: settings.modelChecker,
       // Specify compilation targets. Each target uses defaultSelectors,
       // defaulting to single target `*` if targets are unspecified
       outputSelection: prepareOutputSelection({ targets })


### PR DESCRIPTION
Solidity 0.7.6 and up use `settings.modelChecker` rather than a separate `modelCheckerSettings`, so I've added support for that.

NB @gnidan and @fainashalts: Despite being moved under `settings` now, the model checker settings still do not go in the metadata.