### PR TITLE
Add @truffle/db couch adapter

### DIFF
--- a/packages/db/src/pouch/couch.ts
+++ b/packages/db/src/pouch/couch.ts
@@ -1,0 +1,41 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:pouch:couch");
+
+import PouchDB from "pouchdb";
+import { kebabCase } from "change-case";
+
+import { Collections } from "@truffle/db/meta";
+import { Databases } from "./databases";
+
+export interface CouchDatabaseSettings {
+  url: string;
+  auth: {
+    username: string;
+    password: string;
+  };
+}
+
+export class CouchDatabases<C extends Collections> extends Databases<C> {
+  private _createDatabase: (resource) => PouchDB.Database;
+
+  setup(options) {
+    const { auth } = options.settings;
+
+    let { url } = options.settings;
+    if (url.endsWith("/")) {
+      url = url.slice(0, -1);
+    }
+
+    // put sensitive information inside a closure so it's not as easily found
+    this._createDatabase = resource => {
+      const remotePath = `${url}/${kebabCase(resource)}`;
+      debug("remotePath %O", remotePath);
+
+      return new PouchDB(remotePath, { auth });
+    };
+  }
+
+  createDatabase(resource) {
+    return this._createDatabase(resource);
+  }
+}

--- a/packages/db/src/pouch/index.ts
+++ b/packages/db/src/pouch/index.ts
@@ -7,6 +7,7 @@ export * from "./types";
 
 import { DatabasesOptions } from "./databases";
 
+import { CouchDatabases } from "./couch";
 import { FSDatabases } from "./fs";
 import { MemoryDatabases } from "./memory";
 import { SqliteDatabases } from "./sqlite";
@@ -46,6 +47,12 @@ const concretize = <C extends Collections>(
 
   debug("Selecting %s adapter", name);
   switch (name) {
+    case "couch": {
+      return {
+        constructor: CouchDatabases,
+        settings: settings || getDefaultCouchAdapterSettings()
+      };
+    }
     case "fs": {
       return {
         constructor: FSDatabases,
@@ -69,6 +76,10 @@ const concretize = <C extends Collections>(
     }
   }
 };
+
+const getDefaultCouchAdapterSettings = () => ({
+  url: "http://localhost:5984"
+});
 
 const getDefaultFSAdapterSettings = workingDirectory => ({
   directory: path.join(workingDirectory, ".db", "json")


### PR DESCRIPTION
This PR allows the use of an existing CouchDB service as the persistence layer for @truffle/db.

To use this, update `truffle-config.js` with the URL and auth credentials, e.g.:
```javascript
module.exports = {
  // ... rest of truffle-config
  db: {
    enabled: true,
    adapter: {
      name: "couch",
      settings: {
        url: "http://localhost:5984",
        auth: {
          username: "admin",
          password: "password"
        }
      }
    }
  }
};
```