### PR TITLE
Update Solidity sources (e.g. Truffle Init Migrations file) for 0.8.0

### DIFF
--- a/packages/core/lib/commands/create/templates/Example.sol
+++ b/packages/core/lib/commands/create/templates/Example.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.4.22 <0.8.0;
+pragma solidity >=0.4.22 <0.9.0;
 
 contract Example {
   constructor() public {

--- a/packages/core/lib/commands/create/templates/Test.sol
+++ b/packages/core/lib/commands/create/templates/Test.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.4.22 <0.8.0;
+pragma solidity >=0.4.22 <0.9.0;
 
 import "truffle/DeployedAddresses.sol";
 import "truffle/Assert.sol";

--- a/packages/core/lib/commands/init/initSource/contracts/Migrations.sol
+++ b/packages/core/lib/commands/init/initSource/contracts/Migrations.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.4.22 <0.8.0;
+pragma solidity >=0.4.22 <0.9.0;
 
 contract Migrations {
   address public owner = msg.sender;

--- a/packages/core/test/lib/create.js
+++ b/packages/core/test/lib/create.js
@@ -43,8 +43,8 @@ describe("create", function () {
       assert.isNotNull(fileData, "File's data is null");
       assert.notEqual(fileData, "", "File's data is blank");
       assert.isTrue(
-        fileData.includes("pragma solidity >=0.4.22 <0.8.0;"),
-        "File's solidity version does not match >=0.4.22 <0.8.0"
+        fileData.includes("pragma solidity >=0.4.22 <0.9.0;"),
+        "File's solidity version does not match >=0.4.22 <0.9.0"
       );
       done();
     });

--- a/packages/resolver/lib/sources/truffle/Deployed.ts
+++ b/packages/resolver/lib/sources/truffle/Deployed.ts
@@ -13,7 +13,7 @@ export class Deployed {
     let source = "";
     source +=
       "//SPDX-License-Identifier: MIT\n" +
-      "pragma solidity >= 0.5.0 < 0.8.0; \n\n library DeployedAddresses {" +
+      "pragma solidity >= 0.5.0 < 0.9.0; \n\n library DeployedAddresses {" +
       "\n";
 
     for (let [name, address] of Object.entries(mapping)) {

--- a/packages/resolver/solidity/Assert.sol
+++ b/packages/resolver/solidity/Assert.sol
@@ -2,7 +2,7 @@
 // This file taken from here: https://raw.githubusercontent.com/smartcontractproduction/sol-unit/master/contracts/src/Assertions.sol
 // It was renamed to Assert.sol by Tim Coulter. Refactored for solidity 0.5.0 by Cruz Molina.
 
-pragma solidity >= 0.4.15 < 0.8.0;
+pragma solidity >= 0.4.15 < 0.9.0;
 
 import "truffle/AssertString.sol";
 import "truffle/AssertBytes32.sol";

--- a/packages/resolver/solidity/AssertAddress.sol
+++ b/packages/resolver/solidity/AssertAddress.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity >= 0.4.15 < 0.8.0;
+pragma solidity >= 0.4.15 < 0.9.0;
 
 library AssertAddress {
 

--- a/packages/resolver/solidity/AssertAddressArray.sol
+++ b/packages/resolver/solidity/AssertAddressArray.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity >= 0.4.15 < 0.8.0;
+pragma solidity >= 0.4.15 < 0.9.0;
 
 library AssertAddressArray {
     

--- a/packages/resolver/solidity/AssertBalance.sol
+++ b/packages/resolver/solidity/AssertBalance.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity >= 0.4.15 < 0.8.0;
+pragma solidity >= 0.4.15 < 0.9.0;
 
 library AssertBalance {
 

--- a/packages/resolver/solidity/AssertBool.sol
+++ b/packages/resolver/solidity/AssertBool.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity >= 0.4.15 < 0.8.0;
+pragma solidity >= 0.4.15 < 0.9.0;
 
 library AssertBool {
 

--- a/packages/resolver/solidity/AssertBytes32.sol
+++ b/packages/resolver/solidity/AssertBytes32.sol
@@ -1,6 +1,6 @@
 //SPDX-License-Identifier: MIT
 
-pragma solidity >= 0.4.15 < 0.8.0;
+pragma solidity >= 0.4.15 < 0.9.0;
 
 library AssertBytes32 {
 

--- a/packages/resolver/solidity/AssertBytes32Array.sol
+++ b/packages/resolver/solidity/AssertBytes32Array.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity >= 0.4.15 < 0.8.0;
+pragma solidity >= 0.4.15 < 0.9.0;
 
 library AssertBytes32Array {
     

--- a/packages/resolver/solidity/AssertGeneral.sol
+++ b/packages/resolver/solidity/AssertGeneral.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity >= 0.4.15 < 0.8.0;
+pragma solidity >= 0.4.15 < 0.9.0;
 
 library AssertGeneral {
 

--- a/packages/resolver/solidity/AssertInt.sol
+++ b/packages/resolver/solidity/AssertInt.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity >= 0.4.15 < 0.8.0;
+pragma solidity >= 0.4.15 < 0.9.0;
 
 library AssertInt {
 

--- a/packages/resolver/solidity/AssertIntArray.sol
+++ b/packages/resolver/solidity/AssertIntArray.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity >= 0.4.15 < 0.8.0;
+pragma solidity >= 0.4.15 < 0.9.0;
 
 library AssertIntArray {
 

--- a/packages/resolver/solidity/AssertString.sol
+++ b/packages/resolver/solidity/AssertString.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity >= 0.4.15 < 0.8.0;
+pragma solidity >= 0.4.15 < 0.9.0;
 
 library AssertString {
 

--- a/packages/resolver/solidity/AssertUint.sol
+++ b/packages/resolver/solidity/AssertUint.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity >= 0.4.15 < 0.8.0;
+pragma solidity >= 0.4.15 < 0.9.0;
 
 library AssertUint {
 

--- a/packages/resolver/solidity/AssertUintArray.sol
+++ b/packages/resolver/solidity/AssertUintArray.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity >= 0.4.15 < 0.8.0;
+pragma solidity >= 0.4.15 < 0.9.0;
 
 library AssertUintArray {
 

--- a/packages/resolver/solidity/NewSafeSend.sol
+++ b/packages/resolver/solidity/NewSafeSend.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity >= 0.5.0 < 0.8.0;
+pragma solidity >= 0.5.0 < 0.9.0;
 
 contract NewSafeSend {
   address payable public recipient;


### PR DESCRIPTION
Updates the Migrations file for 0.8.0.  Because we got rid of the explicit constructor earlier, all we should need to do is bump the pragma here. :)

Note @cds-amal I'm guessing you may want to do the same thing in your Truffle Boxes...