### PR TITLE
Add config defaults

### DIFF
--- a/packages/core/lib/commands/init/initSource/truffle-config.js
+++ b/packages/core/lib/commands/init/initSource/truffle-config.js
@@ -98,7 +98,7 @@ module.exports = {
   //
   // Note: if you migrated your contracts prior to enabling this field in your Truffle project and want
   // those previously migrated contracts available in the .db directory, you will need to run the following:
-  // $ migrate --reset --compile-all
+  // $ truffle migrate --reset --compile-all
 
   db: {
     enabled: false

--- a/packages/core/lib/commands/init/initSource/truffle-config.js
+++ b/packages/core/lib/commands/init/initSource/truffle-config.js
@@ -92,5 +92,15 @@ module.exports = {
       //  evmVersion: "byzantium"
       // }
     }
+  },
+
+  // Truffle DB is currently disabled by default; to enable it, change enabled: false to enabled: true
+  //
+  // Note: if you migrated your contracts prior to enabling this field in your Truffle project and want
+  // those previously migrated contracts available in the .db directory, you will need to run the following:
+  // $ migrate --reset --compile-all
+
+  db: {
+    enabled: false
   }
 };


### PR DESCRIPTION
This PR adds the default db config to the `truffle init` command's default config values, with `enabled` set to `false`. It also adds a note about ensuring users can properly migrate their contracts and have them show up in the DB. 