### PR TITLE
Bug fix: Fix RangeUtils method

### DIFF
--- a/packages/compile-solidity/compilerSupplier/rangeUtils.js
+++ b/packages/compile-solidity/compilerSupplier/rangeUtils.js
@@ -34,10 +34,10 @@ const RangeUtils = {
     //the following line doesn't, despite the flag, but does work with version ranges
     const rangeAtLeast =
       semver.validRange(range, { loose: true }) &&
-      !semver.ltr(comparisonVersion, range, {
+      (semver.ltr(comparisonVersion, range, {
         includePrerelease: true,
         loose: true
-      }); //intersects will throw if given undefined so must ward against
+      }) || semver.satisfies(comparisonVersion, range)); //intersects will throw if given undefined so must ward against
     return individualAtLeast || rangeAtLeast;
   },
 

--- a/packages/compile-solidity/compilerSupplier/rangeUtils.js
+++ b/packages/compile-solidity/compilerSupplier/rangeUtils.js
@@ -34,10 +34,10 @@ const RangeUtils = {
     //the following line doesn't, despite the flag, but does work with version ranges
     const rangeAtLeast =
       semver.validRange(range, { loose: true }) &&
-      (semver.ltr(comparisonVersion, range, {
+      !semver.gtr(comparisonVersion, range, {
         includePrerelease: true,
         loose: true
-      }) || semver.satisfies(comparisonVersion, range)); //intersects will throw if given undefined so must ward against
+      }); //intersects will throw if given undefined so must ward against
     return individualAtLeast || rangeAtLeast;
   },
 

--- a/packages/compile-solidity/test/compilerSupplier/rangeUtils.js
+++ b/packages/compile-solidity/test/compilerSupplier/rangeUtils.js
@@ -1,0 +1,35 @@
+const assert = require("assert");
+const { rangeContainsAtLeast } = require("../../compilerSupplier/rangeUtils");
+
+describe("rangeUtils", () => {
+  describe(".rangeContainsAtLeast(range, comparisonVersion)", () => {
+    describe("using a semver range for the range argument", () => {
+      it("returns false if the whole range is less", () => {
+        const result = rangeContainsAtLeast("^0.5.0", "0.6.0");
+        assert.equal(result, false);
+      });
+      it("returns true if the whole range is greater", () => {
+        const result = rangeContainsAtLeast("^0.5.0", "0.4.7");
+        assert.equal(result, true);
+      });
+      it("returns true if the range contains the version", () => {
+        const result = rangeContainsAtLeast("^0.5.0", "0.5.11");
+        assert.equal(result, true);
+      });
+    });
+    describe("using a single version for the range argument", () => {
+      it("returns false if the range arg is less", () => {
+        const result = rangeContainsAtLeast("0.5.0", "0.6.0");
+        assert.equal(result, false);
+      });
+      it("returns true if the range arg is greater", () => {
+        const result = rangeContainsAtLeast("0.6.0", "0.5.7");
+        assert.equal(result, true);
+      });
+      it("returns true if the version is the same", () => {
+        const result = rangeContainsAtLeast("0.5.0", "0.5.0");
+        assert.equal(result, true);
+      });
+    });
+  });
+});


### PR DESCRIPTION
There was an error in the `rangeContainsAtLeast` method and here it is fixed. Some tests have also been added.