### PR TITLE
Internal improvement: Increase timeout on timing-out decoder tests

### DIFF
--- a/packages/decoder/test/current/test/decoding-test.js
+++ b/packages/decoder/test/current/test/decoding-test.js
@@ -18,7 +18,7 @@ describe("State variable decoding", function() {
   });
 
   before("Prepare contracts and artifacts", async function () {
-    this.timeout(30000);
+    this.timeout(50000);
 
     const prepared = await prepareContracts(provider, path.resolve(__dirname, ".."));
     abstractions = prepared.abstractions;


### PR DESCRIPTION
So, since I switched the decoder tests to `Ganache.provider`, they're slower than they used to be, and this preparation step keeps timing out.  I'm upping the timeout.

Note: I also made this change on #3627, but that isn't merged yet and I assume @gnidan is going to take some time to review that, so I made this separate PR in addition so it can get merged quickly.