### PR TITLE
Implement @truffle/preserve-fs

### DIFF
--- a/packages/preserve-fs/.gitignore
+++ b/packages/preserve-fs/.gitignore
@@ -1,0 +1,4 @@
+node_modules/*
+yarn.lock
+package-lock.json
+dist

--- a/packages/preserve-fs/jest.config.js
+++ b/packages/preserve-fs/jest.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  moduleFileExtensions: ["ts", "js", "json", "node"],
+  testEnvironment: "node",
+  transform: {
+    "^.+\\.ts$": "ts-jest"
+  },
+  globals: {
+    "ts-jest": {
+      tsConfig: "<rootDir>/tsconfig.json",
+      diagnostics: true
+    }
+  },
+  testMatch: [
+    // match files in test/ directories (exclude root `./test/`)
+    "<rootDir>/@(lib|test)/**/test/*.@(ts|js)",
+
+    // or files that use a test extension prefix
+    "<rootDir>/@(lib|test)/**/*.@(test|spec).@(ts|js)"
+  ]
+};

--- a/packages/preserve-fs/lib/fs.ts
+++ b/packages/preserve-fs/lib/fs.ts
@@ -1,0 +1,104 @@
+import fs from "fs";
+import { join as joinPath } from "path";
+
+import * as Preserve from "@truffle/preserve";
+import { TargetPathOptions, PathEntryOptions } from "./types";
+
+export async function* targetPath(
+  options: TargetPathOptions
+): Preserve.Process<Preserve.Target> {
+  const { path } = options;
+
+  const stats = await fs.promises.stat(path);
+
+  if (stats.isFile()) {
+    return {
+      source: yield* pathContent(options)
+    };
+  } else if (stats.isDirectory()) {
+    return {
+      source: yield* pathContainer(options)
+    };
+  }
+}
+
+async function* pathContent(
+  options: TargetPathOptions
+): Preserve.Process<Preserve.Targets.Sources.Content> {
+  const { path, verbose, controls } = options;
+  const { step } = controls;
+
+  const task = verbose
+    ? yield* step({ message: `Opening ./${path}...` })
+    : controls;
+
+  const content = fs.createReadStream(path);
+
+  if (verbose) {
+    yield* (task as Preserve.Control.StepsController).succeed();
+  }
+
+  return content;
+}
+
+async function* pathContainer(
+  options: TargetPathOptions
+): Preserve.Process<Preserve.Targets.Sources.Container> {
+  const { path, verbose, controls } = options;
+
+  const { step } = controls;
+
+  const task = verbose
+    ? yield* step({ message: `Reading directory ${path}...` })
+    : controls;
+
+  const directory = await fs.promises.readdir(path);
+
+  const entries: Preserve.Targets.Sources.Entry[] = [];
+  for (const childPath of directory) {
+    const entry = yield* pathEntry({
+      ...options,
+      controls: task,
+      path: childPath,
+      parent: path
+    });
+
+    entries.push(entry);
+  }
+
+  if (verbose) {
+    yield* (task as Preserve.Control.StepsController).succeed();
+  }
+
+  return {
+    entries
+  };
+}
+
+async function* pathEntry(
+  options: PathEntryOptions
+): Preserve.Process<Preserve.Targets.Sources.Entry> {
+  const { path, parent } = options;
+
+  const stats = await fs.promises.stat(joinPath(parent, path));
+
+  if (stats.isFile()) {
+    return {
+      path,
+      source: yield* pathContent({
+        ...options,
+        path: joinPath(parent, path)
+      })
+    };
+  }
+
+  if (stats.isDirectory()) {
+    return {
+      path,
+      source: yield* pathContainer({
+        ...options,
+        path: joinPath(parent, path)
+      })
+    };
+  }
+}

--- a/packages/preserve-fs/lib/index.ts
+++ b/packages/preserve-fs/lib/index.ts
@@ -1,0 +1,22 @@
+/**
+ * @module @truffle/preserve-fs
+ */ /** */
+
+import * as Preserve from "@truffle/preserve";
+
+import { targetPath } from "./fs";
+import { LoadOptions } from "./types";
+
+export class Loader implements Preserve.Loader {
+  name = "@truffle/preserve-fs";
+
+  async *load(options: LoadOptions): Preserve.Process<Preserve.Target> {
+    const { controls } = options;
+
+    const { log } = controls;
+
+    yield* log({ message: "Loading target..." });
+
+    return yield* targetPath(options);
+  }
+}

--- a/packages/preserve-fs/lib/types.ts
+++ b/packages/preserve-fs/lib/types.ts
@@ -1,0 +1,14 @@
+import * as Preserve from "@truffle/preserve";
+
+export interface LoadOptions extends Preserve.Loaders.LoadOptions {
+  path: string;
+  verbose?: boolean;
+}
+
+export interface TargetPathOptions extends LoadOptions {
+  controls: Preserve.Controls | Preserve.Control.StepsController;
+}
+
+export interface PathEntryOptions extends TargetPathOptions {
+  parent: string;
+}

--- a/packages/preserve-fs/package.json
+++ b/packages/preserve-fs/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@truffle/preserve-fs",
+  "version": "0.1.0-preserves.8",
+  "description": "Truffle `preserve` command support for arbitrary files and directories",
+  "main": "dist/lib/index.js",
+  "types": "dist/lib/index.d.ts",
+  "files": [
+    "dist",
+    "truffle-plugin.json"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "prepare": "yarn build",
+    "test": "jest --verbose --detectOpenHandles"
+  },
+  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/preserve-directory",
+  "author": "g. nicholas d'andrea <gnidan@trufflesuite.com>",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@types/fs-extra": "^9.0.1",
+    "@types/jest": "^26.0.0",
+    "@types/node": "^14.0.13",
+    "fs-extra": "^9.0.1",
+    "jest": "^26.0.1",
+    "tmp-promise": "^3.0.2",
+    "ts-jest": "^26.1.0",
+    "typescript": "^3.8.3"
+  },
+  "dependencies": {
+    "@truffle/preserve": "^0.1.0-preserves.8"
+  }
+}

--- a/packages/preserve-fs/test/fs.fixture.ts
+++ b/packages/preserve-fs/test/fs.fixture.ts
@@ -1,0 +1,106 @@
+import * as Preserve from "@truffle/preserve";
+
+export interface File {
+  path: string;
+  content: string;
+}
+
+export interface Test {
+  name: string;
+  files: File[];
+  targeted: string; // path to target (will be prefixed)
+  expected: Preserve.Targets.Stringified.Target;
+}
+
+export const tests: Test[] = [
+  {
+    name: "single-file",
+    files: [
+      {
+        path: "./a",
+        content: "a"
+      }
+    ],
+    targeted: "a",
+    expected: {
+      source: "a"
+    }
+  },
+  {
+    name: "extra-files",
+    files: [
+      {
+        path: "./a",
+        content: "a"
+      },
+      {
+        path: "./b",
+        content: "b"
+      },
+      {
+        path: "./c",
+        content: "c"
+      }
+    ],
+    targeted: "b",
+    expected: {
+      source: "b"
+    }
+  },
+  {
+    name: "single-directory",
+    files: [
+      {
+        path: "./directory/1",
+        content: "1"
+      },
+      {
+        path: "./directory/2",
+        content: "2"
+      }
+    ],
+    targeted: "directory",
+    expected: {
+      source: {
+        entries: [
+          {
+            path: "1",
+            source: "1"
+          },
+          {
+            path: "2",
+            source: "2"
+          }
+        ]
+      }
+    }
+  },
+  {
+    name: "sub-directory",
+    files: [
+      {
+        path: "./a/a/a",
+        content: "aaa"
+      },
+      {
+        path: "./a/b/a",
+        content: "aba"
+      },
+      {
+        path: "./a/c",
+        content: "ac"
+      }
+    ],
+    targeted: "a/a",
+    expected: {
+      source: {
+        entries: [
+          {
+            path: "a",
+            source: "aaa"
+          }
+        ]
+      }
+    }
+  }
+];

--- a/packages/preserve-fs/test/fs.test.ts
+++ b/packages/preserve-fs/test/fs.test.ts
@@ -1,0 +1,57 @@
+import fs from "fs-extra";
+import path from "path";
+import tmp from "tmp-promise";
+
+import * as Preserve from "@truffle/preserve";
+import { Loader } from "../lib";
+import { tests } from "./fs.fixture";
+
+const writeFile = async (fullPath: string, content: string): Promise<void> => {
+  // ensure directory exists for file
+  await fs.ensureDir(path.dirname(fullPath));
+
+  await fs.promises.writeFile(fullPath, content);
+};
+
+describe("Loader", () => {
+  let workspace: tmp.DirectoryResult;
+
+  beforeAll(async () => {
+    workspace = await tmp.dir();
+  });
+
+  afterAll(async () => {
+    await workspace.cleanup();
+  });
+
+  for (const { name, files, targeted, expected } of tests) {
+    describe(`test: ${name}`, () => {
+      beforeAll(async () => {
+        for (const file of files) {
+          const fullPath = path.join(workspace.path, name, file.path);
+
+          await writeFile(fullPath, file.content);
+        }
+      });
+
+      it("returns correct target", async () => {
+        const fullPath = path.join(workspace.path, name, targeted);
+
+        const loader = new Loader();
+
+        const target: Preserve.Target = await Preserve.Control.run(
+          {
+            method: loader.load.bind(loader)
+          },
+          {
+            path: fullPath
+          }
+        );
+
+        const stringified = await Preserve.Targets.stringify(target);
+
+        expect(stringified).toEqual(expected);
+      });
+    });
+  }
+});

--- a/packages/preserve-fs/truffle-plugin.json
+++ b/packages/preserve-fs/truffle-plugin.json
@@ -1,0 +1,6 @@
+{
+  "preserve": {
+    "defaultTag": "path",
+    "loader": "."
+  }
+}

--- a/packages/preserve-fs/tsconfig.json
+++ b/packages/preserve-fs/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "declaration": true,
+    "target": "es6",
+    "noImplicitAny": true,
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "outDir": "dist",
+    "baseUrl": ".",
+    "lib": ["es2017"],
+    "paths": {
+    },
+    "rootDir": ".",
+    "types": [
+      "jest",
+      "node"
+    ]
+  },
+  "include": [
+    "./lib/**/*.ts",
+    "./test/**/*.ts"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2964,6 +2964,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/fs-extra@^9.0.1":
+  version "9.0.6"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.6.tgz#488e56b77299899a608b8269719c1d133027a6ab"
+  integrity sha512-ecNRHw4clCkowNOBJH1e77nvbPxHYnWIXMv1IAoG/9+MYGkgoyr3Ppxr7XYFNL41V422EDhyV4/4SSK8L2mlig==
+  dependencies:
+    "@types/node" "*"
+
 "@types/glob@^7.1.1":
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"
@@ -10651,7 +10658,7 @@ fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^9.1.0:
+fs-extra@^9.0.1, fs-extra@^9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
   integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
@@ -20976,6 +20983,13 @@ title-case@^2.1.0:
     no-case "^2.2.0"
     upper-case "^1.0.3"
 
+tmp-promise@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-3.0.2.tgz#6e933782abff8b00c3119d63589ca1fb9caaa62a"
+  integrity sha512-OyCLAKU1HzBjL6Ev3gxUeraJNlbNingmi8IrHHEsYH8LTmEuhvYfqvhn2F/je+mjf4N58UmZ96OMEy1JanSCpA==
+  dependencies:
+    tmp "^0.2.0"
+
 tmp@0.0.33, tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -20990,7 +21004,7 @@ tmp@0.1.0:
   dependencies:
     rimraf "^2.6.3"
 
-tmp@^0.2.1:
+tmp@^0.2.0, tmp@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
   integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==


### PR DESCRIPTION
This PR replaces #3722 and extracts only the @truffle/preserve-fs changes so it can be merged into develop without completing the other packages.

Changes from @gnidan's original implementation:
- Extract common types/interfaces into separate types.ts file
- Slightly reorder fs.ts to accommodate reading the file top-down
- Slight changes due to refactoring of @truffle/preserve
- Split up test file into fs.fixture.ts and fs.test.ts