### PR TITLE
Internal improvement: Prevent txlog from being confused by unmapped code in function startup

### DIFF
--- a/packages/debugger/lib/txlog/selectors/index.js
+++ b/packages/debugger/lib/txlog/selectors/index.js
@@ -196,8 +196,12 @@ let txlog = createSelectorTree({
      * txlog.current.onFunctionDefinition
      */
     onFunctionDefinition: createLeaf(
-      ["./astNode", "./isSourceRangeFinal"],
-      (node, ready) => ready && node && node.nodeType === "FunctionDefinition"
+      ["./astNode", "./isSourceRangeFinal", "/next/inInternalSourceOrYul"],
+      (node, ready, isNextInternal) =>
+        ready &&
+        node &&
+        node.nodeType === "FunctionDefinition" &&
+        !isNextInternal //need to make sure we're not just jumping to a generated source or unmapped code
     ),
 
     /**


### PR DESCRIPTION
This PR fixes a problem where the txlog would incorrectly handle function calls if said function call made a jump to unmapped code or a generated source in the middle of the function definition node.  Now we have it ignore such jumps, since they're not the real end of the function definition node.  In `data` this doesn't cause a problem because allocations can be overwritten later, but in `txlog` we deliberately *don't* do that (because we want to rely on the more robust `decodeCall` when possible), so we have to get it right the first time.  Hopefully, this should plug up the holes here.  (Well, except for optimized code, but...)