### PR TITLE
Hook up @truffle/db name assignments in compile and migrate

### DIFF
--- a/packages/core/lib/commands/compile.js
+++ b/packages/core/lib/commands/compile.js
@@ -93,7 +93,9 @@ const command = {
         );
       }
 
-      return await WorkflowCompile.save(config, compilationOutput);
+      const result = await WorkflowCompile.save(config, compilationOutput);
+      await WorkflowCompile.assignNames(config, result);
+      return result;
     }
   },
 

--- a/packages/core/lib/commands/migrate.js
+++ b/packages/core/lib/commands/migrate.js
@@ -201,7 +201,8 @@ const command = {
       conf.compiler = "none";
     }
 
-    await WorkflowCompile.compileAndSave(conf);
+    const result = await WorkflowCompile.compileAndSave(conf);
+    await WorkflowCompile.assignNames(conf, result);
     await Environment.detect(conf);
 
     const {dryRunOnly, dryRunAndMigrations} = command.determineDryRunSettings(

--- a/packages/db/src/project/names/resources.ts
+++ b/packages/db/src/project/names/resources.ts
@@ -40,6 +40,14 @@ export const generateResourceNames = Batch.generate<{
       `
     );
 
+    // catch unknown resources so we can abort
+    const missing = results
+      .map((resource, index) => !resource && entries[index].id)
+      .filter(id => id);
+    if (missing.length > 0) {
+      throw new Error(`Unknown ${collectionName}: ${missing.join(", ")}`);
+    }
+
     return results.map(({ name }) => ({ name, type }));
   },
 

--- a/packages/db/src/project/test/assignNames.spec.ts
+++ b/packages/db/src/project/test/assignNames.spec.ts
@@ -87,6 +87,16 @@ describe("Project.assignNames", () => {
     });
   });
 
+  it("aborts if specified resources don't exist", async () => {
+    expect(
+      project.assignNames({
+        assignments: {
+          networks: [{ id: "0xdeadbeef" }, { id: "pizza" }]
+        }
+      })
+    ).rejects.toThrow("Unknown networks: 0xdeadbeef, pizza");
+  });
+
   it("resolves to new contract with no prior contract", async () => {
     const { addContract, resolveContractNameRecord } = helpers(db, project);
 

--- a/packages/migrate/Migration.js
+++ b/packages/migrate/Migration.js
@@ -118,14 +118,22 @@ class Migration {
           }
         });
 
-        ({artifacts} = await project
+        const result = await project
           .connect({provider: this.config.provider})
           .loadMigrate({
             network: {
               name: this.config.network
             },
             artifacts
-          }));
+          });
+
+        ({ artifacts } = result);
+
+        await project.assignNames({
+          assignments: {
+            networks: [result.network]
+          }
+        });
       }
 
       // Save artifacts to local filesystem


### PR DESCRIPTION
This PR updates the logic for `truffle compile` and `truffle migrate` to assign contract names. This works by exposing a new `Compile.assignNames` method in workflow-compile and calling that from the places where it's relevant.

Note that doing it this way means that we get name assignments for those commands, but not for `truffle test`.