### PR TITLE
Bug fix: Update profiler method to allow json files for compilation

### DIFF
--- a/packages/compile-solidity/index.js
+++ b/packages/compile-solidity/index.js
@@ -86,7 +86,7 @@ const Compile = {
 
     // we need to remove all JSON files so Vyper-related stuff doesn't get
     // sent to the compiler - the Profiler will find JSON imports
-    const filteredPaths = paths.filter(path => path.extname !== ".json");
+    const filteredPaths = paths.filter(file => path.extname(file) !== ".json");
 
     options = Config.default().merge(options);
     const { allSources, compilationTargets } = await Profiler.requiredSources(

--- a/packages/compile-solidity/index.js
+++ b/packages/compile-solidity/index.js
@@ -99,7 +99,7 @@ const Compile = {
     const solidityTargets = compilationTargets.filter(fileName => {
       return fileName.endsWith(".sol");
     });
-    if (compilationTargets !== 0 && solidityTargets.length === 0) {
+    if (compilationTargets.length !== 0 && solidityTargets.length === 0) {
       return { compilations: [] };
     }
     const hasTargets = compilationTargets.length;

--- a/packages/compile-solidity/index.js
+++ b/packages/compile-solidity/index.js
@@ -84,10 +84,14 @@ const Compile = {
       "resolver"
     ]);
 
+    // we need to remove all JSON files so Vyper-related stuff doesn't get
+    // sent to the compiler - the Profiler will find JSON imports
+    const filteredPaths = paths.filter(path => path.extname !== ".json");
+
     options = Config.default().merge(options);
     const { allSources, compilationTargets } = await Profiler.requiredSources(
       options.with({
-        paths,
+        paths: filteredPaths,
         base_path: options.contracts_directory,
         resolver: options.resolver
       })

--- a/packages/compile-solidity/index.js
+++ b/packages/compile-solidity/index.js
@@ -100,12 +100,12 @@ const Compile = {
       ? Compile.display(compilationTargets, options)
       : Compile.display(allSources, options);
 
-    // if there are no Solidity files to compile, then we can exit
-    // since we may only have Vyper-related JSON
     const soliditySources = Object.keys(allSources).filter(fileName => {
       return fileName.endsWith(".sol");
     });
     // when there are no sources, don't call run
+    // we can also exit if there are no Soldity files to compile since
+    // it is possible that we only have Vyper-related JSON
     if (soliditySources.length === 0 || Object.keys(allSources).length === 0) {
       return { compilations: [] };
     }

--- a/packages/compile-solidity/profiler/shouldIncludePath.js
+++ b/packages/compile-solidity/profiler/shouldIncludePath.js
@@ -1,7 +1,8 @@
 const path = require("path");
 
 function shouldIncludePath(filePath) {
-  return path.extname(filePath) === ".sol";
+  const validExtensions = [".sol", ".abi.json", ".json"];
+  return validExtensions.some(extension => path.extname(filePath) === extension);
 }
 
 module.exports = { shouldIncludePath };

--- a/packages/compile-solidity/profiler/shouldIncludePath.js
+++ b/packages/compile-solidity/profiler/shouldIncludePath.js
@@ -1,7 +1,7 @@
 const path = require("path");
 
 function shouldIncludePath(filePath) {
-  const validExtensions = [".sol", ".abi.json", ".json"];
+  const validExtensions = [".sol", ".json"];
   return validExtensions.some(extension => path.extname(filePath) === extension);
 }
 

--- a/packages/compile-solidity/test/profiler/shouldIncludePath.js
+++ b/packages/compile-solidity/test/profiler/shouldIncludePath.js
@@ -1,0 +1,19 @@
+const assert = require("assert");
+const { shouldIncludePath } = require("../../profiler/shouldIncludePath");
+
+describe(".shouldIncludePath(filename)", () => {
+  it("returns true if the file has a .sol extension", () => {
+    const result = shouldIncludePath("jibberJabber.sol");
+    assert(result);
+  });
+  it("returns true if the file has a .json extension", () => {
+    const result = shouldIncludePath("iPityTheFool.json");
+    assert(result);
+  });
+  it("returns false for other extensions", () => {
+    const otherExtensions = [ ".js", ".ts", ".test.js", ".onion" ];
+    assert(
+      !otherExtensions.some(extension => shouldIncludePath(`file${extension}`))
+    );
+  });
+});

--- a/packages/resolver/lib/sources/abi.ts
+++ b/packages/resolver/lib/sources/abi.ts
@@ -43,7 +43,14 @@ export class ABI extends FS {
         body: soliditySource
       };
     } catch (e) {
-      return { filePath, body };
+      const emptySolidity = `
+        // SPDX-License-Identifier: MIT
+        pragma solidity >0.0.0;
+      `;
+      return {
+        filePath,
+        body: emptySolidity
+      };
     }
   }
 }

--- a/packages/truffle/test/scenarios/compile/compile.js
+++ b/packages/truffle/test/scenarios/compile/compile.js
@@ -56,6 +56,10 @@ describe("Repeated compilation of contracts with inheritance [ @standalone ]", f
     fs.writeFileSync(mapping[key].sourcePath, source);
   }
 
+  function hasBeenUpdated(fileName) {
+    return initialTimes[fileName] < finalTimes[fileName];
+  }
+
   // ----------------------- Setup -----------------------------
 
   before("set up the server", function (done) {
@@ -124,16 +128,11 @@ describe("Repeated compilation of contracts with inheritance [ @standalone ]", f
     finalTimes = getArtifactStats();
 
     try {
-      assert(
-        initialTimes["Root.sol"] < finalTimes["Root.sol"],
-        "Should update root"
-      );
+      assert(hasBeenUpdated("Root.sol"), "Should update root");
+
       for (const file of Object.keys(mapping)) {
         if (file !== "Root.sol") {
-          assert(
-            initialTimes[file] === finalTimes[file],
-            `Should not update ${file}`
-          );
+          assert(!hasBeenUpdated(file), `Should not update ${file}`);
         }
       }
     } catch (err) {
@@ -163,21 +162,12 @@ describe("Repeated compilation of contracts with inheritance [ @standalone ]", f
     finalTimes = getArtifactStats();
 
     try {
-      assert(
-        initialTimes["Root.sol"] < finalTimes["Root.sol"],
-        "Should update root"
-      );
-      assert(
-        initialTimes["LibraryA.sol"] < finalTimes["LibraryA.sol"],
-        "Should update LibraryA"
-      );
-      // ensure that the rest of the files have not been updated
+      assert(hasBeenUpdated("Root.sol"), "Should update root");
+      assert(hasBeenUpdated("LibraryA.sol"), "Should update LibraryA");
+
       for (const file of Object.keys(mapping)) {
         if (file !== "Root.sol" && file !== "LibraryA.sol") {
-          assert(
-            initialTimes[file] === finalTimes[file],
-            `Should not update ${file}`
-          );
+          assert(!hasBeenUpdated(file), `Should not update ${file}`);
         }
       }
     } catch (err) {
@@ -207,21 +197,12 @@ describe("Repeated compilation of contracts with inheritance [ @standalone ]", f
     finalTimes = getArtifactStats();
 
     try {
-      assert(
-        initialTimes["Root.sol"] < finalTimes["Root.sol"],
-        "Should update root"
-      );
-      assert(
-        initialTimes["Branch.sol"] < finalTimes["Branch.sol"],
-        "Should update Branch"
-      );
-      // ensure that the rest of the files have not been updated
+      assert(hasBeenUpdated("Root.sol"), "Should update root");
+      assert(hasBeenUpdated("Branch.sol"), "Should update Branch");
+
       for (const file of Object.keys(mapping)) {
         if (file !== "Root.sol" && file !== "Branch.sol") {
-          assert(
-            initialTimes[file] === finalTimes[file],
-            `Should not update ${file}`
-          );
+          assert(!hasBeenUpdated(file), `Should not update ${file}`);
         }
       }
     } catch (err) {
@@ -251,29 +232,17 @@ describe("Repeated compilation of contracts with inheritance [ @standalone ]", f
     finalTimes = getArtifactStats();
 
     try {
-      assert(
-        initialTimes["Root.sol"] < finalTimes["Root.sol"],
-        "Should update root"
-      );
-      assert(
-        initialTimes["Branch.sol"] < finalTimes["Branch.sol"],
-        "Should update Branch"
-      );
-      assert(
-        initialTimes["LeafA.sol"] < finalTimes["LeafA.sol"],
-        "Should update LeafA"
-      );
-      // ensure that the rest of the files have not been updated
+      assert(hasBeenUpdated("LeafA.sol"), "Should update LeafA");
+      assert(hasBeenUpdated("Branch.sol"), "Should update Branch");
+      assert(hasBeenUpdated("Root.sol"), "Should update root");
+
       for (const file of Object.keys(mapping)) {
         if (
           file !== "Root.sol" &&
           file !== "Branch.sol" &&
           file !== "LeafA.sol"
         ) {
-          assert(
-            initialTimes[file] === finalTimes[file],
-            `Should not update ${file}`
-          );
+          assert(!hasBeenUpdated(file), `Should not update ${file}`);
         }
       }
     } catch (err) {
@@ -303,21 +272,12 @@ describe("Repeated compilation of contracts with inheritance [ @standalone ]", f
     finalTimes = getArtifactStats();
 
     try {
-      assert(
-        initialTimes["LibraryA.sol"] === finalTimes["LibraryA.sol"],
-        "Should not update LibraryA"
-      );
-      assert(
-        initialTimes["Abi.abi.json"] === finalTimes["Abi.abi.json"],
-        "Should not update Abi"
-      );
-      // ensure that the rest of the files have been updated
+      assert(!hasBeenUpdated("LibraryA.sol"), "Should not update LibraryA");
+      assert(!hasBeenUpdated("Abi.abi.json"), "Should not update Abi");
+
       for (const file of Object.keys(mapping)) {
         if (file !== "LibraryA.sol" && file !== "Abi.abi.json") {
-          assert(
-            initialTimes[file] < finalTimes[file],
-            `Should not update ${file}`
-          );
+          assert(hasBeenUpdated(file), `Should not update ${file}`);
         }
       }
     } catch (err) {
@@ -347,21 +307,11 @@ describe("Repeated compilation of contracts with inheritance [ @standalone ]", f
     finalTimes = getArtifactStats();
 
     try {
-      assert(
-        initialTimes["Root.sol"] < finalTimes["Root.sol"],
-        "Should update root"
-      );
-      assert(
-        initialTimes["Abi.abi.json"] < finalTimes["Abi.abi.json"],
-        "Should not update Abi"
-      );
-      // ensure that everything has been updated
+      assert(hasBeenUpdated("Root.sol"), "Should update root");
+      assert(hasBeenUpdated("Abi.abi.json"), "Should update Abi");
       for (const file of Object.keys(mapping)) {
         if (file !== "Root.sol" && file !== "Abi.abi.json") {
-          assert(
-            initialTimes[file] === finalTimes[file],
-            `Should not update ${file}`
-          );
+          assert(!hasBeenUpdated(file), `Should not update ${file}`);
         }
       }
     } catch (err) {

--- a/packages/truffle/test/scenarios/compile/compile.js
+++ b/packages/truffle/test/scenarios/compile/compile.js
@@ -8,26 +8,21 @@ const Reporter = require("../reporter");
 const sandbox = require("../sandbox");
 const log = console.log;
 
-describe("Repeated compilation of contracts with inheritance [ @standalone ]", function() {
-  let config,
-    sourcePaths,
-    artifactPaths,
-    initialTimes,
-    finalTimes,
-    output,
-    sources;
+describe("Repeated compilation of contracts with inheritance [ @standalone ]", function () {
+  let config, artifactPaths, initialTimes, finalTimes, output;
   const mapping = {};
 
   const project = path.join(__dirname, "../../sources/inheritance");
   const names = [
-    "Root",
-    "Branch",
-    "LeafA",
-    "LeafB",
-    "LeafC",
-    "SameFile1",
-    "SameFile2",
-    "LibraryA"
+    "Root.sol",
+    "Branch.sol",
+    "LeafA.sol",
+    "LeafB.sol",
+    "LeafC.sol",
+    "SameFile1.sol",
+    "SameFile2.sol",
+    "LibraryA.sol",
+    "Abi.abi.json"
   ];
   const logger = new MemoryLogger();
 
@@ -63,15 +58,15 @@ describe("Repeated compilation of contracts with inheritance [ @standalone ]", f
 
   // ----------------------- Setup -----------------------------
 
-  before("set up the server", function(done) {
+  before("set up the server", function (done) {
     Server.start(done);
   });
 
-  after("stop server", function(done) {
+  after("stop server", function (done) {
     Server.stop(done);
   });
 
-  beforeEach("set up sandbox and do initial compile", async function() {
+  beforeEach("set up sandbox and do initial compile", async function () {
     this.timeout(30000);
 
     const conf = await sandbox.create(project);
@@ -82,19 +77,17 @@ describe("Repeated compilation of contracts with inheritance [ @standalone ]", f
       reporter: new Reporter(logger)
     };
 
-    sources = names.map(name => name + ".sol");
-    artifactPaths = names.map(name =>
-      path.join(config.contracts_build_directory, name + ".json")
-    );
-    sourcePaths = sources.map(source =>
-      path.join(config.contracts_directory, source)
-    );
+    // create artifact path array
+    artifactPaths = names.map(name => {
+      const basename = path.basename(path.basename(name, ".sol"), ".abi.json");
+      return path.join(config.contracts_build_directory, `${basename}.json`);
+    });
 
+    // create mapping from name to source path
     names.forEach((name, i) => {
       mapping[name] = {};
-      mapping[name].source = sources[i];
       mapping[name].artifactPath = artifactPaths[i];
-      mapping[name].sourcePath = sourcePaths[i];
+      mapping[name].sourcePath = path.join(config.contracts_directory, name);
     });
 
     try {
@@ -115,14 +108,15 @@ describe("Repeated compilation of contracts with inheritance [ @standalone ]", f
   //      LibA         LeafA              |    SameFile1 - LeafC
   //     /           /       \            |
   // Root* - Branch -           - LeafC   |    SameFile2
-  //                 \       /            |
-  //                   LeafB              |
+  //     \           \       /            |
+  //      Abi          LeafB              |
+  //                                      |
   // ------------------------------------------------------------
 
-  it("Updates only Root when Root is touched", async function() {
+  it("updates only Root when Root is touched", async function () {
     this.timeout(30000);
 
-    touchSource("Root");
+    touchSource("Root.sol");
 
     await CommandRunner.run("compile", config);
     output = logger.contents();
@@ -130,35 +124,18 @@ describe("Repeated compilation of contracts with inheritance [ @standalone ]", f
     finalTimes = getArtifactStats();
 
     try {
-      assert(initialTimes["Root"] < finalTimes["Root"], "Should update root");
       assert(
-        initialTimes["Branch"] === finalTimes["Branch"],
-        "Should not update Branch"
+        initialTimes["Root.sol"] < finalTimes["Root.sol"],
+        "Should update root"
       );
-      assert(
-        initialTimes["LeafA"] === finalTimes["LeafA"],
-        "Should not update LeafA"
-      );
-      assert(
-        initialTimes["LeafB"] === finalTimes["LeafB"],
-        "Should not update LeafB"
-      );
-      assert(
-        initialTimes["LeafC"] === finalTimes["LeafC"],
-        "Should not update LeafC"
-      );
-      assert(
-        initialTimes["LibraryA"] === finalTimes["LibraryA"],
-        "Should not update LibraryA"
-      );
-      assert(
-        initialTimes["SameFile1"] === finalTimes["SameFile1"],
-        "Should not update SameFile1"
-      );
-      assert(
-        initialTimes["SameFile2"] === finalTimes["SameFile2"],
-        "Should not update SameFile2"
-      );
+      for (const file of Object.keys(mapping)) {
+        if (file !== "Root.sol") {
+          assert(
+            initialTimes[file] === finalTimes[file],
+            `Should not update ${file}`
+          );
+        }
+      }
     } catch (err) {
       err.message += "\n\n" + output;
       throw new Error(err);
@@ -170,14 +147,15 @@ describe("Repeated compilation of contracts with inheritance [ @standalone ]", f
   //      LibA*        LeafA              |    SameFile1 - LeafC
   //     /           /       \            |
   // Root* - Branch -           - LeafC   |    SameFile2
-  //                 \       /            |
-  //                   LeafB              |
+  //     \           \       /            |
+  //      Abi          LeafB              |
+  //                                      |
   // ------------------------------------------------------------
 
-  it("Updates Root and Library when Library is touched", async function() {
+  it("updates Root and Library when Library is touched", async function () {
     this.timeout(30000);
 
-    touchSource("LibraryA");
+    touchSource("LibraryA.sol");
 
     await CommandRunner.run("compile", config);
     output = logger.contents();
@@ -185,35 +163,23 @@ describe("Repeated compilation of contracts with inheritance [ @standalone ]", f
     finalTimes = getArtifactStats();
 
     try {
-      assert(initialTimes["Root"] < finalTimes["Root"], "Should update root");
       assert(
-        initialTimes["Branch"] === finalTimes["Branch"],
-        "Should not update Branch"
+        initialTimes["Root.sol"] < finalTimes["Root.sol"],
+        "Should update root"
       );
       assert(
-        initialTimes["LeafA"] === finalTimes["LeafA"],
-        "Should not update LeafA"
-      );
-      assert(
-        initialTimes["LeafB"] === finalTimes["LeafB"],
-        "Should not update LeafB"
-      );
-      assert(
-        initialTimes["LeafC"] === finalTimes["LeafC"],
-        "Should not update LeafC"
-      );
-      assert(
-        initialTimes["LibraryA"] < finalTimes["LibraryA"],
+        initialTimes["LibraryA.sol"] < finalTimes["LibraryA.sol"],
         "Should update LibraryA"
       );
-      assert(
-        initialTimes["SameFile1"] === finalTimes["SameFile1"],
-        "Should not update SameFile1"
-      );
-      assert(
-        initialTimes["SameFile2"] === finalTimes["SameFile2"],
-        "Should not update SameFile2"
-      );
+      // ensure that the rest of the files have not been updated
+      for (const file of Object.keys(mapping)) {
+        if (file !== "Root.sol" && file !== "LibraryA.sol") {
+          assert(
+            initialTimes[file] === finalTimes[file],
+            `Should not update ${file}`
+          );
+        }
+      }
     } catch (err) {
       err.message += "\n\n" + output;
       throw new Error(err);
@@ -225,14 +191,15 @@ describe("Repeated compilation of contracts with inheritance [ @standalone ]", f
   //      LibA         LeafA              |    SameFile1 - LeafC
   //     /           /       \            |
   // Root* - Branch* -           - LeafC  |    SameFile2
-  //                 \       /            |
-  //                   LeafB              |
+  //     \           \       /            |
+  //      Abi          LeafB              |
+  //                                      |
   // ------------------------------------------------------------
 
-  it("Updates Branch and Root when Branch is touched", async function() {
+  it("updates Branch and Root when Branch is touched", async function () {
     this.timeout(30000);
 
-    touchSource("Branch");
+    touchSource("Branch.sol");
 
     await CommandRunner.run("compile", config);
     output = logger.contents();
@@ -240,35 +207,23 @@ describe("Repeated compilation of contracts with inheritance [ @standalone ]", f
     finalTimes = getArtifactStats();
 
     try {
-      assert(initialTimes["Root"] < finalTimes["Root"], "Should update root");
       assert(
-        initialTimes["Branch"] < finalTimes["Branch"],
+        initialTimes["Root.sol"] < finalTimes["Root.sol"],
+        "Should update root"
+      );
+      assert(
+        initialTimes["Branch.sol"] < finalTimes["Branch.sol"],
         "Should update Branch"
       );
-      assert(
-        initialTimes["LeafA"] === finalTimes["LeafA"],
-        "Should not update LeafA"
-      );
-      assert(
-        initialTimes["LeafB"] === finalTimes["LeafB"],
-        "Should not update LeafB"
-      );
-      assert(
-        initialTimes["LeafC"] === finalTimes["LeafC"],
-        "Should not update LeafC"
-      );
-      assert(
-        initialTimes["LibraryA"] === finalTimes["LibraryA"],
-        "Should not update LibraryA"
-      );
-      assert(
-        initialTimes["SameFile1"] === finalTimes["SameFile1"],
-        "Should not update SameFile1"
-      );
-      assert(
-        initialTimes["SameFile2"] === finalTimes["SameFile2"],
-        "Should not update SameFile2"
-      );
+      // ensure that the rest of the files have not been updated
+      for (const file of Object.keys(mapping)) {
+        if (file !== "Root.sol" && file !== "Branch.sol") {
+          assert(
+            initialTimes[file] === finalTimes[file],
+            `Should not update ${file}`
+          );
+        }
+      }
     } catch (err) {
       err.message += "\n\n" + output;
       throw new Error(err);
@@ -280,14 +235,15 @@ describe("Repeated compilation of contracts with inheritance [ @standalone ]", f
   //      LibA          LeafA*             |    SameFile1 - LeafC
   //     /            /       \            |
   // Root* - Branch* -           - LeafC   |    SameFile2
-  //                  \       /            |
-  //                    LeafB              |
+  //     \            \       /            |
+  //      Abi           LeafB              |
+  //                                       |
   // ------------------------------------------------------------
 
-  it("Updates LeafA, Branch and Root when LeafA is touched", async function() {
+  it("updates LeafA, Branch and Root when LeafA is touched", async function () {
     this.timeout(30000);
 
-    touchSource("LeafA");
+    touchSource("LeafA.sol");
 
     await CommandRunner.run("compile", config);
     output = logger.contents();
@@ -295,35 +251,31 @@ describe("Repeated compilation of contracts with inheritance [ @standalone ]", f
     finalTimes = getArtifactStats();
 
     try {
-      assert(initialTimes["Root"] < finalTimes["Root"], "Should update root");
       assert(
-        initialTimes["Branch"] < finalTimes["Branch"],
+        initialTimes["Root.sol"] < finalTimes["Root.sol"],
+        "Should update root"
+      );
+      assert(
+        initialTimes["Branch.sol"] < finalTimes["Branch.sol"],
         "Should update Branch"
       );
       assert(
-        initialTimes["LeafA"] < finalTimes["LeafA"],
+        initialTimes["LeafA.sol"] < finalTimes["LeafA.sol"],
         "Should update LeafA"
       );
-      assert(
-        initialTimes["LeafB"] === finalTimes["LeafB"],
-        "Should not update LeafB"
-      );
-      assert(
-        initialTimes["LeafC"] === finalTimes["LeafC"],
-        "Should not update LeafC"
-      );
-      assert(
-        initialTimes["LibraryA"] === finalTimes["LibraryA"],
-        "Should not update LibraryA"
-      );
-      assert(
-        initialTimes["SameFile1"] === finalTimes["SameFile1"],
-        "Should not update SameFile1"
-      );
-      assert(
-        initialTimes["SameFile2"] === finalTimes["SameFile2"],
-        "Should not update SameFile2"
-      );
+      // ensure that the rest of the files have not been updated
+      for (const file of Object.keys(mapping)) {
+        if (
+          file !== "Root.sol" &&
+          file !== "Branch.sol" &&
+          file !== "LeafA.sol"
+        ) {
+          assert(
+            initialTimes[file] === finalTimes[file],
+            `Should not update ${file}`
+          );
+        }
+      }
     } catch (err) {
       err.message += "\n\n" + output;
       throw new Error(err);
@@ -335,14 +287,15 @@ describe("Repeated compilation of contracts with inheritance [ @standalone ]", f
   //      LibA         LeafA*              |  SameFile1* - LeafC*
   //     /           /        \            |
   // Root* - Branch* -           - LeafC*  |  SameFile2*
-  //                 \        /            |
-  //                   LeafB*              |
+  //     \           \        /            |
+  //      Abi          LeafB*              |
+  //                                       |
   // ------------------------------------------------------------
 
-  it("Updates everything except LibraryA when LeafC is touched", async function() {
+  it("updates everything except LibraryA and Abi when LeafC is touched", async function () {
     this.timeout(30000);
 
-    touchSource("LeafC");
+    touchSource("LeafC.sol");
 
     await CommandRunner.run("compile", config);
     output = logger.contents();
@@ -350,35 +303,67 @@ describe("Repeated compilation of contracts with inheritance [ @standalone ]", f
     finalTimes = getArtifactStats();
 
     try {
-      assert(initialTimes["Root"] < finalTimes["Root"], "Should update root");
       assert(
-        initialTimes["Branch"] < finalTimes["Branch"],
-        "Should update Branch"
-      );
-      assert(
-        initialTimes["LeafA"] < finalTimes["LeafA"],
-        "Should update LeafA"
-      );
-      assert(
-        initialTimes["LeafB"] < finalTimes["LeafB"],
-        "Should update LeafB"
-      );
-      assert(
-        initialTimes["LeafC"] < finalTimes["LeafC"],
-        "Should update LeafC"
-      );
-      assert(
-        initialTimes["LibraryA"] === finalTimes["LibraryA"],
+        initialTimes["LibraryA.sol"] === finalTimes["LibraryA.sol"],
         "Should not update LibraryA"
       );
       assert(
-        initialTimes["SameFile1"] < finalTimes["SameFile1"],
-        "Should update SameFile1"
+        initialTimes["Abi.abi.json"] === finalTimes["Abi.abi.json"],
+        "Should not update Abi"
+      );
+      // ensure that the rest of the files have been updated
+      for (const file of Object.keys(mapping)) {
+        if (file !== "LibraryA.sol" && file !== "Abi.abi.json") {
+          assert(
+            initialTimes[file] < finalTimes[file],
+            `Should not update ${file}`
+          );
+        }
+      }
+    } catch (err) {
+      err.message += "\n\n" + output;
+      throw new Error(err);
+    }
+  });
+
+  // -------------Inheritance Graph -----------------------------
+  //                                       |
+  //      LibA         LeafA*              |  SameFile1* - LeafC*
+  //     /           /        \            |
+  // Root* - Branch* -           - LeafC*  |  SameFile2*
+  //     \           \        /            |
+  //      Abi          LeafB*              |
+  //                                       |
+  // ------------------------------------------------------------
+
+  it("updates Root and Abi when Abi is touched", async function () {
+    this.timeout(30000);
+
+    touchSource("Abi.abi.json");
+
+    await CommandRunner.run("compile", config);
+    output = logger.contents();
+
+    finalTimes = getArtifactStats();
+
+    try {
+      assert(
+        initialTimes["Root.sol"] < finalTimes["Root.sol"],
+        "Should update root"
       );
       assert(
-        initialTimes["SameFile2"] < finalTimes["SameFile2"],
-        "Should update SameFile2"
+        initialTimes["Abi.abi.json"] < finalTimes["Abi.abi.json"],
+        "Should not update Abi"
       );
+      // ensure that everything has been updated
+      for (const file of Object.keys(mapping)) {
+        if (file !== "Root.sol" && file !== "Abi.abi.json") {
+          assert(
+            initialTimes[file] === finalTimes[file],
+            `Should not update ${file}`
+          );
+        }
+      }
     } catch (err) {
       err.message += "\n\n" + output;
       throw new Error(err);

--- a/packages/truffle/test/sources/inheritance/contracts/Abi.abi.json
+++ b/packages/truffle/test/sources/inheritance/contracts/Abi.abi.json
@@ -1,0 +1,34 @@
+[
+  {
+    "inputs": [],
+    "name": "conversionRate",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountEther",
+        "type": "uint256"
+      }
+    ],
+    "name": "convertEthValueToNumberTokens",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "convertedAmount",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/packages/truffle/test/sources/inheritance/contracts/Root.sol
+++ b/packages/truffle/test/sources/inheritance/contracts/Root.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.5.0;
 import "./Branch.sol";
 import "./LeafC.sol";
 import "./LibraryA.sol";
+import "./Abi.abi.json";
 
 contract Root is Branch {
   uint root;


### PR DESCRIPTION
JSON files were not being included in compilation because the `shouldIncludePath` in the profiler was not updated to allow this. With the additions of support for abi JSON files, we now have to allow these sources to be whitelisted here so they can be passed to the Solidity compiler (after resolution and the generation of the relevant Solidity of course).

**Update:** There are a couple of additional changes added to this PR:
 - when the abi resolver has a problem resolving a JSON file (likely because it is Vyper-related JSON) it will return a blank Solidity file (with just a license line and pragma expression)
 - after `requiredSources` we exit compilation when we only find JSON files to be compiled (in this case no Solidity must import the JSON and thus must not be appropriate for `compile-solidity`)