### PR TITLE
Bug fix: Prevent unnecessary recompilation when debugging Vyper

### DIFF
--- a/packages/core/lib/debug/cli.js
+++ b/packages/core/lib/debug/cli.js
@@ -86,8 +86,10 @@ class CLIDebugger {
       );
       //if they were compiled simultaneously, yay, we can use it!
       if (shimmedCompilations.every(DebugUtils.isUsableCompilation)) {
+        debug("shimmed compilations usable")
         return shimmedCompilations;
       }
+      debug("shimmed compilations unusable")
     }
     //if not, or if build directory doens't exist, we have to recompile
     return await this.compileSources();

--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -193,6 +193,7 @@ var DebugUtils = {
   isUsableCompilation: function (compilation) {
     //check #1: is the source order reliable?
     if (compilation.unreliableSourceOrder) {
+      debug("unreliable source order");
       return false;
     }
 
@@ -205,6 +206,7 @@ var DebugUtils = {
     //(since the real concern is empty spots, not undefined, yet this turns
     //this up anyhow)
     if (compilation.sources.includes(undefined)) {
+      debug("nonconsecutive sources");
       return false;
     }
 
@@ -231,6 +233,7 @@ var DebugUtils = {
       if (lowestInternalIndex !== compilation.sources.length) {
         //if it's a usable compilation, these should be equal,
         //as length = 1 + last user source
+        debug("gap before internal sources");
         return false;
       }
     }
@@ -244,6 +247,7 @@ var DebugUtils = {
       } else if (node !== null && typeof node === "object") {
         if (node.id !== undefined) {
           if (astIds.has(node.id)) {
+            debug("id occured twice: %o", node.id);
             return false;
           } else {
             astIds.add(node.id);
@@ -255,9 +259,12 @@ var DebugUtils = {
       }
     };
 
-    //now: walk each AST
+    //now: walk each Solidity AST
+    //(and don't bother checking generated sources as they're
+    //never Solidity)
+    debug("checking Solidity ASTs for collisions");
     return compilation.sources.every(source =>
-      source ? allIDsUnseenSoFar(source.ast) : true
+      !source || source.language !== "Solidity" || allIDsUnseenSoFar(source.ast)
     );
   },
 


### PR DESCRIPTION
I noticed that the debugger was doing a recompile every time I tried to debug Vyper.  Something about Vyper was always triggering the recompile check.  What was it?  That in Vyper ASTs, some nodes do have an `id` field, but it's not the node ID, it's something else, and so these often generate false-positive for collisions.  So, I've restricted the check to Solidity sources.

Note that Vyper ASTs do have node IDs, but they're in the `node_id` field, not the `id` field.  However, checking them for collisions would be pointless, as they're only unique per source, not per compilation.  So, as mentioned, we restrict the check to Solidity.