### PR TITLE
Account for new-style invalid functions (uninitialized internal function pointers); update debugger tests to 0.8.0; fix various problems with generated sources

### DIFF
--- a/packages/codec/lib/format/utils/inspect.ts
+++ b/packages/codec/lib/format/utils/inspect.ts
@@ -266,7 +266,7 @@ export class ResultInspector {
                   case "exception":
                     return coercedResult.value.deployedProgramCounter === 0
                       ? options.stylize(`[Function: <zero>]`, "special")
-                      : options.stylize(`[Function: assert(false)]`, "special");
+                      : options.stylize(`[Function: <uninitialized>]`, "special");
                   case "unknown":
                     let firstLine = `[Function: decoding not supported (raw info:`;
                     let secondLine = `deployed PC=${coercedResult.value.deployedProgramCounter}, constructor PC=${coercedResult.value.constructorProgramCounter})]`;
@@ -618,7 +618,7 @@ function nativizeWithTable(
             case "exception":
               return coercedResult.value.deployedProgramCounter === 0
                 ? `<zero>`
-                : `assert(false)`;
+                : `<uninitialized>`;
             case "unknown":
               return `<decoding not supported>`;
           }

--- a/packages/debugger/lib/stacktrace/reducers.js
+++ b/packages/debugger/lib/stacktrace/reducers.js
@@ -86,8 +86,8 @@ function lastPosition(state = null, action) {
     case actions.UPDATE_POSITION:
     case actions.EXECUTE_RETURN:
       const { location } = action;
-      if (location.source.id === undefined) {
-        //don't update for unmapped!
+      if (location.source.id === undefined || location.source.internal) {
+        //don't update for unmapped or internal!
         return state;
       }
       return location;

--- a/packages/debugger/lib/stacktrace/sagas/index.js
+++ b/packages/debugger/lib/stacktrace/sagas/index.js
@@ -49,12 +49,14 @@ function* stacktraceSaga() {
   //technically, an EXECUTE_RETURN could happen as well as those below,
   //resulting in 2 actions instead of just one, but it's pretty unlikely.
   //(an EXTERNAL_RETURN, OTOH, is obviously exclusive of the possibilities below)
-  if (yield select(stacktrace.current.willJumpIn)) {
+  if ((yield select(stacktrace.current.willJumpIn)) && returnCounter === 0) {
+    //note: do NOT process jumps while there are returns waiting to execute
     const nextLocation = yield select(stacktrace.next.location);
     const nextParent = yield select(stacktrace.next.contractNode);
     yield put(actions.jumpIn(currentLocation, nextLocation.node, nextParent));
     positionUpdated = true;
-  } else if (yield select(stacktrace.current.willJumpOut)) {
+  } else if ((yield select(stacktrace.current.willJumpOut)) && returnCounter === 0) {
+    //again, do not process jumps while there are returns waiting to execute
     yield put(actions.jumpOut(currentLocation));
     positionUpdated = true;
   } else if (yield select(stacktrace.current.willCall)) {

--- a/packages/debugger/lib/stacktrace/selectors/index.js
+++ b/packages/debugger/lib/stacktrace/selectors/index.js
@@ -255,18 +255,20 @@ let stacktrace = createSelectorTree({
 
     /**
      * stacktrace.current.positionWillChange
+     * note: we disregard internal sources here!
      */
     positionWillChange: createLeaf(
       ["/next/location", "/current/location", "./lastPosition"],
       (nextLocation, currentLocation, lastLocation) => {
         let oldLocation =
-          currentLocation.source.id !== undefined
+          currentLocation.source.id !== undefined && !currentLocation.source.internal
             ? currentLocation
             : lastLocation;
         return (
           Boolean(oldLocation) && //if there's no current or last position, we don't need this check
           Boolean(nextLocation.source) &&
           nextLocation.source.id !== undefined && //if next location is unmapped, we consider ourselves to have not moved
+          !nextLocation.source.internal && //similarly if it's internal
           (nextLocation.source.id !== oldLocation.source.id ||
             nextLocation.sourceRange.start !== oldLocation.sourceRange.start ||
             nextLocation.sourceRange.length !== oldLocation.sourceRange.length)

--- a/packages/debugger/test/ast.js
+++ b/packages/debugger/test/ast.js
@@ -14,7 +14,7 @@ import trace from "lib/trace/selectors";
 import SourceMapUtils from "@truffle/source-map-utils";
 
 const __VARIABLES = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract Variables {
   event Result(uint256 result);

--- a/packages/debugger/test/context.js
+++ b/packages/debugger/test/context.js
@@ -11,7 +11,7 @@ import Debugger from "lib/debugger";
 import sessionSelector from "lib/session/selectors";
 
 const __OUTER = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 import "./InnerContract.sol";
 
@@ -33,7 +33,7 @@ contract OuterContract {
 `;
 
 const __INNER = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract InnerContract {
   event Inner();
@@ -45,7 +45,7 @@ contract InnerContract {
 `;
 
 const __IMMUTABLE = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract ImmutableTest {
   uint immutable x = 35;
@@ -63,7 +63,7 @@ library TestLibrary {
 `;
 
 const __CREATION = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract CreationTest {
   function run() public {

--- a/packages/debugger/test/data/calldata.js
+++ b/packages/debugger/test/data/calldata.js
@@ -13,8 +13,7 @@ import * as Codec from "@truffle/codec";
 import solidity from "lib/solidity/selectors";
 
 const __CALLDATA = `
-pragma solidity ^0.7.0;
-pragma experimental ABIEncoderV2;
+pragma solidity ^0.8.0;
 
 contract CalldataTest {
 

--- a/packages/debugger/test/data/codex.js
+++ b/packages/debugger/test/data/codex.js
@@ -10,7 +10,7 @@ import {prepareContracts} from "../helpers";
 import Debugger from "lib/debugger";
 
 const __LIBTEST = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract MappingPointerTest {
   mapping(string => uint) surface;
@@ -28,7 +28,7 @@ library TouchLib {
 `;
 
 const __REVERT_TEST = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract RevertTest {
 

--- a/packages/debugger/test/data/decoding.js
+++ b/packages/debugger/test/data/decoding.js
@@ -104,7 +104,7 @@ describe("Decoding", function () {
     evm.current.state.storage,
 
     (contractName, fixtures) => {
-      return `pragma solidity ^0.7.0;
+      return `pragma solidity ^0.8.0;
 
 contract ${contractName} {
 
@@ -131,7 +131,7 @@ contract ${contractName} {
     evm.current.state.storage,
 
     (contractName, fixtures) => {
-      return `pragma solidity ^0.7.0;
+      return `pragma solidity ^0.8.0;
 
 contract ${contractName} {
   event Done();
@@ -183,7 +183,7 @@ contract ${contractName} {
         }
       }
 
-      return `pragma solidity ^0.7.0;
+      return `pragma solidity ^0.8.0;
 
 contract ${contractName} {
 

--- a/packages/debugger/test/data/function-decoding.js
+++ b/packages/debugger/test/data/function-decoding.js
@@ -12,7 +12,7 @@ import * as Codec from "@truffle/codec";
 import solidity from "lib/solidity/selectors";
 
 const __EXTERNALS = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract ExternalsTester {
 
@@ -55,7 +55,7 @@ contract ExternalsDerived is ExternalsBase {
 `;
 
 const __INTERNALS = `
-pragma solidity ^0.7.1;
+pragma solidity ^0.8.0;
 
 contract InternalsBase {
 

--- a/packages/debugger/test/data/function-decoding.js
+++ b/packages/debugger/test/data/function-decoding.js
@@ -216,7 +216,7 @@ describe("Function Pointer Decoding", function () {
       baseFn: "InternalsBase.inherited",
       libFn: "InternalsLib.libraryFn",
       storedFreeFn: "freeFn",
-      undefFn: "assert(false)",
+      undefFn: "<uninitialized>",
       storageFn: "InternalsTest.run",
       readFromConstructor: "InternalsTest.run"
     };
@@ -251,7 +251,7 @@ describe("Function Pointer Decoding", function () {
       baseFn: "InternalsBase.inherited",
       libFn: "InternalsLib.libraryFn",
       storedFreeFn: "freeFn",
-      undefFn: "assert(false)",
+      undefFn: "<uninitialized>",
       storageFn: "InternalsTest.run"
     };
 

--- a/packages/debugger/test/data/global-const.js
+++ b/packages/debugger/test/data/global-const.js
@@ -12,7 +12,7 @@ import * as Codec from "@truffle/codec";
 
 const __TESTER = `
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.7.4;
+pragma solidity ^0.8.0;
 
 import "./Constants.sol";
 
@@ -26,7 +26,7 @@ contract ConstTest {
 
 const __CONSTANTS = `
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.7.4;
+pragma solidity ^0.8.0;
 
 uint constant secret = 77;
 

--- a/packages/debugger/test/data/global.js
+++ b/packages/debugger/test/data/global.js
@@ -13,7 +13,7 @@ import * as Codec from "@truffle/codec";
 import solidity from "lib/solidity/selectors";
 
 const __GLOBAL = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract GlobalTest {
 
@@ -21,13 +21,13 @@ contract GlobalTest {
 
   struct Msg {
     bytes data;
-    address payable sender;
+    address sender;
     bytes4 sig;
     uint value;
   }
 
   struct Tx {
-    address payable origin;
+    address origin;
     uint gasprice;
   }
 
@@ -67,7 +67,7 @@ contract GlobalTest {
     __tx = Tx(tx.origin, tx.gasprice);
     __block = Block(block.coinbase, block.difficulty,
       block.gaslimit, block.number, block.timestamp);
-    return x + uint(address(__this)) //BREAK STATIC
+    return x + uint160(address(__this)) //BREAK STATIC
       + __msg.value + __tx.gasprice + __block.number;
   }
 

--- a/packages/debugger/test/data/ids.js
+++ b/packages/debugger/test/data/ids.js
@@ -13,30 +13,30 @@ import solidity from "lib/solidity/selectors";
 import * as Codec from "@truffle/codec";
 
 const __FACTORIAL = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract FactorialTest {
 
   uint lastResult;
 
   function factorial(uint n) public returns(uint nbang) {
-    uint prev;
     uint prevFac;
     nbang = n;
-    prev = n - 1; //break here #1 (12)
+    lastResult = nbang; //break here #1
     if (n > 0) {
+      uint prev = n - 1;
       prevFac = factorial(n - 1);
       nbang = n * prevFac;
     } else {
       nbang = 1;
     }
-    lastResult = nbang; //break here #2 (22)
+    lastResult = nbang; //break here #2
   }
 }
 `;
 
 const __ADDRESS = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract AddressTest {
 
@@ -71,7 +71,7 @@ contract SecretByte {
 `;
 
 const __INTERVENING = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 import "./InterveningLib.sol";
 
@@ -119,7 +119,7 @@ contract Inner {
 `;
 
 const __INTERVENINGLIB = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 library InterveningLib {
 
@@ -130,7 +130,7 @@ library InterveningLib {
 `;
 
 const __MODIFIERS = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract ModifierTest {
 

--- a/packages/debugger/test/data/immutable.js
+++ b/packages/debugger/test/data/immutable.js
@@ -13,7 +13,7 @@ import * as Codec from "@truffle/codec";
 import solidity from "lib/solidity/selectors";
 
 const __IMMUTABLE = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract Base {
   int8 immutable base = -37;
@@ -27,7 +27,7 @@ contract ImmutableTest is Base {
   Color immutable background;
   bool immutable truth;
   address immutable self;
-  byte immutable secret;
+  bytes1 immutable secret;
   uint8 immutable trulySecret;
 
   event Done();
@@ -45,7 +45,7 @@ contract ImmutableTest is Base {
   event Enum(Color);
   event Bool(bool);
   event Address(address);
-  event Byte(byte);
+  event Byte(bytes1);
 
   function run() public {
     emit Number(base);

--- a/packages/debugger/test/data/more-decoding.js
+++ b/packages/debugger/test/data/more-decoding.js
@@ -16,7 +16,7 @@ import evm from "lib/evm/selectors";
 import * as Codec from "@truffle/codec";
 
 const __CONTAINERS = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract ContainersTest {
 
@@ -74,7 +74,7 @@ contract ContainersTest {
 `;
 
 const __KEYSANDBYTES = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract ElementaryTest {
 
@@ -84,7 +84,7 @@ contract ElementaryTest {
 
   //storage variables to be tested
   mapping(bool => bool) boolMap;
-  mapping(byte => byte) byteMap;
+  mapping(bytes1 => bytes1) byteMap;
   mapping(bytes => bytes) bytesMap;
   mapping(uint => uint) uintMap;
   mapping(int => int) intMap;
@@ -98,12 +98,12 @@ contract ElementaryTest {
 
   function run() public {
     //local variables to be tested
-    byte oneByte;
-    byte[] memory severalBytes;
+    bytes1 oneByte;
+    bytes1[] memory severalBytes;
 
     //set up variables for testing
     oneByte = 0xff;
-    severalBytes = new byte[](1);
+    severalBytes = new bytes1[](1);
     severalBytes[0] = 0xff;
 
     boolMap[true] = true;
@@ -132,7 +132,7 @@ contract ElementaryTest {
 `;
 
 const __SPLICING = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract SpliceTest {
   //splicing is (nontrivially) used in two contexts right now:
@@ -170,7 +170,7 @@ contract SpliceTest {
 `;
 
 const __INNERMAPS = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract ComplexMappingTest {
 
@@ -196,39 +196,44 @@ contract ComplexMappingTest {
 `;
 
 const __OVERFLOW = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract OverflowTest {
 
   event Unsigned(uint8);
-  event Raw(byte);
+  event Raw(bytes1);
   event Signed(int8);
 
   function unsignedTest() public {
-    uint8[1] memory memoryByte;
-    uint8 byte1 = 255;
-    uint8 byte2 = 255;
-    uint8 sum = byte1 + byte2;
-    emit Unsigned(sum); //BREAK UNSIGNED
+    unchecked {
+      uint8[1] memory memoryByte;
+      uint8 byte1 = 255;
+      uint8 byte2 = 255;
+      uint8 sum = byte1 + byte2;
+      emit Unsigned(sum); //BREAK UNSIGNED
+    }
   }
 
   function rawTest() public {
-    byte full = 0xff;
-    byte right = full >> 1;
+    bytes1 full = 0xff;
+    bytes1 right = full >> 1;
     emit Raw(right); //BREAK RAW
   }
 
   function signedTest() public {
-    int8 byte1 = -128;
-    int8 byte2 = -128;
-    int8 sum = byte1 + byte2;
-    emit Signed(sum); //BREAK SIGNED
+    unchecked {
+      int8 byte1 = -128;
+      int8 byte2 = -128;
+      int8 sum = byte1 + byte2;
+      emit Signed(sum); //BREAK SIGNED
+    }
   }
 }
 `;
 
 const __BADBOOL = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
+pragma abicoder v1;
 
 contract BadBoolTest {
 
@@ -241,7 +246,7 @@ contract BadBoolTest {
 `;
 
 const __CIRCULAR = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract CircularTest {
 
@@ -265,7 +270,7 @@ contract CircularTest {
 `;
 
 const __GLOBALDECLS = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 struct GlobalStruct {
   uint x;

--- a/packages/debugger/test/data/returnvalue.js
+++ b/packages/debugger/test/data/returnvalue.js
@@ -11,7 +11,7 @@ import Debugger from "lib/debugger";
 import * as Codec from "@truffle/codec";
 
 const __RETURNVALUES = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract ReturnValues {
 
@@ -19,7 +19,7 @@ contract ReturnValues {
 
   constructor(bool fail) {
     if(fail) {
-      selfdestruct(tx.origin);
+      selfdestruct(payable(tx.origin));
     }
   }
 

--- a/packages/debugger/test/data/yul.js
+++ b/packages/debugger/test/data/yul.js
@@ -13,7 +13,7 @@ import solidity from "lib/solidity/selectors";
 import * as Codec from "@truffle/codec";
 
 const __YUL = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract AssemblyTest {
   function run() public {

--- a/packages/debugger/test/endstate.js
+++ b/packages/debugger/test/endstate.js
@@ -13,7 +13,7 @@ import evm from "lib/evm/selectors";
 import * as Codec from "@truffle/codec";
 
 const __FAILURE = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract FailureTest {
   function run() public {
@@ -23,7 +23,7 @@ contract FailureTest {
 `;
 
 const __SUCCESS = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract SuccessTest {
 uint x;

--- a/packages/debugger/test/evm.js
+++ b/packages/debugger/test/evm.js
@@ -12,7 +12,7 @@ import evm from "lib/evm/selectors";
 import trace from "lib/trace/selectors";
 
 const __OUTER = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 import "./Inner.sol";
 
@@ -35,7 +35,7 @@ contract Outer {
 `;
 
 const __INNER = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract Inner {
   function run() public {

--- a/packages/debugger/test/helpers.js
+++ b/packages/debugger/test/helpers.js
@@ -26,7 +26,7 @@ export async function prepareContracts(provider, sources = {}, migrations) {
 
   config.compilers = {
     solc: {
-      version: "0.7.4",
+      version: "0.8.0",
       settings: {
         optimizer: { enabled: false, runs: 200 },
         evmVersion: "constantinople"

--- a/packages/debugger/test/load.js
+++ b/packages/debugger/test/load.js
@@ -13,7 +13,7 @@ import trace from "lib/trace/selectors";
 import controller from "lib/controller/selectors";
 
 const __TWOCONTRACTS = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract Contract1 {
   uint x;

--- a/packages/debugger/test/precompiles.js
+++ b/packages/debugger/test/precompiles.js
@@ -13,7 +13,7 @@ import trace from "lib/trace/selectors";
 import solidity from "lib/solidity/selectors";
 
 const __PRECOMPILE = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract HasPrecompile {
   event Called();

--- a/packages/debugger/test/reset.js
+++ b/packages/debugger/test/reset.js
@@ -12,7 +12,7 @@ import Debugger from "lib/debugger";
 import solidity from "lib/solidity/selectors";
 
 const __SETSTHINGS = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract SetsThings {
   int x;

--- a/packages/debugger/test/solidity.js
+++ b/packages/debugger/test/solidity.js
@@ -13,7 +13,7 @@ import controller from "lib/controller/selectors";
 import trace from "lib/trace/selectors";
 
 const __SINGLE_CALL = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract SingleCall {
   event Called();
@@ -32,7 +32,7 @@ contract SingleCall {
 `;
 
 const __NESTED_CALL = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract NestedCall {
   event First();
@@ -66,7 +66,7 @@ contract NestedCall {
 `;
 
 const __FAILED_CALL = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract RevertTest {
 
@@ -94,7 +94,7 @@ contract RevertTest {
 `;
 
 const __OVER_TRANSFER = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract BadTransferTest {
 
@@ -112,7 +112,7 @@ contract Recipient {
 `;
 
 const __ADJUSTMENT = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract AdjustTest {
 

--- a/packages/debugger/test/stacktrace.js
+++ b/packages/debugger/test/stacktrace.js
@@ -12,7 +12,7 @@ import solidity from "lib/solidity/selectors";
 import stacktrace from "lib/stacktrace/selectors";
 
 const __STACKTRACE = `
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract StacktraceTest {
 
@@ -74,7 +74,7 @@ contract StacktraceTest {
 
 contract Boom {
   function boom() public returns (uint) {
-    selfdestruct(address(this)); //BOOM
+    selfdestruct(payable(address(this))); //BOOM
   }
 
   receive() external payable{

--- a/packages/debugger/test/txlog.js
+++ b/packages/debugger/test/txlog.js
@@ -13,7 +13,7 @@ import txlog from "lib/txlog/selectors";
 
 const __TXLOG = `
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract VizTest {
 
@@ -33,7 +33,7 @@ contract VizTest {
   }
 
   function testTransfer() public {
-    tx.origin.transfer(1);
+    payable(tx.origin).transfer(1);
   }
 
   fallback() external {

--- a/packages/source-map-utils/package.json
+++ b/packages/source-map-utils/package.json
@@ -28,7 +28,8 @@
     "@truffle/codec": "^0.9.1",
     "debug": "^4.1.1",
     "json-pointer": "^0.6.0",
-    "node-interval-tree": "^1.3.3"
+    "node-interval-tree": "^1.3.3",
+    "web3-utils": "^1.3.0"
   },
   "gitHead": "6b84be7849142588ef2e3224d8a9d7c2ceeb6e4a"
 }


### PR DESCRIPTION
OK, so, this PR does a few things.

The original purpose of this PR was to update how we check for designated invalid functions in `source-map-utils`.  Prior to 0.8.0 these were very simple: Just a `JUMPDEST` followed by an `INVALID`.  But as of 0.8.0, they're a bit more complicated, as they need to throw a `Panic(0x51)`.  Fortunately, it seems to always be the same, short, set series of instructions -- and I think this will hold with optimization turned on, too, because it's a pretty hard sequence to optimize!  So, now we check for either the old sequence (`JUMPDEST INVALID`), or the new sequence (which is ten instructions long and I'm not going to write it all out here, particularly as it includes a `PUSH32`).

Also, in Codec, I changed it so that such pointers now display as `<uninitialized>` rather than `<assert(false)>`, since an uninitialized internal function pointer no longer does the same thing as `assert(false)` (the former throws a `Panic(0x51)`, the latter a `Panic(0x01)`).

However, testing this necessitated updating the debugger tests to 0.8.0.  And doing this revealed another problem that needed fixing.

See, 0.8.0 makes much more use of generated sources than previous versions, and this was screwing some things up.  See the debugger often makes use of the idea that a given AST node is ready for processing when we're just about to leave it.  But if we're just about to leave it, from a user source into a generated source... yeah.  Sometimes we're jumping away in what used to be the middle of it, you know?  So now, we no longer count a source range as final if we're currently in a user source and about to jump into a generated source (unless we're at a context change).  I don't *think* this should screw anything up -- all tests are currently passing, after all?  But we'll see.  Definitely *not* doing this screwed things up for sure...

In addition to the above change to the `solidity` submodule, I also had to make a similar change to the `stacktrace` submodule.  The stacktrace submodule has to try to tell where a revert originated, see, which means that when an inner transaction reverts, it has to somehow identify that the revert from the outer transaction was caused by the inner one.  It does this by checking whether the current position changes inbetween receving the inner revert and throwing the outer revert.  If it doesn't, it infers that the inner one caused the outer one.  Except, once again, generated sources screw this up.  So we have to say that generated sources don't count as moving, and also not to process jumps until motion has occurred (otherwise we'll add generated sources that shouldn't appear -- there's nothing wrong with generated sources appearing in stacktraces, but these are the *wrong* generated sources!).

Funnily enough I kind of accounted for this when writing `stacktrace` -- I said that unmapped code doesn't count as having moved.  But when generated sources were added, I never updated this to also say that generated sources don't count as having moved.  Well, now I have.  Hooray.