### PR TITLE
Bug fix: Have txlog handle constructor code that should be unmapped but isn't

### DIFF
--- a/packages/debugger/lib/txlog/selectors/index.js
+++ b/packages/debugger/lib/txlog/selectors/index.js
@@ -31,12 +31,14 @@ function createMultistepSelectors(stepSelector) {
      * .inInternalSourceOrYul
      */
     inInternalSourceOrYul: createLeaf(
-      ["./source", "./astNode"],
-      //note: the first of these won't actually happen atm, as source id
-      //of -1 would instead result in source.id === undefined, but I figure
-      //I'll include that condition in case I end up changing this later
-      (source, node) =>
+      ["./source", "./astNode", "/current/context"],
+      (source, node, { isConstructor }) =>
         !node || source.internal || node.nodeType.startsWith("Yul")
+        || (isConstructor && node.nodeType === "ContractDefinition") //HACK
+        //HACK: this last case is to handle a Solidity bug where code that in
+        //deployed contexts is unmapped, in constructor contexts can instead
+        //get mapped to the contract definition node.  I'm worried that this
+        //might screw things up for optimized code, but... we'll see?
     )
   };
 }


### PR DESCRIPTION
This PR makes it so that txlog will, when in a constructor context, treat code mapped to a contract definition node as if it were unmapped code.  This is due to [this Solidity bug](https://github.com/ethereum/solidity/issues/10935).

I'm a little worried this PR will screw things up for optimized code.  We'll see, I guess? :-/