### PR TITLE
Show progress when webpacking truffle

### DIFF
--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -15,8 +15,9 @@
   },
   "scripts": {
     "analyze": "./scripts/analyze.sh",
-    "build": "yarn build-cli",
-    "build-cli": "node ./scripts/patchHighlightJsSolidity.js && node --max-old-space-size=8192 ./node_modules/webpack/bin/webpack --config ./webpack.config.js",
+    "build": "yarn build:patch && yarn build:cli",
+    "build:patch": "node ./scripts/patchHighlightJsSolidity.js",
+    "build:cli": "node --max-old-space-size=8192 ./node_modules/webpack/bin/webpack --config ./webpack.config.js",
     "postinstall": "node ./scripts/postinstall.js",
     "prepare": "yarn build",
     "publish:byoc": "node ./scripts/prereleaseVersion.js byoc-safe byoc",

--- a/packages/truffle/webpack.config.js
+++ b/packages/truffle/webpack.config.js
@@ -165,6 +165,8 @@ module.exports = {
     // Put the shebang back on.
     new webpack.BannerPlugin({ banner: "#!/usr/bin/env node\n", raw: true }),
 
+    new webpack.ProgressPlugin(),
+
     // `truffle test`
     new CopyWebpackPlugin({
       patterns: [


### PR DESCRIPTION
@tcoulter's excellent work in #3794 made Truffle _so much faster_, but the tradeoff there is that the build itself is slower now. Easy choice, but I couldn't stand to see nothing happening in the terminal.

This PR enables [webpack's ProgressPlugin](https://webpack.js.org/plugins/progress-plugin/) to output percentage complete to the console.