### PR TITLE
Internal improvement: Add compatibleNativize function (and some missing codec/decoder functions)

### DIFF
--- a/packages/codec/lib/export.ts
+++ b/packages/codec/lib/export.ts
@@ -1,0 +1,182 @@
+import debugModule from "debug";
+const debug = debugModule("codec:export");
+
+import * as Abify from "./abify";
+import * as Format from "@truffle/codec/format";
+import {
+  LogDecoding,
+  ReturndataDecoding
+} from "@truffle/codec/types";
+
+import { ResultInspector, nativize } from "@truffle/codec/format/utils/inspect";
+export { ResultInspector, nativize };
+
+type NumberFormatter = (n: BigInt) => any //not parameterized since we output any anyway
+
+/**
+ * This function is similar to [[Format.Utils.Inspect.nativize|nativize]], but
+ * is intended to match the way that Truffle Contract currently returns values
+ * (based on the Ethers decoder).  As such, it only handles ABI types, and in
+ * addition does not handle the types fixed, ufixed, or function.  Note that in
+ * these cases it returns `undefined` rather than throwing, as we want this
+ * function to be used in contexts where it had better not throw.  It also does
+ * not handle circularities, for similar reasons.
+ *
+ * To handle numeric types, this function takes an optional second argument,
+ * numberFormatter, that tells it how to handle numbers; this function should
+ * take a BigInt as input.  By default, this function will be the identity,
+ * and so numbers will be represented as BigInts.
+ *
+ * Note that this function begins by calling abify, so out-of-range enums (that
+ * aren't so out-of-range as to be padding errors) will not return `undefined`.
+ * Out-of-range booleans similarly will return true rather than `undefined`.
+ * However, other range errors may return `undefined`; this may technically be a
+ * slight incompatibility with existing behavior, but should not be relevant
+ * except in quite unusual cases.
+ *
+ * In order to match the behavior for tuples, tuples will be transformed into
+ * arrays, but named entries will additionally be keyed by name.  Moreover,
+ * indexed variables of reference type will be nativized to an undecoded hex
+ * string.
+ */
+export function compatibleNativize(
+  result: Format.Values.Result,
+  numberFormatter: NumberFormatter = x => x
+): any {
+  return compatibleNativizeAbified(
+    Abify.abifyResult(result),
+    numberFormatter
+  );
+}
+
+//HACK; this was going to be parameterized
+//but TypeScript didn't like that, so, whatever
+interface MixedArray extends Array<any> {
+  [key: string]: any
+}
+
+function compatibleNativizeAbified(
+  result: Format.Values.Result,
+  numberFormatter: NumberFormatter
+): any {
+  if (result.kind === "error") {
+    switch (result.error.kind) {
+      case "BoolOutOfRangeError":
+        return true;
+      case "IndexedReferenceTypeError":
+        //strictly speaking for arrays ethers will fail to decode
+        //rather than do this, but, eh
+        return result.error.raw;
+      default:
+        return undefined;
+    }
+  }
+  switch (result.type.typeClass) {
+    case "uint":
+    case "int":
+      const asBN = (<Format.Values.UintValue | Format.Values.IntValue>(
+        result
+      )).value.asBN;
+      //BN is binary-based, so we convert by means of a hex string in order
+      //to avoid having to do a binary-decimal conversion and back :P
+      const asBigInt = !asBN.isNeg()
+        ? BigInt("0x" + asBN.toString(16))
+        : -BigInt("0x" + asBN.neg().toString(16)); //can't directly make negative BigInt from hex string
+      return numberFormatter(asBigInt);
+    case "bool":
+      return (<Format.Values.BoolValue>result).value.asBoolean;
+    case "bytes":
+      return (<Format.Values.BytesValue>result).value.asHex;
+    case "address":
+      return (<Format.Values.AddressValue>result).value.asAddress;
+    case "string": {
+      let coercedResult = <Format.Values.StringValue>result;
+      switch (coercedResult.value.kind) {
+        case "valid":
+          return coercedResult.value.asString;
+        case "malformed":
+          // this will turn malformed utf-8 into replacement characters (U+FFFD) (WARNING)
+          // note we need to cut off the 0x prefix
+          return Buffer.from(
+            coercedResult.value.asHex.slice(2),
+            "hex"
+          ).toString();
+      }
+    }
+    case "fixed":
+    case "ufixed":
+      return undefined;
+    case "array":
+      return (<Format.Values.ArrayValue>result).value.map(value =>
+        compatibleNativizeAbified(value, numberFormatter)
+      );
+    case "tuple":
+      //in this case, we need the result to be an array, but also
+      //to have the field names (where extant) as keys
+      const nativized: MixedArray = [];
+      for (const { name, value } of (<Format.Values.TupleValue>result).value) {
+        const nativizedValue = compatibleNativizeAbified(value, numberFormatter);
+        nativized.push(nativizedValue);
+        if (name) {
+          nativized[name] = nativizedValue;
+        }
+      }
+      return nativized;
+    case "function":
+      return undefined;
+  }
+}
+
+/**
+ * This function is similar to [[compatibleNativize]], but takes
+ * a [[ReturndataDecoding]].  If there's only one returned value, it
+ * will be run through compatibleNativize but otherwise unaltered;
+ * otherwise the results will be put in an object.
+ *
+ * Note that if the ReturndataDecoding is not a [[ReturnDecoding]],
+ * this will just return `undefined`.
+ */
+export function compatibleNativizeReturn(
+  decoding: ReturndataDecoding,
+  numberFormatter: NumberFormatter = x => x
+): any {
+  if (decoding.kind !== "return") {
+    return undefined;
+  }
+  if (decoding.arguments.length === 1) {
+    return compatibleNativize(decoding.arguments[0].value);
+  }
+  const result: any = {};
+  for (let i = 0; i < decoding.arguments.length; i++) {
+    const { name, value } = decoding.arguments[i];
+    const nativized = compatibleNativize(value, numberFormatter);
+    result[i] = nativized;
+    if (name) {
+      result[name] = nativized;
+    }
+  }
+  return result;
+}
+
+/**
+ * This function is similar to [[compatibleNativize]], but takes
+ * a [[LogDecoding]], and puts the results in an object.  Note
+ * that this does not return the entire event info, but just the
+ * `args` for the event.
+ */
+export function compatibleNativizeEventArgs(
+  decoding: LogDecoding,
+  numberFormatter: NumberFormatter = x => x
+): any {
+  const result: any = {};
+  for (let i = 0; i < decoding.arguments.length; i++) {
+    const { name, value } = decoding.arguments[i];
+    const nativized = compatibleNativize(value, numberFormatter);
+    result[i] = nativized;
+    if (name) {
+      result[name] = nativized;
+    }
+  }
+  result.__length__ = decoding.arguments.length;
+  return result;
+}

--- a/packages/codec/lib/export.ts
+++ b/packages/codec/lib/export.ts
@@ -103,9 +103,6 @@ function compatibleNativizeAbified(
           ).toString();
       }
     }
-    case "fixed":
-    case "ufixed":
-      return undefined;
     case "array":
       return (<Format.Values.ArrayValue>result).value.map(value =>
         compatibleNativizeAbified(value, numberFormatter)
@@ -122,6 +119,8 @@ function compatibleNativizeAbified(
         }
       }
       return nativized;
+    case "fixed":
+    case "ufixed":
     case "function":
       return undefined;
   }

--- a/packages/codec/lib/export.ts
+++ b/packages/codec/lib/export.ts
@@ -41,10 +41,11 @@ type NumberFormatter = (n: BigInt) => any //not parameterized since we output an
  */
 export function compatibleNativize(
   result: Format.Values.Result,
+  userDefinedTypes: Format.Types.TypesById,
   numberFormatter: NumberFormatter = x => x
 ): any {
   return compatibleNativizeAbified(
-    Abify.abifyResult(result),
+    Abify.abifyResult(result, userDefinedTypes),
     numberFormatter
   );
 }
@@ -137,18 +138,27 @@ function compatibleNativizeAbified(
  */
 export function compatibleNativizeReturn(
   decoding: ReturndataDecoding,
+  userDefinedTypes: Format.Types.TypesById,
   numberFormatter: NumberFormatter = x => x
 ): any {
   if (decoding.kind !== "return") {
     return undefined;
   }
   if (decoding.arguments.length === 1) {
-    return compatibleNativize(decoding.arguments[0].value);
+    return compatibleNativize(
+      decoding.arguments[0].value,
+      userDefinedTypes,
+      numberFormatter
+    );
   }
   const result: any = {};
   for (let i = 0; i < decoding.arguments.length; i++) {
     const { name, value } = decoding.arguments[i];
-    const nativized = compatibleNativize(value, numberFormatter);
+    const nativized = compatibleNativize(
+      value,
+      userDefinedTypes,
+      numberFormatter
+    );
     result[i] = nativized;
     if (name) {
       result[name] = nativized;
@@ -165,12 +175,17 @@ export function compatibleNativizeReturn(
  */
 export function compatibleNativizeEventArgs(
   decoding: LogDecoding,
+  userDefinedTypes: Format.Types.TypesById,
   numberFormatter: NumberFormatter = x => x
 ): any {
   const result: any = {};
   for (let i = 0; i < decoding.arguments.length; i++) {
     const { name, value } = decoding.arguments[i];
-    const nativized = compatibleNativize(value, numberFormatter);
+    const nativized = compatibleNativize(
+      value,
+      userDefinedTypes,
+      numberFormatter
+    );
     result[i] = nativized;
     if (name) {
       result[name] = nativized;

--- a/packages/codec/lib/export.ts
+++ b/packages/codec/lib/export.ts
@@ -176,6 +176,11 @@ export function compatibleNativizeEventArgs(
       result[name] = nativized;
     }
   }
+  //note: if you have an argument named __length__, what ethers
+  //actually does is... weird.  we're just going to do this instead,
+  //which is simpler and probably more useful, even if it's not strictly
+  //the same (I *seriously* doubt anyone was relying on the old behavior,
+  //because it's, uh, not very useful)
   result.__length__ = decoding.arguments.length;
   return result;
 }

--- a/packages/codec/lib/export.ts
+++ b/packages/codec/lib/export.ts
@@ -62,8 +62,6 @@ function compatibleNativizeAbified(
 ): any {
   if (result.kind === "error") {
     switch (result.error.kind) {
-      case "BoolOutOfRangeError":
-        return true;
       case "IndexedReferenceTypeError":
         //strictly speaking for arrays ethers will fail to decode
         //rather than do this, but, eh

--- a/packages/codec/lib/format/utils/inspect.ts
+++ b/packages/codec/lib/format/utils/inspect.ts
@@ -4,7 +4,6 @@ const debug = debugModule("codec:format:utils:inspect");
 import util from "util";
 import * as Format from "@truffle/codec/format/common";
 import * as Exception from "./exception";
-import * as Abify from "../../abify";
 
 //we'll need to write a typing for the options type ourself, it seems; just
 //going to include the relevant properties here
@@ -628,120 +627,5 @@ function nativizeWithTable(
           }
         }
       }
-  }
-}
-
-/**
- * This function is similar to [[nativize]], but is intended to match the way
- * that Truffle Contract currently returns values (based on the Ethers
- * decoder).  As such, it only handles ABI types, and in addition does not
- * handle the types fixed, ufixed, or function.  Note that in these cases it
- * returns undefined rather than throwing, as we want this function to be used
- * in contexts where it had better not throw.  It also does not handle
- * circularities, for similar reasons.
- *
- * To handle numeric types, this function takes an optional second argument,
- * numberFormatter, that tells it how to handle numbers; this function should
- * take a BigInt as input.  By default, this function will be the identity,
- * and so numbers will be represented as BigInts.
- *
- * Note that this function begins by calling abify, so out-of-range enums (that
- * aren't so out-of-range as to be padding errors) will not return undefined.
- * Out-of-range booleans similarly will return true rather than undefined.
- * However, other range errors may return undefined; this may technically be a
- * slight incompatibility with existing behavior, but should not be relevant
- * except in quite unusual cases.
- *
- * In order to match the behavior for tuples, tuples will be transformed into
- * arrays, but named entries will additionally be keyed by name.  Moreover,
- * indexed variables of reference type will be nativized to an undecoded hex
- * string.
- */
-export function compatibleNativize(
-  result: Format.Values.Result,
-  numberFormatter: (n: BigInt) => any //not parameterized since result is any anyway
-    = x => x
-): any {
-  return compatibleNativizeAbified(
-    Abify.abifyResult(result),
-    numberFormatter
-  );
-}
-
-//HACK; this was going to be parameterized
-//but TypeScript didn't like that, so, whatever
-interface MixedArray extends Array<any> {
-  [key: string]: any
-}
-
-function compatibleNativizeAbified(
-  result: Format.Values.Result,
-  numberFormatter: (n: BigInt) => any
-): any {
-  if (result.kind === "error") {
-    switch (result.error.kind) {
-      case "BoolOutOfRangeError":
-        return true;
-      case "IndexedReferenceTypeError":
-        //strictly speaking for arrays ethers will fail to decode
-        //rather than do this, but, eh
-        return result.error.raw;
-      default:
-        return undefined;
-    }
-  }
-  switch (result.type.typeClass) {
-    case "uint":
-    case "int":
-      const asBN = (<Format.Values.UintValue | Format.Values.IntValue>(
-        result
-      )).value.asBN;
-      //BN is binary-based, so we convert by means of a hex string in order
-      //to avoid having to do a binary-decimal conversion and back :P
-      const asBigInt = !asBN.isNeg()
-        ? BigInt("0x" + asBN.toString(16))
-        : -BigInt("0x" + asBN.neg().toString(16)); //can't directly make negative BigInt from hex string
-      return numberFormatter(asBigInt);
-    case "bool":
-      return (<Format.Values.BoolValue>result).value.asBoolean;
-    case "bytes":
-      return (<Format.Values.BytesValue>result).value.asHex;
-    case "address":
-      return (<Format.Values.AddressValue>result).value.asAddress;
-    case "string": {
-      let coercedResult = <Format.Values.StringValue>result;
-      switch (coercedResult.value.kind) {
-        case "valid":
-          return coercedResult.value.asString;
-        case "malformed":
-          // this will turn malformed utf-8 into replacement characters (U+FFFD) (WARNING)
-          // note we need to cut off the 0x prefix
-          return Buffer.from(
-            coercedResult.value.asHex.slice(2),
-            "hex"
-          ).toString();
-      }
-    }
-    case "fixed":
-    case "ufixed":
-      return undefined;
-    case "array":
-      return (<Format.Values.ArrayValue>result).value.map(value =>
-        compatibleNativize(value, numberFormatter)
-      );
-    case "tuple":
-      //in this case, we need the result to be an array, but also
-      //to have the field names (where extant) as keys
-      const nativized: MixedArray = [];
-      for (const { name, value } of (<Format.Values.TupleValue>result).value) {
-        const nativizedValue = compatibleNativize(value, numberFormatter);
-        nativized.push(nativizedValue);
-        if (name) {
-          nativized[name] = nativizedValue;
-        }
-      }
-      return nativized;
-    case "function":
-      return undefined;
   }
 }

--- a/packages/codec/lib/index.ts
+++ b/packages/codec/lib/index.ts
@@ -392,3 +392,6 @@ export { Pointer };
 
 import * as Evm from "./evm";
 export { Evm };
+
+import * as Export from "./export";
+export { Export };

--- a/packages/codec/lib/index.ts
+++ b/packages/codec/lib/index.ts
@@ -278,7 +278,11 @@ export {
 } from "./types";
 export * from "./common";
 
-export { abifyCalldataDecoding, abifyLogDecoding } from "./abify";
+export {
+  abifyCalldataDecoding,
+  abifyLogDecoding,
+  abifyReturndataDecoding
+} from "./abify";
 
 // data locations - common
 import * as Basic from "./basic";

--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -498,6 +498,19 @@ export class WireDecoder {
     return Codec.abifyLogDecoding(decoding, this.userDefinedTypes);
   }
 
+  /**
+   * Takes a [[ReturndataDecoding]], which may have been produced in full mode
+   * or ABI mode, and converts it to its ABI mode equivalent.  See the README
+   * for more information.
+   *
+   * Please only use on decodings produced by this same decoder instance; use
+   * on decodings produced by other instances may not work consistently.
+   * @param decoding The decoding to abify
+   */
+  public abifyReturndataDecoding(decoding: ReturndataDecoding): ReturndataDecoding {
+    return Codec.abifyReturndataDecoding(decoding, this.userDefinedTypes);
+  }
+
   //normally, this function gets the code of the given address at the given block,
   //and checks this against the known contexts to determine the contract type
   //however, if this fails and constructorBinary is passed in, it will then also
@@ -1009,6 +1022,13 @@ export class ContractDecoder {
    */
   public abifyLogDecoding(decoding: LogDecoding): LogDecoding {
     return this.wireDecoder.abifyLogDecoding(decoding);
+  }
+
+  /**
+   * See [[WireDecoder.abifyReturndataDecoding]].
+   */
+  public abifyReturndataDecoding(decoding: ReturndataDecoding): ReturndataDecoding {
+    return this.wireDecoder.abifyReturndataDecoding(decoding);
   }
 
   //the following functions are for internal use
@@ -1677,6 +1697,13 @@ export class ContractInstanceDecoder {
    */
   public abifyLogDecoding(decoding: LogDecoding): LogDecoding {
     return this.wireDecoder.abifyLogDecoding(decoding);
+  }
+
+  /**
+   * See [[WireDecoder.abifyReturndataDecoding]].
+   */
+  public abifyReturndataDecoding(decoding: ReturndataDecoding): ReturndataDecoding {
+    return this.wireDecoder.abifyReturndataDecoding(decoding);
   }
 
   /**

--- a/packages/decoder/test/current/contracts/CompatibleTest.sol
+++ b/packages/decoder/test/current/contracts/CompatibleTest.sol
@@ -1,0 +1,39 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+contract CompatibleNativizeTest {
+
+  struct Pair {
+    string x;
+    string y;
+  }
+
+  event String(string z);
+  event TwoStrings(string w, string z);
+  event StringPair(Pair z);
+
+  function returnString() public pure returns (string memory z) {
+    return "hello";
+  }
+
+  function emitString() public {
+    emit String("hello");
+  }
+
+  function returnTwoStrings() public pure returns (string memory w, string memory z) {
+    return ("hello", "goodbye");
+  }
+
+  function emitTwoStrings() public {
+    emit TwoStrings("hello", "goodbye");
+  }
+
+  function returnStringPair() public pure returns (Pair memory z) {
+    return Pair("hello", "goodbye");
+  }
+
+  function emitStringPair() public {
+    emit StringPair(Pair("hello", "goodbye"));
+  }
+}

--- a/packages/decoder/test/current/test/compatible-nativize.js
+++ b/packages/decoder/test/current/test/compatible-nativize.js
@@ -90,7 +90,10 @@ describe("compatibleNativize", function () {
           const decodings = await decoder.decodeReturnValue(entry, data);
           assert.lengthOf(decodings, 1);
           const decoding = decodings[0];
-          const nativized = Codec.Export.compatibleNativizeReturn(decoding);
+          const nativized = Codec.Export.compatibleNativizeReturn(
+            decoding,
+            decoder.getWireDecoder().getUserDefinedTypes() //hack?
+          );
           assert.deepEqual(nativized, expected[entry.name]);
         } else {
           //send a transaction, decode the events
@@ -106,7 +109,10 @@ describe("compatibleNativize", function () {
           const decodings = await decoder.decodeLog(log);
           assert.lengthOf(decodings, 1);
           const decoding = decodings[0];
-          const nativized = Codec.Export.compatibleNativizeEventArgs(decoding);
+          const nativized = Codec.Export.compatibleNativizeEventArgs(
+            decoding,
+            decoder.getWireDecoder().getUserDefinedTypes() //hack?
+          );
           assert.deepEqual(nativized, expected[entry.name]);
         }
       }

--- a/packages/decoder/test/current/test/compatible-nativize.js
+++ b/packages/decoder/test/current/test/compatible-nativize.js
@@ -1,0 +1,115 @@
+const debug = require("debug")("decoder:test:compatible-nativize");
+const assert = require("chai").assert;
+const BN = require("bn.js");
+const Ganache = require("ganache-core");
+const path = require("path");
+const Web3 = require("web3");
+
+const Decoder = require("../../..");
+const Codec = require("@truffle/codec");
+
+const { prepareContracts } = require("../../helpers");
+
+describe("compatibleNativize", function () {
+
+  let provider;
+  let abstractions;
+  let compilations;
+  let web3;
+
+  let Contracts;
+
+  before("Create Provider", async function () {
+    provider = Ganache.provider({seed: "decoder", gasLimit: 7000000});
+    web3 = new Web3(provider);
+  });
+
+  before("Prepare contracts and artifacts", async function () {
+    this.timeout(30000);
+
+    const prepared = await prepareContracts(provider, path.resolve(__dirname, ".."));
+    abstractions = prepared.abstractions;
+    compilations = prepared.compilations;
+
+    Contracts = [abstractions.CompatibleNativizeTest];
+  });
+
+  it("should compatibly nativize return values and event arguments", async function () {
+    const { CompatibleNativizeTest } = abstractions;
+    const instance = await CompatibleNativizeTest.new();
+
+    const decoder = await Decoder.forContract(CompatibleNativizeTest);
+
+    const keyedArray = ["hello", "goodbye"];
+    keyedArray.w = "hello";
+    keyedArray.z = "goodbye";
+
+    let expected = {
+      returnString: "hello",
+      emitString: {
+        '0': "hello",
+        z: "hello",
+        __length__: 1
+      },
+      returnTwoStrings: {
+        '0': "hello",
+        w: "hello",
+        '1': "goodbye",
+        z: "goodbye"
+      },
+      emitTwoStrings: {
+        '0': "hello",
+        w: "hello",
+        '1': "goodbye",
+        z: "goodbye",
+        __length__: 2
+      },
+      returnStringPair: keyedArray,
+      emitStringPair: {
+        '0': keyedArray,
+        z: keyedArray,
+        __length__: 1
+      }
+    };
+    expected.returnStringPair.w = "hello";
+    expected.returnStringPair.z = "goodbye";
+
+    for (const entry of CompatibleNativizeTest.abi) {
+      if (entry.type === "function") {
+        const selector = web3.eth.abi.encodeFunctionSignature(entry);
+        if (
+          entry.stateMutability === "view" || entry.stateMutability === "pure"
+        ) {
+          //do a call, decode the return value
+          //we need the raw return data, and contract.call() does not exist yet,
+          //so we're going to have to use web3.eth.call()
+          const data = await web3.eth.call({
+            to: instance.address,
+            data: selector //no arguments
+          });
+          const decodings = await decoder.decodeReturnValue(entry, data);
+          assert.lengthOf(decodings, 1);
+          const decoding = decodings[0];
+          const nativized = Codec.Export.compatibleNativizeReturn(decoding);
+          assert.deepEqual(nativized, expected[entry.name]);
+        } else {
+          //send a transaction, decode the events
+          const accounts = await web3.eth.getAccounts();
+          const receipt = await web3.eth.sendTransaction({
+            from: accounts[0],
+            to: instance.address,
+            data: selector //no arguments
+          });
+          const logs = receipt.logs;
+          assert.lengthOf(logs, 1);
+          const log = logs[0];
+          const decodings = await decoder.decodeLog(log);
+          assert.lengthOf(decodings, 1);
+          const decoding = decodings[0];
+          const nativized = Codec.Export.compatibleNativizeEventArgs(decoding);
+          assert.deepEqual(nativized, expected[entry.name]);
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
This PR adds the `compatibleNativize` function to Truffle Codec, intended for use as part of the Truffle Contract rewrite.  It, uh, also adds some other stuff that in the process turned out to be missing.

The purpose of `compatibleNativize` is to act like `nativize`, except that instead of yielding a JS equivalent for use in the debugger, it yields the sort of thing Truffle Contract (by means of ethers) currently outputs.  There are some slight differences, but, as I'll describe below, I don't think they're a problem.

There are three `compatibleNativize` functions: `compatibleNativize`, which takes an individual value; `compatibleNativizeReturn`, which takes a `ReturndataDecoding` (assumed to be of type `"return"`, it returns `undefined` otherwise); and `compatibleNativizeEventArgs`, which takes a `LogDecoding`.  (Note that this last one returns *only* the `args` part of the current-style event decoding, not anything else.)

Each of these functions takes three arguments.  First, the thing to be nativized.  Second, `userDefinedTypes`, since it may have to handle user defined types; I'll discuss below how this could possibly be eliminated.  Thirdly and optionally, `numberFormatter`.  Now, ethers decodes numbers as its own `BigNumber` class (not to be confused with the more common class of that name), but we will by default will decode numbers as `BigInt`s, and you can pass a `numberFormatter` that takes `BigInt`s and outputs someting else if you want something else.  Unfortunately I couldn't get the typing on this to work like it should, but I'm not sure how much it matters seeing as how the output of all this stuff is all `any` anyway.

Let's start with `compatibleNativize`.  It's a lot like `nativize`.  However, it begins by calling `abifyValue`, to make sure that we're doing things the ABI way.  It then has a `switch` like `nativize`, but, because we're dealing with ABI types only, and no circularities, it's much simpler.  The cases of `"fixed"`, `"ufixed"`, and `"function"` all simply return `undefined`.  Currently in Truffle Contract these throw, but we do not want this throwing!  Since we don't want, like, a decoding error screwing up your ability to get a transaction receipt or whatever.  So they simply return `undefined`.

The one case that has some seriously different behavior from `nativize` is the case of `"tuple"`.  In this case, rather than returning an array, or an object keyed with the component names, we return an array which is *also* keyed by the component names (when they exist).  That's because this is what `ethers` does, and so what Truffle Contract does currently.

There's one other quirk here: If we're nativizing a value of reference type that couldn't be decoded because it was indexed, we nativize it to the undecoded hash.  I'll discuss this case more below.

Then we have `compatibleNativizeReturn`.  This checks how many return values there are; if there's only one, it just calls `compatibleNativize` and that's it; it doesn't wrap the result in anything else.  If the count of return values is different from 1, though, it returns the results wrapped in an object, keyed both by index and by name (when names exist).

Finaly we have `compatibleNativizeEventArgs`.  This one *always* wraps the results in an object, whether there's 0, 1, or more; and it also includes a `__length__` field to indicate how many of them there are.

And that's basically it!  Although there are some slight differences from how ethers does things, which I'll discuss below.  I don't think they'll be problems, though.

...except, that's not quite it, because while writing this I realized something was missing.  It doesn't affect the rest of the PR, but -- the `abifyReturndata` function never got properly exported from `Codec` like the other abification functions.  Moreover, it didn't get corresponding functions in `@truffle/decoder`.  So, uh, I added those.

Which brings up the point -- having to pass in `userDefinedTypes` is kind of inconvenient, isn't it?  Should I add `decoder` versions of the `compatibleNativize` functions, that wouldn't need that as an argument, like how the `decoder` versions of the abify functions don't need it?  Not sure there's much of a point, but it's something I could do.

OK, so what are the differences from current behavior, and why don't I think they're a problem?

1. Numbers in tuples actually get decoded properly, instead of decoded as strings -- I'd call that a bug fix!
2. Indexed reference types -- currently, sometimes events with these are decoded by leaving the undecoded hash in place undecoded, but sometimes they're not decoded at all.  I decided it was simpler to just always do the former more informative thing.  Like, this shouldn't cause problems, right?
3. To avoid importing ethers in `codec`, we don't use their `Result` class, instead we just use objects.  I think this is fine -- in Ethers v5 I'm pretty sure `Result` isn't even a class anymore, just an interface.
4. Things that aren't encoded right -- `ethers` will handle these fine, whereas we'll fail to decode them.  This shouldn't really happen as long as we're only decoding things output by Solidity (return values and event arguments), so I think it's fine, and there's not really an way we can change this without fundamentally changing how our decoding works.
5. What happens if you have an event with `__length__` as one of the argument names?  Currently, the way this acts is... weird and not very useful.  I replaced it with having it still be the argument count, overwriting any argument by that name, because that seems more expected.  I seriously doubt that anyone was relying on the old behavior.

Also: I put these functions in a new `export.js`, and also reexported `nativize` and `ResultInspector` from there for consistency.  So yeah.

Also there's a test added.