### PR TITLE
Use correct bytecode for immutableReferences in @truffle/db

### DIFF
--- a/packages/db/src/project/loadCompile/compilations.ts
+++ b/packages/db/src/project/loadCompile/compilations.ts
@@ -192,7 +192,7 @@ function toImmutableReferencesInputs(options: {
 
           return {
             astNode,
-            bytecode: contract.db.createBytecode,
+            bytecode: contract.db.callBytecode,
             length: definedSlices[0].length,
             offsets: definedSlices.map(({ start }) => start)
           };

--- a/packages/db/src/project/test/integration.spec.ts
+++ b/packages/db/src/project/test/integration.spec.ts
@@ -737,7 +737,9 @@ describe("Compilation", () => {
       Object.entries(artifacts[0].immutableReferences)[0][1][0].start
     );
 
-    let shimmedBytecode = Shims.LegacyToNew.forBytecode(artifacts[0].bytecode);
+    let shimmedBytecode = Shims.LegacyToNew.forBytecode(
+      artifacts[0].deployedBytecode
+    );
     // @ts-ignore
     expect(solcCompilation.immutableReferences[0].bytecode.bytes).toEqual(
       shimmedBytecode.bytes


### PR DESCRIPTION
Since only runtime bytecodes can have immutables.