### PR TITLE
Refactor @truffle/preserve-fs

### DIFF
--- a/packages/preserve-fs/lib/index.ts
+++ b/packages/preserve-fs/lib/index.ts
@@ -5,20 +5,15 @@
 import * as Preserve from "@truffle/preserve";
 
 import { targetPath } from "./fs";
+import { LoadOptions } from "./types";
 
-export interface LoadOptions {
-  path: string;
-  controls: Preserve.Controls;
-}
-
-export class Loader implements Preserve.Targets.Loader {
+export class Loader implements Preserve.Loader {
   name = "@truffle/preserve-fs";
 
   async *load(options: LoadOptions): Preserve.Process<Preserve.Target> {
-    const {
-      path,
-      controls: { log }
-    } = options;
+    const { controls } = options;
+
+    const { log } = controls;
 
     yield* log({ message: "Loading target..." });
 

--- a/packages/preserve-fs/lib/types.ts
+++ b/packages/preserve-fs/lib/types.ts
@@ -1,0 +1,14 @@
+import * as Preserve from "@truffle/preserve";
+
+export interface LoadOptions extends Preserve.Loaders.LoadOptions {
+  path: string;
+  verbose?: boolean;
+}
+
+export interface TargetPathOptions extends LoadOptions {
+  controls: Preserve.Controls | Preserve.Control.StepsController;
+}
+
+export interface PathEntryOptions extends TargetPathOptions {
+  parent: string;
+}

--- a/packages/preserve-fs/test/fs.test.ts
+++ b/packages/preserve-fs/test/fs.test.ts
@@ -1,0 +1,57 @@
+import fs from "fs-extra";
+import path from "path";
+import tmp from "tmp-promise";
+
+import * as Preserve from "@truffle/preserve";
+import { Loader } from "../lib";
+import { tests } from "./fs.fixture";
+
+const writeFile = async (fullPath: string, content: string): Promise<void> => {
+  // ensure directory exists for file
+  await fs.ensureDir(path.dirname(fullPath));
+
+  await fs.promises.writeFile(fullPath, content);
+};
+
+describe("Loader", () => {
+  let workspace: tmp.DirectoryResult;
+
+  beforeAll(async () => {
+    workspace = await tmp.dir();
+  });
+
+  afterAll(async () => {
+    await workspace.cleanup();
+  });
+
+  for (const { name, files, targeted, expected } of tests) {
+    describe(`test: ${name}`, () => {
+      beforeAll(async () => {
+        for (const file of files) {
+          const fullPath = path.join(workspace.path, name, file.path);
+
+          await writeFile(fullPath, file.content);
+        }
+      });
+
+      it("returns correct target", async () => {
+        const fullPath = path.join(workspace.path, name, targeted);
+
+        const loader = new Loader();
+
+        const target: Preserve.Target = await Preserve.Control.run(
+          {
+            method: loader.load.bind(loader)
+          },
+          {
+            path: fullPath
+          }
+        );
+
+        const thunked = await Preserve.Targets.stringify(target);
+
+        expect(thunked).toEqual(expected);
+      });
+    });
+  }
+});

--- a/packages/preserve-fs/tsconfig.json
+++ b/packages/preserve-fs/tsconfig.json
@@ -20,7 +20,6 @@
   },
   "include": [
     "./lib/**/*.ts",
-    "./test/**/*.ts",
-    "../preserve/typings/**/*.ts"
+    "./test/**/*.ts"
   ]
 }


### PR DESCRIPTION
- Extract common types/interfaces into separate types.ts file
- Slightly reorder fs.ts to accommodate reading the file top-down
- Slight changes due to refactoring of @truffle/preserve
- Split up test file into fs.fixture.ts and fs.test.ts