### PR TITLE
Bug fix: Fix several Vyper compilation bugs (specific to non-JSON Vyper and prerelease Vyper)

### DIFF
--- a/packages/compile-vyper/index.js
+++ b/packages/compile-vyper/index.js
@@ -37,7 +37,8 @@ function checkVyper() {
 
 // Execute vyper for single source file
 function execVyper(options, sourcePath, version, callback) {
-  const formats = ["abi", "bytecode", "bytecode_runtime", "source_map"];
+  const formats = ["abi", "bytecode", "bytecode_runtime"];
+  debug("version: %s", version);
   if (
     semver.satisfies(version, ">=0.1.0-beta.7", {
       loose: true,
@@ -75,6 +76,9 @@ function execVyper(options, sourcePath, version, callback) {
       );
 
     var outputs = stdout.split(/\r?\n/);
+
+    debug("formats: %O", formats);
+    debug("outputs: %O", outputs);
 
     const compiledContract = outputs.reduce((contract, output, index) => {
       return Object.assign(contract, { [formats[index]]: output });
@@ -117,6 +121,8 @@ async function compileNoJson({ paths: sources, options, version }) {
         ) {
           if (error) return reject(error);
 
+          debug("compiledContract: %O", compiledContract);
+
           // remove first extension from filename
           const extension = path.extname(sourcePath);
           const basename = path.basename(sourcePath, extension);
@@ -128,6 +134,9 @@ async function compileNoJson({ paths: sources, options, version }) {
               : path.basename(basename, path.extname(basename));
 
           const sourceContents = readSource(sourcePath);
+          const deployedSourceMap = compiledContract.source_map //there is no constructor source map
+            ? JSON.parse(compiledContract.source_map)
+            : undefined;
 
           const contractDefinition = {
             contractName: contractName,
@@ -142,7 +151,7 @@ async function compileNoJson({ paths: sources, options, version }) {
               bytes: compiledContract.bytecode_runtime.slice(2), //remove "0x" prefix
               linkReferences: [] //no libraries in Vyper
             },
-            deployedSourceMap: JSON.parse(compiledContract.source_map), //there is no constructor source map
+            deployedSourceMap,
             compiler
           };
 

--- a/packages/compile-vyper/index.js
+++ b/packages/compile-vyper/index.js
@@ -24,15 +24,20 @@ function checkVyper() {
           if (err) {
             return reject(`${colors.red("Error executing vyper:")}\n${stderr}`);
           }
-          const version = stdout.trim();
+          const version = normalizeVersion(stdout.trim());
           resolve({ version, json: false });
         });
       } else {
-        const version = stdout.trim();
+        const version = normalizeVersion(stdout.trim());
         resolve({ version, json: true });
       }
     });
   });
+}
+
+//HACK: alters prerelease versions so semver can understand them
+function normalizeVersion(version) {
+  return version.replace(/^(\d+\.\d+\.\d+)b(\d+)/, "$1-beta.$2");
 }
 
 // Execute vyper for single source file


### PR DESCRIPTION
Addresses #3755.

This PR fixes three bugs in Vyper compilation.  Two of these are specific to non-JSON compilation, and one is specific to Vyper prerelease versions.

1. In non-JSON compilation, the `source_map` format was included even if the version was too low (apparently it's only `vyper-json` that complains about such things); if the version was high enough, it would be included twice!  Now I've removed it from the starting array of formats, so if it doesn't get pushed on, it's not there, and if it does get pushed on, it's the only copy.  (It's this one that caused #3755; including `source_map` twice caused the source map to get read as the empty string, and then `JSON.parse` would fail on that.)
2. Also in non-JSON compilation, later code below didn't account for the possibility that the source map might not exist, and would crash on attempting to parse `undefined` as JSON.  Now we check for that.
3. Finally, our version checks against Vyper prerelease versions didn't actually work, as Vyper prerelease versions report the version as (e.g.) `0.1.0b17` rather than `0.1.0-beta.17`.  Semver doesn't recognize and can't work with the former format (so no, changing our comparison versions to that format doesn't help!), so instead I wrote a quick regex-replace to normalize the reported versions.  Now the version checks actually work.  Note that this bug only affected Vyper prerelease versions, as release versions would compare correctly here.