### PR TITLE
Bug fix: Prevent Vyper compilations when JSON but no Vyper

### DIFF
--- a/packages/compile-vyper/index.js
+++ b/packages/compile-vyper/index.js
@@ -13,6 +13,7 @@ const Config = require("@truffle/config");
 const { compileAllJson } = require("./vyper-json");
 
 const VYPER_PATTERN = "**/*.{vy,v.py,vyper.py,json}"; //include JSON for interfaces
+const VYPER_PATTERN_STRICT = "**/*.{vy,v.py,vyper.py}"; //no JSON
 
 // Check that vyper is available, return its version
 function checkVyper() {
@@ -180,10 +181,16 @@ const Compile = {
   async sources({ sources = [], options }) {
     options = Config.default().merge(options);
     // filter out non-vyper paths
-    const vyperFiles = sources.filter(path => minimatch(path, VYPER_PATTERN, { dot: true }));
+    const vyperFiles = sources.filter(
+      path => minimatch(path, VYPER_PATTERN, { dot: true })
+    );
+    const vyperFilesStrict = vyperFiles.filter(
+      path => minimatch(path, VYPER_PATTERN_STRICT, { dot: true })
+    );
 
     // no vyper files found, no need to check vyper
-    if (vyperFiles.length === 0) {
+    // (note that JSON-only will not activate vyper)
+    if (vyperFilesStrict.length === 0) {
       return { compilations: [] };
     }
 


### PR DESCRIPTION
Addresses #3647.

This PR makes it so that `compile-vyper` won't attempt to do anything if there are JSON files present in the contracts directory but no actual Vyper files.  I had JSON count as Vyper to support Vyper's native ability to import JSON, but we don't always want that, as there might be JSON present for other reasons and no actual Vyper.  So, I changed the "are there any Vyper files present?" check to restrict to actual Vyper files, not including JSON.