### PR TITLE
Bug fix: Allow resolution failure in resolveAllSources(); allow resolution of empty sources

### DIFF
--- a/packages/compile-common/src/profiler/resolveAllSources.ts
+++ b/packages/compile-common/src/profiler/resolveAllSources.ts
@@ -5,7 +5,7 @@ import { getImports, ResolvedSource } from "./getImports";
 
 export interface ResolveAllSourcesOptions {
   paths: string[];
-  resolve(source: UnresolvedSource): Promise<ResolvedSource>;
+  resolve(source: UnresolvedSource): Promise<ResolvedSource | undefined>;
   parseImports(body: string): Promise<string[]>;
   shouldIncludePath(filePath: string): boolean;
 }
@@ -65,10 +65,9 @@ export async function resolveAllSources({
     // Queue unknown imports for the next resolver cycle
     while (results.length) {
       const source = results.shift();
-      debug("source.filePath: %s", source.filePath);
 
-      if (mapping[source.filePath]) {
-        //skip ones that are already recorded
+      if (!source || mapping[source.filePath]) {
+        //skip ones that couldn't be resolved, or are already recorded
         continue;
       }
 

--- a/packages/resolver/lib/resolver.ts
+++ b/packages/resolver/lib/resolver.ts
@@ -89,12 +89,12 @@ export class Resolver {
     for (source of this.sources) {
       ({ body, filePath } = await source.resolve(importPath, importedFrom));
 
-      if (body) {
+      if (body !== undefined) {
         break;
       }
     }
 
-    if (!body) {
+    if (body === undefined) {
       let message = `Could not find ${importPath} from any sources`;
 
       if (importedFrom) {

--- a/packages/resolver/lib/sources/truffle/index.ts
+++ b/packages/resolver/lib/sources/truffle/index.ts
@@ -98,7 +98,7 @@ export class Truffle implements ResolverSource {
       }
     }
 
-    return { body: null, filePath: null };
+    return { body: undefined, filePath: undefined };
   }
 
   require(): null {

--- a/packages/resolver/lib/sources/vyper.ts
+++ b/packages/resolver/lib/sources/vyper.ts
@@ -37,7 +37,7 @@ export class Vyper implements ResolverSource {
         importModule,
         importedFrom
       );
-      if (directlyResolvedSource.body) {
+      if (directlyResolvedSource.body !== undefined) {
         debug("found directly");
         return directlyResolvedSource;
       }
@@ -91,7 +91,7 @@ export class Vyper implements ResolverSource {
         for (const source of this.wrappedSources) {
           debug("source: %o", source);
           resolvedSource = await source.resolve(possiblePath, importedFrom);
-          if (resolvedSource.body) {
+          if (resolvedSource.body !== undefined) {
             debug("found via this source");
             break;
           }
@@ -99,7 +99,7 @@ export class Vyper implements ResolverSource {
         this.cache[possiblePath] = resolvedSource; //yes, even failures are cached!
       }
 
-      if (resolvedSource.body) {
+      if (resolvedSource.body !== undefined) {
         debug("found");
         return resolvedSource;
       }

--- a/packages/truffle/test/scenarios/resolver/resolver.js
+++ b/packages/truffle/test/scenarios/resolver/resolver.js
@@ -6,7 +6,7 @@ var Server = require("../server");
 var Reporter = require("../reporter");
 var sandbox = require("../sandbox");
 
-describe("Solidity Imports [ @standalone ]", function() {
+describe("Solidity Imports [ @standalone ]", function () {
   var config;
   var project = path.join(__dirname, "../../sources/monorepo");
   var logger = new MemoryLogger();
@@ -41,8 +41,8 @@ describe("Solidity Imports [ @standalone ]", function() {
    * |
    */
 
-  describe("success", function() {
-    before(function() {
+  describe("success", function () {
+    before(function () {
       this.timeout(10000);
       return sandbox.create(project, "truffleproject").then(conf => {
         config = conf;
@@ -54,7 +54,7 @@ describe("Solidity Imports [ @standalone ]", function() {
       });
     });
 
-    it("resolves solidity imports located outside the working directory", async function() {
+    it("resolves solidity imports located outside the working directory", async function () {
       this.timeout(30000);
 
       await CommandRunner.run("compile", config);
@@ -68,8 +68,8 @@ describe("Solidity Imports [ @standalone ]", function() {
     });
   });
 
-  describe("failure", function() {
-    before(function() {
+  describe("failure", function () {
+    before(function () {
       this.timeout(10000);
       return sandbox.create(project, "errorproject").then(conf => {
         config = conf;
@@ -81,15 +81,15 @@ describe("Solidity Imports [ @standalone ]", function() {
       });
     });
 
-    it("fails gracefully if an import is not found", async function() {
+    it("exposes compile error if an import is not found", async function () {
       this.timeout(30000);
 
       try {
         await CommandRunner.run("compile", config);
-      } catch (_error) {
+      } catch (_) {
         const output = logger.contents();
         assert(output.includes("Error"));
-        assert(output.includes("Could not find nodepkg/DoesNotExist.sol"));
+        assert(output.includes('Source "nodepkg/DoesNotExist.sol" not found'));
         assert(output.includes("Importer.sol"));
       }
     });


### PR DESCRIPTION
Addresses #3668.

This PR does two things:

Firstly, it allows resolution to fail in `resolveAllSources`.  This is so that resolution errors will show up to the user as compile errors rather than often-unhelpful Truffle errors.  To do this, the `resolve()` wrapper in `profiler.ts` is modified to include a try/catch, and a definedness check is added in `resolveAllSources`.  Note that I wanted to make sure unexpected errors get rethrown, but resolver doesn't currently throw structured errors; and, well, I didn't want to bother making it do so, this is just a quick fix, so I just checked the start of the message instead.

Secondly, it allows resolution of empty sources.  Currently we just checked whether `body` is truthy, which would mean that empty sources could not be resolved.  So I changed this everywhere to `body !== undefined`.  (This includes inside the Vyper resolver source, since that one acts as a wrapper.)  Note that the Truffle resolver source, unlike the others, would return `body: null` if nothing were found, rather than `body: undefined`, so I changed this resolver source to use `undefined` to signify failure like the others.