### PR TITLE
Bug fix: Fix problems with using debugger with Vyper versions prior to 0.1.0-beta.17

### DIFF
--- a/packages/debugger/lib/session/index.js
+++ b/packages/debugger/lib/session/index.js
@@ -147,9 +147,13 @@ export default class Session {
         if (!source) {
           continue; //just for safety (in case there are gaps)
         }
+        let ast = source.ast;
+        if (ast && !ast.nodeType) {
+          ast = undefined; //HACK: remove Vyper asts for now
+        }
         sources.user[compilation.id][index] = {
           ...source,
-          ast: source.ast.nodeType ? source.ast : undefined, //HACK: remove Vyper asts for now
+          ast,
           compiler: source.compiler || compiler,
           compilationId: compilation.id,
           index,


### PR DESCRIPTION
This PR fixes two bugs that would prevent using the debugger with Vyper versions prior to 0.1.0-beta.17.

The first bug is that it turns out, in Vyper versions prior to 0.1.0-beta.17, the AST's root node is... not a node.  The AST is just an array of nodes, there's nothing for the root.  This naturally caused problems when we tried to do things with its `src` field to determine a contract's primary source.  So, now, we check if the AST is an array, and if it is, we replace it by `ast[0]`.  What if it's an *empty* array...?  Well, uh, then that attempt fails, but I also generally made things more robust by allowing `shimContracts` to check the source map as well, because why not.

The second bug is that sufficiently old Vyper versions don't have an AST.  Now that should be fine, right?  A big part of the Vyper PR was letting the debugger work without an AST, right?  Yeah, except at startup I still checked `ast.nodeType` to determine whether it's a Solidity/Yul AST, which will crash if `ast` is undefined.  Oops.  Now there's a guard there.