### PR TITLE
Allow querying collections of project names

### DIFF
--- a/packages/db/src/resources/types.ts
+++ b/packages/db/src/resources/types.ts
@@ -156,3 +156,5 @@ export type NamedResource<
 > = Meta.NamedResource<Collections, N>;
 
 export type NamedCollectionName = Meta.NamedCollectionName<Collections>;
+
+export type Workspace = Pouch.Workspace<Collections>;

--- a/packages/db/src/test/projects.graphql.ts
+++ b/packages/db/src/test/projects.graphql.ts
@@ -26,6 +26,21 @@ export const LookupNames = gql`
   }
 `;
 
+export const ListResources = gql`
+  query ListResources(
+    $projectId: ID!
+  ) {
+    project(id: $projectId) {
+      networks {
+        name
+      }
+      contracts {
+        name
+      }
+    }
+  }
+`;
+
 export const AddProject = gql`
   mutation AddProject($directory: String!) {
     projectsAdd(input: { projects: [{ directory: $directory }] }) {

--- a/packages/db/src/test/projects.spec.ts
+++ b/packages/db/src/test/projects.spec.ts
@@ -5,6 +5,7 @@ import { generateId, Migrations, WorkspaceClient } from "./utils";
 import {
   GetProject,
   LookupNames,
+  ListResources,
   AddProject,
   AssignProjectName
 } from "./projects.graphql";
@@ -184,6 +185,29 @@ describe("Project", () => {
     const { network, contract } = project;
 
     expect(network.name).toEqual("ganache");
+    expect(contract.name).toEqual("Migrations");
+  });
+
+  test("enumerates known named resources", async () => {
+    const result = await wsClient.execute(ListResources, {
+      projectId
+    });
+
+    expect(result).toHaveProperty("project");
+    const { project } = result;
+
+    debug("project %O", project);
+
+    expect(project).toHaveProperty("networks");
+    expect(project).toHaveProperty("contracts");
+    const { networks, contracts } = project;
+
+    expect(networks).toHaveLength(1);
+    const [ network ] = networks;
+    expect(network.name).toEqual("ganache");
+
+    expect(contracts).toHaveLength(1);
+    const [ contract ] = contracts;
     expect(contract.name).toEqual("Migrations");
   });
 });


### PR DESCRIPTION
- Add `contracts` field to Project, to query for all current, name-assigned contracts
- Add `networks` field to Project, to query for all current, name-assigned networks
- Factor out a `resolve` function to resolve a given name and/or type for a project; update the existing `network` and `contract` resolvers to use this new function.