### PR TITLE
Internal improvement: Rename debugger compile options for consistency

### DIFF
--- a/packages/core/lib/commands/debug.js
+++ b/packages/core/lib/commands/debug.js
@@ -17,12 +17,12 @@ const command = {
       type: "boolean",
       default: false
     },
-    "force-recompile": {
+    "compile-all": {
       describe: "Force debugger to compile all contracts for extra safety",
       type: "boolean",
       default: false
     },
-    "force-no-recompile": {
+    "compile-none": {
       describe: "Force debugger to skip compilation (dangerous!)",
       type: "boolean",
       default: false
@@ -30,8 +30,8 @@ const command = {
   },
   help: {
     usage:
-      "truffle debug [<transaction_hash>] [--network <network>] [--fetch-external] [--compile-tests]" + OS.EOL +
-      "                             [--force-[no-]recompile]",
+      "truffle debug [<transaction_hash>] [--network <network>] [--fetch-external]" + OS.EOL +
+      "                             [--compile-tests|--compile-all|--compile-none]",
     options: [
       {
         option: "<transaction_hash>",
@@ -50,15 +50,15 @@ const command = {
       {
         option: "--compile-tests",
         description:
-          "Allows debugging of Solidity test contracts from the test directory.  Forces a recompile."
+          "Allows debugging of Solidity test contracts from the test directory.  Implies --compile-all."
       },
       {
-        option: "--force-recompile",
+        option: "--compile-all",
         description:
           "Forces the debugger to recompile all contracts even if it detects that it can use the artifacts."
       },
       {
-        option: "--force-no-recompile",
+        option: "--compile-none",
         description:
           "Forces the debugger to use artifacts even if it detects a problem.  Dangerous; may cause errors."
       }
@@ -85,11 +85,11 @@ const command = {
           );
         }
         if (config.compileTests) {
-          config.forceRecompile = true;
+          config.compileAll = true;
         }
-        if (config.forceRecompile && config.forceNoRecompile) {
+        if (config.compileAll && config.compileNone) {
           throw new Error(
-            "Incompatible options passed regarding whether to recompile"
+            "Incompatible options passed regarding what to compile"
           );
         }
         return await new CLIDebugger(config, { txHash }).run();

--- a/packages/core/lib/debug/cli.js
+++ b/packages/core/lib/debug/cli.js
@@ -80,14 +80,14 @@ class CLIDebugger {
   async getCompilations() {
     let artifacts;
     artifacts = await this.gatherArtifacts();
-    if ((artifacts && !this.config.forceRecompile) || this.config.forceNoRecompile) {
+    if ((artifacts && !this.config.compileAll) || this.config.compileNone) {
       let shimmedCompilations = Codec.Compilations.Utils.shimArtifacts(
         artifacts
       );
       //if they were compiled simultaneously, yay, we can use it!
       //(or if we *force* it to...)
       if (
-        this.config.forceNoRecompile ||
+        this.config.compileNone ||
         shimmedCompilations.every(DebugUtils.isUsableCompilation)
       ) {
         debug("shimmed compilations usable")


### PR DESCRIPTION
Rename some of the options I introduced in #3637 for consistency.  I avoided doing this at first because I thought it would be inconsistent with how `truffle migrate` works, which it would, but it would be totally consistent with how `truffle test` works, so it's fine I figure.  (I guess `truffle test` technically *does* do a save, but it does it to a temporary directory, so that doesn't count!)