### PR TITLE
Dependency update: Upgrade highlightjs-solidity to 1.0.20 (Update syntax highlighting for 0.8.0)

### DIFF
--- a/packages/debug-utils/package.json
+++ b/packages/debug-utils/package.json
@@ -19,7 +19,7 @@
     "chalk": "^2.4.2",
     "debug": "^4.1.0",
     "highlight.js": "^10.4.0",
-    "highlightjs-solidity": "^1.0.19"
+    "highlightjs-solidity": "^1.0.20"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11763,10 +11763,10 @@ highlight.js@^9.15.8:
   dependencies:
     handlebars "^4.5.3"
 
-highlightjs-solidity@^1.0.19:
-  version "1.0.19"
-  resolved "https://registry.yarnpkg.com/highlightjs-solidity/-/highlightjs-solidity-1.0.19.tgz#a2f05bcfadd295a8eefb9cc20dcb18a3ba48e49c"
-  integrity sha512-ZIzMlxZxkcNnzWC1LeOeUjQjywzXnGyDxexOPKzz8hWFqdE2uRvz1BxD0joOkr41z4SU2ABXVGDx6EWlbzTBLQ==
+highlightjs-solidity@^1.0.20:
+  version "1.0.20"
+  resolved "https://registry.yarnpkg.com/highlightjs-solidity/-/highlightjs-solidity-1.0.20.tgz#37482fd47deda617994e1d1262df5a319c0a8580"
+  integrity sha512-Ixb87/4huazRJ7mriimL0DP2GvE5zgSk11VdMPGKMQCNwszDe8qK0PySySsuB88iXyDT/H2gdmvC2bgfrOi3qQ==
 
 hkts@^0.3.1:
   version "0.3.1"


### PR DESCRIPTION
I published a new version of highlightjs-solidity with syntax highlighting updates for Solidity 0.8.0, now this PR has us use it.