### PR TITLE
Enhancement: Allow importing ABI JSON from non-FS sources

### DIFF
--- a/packages/resolver/lib/resolver.ts
+++ b/packages/resolver/lib/resolver.ts
@@ -42,20 +42,21 @@ export class Resolver {
 
     this.options = options;
     this.sources = [
-      ...(includeTruffleSources ? [new Truffle(options)] : []),
       new EthPMv1(options.working_directory),
       new NPM(options.working_directory),
       new GlobalNPM(),
-      ...(translateJsonToSolidity
-        ? [
-            new ABI(
-              options.working_directory,
-              options.contracts_build_directory
-            )
-          ]
-        : []),
       new FS(options.working_directory, options.contracts_build_directory)
     ];
+
+    if (includeTruffleSources) {
+      this.sources.unshift(new Truffle(options));
+    }
+
+    if (translateJsonToSolidity) {
+      this.sources = [].concat(
+        ...this.sources.map(source => [new ABI(source), source])
+      );
+    }
 
     if (resolveVyperModules) {
       this.sources = [new Vyper(this.sources, options.contracts_directory)];


### PR DESCRIPTION
This PR alters the `ABI` resolver source so that, instead of extending `FS`, it acts as a wrapper over another resolver source.  And if the ABI resolver source is turned on, instead of being added singly right before FS, every resolver source gets an ABI equivalent wrapped around it and added right before it.  So, the effect is that now you can also import JSON files as Solidity from e.g. an NPM module or whatever.

I was originally going to do it where there's *just* the `ABI` resolver sources, and these handle both the ABI and non-ABI cases (like the `Vyper` resolver source), but, uh, I thought that might be a bit confusing, and, well, this was easier.  Um, the `resolveDependencyPath` that I added is still in there from that approach, guess that's not actually needed, oops, just noticed that.  Oh well, I won't bother removing it unless people think it should go.

So yeah -- now rather than `ABI` calling `super.resolve(...)`, it calls `this.wrappedSource.resolve(...)`.  But basically it's the same!

Also, I changed `!resolution.body` to `resolution.body === undefined` as per #3750.

Also, I changed `>0.0.0` to `>=0.4.0` because it turns out that's when `pragma` statements were introduced so there's not much sense in going any earlier. :P