### PR TITLE
Dependency update: Update Typescript versions to 3.9.8 and 4.1.4

### DIFF
--- a/packages/abi-utils/package.json
+++ b/packages/abi-utils/package.json
@@ -40,7 +40,7 @@
     "jest-json-schema": "^2.1.0",
     "ts-jest": "^26.4.1",
     "ts-node": "^9.0.0",
-    "typescript": "^4.0.3"
+    "typescript": "^4.1.4"
   },
   "dependencies": {
     "change-case": "3.0.2",

--- a/packages/artifactor/package.json
+++ b/packages/artifactor/package.json
@@ -34,7 +34,7 @@
     "sinon": "^9.0.2",
     "tmp": "^0.2.1",
     "ts-node": "^9.0.0",
-    "typescript": "3.9.6",
+    "typescript": "3.9.8",
     "web3": "1.2.9"
   },
   "publishConfig": {

--- a/packages/blockchain-utils/package.json
+++ b/packages/blockchain-utils/package.json
@@ -26,7 +26,7 @@
     "@types/web3": "^1.0.20",
     "mocha": "8.1.2",
     "ts-node": "^9.0.0",
-    "typescript": "3.9.6"
+    "typescript": "3.9.8"
   },
   "keywords": [
     "blockchain",

--- a/packages/box/package.json
+++ b/packages/box/package.json
@@ -32,7 +32,7 @@
     "mocha": "8.1.2",
     "sinon": "^9.0.2",
     "ts-node": "^9.0.0",
-    "typescript": "3.9.6"
+    "typescript": "3.9.8"
   },
   "keywords": [
     "boilerplate",

--- a/packages/code-utils/package.json
+++ b/packages/code-utils/package.json
@@ -22,7 +22,7 @@
     "@types/node": "12.12.21",
     "mocha": "8.1.2",
     "ts-node": "^9.0.0",
-    "typescript": "3.9.6"
+    "typescript": "3.9.8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/codec/package.json
+++ b/packages/codec/package.json
@@ -54,7 +54,7 @@
     "ttypescript": "^1.5.7",
     "typedoc": "0.15.0",
     "typedoc-plugin-external-module-name": "^2.1.0",
-    "typescript": "3.9.6"
+    "typescript": "3.9.8"
   },
   "keywords": [
     "abi",

--- a/packages/compile-common/package.json
+++ b/packages/compile-common/package.json
@@ -16,7 +16,7 @@
     "@truffle/contract-schema": "^3.3.3",
     "@types/fs-extra": "^8.1.0",
     "@types/mocha": "^5.2.7",
-    "typescript": "3.9.6"
+    "typescript": "3.9.8"
   },
   "dependencies": {
     "@truffle/contract-sources": "^0.1.10",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -38,7 +38,7 @@
     "mocha": "8.1.2",
     "sinon": "^9.0.2",
     "ts-node": "^9.0.0",
-    "typescript": "3.9.6"
+    "typescript": "3.9.8"
   },
   "keywords": [
     "config",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -84,7 +84,7 @@
     "ttypescript": "^1.5.7",
     "typedoc": "^0.20.19",
     "typedoc-neo-theme": "^1.1.0",
-    "typescript": "^4.1.3",
+    "typescript": "^4.1.4",
     "typescript-transform-paths": "^2.1.0",
     "web3": "1.2.9"
   },

--- a/packages/decoder/package.json
+++ b/packages/decoder/package.json
@@ -45,7 +45,7 @@
     "lodash.clonedeep": "^4.5.0",
     "lodash.flatten": "^4.4.0",
     "tmp": "^0.2.1",
-    "typescript": "3.9.6"
+    "typescript": "3.9.8"
   },
   "keywords": [
     "abi",

--- a/packages/error/package.json
+++ b/packages/error/package.json
@@ -28,6 +28,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "typescript": "^3.9.7"
+    "typescript": "^3.9.8"
   }
 }

--- a/packages/hdwallet-provider/package.json
+++ b/packages/hdwallet-provider/package.json
@@ -38,7 +38,7 @@
     "ganache-core": "2.13.0",
     "mocha": "8.1.2",
     "ts-node": "^9.0.0",
-    "typescript": "3.9.6"
+    "typescript": "3.9.8"
   },
   "keywords": [
     "etheruem",

--- a/packages/interface-adapter/package.json
+++ b/packages/interface-adapter/package.json
@@ -32,7 +32,7 @@
     "ganache-core": "2.13.0",
     "mocha": "8.1.2",
     "ts-node": "^9.0.0",
-    "typescript": "3.9.6"
+    "typescript": "3.9.8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/provisioner/package.json
+++ b/packages/provisioner/package.json
@@ -28,7 +28,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "typescript": "^3.9.7"
+    "typescript": "^3.9.8"
   },
   "dependencies": {
     "@truffle/config": "^1.2.34"

--- a/packages/resolver/package.json
+++ b/packages/resolver/package.json
@@ -39,7 +39,7 @@
     "mocha": "8.1.2",
     "sinon": "^9.0.2",
     "ts-node": "^9.0.0",
-    "typescript": "3.9.6"
+    "typescript": "3.9.8"
   },
   "keywords": [
     "dependencies",

--- a/packages/source-fetcher/package.json
+++ b/packages/source-fetcher/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@types/debug": "^4.1.5",
     "@types/request-promise-native": "^1.0.17",
-    "typescript": "3.9.6"
+    "typescript": "3.9.8"
   },
   "keywords": [
     "ethereum",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21519,25 +21519,20 @@ typescript@3.6.x:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.4.tgz#b18752bb3792bc1a0281335f7f6ebf1bbfc5b91d"
   integrity sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==
 
-typescript@3.9.6:
-  version "3.9.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.6.tgz#8f3e0198a34c3ae17091b35571d3afd31999365a"
-  integrity sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==
+typescript@3.9.8, typescript@^3.9.8:
+  version "3.9.8"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.8.tgz#7d937ba4e4044af7fa83d127b982f8f61ca816a4"
+  integrity sha512-nDbnFkUZZjkQ92qwKX+C+jtk4OGfU8H9toSEs3uAsl8cxLjG2sqQm6leF/pLWvm9FAEJ6KHkYMAbHYaY2ITeVg==
 
-typescript@^3.0.3, typescript@^3.7.5, typescript@^3.8.3, typescript@^3.9.5, typescript@^3.9.7:
+typescript@^3.0.3, typescript@^3.7.5, typescript@^3.8.3, typescript@^3.9.5:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
-typescript@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
-  integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
-
-typescript@^4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
-  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
+typescript@^4.1.4:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.4.tgz#f058636e2f4f83f94ddaae07b20fd5e14598432f"
+  integrity sha512-+Uru0t8qIRgjuCpiSPpfGuhHecMllk5Zsazj5LZvVsEStEjmIRRBZe+jHjGQvsgS7M1wONy2PQXd67EMyV6acg==
 
 typewise-core@^1.2, typewise-core@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Typescript had some security release, so I figured I'd update to their new releases with the fix.  I updated the 3.9.x ones to 3.9.8 and the 4.x ones to 4.1.4.  This also gets us down to just two Typescript versions. :P  (Well, lerna would count it as more, since some of them are pinned and some are not; I didn't bother standardizing that.)  I'm not going to attempt to consolidate them futher, since finding a single Typescript version that works for everything (or updating the stuff that relies on 3.9.x to work with 4) would be a bigger task...