### PR TITLE
Unalias `byte` to `bytes1`

### DIFF
--- a/packages/resolver/solidity/AssertAddressArray.sol
+++ b/packages/resolver/solidity/AssertAddressArray.sol
@@ -3,8 +3,8 @@ pragma solidity >= 0.4.15 < 0.9.0;
 
 library AssertAddressArray {
     
-    uint8 constant ZERO = uint8(byte('0'));
-    uint8 constant A = uint8(byte('a'));
+    uint8 constant ZERO = uint8(bytes1('0'));
+    uint8 constant A = uint8(bytes1('a'));
     
     /*
         Event: TestEvent
@@ -188,11 +188,11 @@ library AssertAddressArray {
         Returns:
             result (string) - The ASCII byte.
     */
-    function _utoa(uint8 u) internal pure returns (byte) {
+    function _utoa(uint8 u) internal pure returns (bytes1) {
         if (u < 10)
-            return byte(u + ZERO);
+            return bytes1(u + ZERO);
         else if (u < 16)
-            return byte(u - 10 + A);
+            return bytes1(u - 10 + A);
         else
             return 0;
     }

--- a/packages/resolver/solidity/AssertBytes32.sol
+++ b/packages/resolver/solidity/AssertBytes32.sol
@@ -8,7 +8,7 @@ library AssertBytes32 {
     // The null bytes32: 0
     bytes32 constant BYTES32_NULL = 0x0;
 
-    byte constant MINUS = byte('-');
+    bytes1 constant MINUS = bytes1('-');
 
     /*
         Event: TestEvent

--- a/packages/resolver/solidity/AssertBytes32Array.sol
+++ b/packages/resolver/solidity/AssertBytes32Array.sol
@@ -3,8 +3,8 @@ pragma solidity >= 0.4.15 < 0.9.0;
 
 library AssertBytes32Array {
     
-    uint8 constant ZERO = uint8(byte('0'));
-    uint8 constant A = uint8(byte('a'));
+    uint8 constant ZERO = uint8(bytes1('0'));
+    uint8 constant A = uint8(bytes1('a'));
     /*
         Event: TestEvent
 
@@ -187,11 +187,11 @@ library AssertBytes32Array {
         Returns:
             result (string) - The ASCII byte.
     */
-    function _utoa(uint8 u) internal pure returns (byte) {
+    function _utoa(uint8 u) internal pure returns (bytes1) {
         if (u < 10)
-            return byte(u + ZERO);
+            return bytes1(u + ZERO);
         else if (u < 16)
-            return byte(u - 10 + A);
+            return bytes1(u - 10 + A);
         else
             return 0;
     }

--- a/packages/resolver/solidity/AssertInt.sol
+++ b/packages/resolver/solidity/AssertInt.sol
@@ -3,10 +3,10 @@ pragma solidity >= 0.4.15 < 0.9.0;
 
 library AssertInt {
 
-    uint8 constant ZERO = uint8(byte('0'));
-    uint8 constant A = uint8(byte('a'));
+    uint8 constant ZERO = uint8(bytes1('0'));
+    uint8 constant A = uint8(bytes1('a'));
 
-    byte constant MINUS = byte('-');
+    bytes1 constant MINUS = bytes1('-');
 
     /*
         Event: TestEvent
@@ -277,11 +277,11 @@ library AssertInt {
         Returns:
             result (string) - The ASCII byte.
     */
-    function _utoa(uint8 u) internal pure returns (byte) {
+    function _utoa(uint8 u) internal pure returns (bytes1) {
         if (u < 10)
-            return byte(u + ZERO);
+            return bytes1(u + ZERO);
         else if (u < 16)
-            return byte(u - 10 + A);
+            return bytes1(u - 10 + A);
         else
             return 0;
     }

--- a/packages/resolver/solidity/AssertIntArray.sol
+++ b/packages/resolver/solidity/AssertIntArray.sol
@@ -3,10 +3,10 @@ pragma solidity >= 0.4.15 < 0.9.0;
 
 library AssertIntArray {
 
-    uint8 constant ZERO = uint8(byte('0'));
-    uint8 constant A = uint8(byte('a'));
+    uint8 constant ZERO = uint8(bytes1('0'));
+    uint8 constant A = uint8(bytes1('a'));
 
-    byte constant MINUS = byte('-');
+    bytes1 constant MINUS = bytes1('-');
 
     /*
         Event: TestEvent
@@ -234,11 +234,11 @@ library AssertIntArray {
         Returns:
             result (string) - The ASCII byte.
     */
-    function _utoa(uint8 u) internal pure returns (byte) {
+    function _utoa(uint8 u) internal pure returns (bytes1) {
         if (u < 10)
-            return byte(u + ZERO);
+            return bytes1(u + ZERO);
         else if (u < 16)
-            return byte(u - 10 + A);
+            return bytes1(u - 10 + A);
         else
             return 0;
     }

--- a/packages/resolver/solidity/AssertUint.sol
+++ b/packages/resolver/solidity/AssertUint.sol
@@ -3,8 +3,8 @@ pragma solidity >= 0.4.15 < 0.9.0;
 
 library AssertUint {
 
-    uint8 constant ZERO = uint8(byte('0'));
-    uint8 constant A = uint8(byte('a'));
+    uint8 constant ZERO = uint8(bytes1('0'));
+    uint8 constant A = uint8(bytes1('a'));
 
     /*
         Event: TestEvent
@@ -260,11 +260,11 @@ library AssertUint {
         Returns:
             result (string) - The ASCII byte.
     */
-    function _utoa(uint8 u) internal pure returns (byte) {
+    function _utoa(uint8 u) internal pure returns (bytes1) {
         if (u < 10)
-            return byte(u + ZERO);
+            return bytes1(u + ZERO);
         else if (u < 16)
-            return byte(u - 10 + A);
+            return bytes1(u - 10 + A);
         else
             return 0;
     }

--- a/packages/resolver/solidity/AssertUintArray.sol
+++ b/packages/resolver/solidity/AssertUintArray.sol
@@ -3,8 +3,8 @@ pragma solidity >= 0.4.15 < 0.9.0;
 
 library AssertUintArray {
 
-    uint8 constant ZERO = uint8(byte('0'));
-    uint8 constant A = uint8(byte('a'));
+    uint8 constant ZERO = uint8(bytes1('0'));
+    uint8 constant A = uint8(bytes1('a'));
 
     /*
         Event: TestEvent
@@ -189,11 +189,11 @@ library AssertUintArray {
         Returns:
             result (string) - The ASCII byte.
     */
-    function _utoa(uint8 u) internal pure returns (byte) {
+    function _utoa(uint8 u) internal pure returns (bytes1) {
         if (u < 10)
-            return byte(u + ZERO);
+            return bytes1(u + ZERO);
         else if (u < 16)
-            return byte(u - 10 + A);
+            return bytes1(u - 10 + A);
         else
             return 0;
     }


### PR DESCRIPTION
Since [Solidity 0.8.0](https://blog.soliditylang.org/2020/12/16/solidity-v0.8.0-release-announcement/), the use of `byte` has been disallowed and `bytes1` must be used instead. 
> Type System: Disallow the byte type. It was an alias to bytes1.

This PR removes `byte` to compile `Assert*.sol` with Solidity 0.8.0.

