### PR TITLE
Enhancement: Allow debugger to debug Solidity test contracts (also, some other new options)

### DIFF
--- a/packages/core/lib/commands/debug.js
+++ b/packages/core/lib/commands/debug.js
@@ -10,11 +10,26 @@ const command = {
       alias: "x",
       type: "boolean",
       default: false
+    },
+    "compile-tests": {
+      describe: "Allow debugging of Solidity test contracts",
+      type: "boolean",
+      default: false
+    },
+    "force-recompile": {
+      describe: "Force debugger to compile all contracts for extra safety",
+      type: "boolean",
+      default: false
+    },
+    "force-no-recompile": {
+      describe: "Force debugger to skip compilation (dangerous!)",
+      type: "boolean",
+      default: false
     }
   },
   help: {
     usage:
-      "truffle debug [--network <network>] [--fetch-external] [<transaction_hash>]",
+      "truffle debug [--network <network>] [--fetch-external] [--compile-tests] [--force-[no-]recompile] [<transaction_hash>]",
     options: [
       {
         option: "--network",
@@ -29,6 +44,21 @@ const command = {
         option: "<transaction_hash>",
         description:
           "Transaction ID to use for debugging.  Mandatory if --fetch-external is passed."
+      },
+      {
+        option: "--compile-tests",
+        description:
+          "Allows debugging of Solidity test contracts from the test directory.  Forces a recompile."
+      },
+      {
+        option: "--force-recompile",
+        description:
+          "Forces the debugger to recompile all contracts even if it detects that it can use the artifacts."
+      },
+      {
+        option: "--force-no-recompile",
+        description:
+          "Forces the debugger to use artifacts even if it detects a problem.  Dangerous; may cause errors."
       }
     ]
   },
@@ -50,6 +80,14 @@ const command = {
         if (config.fetchExternal && txHash === undefined) {
           throw new Error(
             "Fetch-external mode requires a specific transaction to debug"
+          );
+        }
+        if (config.compileTests) {
+          config.forceRecompile = true;
+        }
+        if (config.forceRecompile && config.forceNoRecompile) {
+          throw new Error(
+            "Incompatible options passed regarding whether to recompile"
           );
         }
         return await new CLIDebugger(config, { txHash }).run();

--- a/packages/core/lib/commands/debug.js
+++ b/packages/core/lib/commands/debug.js
@@ -1,3 +1,4 @@
+const OS = require("os");
 const command = {
   command: "debug",
   description: "Interactively debug any transaction on the blockchain",
@@ -29,8 +30,14 @@ const command = {
   },
   help: {
     usage:
-      "truffle debug [--network <network>] [--fetch-external] [--compile-tests] [--force-[no-]recompile] [<transaction_hash>]",
+      "truffle debug [<transaction_hash>] [--network <network>] [--fetch-external] [--compile-tests]" + OS.EOL +
+      "                             [--force-[no-]recompile]",
     options: [
+      {
+        option: "<transaction_hash>",
+        description:
+          "Transaction ID to use for debugging.  Mandatory if --fetch-external is passed."
+      },
       {
         option: "--network",
         description: "Network to connect to."
@@ -39,11 +46,6 @@ const command = {
         option: "--fetch-external",
         description:
           "Allows debugging of external contracts with verified sources.  Alias: -x"
-      },
-      {
-        option: "<transaction_hash>",
-        description:
-          "Transaction ID to use for debugging.  Mandatory if --fetch-external is passed."
       },
       {
         option: "--compile-tests",

--- a/packages/core/lib/debug/cli.js
+++ b/packages/core/lib/debug/cli.js
@@ -80,23 +80,29 @@ class CLIDebugger {
   async getCompilations() {
     let artifacts;
     artifacts = await this.gatherArtifacts();
-    if (artifacts) {
+    if ((artifacts && !this.config.forceRecompile) || this.config.forceNoRecompile) {
       let shimmedCompilations = Codec.Compilations.Utils.shimArtifacts(
         artifacts
       );
       //if they were compiled simultaneously, yay, we can use it!
-      if (shimmedCompilations.every(DebugUtils.isUsableCompilation)) {
+      //(or if we *force* it to...)
+      if (
+        this.config.forceNoRecompile ||
+        shimmedCompilations.every(DebugUtils.isUsableCompilation)
+      ) {
         return shimmedCompilations;
       }
     }
-    //if not, or if build directory doens't exist, we have to recompile
+    //if not, or if build directory doesn't exist, we have to recompile
     return await this.compileSources();
   }
 
   async compileSources() {
     const compileSpinner = ora("Compiling your contracts...").start();
 
-    const compilationResult = await new DebugCompiler(this.config).compile();
+    const compilationResult = await new DebugCompiler(this.config).compile({
+      withTests: this.config.compileTests
+    });
     debug("compilationResult: %O", compilationResult);
 
     compileSpinner.succeed();

--- a/packages/core/lib/debug/compiler.js
+++ b/packages/core/lib/debug/compiler.js
@@ -1,13 +1,28 @@
 const { Compile } = require("@truffle/compile-solidity");
 const WorkflowCompile = require("@truffle/workflow-compile");
+const Resolver = require("@truffle/resolver");
+const glob = require("glob");
+const path = require("path");
 
 class DebugCompiler {
   constructor(config) {
     this.config = config;
   }
 
-  async compile(sources = undefined) {
-    const compileConfig = this.config.with({ quiet: true });
+  async compile({ sources, withTests }) {
+    let compileConfig = this.config.with({ quiet: true });
+
+    if (withTests) {
+      const testResolver = new Resolver(this.config, true);
+      const testFiles = glob.sync(
+        `${this.config.test_directory}/**/*.sol`
+      ).map(filePath => path.resolve(filePath));
+      compileConfig = compileConfig.with({
+        resolver: testResolver,
+        //note we only need to pass *additional* files
+        files: testFiles
+      });
+    }
 
     const { compilations } = sources
       ? await Compile.sources({ sources, options: compileConfig }) //used by external.js

--- a/packages/core/lib/debug/external.js
+++ b/packages/core/lib/debug/external.js
@@ -112,7 +112,7 @@ class DebugExternalHandler {
         let compilations;
         try {
           compilations = await new DebugCompiler(externalConfig).compile(
-            sources
+            { sources }
           );
         } catch (error) {
           debug("compile error: %O", error);


### PR DESCRIPTION
As requested by @cds-amal.

This PR adds three new options to the debugger CLI: `--compile-tests`, `--force-recompile`, and `--force-no-recompile`.

The interesting new one is `--compile-tests`.  This causes the debugger CLI to compile your Solidity test contracts so you can debug them.  Hooray!  It also forces a recompilation more generally.

There's also `--force-recompile`.  It's not called `--compile-all` because it doesn't save the results.  Anyway, this forces the debugger to do a recompile on startup, even if its heuristics would say that it doesn't need to.  You know, in case there's a problem they miss.

Finally there's `--force-no-recompile`.  This forces the debugger *not* to recompile, in case the debugger erroneously thinks there's a problem, or you're pretty sure any problems are irrelevant, or you just think the check takes too long and you're sure there's no problems.  This is marked dangerous, for obvious reasons.  Combining it will either of the previous two options will error out.

Basically the `compile` method on `DebugCompiler` now takes a `withTests` option; if passed, it'll get the Solidity tests (in basically the same way that `truffle test` does) and set up a test resolver (for importing Truffle sources -- yup, you can debug these! :) )  Then it does the compilation!  And, well, the rest of this PR is pretty straightforward, I think.

Note that I changed the `compile` method on `DebugCompiler` to take named arguments instead of positional, and updated `external.js` to pass `sources` appropriately.  Since I don't think this can be called exposed in any reasonable sense, I wouldn't call this any sort of breaking change.

Of course the debugger help text has been updated appropriately; I'll put up a docs PR once this is merged.

No tests added; I just tested it manually.