### PR TITLE
Add missing dependencies to compile-common

### DIFF
--- a/packages/compile-common/package.json
+++ b/packages/compile-common/package.json
@@ -19,7 +19,9 @@
     "typescript": "3.9.6"
   },
   "dependencies": {
+    "@truffle/contract-sources": "^0.1.10",
     "@truffle/error": "^0.0.11",
+    "@truffle/expect": "^0.0.15",
     "colors": "^1.4.0",
     "fs-extra": "^8.1.0",
     "mocha": "8.0.1",


### PR DESCRIPTION
I just noticed that, although `compile-common` depends on `contract-sources` and `expect`, they weren't in its `package.json`.  This PR fixes that.