### PR TITLE
Implement @truffle/preserve

### DIFF
--- a/packages/preserve/.gitignore
+++ b/packages/preserve/.gitignore
@@ -1,0 +1,4 @@
+node_modules/*
+yarn.lock
+package-lock.json
+dist

--- a/packages/preserve/.gitignore
+++ b/packages/preserve/.gitignore
@@ -2,3 +2,4 @@ node_modules/*
 yarn.lock
 package-lock.json
 dist
+coverage

--- a/packages/preserve/docs/README.md
+++ b/packages/preserve/docs/README.md
@@ -1,0 +1,3 @@
+# `truffle preserve`
+
+Yum! :d

--- a/packages/preserve/docs/biblio.json
+++ b/packages/preserve/docs/biblio.json
@@ -1,0 +1,6 @@
+{
+  "Iterable": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#The_iterable_protocol",
+  "AsyncIterable": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of",
+  "ArrayBuffer": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer",
+  "string": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String"
+}

--- a/packages/preserve/docs/tsconfig.json
+++ b/packages/preserve/docs/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "target": "es6",
+    "noImplicitAny": true,
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "outDir": "dist",
+    "baseUrl": "..",
+    "lib": ["es2017"],
+    "paths": {
+      "@truffle/preserve": ["../preserve/lib"],
+      "@truffle/preserve/*": ["../preserve/lib/*"]
+    },
+    "rootDir": "../..",
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "./lib/**/*.ts",
+    "./typings/**/*.d.ts"
+  ]
+}

--- a/packages/preserve/docs/typedoc.json
+++ b/packages/preserve/docs/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "name": "@truffle/preserve",
+  "mode": "modules",
+  "module": "commonjs",
+  "theme": "../../node_modules/@trufflesuite/typedoc-default-themes/bin/default/",
+  "includeDeclarations": false,
+  "ignoreCompilerErrors": true,
+  "preserveConstEnums": true,
+  "excludeExternals": true,
+  "exclude": [
+    "**/test/*"
+  ],
+  "target": "ES6"
+}

--- a/packages/preserve/jest.config.js
+++ b/packages/preserve/jest.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  moduleFileExtensions: ["ts", "js", "json", "node"],
+  testEnvironment: "node",
+  transform: {
+    "^.+\\.ts$": "ts-jest"
+  },
+  globals: {
+    "ts-jest": {
+      tsConfig: "<rootDir>/tsconfig.json",
+      diagnostics: true
+    }
+  },
+  testMatch: [
+    // match files in test/ directories (exclude root `./test/`)
+    "<rootDir>/@(lib|test)/**/test/*.@(ts|js)",
+
+    // or files that use a test extension prefix
+    "<rootDir>/@(lib|test)/**/*.@(test|spec).@(ts|js)"
+  ]
+};

--- a/packages/preserve/lib/ConsoleReporter.ts
+++ b/packages/preserve/lib/ConsoleReporter.ts
@@ -1,0 +1,154 @@
+import chalk from "chalk";
+import Spinnies from "spinnies";
+
+import * as Control from "./control";
+
+export interface ConsoleReporterConstructorOptions {
+  console: Console;
+}
+
+export class ConsoleReporter {
+  private spinners: Spinnies;
+  private console: Console;
+
+  constructor(options: ConsoleReporterConstructorOptions) {
+    this.spinners = new Spinnies();
+    this.console = options.console;
+  }
+
+  async report(events: AsyncIterable<Control.Event>) {
+    for await (const event of events) {
+      this[event.type].bind(this)(event);
+    }
+  }
+
+  /*
+   * Error events
+   */
+
+  private fail(event: Control.Events.Fail) {
+    const { error } = event;
+
+    const { key } = eventProperties(event);
+
+    // get current text
+    const { text, indent } = this.spinners.pick(key);
+
+    const options = error
+      ? {
+          text: `${text}\n${" ".repeat(indent)}${chalk.red(error.toString())}`
+        }
+      : {};
+
+    this.spinners.fail(key, options);
+  }
+
+  private abort(event: Control.Events.Abort) {
+    const { key } = eventProperties(event);
+
+    this.spinners.fail(key);
+  }
+
+  private stop(event: Control.Events.Stop) {
+    const { key } = eventProperties(event);
+
+    this.spinners.remove(key);
+  }
+
+  /*
+   * Step events
+   */
+
+  private begin(event: Control.Events.Begin) {
+    this.console.log();
+
+    const { key, indent } = eventProperties(event);
+
+    this.spinners.add(key, {
+      succeedColor: "white",
+      failColor: "white",
+      indent: indent
+    });
+  }
+
+  private log(event: Control.Events.Log) {
+    const { message } = event;
+
+    const { key } = eventProperties(event);
+
+    this.spinners.update(key, {
+      text: `${message}`
+    });
+  }
+
+  private succeed(event: Control.Events.Succeed) {
+    const { message } = event;
+
+    const { key } = eventProperties(event);
+
+    const options = message ? { text: message } : {};
+
+    this.spinners.succeed(key, options);
+  }
+
+  private step(event: Control.Events.Step) {
+    const { key, indent } = eventProperties(event);
+
+    const { message } = event;
+
+    this.spinners.add(key, {
+      text: message,
+      indent,
+      succeedColor: "white",
+      failColor: "white"
+    });
+  }
+
+  /*
+   * Value resolution events
+   */
+  private declare(event: Control.Events.Declare) {
+    const { key, indent } = eventProperties(event);
+
+    const { message } = event;
+
+    this.spinners.add(key, {
+      text: message,
+      indent,
+      succeedColor: "white",
+      failColor: "white"
+    });
+  }
+
+  private resolve(event: Control.Events.Resolve) {
+    const { payload } = event;
+
+    const { key } = eventProperties(event);
+
+    const { text } = this.spinners.pick(key);
+
+    const options = payload ? { text: `${chalk.cyan(text)}: ${payload}` } : {};
+
+    this.spinners.update(key, {
+      ...options,
+      status: "stopped"
+    });
+  }
+
+  private update(event: Control.Events.Update) {
+    const { payload } = event;
+
+    const { key } = eventProperties(event);
+
+    const { text } = this.spinners.pick(key);
+
+    const options = payload ? { text: `${chalk.cyan(text)}: ${payload}` } : {};
+
+    this.spinners.update(key, options);
+  }
+}
+
+const eventProperties = (event: Control.Event) => ({
+  key: Control.Scopes.toKey(event.scope),
+  indent: event.scope.length * 2
+});

--- a/packages/preserve/lib/control/control.ts
+++ b/packages/preserve/lib/control/control.ts
@@ -1,0 +1,59 @@
+import { StepsController } from "./controllers";
+import { Process, State, HasControls } from "./types";
+
+export interface ControlOptions<R, O extends HasControls> {
+  name?: string;
+  method: (options: O) => Process<R>;
+}
+
+export async function* control<R, O extends HasControls>(
+  controlOptions: ControlOptions<R, O>,
+  methodOptions: Omit<O, "controls">
+): Process<R> {
+  const { name, method } = controlOptions;
+
+  const scope = [name || ""];
+
+  const controller = new StepsController({ scope });
+
+  const controls = {
+    log: controller.log,
+    declare: controller.declare,
+    step: controller.step
+  };
+
+  yield* controller.begin();
+
+  try {
+    const completeMethodOptions = { ...methodOptions, controls } as O;
+    const result = yield* method(completeMethodOptions);
+
+    yield* controller.succeed({ result });
+
+    // check for error state (in case of cascaded failures)
+    if (controller.state !== State.Done) {
+      return;
+    }
+
+    return result;
+  } catch (error) {
+    yield* controller.fail({ error });
+
+    return;
+  }
+}
+
+export const run = async <R, O extends HasControls>(
+  controlOptions: ControlOptions<R, O>,
+  methodOptions: Omit<O, "controls">
+): Promise<R> => {
+  const generator = control(controlOptions, methodOptions);
+
+  while (true) {
+    const { done, value } = await generator.next();
+
+    if (done) {
+      return value as R;
+    }
+  }
+};

--- a/packages/preserve/lib/control/controllers/BaseController.ts
+++ b/packages/preserve/lib/control/controllers/BaseController.ts
@@ -1,0 +1,40 @@
+import { Event } from "../events";
+import { Scope } from "../scopes";
+import { State } from "../types";
+
+export interface ConstructorOptions {
+  scope: Scope;
+  state?: State;
+}
+
+export interface IBaseController {
+  readonly state: State;
+  emit<E extends Event>(event: Omit<E, "scope">): E;
+}
+
+export abstract class BaseController implements IBaseController {
+  protected _state: State;
+  protected scope: Scope;
+
+  public get state() {
+    return this._state;
+  }
+
+  constructor(options: ConstructorOptions) {
+    const { scope, state } = options;
+
+    this.scope = scope;
+    this._state = state ?? State.Pending;
+  }
+
+  emit<E extends Event>(event: Omit<E, "scope">): E {
+    return {
+      ...Object.entries(event)
+        .filter(([_, value]) => value !== undefined)
+        .map(([key, value]) => ({ [key]: value }))
+        .reduce((a, b) => ({ ...a, ...b })),
+
+      scope: this.scope
+    } as E;
+  }
+}

--- a/packages/preserve/lib/control/controllers/ErrorController.ts
+++ b/packages/preserve/lib/control/controllers/ErrorController.ts
@@ -1,0 +1,118 @@
+import { Events } from "../events";
+import { Process, State } from "../types";
+import {
+  BaseController,
+  ConstructorOptions as BaseConstructorOptions,
+  IBaseController
+} from "./BaseController";
+
+export namespace Options {
+  export interface Fail {
+    cascade?: boolean;
+    error?: Error;
+  }
+
+  export interface Abort {
+    cascade?: boolean;
+  }
+
+  export interface Stop {}
+}
+
+export interface ConstructorOptions extends BaseConstructorOptions {
+  parent?: IErrorController;
+}
+
+export interface IErrorController extends IBaseController {
+  fail(
+    options: Options.Fail
+  ): Process<void, Events.Fail | Events.Abort | Events.Stop>;
+  abort(options: Options.Abort): Process<void, Events.Abort | Events.Stop>;
+  stop(options?: Options.Stop): Process<void, Events.Stop>;
+}
+
+export abstract class ErrorController
+  extends BaseController
+  implements IErrorController {
+  protected parent?: IErrorController;
+  protected children: IErrorController[];
+
+  constructor(options: ConstructorOptions) {
+    const { parent, ...superOptions } = options;
+
+    super(superOptions);
+
+    this.children = [];
+    if (parent) {
+      this.parent = parent;
+    }
+
+    // so we can pass these around as functions
+    this.fail = this.fail.bind(this);
+    this.abort = this.abort.bind(this);
+    this.stop = this.stop.bind(this);
+  }
+
+  async *fail({ error, cascade = true }: Options.Fail = {}) {
+    // only meaningful to fail if we're currently active
+    if (this._state !== State.Active) {
+      return;
+    }
+
+    // stop all children
+    for (const child of this.children) {
+      yield* child.stop();
+    }
+
+    yield this.emit<Events.Fail>({
+      type: "fail",
+      error
+    });
+
+    this._state = State.Error;
+
+    // propagate to parent
+    if (this.parent && cascade) {
+      yield* this.parent.abort({ cascade });
+    }
+  }
+
+  async *abort({ cascade = true }: Options.Abort = {}) {
+    // only meaningful to stop if we're currently active
+    if (this._state !== State.Active) {
+      return;
+    }
+
+    // stop all children
+    for (const child of this.children) {
+      yield* child.stop();
+    }
+
+    yield this.emit<Events.Abort>({
+      type: "abort"
+    });
+
+    this._state = State.Error;
+
+    // propagate to parent
+    if (this.parent && cascade) {
+      yield* this.parent.abort({ cascade });
+    }
+  }
+
+  async *stop({}: Options.Stop = {}) {
+    // only meaningful to stop if we're currently active
+    if (this._state !== State.Active) {
+      return;
+    }
+
+    // stop all children
+    for (const child of this.children) {
+      yield* child.stop();
+    }
+
+    yield this.emit<Events.Stop>({
+      type: "stop"
+    });
+  }
+}

--- a/packages/preserve/lib/control/controllers/ErrorController.ts
+++ b/packages/preserve/lib/control/controllers/ErrorController.ts
@@ -114,5 +114,7 @@ export abstract class ErrorController
     yield this.emit<Events.Stop>({
       type: "stop"
     });
+
+    this._state = State.Error;
   }
 }

--- a/packages/preserve/lib/control/controllers/StepsController.ts
+++ b/packages/preserve/lib/control/controllers/StepsController.ts
@@ -1,0 +1,137 @@
+import {
+  ErrorController,
+  ConstructorOptions as ErrorControllerConstructorOptions,
+  IErrorController
+} from "./ErrorController";
+import { Events } from "../events";
+import {
+  IValueResolutionController,
+  ValueResolutionController
+} from "./ValueResolutionController";
+import { Process, State } from "../types";
+
+export namespace Options {
+  export interface Begin {
+    message?: string;
+  }
+
+  export interface Log {
+    message: string;
+  }
+
+  export interface Succeed {
+    result?: any;
+    message?: string;
+  }
+
+  export interface Declare {
+    identifier: string;
+    message?: string;
+  }
+
+  export interface Step {
+    identifier?: string;
+    message?: string;
+  }
+}
+
+export interface ConstructorOptions extends ErrorControllerConstructorOptions {}
+
+export interface IStepsController extends IErrorController {
+  begin(options?: Options.Begin): Process<void, Events.Begin>;
+  log(options: Options.Log): Process<void, Events.Log>;
+  succeed(options?: Options.Succeed): Process<void, Events.Succeed>;
+  declare(
+    options: Options.Declare
+  ): Process<IValueResolutionController, Events.Declare>;
+  step(options: Options.Step): Process<IStepsController, Events.Step>;
+}
+
+export class StepsController
+  extends ErrorController
+  implements IStepsController {
+  constructor(options: ConstructorOptions) {
+    const { ...superOptions } = options;
+    super(superOptions);
+
+    // so we can pass these around as functions
+    this.begin = this.begin.bind(this);
+    this.succeed = this.succeed.bind(this);
+    this.log = this.log.bind(this);
+    this.declare = this.declare.bind(this);
+    this.step = this.step.bind(this);
+  }
+
+  async *begin() {
+    // can only begin not begun yet
+    if (this._state !== State.Pending) {
+      return;
+    }
+
+    yield this.emit<Events.Begin>({
+      type: "begin"
+    });
+
+    this._state = State.Active;
+  }
+
+  async *succeed({ result, message }: Options.Succeed = {}) {
+    // only meaningful to succeed if we're currently active
+    if (this._state !== State.Active) {
+      return;
+    }
+
+    yield this.emit<Events.Succeed>({
+      type: "succeed",
+      result,
+      message
+    });
+
+    this._state = State.Done;
+  }
+
+  async *log({ message }: Options.Log) {
+    yield this.emit<Events.Log>({
+      type: "log",
+      message
+    });
+  }
+
+  async *declare({ identifier, message }: Options.Declare) {
+    const parent = this;
+
+    const child = new ValueResolutionController({
+      scope: [...this.scope, identifier],
+      parent,
+      state: State.Active
+    });
+
+    this.children.push(child);
+
+    yield child.emit<Events.Declare>({
+      type: "declare",
+      message: message || identifier
+    });
+
+    return child;
+  }
+
+  async *step({ identifier, message }: Options.Step) {
+    const parent = this;
+
+    const child = new StepsController({
+      scope: [...this.scope, identifier || message],
+      parent,
+      state: State.Active
+    });
+
+    this.children.push(child);
+
+    yield child.emit<Events.Step>({
+      type: "step",
+      message: message || identifier
+    });
+
+    return child;
+  }
+}

--- a/packages/preserve/lib/control/controllers/ValueResolutionController.ts
+++ b/packages/preserve/lib/control/controllers/ValueResolutionController.ts
@@ -1,0 +1,91 @@
+import { Events } from "../events";
+import { Process, State } from "../types";
+import {
+  ErrorController,
+  ConstructorOptions as ErrorControllerConstructorOptions,
+  IErrorController
+} from "./ErrorController";
+
+export namespace Options {
+  export interface Update {
+    payload?: string;
+  }
+
+  export interface Resolve {
+    resolution?: any;
+    payload?: string;
+  }
+
+  export interface Extend {
+    identifier: string;
+    message?: string;
+  }
+}
+
+export interface ConstructorOptions extends ErrorControllerConstructorOptions {}
+
+export interface IValueResolutionController extends IErrorController {
+  resolve(options: Options.Resolve): Process<void, Events.Resolve>;
+  extend(options: Options.Extend): Process<IErrorController, Events.Declare>;
+}
+
+export class ValueResolutionController
+  extends ErrorController
+  implements IValueResolutionController {
+  constructor(options: ConstructorOptions) {
+    const { ...superOptions } = options;
+    super(superOptions);
+
+    // so we can pass these around as functions
+    this.resolve = this.resolve.bind(this);
+    this.extend = this.extend.bind(this);
+  }
+
+  async *update({ payload }: Options.Update = {}) {
+    // only meaningful to succeed if we're currently active
+    if (this._state !== State.Active) {
+      return;
+    }
+
+    yield this.emit<Events.Update>({
+      type: "update",
+      payload
+    });
+
+    this._state = State.Done;
+  }
+
+  async *resolve({ resolution, payload }: Options.Resolve = {}) {
+    // only meaningful to succeed if we're currently active
+    if (this._state !== State.Active) {
+      return;
+    }
+
+    yield this.emit<Events.Resolve>({
+      type: "resolve",
+      resolution,
+      payload
+    });
+
+    this._state = State.Done;
+  }
+
+  async *extend({ identifier, message }: Options.Extend) {
+    const parent = this;
+
+    const child = new ValueResolutionController({
+      scope: [...this.scope, identifier],
+      parent,
+      state: State.Active
+    });
+
+    this.children.push(child);
+
+    yield child.emit<Events.Declare>({
+      type: "declare",
+      message: message || identifier
+    });
+
+    return child;
+  }
+}

--- a/packages/preserve/lib/control/controllers/index.ts
+++ b/packages/preserve/lib/control/controllers/index.ts
@@ -1,0 +1,15 @@
+export { BaseController } from "./BaseController";
+import * as Base from "./BaseController";
+export { Base };
+
+export { ErrorController } from "./ErrorController";
+import * as Error from "./ErrorController";
+export { Error };
+
+export { StepsController } from "./StepsController";
+import * as Steps from "./StepsController";
+export { Steps };
+
+export { ValueResolutionController } from "./ValueResolutionController";
+import * as ValueResolution from "./ValueResolutionController";
+export { ValueResolution };

--- a/packages/preserve/lib/control/events.ts
+++ b/packages/preserve/lib/control/events.ts
@@ -1,0 +1,73 @@
+import { Scope } from "./scopes";
+
+export type EventName =
+  | "fail"
+  | "abort"
+  | "stop"
+  | "begin"
+  | "log"
+  | "succeed"
+  | "step"
+  | "declare"
+  | "resolve"
+  | "update";
+
+export interface Event {
+  type: EventName;
+  scope: Scope;
+}
+
+export namespace Events {
+  // Error events
+  export interface Fail extends Event {
+    type: "fail";
+    error: Error;
+  }
+
+  export interface Abort extends Event {
+    type: "abort";
+  }
+
+  export interface Stop extends Event {
+    type: "stop";
+  }
+
+  // Steps events
+  export interface Begin extends Event {
+    type: "begin";
+    message?: string;
+  }
+
+  export interface Log extends Event {
+    type: "log";
+    message: string;
+  }
+
+  export interface Succeed extends Event {
+    type: "succeed";
+    result?: any;
+    message?: string;
+  }
+
+  export interface Step extends Event {
+    type: "step";
+    message?: string;
+  }
+
+  // Value resolution events
+  export interface Declare extends Event {
+    type: "declare";
+    message: string;
+  }
+
+  export interface Resolve extends Event {
+    type: "resolve";
+    resolution?: any;
+    payload?: string;
+  }
+
+  export interface Update extends Event {
+    type: "update";
+    payload?: string;
+  }
+}

--- a/packages/preserve/lib/control/index.ts
+++ b/packages/preserve/lib/control/index.ts
@@ -1,0 +1,16 @@
+export * from "./control";
+export * from "./events";
+export * from "./types";
+
+export { Scope } from "./scopes";
+import * as Scopes from "./scopes";
+export { Scopes };
+
+export {
+  BaseController,
+  ErrorController,
+  StepsController,
+  ValueResolutionController
+} from "./controllers";
+import * as Controllers from "./controllers";
+export { Controllers };

--- a/packages/preserve/lib/control/scopes.ts
+++ b/packages/preserve/lib/control/scopes.ts
@@ -1,0 +1,7 @@
+export type Scope = string[];
+
+const separator = "␟"; // ASCII delimiter: unit separator
+
+export const toKey = (scope: Scope): string => scope.join(separator);
+
+export const fromKey = (key: string): Scope => key.split(separator);

--- a/packages/preserve/lib/control/types.ts
+++ b/packages/preserve/lib/control/types.ts
@@ -1,0 +1,20 @@
+import { StepsController } from "./controllers";
+import { Event } from "./events";
+
+export enum State {
+  Pending = "pending",
+  Active = "active",
+  Done = "done",
+  Error = "error"
+}
+
+export interface HasControls {
+  controls: Controls;
+}
+
+export type Controls = Pick<StepsController, "log" | "declare" | "step">;
+
+export type Process<
+  R extends any = any,
+  E extends Event = Event
+> = AsyncGenerator<E, R, void>;

--- a/packages/preserve/lib/index.ts
+++ b/packages/preserve/lib/index.ts
@@ -1,0 +1,22 @@
+/**
+ * @module @truffle/preserve
+ */ /** */
+
+export * from "./ConsoleReporter";
+export * from "./preserve";
+
+export { Controls, Process } from "./control";
+import * as Control from "./control";
+export { Control };
+
+export { Target } from "./targets";
+import * as Targets from "./targets";
+export { Targets };
+
+export { Recipe } from "./recipes";
+import * as Recipes from "./recipes";
+export { Recipes };
+
+export { Loader } from "./loaders";
+import * as Loaders from "./loaders";
+export { Loaders };

--- a/packages/preserve/lib/loaders.ts
+++ b/packages/preserve/lib/loaders.ts
@@ -1,0 +1,19 @@
+import { Target } from "./targets";
+
+import { Process, Controls } from "./control";
+
+export interface ConstructorOptions {}
+
+export interface Constructor {
+  new (options?: ConstructorOptions): Loader;
+}
+
+export interface LoadOptions {
+  controls: Controls;
+}
+
+export interface Loader {
+  name: string;
+
+  load(options: LoadOptions): Process<Target>;
+}

--- a/packages/preserve/lib/preserve.ts
+++ b/packages/preserve/lib/preserve.ts
@@ -1,0 +1,132 @@
+import { Loader } from "./loaders";
+import { Recipe } from "./recipes";
+import { control, Event } from "./control";
+
+export interface Request {
+  loader: string; // package name
+  recipe: string; // package name
+  settings?: Map<string, any>; // map package name to settings
+}
+
+export interface PreserveOptions {
+  request: Request;
+  loaders: Map<string, Loader>;
+  recipes: Map<string, Recipe>;
+}
+
+export async function* preserve(
+  options: PreserveOptions
+): AsyncIterable<Event> {
+  const { request, loaders, recipes } = options;
+
+  if (!("settings" in request)) {
+    request.settings = new Map([]);
+  }
+
+  assertLoaderExists({
+    name: request.loader,
+    modules: loaders
+  });
+
+  /*
+   * setup
+   */
+  const loader = loaders.get(request.loader);
+  const recipe = recipes.get(request.recipe);
+
+  /*
+   * loading
+   */
+  const loaderSettings = request.settings.get(request.loader);
+
+  const target = yield* control(
+    {
+      name: loader.name,
+      method: loader.load.bind(loader)
+    },
+    loaderSettings
+  );
+
+  /*
+   * planning
+   * (use BFS)
+   */
+  const visited: Set<string> = new Set([]);
+  const queue: string[] = [recipe.name];
+
+  const plan: Recipe[] = [];
+  while (queue.length > 0) {
+    const current = recipes.get(queue.shift());
+
+    assertRecipeExists({
+      name: current.name,
+      modules: recipes
+    });
+
+    plan.unshift(current);
+
+    const unvisited = current.dependencies.filter(
+      dependency => !visited.has(dependency)
+    );
+
+    for (const name of unvisited) {
+      visited.add(name);
+      queue.push(name);
+    }
+  }
+
+  /*
+   * execution
+   */
+  let results: Map<string, any> = new Map([]);
+
+  for (const recipe of plan) {
+    const settings = request.settings.get(recipe.name);
+
+    // for the result
+    const result = yield* control(
+      {
+        name: recipe.name,
+        method: recipe.preserve.bind(recipe)
+      },
+      {
+        target,
+        results,
+        settings
+      }
+    );
+
+    if (!result) {
+      return;
+    }
+
+    results.set(recipe.name, result);
+  }
+}
+
+type AssertModuleExistsOptions<T extends Loader | Recipe> = {
+  name: string;
+  kind?: string;
+  modules: Map<string, T>;
+};
+
+const assertModuleExists = <T extends Loader | Recipe>(
+  options: AssertModuleExistsOptions<T>
+): void => {
+  const { name, kind = "module", modules } = options;
+
+  if (!modules.has(name)) {
+    throw new Error(
+      `Unknown ${kind} with name ${name}. ` +
+        `Possible choices: [${Array.from(modules.keys()).join(", ")}]`
+    );
+  }
+};
+
+const assertLoaderExists = (
+  options: Omit<AssertModuleExistsOptions<Loader>, "kind">
+): void => assertModuleExists({ ...options, kind: "loader" });
+
+const assertRecipeExists = (
+  options: Omit<AssertModuleExistsOptions<Recipe>, "kind">
+): void => assertModuleExists({ ...options, kind: "recipe" });

--- a/packages/preserve/lib/recipes.ts
+++ b/packages/preserve/lib/recipes.ts
@@ -1,0 +1,25 @@
+import { Target } from "./targets";
+
+import { Process, Controls } from "./control";
+
+export interface ConstructorOptions {}
+
+export interface Constructor {
+  help?: string;
+
+  new (options: ConstructorOptions): Recipe;
+}
+
+export interface PreserveOptions {
+  target: Target;
+  results?: Map<string, any>;
+  settings?: any;
+  controls: Controls;
+}
+
+export interface Recipe {
+  name: string;
+  dependencies: string[];
+
+  preserve(options: PreserveOptions): Process;
+}

--- a/packages/preserve/lib/targets/index.ts
+++ b/packages/preserve/lib/targets/index.ts
@@ -1,0 +1,6 @@
+export { Source } from "./sources";
+import * as Sources from "./sources";
+export { Sources };
+
+export * from "./types";
+export * from "./utils";

--- a/packages/preserve/lib/targets/sources/contents/index.ts
+++ b/packages/preserve/lib/targets/sources/contents/index.ts
@@ -1,0 +1,1 @@
+export * from "./types";

--- a/packages/preserve/lib/targets/sources/contents/types.ts
+++ b/packages/preserve/lib/targets/sources/contents/types.ts
@@ -1,0 +1,31 @@
+// (blech...)
+type TypedArray =
+  | Int8Array
+  | Uint8Array
+  | Int16Array
+  | Uint16Array
+  | Int32Array
+  | Uint32Array
+  | Uint8ClampedArray
+  | Float32Array
+  | Float64Array;
+
+export type Bytes = Buffer | ArrayBuffer | TypedArray;
+
+export type Content = string | Bytes | Iterable<Bytes> | AsyncIterable<Bytes>;
+
+export const isString = (content: Content): content is string =>
+  typeof content === "string";
+
+export const isBytes = (content: Content): content is Bytes =>
+  Buffer.isBuffer(content) ||
+  content instanceof ArrayBuffer ||
+  ArrayBuffer.isView(content);
+
+export const isIterable = (content: Content): content is Iterable<Bytes> =>
+  content && typeof content === "object" && Symbol.iterator in content;
+
+export const isAsyncIterable = (
+  content: Content
+): content is AsyncIterable<Bytes> =>
+  content && typeof content === "object" && Symbol.asyncIterator in content;

--- a/packages/preserve/lib/targets/sources/index.ts
+++ b/packages/preserve/lib/targets/sources/index.ts
@@ -1,0 +1,5 @@
+export * from "./types";
+
+export { Content } from "./contents";
+import * as Contents from "./contents";
+export { Contents };

--- a/packages/preserve/lib/targets/sources/types.ts
+++ b/packages/preserve/lib/targets/sources/types.ts
@@ -1,0 +1,18 @@
+import { Content } from "./contents";
+
+export interface Entry {
+  path: string;
+  source: Source;
+}
+
+export interface Container {
+  entries: Iterable<Entry> | AsyncIterable<Entry>;
+}
+
+export type Source = Content | Container;
+
+export const isContainer = (source: Source): source is Container =>
+  source && typeof source === "object" && "entries" in source;
+
+export const isContent = (source: Source): source is Content =>
+  !isContainer(source);

--- a/packages/preserve/lib/targets/sources/types.ts
+++ b/packages/preserve/lib/targets/sources/types.ts
@@ -12,7 +12,10 @@ export interface Container {
 export type Source = Content | Container;
 
 export const isContainer = (source: Source): source is Container =>
-  source && typeof source === "object" && "entries" in source;
+  source &&
+  typeof source === "object" &&
+  "entries" in source &&
+  typeof source.entries === "object";
 
 export const isContent = (source: Source): source is Content =>
   !isContainer(source);

--- a/packages/preserve/lib/targets/types.ts
+++ b/packages/preserve/lib/targets/types.ts
@@ -1,0 +1,5 @@
+import { Source } from "./sources";
+
+export interface Target {
+  source: Source;
+}

--- a/packages/preserve/lib/targets/utils/index.ts
+++ b/packages/preserve/lib/targets/utils/index.ts
@@ -1,0 +1,2 @@
+export * from "./normalize";
+export * from "./stringify";

--- a/packages/preserve/lib/targets/utils/normalize.ts
+++ b/packages/preserve/lib/targets/utils/normalize.ts
@@ -1,0 +1,111 @@
+import * as Common from "..";
+
+export namespace Normalized {
+  export namespace Sources {
+    export type Content = AsyncIterable<Buffer>;
+
+    export interface Entry extends Common.Sources.Entry {
+      path: string;
+      source: Source;
+    }
+
+    export interface Container extends Common.Sources.Container {
+      entries: AsyncIterable<Entry>;
+    }
+
+    export type Source = Content | Container;
+  }
+
+  export type Source = Sources.Source;
+
+  export interface Target extends Common.Target {
+    source: Source;
+  }
+}
+
+export const normalize = (target: Common.Target): Normalized.Target => {
+  const source = normalizeSource(target.source);
+  return { source };
+};
+
+const normalizeSource = (source: Common.Source): Normalized.Source => {
+  if (Common.Sources.isContainer(source)) {
+    return normalizeContainer(source);
+  }
+
+  return normalizeContent(source);
+};
+
+const normalizeContainer = (
+  container: Common.Sources.Container
+): Normalized.Sources.Container => {
+  const entries = normalizeEntries(container.entries);
+  return { entries };
+};
+
+const normalizeEntries = async function* (
+  entries: Iterable<Common.Sources.Entry> | AsyncIterable<Common.Sources.Entry>
+): AsyncIterable<Normalized.Sources.Entry> {
+  for await (const entry of entries) {
+    yield normalizeEntry(entry);
+  }
+};
+
+const normalizeEntry = (
+  entry: Common.Sources.Entry
+): Normalized.Sources.Entry => {
+  const { path } = entry;
+  const source = normalizeSource(entry.source);
+  return { path, source };
+};
+
+const normalizeContent = (
+  content: Common.Sources.Content
+): Normalized.Sources.Content => {
+  if (Common.Sources.Contents.isString(content)) {
+    return normalizeString(content);
+  }
+  if (Common.Sources.Contents.isBytes(content)) {
+    return normalizeBytes(content);
+  }
+  if (Common.Sources.Contents.isIterable(content)) {
+    return normalizeIterable(content);
+  }
+  if (Common.Sources.Contents.isAsyncIterable(content)) {
+    return normalizeAsyncIterable(content);
+  }
+};
+
+const normalizeString = (content: string): Normalized.Sources.Content => {
+  return (async function* () {
+    yield Buffer.from(content);
+  })();
+};
+
+const normalizeBytes = (
+  content: Common.Sources.Contents.Bytes
+): Normalized.Sources.Content => {
+  return (async function* () {
+    yield Buffer.from(content);
+  })();
+};
+
+const normalizeIterable = (
+  content: Iterable<Common.Sources.Contents.Bytes>
+): Normalized.Sources.Content => {
+  return (async function* () {
+    for (const bytes of content) {
+      yield Buffer.from(bytes);
+    }
+  })();
+};
+
+const normalizeAsyncIterable = (
+  content: AsyncIterable<Common.Sources.Contents.Bytes>
+): Normalized.Sources.Content => {
+  return (async function* () {
+    for await (const bytes of content) {
+      yield Buffer.from(bytes);
+    }
+  })();
+};

--- a/packages/preserve/lib/targets/utils/stringify.ts
+++ b/packages/preserve/lib/targets/utils/stringify.ts
@@ -1,0 +1,75 @@
+import { Normalized, normalize } from "./normalize";
+import * as Common from "..";
+
+export namespace Stringified {
+  export namespace Sources {
+    export type Content = string;
+
+    export interface Entry extends Common.Sources.Entry {
+      path: string;
+      source: Source;
+    }
+
+    export interface Container extends Common.Sources.Container {
+      entries: Entry[];
+    }
+
+    export type Source = Content | Container;
+  }
+
+  export type Source = Sources.Source;
+
+  export interface Target extends Common.Target {
+    source: Source;
+  }
+}
+
+export const stringify = async (
+  target: Common.Target
+): Promise<Stringified.Target> => {
+  const normalizedTarget = normalize(target);
+  const source = await stringifySource(normalizedTarget.source);
+  return { source };
+};
+
+const stringifySource = async (
+  source: Normalized.Source
+): Promise<Stringified.Source> => {
+  if (Common.Sources.isContainer(source)) {
+    return await stringifyContainer(source);
+  }
+
+  return await stringifyContent(source);
+};
+
+const stringifyContainer = async (
+  container: Normalized.Sources.Container
+): Promise<Stringified.Sources.Container> => {
+  const entries = [];
+
+  for await (const entry of container.entries) {
+    entries.push(await stringifyEntry(entry));
+  }
+
+  return { entries };
+};
+
+const stringifyEntry = async (
+  entry: Normalized.Sources.Entry
+): Promise<Stringified.Sources.Entry> => {
+  const { path } = entry;
+  const source = await stringifySource(entry.source);
+  return { path, source };
+};
+
+const stringifyContent = async (
+  content: Normalized.Sources.Content
+): Promise<Stringified.Sources.Content> => {
+  const buffers: Buffer[] = [];
+
+  for await (const piece of content) {
+    buffers.push(piece);
+  }
+
+  return Buffer.concat(buffers).toString();
+};

--- a/packages/preserve/package.json
+++ b/packages/preserve/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@truffle/preserve",
+  "version": "0.1.0",
+  "description": "Library for functionality for `truffle preserve` command",
+  "main": "dist/lib/index.js",
+  "types": "dist/lib/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "prepare": "yarn build",
+    "test": "jest --verbose --detectOpenHandles",
+    "docs": "./scripts/generate-docs"
+  },
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/preserve",
+  "author": "g. nicholas d'andrea <gnidan@trufflesuite.com>",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@types/jest": "^26.0.0",
+    "@types/node": "^14.0.13",
+    "iter-tools": "^7.0.2",
+    "jest": "^26.0.1",
+    "ts-jest": "^26.1.0",
+    "typescript": "^3.8.3"
+  },
+  "dependencies": {
+    "spinnies": "^0.5.1"
+  }
+}

--- a/packages/preserve/scripts/generate-docs
+++ b/packages/preserve/scripts/generate-docs
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+typedoc=../../node_modules/@gnd/typedoc/bin/typedoc
+
+DIST_HTML=./dist/docs
+DIST_JSON=./dist/api.json
+
+BIBLIO=./docs/biblio.json
+TSCONFIG=./docs/tsconfig.json
+OPTIONS=./docs/typedoc.json
+PRESERVE=../preserve/lib/index.ts
+PRESERVE_FS=../preserve-fs/lib/index.ts
+PRESERVE_TO_IPFS=../preserve-to-ipfs/lib/index.ts
+PRESERVE_TO_FILECOIN=../preserve-to-filecoin/lib/index.ts
+README=./docs/README.md
+MEDIA=./docs/media
+
+rm -rf $DIST_HTML $DIST_JSON
+
+$typedoc \
+    --options $OPTIONS \
+    --tsconfig $TSCONFIG \
+    --out $DIST_HTML \
+    --readme $README \
+    --media $MEDIA \
+    --json $DIST_JSON \
+    --plugin typedoc-plugin-external-module-name \
+  $PRESERVE $PRESERVE_FS $PRESERVE_TO_IPFS $PRESERVE_TO_FILECOIN # entrypoints to display

--- a/packages/preserve/test/control/StepsController.test.ts
+++ b/packages/preserve/test/control/StepsController.test.ts
@@ -1,0 +1,75 @@
+import { asyncToArray } from "iter-tools";
+import { StepsController } from "../../lib/control";
+
+describe("StepsController", () => {
+  describe("fail()", () => {
+    it("should propagate to all child tasks", async () => {
+      const runTasks = async function* () {
+        const task = new StepsController({ scope: ["test"] });
+        yield* task.begin();
+        const subtask = yield* task.step({ identifier: "a" });
+        yield* task.step({ identifier: "b" });
+        yield* subtask.step({ identifier: "a/a" });
+        yield* task.fail();
+      };
+
+      const events = await asyncToArray(runTasks());
+
+      const expectedEvents = [
+        { type: "begin", scope: ["test"] },
+        { type: "step", message: "a", scope: ["test", "a"] },
+        { type: "step", message: "b", scope: ["test", "b"] },
+        { type: "step", message: "a/a", scope: ["test", "a", "a/a"] },
+        { type: "stop", scope: ["test", "a", "a/a"] },
+        { type: "stop", scope: ["test", "a"] },
+        { type: "stop", scope: ["test", "b"] },
+        { type: "fail", scope: ["test"] }
+      ];
+
+      expect(events).toEqual(expectedEvents);
+    });
+
+    it("should propagate to parent task", async () => {
+      const runTasks = async function* () {
+        const task = new StepsController({ scope: ["test"] });
+        yield* task.begin();
+        const subtask = yield* task.step({ identifier: "a" });
+        yield* subtask.fail();
+      };
+
+      const events = await asyncToArray(runTasks());
+
+      const expectedEvents = [
+        { type: "begin", scope: ["test"] },
+        { type: "step", message: "a", scope: ["test", "a"] },
+        { type: "fail", scope: ["test", "a"] },
+        { type: "abort", scope: ["test"] }
+      ];
+
+      expect(events).toEqual(expectedEvents);
+    });
+
+    it("should propagate to sibling tasks", async () => {
+      const runTasks = async function* () {
+        const task = new StepsController({ scope: ["test"] });
+        yield* task.begin();
+        const subtask = yield* task.step({ identifier: "a" });
+        yield* task.step({ identifier: "b" });
+        yield* subtask.fail();
+      };
+
+      const events = await asyncToArray(runTasks());
+
+      const expectedEvents = [
+        { type: "begin", scope: ["test"] },
+        { type: "step", message: "a", scope: ["test", "a"] },
+        { type: "step", message: "b", scope: ["test", "b"] },
+        { type: "fail", scope: ["test", "a"] },
+        { type: "stop", scope: ["test", "b"] },
+        { type: "abort", scope: ["test"] }
+      ];
+
+      expect(events).toEqual(expectedEvents);
+    });
+  });
+});

--- a/packages/preserve/test/preserve.fixture.ts
+++ b/packages/preserve/test/preserve.fixture.ts
@@ -1,0 +1,190 @@
+import { Loader, Process, Recipe, Target } from "../lib";
+import { ValueResolutionController } from "../lib/control";
+import { stringify } from "../lib/targets";
+
+export const simpleTarget: Target = {
+  source: "hello, world!"
+};
+
+export const simpleLoader: Loader = {
+  name: "simple-loader",
+
+  async *load() {
+    return simpleTarget;
+  }
+};
+
+export const vowelsRecipe: Recipe = {
+  name: "vowels-recipe",
+
+  dependencies: [],
+
+  async *preserve({ target, controls }): Process<{ vowels: string }> {
+    const { log, step } = controls;
+    yield* log({ message: "Filtering vowels..." });
+
+    const vowels = new Set(["a", "e", "i", "o", "u"]);
+
+    // for testing purposes, this only handles the case of a Content target
+    // (no Containers)
+    const source = (await stringify(target)).source as string;
+
+    const finalize = yield* step({
+      identifier: "finalize",
+      message: "Finalizing string..."
+    });
+
+    yield* finalize.succeed();
+
+    return {
+      vowels: source
+        .split("")
+        .filter(character => vowels.has(character))
+        .join("")
+    };
+  }
+};
+
+export const vowelsCounterRecipe: Recipe = {
+  name: "vowels-counter-recipe",
+
+  dependencies: [vowelsRecipe.name],
+
+  async *preserve({ results, controls }): Process<{ count: number }> {
+    const { log, declare } = controls;
+
+    yield* log({ message: "Counting vowels..." });
+
+    const allVowels = ["a", "e", "i", "o", "u"];
+
+    const valueResolutions: { [vowel: string]: ValueResolutionController } = {};
+    for (const vowel of allVowels) {
+      valueResolutions[vowel] = yield* declare({
+        identifier: vowel,
+        message: `# of ${vowel}'s`
+      });
+    }
+
+    const { vowels } = results.get(vowelsRecipe.name) as { vowels: string };
+
+    const counts = allVowels
+      .map(vowel => ({ [vowel]: { count: 0 } }))
+      .reduce((a, b) => ({ ...a, ...b }), {});
+
+    for (const vowel of vowels) {
+      counts[vowel].count++;
+    }
+
+    for (const [vowel, valueResolution] of Object.entries(valueResolutions)) {
+      yield* valueResolution.resolve({
+        resolution: counts[vowel]
+      });
+    }
+
+    return {
+      count: vowels.length
+    };
+  }
+};
+
+export const expectedEventsForVowelsRecipe = [
+  {
+    type: "begin",
+    scope: ["simple-loader"]
+  },
+  {
+    type: "succeed",
+    scope: ["simple-loader"],
+    result: { source: "hello, world!" }
+  },
+  {
+    type: "begin",
+    scope: ["vowels-recipe"]
+  },
+  {
+    type: "log",
+    scope: ["vowels-recipe"],
+    message: "Filtering vowels..."
+  },
+  {
+    type: "step",
+    scope: ["vowels-recipe", "finalize"],
+    message: "Finalizing string..."
+  },
+  {
+    type: "succeed",
+    scope: ["vowels-recipe", "finalize"]
+  },
+  {
+    type: "succeed",
+    scope: ["vowels-recipe"],
+    result: { vowels: "eoo" }
+  }
+];
+
+export const expectedEventsForVowelsCounterRecipe = [
+  {
+    type: "begin",
+    scope: ["vowels-counter-recipe"]
+  },
+  {
+    type: "log",
+    scope: ["vowels-counter-recipe"],
+    message: "Counting vowels..."
+  },
+  {
+    type: "declare",
+    scope: ["vowels-counter-recipe", "a"],
+    message: "# of a's"
+  },
+  {
+    type: "declare",
+    scope: ["vowels-counter-recipe", "e"],
+    message: "# of e's"
+  },
+  {
+    type: "declare",
+    scope: ["vowels-counter-recipe", "i"],
+    message: "# of i's"
+  },
+  {
+    type: "declare",
+    scope: ["vowels-counter-recipe", "o"],
+    message: "# of o's"
+  },
+  {
+    type: "declare",
+    scope: ["vowels-counter-recipe", "u"],
+    message: "# of u's"
+  },
+  {
+    type: "resolve",
+    scope: ["vowels-counter-recipe", "a"],
+    resolution: { count: 0 }
+  },
+  {
+    type: "resolve",
+    scope: ["vowels-counter-recipe", "e"],
+    resolution: { count: 1 }
+  },
+  {
+    type: "resolve",
+    scope: ["vowels-counter-recipe", "i"],
+    resolution: { count: 0 }
+  },
+  {
+    type: "resolve",
+    scope: ["vowels-counter-recipe", "o"],
+    resolution: { count: 2 }
+  },
+  {
+    type: "resolve",
+    scope: ["vowels-counter-recipe", "u"],
+    resolution: { count: 0 }
+  },
+  {
+    type: "succeed",
+    scope: ["vowels-counter-recipe"],
+    result: { count: 3 }
+  }
+];

--- a/packages/preserve/test/preserve.test.ts
+++ b/packages/preserve/test/preserve.test.ts
@@ -1,0 +1,229 @@
+import { asyncToArray } from "iter-tools";
+
+import { Target, stringify } from "../lib/targets";
+import { Recipe } from "../lib/recipes";
+import { Loader } from "../lib/loaders";
+import { Process, ValueResolutionController } from "../lib/control";
+import { preserve } from "../lib/preserve";
+
+const simpleTarget: Target = {
+  source: "hello, world!"
+};
+
+const simpleLoader: Loader = {
+  name: "simple-loader",
+
+  async *load() {
+    return simpleTarget;
+  }
+};
+
+const vowelsRecipe: Recipe = {
+  name: "vowels-recipe",
+
+  dependencies: [],
+
+  async *preserve({ target, controls }): Process<{ vowels: string }> {
+    const { log, step } = controls;
+    yield* log({ message: "Filtering vowels..." });
+
+    const vowels = new Set(["a", "e", "i", "o", "u"]);
+
+    // for testing purposes, this only handles the case of a Content target
+    // (no Containers)
+    const source = (await stringify(target)).source as string;
+
+    const finalize = yield* step({
+      identifier: "finalize",
+      message: "Finalizing string..."
+    });
+
+    yield* finalize.succeed();
+
+    return {
+      vowels: source
+        .split("")
+        .filter(character => vowels.has(character))
+        .join("")
+    };
+  }
+};
+
+const vowelsCounterRecipe: Recipe = {
+  name: "vowels-counter-recipe",
+
+  dependencies: [vowelsRecipe.name],
+
+  async *preserve({ results, controls }): Process<{ count: number }> {
+    const { log, declare } = controls;
+
+    yield* log({ message: "Counting vowels..." });
+
+    const allVowels = ["a", "e", "i", "o", "u"];
+
+    const valueResolutions: { [vowel: string]: ValueResolutionController } = {};
+    for (const vowel of allVowels) {
+      valueResolutions[vowel] = yield* declare({
+        identifier: vowel,
+        message: `# of ${vowel}'s`
+      });
+    }
+
+    const { vowels } = results.get(vowelsRecipe.name) as { vowels: string };
+
+    const counts = allVowels
+      .map(vowel => ({ [vowel]: { count: 0 } }))
+      .reduce((a, b) => ({ ...a, ...b }), {});
+
+    for (const vowel of vowels) {
+      counts[vowel].count++;
+    }
+
+    for (const [vowel, valueResolution] of Object.entries(valueResolutions)) {
+      yield* valueResolution.resolve({
+        resolution: counts[vowel]
+      });
+    }
+
+    return {
+      count: vowels.length
+    };
+  }
+};
+
+const mapByName = <T extends { name: string }>(entities: T[]): Map<string, T> =>
+  new Map(entities.map(entity => [entity.name, entity]));
+
+const loaders = mapByName([simpleLoader]);
+const recipes = mapByName([vowelsRecipe, vowelsCounterRecipe]);
+
+it("preserves via a single recipe", async () => {
+  const preserves = await asyncToArray(
+    preserve({
+      request: {
+        loader: simpleLoader.name,
+        recipe: vowelsRecipe.name
+      },
+      loaders,
+      recipes
+    })
+  );
+
+  expect(preserves).toEqual([
+    {
+      type: "begin",
+      scope: ["simple-loader"]
+    },
+    {
+      type: "succeed",
+      scope: ["simple-loader"],
+      result: { source: "hello, world!" }
+    },
+    {
+      type: "begin",
+      scope: ["vowels-recipe"]
+    },
+    {
+      type: "log",
+      scope: ["vowels-recipe"],
+      message: "Filtering vowels..."
+    },
+    {
+      type: "step",
+      scope: ["vowels-recipe", "finalize"],
+      message: "Finalizing string..."
+    },
+    {
+      type: "succeed",
+      scope: ["vowels-recipe", "finalize"]
+    },
+    {
+      type: "succeed",
+      scope: ["vowels-recipe"],
+      result: { vowels: "eoo" }
+    }
+  ]);
+});
+
+it("preserves via a recipe that depends on another recipe", async () => {
+  const allEvents = await asyncToArray(
+    preserve({
+      request: {
+        loader: simpleLoader.name,
+        recipe: vowelsCounterRecipe.name
+      },
+      loaders,
+      recipes
+    })
+  );
+
+  const relevantEvents = allEvents
+    .filter(({ scope }) => scope[0] === "vowels-counter-recipe");
+
+  expect(relevantEvents).toEqual([
+    {
+      type: "begin",
+      scope: ["vowels-counter-recipe"]
+    },
+    {
+      type: "log",
+      scope: ["vowels-counter-recipe"],
+      message: "Counting vowels..."
+    },
+    {
+      type: "declare",
+      scope: ["vowels-counter-recipe", "a"],
+      message: "# of a's"
+    },
+    {
+      type: "declare",
+      scope: ["vowels-counter-recipe", "e"],
+      message: "# of e's"
+    },
+    {
+      type: "declare",
+      scope: ["vowels-counter-recipe", "i"],
+      message: "# of i's"
+    },
+    {
+      type: "declare",
+      scope: ["vowels-counter-recipe", "o"],
+      message: "# of o's"
+    },
+    {
+      type: "declare",
+      scope: ["vowels-counter-recipe", "u"],
+      message: "# of u's"
+    },
+    {
+      type: "resolve",
+      scope: ["vowels-counter-recipe", "a"],
+      resolution: { count: 0 }
+    },
+    {
+      type: "resolve",
+      scope: ["vowels-counter-recipe", "e"],
+      resolution: { count: 1 }
+    },
+    {
+      type: "resolve",
+      scope: ["vowels-counter-recipe", "i"],
+      resolution: { count: 0 }
+    },
+    {
+      type: "resolve",
+      scope: ["vowels-counter-recipe", "o"],
+      resolution: { count: 2 }
+    },
+    {
+      type: "resolve",
+      scope: ["vowels-counter-recipe", "u"],
+      resolution: { count: 0 }
+    },
+    {
+      type: "succeed",
+      scope: ["vowels-counter-recipe"],
+      result: { count: 3 }
+    }
+  ]);
+});

--- a/packages/preserve/test/preserve.test.ts
+++ b/packages/preserve/test/preserve.test.ts
@@ -1,95 +1,13 @@
 import { asyncToArray } from "iter-tools";
 
-import { Target, stringify } from "../lib/targets";
-import { Recipe } from "../lib/recipes";
-import { Loader } from "../lib/loaders";
-import { Process, ValueResolutionController } from "../lib/control";
 import { preserve } from "../lib/preserve";
-
-const simpleTarget: Target = {
-  source: "hello, world!"
-};
-
-const simpleLoader: Loader = {
-  name: "simple-loader",
-
-  async *load() {
-    return simpleTarget;
-  }
-};
-
-const vowelsRecipe: Recipe = {
-  name: "vowels-recipe",
-
-  dependencies: [],
-
-  async *preserve({ target, controls }): Process<{ vowels: string }> {
-    const { log, step } = controls;
-    yield* log({ message: "Filtering vowels..." });
-
-    const vowels = new Set(["a", "e", "i", "o", "u"]);
-
-    // for testing purposes, this only handles the case of a Content target
-    // (no Containers)
-    const source = (await stringify(target)).source as string;
-
-    const finalize = yield* step({
-      identifier: "finalize",
-      message: "Finalizing string..."
-    });
-
-    yield* finalize.succeed();
-
-    return {
-      vowels: source
-        .split("")
-        .filter(character => vowels.has(character))
-        .join("")
-    };
-  }
-};
-
-const vowelsCounterRecipe: Recipe = {
-  name: "vowels-counter-recipe",
-
-  dependencies: [vowelsRecipe.name],
-
-  async *preserve({ results, controls }): Process<{ count: number }> {
-    const { log, declare } = controls;
-
-    yield* log({ message: "Counting vowels..." });
-
-    const allVowels = ["a", "e", "i", "o", "u"];
-
-    const valueResolutions: { [vowel: string]: ValueResolutionController } = {};
-    for (const vowel of allVowels) {
-      valueResolutions[vowel] = yield* declare({
-        identifier: vowel,
-        message: `# of ${vowel}'s`
-      });
-    }
-
-    const { vowels } = results.get(vowelsRecipe.name) as { vowels: string };
-
-    const counts = allVowels
-      .map(vowel => ({ [vowel]: { count: 0 } }))
-      .reduce((a, b) => ({ ...a, ...b }), {});
-
-    for (const vowel of vowels) {
-      counts[vowel].count++;
-    }
-
-    for (const [vowel, valueResolution] of Object.entries(valueResolutions)) {
-      yield* valueResolution.resolve({
-        resolution: counts[vowel]
-      });
-    }
-
-    return {
-      count: vowels.length
-    };
-  }
-};
+import {
+  expectedEventsForVowelsCounterRecipe,
+  expectedEventsForVowelsRecipe,
+  simpleLoader,
+  vowelsCounterRecipe,
+  vowelsRecipe
+} from "./preserve.fixture";
 
 const mapByName = <T extends { name: string }>(entities: T[]): Map<string, T> =>
   new Map(entities.map(entity => [entity.name, entity]));
@@ -98,7 +16,7 @@ const loaders = mapByName([simpleLoader]);
 const recipes = mapByName([vowelsRecipe, vowelsCounterRecipe]);
 
 it("preserves via a single recipe", async () => {
-  const preserves = await asyncToArray(
+  const events = await asyncToArray(
     preserve({
       request: {
         loader: simpleLoader.name,
@@ -109,40 +27,7 @@ it("preserves via a single recipe", async () => {
     })
   );
 
-  expect(preserves).toEqual([
-    {
-      type: "begin",
-      scope: ["simple-loader"]
-    },
-    {
-      type: "succeed",
-      scope: ["simple-loader"],
-      result: { source: "hello, world!" }
-    },
-    {
-      type: "begin",
-      scope: ["vowels-recipe"]
-    },
-    {
-      type: "log",
-      scope: ["vowels-recipe"],
-      message: "Filtering vowels..."
-    },
-    {
-      type: "step",
-      scope: ["vowels-recipe", "finalize"],
-      message: "Finalizing string..."
-    },
-    {
-      type: "succeed",
-      scope: ["vowels-recipe", "finalize"]
-    },
-    {
-      type: "succeed",
-      scope: ["vowels-recipe"],
-      result: { vowels: "eoo" }
-    }
-  ]);
+  expect(events).toEqual(expectedEventsForVowelsRecipe);
 });
 
 it("preserves via a recipe that depends on another recipe", async () => {
@@ -157,73 +42,9 @@ it("preserves via a recipe that depends on another recipe", async () => {
     })
   );
 
-  const relevantEvents = allEvents
-    .filter(({ scope }) => scope[0] === "vowels-counter-recipe");
+  const relevantEvents = allEvents.filter(
+    ({ scope }) => scope[0] === "vowels-counter-recipe"
+  );
 
-  expect(relevantEvents).toEqual([
-    {
-      type: "begin",
-      scope: ["vowels-counter-recipe"]
-    },
-    {
-      type: "log",
-      scope: ["vowels-counter-recipe"],
-      message: "Counting vowels..."
-    },
-    {
-      type: "declare",
-      scope: ["vowels-counter-recipe", "a"],
-      message: "# of a's"
-    },
-    {
-      type: "declare",
-      scope: ["vowels-counter-recipe", "e"],
-      message: "# of e's"
-    },
-    {
-      type: "declare",
-      scope: ["vowels-counter-recipe", "i"],
-      message: "# of i's"
-    },
-    {
-      type: "declare",
-      scope: ["vowels-counter-recipe", "o"],
-      message: "# of o's"
-    },
-    {
-      type: "declare",
-      scope: ["vowels-counter-recipe", "u"],
-      message: "# of u's"
-    },
-    {
-      type: "resolve",
-      scope: ["vowels-counter-recipe", "a"],
-      resolution: { count: 0 }
-    },
-    {
-      type: "resolve",
-      scope: ["vowels-counter-recipe", "e"],
-      resolution: { count: 1 }
-    },
-    {
-      type: "resolve",
-      scope: ["vowels-counter-recipe", "i"],
-      resolution: { count: 0 }
-    },
-    {
-      type: "resolve",
-      scope: ["vowels-counter-recipe", "o"],
-      resolution: { count: 2 }
-    },
-    {
-      type: "resolve",
-      scope: ["vowels-counter-recipe", "u"],
-      resolution: { count: 0 }
-    },
-    {
-      type: "succeed",
-      scope: ["vowels-counter-recipe"],
-      result: { count: 3 }
-    }
-  ]);
+  expect(relevantEvents).toEqual(expectedEventsForVowelsCounterRecipe);
 });

--- a/packages/preserve/test/targets/utils.fixture.ts
+++ b/packages/preserve/test/targets/utils.fixture.ts
@@ -1,0 +1,174 @@
+import { Normalized, Stringified } from "../../lib/targets";
+import { Target } from "../../lib";
+
+export interface Test {
+  name: string;
+  raw: Target;
+  normalized: Normalized.Target;
+  stringified: Stringified.Target;
+}
+
+const arrayToAsyncIterable = async function* (array: any[]) {
+  for (const element of array) {
+    yield element;
+  }
+};
+
+export const tests: Test[] = [
+  {
+    name: "Simple source",
+    raw: {
+      source: Buffer.from("c0ffee", "hex")
+    },
+    normalized: {
+      source: arrayToAsyncIterable([Buffer.from("c0ffee", "hex")])
+    },
+    stringified: {
+      source: Buffer.from("c0ffee", "hex").toString("utf8")
+    }
+  },
+  {
+    name: "Simple directory without nesting",
+    raw: {
+      source: {
+        entries: [
+          {
+            path: "a",
+            source: Buffer.from("Coffee", "utf8")
+          }
+        ]
+      }
+    },
+    normalized: {
+      source: {
+        entries: arrayToAsyncIterable([
+          {
+            path: "a",
+            source: arrayToAsyncIterable([Buffer.from("Coffee", "utf8")])
+          }
+        ])
+      }
+    },
+    stringified: {
+      source: {
+        entries: [
+          {
+            path: "a",
+            source: "Coffee"
+          }
+        ]
+      }
+    }
+  },
+  {
+    name: "Complex nested directory with inconsistent types",
+    raw: {
+      source: {
+        entries: [
+          {
+            path: "a",
+            source: {
+              entries: [
+                {
+                  path: "a/a",
+                  source: Buffer.from("c0ffee", "hex")
+                },
+                {
+                  path: "a/b",
+                  source: "Coffee"
+                }
+              ]
+            }
+          },
+          {
+            path: "b",
+            source: Buffer.from("Coffee", "utf8")
+          },
+          {
+            path: "c",
+            source: {
+              entries: [
+                {
+                  path: "c/a",
+                  source: new Uint8Array([0, 0, 0, 0])
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    normalized: {
+      source: {
+        entries: arrayToAsyncIterable([
+          {
+            path: "a",
+            source: {
+              entries: arrayToAsyncIterable([
+                {
+                  path: "a/a",
+                  source: arrayToAsyncIterable([Buffer.from("c0ffee", "hex")])
+                },
+                {
+                  path: "a/b",
+                  source: arrayToAsyncIterable([Buffer.from("Coffee", "utf8")])
+                }
+              ])
+            }
+          },
+          {
+            path: "b",
+            source: arrayToAsyncIterable([Buffer.from("Coffee", "utf8")])
+          },
+          {
+            path: "c",
+            source: {
+              entries: arrayToAsyncIterable([
+                {
+                  path: "c/a",
+                  source: arrayToAsyncIterable([Buffer.from("00000000", "hex")])
+                }
+              ])
+            }
+          }
+        ])
+      }
+    },
+    stringified: {
+      source: {
+        entries: [
+          {
+            path: "a",
+            source: {
+              entries: [
+                {
+                  path: "a/a",
+                  source: Buffer.from("c0ffee", "hex").toString("utf8")
+                },
+                {
+                  path: "a/b",
+                  source: "Coffee"
+                }
+              ]
+            }
+          },
+          {
+            path: "b",
+            source: "Coffee"
+          },
+          {
+            path: "c",
+            source: {
+              entries: [
+                {
+                  path: "c/a",
+                  source: Buffer.from("00000000", "hex").toString("utf8")
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+];

--- a/packages/preserve/test/targets/utils.test.ts
+++ b/packages/preserve/test/targets/utils.test.ts
@@ -1,0 +1,34 @@
+import { normalize, stringify } from "../../lib/targets";
+import { tests } from "./utils.fixture";
+
+describe("stringify()", () => {
+  for (const { name, raw, normalized, stringified } of tests) {
+    describe(`test: ${name}`, () => {
+      it("should stringify raw target", async () => {
+        const result = await stringify(raw);
+        expect(result).toEqual(stringified);
+      });
+
+      it("should stringify normalized target", async () => {
+        const result = await stringify(normalized);
+        expect(result).toEqual(stringified);
+      });
+    });
+  }
+});
+
+describe("normalize()", () => {
+  for (const { name, raw, normalized, stringified } of tests) {
+    describe(`test: ${name}`, () => {
+      it("should normalize raw target", async () => {
+        const result = normalize(raw);
+        expect(JSON.stringify(result)).toEqual(JSON.stringify(normalized));
+      });
+
+      it("should normalize stringified target", async () => {
+        const result = normalize(stringified);
+        expect(JSON.stringify(result)).toEqual(JSON.stringify(normalized));
+      });
+    });
+  }
+});

--- a/packages/preserve/tsconfig.json
+++ b/packages/preserve/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "declaration": true,
+    "target": "es6",
+    "noImplicitAny": true,
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "outDir": "dist",
+    "baseUrl": ".",
+    "lib": ["es2017"],
+    "paths": {
+    },
+    "rootDir": ".",
+    "types": [
+      "jest",
+      "node"
+    ]
+  },
+  "include": [
+    "./lib/**/*.ts",
+    "./test/**/*.ts",
+    "./typings/**/*.d.ts"
+  ]
+}

--- a/packages/preserve/typings/spinnies.d.ts
+++ b/packages/preserve/typings/spinnies.d.ts
@@ -1,0 +1,148 @@
+declare module "spinnies" {
+  namespace Spinnies {
+    type StopAllStatus = "succeed" | "fail" | "stopped";
+    type SpinnerStatus = StopAllStatus | "spinning" | "non-spinnable";
+
+    interface Spinner {
+      interval: number;
+      frames: string[];
+    }
+
+    interface SpinnerOptions {
+      /**
+       * Optional text to show in the spinner. If none is provided, the name field will be shown.
+       */
+      text?: string;
+
+      /**
+       *  Optional, indent the spinner with the given number of spaces.
+       * */
+      indent?: number;
+
+      /**
+       * Initial status of the spinner. Valid statuses are: succeed, fail, spinning, non-spinnable and stopped.
+       */
+      status?: SpinnerStatus;
+
+      /**
+       * Any valid chalk color.
+       */
+      color?: string;
+
+      /**
+       * Any valid chalk color.
+       */
+      succeedColor?: string;
+
+      /**
+       * Any valid chalk color.
+       */
+      failColor?: string;
+    }
+
+    interface Options {
+      /**
+       * Any valid chalk color. The default value is white.
+       */
+      color?: string;
+
+      /**
+       * Any valid chalk color. The default value is green.
+       */
+      succeedColor?: string;
+
+      /**
+       * Any valid chalk color. The default value is red.
+       */
+      failColor?: string;
+
+      /**
+       * Any valid chalk color. The default value is greenBright.
+       */
+      spinnerColor?: string;
+
+      /**
+       * The default value is ✓.
+       */
+      succeedPrefix?: string;
+
+      /**
+       * The default value is ✖.
+       */
+      failPrefix?: string;
+
+      /**
+       * Disable spins (will still print raw messages).
+       */
+      disableSpins?: boolean;
+
+      /**
+       * Spinner configuration
+       */
+      spinner?: Spinner;
+    }
+  }
+
+  class Spinnies {
+    static dots: Spinnies.Spinner;
+    static dashes: Spinnies.Spinner;
+
+    constructor(options?: Spinnies.Options);
+
+    /**
+     * Add a new spinner with the given name.
+     */
+    add: (
+      name: string,
+      options?: Spinnies.SpinnerOptions
+    ) => Spinnies.SpinnerOptions;
+
+    /**
+     * Get spinner by name.
+     */
+    pick: (name: string) => Spinnies.SpinnerOptions;
+
+    /**
+     * Remove spinner with name.
+     */
+    remove: (name: string) => Spinnies.SpinnerOptions;
+
+    /**
+     * Updates the spinner with name name with the provided options.
+     */
+    update: (
+      name: string,
+      options?: Spinnies.SpinnerOptions
+    ) => Spinnies.SpinnerOptions;
+
+    /**
+     * Sets the specified spinner status as succeed.
+     */
+    succeed: (
+      name: string,
+      options?: Spinnies.SpinnerOptions
+    ) => Spinnies.SpinnerOptions;
+
+    /**
+     * Sets the specified spinner status as fail.
+     */
+    fail: (
+      name: string,
+      options?: Spinnies.SpinnerOptions
+    ) => Spinnies.SpinnerOptions;
+
+    /**
+     * Stops the spinners and sets the non-succeeded and non-failed ones to the provided status.
+     */
+    stopAll: (
+      status?: Spinnies.StopAllStatus
+    ) => { [name: string]: Spinnies.SpinnerOptions };
+
+    /**
+     * @returns false if all spinners have succeeded, failed or have been stopped
+     */
+    hasActiveSpinners: () => boolean;
+  }
+
+  export = Spinnies;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -732,6 +732,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.1":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.13.tgz#0a21452352b02542db0ffb928ac2d3ca7cb6d66d"
+  integrity sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.5.5":
   version "7.10.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.3.tgz#670d002655a7c366540c67f6fd3342cd09500364"
@@ -6698,7 +6705,7 @@ cli-cursor@^2.1.0:
   dependencies:
     restore-cursor "^2.0.0"
 
-cli-cursor@^3.1.0:
+cli-cursor@^3.0.0, cli-cursor@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
   integrity sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==
@@ -13008,6 +13015,13 @@ isurl@^1.0.0-alpha5:
   dependencies:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
+
+iter-tools@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/iter-tools/-/iter-tools-7.0.2.tgz#3f67b270d80341dc6c464b311c56e279a739672d"
+  integrity sha512-eQOeYO/EocvvxYJO0rcuMNr3sqsOe+LRxDLmAPmKmqIlLoJ90GFxRv/oSJ3yr0FcxOOcrH0ivmKoal/DOmSO+w==
+  dependencies:
+    "@babel/runtime" "^7.12.1"
 
 iterall@^1.1.3, iterall@^1.2.1:
   version "1.2.2"
@@ -20063,6 +20077,15 @@ spdx-license-ids@^3.0.0:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz#3694b5804567a458d3c8045842a6358632f62654"
   integrity sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==
+
+spinnies@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/spinnies/-/spinnies-0.5.1.tgz#6ac88455d9117c7712d52898a02c969811819a7e"
+  integrity sha512-WpjSXv9NQz0nU3yCT9TFEOfpFrXADY9C5fG6eAJqixLhvTX1jP3w92Y8IE5oafIe42nlF9otjhllnXN/QCaB3A==
+  dependencies:
+    chalk "^2.4.2"
+    cli-cursor "^3.0.0"
+    strip-ansi "^5.2.0"
 
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"


### PR DESCRIPTION
This PR replaces #3709 and extracts only the @truffle/preserve changes so it can be merged into develop without completing the other packages.

Changes from @gnidan's original implementation:

- Complete refactor the control/processes/controllers module
  - Remove some layers of generics
  - Move all event types to a single file
  - Define interfaces for all different Controllers
  - Rename the "Unkowns" controller to ValueResolutionController
  - Add update() function to ValueResolution for intermediate values
  - Remove succeed/fail from the initial "Controls" object
  - Change `public state` to `protected _state` + a `get()`
- Move loaders out of the targets folder into its own module
- Rename label(s) to result(s) if they refer to the result of a plugin
- Rename label(s) to resolution(s) if they refer to resolution of a value using the ValueResolutionController
- Move around the `import * as X; export { X }` statements so they are always inside the index.ts files
- Rename thunk to stringify
- Move test folder out of lib
- Some other smaller changes