### PR TITLE
Internal improvement: Add dummy CircleCI job to prevent failure from no config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,21 @@
+version: 2.1
+orbs:
+  node: circleci/node@2.1.1
+jobs:
+  dummy-job:
+    executor:
+      name: node/default
+      tag: '10.20'
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run: "true" #dummy job to stop CI failures for now
+
+workflows:
+  dummy-workflow:
+    jobs:
+      - dummy-job:
+          filters:
+            branches:
+              only:
+                - develop


### PR DESCRIPTION
Adds a dummy CircleCI job so that CircleCI doesn't fail out due to no config being found.

We could probably just have a config file with no jobs or workflows in it, but, eh, erring on the safe side I guess.