### PR TITLE
Bug fix: Fix check for resolved source

### DIFF
--- a/packages/resolver/lib/sources/abi.ts
+++ b/packages/resolver/lib/sources/abi.ts
@@ -20,7 +20,7 @@ export class ABI extends FS {
     }
 
     const resolution = await super.resolve(importPath, importedFrom);
-    if (!resolution) {
+    if (!resolution.body) {
       return { filePath, body };
     }
 


### PR DESCRIPTION
We need to check that `resolver.body` is falsy in the ABI source because what is returned from the FS source is always of the  form `{ body: <value>, filePath: <value> }` and thus `resolver` will always be truthy. It will then proceed to use `undefined` as an argument to the `path` module which would cause it to crash. So to correct this, use `resolver.body` as that will be undefined in the case that nothing is resolved.