### PR TITLE
Work around PouchDB / WebSQL query construction problem in @truffle/db

### DIFF
--- a/packages/db/src/pouch/databases.ts
+++ b/packages/db/src/pouch/databases.ts
@@ -123,9 +123,8 @@ export abstract class Databases<C extends Collections> implements Workspace<C> {
       log("Found.");
       return result;
     } catch (error) {
-      console.log(`Error fetching all ${collectionName}\n`);
-      console.log(error);
-      return ([] as unknown) as SavedInput<C, N>[];
+      log("Error fetching all %s, got error: %O", collectionName, error);
+      throw error;
     }
   }
 

--- a/packages/db/src/project/migrate/networkGenealogies/test/index.spec.ts
+++ b/packages/db/src/project/migrate/networkGenealogies/test/index.spec.ts
@@ -37,9 +37,10 @@ describe("generateNetworkGenealogiesLoad", () => {
         Networks().chain(model => fc.record({
           model: fc.constant(model),
           batches: Batches(model)
-        }))
+        })),
+        fc.boolean()
       ],
-      async ({ model, batches }) => {
+      async ({ model, batches }, disableIndex) => {
         debug("initializing project");
         const { project } = await setupProjectForTest({
           identifier: "test:networkGenealogies:property:latestDescendants"
@@ -61,7 +62,7 @@ describe("generateNetworkGenealogiesLoad", () => {
           debug("loading network genealogies for batch");
           await liveProject.run(
             generateNetworkGenealogiesLoad,
-            { network, artifacts }
+            { network, artifacts, disableIndex }
           );
         }
 
@@ -82,9 +83,9 @@ describe("generateNetworkGenealogiesLoad", () => {
         `) as DataModel.Network[];
         debug("networks %O", networks);
 
-        const ids = new Set(networks.map(
-          ({ descendants: [ latestDescendant ] }) => latestDescendant.id
-        ));
+        const ids = new Set(networks
+          .filter(({ descendants }) => descendants.length > 0)
+          .map(({ descendants: [ latestDescendant ] }) => latestDescendant.id));
         debug("ids %O", ids);
 
         expect(ids).toEqual(

--- a/packages/db/src/resources/networks.ts
+++ b/packages/db/src/resources/networks.ts
@@ -15,7 +15,11 @@ export const networks: Definition<"networks"> = {
     resourcesMutate: "networksAdd",
     ResourcesMutate: "NetworksAdd"
   },
-  createIndexes: [{ fields: ["historicBlock.height"] }],
+  createIndexes: [
+    { fields: ["networkId"] },
+    { fields: ["historicBlock.height"] },
+    { fields: ["networkId", "historicBlock.height"] }
+  ],
   idFields: ["networkId", "historicBlock"],
   typeDefs: gql`
     type Network implements Resource & Named {


### PR DESCRIPTION
Turns out that the `Network.possibleAncestors` and `Network.possibleDescendants` queries start to explode reliably once you add thousands of networks. I found this by slurping mainnet and adding random historic blocks. After awhile (~5000 added blocks or so), WebSQL comes back with "too many parameters", which suggests something is going wrong with how PouchDB+friends end up constructing SQLite queries.

I went down the avenue of implementing an alternative TypeORM adapter, instead of PouchDB entirely, but my naïve approach ran into this same problem, and getting that to work, albeit giving us more control, would be a significant amount of effort, to effectively match much of the functionality of existing adapters.

This PR identifies and proposes a different approach to this problem: hack around it by doing whatever we can to prevent PouchDB from constructing a complex query with lots of variables. Effectively, this PR updates the logic for finding possible relations to:
1. First try looking for candidate related networks the existing way, with PouchDB index bells and whistles.
2. If that fails, re-run the PouchDB find with way less filtering/sorting, and do that in-memory JS.

This has performance ramifications, naturally, but I'd argue that we don't need to target that many networks + sqlite in the immediate term; as long as it doesn't explode, it can be slow.

Additionally, this PR includes changes to:
- Factor `findPossibleRelations` instead of having separate resolvers for ancestors and descendants
- Add a `disableIndex` query param so that our tests can specifically exercise the fallback method described above.
- Add a couple PouchDB indexes that were missing.