### PR TITLE
Bug fix: Fix Vyper bytecode prefix

### DIFF
--- a/packages/compile-vyper/index.js
+++ b/packages/compile-vyper/index.js
@@ -141,11 +141,11 @@ async function compileAllNoJson({ sources, options, version }) {
             source: sourceContents,
             abi: JSON.parse(compiledContract.abi),
             bytecode: {
-              bytes: compiledContract.bytecode,
+              bytes: compiledContract.bytecode.slice(2), //remove "0x" prefix
               linkReferences: [] //no libraries in Vyper
             },
             deployedBytecode: {
-              bytes: compiledContract.bytecode_runtime,
+              bytes: compiledContract.bytecode_runtime.slice(2), //remove "0x" prefix
               linkReferences: [] //no libraries in Vyper
             },
             deployedSourceMap: JSON.parse(compiledContract.source_map), //there is no constructor source map

--- a/packages/compile-vyper/package.json
+++ b/packages/compile-vyper/package.json
@@ -22,7 +22,6 @@
   },
   "devDependencies": {
     "@truffle/code-utils": "^1.2.22",
-    "@truffle/config": "^1.2.33",
     "mocha": "8.1.2"
   },
   "keywords": [

--- a/packages/compile-vyper/test/test_compiler.js
+++ b/packages/compile-vyper/test/test_compiler.js
@@ -29,7 +29,7 @@ describe("vyper compiler", function () {
       );
     });
 
-    const hex_regex = /^[x0-9a-fA-F]+$/;
+    const hex_regex = /^([0-9a-fA-F]{2})*$/;
 
     contracts.forEach((contract, index) => {
       assert.notEqual(
@@ -50,11 +50,11 @@ describe("vyper compiler", function () {
 
       assert(
         hex_regex.test(contract.bytecode.bytes),
-        "Bytecode has only hex characters"
+        "Bytecode is a valid hex string w/o prefix"
       );
       assert(
         hex_regex.test(contract.deployedBytecode.bytes),
-        "Deployed bytecode has only hex characters"
+        "Deployed bytecode is a valid hex string w/o prefix"
       );
 
       assert.equal(

--- a/packages/compile-vyper/vyper-json.js
+++ b/packages/compile-vyper/vyper-json.js
@@ -292,11 +292,11 @@ function processContracts({
           deployedSourceMap,
           ast,
           bytecode: {
-            bytes: bytecode,
+            bytes: bytecode.slice(2), //Vyper uses a "0x" prefix
             linkReferences: [] //no libraries in Vyper
           },
           deployedBytecode: {
-            bytes: deployedBytecode,
+            bytes: deployedBytecode.slice(2), //Vyper uses a "0x" prefix
             linkReferences: [] //no libraries in Vyper
           },
           compiler: {


### PR DESCRIPTION
Addresses #3629.  (PS we should also close the ancient #2209 once this is released; really that should have been closed with #3583, but I only found that issue later, and also #3583 broke things, so, uh, yeah...)

So, when making all the changes to `compile-vyper` recently in #3583, I also changed it to use the new bytecode output format.  Unfortunately, there's something I did not realize: The new bytecode output format requires that there be no `0x` prefix.  And Vyper always puts on such prefixes -- yes, even in its JSON output format, even though Solidity does *not* do this, and even though Vyper's *documentation* says it doesn't do this either.  Because this change happened so late in the PR and seemed harmless, it didn't get properly tested; and because our `compile-vyper` tests are so loose, they didn't catch the mistake either.

This led to Vyper bytecode being saved in the artifact starting with `"0x0x..."`, which, yeah, doesn't work.

This PR fixes that, so Vyper will work again.  It also tightens the check that compile-vyper is emitting valid hex strings, to prevent this from happening again.

Also, oops, I had `@truffle/config` as both a dependency and a devDependency, fixed that as well.