### PR TITLE
Convert GeneratedSource to ProcessedSource in @truffle/db

### DIFF
--- a/packages/compile-common/src/types.ts
+++ b/packages/compile-common/src/types.ts
@@ -50,6 +50,14 @@ export interface LinkReference {
   length: number;
 }
 
+export interface GeneratedSource {
+  id: number;
+  name: string;
+  language: string;
+  contents: string;
+  ast: any;
+}
+
 export type CompiledContract = {
   contractName: string;
   sourcePath: string;
@@ -69,8 +77,8 @@ export type CompiledContract = {
   devdoc: object;
   userdoc: object;
   immutableReferences: ImmutableReferences;
-  generatedSources: any;
-  deployedGeneratedSources: any;
+  generatedSources?: GeneratedSource[];
+  deployedGeneratedSources?: GeneratedSource[];
   db?: {};
 };
 

--- a/packages/db/src/project/loadCompile/batch.ts
+++ b/packages/db/src/project/loadCompile/batch.ts
@@ -63,7 +63,7 @@ export namespace Compilations {
     inputs: Base.Inputs<Batch<C>, I>
   ) => Process<Base.Outputs<Batch<C>, I & O>>) =>
     Base.configure<Batch<C>>({
-      *iterate<_I>({ inputs }) {
+      *iterate({ inputs }) {
         for (const [compilationIndex, compilation] of inputs.entries()) {
           yield {
             input: compilation,
@@ -72,13 +72,13 @@ export namespace Compilations {
         }
       },
 
-      find<_I>({ inputs, breadcrumb }) {
+      find({ inputs, breadcrumb }) {
         const { compilationIndex } = breadcrumb;
 
         return inputs[compilationIndex];
       },
 
-      initialize<_I, _O>({ inputs }) {
+      initialize({ inputs }) {
         return inputs.map(input => ({
           ...input,
           db: {
@@ -87,12 +87,12 @@ export namespace Compilations {
         }));
       },
 
-      merge<I, O>({ outputs, breadcrumb, output }) {
+      merge({ outputs, breadcrumb, output }) {
         debug("outputs %o", outputs);
         const { compilationIndex } = breadcrumb;
 
         const compilationsBefore = outputs.slice(0, compilationIndex);
-        const compilation: I & O = output;
+        const compilation = output;
         const compilationsAfter = outputs.slice(compilationIndex + 1);
 
         return [...compilationsBefore, compilation, ...compilationsAfter];
@@ -104,9 +104,10 @@ export namespace Compilations {
 
 export namespace Contracts {
   export type Structure<C extends Config> = (Omit<
-    Compilation<C>,
+    Common.Compilation,
     "contracts"
-  > & { contracts: _[] })[];
+  > &
+    C["compilation"] & { contracts: (Common.CompiledContract & _)[] })[];
 
   export type Breadcrumb<_C extends Config> = {
     compilationIndex: number;
@@ -135,7 +136,7 @@ export namespace Contracts {
     inputs: Base.Inputs<Batch<C>, I>
   ) => Process<Base.Outputs<Batch<C>, I & O>>) =>
     Base.configure<Batch<C>>({
-      *iterate<_I>({ inputs }) {
+      *iterate({ inputs }) {
         for (const [compilationIndex, { contracts }] of inputs.entries()) {
           for (const [contractIndex, contract] of contracts.entries()) {
             yield {
@@ -146,20 +147,20 @@ export namespace Contracts {
         }
       },
 
-      find<_I>({ inputs, breadcrumb }) {
+      find({ inputs, breadcrumb }) {
         const { compilationIndex, contractIndex } = breadcrumb;
 
         return inputs[compilationIndex].contracts[contractIndex];
       },
 
-      initialize<I, O>({ inputs }) {
+      initialize({ inputs }) {
         return inputs.map(compilation => ({
           ...compilation,
-          contracts: [] as (I & O)[]
+          contracts: []
         }));
       },
 
-      merge<I, O>({ outputs, breadcrumb, output }) {
+      merge({ outputs, breadcrumb, output }) {
         const { compilationIndex, contractIndex } = breadcrumb;
 
         const compilationsBefore = outputs.slice(0, compilationIndex);
@@ -167,7 +168,7 @@ export namespace Contracts {
         const compilationsAfter = outputs.slice(compilationIndex + 1);
 
         const contractsBefore = compilation.contracts.slice(0, contractIndex);
-        const contract: I & O = output;
+        const contract = output;
         const contractsAfter = compilation.contracts.slice(contractIndex + 1);
 
         return [

--- a/packages/db/src/project/loadCompile/batch.ts
+++ b/packages/db/src/project/loadCompile/batch.ts
@@ -23,7 +23,7 @@ export type Config = {
 export type Resources<C extends Config> = C["resources"];
 export type Entry<C extends Config> = C["entry"];
 export type Result<C extends Config> = C["result"];
-export type Source<C extends Config> = Common.Source & C["source"];
+export type Source<C extends Config> = C["source"];
 export type Contract<C extends Config> = Common.CompiledContract &
   C["contract"];
 export type Compilation<C extends Config> = Common.Compilation &
@@ -175,87 +175,6 @@ export namespace Contracts {
           {
             ...compilation,
             contracts: [...contractsBefore, contract, ...contractsAfter]
-          },
-          ...compilationsAfter
-        ];
-      },
-
-      ...options
-    });
-}
-
-export namespace Sources {
-  export type Structure<C extends Config> = (Omit<Compilation<C>, "sources"> & {
-    sources: _[];
-  })[];
-
-  export type Breadcrumb<_C extends Config> = {
-    compilationIndex: number;
-    sourceIndex: number;
-  };
-
-  export type Batch<C extends Config> = {
-    structure: Structure<C>;
-    breadcrumb: Breadcrumb<C>;
-
-    input: Source<C>;
-    output: Source<C> & { db: Resources<C> };
-
-    entry?: Entry<C>;
-    result?: Result<C>;
-  };
-
-  export type Options<C extends Config> = Omit<
-    Base.Options<Batch<C>>,
-    "iterate" | "find" | "initialize" | "find" | "merge"
-  >;
-
-  export const configure = <C extends Config>(
-    options: Options<C>
-  ): (<I extends Base.Input<Batch<C>>, O extends Base.Output<Batch<C>>>(
-    inputs: Base.Inputs<Batch<C>, I>
-  ) => Process<Base.Outputs<Batch<C>, I & O>>) =>
-    Base.configure<Batch<C>>({
-      *iterate<_I>({ inputs }) {
-        for (const [compilationIndex, { sources }] of inputs.entries()) {
-          for (const [sourceIndex, source] of sources.entries()) {
-            yield {
-              input: source,
-              breadcrumb: { sourceIndex, compilationIndex }
-            };
-          }
-        }
-      },
-
-      find<_I>({ inputs, breadcrumb }) {
-        const { compilationIndex, sourceIndex } = breadcrumb;
-
-        return inputs[compilationIndex].sources[sourceIndex];
-      },
-
-      initialize<I, O>({ inputs }) {
-        return inputs.map(compilation => ({
-          ...compilation,
-          sources: [] as (I & O)[]
-        }));
-      },
-
-      merge<I, O>({ outputs, breadcrumb, output }) {
-        const { compilationIndex, sourceIndex } = breadcrumb;
-
-        const compilationsBefore = outputs.slice(0, compilationIndex);
-        const compilation = outputs[compilationIndex];
-        const compilationsAfter = outputs.slice(compilationIndex + 1);
-
-        const sourcesBefore = compilation.sources.slice(0, sourceIndex);
-        const source: I & O = output;
-        const sourcesAfter = compilation.sources.slice(sourceIndex + 1);
-
-        return [
-          ...compilationsBefore,
-          {
-            ...compilation,
-            sources: [...sourcesBefore, source, ...sourcesAfter]
           },
           ...compilationsAfter
         ];

--- a/packages/db/src/project/loadCompile/bytecodes.ts
+++ b/packages/db/src/project/loadCompile/bytecodes.ts
@@ -55,10 +55,7 @@ export const process = Batch.Contracts.configure<{
     }));
   },
 
-  convert<_I, _O>({
-    result: { callBytecode, createBytecode },
-    input: contract
-  }) {
+  convert({ result: { callBytecode, createBytecode }, input: contract }) {
     return {
       ...contract,
       db: {

--- a/packages/db/src/project/loadCompile/compilations.ts
+++ b/packages/db/src/project/loadCompile/compilations.ts
@@ -47,7 +47,7 @@ export const process = Batch.Compilations.configure<{
   source: Source;
   contract: Contract;
   resources: {
-    compilation: IdObject<"compilations">;
+    compilation: IdObject<"compilations"> | undefined;
   };
   entry: Input<"compilations">;
   result: IdObject<"compilations"> | undefined;
@@ -66,7 +66,7 @@ export const process = Batch.Compilations.configure<{
     return yield* resources.load("compilations", entries);
   },
 
-  convert<_I, _O>({ result, input: compilation }) {
+  convert({ result, input: compilation }) {
     return {
       ...compilation,
       db: {

--- a/packages/db/src/project/loadCompile/contracts.ts
+++ b/packages/db/src/project/loadCompile/contracts.ts
@@ -40,7 +40,7 @@ export const process = Batch.Contracts.configure<{
     };
   };
   resources: {
-    contract: IdObject<"contracts">;
+    contract: IdObject<"contracts"> | undefined;
   };
   entry: Input<"contracts">;
   result: IdObject<"contracts"> | undefined;
@@ -94,7 +94,7 @@ export const process = Batch.Contracts.configure<{
     return yield* resources.load("contracts", entries);
   },
 
-  convert<_I, _O>({ result, input: contract }) {
+  convert({ result, input: contract }) {
     return {
       ...contract,
       db: {

--- a/packages/db/src/project/loadCompile/contracts.ts
+++ b/packages/db/src/project/loadCompile/contracts.ts
@@ -5,7 +5,7 @@
 import { logger } from "@truffle/db/logger";
 const debug = logger("db:project:loadCompile:contracts");
 
-import type { Input, IdObject } from "@truffle/db/resources";
+import type { DataModel, Input, IdObject } from "@truffle/db/resources";
 import { resources } from "@truffle/db/process";
 import * as Batch from "./batch";
 
@@ -55,10 +55,10 @@ export const process = Batch.Contracts.configure<{
       )
     };
 
-    const createBytecodeGeneratedSources = toGeneratedSourceInput({
+    const createBytecodeGeneratedSources = toGeneratedSourcesInput({
       generatedSources: input.generatedSources
     });
-    const callBytecodeGeneratedSources = toGeneratedSourceInput({
+    const callBytecodeGeneratedSources = toGeneratedSourcesInput({
       generatedSources: input.deployedGeneratedSources
     });
 
@@ -89,18 +89,19 @@ export const process = Batch.Contracts.configure<{
   }
 });
 
-function toGeneratedSourceInput({ generatedSources }) {
-  const processedGeneratedSources = generatedSources
-    ? generatedSources.map(source => {
-        return {
-          ast: { json: JSON.stringify(source.ast) },
-          id: source.id,
-          contents: source.contents,
-          name: source.name,
-          language: source.language
-        };
-      })
-    : [];
+function toGeneratedSourcesInput({ generatedSources }) {
+  const processedGeneratedSources = (generatedSources || []).reduce(
+    (generatedSources: (DataModel.GeneratedSource | undefined)[], input) => {
+      generatedSources[input.id] = {
+        ast: { json: JSON.stringify(input.ast) },
+        contents: input.contents,
+        name: input.name,
+        language: input.language
+      };
+      return generatedSources;
+    },
+    []
+  );
 
   return processedGeneratedSources;
 }

--- a/packages/db/src/project/loadCompile/contracts.ts
+++ b/packages/db/src/project/loadCompile/contracts.ts
@@ -106,12 +106,15 @@ export const process = Batch.Contracts.configure<{
 });
 
 function toGeneratedSourcesInput({ generatedSources }) {
+  debug("generatedSources %O", generatedSources);
   const processedGeneratedSources = (generatedSources || []).reduce(
-    (generatedSources: (DataModel.GeneratedSource | undefined)[], input) => {
+    (
+      generatedSources: (DataModel.ProcessedSourceInput | undefined)[],
+      input
+    ) => {
       generatedSources[input.id] = {
+        source: input.db.source,
         ast: { json: JSON.stringify(input.ast) },
-        contents: input.contents,
-        name: input.name,
         language: input.language
       };
       return generatedSources;

--- a/packages/db/src/project/loadCompile/contracts.ts
+++ b/packages/db/src/project/loadCompile/contracts.ts
@@ -20,6 +20,20 @@ export const process = Batch.Contracts.configure<{
     contractName: string;
     abi: any;
     sourcePath: string;
+    generatedSources?: {
+      id: number;
+      name: string;
+      language: string;
+      contents: string;
+      ast: any;
+    }[];
+    deployedGeneratedSources?: {
+      id: number;
+      ast: any;
+      contents: string;
+      language: string;
+      name: string;
+    }[];
     db: {
       callBytecode: IdObject<"bytecodes">;
       createBytecode: IdObject<"bytecodes">;
@@ -42,7 +56,9 @@ export const process = Batch.Contracts.configure<{
 
     const {
       contractName: name,
-      db: { createBytecode, callBytecode }
+      db: { createBytecode, callBytecode },
+      generatedSources,
+      deployedGeneratedSources
     } = input;
 
     const abi = {
@@ -56,10 +72,10 @@ export const process = Batch.Contracts.configure<{
     };
 
     const createBytecodeGeneratedSources = toGeneratedSourcesInput({
-      generatedSources: input.generatedSources
+      generatedSources: generatedSources
     });
     const callBytecodeGeneratedSources = toGeneratedSourcesInput({
-      generatedSources: input.deployedGeneratedSources
+      generatedSources: deployedGeneratedSources
     });
 
     return {

--- a/packages/db/src/project/loadCompile/index.ts
+++ b/packages/db/src/project/loadCompile/index.ts
@@ -57,6 +57,7 @@ export function* process(
   // @ts-ignore
   const withSources = yield* AddSources.process(result.compilations);
 
+  // @ts-ignore
   const withSourcesAndBytecodes = yield* AddBytecodes.process(withSources);
 
   const withCompilations = yield* AddCompilations.process(

--- a/packages/db/src/project/loadCompile/index.ts
+++ b/packages/db/src/project/loadCompile/index.ts
@@ -54,7 +54,6 @@ export function* process(
   compilations: Compilation[];
   contracts: Contract[];
 }> {
-  // @ts-ignore
   const withSources = yield* AddSources.process(result.compilations);
 
   // @ts-ignore
@@ -65,6 +64,7 @@ export function* process(
     withSourcesAndBytecodes
   );
 
+  // @ts-ignore
   const withContracts = yield* AddContracts.process(withCompilations);
 
   const compilations = withContracts;
@@ -73,7 +73,7 @@ export function* process(
     // @ts-ignore
     compilations,
     contracts: compilations.reduce(
-      (a, { contracts }) => [...a, ...contracts],
+      (a, { contracts }) => [...a, ...contracts] as Contract[],
       []
     )
   };

--- a/packages/db/src/project/loadCompile/sources.ts
+++ b/packages/db/src/project/loadCompile/sources.ts
@@ -5,43 +5,194 @@
 import { logger } from "@truffle/db/logger";
 const debug = logger("db:project:loadCompile:sources");
 
+import type { _ } from "hkts/src";
+import type * as Common from "@truffle/compile-common";
+
+import * as Meta from "@truffle/db/meta";
 import type { IdObject, Input } from "@truffle/db/resources";
 import { resources } from "@truffle/db/process";
-import * as Batch from "./batch";
 
-interface Source {
-  sourcePath: string;
-  contents: string;
-  language: string;
-  ast: any;
-  legacyAST: any;
-
-  db: { source: IdObject<"sources"> };
-}
-
-export const process = Batch.Sources.configure<{
-  compilation: {};
-  contract: {};
-  source: Source;
-  resources: { source: IdObject<"sources"> };
+export const process = Meta.Batch.configure<{
+  structure: (Omit<Common.Compilation, "sources" | "contracts"> & {
+    sources: (Common.Source & _)[];
+    contracts: (Omit<
+      Common.CompiledContract,
+      "generatedSources" | "deployedGeneratedSources"
+    > & {
+      generatedSources?: (Common.GeneratedSource & _)[];
+      deployedGeneratedSources?: (Common.GeneratedSource & _)[];
+    })[];
+  })[];
+  breadcrumb: {
+    compilationIndex: number;
+    sourcePointer:
+      | {
+          sourceIndex: number;
+        }
+      | {
+          contractIndex: number;
+          property: "generatedSources" | "deployedGeneratedSources";
+          generatedSourceIndex: number;
+        };
+  };
+  input:
+    | {
+        contents: string;
+        sourcePath: string; // normal sources
+      }
+    | {
+        contents: string;
+        name: string; // generated sources
+      };
   entry: Input<"sources">;
-  result: IdObject<"sources">;
+  result: IdObject<"sources"> | undefined;
+  output: {
+    db: {
+      source: IdObject<"sources">;
+    };
+  };
 }>({
-  extract<_I>({ input: { sourcePath, contents } }) {
-    return { contents, sourcePath };
+  *iterate({ inputs }) {
+    for (const [compilationIndex, { sources, contracts }] of inputs.entries()) {
+      for (const [sourceIndex, source] of sources.entries()) {
+        yield {
+          input: source,
+          breadcrumb: {
+            compilationIndex,
+            sourcePointer: {
+              sourceIndex
+            }
+          }
+        };
+      }
+
+      for (const [contractIndex, contract] of contracts.entries()) {
+        for (const property of [
+          "generatedSources",
+          "deployedGeneratedSources"
+        ] as const) {
+          const generatedSources = contract[property];
+          if (generatedSources) {
+            for (const [
+              generatedSourceIndex,
+              source
+            ] of generatedSources.entries()) {
+              yield {
+                input: source,
+                breadcrumb: {
+                  compilationIndex,
+                  sourcePointer: {
+                    contractIndex,
+                    property,
+                    generatedSourceIndex
+                  }
+                }
+              };
+            }
+          }
+        }
+      }
+    }
+  },
+
+  find({ inputs, breadcrumb }) {
+    const { compilationIndex, sourcePointer } = breadcrumb;
+    const compilation = inputs[compilationIndex];
+
+    if ("generatedSourceIndex" in sourcePointer) {
+      const { contractIndex, property, generatedSourceIndex } = sourcePointer;
+
+      // @ts-ignore
+      return compilation.contracts[contractIndex][property][
+        generatedSourceIndex
+      ];
+    }
+
+    const { sourceIndex } = sourcePointer;
+    return compilation.sources[sourceIndex];
+  },
+
+  extract({ input }) {
+    return {
+      contents: input.contents,
+      sourcePath: "sourcePath" in input ? input["sourcePath"] : input["name"]
+    };
   },
 
   *process({ entries }) {
     return yield* resources.load("sources", entries);
   },
 
-  convert<_I, _O>({ result, input: source }) {
+  initialize<_I, _O>({ inputs }) {
+    return inputs.map(compilation => ({
+      ...compilation
+    }));
+  },
+
+  convert<_I, _O>({ result, input }) {
     return {
-      ...source,
+      ...input,
       db: {
-        ...source.db,
         source: result
       }
     };
+  },
+
+  merge<I, O>({ outputs, breadcrumb, output }) {
+    const { compilationIndex, sourcePointer } = breadcrumb;
+
+    const compilationsBefore = outputs.slice(0, compilationIndex);
+    const compilation = outputs[compilationIndex];
+    const compilationsAfter = outputs.slice(compilationIndex + 1);
+
+    if ("generatedSourceIndex" in sourcePointer) {
+      const { contractIndex, property, generatedSourceIndex } = sourcePointer;
+      const contractsBefore = compilation.contracts.slice(0, contractIndex);
+      const contract = compilation.contracts[contractIndex];
+      const contractsAfter = compilation.contracts.slice(contractIndex + 1);
+
+      const generatedSourcesBefore = contract[property].slice(
+        0,
+        generatedSourceIndex
+      );
+      const generatedSource = output;
+      const generatedSourcesAfter = contract[property].slice(
+        generatedSourceIndex + 1
+      );
+
+      return [
+        ...compilationsBefore,
+        {
+          ...compilation,
+          contracts: [
+            ...contractsBefore,
+            {
+              ...contract,
+              [property]: [
+                ...generatedSourcesBefore,
+                generatedSource,
+                ...generatedSourcesAfter
+              ]
+            },
+            ...contractsAfter
+          ]
+        },
+        ...compilationsAfter
+      ];
+    }
+
+    const { sourceIndex } = sourcePointer;
+    const sourcesBefore = compilation.sources.slice(0, sourceIndex);
+    const source: I & O = output;
+    const sourcesAfter = compilation.sources.slice(sourceIndex + 1);
+
+    return [
+      ...compilationsBefore,
+      {
+        ...compilation,
+        sources: [...sourcesBefore, source, ...sourcesAfter]
+      },
+      ...compilationsAfter
+    ];
   }
 });

--- a/packages/db/src/project/loadMigrate/batch.ts
+++ b/packages/db/src/project/loadMigrate/batch.ts
@@ -92,7 +92,7 @@ export const configure = <C extends Config>(
   inputs: Base.Inputs<Batch<C>, I>
 ) => Process<Base.Outputs<Batch<C>, I & O>>) =>
   Base.configure<Batch<C>>({
-    *iterate<_I>({
+    *iterate({
       inputs: {
         artifacts,
         network: { networkId }
@@ -116,7 +116,7 @@ export const configure = <C extends Config>(
       }
     },
 
-    find<_I>({
+    find({
       inputs: {
         artifacts,
         network: { networkId }
@@ -124,39 +124,32 @@ export const configure = <C extends Config>(
       breadcrumb
     }) {
       const { artifactIndex } = breadcrumb;
-      return artifacts[artifactIndex].networks[networkId];
+      return (artifacts[artifactIndex].networks || {})[networkId];
     },
 
-    initialize<I, O>({ inputs: { artifacts, network } }) {
+    initialize({ inputs: { artifacts, network } }) {
       return {
         network,
-        artifacts: artifacts.map(
-          artifact =>
-            ({
-              ...artifact,
+        artifacts: artifacts.map(artifact => ({
+          ...artifact,
 
-              networks: {
-                ...artifact.networks
-              } as { [networkId: string]: I & O }
-            } as Artifact<C> & { networks?: { [networkId: string]: I & O } })
-        )
+          networks: {
+            ...artifact.networks
+          }
+        }))
       };
     },
 
-    merge<I, O>({ outputs: { network, artifacts }, breadcrumb, output }) {
+    merge({ outputs: { network, artifacts }, breadcrumb, output }) {
       debug("output %o", output);
       const { networkId } = network;
       const { artifactIndex } = breadcrumb;
-      const artifactsBefore: (Artifact<C> & {
-        networks?: { [networkId: string]: I & O };
-      })[] = artifacts.slice(0, artifactIndex);
+      const artifactsBefore = artifacts.slice(0, artifactIndex);
       const artifact = artifacts[artifactIndex];
-      const artifactsAfter: (Artifact<C> & {
-        networks?: { [networkId: string]: I & O };
-      })[] = artifacts.slice(artifactIndex + 1);
+      const artifactsAfter = artifacts.slice(artifactIndex + 1);
 
-      const artifactNetwork: I & O = {
-        ...artifact.networks[networkId],
+      const artifactNetwork = {
+        ...(artifact.networks || {})[networkId],
         ...output
       };
 

--- a/packages/db/src/project/loadMigrate/contractInstances.ts
+++ b/packages/db/src/project/loadMigrate/contractInstances.ts
@@ -19,10 +19,10 @@ export const process = Batch.configure<{
   };
   requires: {
     callBytecode?: {
-      linkReferences: { name: string }[];
+      linkReferences: { name: string | null }[] | null;
     };
     createBytecode?: {
-      linkReferences: { name: string }[];
+      linkReferences: { name: string | null }[] | null;
     };
     db?: {
       network: IdObject<"networks">;
@@ -77,7 +77,8 @@ export const process = Batch.configure<{
     return yield* resources.load("contractInstances", entries);
   },
 
-  convert<_I, _O>({ result, input }) {
+  // @ts-ignore to overcome limitations in contract-schema
+  convert({ result, input }) {
     return {
       ...input,
       db: {
@@ -90,7 +91,7 @@ export const process = Batch.configure<{
 
 function link(
   bytecode: IdObject<"bytecodes">,
-  linkReferences: { name: string }[],
+  linkReferences: { name: string | null }[] | null,
   links?: { [name: string]: string }
 ): DataModel.LinkedBytecodeInput {
   if (!links) {
@@ -104,7 +105,7 @@ function link(
     value,
     linkReference: {
       bytecode,
-      index: linkReferences.findIndex(
+      index: (linkReferences || []).findIndex(
         linkReference => name === linkReference.name
       )
     }

--- a/packages/db/src/project/loadMigrate/contracts.ts
+++ b/packages/db/src/project/loadMigrate/contracts.ts
@@ -19,22 +19,22 @@ export const process = Batch.configure<{
     };
   };
   produces: {
-    callBytecode: {
-      linkReferences: { name: string }[];
+    callBytecode?: {
+      linkReferences: { name: string | null }[] | null;
     };
-    createBytecode: {
-      linkReferences: { name: string }[];
+    createBytecode?: {
+      linkReferences: { name: string | null }[] | null;
     };
   };
   entry: IdObject<"contracts">;
   result:
     | {
-        callBytecode: {
+        callBytecode?: {
           linkReferences: { name: string | null }[] | null;
-        } | null;
-        createBytecode: {
+        };
+        createBytecode?: {
           linkReferences: { name: string | null }[] | null;
-        } | null;
+        };
       }
     | undefined;
 }>({
@@ -42,18 +42,9 @@ export const process = Batch.configure<{
     return artifacts[artifactIndex].db.contract;
   },
 
+  // @ts-ignore to accommodate non-obvious mismatch
   *process({ entries }) {
-    const contracts: (
-      | {
-          callBytecode: {
-            linkReferences: { name: string | null }[] | null;
-          } | null;
-          createBytecode: {
-            linkReferences: { name: string | null }[] | null;
-          } | null;
-        }
-      | undefined
-    )[] = yield* resources.find(
+    const contracts = yield* resources.find(
       "contracts",
       entries.map(({ id }) => id),
       gql`
@@ -77,7 +68,7 @@ export const process = Batch.configure<{
     return contracts;
   },
 
-  convert<_I, _O>({ result, input }) {
+  convert({ result, input }) {
     return {
       ...input,
       ...result

--- a/packages/db/src/project/test/integration.spec.ts
+++ b/packages/db/src/project/test/integration.spec.ts
@@ -310,7 +310,6 @@ const GetWorkspaceContract = gql`
         ast {
           json
         }
-        id
         language
         contents
       }
@@ -845,21 +844,15 @@ describe("Compilation", () => {
 
       //only test generatedSources for solc compiled contracts
       if (name !== "VyperStorage") {
-        expect(callBytecodeGeneratedSources[0].name).toEqual(
-          artifacts[index].deployedGeneratedSources[0].name
-        );
-        expect(callBytecodeGeneratedSources[0].ast.json).toEqual(
-          JSON.stringify(artifacts[index].deployedGeneratedSources[0].ast)
-        );
-        expect(callBytecodeGeneratedSources[0].id).toEqual(
-          artifacts[index].deployedGeneratedSources[0].id
-        );
-        expect(callBytecodeGeneratedSources[0].contents).toEqual(
-          artifacts[index].deployedGeneratedSources[0].contents
-        );
-        expect(callBytecodeGeneratedSources[0].language).toEqual(
-          artifacts[index].deployedGeneratedSources[0].language
-        );
+        for (const { id, name, ast, contents, language } of artifacts[index]
+          .deployedGeneratedSources) {
+          const generatedSource = callBytecodeGeneratedSources[id];
+          expect(generatedSource).toBeDefined();
+          expect(generatedSource.name).toEqual(name);
+          expect(generatedSource.ast.json).toEqual(JSON.stringify(ast));
+          expect(generatedSource.contents).toEqual(contents);
+          expect(generatedSource.language).toEqual(language);
+        }
       }
 
       const artifactsCallBytecode = Shims.LegacyToNew.forBytecode(

--- a/packages/db/src/project/test/integration.spec.ts
+++ b/packages/db/src/project/test/integration.spec.ts
@@ -248,10 +248,14 @@ const AddContracts = gql`
           }
         }
         callBytecodeGeneratedSources {
-          name
+          source {
+            sourcePath
+          }
         }
         createBytecodeGeneratedSources {
-          name
+          source {
+            sourcePath
+          }
         }
       }
     }
@@ -306,15 +310,19 @@ const GetWorkspaceContract = gql`
         }
       }
       callBytecodeGeneratedSources {
-        name
+        source {
+          sourcePath
+          contents
+        }
         ast {
           json
         }
         language
-        contents
       }
       createBytecodeGeneratedSources {
-        name
+        source {
+          sourcePath
+        }
       }
       compilation {
         compiler {
@@ -832,7 +840,10 @@ describe("Compilation", () => {
             compilation: Resource<"compilations">;
             createBytecode: Resource<"bytecodes">;
             callBytecode: Resource<"bytecodes">;
-            callBytecodeGeneratedSources: DataModel.GeneratedSource[];
+            callBytecodeGeneratedSources: (
+              | DataModel.ProcessedSource
+              | undefined
+            )[];
           };
         };
       };
@@ -848,9 +859,9 @@ describe("Compilation", () => {
           .deployedGeneratedSources) {
           const generatedSource = callBytecodeGeneratedSources[id];
           expect(generatedSource).toBeDefined();
-          expect(generatedSource.name).toEqual(name);
-          expect(generatedSource.ast.json).toEqual(JSON.stringify(ast));
-          expect(generatedSource.contents).toEqual(contents);
+          expect(generatedSource.source.sourcePath).toEqual(name);
+          expect(generatedSource.ast?.json).toEqual(JSON.stringify(ast));
+          expect(generatedSource.source.contents).toEqual(contents);
           expect(generatedSource.language).toEqual(language);
         }
       }

--- a/packages/db/src/resources/compilations.ts
+++ b/packages/db/src/resources/compilations.ts
@@ -50,7 +50,7 @@ export const compilations: Definition<"compilations"> = {
 
     type ProcessedSource {
       source: Source!
-      contracts: [Contract]!
+      contracts: [Contract!]
       ast: AST
       language: String!
     }

--- a/packages/db/src/resources/contracts.ts
+++ b/packages/db/src/resources/contracts.ts
@@ -33,15 +33,8 @@ export const contracts: Definition<"contracts"> = {
       processedSource: ProcessedSource
       createBytecode: Bytecode
       callBytecode: Bytecode
-      callBytecodeGeneratedSources: [GeneratedSource]
-      createBytecodeGeneratedSources: [GeneratedSource]
-    }
-
-    type GeneratedSource {
-      ast: AST!
-      contents: String!
-      name: String!
-      language: String!
+      callBytecodeGeneratedSources: [ProcessedSource]
+      createBytecodeGeneratedSources: [ProcessedSource]
     }
 
     type ABI {
@@ -56,15 +49,8 @@ export const contracts: Definition<"contracts"> = {
       processedSource: IndexReferenceInput
       createBytecode: ResourceReferenceInput
       callBytecode: ResourceReferenceInput
-      callBytecodeGeneratedSources: [GeneratedSourceInput]
-      createBytecodeGeneratedSources: [GeneratedSourceInput]
-    }
-
-    input GeneratedSourceInput {
-      ast: ASTInput!
-      contents: String!
-      name: String!
-      language: String!
+      callBytecodeGeneratedSources: [ProcessedSourceInput]
+      createBytecodeGeneratedSources: [ProcessedSourceInput]
     }
 
     input IndexReferenceInput {

--- a/packages/db/src/resources/contracts.ts
+++ b/packages/db/src/resources/contracts.ts
@@ -57,11 +57,11 @@ export const contracts: Definition<"contracts"> = {
       processedSource: IndexReferenceInput
       createBytecode: ResourceReferenceInput
       callBytecode: ResourceReferenceInput
-      callBytecodeGeneratedSources: [GeneratedInput]
-      createBytecodeGeneratedSources: [GeneratedInput]
+      callBytecodeGeneratedSources: [GeneratedSourceInput]
+      createBytecodeGeneratedSources: [GeneratedSourceInput]
     }
 
-    input GeneratedInput {
+    input GeneratedSourceInput {
       ast: ASTInput!
       id: Int!
       contents: String!

--- a/packages/db/src/resources/contracts.ts
+++ b/packages/db/src/resources/contracts.ts
@@ -39,7 +39,6 @@ export const contracts: Definition<"contracts"> = {
 
     type GeneratedSource {
       ast: AST!
-      id: Int!
       contents: String!
       name: String!
       language: String!
@@ -63,7 +62,6 @@ export const contracts: Definition<"contracts"> = {
 
     input GeneratedSourceInput {
       ast: ASTInput!
-      id: Int!
       contents: String!
       name: String!
       language: String!

--- a/packages/db/src/test/contract.graphql.ts
+++ b/packages/db/src/test/contract.graphql.ts
@@ -16,10 +16,14 @@ export const GetContract = gql`
         }
       }
       callBytecodeGeneratedSources {
-        name
+        source {
+          sourcePath
+        }
       }
       createBytecodeGeneratedSources {
-        name
+        source {
+          sourcePath
+        }
       }
     }
   }
@@ -58,9 +62,8 @@ export const AddContracts = gql`
     $compilationId: ID!
     $bytecodeId: ID!
     $abi: String!
-    $name: String!
+    $generatedSourceId: ID!
     $ast: String!
-    $contents: String!
     $language: String!
   ) {
     contractsAdd(
@@ -74,9 +77,8 @@ export const AddContracts = gql`
             constructor: { createBytecode: { bytecode: { id: $bytecodeId } } }
             callBytecodeGeneratedSources: [
               {
-                name: $name
+                source: { id: $generatedSourceId }
                 ast: { json: $ast }
-                contents: $contents
                 language: $language
               }
             ]
@@ -111,16 +113,19 @@ export const AddContracts = gql`
           }
         }
         callBytecodeGeneratedSources {
-          name
+          source {
+            sourcePath
+            contents
+          }
+          language
           ast {
             json
           }
-          id
-          contents
-          language
         }
         createBytecodeGeneratedSources {
-          name
+          source {
+            sourcePath
+          }
         }
       }
     }

--- a/packages/db/src/test/contract.graphql.ts
+++ b/packages/db/src/test/contract.graphql.ts
@@ -60,7 +60,6 @@ export const AddContracts = gql`
     $abi: String!
     $name: String!
     $ast: String!
-    $id: Int!
     $contents: String!
     $language: String!
   ) {
@@ -77,7 +76,6 @@ export const AddContracts = gql`
               {
                 name: $name
                 ast: { json: $ast }
-                id: $id
                 contents: $contents
                 language: $language
               }

--- a/packages/db/src/test/contract.spec.ts
+++ b/packages/db/src/test/contract.spec.ts
@@ -15,6 +15,13 @@ describe("Contract", () => {
   let compilationId;
   let sourceId;
   let bytecodeId;
+  const generatedSource = {
+    name: "#utility.yul",
+    contents: "secret_sauce() { }",
+    ast: { node: "yep" },
+    language: "Yul"
+  };
+  let generatedSourceId;
   let expectedId;
 
   beforeEach(async () => {
@@ -27,6 +34,12 @@ describe("Contract", () => {
     };
     const sourceResult = await wsClient.execute(AddSource, sourceVariables);
     sourceId = sourceResult.sourcesAdd.sources[0].id;
+
+    const generatedSourceResult = await wsClient.execute(AddSource, {
+      sourcePath: generatedSource.name,
+      contents: generatedSource.contents
+    });
+    generatedSourceId = generatedSourceResult.sourcesAdd.sources[0].id;
 
     //add bytecode and get id
     const shimmedBytecode = Shims.LegacyToNew.forBytecode(Migrations.bytecode);
@@ -58,13 +71,12 @@ describe("Contract", () => {
   test("can be added", async () => {
     const variables = {
       contractName: Migrations.contractName,
-      compilationId: compilationId,
-      bytecodeId: bytecodeId,
+      compilationId,
+      bytecodeId,
       abi: JSON.stringify(Migrations.abi),
-      name: "#utility.yul",
-      ast: JSON.stringify(Migrations.ast),
-      contents: Migrations.source,
-      language: "Yul"
+      generatedSourceId,
+      ast: JSON.stringify(generatedSource.ast),
+      language: generatedSource.language
     };
 
     const addContractsResult = await wsClient.execute(AddContracts, variables);
@@ -91,10 +103,12 @@ describe("Contract", () => {
     expect(processedSource).toHaveProperty("ast");
 
     expect(createBytecodeGeneratedSources).toEqual([]);
-    expect(callBytecodeGeneratedSources[0].name).toEqual(variables.name);
+    expect(callBytecodeGeneratedSources[0].source.sourcePath).toEqual(
+      generatedSource.name
+    );
     expect(callBytecodeGeneratedSources[0].ast.json).toEqual(variables.ast);
-    expect(callBytecodeGeneratedSources[0].contents).toEqual(
-      variables.contents
+    expect(callBytecodeGeneratedSources[0].source.contents).toEqual(
+      generatedSource.contents
     );
     expect(callBytecodeGeneratedSources[0].language).toEqual(
       variables.language

--- a/packages/db/src/test/contract.spec.ts
+++ b/packages/db/src/test/contract.spec.ts
@@ -63,7 +63,6 @@ describe("Contract", () => {
       abi: JSON.stringify(Migrations.abi),
       name: "#utility.yul",
       ast: JSON.stringify(Migrations.ast),
-      id: 3,
       contents: Migrations.source,
       language: "Yul"
     };
@@ -94,7 +93,6 @@ describe("Contract", () => {
     expect(createBytecodeGeneratedSources).toEqual([]);
     expect(callBytecodeGeneratedSources[0].name).toEqual(variables.name);
     expect(callBytecodeGeneratedSources[0].ast.json).toEqual(variables.ast);
-    expect(callBytecodeGeneratedSources[0].id).toEqual(variables.id);
     expect(callBytecodeGeneratedSources[0].contents).toEqual(
       variables.contents
     );

--- a/packages/db/src/test/projects.spec.ts
+++ b/packages/db/src/test/projects.spec.ts
@@ -80,10 +80,8 @@ describe("Project", () => {
       compilationId: "123",
       bytecodeId: "1234",
       abi: JSON.stringify(Migrations.abi),
-      name: "#utility.yul",
+      generatedSourceId: "",
       ast: JSON.stringify(Migrations.ast),
-      id: 3,
-      contents: Migrations.source,
       language: "Yul"
     });
 


### PR DESCRIPTION
This PR re-uses the ProcessedSource entity for contract generated sources, removing the GeneratedSource types in the process.

In addition, this ensures that the input `id` property from the compile-common type is used for the index of a sparse array, as opposed to storing these sources in a tightly-packed array whose items encode their index. This also replaces the `any` in those types with actual interfaces (cc @haltman-at).

To get this to work, since each ProcessedSource references a Source resource, this PR reworks the sources-loading inside the Project abstraction to include information from generated sources (on top of the `sources` field already used). To do this, I've gotten rid of the hokey `Batch.Sources` abstraction and just used `Meta.Batch` directly.

Also, while I was it it, I made some moves to simplify the Meta.Batch abstraction: removing a bunch of internal generics. This was creating noise without benefit, since we've had to `@ts-ignore` everything anyway. Hopefully this is a step in the right direction there.