### PR TITLE
Allow querying @truffle/db for a project's contract instances

### DIFF
--- a/packages/db/src/meta/data.ts
+++ b/packages/db/src/meta/data.ts
@@ -11,6 +11,7 @@ import type {
   MutationInput,
   MutationPayload
 } from "./collections";
+import type { IdObject } from "./id";
 
 export interface Workspace<C extends Collections> {
   all<N extends CollectionName<C>>(
@@ -19,7 +20,7 @@ export interface Workspace<C extends Collections> {
 
   find<N extends CollectionName<C>>(
     collectionName: N,
-    options: PouchDB.Find.FindRequest<{}>
+    options: (IdObject<C, N> | undefined)[] | PouchDB.Find.FindRequest<{}>
   ): Promise<SavedInput<C, N>[]>;
 
   get<N extends CollectionName<C>>(

--- a/packages/db/src/meta/graph/schema.ts
+++ b/packages/db/src/meta/graph/schema.ts
@@ -256,20 +256,13 @@ abstract class DefinitionSchema<
             if (filter) {
               logFilter("Filtering for ids: %o...", filter.ids);
 
-              const results = await workspace.find(resources, {
-                selector: {
-                  id: { $in: filter.ids.filter(id => id) }
-                }
-              });
-
-              const byId = results
-                .map(result => ({
-                  [result.id]: result
-                }))
-                .reduce((a, b) => ({ ...a, ...b }), {});
+              const results = await workspace.find(
+                resources,
+                filter.ids.map(id => ({ id }))
+              );
 
               logFilter("Filtered for ids: %o", filter.ids);
-              return filter.ids.map(id => (id ? byId[id] : undefined));
+              return results;
             } else {
               logAll("Fetching all...");
 

--- a/packages/db/src/meta/graph/schema.ts
+++ b/packages/db/src/meta/graph/schema.ts
@@ -60,6 +60,10 @@ class DefinitionsSchema<C extends Collections> {
         id: ID!
       }
 
+      input ResourceNameInput {
+        name: String!
+      }
+
       input TypedResourceReferenceInput {
         id: ID!
         type: String!

--- a/packages/db/src/meta/index.ts
+++ b/packages/db/src/meta/index.ts
@@ -23,7 +23,7 @@ export {
   NamedResource
 } from "./collections";
 export { Db, ConnectOptions } from "./interface";
-export { Workspace } from "./data";
+export { SavedInput, Workspace } from "./data";
 export { Definition, Definitions } from "./definitions";
 
 import * as Graph from "./graph";

--- a/packages/db/src/resources/contractInstances.ts
+++ b/packages/db/src/resources/contractInstances.ts
@@ -14,7 +14,7 @@ export const contractInstances: Definition<"contractInstances"> = {
     resourcesMutate: "contractInstancesAdd",
     ResourcesMutate: "ContractInstancesAdd"
   },
-  createIndexes: [],
+  createIndexes: [{ fields: ["contract.id"] }],
   idFields: ["address", "network"],
   typeDefs: gql`
     type ContractInstance implements Resource {

--- a/packages/db/src/resources/networks/index.ts
+++ b/packages/db/src/resources/networks/index.ts
@@ -31,7 +31,6 @@ export const networks: Definition<"networks"> = {
       name: String!
       networkId: NetworkId!
       historicBlock: Block!
-      fork: Network
 
       ancestors(
         limit: Int # default all

--- a/packages/db/src/resources/projects/index.ts
+++ b/packages/db/src/resources/projects/index.ts
@@ -78,11 +78,10 @@ export const projects: Definition<"projects"> = {
             { workspace }
           );
 
-          const resourceIds = nameRecords.map(({ resource }) => resource.id);
-
-          const result = await workspace.find("networks", {
-            selector: { id: { $in: resourceIds } }
-          });
+          const result = await workspace.find(
+            "networks",
+            nameRecords.map(({ resource }) => resource)
+          );
 
           debug("Resolved Project.networks.");
           return result;
@@ -118,11 +117,10 @@ export const projects: Definition<"projects"> = {
             { workspace }
           );
 
-          const resourceIds = nameRecords.map(({ resource }) => resource.id);
-
-          const result = await workspace.find("contracts", {
-            selector: { id: { $in: resourceIds } }
-          });
+          const result = await workspace.find(
+            "contracts",
+            nameRecords.map(({ resource }) => resource)
+          );
 
           debug("Resolved Project.contracts.");
           return result;

--- a/packages/db/src/resources/projects/index.ts
+++ b/packages/db/src/resources/projects/index.ts
@@ -5,6 +5,7 @@ import gql from "graphql-tag";
 
 import type { Definition } from "@truffle/db/resources/types";
 import { resolveNameRecords } from "./resolveNameRecords";
+import { resolveContractInstances } from "./resolveContractInstances";
 
 export const projects: Definition<"projects"> = {
   names: {
@@ -26,6 +27,15 @@ export const projects: Definition<"projects"> = {
 
       network(name: String!): Network
       networks: [Network]!
+
+      contractInstance(
+        contract: ResourceNameInput!
+        network: ResourceNameInput!
+      ): ContractInstance
+      contractInstances(
+        contract: ResourceNameInput
+        network: ResourceNameInput
+      ): [ContractInstance]
 
       resolve(type: String, name: String): [NameRecord] # null means unknown type
     }
@@ -123,6 +133,36 @@ export const projects: Definition<"projects"> = {
           );
 
           debug("Resolved Project.contracts.");
+          return result;
+        }
+      },
+      contractInstance: {
+        async resolve(project, inputs, context, info) {
+          debug("Resolving Project.contractInstance...");
+
+          const [result] = await resolveContractInstances(
+            project,
+            inputs,
+            context,
+            info
+          );
+
+          debug("Resolved Project.contractInstance.");
+          return result;
+        }
+      },
+      contractInstances: {
+        async resolve(project, inputs, context, info) {
+          debug("Resolving Project.contractInstances...");
+
+          const result = await resolveContractInstances(
+            project,
+            inputs,
+            context,
+            info
+          );
+
+          debug("Resolved Project.contractInstances.");
           return result;
         }
       }

--- a/packages/db/src/resources/projects/resolveContractInstances.ts
+++ b/packages/db/src/resources/projects/resolveContractInstances.ts
@@ -1,0 +1,214 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:resources:projects:resolveContractInstances");
+
+import gql from "graphql-tag";
+import { delegateToSchema } from "graphql-tools";
+import type * as graphql from "graphql";
+import type {
+  DataModel,
+  NamedCollectionName,
+  IdObject,
+  SavedInput,
+  Workspace
+} from "@truffle/db/resources/types";
+import { resolveNameRecords } from "./resolveNameRecords";
+
+/**
+ * For given contract and/or network names, find all contract instances
+ * matching either/both of those filters.
+ *
+ * Returns contract instances for the most current contract according to that
+ * contract's name record history - i.e., if a contract has been revised since
+ * being deployed to mainnet, this function will return the contract instance
+ * for that past revision.
+ */
+export async function resolveContractInstances(
+  project: IdObject<"projects">,
+  inputs: {
+    contract?: DataModel.ResourceNameInput;
+    network?: DataModel.ResourceNameInput;
+  },
+  context: {
+    workspace: Workspace;
+  },
+  info: graphql.GraphQLResolveInfo
+): Promise<SavedInput<"contractInstances">[]> {
+  const { workspace } = context;
+
+  const contractNameRecords = await resolveNameRecords(
+    project,
+    { ...inputs.contract, type: "Contract" },
+    { workspace }
+  );
+
+  const contractInstances: SavedInput<"contractInstances">[] = [];
+  debug("inputs %O", inputs);
+
+  for await (const { skip, contracts } of findResourcesHistories<"contracts">({
+    collectionName: "contracts",
+    nameRecords: contractNameRecords,
+    workspace
+  })) {
+    let stepContractInstances = await workspace.find("contractInstances", {
+      selector: {
+        "contract.id": { $in: contracts.map(({ id }) => id) }
+      }
+    });
+
+    if (inputs.network) {
+      const ancestors = await filterProjectNetworkAncestors({
+        project,
+        network: inputs.network,
+        candidates: stepContractInstances.map(({ network }) => network),
+        workspace,
+        info
+      });
+
+      const ancestorIds = new Set([...ancestors.map(({ id }) => id)]);
+      stepContractInstances = stepContractInstances.filter(({ network }) =>
+        ancestorIds.has(network.id)
+      );
+    }
+
+    const byContractId = stepContractInstances.reduce(
+      (byContractId, contractInstance) => ({
+        ...byContractId,
+        [contractInstance.contract.id]: contractInstance
+      }),
+      {}
+    );
+
+    const found = contracts.map(({ id }, index) =>
+      id in byContractId ? index : undefined
+    );
+
+    debug("skipping found indexes: %O", found);
+    skip(...found);
+
+    contractInstances.push(...stepContractInstances);
+  }
+
+  return contractInstances;
+}
+
+/**
+ * Steps backwards through name record history for a given set of name records,
+ * yielding an array of past resources in a breadth-first search manner.
+ *
+ * At each step, yields a [somewhat HACKy] `skip` function, to omit specific
+ * indexes from further consideration.
+ *
+ * Returns when all name records histories have been exhausted.
+ */
+async function* findResourcesHistories<N extends NamedCollectionName>(options: {
+  collectionName: N;
+  nameRecords: (SavedInput<"nameRecords"> | undefined)[];
+  workspace: Workspace;
+}): AsyncIterable<
+  {
+    [K in "skip" | N]: "skip" extends K
+      ? (...indexes: number[]) => void
+      : (IdObject<N> | undefined)[];
+  }
+> {
+  const { collectionName, workspace } = options;
+  let { nameRecords } = options;
+
+  do {
+    const skip = (...indexes: (number | undefined)[]) => {
+      for (const index of indexes) {
+        if (typeof index === "number") {
+          nameRecords[index] = undefined;
+        }
+      }
+    };
+
+    // @ts-ignore
+    yield {
+      skip,
+      [collectionName]: nameRecords.map(nameRecord =>
+        nameRecord && nameRecord.resource
+          ? ({ id: nameRecord.resource.id } as IdObject<N>)
+          : undefined
+      )
+    };
+
+    // preserving order, iterate to next set of previous records
+    nameRecords = await workspace.find(
+      "nameRecords",
+      nameRecords.map(nameRecord =>
+        nameRecord && nameRecord.previous ? nameRecord.previous : undefined
+      )
+    );
+  } while (nameRecords.find(nameRecord => nameRecord));
+}
+
+/**
+ * Given a list of candidate networks, returns a subset list that are each
+ * ancestor to the network currently known to a project as a given name.
+ */
+async function filterProjectNetworkAncestors(options: {
+  project: IdObject<"projects">;
+  network: DataModel.ResourceNameInput;
+  candidates: IdObject<"networks">[];
+  workspace: Workspace;
+  info: graphql.GraphQLResolveInfo;
+}): Promise<IdObject<"networks">[]> {
+  const { project, network, workspace, info } = options;
+
+  // short-circuit early to avoid extra queries and to avoid index lookup guard
+  if (options.candidates.length === 0) {
+    return [];
+  }
+
+  const candidates = await workspace.find("networks", options.candidates);
+
+  // find earliest among candidates to specify minimumHeight to ancestors query
+  const earliestCandidate = candidates
+    .slice(1)
+    .reduce(
+      (earliest, network) =>
+        earliest.historicBlock.height < network.historicBlock.height
+          ? earliest
+          : network,
+      candidates[0]
+    );
+
+  // query ancestors for project network name
+  const { network: { ancestors = [] } = {} } = await delegateToSchema({
+    schema: info.schema,
+    operation: "query",
+    fieldName: "project",
+    returnType: info.schema.getType("Project") as graphql.GraphQLOutputType,
+    args: project,
+    info,
+    context: { workspace },
+    selectionSet: extractSelectionSet(gql`{
+      network(name: "${network.name}") {
+        ancestors(
+          includeSelf: true
+          minimumHeight: ${earliestCandidate.historicBlock.height}
+        ) {
+          id
+        }
+      }
+    }`)
+  });
+
+  // filter candidates
+  const ancestorIds = new Set([...ancestors.map(({ id }) => id)]);
+  // @ts-ignore for the stubs
+  return candidates.filter(({ id }) => ancestorIds.has(id));
+}
+
+/**
+ * Converts a normal gql`` expression into its (preconditional) subset
+ * selection set.
+ *
+ * (To make it easier to construct `delegateToSchema` calls)
+ */
+function extractSelectionSet(document) {
+  return document.definitions
+    .map(({ selectionSet }) => selectionSet)
+    .find(selectionSet => selectionSet);
+}

--- a/packages/db/src/resources/projects/resolveNameRecords.ts
+++ b/packages/db/src/resources/projects/resolveNameRecords.ts
@@ -29,12 +29,11 @@ export async function resolveNameRecords(
       "key.type": type
     }
   });
-  const nameRecordIds = results.map(({ nameRecord: { id } }) => id);
-  const nameRecords = await workspace.find("nameRecords", {
-    selector: {
-      id: { $in: nameRecordIds }
-    }
-  });
+
+  const nameRecords = await workspace.find(
+    "nameRecords",
+    results.map(({ nameRecord }) => nameRecord)
+  );
 
   return nameRecords;
 }

--- a/packages/db/src/resources/projects/resolveNameRecords.ts
+++ b/packages/db/src/resources/projects/resolveNameRecords.ts
@@ -1,0 +1,40 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:resources:projects:resolveNameRecords");
+
+import type {
+  SavedInput,
+  IdObject,
+  Workspace
+} from "@truffle/db/resources/types";
+
+export async function resolveNameRecords(
+  project: IdObject<"projects">,
+  inputs: {
+    name?: string;
+    type?: string;
+  },
+  context: {
+    workspace: Workspace;
+  },
+  _?
+): Promise<SavedInput<"nameRecords">[]> {
+  const { id } = project;
+  const { name, type } = inputs;
+  const { workspace } = context;
+
+  const results = await workspace.find("projectNames", {
+    selector: {
+      "project.id": id,
+      "key.name": name,
+      "key.type": type
+    }
+  });
+  const nameRecordIds = results.map(({ nameRecord: { id } }) => id);
+  const nameRecords = await workspace.find("nameRecords", {
+    selector: {
+      id: { $in: nameRecordIds }
+    }
+  });
+
+  return nameRecords;
+}

--- a/packages/db/src/resources/projects/test/contractInstances.spec.ts
+++ b/packages/db/src/resources/projects/test/contractInstances.spec.ts
@@ -1,0 +1,188 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:resources:projects:test:contractInstances");
+
+import gql from "graphql-tag";
+
+import { connect } from "@truffle/db";
+import * as Project from "@truffle/db/project";
+import { resources, Run } from "@truffle/db/process";
+import { Resource } from "@truffle/db/resources";
+
+describe("Project.contractInstances", () => {
+  describe("for networks with differing contract revisions", () => {
+    it("resolves contract-instances correctly", async () => {
+      /*
+       * Setup
+       */
+      const db = connect({ workingDirectory: "", adapter: { name: "memory" } });
+      const { run } = Run.forDb(db);
+      const project = await Project.initialize({
+        db,
+        project: { directory: "/" }
+      });
+
+      /*
+       * Common definitions: test two contracts on two different networks
+       */
+      const A = { name: "A" };
+      const B = { name: "B" };
+      const vnet = { name: "vnet", networkId: "v" };
+      const wnet = { name: "wnet", networkId: "w" };
+
+      /*
+       * First, simulate deployment of A and B to vnet
+       */
+      {
+        // create network resources
+        const vnets = await run(resources.load, "networks", [
+          { ...vnet, historicBlock: { height: 0, hash: "v0" } },
+          { ...vnet, historicBlock: { height: 1, hash: "v1" } },
+          { ...vnet, historicBlock: { height: 2, hash: "v2" } }
+        ]);
+        await run(resources.load, "networkGenealogies", [
+          { ancestor: vnets[0], descendant: vnets[1] },
+          { ancestor: vnets[1], descendant: vnets[2] }
+        ]);
+
+        // create contracts
+        const contracts = await run(resources.load, "contracts", [
+          { ...A, abi: { json: JSON.stringify("a1") } },
+          { ...B, abi: { json: JSON.stringify("b1") } }
+        ]);
+
+        // assign names
+        await project.assignNames({
+          assignments: {
+            contracts,
+            networks: [vnets[2]]
+          }
+        });
+
+        // create contract instances
+        await run(resources.load, "contractInstances", [
+          // Deploy A in first block after genesis (skip genesis for fun)
+          { contract: contracts[0], network: vnets[1], address: "v-a" },
+          // Deploy B after
+          { contract: contracts[1], network: vnets[2], address: "v-b" }
+        ]);
+      }
+
+      /*
+       * Then, revise A and B and deploy new revisions to wnet
+       */
+      {
+        // create network resources
+        const wnets = await run(resources.load, "networks", [
+          { ...wnet, historicBlock: { height: 0, hash: "w0" } },
+          { ...wnet, historicBlock: { height: 1, hash: "w1" } },
+          { ...wnet, historicBlock: { height: 2, hash: "w2" } }
+        ]);
+        await run(resources.load, "networkGenealogies", [
+          { ancestor: wnets[0], descendant: wnets[1] },
+          { ancestor: wnets[1], descendant: wnets[2] }
+        ]);
+
+        // create contracts
+        const contracts = await run(resources.load, "contracts", [
+          { ...A, abi: { json: JSON.stringify("a2") } },
+          { ...B, abi: { json: JSON.stringify("b2") } }
+        ]);
+
+        // assign names
+        await project.assignNames({
+          assignments: {
+            contracts,
+            networks: [wnets[2]]
+          }
+        });
+
+        // create contract instances
+        await run(resources.load, "contractInstances", [
+          // Deploy A in first block after genesis (skip genesis for fun)
+          { contract: contracts[0], network: wnets[1], address: "w-a" },
+          // Deploy B after
+          { contract: contracts[1], network: wnets[2], address: "w-b" }
+        ]);
+      }
+
+      /*
+       * Prepare to query results
+       */
+      let fragmentIndex = 0;
+      const forNetwork = networkName => gql`
+        fragment ForNetwork__${fragmentIndex++} on Project {
+          contractInstances(
+            network: { name: "${networkName}" }
+          ) {
+            address
+            network {
+              networkId
+            }
+            contract {
+              name
+              abi { json }
+            }
+          }
+        }
+      `;
+
+      /*
+       * vnet should have the old versions
+       */
+      {
+        // @ts-ignore
+        const { contractInstances }: Resource<"projects"> = await run(
+          resources.get,
+          "projects",
+          project.id,
+          forNetwork("vnet")
+        );
+
+        const a = contractInstances.find(
+          ({ contract: { name } }) => name === "A"
+        );
+
+        expect(a.address).toEqual("v-a");
+        expect(a.network.networkId).toEqual("v");
+        expect(a.contract.abi.json).toEqual(JSON.stringify("a1"));
+
+        const b = contractInstances.find(
+          ({ contract: { name } }) => name === "B"
+        );
+
+        expect(b.address).toEqual("v-b");
+        expect(b.network.networkId).toEqual("v");
+        expect(b.contract.abi.json).toEqual(JSON.stringify("b1"));
+      }
+
+      /*
+       * wnet should have the new versions
+       */
+      {
+        // @ts-ignore
+        const { contractInstances }: Resource<"projects"> = await run(
+          resources.get,
+          "projects",
+          project.id,
+          forNetwork("wnet")
+        );
+
+        const a = contractInstances.find(
+          ({ contract: { name } }) => name === "A"
+        );
+
+        expect(a.address).toEqual("w-a");
+        expect(a.network.networkId).toEqual("w");
+        expect(a.contract.abi.json).toEqual(JSON.stringify("a2"));
+
+        const b = contractInstances.find(
+          ({ contract: { name } }) => name === "B"
+        );
+
+        expect(b.address).toEqual("w-b");
+        expect(b.network.networkId).toEqual("w");
+        expect(b.contract.abi.json).toEqual(JSON.stringify("b2"));
+      }
+    });
+  });
+});

--- a/packages/db/src/resources/types.ts
+++ b/packages/db/src/resources/types.ts
@@ -248,6 +248,10 @@ export type Resource<N extends CollectionName = CollectionName> = Meta.Resource<
   N
 >;
 
+export type SavedInput<
+  N extends CollectionName = CollectionName
+> = Meta.SavedInput<Collections, N>;
+
 export type IdFields<N extends CollectionName = CollectionName> = Meta.IdFields<
   Collections,
   N

--- a/packages/db/types/stub.d.ts
+++ b/packages/db/types/stub.d.ts
@@ -3,6 +3,7 @@
 
 declare namespace _DataModel {
   type ResourceReferenceInput = any;
+  type ResourceNameInput = any;
   type Block = any;
   type BlockInput = any;
   type Bytecode = any;


### PR DESCRIPTION
This PR adds the `Project.contractInstance` and `Project.contractInstances` queries for easy deployed instance lookups.

Since contract instances _themselves_ are not named, these queries filter based on **contract name** and/or **network name**. (`Project.contractInstance` requires both, `Project.contractInstances` allows either/both/neither). These queries use these names to determine a "best fit" match for contract instances.

The process is a bit tricky, and different for contract names vs. for network names.

For filtering by network name:
- The name resolution part is easy: there's no need to look for historical name records for a given network. Assume that the currently assigned network resource for that name represents the actual blockchain we want, and that the contract instances we're looking for are deployed to some ancestor of this network resource.
- So, we just need to find all ancestors and filter contract instances by those IDs.

For filtering by contract name (or omitting this filter, thus filtering for "any known contract name"):
- The name resolution is the more important one here: search through each contract name history until we find that it has a corresponding contract instance (possibly filtered by network)
- Stop searching for each particular contract name once we have a matching contract instance for that name (possibly continuing for other names not found yet).

Putting these together, the process primarily searches through the history for a number of contract names simultaneously, keeping a sparse list of discovered contract instances (matching index with list of contract names) on a _per contract name_ basis. At each contract name revision, query for contract instances corresponding to that contract and match against the network filter. Return all contract instances found this way after we've exhausted _every contract name_: for each, either find a matching instance for that name or exhaust the known history of that name.

This PR does a couple other things that are arguably related:
- Remove `Network.fork` again. Guess I missed this is in #3733.
- Add a friendly overload to `workspace.find()` that lets you query for a list of IdObjects, preserving order between queried list and returned results. Since we do this in a lot of places.
- Fix an internal return type.

I've included a pretty barebones test, just to exercise the essential mechanism here: what happens if contracts are deployed to one network, then deployed to another network after some revisions?