### PR TITLE
Bug fix: Prevent crash from missing build directory in Truffle resolver source

### DIFF
--- a/packages/resolver/lib/sources/truffle/index.ts
+++ b/packages/resolver/lib/sources/truffle/index.ts
@@ -16,12 +16,11 @@ export class Truffle implements ResolverSource {
     if (importPath === "truffle/DeployedAddresses.sol") {
       const sourceFiles = await findContracts(this.options.contracts_directory);
 
-      let abstractionFiles: string[] =
+      const buildDirFiles: string[] =
         fse.existsSync(this.options.contracts_build_directory)
           ? fse.readdirSync(this.options.contracts_build_directory)
           : [];
-      const buildDirFiles = abstractionFiles;
-      abstractionFiles = buildDirFiles.filter(file => file.match(/^.*.json$/));
+      const abstractionFiles = buildDirFiles.filter(file => file.match(/^.*.json$/));
 
       const mapping: { [key: string]: string | false } = {};
 

--- a/packages/resolver/lib/sources/truffle/index.ts
+++ b/packages/resolver/lib/sources/truffle/index.ts
@@ -18,7 +18,7 @@ export class Truffle implements ResolverSource {
 
       let abstractionFiles: string[] =
         fse.existsSync(this.options.contracts_build_directory)
-          ? fse.readdirSync(this.options.contract_build_directory)
+          ? fse.readdirSync(this.options.contracts_build_directory)
           : [];
       const buildDirFiles = abstractionFiles;
       abstractionFiles = buildDirFiles.filter(file => file.match(/^.*.json$/));

--- a/packages/resolver/lib/sources/truffle/index.ts
+++ b/packages/resolver/lib/sources/truffle/index.ts
@@ -16,10 +16,11 @@ export class Truffle implements ResolverSource {
     if (importPath === "truffle/DeployedAddresses.sol") {
       const sourceFiles = await findContracts(this.options.contracts_directory);
 
-      let abstractionFiles: string[];
-      const buildDirFiles = (abstractionFiles = fse.readdirSync(
-        this.options.contracts_build_directory
-      ));
+      let abstractionFiles: string[] =
+        fse.existsSync(this.options.contracts_build_directory)
+          ? fse.readdirSync(this.options.contract_build_directory)
+          : [];
+      const buildDirFiles = abstractionFiles;
       abstractionFiles = buildDirFiles.filter(file => file.match(/^.*.json$/));
 
       const mapping: { [key: string]: string | false } = {};


### PR DESCRIPTION
Addresses #3651.

This PR fixes a problem that if you tried to use a `truffle` resolver source, but the contracts build directory was missing, the `resolve` function would crash.  It would call `fs.readdirSync` on the build directory, but if the build directory was absent, this would crash.  So, I added a check to see first if it exists, and if not, it just sets the files found there to `[]`.  This seems to solve the problem.