### PR TITLE
Add license to Console.sol

### DIFF
--- a/packages/resolver/solidity/Console.sol
+++ b/packages/resolver/solidity/Console.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.4.21 <0.8.0;
 
 library Console {

--- a/packages/resolver/solidity/Console.sol
+++ b/packages/resolver/solidity/Console.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.4.21 <0.8.0;
+pragma solidity >=0.4.21 <0.9.0;
 
 library Console {
   event _TruffleConsoleLog(bool boolean);


### PR DESCRIPTION
`Console.sol` currently has no license identifier and causes the compiler to print warnings which is ugly. Get rid of them!