### PR TITLE
Bug fix: Add newly-required type conversions in Assert libraries for Solidity 0.8.0

### DIFF
--- a/packages/resolver/lib/sources/truffle/Deployed.ts
+++ b/packages/resolver/lib/sources/truffle/Deployed.ts
@@ -23,7 +23,7 @@ export class Deployed {
       if (address) {
         address = Deployed.toChecksumAddress(address);
 
-        body = "return " + address + ";";
+        body = "return payable(" + address + ");";
       }
 
       source +=
@@ -39,8 +39,12 @@ export class Deployed {
 
     version = RangeUtils.resolveToRange(version);
     if (!RangeUtils.rangeContainsAtLeast(version, "0.5.0")) {
-      //remove "payable"s if we're before 0.5.0
-      source = source.replace(/address payable/gm, "address");
+      //remove "payable"s in types if we're before 0.5.0
+      source = source.replace(/address payable/g, "address");
+    }
+    if (!RangeUtils.rangeContainsAtLeast(version, "0.6.0")) {
+      //remove "payable"s in conversions if we're before 0.6.0
+      source = source.replace(/payable(\1)/g, "$1");
     }
     //regardless of version, replace all pragmas with the new version
     const coercedVersion = RangeUtils.coerce(version);
@@ -48,8 +52,8 @@ export class Deployed {
     // we need to update the pragma expression differently depending on whether
     // a single version or range is suppplied
     source = semver.valid(coercedVersion) ?
-      source.replace(/0\.5\.0/gm, coercedVersion) :
-      source.replace(/>= 0.5.0 < 0.9.0/gm, coercedVersion);
+      source.replace(/0\.5\.0/g, coercedVersion) :
+      source.replace(/>= 0.5.0 < 0.9.0/g, coercedVersion);
 
     return source;
   }

--- a/packages/resolver/lib/sources/truffle/Deployed.ts
+++ b/packages/resolver/lib/sources/truffle/Deployed.ts
@@ -44,7 +44,7 @@ export class Deployed {
     }
     if (!RangeUtils.rangeContainsAtLeast(version, "0.6.0")) {
       //remove "payable"s in conversions if we're before 0.6.0
-      source = source.replace(/payable(\1)/g, "$1");
+      source = source.replace(/payable(.*)/g, "$1");
     }
     //regardless of version, replace all pragmas with the new version
     const coercedVersion = RangeUtils.coerce(version);

--- a/packages/resolver/lib/sources/truffle/Deployed.ts
+++ b/packages/resolver/lib/sources/truffle/Deployed.ts
@@ -44,7 +44,7 @@ export class Deployed {
     }
     if (!RangeUtils.rangeContainsAtLeast(version, "0.6.0")) {
       //remove "payable"s in conversions if we're before 0.6.0
-      source = source.replace(/payable(.*)/g, "$1");
+      source = source.replace(/payable\((.*)\)/g, "$1");
     }
     //regardless of version, replace all pragmas with the new version
     const coercedVersion = RangeUtils.coerce(version);

--- a/packages/resolver/solidity/AssertInt.sol
+++ b/packages/resolver/solidity/AssertInt.sol
@@ -244,7 +244,7 @@ library AssertInt {
             neg = true;
         }
         while (n > 0) {
-            bts[i++] = _utoa(uint8(n % radix)); // Turn it to ascii.
+            bts[i++] = _utoa(uint8(uint(n % radix))); // Turn it to ascii.
             n /= radix;
         }
         // Reverse

--- a/packages/resolver/solidity/AssertIntArray.sol
+++ b/packages/resolver/solidity/AssertIntArray.sol
@@ -173,7 +173,7 @@ library AssertIntArray {
             neg = true;
         }
         while (n > 0) {
-            bts[i++] = _utoa(uint8(n % radix)); // Turn it to ascii.
+            bts[i++] = _utoa(uint8(uint(n % radix))); // Turn it to ascii.
             n /= radix;
         }
         // Reverse
@@ -212,7 +212,7 @@ library AssertIntArray {
         bytes memory bts = new bytes(256);
         uint i;
         while (n > 0) {
-            bts[i++] = _utoa(uint8(n % radix)); // Turn it to ascii.
+            bts[i++] = _utoa(uint8(uint(n % radix))); // Turn it to ascii.
             n /= radix;
         }
         // Reverse


### PR DESCRIPTION
Solidity 0.8.0 requires additional explicitness in type conversions that wasn't required before.  The ones that are relevant here are the following:

1. You can't directly convert `int256` to `uint8`, because that's changing both size and signedness at once;
2. Address literals are no longer considered payable.

The former caused a problem with `AssertInt` and `AssertIntArray`, since there are points where those do `uint8(n % radix)`, with `n` being an `int256`.  Fortunately in these cases we are guaranteed that `n` is positive, as they all lie within `if (n>0) { ... }` blocks, so I just changed these to `uint8(uint(n % radix))`, which works fine.

The latter caused a problem with creating the `DeployedAddresses` library, since it would attempt to use literal addresses as `address payable`.  I've changed this by adding an explicit `payable` conversion there.  However I also had to add a check to remove this in versions prior to 0.6.0, since such conversions only became legal then.

(I also removed a bunch of unnecessary `/m` flags on the regular expressions in that file... dunno why those were there.  That flag only affects the behavior of the `$` and `^` special characters, none of which are used in any of these regular expressions.)