### PR TITLE
Bug fix: Fix Truffle's Assert libraries for Solidity 0.8.1

### DIFF
--- a/packages/resolver/solidity/AssertInt.sol
+++ b/packages/resolver/solidity/AssertInt.sol
@@ -244,8 +244,8 @@ library AssertInt {
             neg = true;
         }
         while (n > 0) {
-            bts[i++] = _utoa(uint8(uint(n % radix))); // Turn it to ascii.
-            n /= radix;
+            bts[i++] = _utoa(uint8(uint(n) % radix)); // Turn it to ascii.
+            n = int(uint(n) / radix);
         }
         // Reverse
         uint size = i;

--- a/packages/resolver/solidity/AssertIntArray.sol
+++ b/packages/resolver/solidity/AssertIntArray.sol
@@ -173,8 +173,8 @@ library AssertIntArray {
             neg = true;
         }
         while (n > 0) {
-            bts[i++] = _utoa(uint8(uint(n % radix))); // Turn it to ascii.
-            n /= radix;
+            bts[i++] = _utoa(uint8(uint(n) % radix)); // Turn it to ascii.
+            n = int(uint(n) / radix);
         }
         // Reverse
         uint size = i;


### PR DESCRIPTION
Solidity 0.8.1 wasn't supposed to be a breaking release, sure, but, well, there are certain conversions they meant to disallow in 0.8.0 but forgot to, so now they're disallowed in 0.8.1.  So, I've updated our Assert libraries once again to ensure that they still compile with Solidity 0.8.1.