### PR TITLE
Enhancement: Update globally-available variables for 0.8.0; also set _chainId in exposed Ganache instances

### DIFF
--- a/packages/codec/lib/ast/import/index.ts
+++ b/packages/codec/lib/ast/import/index.ts
@@ -34,6 +34,7 @@ export function definitionToType(
       };
     case "address": {
       switch (Compiler.Utils.solidityFamily(compiler)) {
+        case "unknown": //I guess?
         case "pre-0.5.0":
           return {
             typeClass,
@@ -41,6 +42,7 @@ export function definitionToType(
             typeHint
           };
         case "0.5.x":
+        case "0.8.x":
           return {
             typeClass,
             kind: "specific",

--- a/packages/codec/lib/compiler/types.ts
+++ b/packages/codec/lib/compiler/types.ts
@@ -5,7 +5,7 @@ export interface CompilerVersion {
   //but they need to be optional for compilation reasons
 }
 
-//Note: 0.5.x should really be 0.5.x or 0.6.x, but for the sake
-//of not breaking things, I'm going to avoid changing this until
-//there's a need (which might happen when 0.7.x hits)
-export type SolidityFamily = "unknown" | "pre-0.5.0" | "0.5.x";
+//NOTE: Families 0.5.0 and up will be named by the lowest version that
+//fits in the given family.  So e.g. 0.5.x covers 0.5.x-0.7.x;
+//0.8.x covers 0.8.x-current (as I write this)
+export type SolidityFamily = "unknown" | "pre-0.5.0" | "0.5.x" | "0.8.x";

--- a/packages/codec/lib/compiler/utils.ts
+++ b/packages/codec/lib/compiler/utils.ts
@@ -9,6 +9,13 @@ export function solidityFamily(compiler: CompilerVersion): SolidityFamily {
     return "unknown";
   }
   if (
+    semver.satisfies(compiler.version, "~0.8 || >=0.8.0", {
+      includePrerelease: true
+    })
+  ) {
+    //see comment below about the weird-looking condition
+    return "0.8.x";
+  } else if (
     semver.satisfies(compiler.version, "~0.5 || >=0.5.0", {
       includePrerelease: true
     })

--- a/packages/core/lib/commands/develop.js
+++ b/packages/core/lib/commands/develop.js
@@ -78,7 +78,8 @@ const command = {
       gasLimit: customConfig.gas || 0x6691b7,
       gasPrice: customConfig.gasPrice || 0x77359400,
       noVMErrorsOnRPCResponse: true,
-      time: config.genesis_time
+      time: config.genesis_time,
+      _chainId: 1337 //temporary until Ganache v3!
     };
 
     if (customConfig.hardfork !== null && customConfig.hardfork !== undefined) {

--- a/packages/core/lib/commands/test/index.js
+++ b/packages/core/lib/commands/test/index.js
@@ -192,7 +192,8 @@ const command = {
             mnemonic:
               "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat",
             gasLimit: config.gas,
-            time: config.genesis_time
+            time: config.genesis_time,
+            _chainId: 1337 //temporary until Ganache v3!
           };
         })
         .then(() => {

--- a/packages/debugger/lib/evm/reducers.js
+++ b/packages/debugger/lib/evm/reducers.js
@@ -93,7 +93,8 @@ const DEFAULT_BLOCK = {
   difficulty: new BN(0),
   gaslimit: new BN(0),
   number: new BN(0),
-  timestamp: new BN(0)
+  timestamp: new BN(0),
+  chainid: new BN(0)
 };
 
 function block(state = DEFAULT_BLOCK, action) {

--- a/packages/debugger/lib/web3/adapter.js
+++ b/packages/debugger/lib/web3/adapter.js
@@ -44,6 +44,10 @@ export default class Web3Adapter {
     return await this.web3.eth.getBlock(blockNumberOrHash);
   }
 
+  async getChainId() {
+    return await this.web3.eth.getChainId();
+  }
+
   /**
    * getDeployedCode - get the deployed code for an address from the client
    * NOTE: the block argument is optional

--- a/packages/debugger/lib/web3/sagas/index.js
+++ b/packages/debugger/lib/web3/sagas/index.js
@@ -55,12 +55,13 @@ function* fetchTransactionInfo(adapter, { txHash }) {
   trace = padStackAndMemory(trace); //for Besu compatibility
   yield put(actions.receiveTrace(trace));
 
-  let tx = yield apply(adapter, adapter.getTransaction, [txHash]);
+  const tx = yield apply(adapter, adapter.getTransaction, [txHash]);
   debug("tx %O", tx);
-  let receipt = yield apply(adapter, adapter.getReceipt, [txHash]);
+  const receipt = yield apply(adapter, adapter.getReceipt, [txHash]);
   debug("receipt %O", receipt);
-  let block = yield apply(adapter, adapter.getBlock, [tx.blockNumber]);
+  const block = yield apply(adapter, adapter.getBlock, [tx.blockNumber]);
   debug("block %O", block);
+  const chainId = yield apply(adapter, adapter.getChainId);
 
   yield put(session.saveTransaction(tx));
   yield put(session.saveReceipt(receipt));
@@ -72,7 +73,8 @@ function* fetchTransactionInfo(adapter, { txHash }) {
     difficulty: new BN(block.difficulty),
     gaslimit: new BN(block.gasLimit),
     number: new BN(block.number),
-    timestamp: new BN(block.timestamp)
+    timestamp: new BN(block.timestamp),
+    chainid: new BN(chainId) //key is lowercase because that's what Solidity does
   };
 
   if (tx.to != null) {

--- a/packages/debugger/test/data/global.js
+++ b/packages/debugger/test/data/global.js
@@ -37,6 +37,7 @@ contract GlobalTest {
     uint gaslimit;
     uint number;
     uint timestamp;
+    uint chainid;
   }
 
   Msg _msg;
@@ -49,7 +50,7 @@ contract GlobalTest {
     _msg = Msg(msg.data, msg.sender, msg.sig, msg.value);
     _tx = Tx(tx.origin, tx.gasprice);
     _block = Block(block.coinbase, block.difficulty,
-      block.gaslimit, block.number, block.timestamp);
+      block.gaslimit, block.number, block.timestamp, block.chainid);
     emit Done(x); //BREAK SIMPLE
   }
 
@@ -66,7 +67,7 @@ contract GlobalTest {
     __msg = Msg(msg.data, msg.sender, msg.sig, 0);
     __tx = Tx(tx.origin, tx.gasprice);
     __block = Block(block.coinbase, block.difficulty,
-      block.gaslimit, block.number, block.timestamp);
+      block.gaslimit, block.number, block.timestamp, block.chainid);
     return x + uint160(address(__this)) //BREAK STATIC
       + __msg.value + __tx.gasprice + __block.number;
   }
@@ -106,7 +107,7 @@ contract CreationTest {
     _msg = GlobalTest.Msg(msg.data, msg.sender, msg.sig, msg.value);
     _tx = GlobalTest.Tx(tx.origin, tx.gasprice);
     _block = GlobalTest.Block(block.coinbase, block.difficulty,
-      block.gaslimit, block.number, block.timestamp);
+      block.gaslimit, block.number, block.timestamp, block.chainid);
     require(succeed); //BREAK CREATE
     emit Done(x);
   }
@@ -123,7 +124,7 @@ library GlobalTestLib {
     __msg = GlobalTest.Msg(msg.data, msg.sender, msg.sig, msg.value);
     __tx = GlobalTest.Tx(tx.origin, tx.gasprice);
     __block = GlobalTest.Block(block.coinbase, block.difficulty,
-      block.gaslimit, block.number, block.timestamp);
+      block.gaslimit, block.number, block.timestamp, block.chainid);
     emit Done(x + __msg.value + __tx.gasprice + __block.number); //BREAK LIBRARY
   }
 }
@@ -156,7 +157,11 @@ describe("Globally-available variables", function () {
   var compilations;
 
   before("Create Provider", async function () {
-    provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
+    provider = Ganache.provider({
+      seed: "debugger",
+      gasLimit: 7000000,
+      _chainId: 1337 //temporary until Ganache v3!
+    });
   });
 
   before("Prepare contracts and artifacts", async function () {

--- a/packages/debugger/test/helpers.js
+++ b/packages/debugger/test/helpers.js
@@ -29,7 +29,7 @@ export async function prepareContracts(provider, sources = {}, migrations) {
       version: "0.8.0",
       settings: {
         optimizer: { enabled: false, runs: 200 },
-        evmVersion: "constantinople"
+        evmVersion: "istanbul"
       }
     }
   };

--- a/packages/decoder/package.json
+++ b/packages/decoder/package.json
@@ -41,7 +41,7 @@
     "@types/debug": "^0.0.31",
     "@types/web3": "1.0.19",
     "chai": "^4.2.0",
-    "ganache-core": "^2.13.1",
+    "ganache-core": "2.13.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.flatten": "^4.4.0",
     "tmp": "^0.2.1",

--- a/packages/environment/environment.js
+++ b/packages/environment/environment.js
@@ -42,7 +42,8 @@ const Environment = {
     const forkedNetwork = config.network + "-fork";
     const ganacheOptions = {
       fork: config.provider,
-      gasLimit: block.gasLimit
+      gasLimit: block.gasLimit,
+      _chainId: 1337 //temporary until Ganache v3!
     };
     if (accounts.length > 0) ganacheOptions.unlocked_accounts = accounts;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9222,18 +9222,6 @@ eth-sig-util@^1.4.2:
     ethereumjs-abi "git+https://github.com/ethereumjs/ethereumjs-abi.git"
     ethereumjs-util "^5.1.1"
 
-eth-sig-util@^2.0.0:
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/eth-sig-util/-/eth-sig-util-2.5.3.tgz#6938308b38226e0b3085435474900b03036abcbe"
-  integrity sha512-KpXbCKmmBUNUTGh9MRKmNkIPietfhzBqqYqysDavLseIiMUGl95k6UcPEkALAZlj41e9E6yioYXc1PC333RKqw==
-  dependencies:
-    buffer "^5.2.1"
-    elliptic "^6.4.0"
-    ethereumjs-abi "0.6.5"
-    ethereumjs-util "^5.1.1"
-    tweetnacl "^1.0.0"
-    tweetnacl-util "^0.15.0"
-
 eth-tx-summary@^3.1.2:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/eth-tx-summary/-/eth-tx-summary-3.2.4.tgz#e10eb95eb57cdfe549bf29f97f1e4f1db679035c"
@@ -9331,7 +9319,7 @@ ethereumjs-abi@0.6.7:
     bn.js "^4.11.8"
     ethereumjs-util "^6.0.0"
 
-ethereumjs-abi@0.6.8, ethereumjs-abi@^0.6.8, "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git":
+ethereumjs-abi@^0.6.8, "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git":
   version "0.6.8"
   resolved "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b"
   dependencies:
@@ -10758,43 +10746,6 @@ ganache-core@2.13.0:
     encoding-down "5.0.4"
     eth-sig-util "2.3.0"
     ethereumjs-abi "0.6.7"
-    ethereumjs-account "3.0.0"
-    ethereumjs-block "2.2.2"
-    ethereumjs-common "1.5.0"
-    ethereumjs-tx "2.1.2"
-    ethereumjs-util "6.2.1"
-    ethereumjs-vm "4.2.0"
-    heap "0.2.6"
-    keccak "3.0.1"
-    level-sublevel "6.6.4"
-    levelup "3.1.1"
-    lodash "4.17.20"
-    lru-cache "5.1.1"
-    merkle-patricia-tree "3.0.0"
-    patch-package "6.2.2"
-    seedrandom "3.0.1"
-    source-map-support "0.5.12"
-    tmp "0.1.0"
-    web3-provider-engine "14.2.1"
-    websocket "1.0.32"
-  optionalDependencies:
-    ethereumjs-wallet "0.6.5"
-    web3 "1.2.11"
-
-ganache-core@^2.13.1:
-  version "2.13.1"
-  resolved "https://registry.yarnpkg.com/ganache-core/-/ganache-core-2.13.1.tgz#bf60399a2dd084e1090db91cbbc7ed3885dc01e4"
-  integrity sha512-Ewg+kNcDqXtOohe7jCcP+ZUv9EMzOx2MoqOYYP3BCfxrDh3KjBXXaKK+Let7li0TghAs9lxmBgevZku35j5YzA==
-  dependencies:
-    abstract-leveldown "3.0.0"
-    async "2.6.2"
-    bip39 "2.5.0"
-    cachedown "1.0.0"
-    clone "2.1.2"
-    debug "3.2.6"
-    encoding-down "5.0.4"
-    eth-sig-util "^2.0.0"
-    ethereumjs-abi "0.6.8"
     ethereumjs-account "3.0.0"
     ethereumjs-block "2.2.2"
     ethereumjs-common "1.5.0"


### PR DESCRIPTION
The main purpose of this PR is to update the debugger's globally-available support for Solidity 0.8.0.  This means two things:

1. In Solidity 0.8.0, `msg.sender` and `tx.origin` are now of type `address`, rather than `address payable`.  That doesn't really matter that much, but we keep track of it, so I updated it.  This purely required changes in `codec`.

2. In Solidity 0.8.0, the `block` special variable has a new property `block.chainid`, which contains the chain ID as a `uint`.  I added support for this.  Note that there is a version check; it won't appear when debugging an earlier version.

Doing this second part required both changes in `codec/lib/special/decode`, but also in the debugger itself, to actually get the chain ID and pass it to `codec`.  Fortunately very little needed to be altered here, as it can really piggyback off of the existing globally-available variables code.  The only real work that needed to be done here was actually getting the chain ID in `web3/sagas` and putting it in the block info; the rest is basically taken care of automatically.

However, there was a bit of a snag here; while testing, I ran into Ganache's chain ID bug, where the `eth_chainId` method reports the ID as 1337, but the `CHAINID` opcode reports it as 1.  Since the debugger relies on `eth_chainId` to report the value of `block.chainid`, that means it would misreport it.  I wanted to minimize the cases where that would happen, so I found (what I think is) everywhere in Truffle that we spin up a user-exposed Ganache instance (not ones for internal testing) and added `_chainId: 1337` to the Ganache options, to make it consistent.  I don't think this should be a breaking change.  Again, I left our own test instances of Ganache alone, but I did add it to one such test instance, namely, the one in the debugger's globally-available variable tests, because I added tests of `block.chainid` to that, so that one would need to have it consistent.

Also, while it isn't the main point of the PR, I realized that `decoder` was using a different `ganache-core` version from all the other packages, so I made it consistent.  Possibly I should have made it consistent by updating the others, but, eh, we can do that later.  With any luck we'll be on v3 soon enough anyway. :)