### PR TITLE
Bug fix: Ensure range is a single version before using it in semver.gte

### DIFF
--- a/packages/compile-solidity/compilerSupplier/rangeUtils.js
+++ b/packages/compile-solidity/compilerSupplier/rangeUtils.js
@@ -25,10 +25,12 @@ const RangeUtils = {
   //parameter range may be either an individual version or a range
   rangeContainsAtLeast: function (range, comparisonVersion) {
     //the following line works with prereleases
-    const individualAtLeast = semver.gte(range, comparisonVersion, {
-      includePrerelease: true,
-      loose: true
-    });
+    const individualAtLeast =
+      semver.valid(range) &&
+      semver.gte(range, comparisonVersion, {
+        includePrerelease: true,
+        loose: true
+      });
     //the following line doesn't, despite the flag, but does work with version ranges
     const rangeAtLeast =
       semver.validRange(range) &&


### PR DESCRIPTION
This causes a crash when a range is used in this method as `gte` takes a single version and not a range.