### PR TITLE
Internal improvement: Make @truffle/debugger a webpack external for truffle

### DIFF
--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -27,6 +27,7 @@
     "test:raw": "NO_BUILD=true mocha"
   },
   "dependencies": {
+    "@truffle/debugger": "^8.0.12",
     "app-module-path": "^2.2.0",
     "mocha": "8.1.2",
     "original-require": "1.0.1"
@@ -35,7 +36,6 @@
     "@truffle/box": "^2.1.5",
     "@truffle/contract": "^4.3.6",
     "@truffle/core": "^5.1.65",
-    "@truffle/debugger": "^8.0.12",
     "@truffle/interface-adapter": "^0.4.18",
     "clean-webpack-plugin": "^3.0.0",
     "copy-webpack-plugin": "^5.1.1",

--- a/packages/truffle/webpack.config.js
+++ b/packages/truffle/webpack.config.js
@@ -105,6 +105,7 @@ module.exports = {
     // module that's a dependency of Truffle instead.
     /^original-require$/,
     /^mocha$/,
+    /^@truffle\/debugger/, //no longer part of the bundle to keep size down
     // this is the commands portion shared by cli.js and console-child.js
     /^\.\/commands.bundled.js$/
   ],


### PR DESCRIPTION
As per #3768, to keep the bundle size down.