### PR TITLE
Remove Network.fork field from @truffle/db

### DIFF
--- a/packages/db/src/resources/networks.ts
+++ b/packages/db/src/resources/networks.ts
@@ -26,7 +26,6 @@ export const networks: Definition<"networks"> = {
       name: String!
       networkId: NetworkId!
       historicBlock: Block!
-      fork: Network
 
       ancestors(
         limit: Int, # default all


### PR DESCRIPTION
Since this has long been replaced by the network genealogy system