### PR TITLE
Merge resourceInput with existing resource

### DIFF
--- a/packages/db/src/pouch/databases.ts
+++ b/packages/db/src/pouch/databases.ts
@@ -5,6 +5,8 @@ import PouchDB from "pouchdb";
 import PouchDBDebug from "pouchdb-debug";
 import PouchDBFind from "pouchdb-find";
 
+import * as lodash from "lodash";
+
 import {
   CollectionName,
   Collections,
@@ -176,7 +178,8 @@ export abstract class Databases<C extends Collections> implements Workspace<C> {
         // check for existing
         const resource = await this.get(collectionName, id);
         if (resource) {
-          return resource;
+          const mergedResource = lodash.merge(resource, resourceInput);
+          return mergedResource;
         }
 
         await this.collections[collectionName].put({

--- a/packages/db/src/pouch/databases.ts
+++ b/packages/db/src/pouch/databases.ts
@@ -12,6 +12,7 @@ import {
   MutationPayload,
   MutableCollectionName,
   SavedInput,
+  Input,
   generateId
 } from "@truffle/db/meta";
 
@@ -154,8 +155,8 @@ export abstract class Databases<C extends Collections> implements Workspace<C> {
 
   public async merge<N extends CollectionName<C>>(
     collectionName: N,
-    input: any,
-    resource: any
+    resource: Historical<SavedInput<C, N>>,
+    input: Input<C, N>
   ): Promise<SavedInput<C, N>> {
     await this.ready;
 

--- a/packages/db/src/pouch/types.ts
+++ b/packages/db/src/pouch/types.ts
@@ -54,12 +54,6 @@ export interface Workspace<C extends Collections> {
     input: MutationInput<C, M>
   ): Promise<MutationPayload<C, M>>;
 
-  merge<N extends CollectionName<C>>(
-    collectionName: N,
-    resource: Historical<SavedInput<C, N>>,
-    input: Input<C, N>
-  ): Promise<SavedInput<C, N>>;
-
   remove<M extends MutableCollectionName<C>>(
     collectionName: M,
     input: MutationInput<C, M>

--- a/packages/db/src/pouch/types.ts
+++ b/packages/db/src/pouch/types.ts
@@ -16,6 +16,7 @@ export type Definitions<C extends Collections> = {
   [N in CollectionName<C>]: {
     createIndexes: PouchDB.Find.CreateIndexOptions["index"][];
     idFields: string[];
+    merge: (resource: any, input: any) => any;
   };
 };
 
@@ -48,6 +49,12 @@ export interface Workspace<C extends Collections> {
     collectionName: M,
     input: MutationInput<C, M>
   ): Promise<MutationPayload<C, M>>;
+
+  merge<N extends CollectionName<C>>(
+    collectionName: N,
+    input: SavedInput<C, N>,
+    resource: Historical<SavedInput<C, N>>
+  ): Promise<SavedInput<C, N>>;
 
   remove<M extends MutableCollectionName<C>>(
     collectionName: M,

--- a/packages/db/src/pouch/types.ts
+++ b/packages/db/src/pouch/types.ts
@@ -9,14 +9,18 @@ import {
   MutationInput,
   MutationPayload,
   MutableCollectionName,
-  SavedInput
+  SavedInput,
+  Input
 } from "@truffle/db/meta";
 
 export type Definitions<C extends Collections> = {
   [N in CollectionName<C>]: {
     createIndexes: PouchDB.Find.CreateIndexOptions["index"][];
     idFields: string[];
-    merge: (resource: any, input: any) => any;
+    merge: (
+      resource: Historical<SavedInput<C, N>>,
+      input: Input<C, N>
+    ) => SavedInput<C, N>;
   };
 };
 
@@ -52,8 +56,8 @@ export interface Workspace<C extends Collections> {
 
   merge<N extends CollectionName<C>>(
     collectionName: N,
-    input: SavedInput<C, N>,
-    resource: Historical<SavedInput<C, N>>
+    resource: Historical<SavedInput<C, N>>,
+    input: Input<C, N>
   ): Promise<SavedInput<C, N>>;
 
   remove<M extends MutableCollectionName<C>>(

--- a/packages/db/src/project/test/compilationSources/truffle-config.js
+++ b/packages/db/src/project/test/compilationSources/truffle-config.js
@@ -4,11 +4,6 @@ module.exports = {
       host: "127.0.0.1",
       port: 8545,
       network_id: "*"
-    },
-    test: {
-      host: "127.0.0.1",
-      port: 8545,
-      network_id: "*"
     }
   }
 };

--- a/packages/db/src/resources/bytecodes.ts
+++ b/packages/db/src/resources/bytecodes.ts
@@ -17,6 +17,13 @@ export const bytecodes: Definition<"bytecodes"> = {
   },
   createIndexes: [],
   idFields: ["bytes", "linkReferences"],
+  merge: (resource: any, input: any) => {
+    return {
+      ...resource,
+      ...input,
+      linkReferences: [...resource.linkReferences, ...input.linkReferences]
+    };
+  },
   typeDefs: gql`
     type Bytecode implements Resource {
       bytes: Bytes!

--- a/packages/db/src/resources/bytecodes.ts
+++ b/packages/db/src/resources/bytecodes.ts
@@ -20,8 +20,7 @@ export const bytecodes: Definition<"bytecodes"> = {
   merge: (resource, input) => {
     return {
       ...resource,
-      ...input,
-      linkReferences: [...resource.linkReferences, ...input.linkReferences]
+      ...input
     };
   },
   typeDefs: gql`

--- a/packages/db/src/resources/bytecodes.ts
+++ b/packages/db/src/resources/bytecodes.ts
@@ -17,7 +17,7 @@ export const bytecodes: Definition<"bytecodes"> = {
   },
   createIndexes: [],
   idFields: ["bytes", "linkReferences"],
-  merge: (resource: any, input: any) => {
+  merge: (resource, input) => {
     return {
       ...resource,
       ...input,

--- a/packages/db/src/resources/compilations.ts
+++ b/packages/db/src/resources/compilations.ts
@@ -16,6 +16,18 @@ export const compilations: Definition<"compilations"> = {
   },
   createIndexes: [],
   idFields: ["compiler", "sources"],
+  merge: (input: any, resource: any) => {
+    return {
+      ...resource,
+      ...input,
+      sources: [...resource.sources, ...input.sources],
+      processedSources: [
+        ...resource.processedSources,
+        ...input.processedSources
+      ],
+      sourceMaps: [...resource.sourceMaps, ...input.sourceMaps]
+    };
+  },
   typeDefs: gql`
     type Compilation implements Resource {
       compiler: Compiler!

--- a/packages/db/src/resources/compilations.ts
+++ b/packages/db/src/resources/compilations.ts
@@ -19,13 +19,7 @@ export const compilations: Definition<"compilations"> = {
   merge: (input, resource) => {
     return {
       ...resource,
-      ...input,
-      sources: [...resource.sources, ...input.sources],
-      processedSources: [
-        ...resource.processedSources,
-        ...input.processedSources
-      ],
-      sourceMaps: [...resource.sourceMaps, ...input.sourceMaps]
+      ...input
     };
   },
   typeDefs: gql`

--- a/packages/db/src/resources/compilations.ts
+++ b/packages/db/src/resources/compilations.ts
@@ -16,7 +16,7 @@ export const compilations: Definition<"compilations"> = {
   },
   createIndexes: [],
   idFields: ["compiler", "sources"],
-  merge: (input: any, resource: any) => {
+  merge: (input, resource) => {
     return {
       ...resource,
       ...input,

--- a/packages/db/src/resources/contractInstances.ts
+++ b/packages/db/src/resources/contractInstances.ts
@@ -16,7 +16,7 @@ export const contractInstances: Definition<"contractInstances"> = {
   },
   createIndexes: [],
   idFields: ["address", "network"],
-  merge: (resource: any, input: any) => {
+  merge: (resource, input) => {
     return { ...resource, ...input };
   },
   typeDefs: gql`

--- a/packages/db/src/resources/contractInstances.ts
+++ b/packages/db/src/resources/contractInstances.ts
@@ -16,6 +16,9 @@ export const contractInstances: Definition<"contractInstances"> = {
   },
   createIndexes: [],
   idFields: ["address", "network"],
+  merge: (resource: any, input: any) => {
+    return { ...resource, ...input };
+  },
   typeDefs: gql`
     type ContractInstance implements Resource {
       address: Address!

--- a/packages/db/src/resources/contracts.ts
+++ b/packages/db/src/resources/contracts.ts
@@ -25,7 +25,7 @@ export const contracts: Definition<"contracts"> = {
     }
   ],
   idFields: ["name", "abi", "processedSource", "compilation"],
-  merge: (resource: any, input: any) => {
+  merge: (resource, input) => {
     return { ...resource, ...input };
   },
   typeDefs: gql`

--- a/packages/db/src/resources/contracts.ts
+++ b/packages/db/src/resources/contracts.ts
@@ -25,6 +25,9 @@ export const contracts: Definition<"contracts"> = {
     }
   ],
   idFields: ["name", "abi", "processedSource", "compilation"],
+  merge: (resource: any, input: any) => {
+    return { ...resource, ...input };
+  },
   typeDefs: gql`
     type Contract implements Resource & Named {
       name: String!

--- a/packages/db/src/resources/nameRecords.ts
+++ b/packages/db/src/resources/nameRecords.ts
@@ -18,6 +18,9 @@ export const nameRecords: Definition<"nameRecords"> = {
   },
   createIndexes: [],
   idFields: ["resource", "previous"],
+  merge: (resource: any, input: any) => {
+    return { ...resource, ...input };
+  },
   typeDefs: gql`
     type NameRecord implements Resource {
       resource: Named!
@@ -64,9 +67,9 @@ export const nameRecords: Definition<"nameRecords"> = {
       },
       history: {
         async resolve(
-          {id, resource, previous},
-          {limit, includeSelf = false},
-          {workspace}
+          { id, resource, previous },
+          { limit, includeSelf = false },
+          { workspace }
         ) {
           debug(
             "Resolving NameRecord.history with limit: %s...",
@@ -74,7 +77,7 @@ export const nameRecords: Definition<"nameRecords"> = {
           );
 
           let depth = 0;
-          const nameRecords = includeSelf ? [{id, resource, previous}] : [];
+          const nameRecords = includeSelf ? [{ id, resource, previous }] : [];
 
           debug("previous %o", previous);
           while (previous && (typeof limit !== "number" || depth < limit)) {

--- a/packages/db/src/resources/nameRecords.ts
+++ b/packages/db/src/resources/nameRecords.ts
@@ -18,7 +18,7 @@ export const nameRecords: Definition<"nameRecords"> = {
   },
   createIndexes: [],
   idFields: ["resource", "previous"],
-  merge: (resource: any, input: any) => {
+  merge: (resource, input) => {
     return { ...resource, ...input };
   },
   typeDefs: gql`

--- a/packages/db/src/resources/networkGenealogies.ts
+++ b/packages/db/src/resources/networkGenealogies.ts
@@ -13,7 +13,7 @@ export const networkGenealogies: Definition<"networkGenealogies"> = {
   },
   createIndexes: [],
   idFields: ["ancestor", "descendant"],
-  merge: (resource: any, input: any) => {
+  merge: (resource, input) => {
     return { ...resource, ...input };
   },
   typeDefs: gql`

--- a/packages/db/src/resources/networkGenealogies.ts
+++ b/packages/db/src/resources/networkGenealogies.ts
@@ -13,6 +13,9 @@ export const networkGenealogies: Definition<"networkGenealogies"> = {
   },
   createIndexes: [],
   idFields: ["ancestor", "descendant"],
+  merge: (resource: any, input: any) => {
+    return { ...resource, ...input };
+  },
   typeDefs: gql`
     type NetworkGenealogy implements Resource {
       ancestor: Network

--- a/packages/db/src/resources/networks.ts
+++ b/packages/db/src/resources/networks.ts
@@ -16,6 +16,9 @@ export const networks: Definition<"networks"> = {
   },
   createIndexes: [{ fields: ["historicBlock.height"] }],
   idFields: ["networkId", "historicBlock"],
+  merge: (resource: any, input: any) => {
+    return { ...resource, ...input };
+  },
   typeDefs: gql`
     type Network implements Resource & Named {
       name: String!

--- a/packages/db/src/resources/networks.ts
+++ b/packages/db/src/resources/networks.ts
@@ -16,7 +16,7 @@ export const networks: Definition<"networks"> = {
   },
   createIndexes: [{ fields: ["historicBlock.height"] }],
   idFields: ["networkId", "historicBlock"],
-  merge: (resource: any, input: any) => {
+  merge: (resource, input) => {
     return { ...resource, ...input };
   },
   typeDefs: gql`

--- a/packages/db/src/resources/projectNames.ts
+++ b/packages/db/src/resources/projectNames.ts
@@ -26,6 +26,9 @@ export const projectNames: Definition<"projectNames"> = {
     }
   ],
   idFields: ["project", "key"],
+  merge: (resource: any, input: any) => {
+    return { ...resource, ...input };
+  },
   mutable: true,
   typeDefs: gql`
     type ProjectName implements Resource {

--- a/packages/db/src/resources/projectNames.ts
+++ b/packages/db/src/resources/projectNames.ts
@@ -26,7 +26,7 @@ export const projectNames: Definition<"projectNames"> = {
     }
   ],
   idFields: ["project", "key"],
-  merge: (resource: any, input: any) => {
+  merge: (resource, input) => {
     return { ...resource, ...input };
   },
   mutable: true,

--- a/packages/db/src/resources/projects.ts
+++ b/packages/db/src/resources/projects.ts
@@ -16,6 +16,9 @@ export const projects: Definition<"projects"> = {
   },
   createIndexes: [],
   idFields: ["directory"],
+  merge: (resource: any, input: any) => {
+    return { ...resource, ...input };
+  },
   typeDefs: gql`
     type Project implements Resource {
       directory: String!

--- a/packages/db/src/resources/projects.ts
+++ b/packages/db/src/resources/projects.ts
@@ -16,7 +16,7 @@ export const projects: Definition<"projects"> = {
   },
   createIndexes: [],
   idFields: ["directory"],
-  merge: (resource: any, input: any) => {
+  merge: (resource, input) => {
     return { ...resource, ...input };
   },
   typeDefs: gql`

--- a/packages/db/src/resources/sources.ts
+++ b/packages/db/src/resources/sources.ts
@@ -16,7 +16,7 @@ export const sources: Definition<"sources"> = {
   },
   createIndexes: [],
   idFields: ["contents", "sourcePath"],
-  merge: (resource: any, input: any) => {
+  merge: (resource, input) => {
     return { ...resource, ...input };
   },
   typeDefs: gql`

--- a/packages/db/src/resources/sources.ts
+++ b/packages/db/src/resources/sources.ts
@@ -16,6 +16,9 @@ export const sources: Definition<"sources"> = {
   },
   createIndexes: [],
   idFields: ["contents", "sourcePath"],
+  merge: (resource: any, input: any) => {
+    return { ...resource, ...input };
+  },
   typeDefs: gql`
     type Source implements Resource {
       sourcePath: String


### PR DESCRIPTION
This PR add a merge of `resourceInput` with an existing `resource` in `@truffle/db`. This is needed to handle the case where the underlying resource's contents change but the id does not. This is not likely to happen regularly but this should handle the edge case.

I did not write tests for this because I didn't see a straightforward way to do it, but one can test this by loading the db in a project (by running `truffle compile`), then adding a new value to any resource. Recompile the project, and check that the resource now contains the new value.