### PR TITLE
Ensure `truffle db serve` does not exit

### DIFF
--- a/packages/core/lib/commands/db/commands/serve.js
+++ b/packages/core/lib/commands/db/commands/serve.js
@@ -26,6 +26,8 @@ const command = {
 
     console.log(`🚀 Playground listening at ${url}`);
     console.log(`ℹ  Press Ctrl-C to exit`);
+
+    await new Promise(() => {});
   }
 };
 


### PR DESCRIPTION
Since there's no longer any such thing as "just don't call the callback"