### PR TITLE
Enhancement: Add support for decoding of panics and fallback return values (and also some other stacktracing improvements)

### DIFF
--- a/packages/abi-utils/lib/normalize.ts
+++ b/packages/abi-utils/lib/normalize.ts
@@ -7,8 +7,8 @@ export const normalize = (looseAbi: SchemaAbi | Abi): Abi =>
 type Item<A> = A extends (infer I)[] ? I : never;
 
 export const normalizeEntry = (looseEntry: Item<SchemaAbi> | Entry): Entry => {
-  if (looseEntry.type === "event") {
-    // nothing gets normalized for events right now
+  if (looseEntry.type === "event" || looseEntry.type === "error") {
+    // nothing gets normalized for events or errorsright now
     return looseEntry as Entry;
   }
 

--- a/packages/abi-utils/lib/types.ts
+++ b/packages/abi-utils/lib/types.ts
@@ -5,7 +5,8 @@ export type Entry =
   | ConstructorEntry
   | FallbackEntry
   | ReceiveEntry
-  | EventEntry;
+  | EventEntry
+  | ErrorEntry;
 
 export type StateMutability = "pure" | "view" | "nonpayable" | "payable";
 
@@ -38,6 +39,12 @@ export interface EventEntry {
   name: string;
   inputs: EventParameter[];
   anonymous: boolean;
+}
+
+export interface ErrorEntry {
+  type: "error";
+  name: string;
+  inputs: Parameter[];
 }
 
 export interface Parameter {

--- a/packages/codec/lib/abi-data/allocate/index.ts
+++ b/packages/codec/lib/abi-data/allocate/index.ts
@@ -21,6 +21,7 @@ import {
   ReturndataAllocation,
   FunctionReturndataAllocation,
   ConstructorReturndataAllocation,
+  AdditionalReturndataAllocation,
   ReturnImmutableAllocation,
   CalldataAllocations,
   CalldataAllocationTemporary,
@@ -58,6 +59,12 @@ interface EventParameterInfo {
   name: string;
   indexed: boolean;
 }
+
+export const FallbackOutputAllocation: AdditionalReturndataAllocation = {
+  kind: "returnmessage",
+  selector: new Uint8Array(), //empty
+  allocationMode: "full"
+};
 
 export function getAbiAllocations(
   userDefinedTypes: Format.Types.TypesById

--- a/packages/codec/lib/abi-data/allocate/types.ts
+++ b/packages/codec/lib/abi-data/allocate/types.ts
@@ -138,10 +138,12 @@ export type FunctionReturndataKind =
   | "failure"
   | "selfdestruct";
 export type ConstructorReturndataKind = "bytecode";
+export type AdditionalReturndataKind = "returnmessage";
 
 export type ReturndataAllocation =
   | FunctionReturndataAllocation
-  | ConstructorReturndataAllocation;
+  | ConstructorReturndataAllocation
+  | AdditionalReturndataAllocation;
 
 export interface FunctionReturndataAllocation {
   kind: FunctionReturndataKind;
@@ -157,6 +159,12 @@ export interface ConstructorReturndataAllocation {
   selector: Uint8Array; //must be empty, but is required for type niceness
   immutables?: ReturnImmutableAllocation[];
   delegatecallGuard: boolean;
+  allocationMode: DecodingMode;
+}
+
+export interface AdditionalReturndataAllocation {
+  kind: AdditionalReturndataKind;
+  selector: Uint8Array; //must be empty, but is required for type niceness
   allocationMode: DecodingMode;
 }
 

--- a/packages/codec/lib/abi-data/allocate/types.ts
+++ b/packages/codec/lib/abi-data/allocate/types.ts
@@ -129,7 +129,7 @@ export interface EventArgumentAllocation {
   pointer: Pointer.EventDataPointer | Pointer.EventTopicPointer;
 }
 
-//now let's go back ands fill in returndata
+//now let's go back and fill in returndata
 export type ReturndataKind = FunctionReturndataKind | ConstructorReturndataKind;
 
 export type FunctionReturndataKind =
@@ -146,6 +146,8 @@ export type ReturndataAllocation =
 export interface FunctionReturndataAllocation {
   kind: FunctionReturndataKind;
   selector: Uint8Array;
+  abi?: Abi.ErrorEntry; //only included when kind === "revert", but
+  //I'm not going to bother putting that in the type system
   arguments: ReturndataArgumentAllocation[];
   allocationMode: DecodingMode;
 }

--- a/packages/codec/lib/abi-data/utils.ts
+++ b/packages/codec/lib/abi-data/utils.ts
@@ -47,7 +47,7 @@ export function abiHasPayableFallback(
 
 //NOTE: this function returns the written out SIGNATURE, not the SELECTOR
 export function abiSignature(
-  abiEntry: Abi.FunctionEntry | Abi.EventEntry
+  abiEntry: Abi.FunctionEntry | Abi.EventEntry | Abi.ErrorEntry
 ): string {
   return abiEntry.name + abiTupleSignature(abiEntry.inputs);
 }
@@ -70,7 +70,7 @@ function abiTypeSignature(parameter: Abi.Parameter): string {
 }
 
 export function abiSelector(
-  abiEntry: Abi.FunctionEntry | Abi.EventEntry
+  abiEntry: Abi.FunctionEntry | Abi.EventEntry | Abi.ErrorEntry
 ): string {
   let signature = abiSignature(abiEntry);
   //NOTE: web3's soliditySha3 has a problem if the empty
@@ -80,6 +80,7 @@ export function abiSelector(
     case "event":
       return hash;
     case "function":
+    case "error":
       return hash.slice(0, 2 + 2 * Evm.Utils.SELECTOR_SIZE); //arithmetic to account for hex string
   }
 }
@@ -101,6 +102,7 @@ export function abisMatch(
   switch (entry1.type) {
     case "function":
     case "event":
+    case "error":
       return (
         abiSignature(entry1) ===
         abiSignature(<Abi.FunctionEntry | Abi.EventEntry>entry2)
@@ -145,6 +147,7 @@ export function abiEntryIsObviouslyIllTyped(abiEntry: Abi.Entry): boolean {
       return false;
     case "constructor":
     case "event":
+    case "error":
       return abiEntry.inputs.some(abiParameterIsObviouslyIllTyped);
     case "function":
       return (

--- a/packages/codec/lib/types.ts
+++ b/packages/codec/lib/types.ts
@@ -30,6 +30,7 @@ export type LogDecoding = EventDecoding | AnonymousDecoding;
  */
 export type ReturndataDecoding =
   | ReturnDecoding
+  | RawReturnDecoding
   | BytecodeDecoding
   | UnknownBytecodeDecoding
   | SelfDestructDecoding
@@ -324,6 +325,31 @@ export interface ReturnDecoding {
 }
 
 /**
+ * This type represents a decoding of the return data as a raw bytestring
+ * (as might be returned from a fallback function).
+ * @Category Output
+ */
+export interface RawReturnDecoding {
+  /**
+   * The kind of decoding; indicates that this is a RawReturnDecoding.
+   */
+  kind: "returnmessage";
+  /**
+   * Indicates that this kind of decoding indicates a successful return.
+   */
+  status: true;
+  /**
+   * The returned bytestring, as a hex string.
+   */
+  data: string;
+  /**
+   * The decoding mode that was used; [see the README](../#decoding-modes) for
+   * more on these.
+   */
+  decodingMode: DecodingMode;
+}
+
+/**
  * This type represents a decoding of unexpectedly empty return data from a
  * successful call, indicating that the contract self-destructed.
  * @Category Output
@@ -376,6 +402,12 @@ export interface RevertMessageDecoding {
    * The kind of decoding; indicates that this is a RevertMessageDecoding.
    */
   kind: "revert";
+  /**
+   * The ABI entry for the error that was thrown.  You can use this
+   * to extract the name, for instance.  This may be spoofed for built-in
+   * types of errors.
+   */
+  abi: Abi.ErrorEntry;
   /**
    * Indicates that this kind of decoding indicates an unsuccessful return.
    */

--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -499,6 +499,22 @@ class DebugPrinter {
     this.config.logger.log(DebugUtils.formatStacktrace(report));
   }
 
+  printErrorLocation(linesBefore, linesAfter) {
+    const stacktraceReport = this.session.view(stacktrace.current.finalReport);
+    const lastUserFrame = stacktraceReport
+      .slice()
+      .reverse() //clone before reversing, reverse is in-place!
+      .find(frame => !frame.location.internal);
+    if (lastUserFrame) {
+      this.config.logger.log("");
+      this.config.logger.log(
+        DebugUtils.truffleColors.red("Location of error:")
+      );
+      this.printFile(lastUserFrame.location);
+      this.printState(linesBefore, linesAfter, lastUserFrame.location);
+    }
+  }
+
   async printWatchExpressionsResults(expressions) {
     debug("expressions %o", expressions);
     for (let expression of expressions) {

--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -374,18 +374,13 @@ class DebugPrinter {
         "No value was returned even though one was expected.  This may indicate a self-destruct."
       );
       this.config.logger.log("");
-    } else if (decodings[0].kind === "returnmessage") {
-      //case 5: raw binary data
-      this.config.logger.log("");
-      this.config.logger.log(`Data returned: ${decodings[0].data}`);
-      this.config.logger.log("");
     } else if (decodings[0].kind === "failure") {
-      //case 6: revert (no message)
+      //case 5: revert (no message)
       this.config.logger.log("");
       this.config.logger.log("There was no revert message.");
       this.config.logger.log("");
     } else if (decodings[0].kind === "unknownbytecode") {
-      //case 7: unknown bytecode
+      //case 6: unknown bytecode
       this.config.logger.log("");
       this.config.logger.log(
         "Bytecode was returned, but it could not be identified."
@@ -395,10 +390,10 @@ class DebugPrinter {
       decodings[0].kind === "return" &&
       decodings[0].arguments.length === 0
     ) {
-      //case 8: return values but with no content
+      //case 7: return values but with no content
       //do nothing
     } else if (decodings[0].kind === "bytecode") {
-      //case 9: known bytecode
+      //case 8: known bytecode
       this.config.logger.log("");
       const decoding = decodings[0];
       const contractKind = decoding.contractKind || "contract";
@@ -429,12 +424,12 @@ class DebugPrinter {
       }
       this.config.logger.log("");
     } else if (decodings[0].kind === "revert") {
-      //case 10: revert (with message)
+      //case 9: revert (with message)
       const decoding = decodings[0];
       this.config.logger.log("");
       switch (decoding.abi.name) {
         case "Error": {
-          //case 10a: revert string
+          //case 9a: revert string
           const prefix = "Revert string: ";
           const value = decodings[0].arguments[0].value;
           const formatted = DebugUtils.formatValue(value, prefix.length);
@@ -442,7 +437,7 @@ class DebugPrinter {
           break;
         }
         case "Panic": {
-          //case 10b: panic code
+          //case 9b: panic code
           const prefix = "Panic code: ";
           const value = decodings[0].arguments[0].value;
           const formatted = DebugUtils.formatValue(value, prefix.length);
@@ -451,7 +446,7 @@ class DebugPrinter {
           break;
         }
         default:
-          //case 10c: ??? this shouldn't happen
+          //case 9c: ??? this shouldn't happen
           this.config.logger.log(
             "There was a revert message, but it was not of a recognized type."
           );
@@ -461,17 +456,17 @@ class DebugPrinter {
       decodings[0].kind === "return" &&
       decodings[0].arguments.length > 0
     ) {
-      //case 11: actual return values to print!
+      //case 10: actual return values to print!
       this.config.logger.log("");
       const values = decodings[0].arguments;
       if (values.length === 1 && !values[0].name) {
-        //case 11a: if there's only one value and it's unnamed
+        //case 10a: if there's only one value and it's unnamed
         const value = values[0].value;
         const prefix = "Returned value: ";
         const formatted = DebugUtils.formatValue(value, prefix.length);
         this.config.logger.log(prefix + formatted);
       } else {
-        //case 11b: otherwise
+        //case 10b: otherwise
         this.config.logger.log("Returned values:");
         const prefixes = values.map(({ name }, index) =>
           name ? `${name}: ` : `Component #${index + 1}: `
@@ -487,6 +482,31 @@ class DebugPrinter {
           this.config.logger.log(prefix + formatted);
         }
       }
+      this.config.logger.log("");
+    } else if (decodings[0].kind === "returnmessage") {
+      //case 11: raw binary data
+      this.config.logger.log("");
+      const fallbackOutputDefinition = this.session.view(
+        data.current.fallbackOutputForContext
+      );
+      const name = (fallbackOutputDefinition || {}).name;
+      const prettyData = `${colors.green("hex")}${DebugUtils.formatValue(
+        decodings[0].data.slice(2), //remove '0x'
+        0,
+        true
+      )}`;
+      if (name) {
+        //case 11a: it has a name
+        this.config.logger.log("Returned values:");
+        this.config.logger.log(`${name}: ${prettyData}`);
+      } else {
+        //case 11b: it doesn't
+        this.config.logger.log(`Returned value: ${prettyData}`);
+      }
+      //it's already a string, so we'll pass the nativized parameter
+      //and hack this together :)
+      //also, since we only have one thing and it's a string, we'll skip
+      //fancy indent processing
       this.config.logger.log("");
     }
   }

--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -8,6 +8,30 @@ var hljsDefineSolidity = require("highlightjs-solidity");
 hljsDefineSolidity(chromafi.hljs);
 var chalk = require("chalk");
 
+const panicTable = {
+  0x01: "Failed assertion",
+  0x11: "Arithmetic overflow",
+  0x12: "Division by zero",
+  0x21: "Enum value out of bounds",
+  0x22: "Malformed string",
+  0x31: "Array underflow",
+  0x32: "Index out of bounds",
+  0x41: "Oversized array or out of memory",
+  0x51: "Call to invalid function"
+};
+
+const verbosePanicTable = {
+  0x01: "An assert() check was not satisfied.",
+  0x11: "An arithmetic overflow occurred outside an unchecked { ... } block.",
+  0x12: "A division by zero occurred.",
+  0x21: "An integer was cast to an enum type that cannot hold it.",
+  0x22: "There was an attempt to read an incorrectly-encoded string or bytestring.",
+  0x31: "An empty array's pop() method was called.",
+  0x32: "An array or bytestring was indexed or sliced with an out-of-bounds index.",
+  0x41: "An oversized array was created, or the contract ran out of memory.",
+  0x51: "An uninitialized internal function pointer was called."
+};
+
 const commandReference = {
   "o": "step over",
   "i": "step into",
@@ -143,6 +167,8 @@ const trufflePalette = {
 
 var DebugUtils = {
   truffleColors, //make these externally available
+  panicTable,
+  verbosePanicTable,
 
   //attempts to test whether a given compilation is a real compilation,
   //i.e., was compiled all at once.

--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -695,7 +695,7 @@ var DebugUtils = {
     //reverse
     stacktrace = stacktrace.slice().reverse(); //reverse is in-place so clone first
     let lines = stacktrace.map(
-      ({ functionName, contractName, address, location }) => {
+      ({ functionName, contractName, address, location, type }) => {
         let name;
         if (contractName && functionName) {
           name = `${contractName}.${functionName}`;
@@ -723,8 +723,12 @@ var DebugUtils = {
           locationString = "unknown location";
         }
         let addressString =
-          address !== undefined ? `address ${address}` : "unknown address";
-        return `at ${name} [${addressString}] (${locationString})`;
+          type === "external"
+            ? address !== undefined
+              ? ` [address ${address}]`
+              : " [unknown address]"
+            : "";
+        return `at ${name}${addressString} (${locationString})`;
       }
     );
     let status = stacktrace[0].status;

--- a/packages/debug-utils/package.json
+++ b/packages/debug-utils/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@truffle/codec": "^0.9.2",
     "@trufflesuite/chromafi": "^2.2.2",
+    "bn.js": "^5.1.3",
     "chalk": "^2.4.2",
     "debug": "^4.1.0",
     "highlight.js": "^10.4.0",

--- a/packages/debugger/lib/data/selectors/index.js
+++ b/packages/debugger/lib/data/selectors/index.js
@@ -896,14 +896,14 @@ const data = createSelectorTree({
     ),
 
     /**
-     * data.current.contractHasFallbackOutput
-     * does the executing contract's fallback function have a return value?
+     * data.current.fallbackOutputForContext
+     * returns null if none
      */
-    contractHasFallbackOutput: createLeaf(
+    fallbackOutputForContext: createLeaf(
       ["./contractForBytecode"],
       contract => {
         if (!contract) {
-          return false;
+          return null;
         }
         const fallbackDefinition = contract.nodes.find(
           node =>
@@ -911,9 +911,9 @@ const data = createSelectorTree({
             Codec.Ast.Utils.functionKind(node) === "fallback"
         );
         if (!fallbackDefinition) {
-          return false;
+          return null;
         }
-        return fallbackDefinition.returnParameters.parameters.length > 0;
+        return fallbackDefinition.returnParameters.parameters[0] || null;
       }
     ),
 
@@ -1442,13 +1442,13 @@ const data = createSelectorTree({
         evm.current.call,
         "/current/context",
         "/info/allocations/calldata",
-        "./contractHasFallbackOutput"
+        "./fallbackOutputForContext"
       ],
       (
         { data: calldata },
         { context, isConstructor, fallbackAbi },
         { constructorAllocations, functionAllocations },
-        contractHasFallbackOutput
+        contractHasFallbackOutput //just using truthiness here
       ) => {
         if (isConstructor) {
           //we're in a constructor call

--- a/packages/debugger/lib/stacktrace/selectors/index.js
+++ b/packages/debugger/lib/stacktrace/selectors/index.js
@@ -20,11 +20,14 @@ function generateReport(callstack, location, status, message) {
   locations.shift();
   locations.push(location);
   debug("locations: %O", locations);
-  const names = callstack.map(({ functionName, contractName, address }) => ({
-    functionName,
-    contractName,
-    address
-  }));
+  const names = callstack.map(
+    ({ functionName, contractName, address, type }) => ({
+      functionName,
+      contractName,
+      address,
+      type
+    })
+  );
   debug("names: %O", names);
   let report = zipWith(locations, names, (location, nameInfo) => ({
     ...nameInfo,

--- a/packages/debugger/lib/stacktrace/selectors/index.js
+++ b/packages/debugger/lib/stacktrace/selectors/index.js
@@ -74,8 +74,8 @@ function createMultistepSelectors(stepSelector) {
      */
     strippedLocation: createLeaf(
       ["./location/source", "./location/sourceRange"],
-      ({ id, sourcePath }, sourceRange) => ({
-        source: { id, sourcePath },
+      ({ id, sourcePath, internal }, sourceRange) => ({
+        source: { id, sourcePath, internal },
         sourceRange
       })
     ),

--- a/packages/debugger/test/data/calldata.js
+++ b/packages/debugger/test/data/calldata.js
@@ -340,5 +340,14 @@ describe("Calldata Decoding", function () {
     };
 
     assert.deepInclude(variables, expectedResult);
+
+    await bugger.continueUntilBreakpoint(); //continue to end
+
+    const decodings = await bugger.returnValue();
+
+    assert.lengthOf(decodings, 1);
+    const decoding = decodings[0];
+    assert.equal(decoding.kind, "returnmessage");
+    assert.equal(decoding.data, "0xdeadbeef");
   });
 });

--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -893,10 +893,7 @@ export class ContractDecoder {
     options: DecoderTypes.ReturnOptions = {},
     additionalContexts: Contexts.Contexts = {}
   ): Promise<ReturndataDecoding[]> {
-    abi = {
-      type: "function",
-      ...abi
-    }; //just to be absolutely certain!
+    abi = <Abi.FunctionEntry>Abi.normalizeEntry(abi); //just to be absolutely certain!
     const block = options.block !== undefined ? options.block : "latest";
     const blockNumber = await this.regularizeBlock(block);
     const status = options.status; //true, false, or undefined
@@ -1208,7 +1205,9 @@ export class ContractInstanceDecoder {
           source ? source.source : undefined
         ),
         this.contractCode,
-        SourceMapUtils.getHumanReadableSourceMap(this.contract.deployedSourceMap)
+        SourceMapUtils.getHumanReadableSourceMap(
+          this.contract.deployedSourceMap
+        )
       );
       try {
         //this can fail if some of the source files are missing :(

--- a/packages/decoder/test/current/test/decoding-test.js
+++ b/packages/decoder/test/current/test/decoding-test.js
@@ -7,22 +7,22 @@ const Decoder = require("../../..");
 const { nativizeDecoderVariables } = require("../../../dist/utils");
 const { prepareContracts } = require("../../helpers");
 
-describe("State variable decoding", function() {
-
+describe("State variable decoding", function () {
   let provider;
   let abstractions;
-  let compilations;
 
   before("Create Provider", async function () {
-    provider = Ganache.provider({seed: "decoder", gasLimit: 7000000});
+    provider = Ganache.provider({ seed: "decoder", gasLimit: 7000000 });
   });
 
   before("Prepare contracts and artifacts", async function () {
-    this.timeout(30000);
+    this.timeout(50000);
 
-    const prepared = await prepareContracts(provider, path.resolve(__dirname, ".."));
+    const prepared = await prepareContracts(
+      provider,
+      path.resolve(__dirname, "..")
+    );
     abstractions = prepared.abstractions;
-    compilations = prepared.compilations;
   });
 
   it("should get the initial state properly", async function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5707,6 +5707,11 @@ bn.js@^5.1.2:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.1.2.tgz#c9686902d3c9a27729f43ab10f9d79c2004da7b0"
   integrity sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA==
 
+bn.js@^5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.1.3.tgz#beca005408f642ebebea80b042b4d18d2ac0ee6b"
+  integrity sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==
+
 body-parser@1.19.0, body-parser@^1.15.0, body-parser@^1.16.0, body-parser@^1.18.3:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"


### PR DESCRIPTION
OK, so, this PR does a few things.  I'll split it into three main groups: Panics; fallback return values; and other stacktrace-related improvements.

Part one: Panics.  This PR adds support for decoding of panics.  This affects Codec, the debugger, `debug-utils`, the debugger CLI, and `abi-utils`.

You may be wondering -- abi-utils?  It affects abi-utils because revert decodings now contain the corresponding ABI.  So, I've added error ABI entries to the types there.  Of course, these don't really exist yet, but acting as if they do seemed the best way to do this decoding in a future-proof manner.  In addition to simply adding the type, I also added support for the type to various ABI-related functions, both here and in Codec.  I did not add arbitraries for this type.

The changes to Codec here are quite small.  I just added spoofed ABIs to revert decoding output, and added an allocation for `Panic` alongside the allocation for `Error`.  Codec just gets the numeric panic code; it doesn't attempt to determine what this code means.  That's a job for `debug-utils`!  The new function `panicString()` takes a panic code (given as a number or a BN) and returns a message describing what it means.  There's also a second optional argument, `verbose`, for when a longer version is appropriate. :)

As for the debugger, it had to have changes made to the `stacktrace` submodule.  Unfortunately (unlike with `txlog` which received no changes), I wrote that submodule assuming revert messages would always be strings.  To keep the change from being breaking, the `message` field still holds a revert string when one is present, but the `panic` field will hold a panic code when one is present.

Speaking of stacktraces, that's another change to `debug-utils`!  The `formatStacktrace` function, used for formatting stacktraces both in the debugger CLI and in Truffle Test, accounts for these changes to `stacktrace`, and uses the aforementioned `panicString` to provide an explanation of the panic.

As for the debugger CLI, it needs to know how to print out these panics.  It'll print both a verbose version on transaction end, and a shorter version on pressing `v` after the transaction is done.  There's one thing here I'm not entirely happy with -- that last one prints it out in decimal, because that's what was convenient, even though everywhere else I'm printing panic codes, I'm doing it in hex (because that's how Solidity documentation describes them).  I think this is probably OK?  They are at least accompanied by a short explanation regardless. :)

So that's panics!  You'll note one thing I *didn't* do: I didn't add support for panic decoding in `contract/lib/reason.js`.  That thing is just such a hacked-up mess I didn't want to touch it, and I don't really a lot of familiarity with how it's used.  So I decided to just leave it alone.  And, of course, I obviously didn't touch revert string decoding in `ganache-core`, as that's a totally separate repo. :P

Part two: Fallback return values.  This was a little bit trickier.  Whereas panics are basically just like revert strings but with an integer instead of a string, these are new.  Now, the decoding here is pretty trivial; it's just raw binary data, there's not really anything to decode.  But it had to be fit into the existing structure.

So, first off, that means a new type of returndata decoding!  I gave it the tag `"returnessage"`, and it has `data` as just a hex string.  It also means a corresponding new type of allocation!  Not that this new type really contains any information beyond "hey, this is the type of allocation that means just treat the data as raw binary".  I created one instance of this allocation as an exported constant in `codec/abi-data/allocate`, for when it's necessary.  And, of course, Codec's `decodeReturndata` had to be updated to account for this new type of allocation and new type of return value.  Note this is not a breaking change to `codec`, as it's only possible to get this new type of output if you pass the new allocation in.

There were no changes to `decoder`; its return value decoding functionality already only works for functions, not constructors or anything else, so I saw no need to add any new support there.

Where there was a bit of work was `debugger` and the debugger CLI.  See, we don't want to "decode" and print fallback output unless the fallback is supposed to *have* output.  (Also, if there is output, we'll want to know its name.)  And the `fallback` ABI entry type hasn't changed, even if declared fallback functions can now include input and output.  So we can't rely on that.

So, instead, the debugger checks the AST for this information (via some new selectors).  And then the CLI can print it appropriately.  There is one little awkwardness here -- since I had codec return the data as just a hex string, we can't use `ResultInspector`, so, uh, instead we just fake things a little with some hackery.  It's OK I think?

Part three: Other stacktracing improvements I made while I was at it.

There's two of these.  First, I made it so that stacktraces only include the addresses for external calls, not internal calls.  That required going into `stacktrace` and adding the external/internal distinction to the stacktrace report object, which wasn't there previously, although since we had that information anyway that wasn't a big alteration.

The second isn't actually a change to stacktraces but rather to the debugger CLI's error location printout.  (Although, it required a change to stacktraces.)  See, when the debugger CLI prints out a stacktrace, it also prints out a selection of the location where the error happened.  Problem: Since 0.8.0 expands the use of generated sources, oftentimes the error-location is inside a generated sources.  This is not that helpful.  So, I added information to the stacktrace report object to distinguish generated sources from user ones.  This information isn't used by `formatStacktrace` -- actualy stacktrace printouts will still include generated sources -- but it is used by the error location printout, so that if the top of the stacktrace is a generated source, it'll look below that until it finds a user source, and it'll print out *that* location so you see something helpful.  (I think the mismatch is OK?)

Also, I factored this functionality into its own function in the debug printer, whereas before it was done twice manually in `interpreter.js`.

(Also, I added some tests.)

And that should be the end of the 0.7.6 / 0.8.0 compatibility work! :D