### PR TITLE
Bug fix: Propagate exit statuses properly

### DIFF
--- a/packages/core/cli.js
+++ b/packages/core/cli.js
@@ -56,8 +56,8 @@ if (userWantsGeneralHelp) {
 
 command
   .run(inputArguments, options)
-  .then(() => {
-    process.exit(0);
+  .then((returnStatus) => {
+    process.exit(returnStatus);
   })
   .catch(error => {
     if (error instanceof TaskError) {


### PR DESCRIPTION
This might address #3756, I'm not sure.  We'll have to ask them.

This PR fixes a bug where exit status codes weren't being set correctly; this is particularly relevant to Truffle Test, where the exit code should be equal to the number of failed tests.  Truffle Test was returning this number correctly, but `cli.js` was ignoring it and returning zero regardless!  Now this is fixed.