### PR TITLE
Enhancement: Allow fetch-external to proceed with warning if compile fails

### DIFF
--- a/packages/core/lib/debug/cli.js
+++ b/packages/core/lib/debug/cli.js
@@ -66,6 +66,13 @@ class CLIDebugger {
           )}.`
         );
       }
+      if (badCompilationAddresses.length > 0) {
+        warningStrings.push(
+          `Errors occurred while compiling sources for addresses ${badCompilations.join(
+            ", "
+          )}.`
+        );
+      }
       fetchSpinner.warn(warningStrings.join("  "));
     }
   }

--- a/packages/core/lib/debug/external.js
+++ b/packages/core/lib/debug/external.js
@@ -16,6 +16,7 @@ class DebugExternalHandler {
   async fetch() {
     let badAddresses = []; //for reporting errors back
     let badFetchers = []; //similar
+    let badCompilationAddresses = []; //similar
     let addressesToSkip = new Set(); //addresses we know we can't get source for
     //note: this should always be a subset of unknownAddresses! [see below]
     //get the network id
@@ -65,6 +66,7 @@ class DebugExternalHandler {
     ) {
       let found = false;
       let failure = false; //set in case something goes wrong while getting source
+      let failureReason; 
       //(not set if there is no source)
       for (const fetcher of fetchers) {
         //now comes all the hard parts!
@@ -76,6 +78,7 @@ class DebugExternalHandler {
         } catch (error) {
           debug("error in getting sources! %o", error);
           failure = true;
+          failureReason = "fetch";
           continue;
         }
         if (result === null) {
@@ -106,9 +109,17 @@ class DebugExternalHandler {
             }
           }
         });
-        const compilations = await new DebugCompiler(externalConfig).compile(
-          sources
-        );
+        let compilations;
+        try {
+          compilations = await new DebugCompiler(externalConfig).compile(
+            sources
+          );
+        } catch (error) {
+          debug("compile error: %O", error);
+          failure = true;
+          failureReason = "compile";
+          continue; //try again with a different fetcher, I guess?
+        }
         //shim the result
         const shimmedCompilations = Codec.Compilations.Utils.shimCompilations(
           compilations,
@@ -116,6 +127,7 @@ class DebugExternalHandler {
         );
         //add it!
         await this.bugger.addExternalCompilations(shimmedCompilations);
+        failure = false; //mark as *not* failed in case a previous fetcher failed
         //check: did this actually help?
         debug("checking result");
         if (!getUnknownAddresses(this.bugger).includes(address)) {
@@ -133,14 +145,25 @@ class DebugExternalHandler {
       if (found === false) {
         //if we couldn't find it, add it to the list of addresses to skip
         addressesToSkip.add(address);
-        //if we couldn't find it *and* there was a network problem, add it to
-        //the failures list
+        //if we couldn't find it *and* there was a network or compile problem,
+        //add it to the failures list
         if (failure === true) {
-          badAddresses.push(address);
+          switch (failureReason) {
+            case "fetch":
+              badAddresses.push(address);
+              break;
+            case "compile":
+              badCompilationAddresses.push(address);
+              break;
+          }
         }
       }
     }
-    return {badAddresses, badFetchers}; //main result is that we've mutated bugger,
+    return {
+      badAddresses,
+      badFetchers,
+      badCompilationAddresses
+    }; //main result is that we've mutated bugger,
     //not the return value!
   }
 }


### PR DESCRIPTION
This PR makes it so that if `truffle debug --fetch-external` encounters an error while compiling contracts, it will print a warning rather than erroring out.  Specifically, there's now a try/catch around the compile step, and on an error, `failure` is set to `true` and we retry with the next fetcher.  Also, there's now `failureReason`, so we can distinguish fetch failures from compile failures; it will be `"fetch"` or `"compile"` as appropriate.  The compile failures get added to a new array, and the warnings printout will include them.

Also, I made it so that `failure` is reset to `false` when getting a particular address succeeds because, like, why do we need to warn that there were problems with a certain address if at least one of the fetchers succeeded?  Like, if etherscan had problems for that address but sourcify worked, do we really need to warn that that address had problems...?

Anyway yeah, pretty simple.  Apologies for the messy code, but, well, uh, `external.js` is like that. :P