### PR TITLE
Add "Panic" to forbidden names in ABI arbitraries

### DIFF
--- a/packages/abi-utils/lib/arbitrary.ts
+++ b/packages/abi-utils/lib/arbitrary.ts
@@ -241,6 +241,7 @@ const ArrayDynamic = fc.memo(n => Type(n - 1).map(type => `${type}[]`));
 
 const reservedWords = new Set([
   "Error",
+  "Panic",
   "_",
   "abi",
   "abstract",


### PR DESCRIPTION
Since Solidity 0.8.1 is out now, which adds `Panic` to the syntax as something you can catch, I figured I'd add `Panic` to the forbidden words in the ABI arbitraries.  It's probably not actually reserved as such, but I figure it's good to err on the safe side and avoid any potential naming collision with any sort of Solidity-meaningful word.