### PR TITLE
Internal improvement: Increase some timeouts and fix some tests that were arrow functions

### DIFF
--- a/packages/core/test/config.js
+++ b/packages/core/test/config.js
@@ -16,7 +16,8 @@ describe("config", function () {
     from: "0x1234567890123456789012345678901234567890"
   };
 
-  before("Create a sandbox with extra config values", async () => {
+  before("Create a sandbox with extra config values", async function () {
+    this.timeout(5000);
     config = await Box.sandbox("default");
     config.resolver = new Resolver(config);
     config.artifactor = new Artifactor(config.contracts_build_directory);

--- a/packages/core/test/lib/create.js
+++ b/packages/core/test/lib/create.js
@@ -10,7 +10,8 @@ const Artifactor = require("@truffle/artifactor");
 describe("create", function () {
   let config;
 
-  before("Create a sandbox", async () => {
+  before("Create a sandbox", async function() {
+    this.timeout(5000);
     config = await Box.sandbox("default");
     config.resolver = new Resolver(config);
     config.artifactor = new Artifactor(config.contracts_build_directory);

--- a/packages/core/test/migrate.js
+++ b/packages/core/test/migrate.js
@@ -14,7 +14,7 @@ var Web3 = require("web3");
 describe("migrate", function () {
   var config;
 
-  before("Create a sandbox", async () => {
+  before("Create a sandbox", async function () {
     config = await Box.sandbox("default");
     config.resolver = new Resolver(config);
     config.artifactor = new Artifactor(config.contracts_build_directory);
@@ -51,7 +51,7 @@ describe("migrate", function () {
     });
   });
 
-  it("profiles a new project as not having any contracts deployed", async () => {
+  it("profiles a new project as not having any contracts deployed", async function() {
     const networks = await Networks.deployed(config);
     assert.equal(
       Object.keys(networks).length,
@@ -70,7 +70,7 @@ describe("migrate", function () {
     );
   });
 
-  it("links libraries in initial project, and runs all migrations", async () => {
+  it("links libraries in initial project, and runs all migrations", async function () {
     this.timeout(10000);
 
     config.network = "primary";
@@ -112,7 +112,7 @@ describe("migrate", function () {
     );
   });
 
-  it("should migrate secondary network without altering primary network", async () => {
+  it("should migrate secondary network without altering primary network", async function () {
     this.timeout(10000);
 
     config.network = "secondary";
@@ -180,7 +180,7 @@ describe("migrate", function () {
     });
   });
 
-  it("should ignore files that don't start with a number", () => {
+  it("should ignore files that don't start with a number", function () {
     fs.writeFileSync(
       path.join(config.migrations_directory, "~2_deploy_contracts.js"),
       "module.exports = function() {};",
@@ -195,7 +195,7 @@ describe("migrate", function () {
     );
   });
 
-  it("should ignore non-js extensions", () => {
+  it("should ignore non-js extensions", function () {
     fs.writeFileSync(
       path.join(config.migrations_directory, "2_deploy_contracts.js~"),
       "module.exports = function() {};",


### PR DESCRIPTION
So, there are these three tests that keep timing out.  I know that @eggplantzzz is working on getting us better CI, but in the meantime, I'm upping the timeouts on two of them.  The third one actually already had a longer timeout set, but, the call to set it did nothing because the test was defined as an arrow function!  For those who don't know, you don't want to write your tests to be arrow functions because then you can't to do things like `this.timeout(10000)` or `this.skip()`.  Anyway so in addition to upping those two timeouts I also made a bunch of tests no longer arrow functions, including the one that was causing the problem.