### PR TITLE
Bug fix: Make receipts work properly with --stacktrace

### DIFF
--- a/packages/contract/lib/execute.js
+++ b/packages/contract/lib/execute.js
@@ -7,7 +7,7 @@ const Reason = require("./reason");
 const handlers = require("./handlers");
 const override = require("./override");
 const reformat = require("./reformat");
-const { sendTransactionManual } = require("./manual-send");
+const { sendTransactionManual, truffleizeReceipt } = require("./manual-send");
 
 const execute = {
   // -----------------------------------  Helpers --------------------------------------------------
@@ -203,7 +203,7 @@ const execute = {
             .sendTransaction(web3, params, promiEvent, context) //the crazy things we do for stacktracing...
             .then(receipt => {
               if (promiEvent.debug) {
-                promiEvent.resolve(receipt);
+                promiEvent.resolve(truffleizeReceipt(constructor, receipt));
               }
               //otherwise, just let the handlers handle things
             })

--- a/packages/contract/lib/execute.js
+++ b/packages/contract/lib/execute.js
@@ -7,7 +7,7 @@ const Reason = require("./reason");
 const handlers = require("./handlers");
 const override = require("./override");
 const reformat = require("./reformat");
-const { sendTransactionManual, truffleizeReceipt } = require("./manual-send");
+const { sendTransactionManual } = require("./manual-send");
 
 const execute = {
   // -----------------------------------  Helpers --------------------------------------------------
@@ -203,7 +203,9 @@ const execute = {
             .sendTransaction(web3, params, promiEvent, context) //the crazy things we do for stacktracing...
             .then(receipt => {
               if (promiEvent.debug) {
-                promiEvent.resolve(truffleizeReceipt(constructor, receipt));
+                // in this case, we need to manually invoke the handler since it
+                // hasn't been set up (hack?)
+                handlers.receipt(context, receipt);
               }
               //otherwise, just let the handlers handle things
             })

--- a/packages/contract/lib/handlers.js
+++ b/packages/contract/lib/handlers.js
@@ -142,7 +142,11 @@ const handlers = {
       logs: receipt.logs
     });
 
-    this.removeListener("receipt", handlers.receipt);
+    //HACK: adding this conditional for when the handler is invoked
+    //manually during stacktracing
+    if (this.removeListener) {
+      this.removeListener("receipt", handlers.receipt);
+    }
   }
 };
 

--- a/packages/contract/lib/manual-send.js
+++ b/packages/contract/lib/manual-send.js
@@ -113,29 +113,6 @@ function translateReceipt(receipt) {
   );
 }
 
-//WARNING: copy-and-paste alert!  this function has copypaste
-//from the receipt function in handlers.js
-function truffleizeReceipt(contract, receipt) {
-  debug("translating");
-  const result = Object.assign({}, receipt); //clone
-
-  result.rawLogs = receipt.logs;
-  result.logs = receipt.logs
-    ? Utils.decodeLogs.call(contract, receipt.logs)
-    : [];
-
-  //I've cut the Reason.get & etc since that never gets called,
-  //since reverted transactions will cause throws at an earlier point
-
-  debug("translated");
-  return {
-    tx: receipt.transactionHash,
-    receipt: result,
-    logs: result.logs
-  };
-}
-
 module.exports = {
-  sendTransactionManual,
-  truffleizeReceipt
+  sendTransactionManual
 }


### PR DESCRIPTION
This PR fixes an issue raised by @jaspertium on Spectrum.  When `--stacktrace` was used with Truffle test, `contract.method()` wouldn't return a receipt in the proper format.  There are two reasons for this, one recent and one preexisting.

1. The recent one: You know that `translateReceipt` function I added to translate receipts from ethers format to web3 format?  Yeah, I forgot to ever actually invoke it!  Oops.  Now it's there.  That said, on its own this wouldn't fix the problem, and actually has little to do with the particular problem that @jaspertium was running into.

2. The preexisting one, and the main problem: Once we got a receipt back from `sendTransactionManual`, we had nothing to convert it to the Truffle format.  Normally that's handled in `handlers`, but since `--stacktrace` is on, those aren't set up like normal.  So, instead I changed the code after the receipt is returned to manually invoke the handler, rather than resolving the promievent with the receipt like I had before.  This requires a hack in the handler so that it doesn't attempt to remove a listener when invoked in this manual way, but it works...

Note that if decoding events throws (due to a `fixed` or `ufixed` or `function` event), this can actually result in sort-of messed-up stacktraces... I say "sort of" because the only effect is that, if the transaction was successful, it will yield a "improper return (may b be a self-destruct)" message.  This is a rare case, and I didn't see any easy way to prevent it, so I didn't bother.  Maybe someone will report a problem eventually, but, until then, <shrug>.