### PR TITLE
Bug fix: Re-add missing solc dependency in compile-solidity

### DIFF
--- a/packages/compile-solidity/package.json
+++ b/packages/compile-solidity/package.json
@@ -26,7 +26,8 @@
     "request": "^2.85.0",
     "request-promise": "^4.2.2",
     "require-from-string": "^2.0.2",
-    "semver": "^7.3.4"
+    "semver": "^7.3.4",
+    "solc": "^0.6.0"
   },
   "devDependencies": {
     "@truffle/artifactor": "^4.0.95",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19902,6 +19902,20 @@ solc@^0.4.20:
     semver "^5.3.0"
     yargs "^4.7.1"
 
+solc@^0.6.0:
+  version "0.6.12"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.6.12.tgz#48ac854e0c729361b22a7483645077f58cba080e"
+  integrity sha512-Lm0Ql2G9Qc7yPP2Ba+WNmzw2jwsrd3u4PobHYlSOxaut3TtUbj9+5ZrT6f4DUpNPEoBaFUOEg9Op9C0mk7ge9g==
+  dependencies:
+    command-exists "^1.2.8"
+    commander "3.0.2"
+    fs-extra "^0.30.0"
+    js-sha3 "0.8.0"
+    memorystream "^0.3.1"
+    require-from-string "^2.0.0"
+    semver "^5.5.0"
+    tmp "0.0.33"
+
 sort-keys-length@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sort-keys-length/-/sort-keys-length-1.0.1.tgz#9cb6f4f4e9e48155a6aa0671edd336ff1479a188"


### PR DESCRIPTION
Addresses #3799.

In PR #3771, when attempting to clean up dependencies, I deleted the `solc` dependency from `compile-solidity`, because, hey, we don't invoke solc that way, right?  I searched for `require("solc")` to be sure.  Big mistake -- it's being used for `solc/wrap`, and my search didn't catch that.  Don't have that, and you can't compile!  Have the wrong version, and your compilation will be full of errors due to malformed import strings!  (I don't know why this happens, but it does.)  Anyway, re-added that dependency to fix the problem.  Sorry about that.