### PR TITLE
Bug fix: Allow compile-vyper to compile hidden files/directories

### DIFF
--- a/packages/compile-vyper/index.js
+++ b/packages/compile-vyper/index.js
@@ -180,7 +180,7 @@ const Compile = {
   async sources({ sources = [], options }) {
     options = Config.default().merge(options);
     // filter out non-vyper paths
-    const vyperFiles = sources.filter(path => minimatch(path, VYPER_PATTERN));
+    const vyperFiles = sources.filter(path => minimatch(path, VYPER_PATTERN, { dot: true }));
 
     // no vyper files found, no need to check vyper
     if (vyperFiles.length === 0) {

--- a/packages/contract-sources/index.js
+++ b/packages/contract-sources/index.js
@@ -14,7 +14,8 @@ module.exports = (pattern, callback) => {
   }
 
   const globOptions = {
-    follow: true // follow symlinks
+    follow: true, // follow symlinks
+    dot: true //check hidden files and directories
   };
 
   return promisify(glob)(pattern, globOptions)


### PR DESCRIPTION
Addresses #3455.

There were two things going wrong here:

1. To some extent this was actually a generic problem and not specific to Vyper; I turned on `dot: true` in `contract-sources` so it can find hidden files and directories.
2. Unfortunately this didn't fix the problem, because `compile-vyper` was doing a separate minimatch check, so I turned on `dot: true` there as well.

Anyway now hidden sources, and sources in hidden directories, should work!