### PR TITLE
Prevent config.merge() from modifying merge(); have config.merge() merge more fields; add config.clone() method; make sure cloned configs have getters & setters

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,6 +1,5 @@
 import "source-map-support/register";
 import path from "path";
-import assignIn from "lodash.assignin";
 import merge from "lodash.merge";
 import Module from "module";
 import findUp from "find-up";
@@ -115,11 +114,23 @@ class TruffleConfig {
     let eventsOptions = this.eventManagerOptions(this);
     this.events.updateSubscriberOptions(eventsOptions);
 
-    return assignIn(
-      TruffleConfig.default(),
-      current,
-      normalized
-    );
+    let combined = TruffleConfig.default();
+    for (const key of Object.keys(current)) {
+      try {
+        combined[key] = current[key];
+      } catch {
+        // ignore things that can't be directly set
+      }
+    }
+    for (const key of Object.keys(normalized)) {
+      try {
+        combined[key] = normalized[key];
+      } catch {
+        // ignore things that can't be directly set
+      }
+    }
+
+    return combined;
   }
 
   public clone(): TruffleConfig {
@@ -131,9 +142,7 @@ class TruffleConfig {
     const current = this.clone(); //clone current so we don't modfiy it
 
     // Only set keys for values that don't throw.
-    const propertyNames = Object.keys(obj);
-
-    propertyNames.forEach(key => {
+    for (const key of Object.keys(obj)) {
       try {
         if (typeof clone[key] === "object" && this._deepCopy.includes(key)) {
           current[key] = merge(current[key], clone[key]);
@@ -143,7 +152,7 @@ class TruffleConfig {
       } catch {
         // ignore
       }
-    });
+    }
 
     const eventsOptions = this.eventManagerOptions(this);
     this.events.updateSubscriberOptions(eventsOptions);

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -115,9 +115,13 @@ class TruffleConfig {
     );
   }
 
+  public clone(): TruffleConfig {
+    return this.with({});
+  }
+
   public merge(obj: any): TruffleConfig {
     const clone = this.normalize(obj);
-    const current = this.with({}); //clone current so we don't modfiy it
+    const current = this.clone(); //clone current so we don't modfiy it
 
     // Only set keys for values that don't throw.
     const propertyNames = Object.keys(obj);

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -117,6 +117,7 @@ class TruffleConfig {
 
   public merge(obj: any): TruffleConfig {
     const clone = this.normalize(obj);
+    const current = this.with({}); //clone current so we don't modfiy it
 
     // Only set keys for values that don't throw.
     const propertyNames = Object.keys(obj);
@@ -124,11 +125,11 @@ class TruffleConfig {
     propertyNames.forEach(key => {
       try {
         if (typeof clone[key] === "object" && this._deepCopy.includes(key)) {
-          this[key] = merge(this[key], clone[key]);
+          current[key] = merge(current[key], clone[key]);
         } else {
-          this[key] = clone[key];
+          current[key] = clone[key];
         }
-      } catch (e) {
+      } catch {
         // ignore
       }
     });
@@ -136,7 +137,7 @@ class TruffleConfig {
     const eventsOptions = this.eventManagerOptions(this);
     this.events.updateSubscriberOptions(eventsOptions);
 
-    return this;
+    return current;
   }
 
   public static default(): TruffleConfig {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -24,7 +24,14 @@ class TruffleConfig {
     workingDirectory?: string,
     network?: any
   ) {
-    this._deepCopy = ["compilers"];
+    this._deepCopy = [
+      "compilers",
+      "solc", //for old versions
+      "networks",
+      "db",
+      "ens",
+      "ethpm"
+    ];
     this._values = getInitialConfig({
       truffleDirectory,
       workingDirectory,

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -116,7 +116,7 @@ class TruffleConfig {
     this.events.updateSubscriberOptions(eventsOptions);
 
     return assignIn(
-      Object.create(TruffleConfig.prototype),
+      TruffleConfig.default(),
       current,
       normalized
     );

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -27,7 +27,7 @@ class TruffleConfig {
     this._deepCopy = [
       "compilers",
       "solc", //for old versions
-      "networks",
+      //networks excluded as deepcloning providers may be unsafe
       "db",
       "ens",
       "ethpm"


### PR DESCRIPTION
This PR does three things:

1. First, it adds a `clone` method to config, since that didn't exist.  Naturally, it just calls `this.with({})`. :)

2. Secondly, it has `config.merge()` call `this.clone()` at the start so that we don't modify the original.  Note, I didn't change any of the code relating to events because uh I don't really understand that stuff but it seems that `with` uses `this` even though it returns a copy so uh hoping this is alright...?

3. Finally, it has `config.merge()` actually merge a few more fields; previously it only merged `compilers`, now it also merges `solc` (for compatibility), `db`, `ens`, and `ethpm`.  Merging the `networks` field was discussed but not done as doing so may be unsafe if there are provider objects in there.  @gnidan had an idea for how to make that more safe, but that won't fit in this quick PR. :P