### PR TITLE
Add missing indexes to @truffle/db resources

### DIFF
--- a/packages/db/src/resources/networkGenealogies.ts
+++ b/packages/db/src/resources/networkGenealogies.ts
@@ -11,7 +11,14 @@ export const networkGenealogies: Definition<"networkGenealogies"> = {
     resourcesMutate: "networkGenealogiesAdd",
     ResourcesMutate: "NetworkGenealogiesAdd"
   },
-  createIndexes: [],
+  createIndexes: [
+    {
+      fields: ["ancestor.id"]
+    },
+    {
+      fields: ["descendant.id"]
+    }
+  ],
   idFields: ["ancestor", "descendant"],
   typeDefs: gql`
     type NetworkGenealogy implements Resource {


### PR DESCRIPTION
This PR adds indexes to NetworkGenealogy for `ancestor` and `descendant` (since that's how we look those up)