### PR TITLE
Internal improvement: Add test that assertion libraries compile with latest Solidity

### DIFF
--- a/packages/truffle/test/scenarios/solidity_testing/ImportEverything.sol
+++ b/packages/truffle/test/scenarios/solidity_testing/ImportEverything.sol
@@ -1,0 +1,12 @@
+pragma solidity >= 0.5.0 < 0.9.0;
+
+import "truffle/Assert.sol";
+import "truffle/DeployedAddresses.sol";
+import "truffle/SafeSend.sol";
+
+contract TestWithBalance {
+
+  function test() public {
+    //just succeed, we're just checking compilation
+  }
+}

--- a/packages/truffle/test/scenarios/solidity_testing/solidityTests.js
+++ b/packages/truffle/test/scenarios/solidity_testing/solidityTests.js
@@ -73,4 +73,26 @@ describe("Solidity Tests", function () {
         });
     });
   });
+
+  describe("compatibility", function () {
+    before(async () => {
+      await initSandbox("ImportEverything.sol");
+    });
+
+    it("compile with latest Solidity", function () {
+      this.timeout(70000);
+
+      return CommandRunner.run(
+        "test",
+        config.with({ solc: { version: "native" } })
+      )
+        .then(() => {
+          const output = logger.contents();
+          assert(output.includes("1 passing"));
+        })
+        .catch(error => {
+          assert(false, `An error occurred: ${error}`);
+        });
+    });
+  });
 });

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -30,8 +30,8 @@ run_geth() {
 if [ "$INTEGRATION" = true ]; then
 
   sudo add-apt-repository -y ppa:deadsnakes/ppa
-  sudo apt install -y jq
-  sudo apt install -y python3.6 python3.6-dev python3.6-venv
+  sudo add-apt-repository -y ppa:ethereum/ethereum
+  sudo apt install -y jq python3.6 python3.6-dev python3.6-venv solc
   wget https://bootstrap.pypa.io/get-pip.py
   sudo python3.6 get-pip.py
   sudo pip3 install vyper


### PR DESCRIPTION
This PR adds a test that our Solidity testing libraries (assertions, deployed addresses, and `SafeSend`) compile with the latest version of Solidity.  Note that (like our other tests that use latest Solidity), this new test uses `version: native`, and I've added an installation of Solidity to the integration tests so that this can work.

**Note that due to the pragma this test will break whenever there's a breaking Solidity release.**  That's a little annoying, I suppose; I could remove the upper bound from the pragma so that doesn't happen.  However, the potential for *non*-pragma breakage is the point of the PR!  This new test ensures that our build breaks whenever a breaking Solidity release breaks our assertion libraries, and forces us to update them when that happens.  (Well, or disable the test, if that proves too hard for some reason.  But that's what it's supposed to get us to to do.)

Basically I'm adding this test due to the recent cases with Solidity 0.8.0 where we didn't notice that Solidity testing was broken, and all the ways that it was broken, until a while after release!