### PR TITLE
Make DeployedAddresses compatible with .abi.json files

### DIFF
--- a/packages/resolver/lib/sources/truffle/index.ts
+++ b/packages/resolver/lib/sources/truffle/index.ts
@@ -29,7 +29,8 @@ export class Truffle implements ResolverSource {
       // Ensure we have a mapping for source files and abstraction files
       // to prevent any compile errors in tests.
       sourceFiles.forEach((file: string) => {
-        const name = path.basename(file, ".sol");
+        // we need to account for .json and .abi.json files
+        const name = path.basename(path.basename(path.basename(file, ".sol"), ".json"), ".abi");
         if (blacklist.has(name)) return;
         mapping[name] = false;
       });


### PR DESCRIPTION
Strip off .json and .abi.json from source file extensions when creating `DeployedAddresses`.

`DeployedAddresses` creates invalid Solidity when you have .json and .abi.json files as you get something like the following created in that contract:
```
function IConversion.abi.json() ...
```
This messes up compilation. In order to account for this we strip off the file extensions like it does for Solidity files.