### PR TITLE
Use `vyper --standard-json` if vyper-json not available

### DIFF
--- a/packages/compile-vyper/vyper-json.js
+++ b/packages/compile-vyper/vyper-json.js
@@ -9,7 +9,7 @@ const partition = require("lodash.partition");
 //from compile-solidity/run.js, so be warned...
 //(some has since been factored into compile-common, but not all)
 
-function compileJson({ sources: rawSources, options, version }) {
+function compileJson({ sources: rawSources, options, version, command }) {
   const compiler = { name: "vyper", version };
 
   const {
@@ -62,7 +62,8 @@ function compileJson({ sources: rawSources, options, version }) {
 
   // perform compilation
   const rawCompilerOutput = invokeCompiler({
-    compilerInput
+    compilerInput,
+    command
   });
   debug("rawCompilerOutput: %O", rawCompilerOutput);
 
@@ -107,14 +108,14 @@ function compileJson({ sources: rawSources, options, version }) {
   return { compilations: [compilation] };
 }
 
-function invokeCompiler({ compilerInput }) {
+function invokeCompiler({ compilerInput, command }) {
   const inputString = JSON.stringify(compilerInput);
-  const outputString = execVyperJson(inputString);
+  const outputString = execVyperJson(inputString, command);
   return JSON.parse(outputString);
 }
 
-function execVyperJson(inputString) {
-  return execSync("vyper-json", {
+function execVyperJson(inputString, command) {
+  return execSync(command, {
     input: inputString,
     maxBuffer: 1024 * 1024 * 10 //I guess?? copied from compile-solidity
   });


### PR DESCRIPTION
This PR makes it so that if `vyper-json` is not installed, we can still compile Vyper using JSON if `vyper` 0.2.5 or later is installed, using `vyper --standard-json`.  This feature, to compile via JSON but with the `vyper` executable instead of a separate `vyper-json` executable, was only added in Vyper 0.2.5, so we can't do it any earlier than that.

Ideally there would be a better way to check for this than checking the version, but I don't see one that wouldn't involve invoking `vyper` a third time, and I want to avoid that.  So, I think this is fine.

So now `checkVyper`, when `json` is set to true, will also return `jsonCommand`, which will either be `"vyper-json"` or `"vyper --standard-json"`.  This will be passed to `compileJson`, which will use the specified command when invoking the compiler.  Pretty simple.

Anyway, this way people won't need `vyper-json` installed to get the benefits of JSON-based Vyper compilation (if they're using Vyper 0.2.5 or later, anyway).