### PR TITLE
Bug fix: Update packages command to not take a callback

### DIFF
--- a/packages/core/lib/commands/packages.js
+++ b/packages/core/lib/commands/packages.js
@@ -1,5 +1,3 @@
-const { callbackify } = require("util");
-
 const command = {
   command: "packages",
   description: "List available packages on connected EthPM Registry",
@@ -8,7 +6,7 @@ const command = {
     usage: "truffle packages",
     options: []
   },
-  run: function (options, done) {
+  run: function (options) {
     const Config = require("@truffle/config");
     const PackageV1 = require("@truffle/ethpm-v1");
     const PackageV3 = require("@truffle/ethpm-v3");
@@ -17,13 +15,13 @@ const command = {
     let listPackages;
 
     if (config.ethpm.version == "1") {
-      listPackages = callbackify(PackageV1.packages);
+      listPackages = PackageV1.packages;
     } else if (config.ethpm.version == "3") {
-      listPackages = callbackify(PackageV3.packages);
+      listPackages = PackageV3.packages;
     } else {
-      done(new Error(`Unsupported ethpm version: ${config.ethpm.version}.`));
+      throw new Error(`Unsupported ethpm version: ${config.ethpm.version}.`);
     }
-    listPackages(config, done);
+    return listPackages(config);
   }
 };
 


### PR DESCRIPTION
The `packages` command used for the ethpm v3 implementation should not take a callback when integrated with the rest of the 5.2.0 work. This PR updates it to return a `Promise`.