### PR TITLE
Bug fix: Have compile-vyper's necessary() call sourcesWithDependencies(), remove compilationTargets logic

### DIFF
--- a/packages/compile-vyper/index.js
+++ b/packages/compile-vyper/index.js
@@ -251,7 +251,7 @@ const Compile = {
     const updatedVyperPaths = updated.filter(path => {
       return path.match(/\.vy$|\.v.py$|\.vyper.py$/);
     });
-    return await Compile.sources({
+    return await Compile.sourcesWithDependencies({
       sources: files,
       options: options.with({
         compilationTargets: updatedVyperPaths

--- a/packages/compile-vyper/index.js
+++ b/packages/compile-vyper/index.js
@@ -252,7 +252,7 @@ const Compile = {
       return path.match(/\.vy$|\.v.py$|\.vyper.py$|\.json$/);
     });
     return await Compile.sourcesWithDependencies({
-      sources: udpatedVyperPaths,
+      sources: updatedVyperPaths,
       options
     });
   },

--- a/packages/compile-vyper/index.js
+++ b/packages/compile-vyper/index.js
@@ -249,13 +249,11 @@ const Compile = {
     }
     // select only Vyper files
     const updatedVyperPaths = updated.filter(path => {
-      return path.match(/\.vy$|\.v.py$|\.vyper.py$/);
+      return path.match(/\.vy$|\.v.py$|\.vyper.py$|\.json$/);
     });
     return await Compile.sourcesWithDependencies({
-      sources: files,
-      options: options.with({
-        compilationTargets: updatedVyperPaths
-      })
+      sources: udpatedVyperPaths,
+      options
     });
   },
 

--- a/packages/compile-vyper/index.js
+++ b/packages/compile-vyper/index.js
@@ -214,6 +214,7 @@ const Compile = {
   // quiet: Boolean. Suppress output. Defaults to false.
   // strict: Boolean. Return compiler warnings as errors. Defaults to false.
   async all(options) {
+    options = Config.default().merge(options);
     const fileSearchPattern = path.join(
       options.contracts_directory,
       VYPER_PATTERN
@@ -234,7 +235,7 @@ const Compile = {
   // quiet: Boolean. Suppress output. Defaults to false.
   // strict: Boolean. Return compiler warnings as errors. Defaults to false.
   async necessary(options) {
-    options.logger = options.logger || console;
+    options = Config.default().merge(options);
 
     const fileSearchPattern = path.join(
       options.contracts_directory,


### PR DESCRIPTION
Right now I occasionally get errors when compiling Vyper without `--all` because `compile-vyper`'s `necessary()` method calls `sources()` instead of `sourcesWithDependencies()`, so sometimes the compiler it can't locate imported sources.  So, this PR changes that.  I also removed the `compilationTargets` logic because -- now that I understand a bit better how that's supposed to work -- I've realized that's not the appropriate place to handle that.

Note that right now the `sourcesWithDependencies()` method in `compile-vyper` just calls `all()`, because we don't currently have an import parser for Vyper like we do with Solidity.  Obviously that's not great for performance, but it's better than failing to compile at all!

Anyway, now Vyper should always compile at least.  We might want to see about writing an import parser for Vyper like we have for Solidity?  I'm having trouble locating where the code for that even is...