### PR TITLE
Upgrade @truffle/db typescript to ^4.1.3

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -71,7 +71,6 @@
     "@types/pouchdb": "^6.3.2",
     "@types/pouchdb-adapter-leveldb": "^6.1.3",
     "@types/web3": "1.0.20",
-    "@zerollup/ts-transform-paths": "^1.7.3",
     "ganache-core": "2.13.0",
     "hkts": "^0.3.1",
     "jest": "26.5.2",
@@ -81,7 +80,8 @@
     "ts-node-dev": "^1.0.0-pre.32",
     "tsconfig-paths": "^3.7.0",
     "ttypescript": "^1.5.7",
-    "typescript": "^3.6.3"
+    "typescript": "^4.1.3",
+    "typescript-transform-paths": "^2.1.0"
   },
   "keywords": [
     "database",

--- a/packages/db/src/process/index.ts
+++ b/packages/db/src/process/index.ts
@@ -4,8 +4,9 @@ const debug = logger("db:process");
 import { Collections } from "@truffle/db/meta";
 
 export * from "./types";
-export { _ } from "./batch";
-export * as Batch from "./batch";
+import { _ } from "./batch";
+import * as Batch from "./batch";
+export { _, Batch };
 export * from "./resources";
 export * from "./run";
 

--- a/packages/db/tsconfig.base.json
+++ b/packages/db/tsconfig.base.json
@@ -24,7 +24,8 @@
       "pouchdb"
     ],
     "plugins": [
-      { "transform": "@zerollup/ts-transform-paths", "exclude": "*" }
+      { "transform": "typescript-transform-paths" },
+      { "transform": "typescript-transform-paths", "afterDeclarations": true }
     ]
   },
   "include": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -21494,6 +21494,11 @@ typescript-logic@^0.0.0:
   resolved "https://registry.yarnpkg.com/typescript-logic/-/typescript-logic-0.0.0.tgz#66ebd82a2548f2b444a43667bec120b496890196"
   integrity sha512-zXFars5LUkI3zP492ls0VskH3TtdeHCqu0i7/duGt60i5IGPIpAHE/DWo5FqJ6EjQ15YKXrt+AETjv60Dat34Q==
 
+typescript-transform-paths@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/typescript-transform-paths/-/typescript-transform-paths-2.1.0.tgz#3d5c492910c59ce1a7bb762d3078185cbd11940d"
+  integrity sha512-xBzFzS5LTfTjyuT4fuqIk3MLDWsrJTNFs3y17CwVR54G6G/KtTZcVc9UjChgDTuoBffd+Q3oD99UtyDXRpuy/g==
+
 typescript-tuple@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/typescript-tuple/-/typescript-tuple-2.2.1.tgz#7d9813fb4b355f69ac55032e0363e8bb0f04dad2"
@@ -21516,7 +21521,7 @@ typescript@3.9.6:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.6.tgz#8f3e0198a34c3ae17091b35571d3afd31999365a"
   integrity sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==
 
-typescript@^3.0.3, typescript@^3.6.3, typescript@^3.7.5, typescript@^3.8.3, typescript@^3.9.5, typescript@^3.9.7:
+typescript@^3.0.3, typescript@^3.7.5, typescript@^3.8.3, typescript@^3.9.5, typescript@^3.9.7:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
@@ -21525,6 +21530,11 @@ typescript@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
   integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
+
+typescript@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
+  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
 
 typewise-core@^1.2, typewise-core@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
- Replace @zerollup/ts-transform-paths with typescript-transform-paths, since the former does not work anymore (for unknown reason)

- Fix an export that seems to go missing from compiler output, possibly due to unsupported syntax with typescript-transform-paths