### PR TITLE
Remove bad filter in @truffle/db pouch adapter

### DIFF
--- a/packages/db/src/meta/pouch/adapters/base.ts
+++ b/packages/db/src/meta/pouch/adapters/base.ts
@@ -206,9 +206,9 @@ export abstract class Databases<C extends Collections> implements Workspace<C> {
     const log = debug.extend(`${collectionName}:add`);
     log("Adding...");
 
-    const resourceInputIds = input[collectionName]
-      .map(resourceInput => this.generateId<N>(collectionName, resourceInput))
-      .filter((id): id is string => id !== undefined);
+    const resourceInputIds = input[collectionName].map(
+      resourceInput => this.generateId<N>(collectionName, resourceInput) || ""
+    );
 
     const resourceInputById = input[collectionName]
       .filter((_, index) => resourceInputIds[index])
@@ -262,9 +262,9 @@ export abstract class Databases<C extends Collections> implements Workspace<C> {
     const log = debug.extend(`${collectionName}:update`);
     log("Updating...");
 
-    const resourceInputIds = input[collectionName]
-      .map(resourceInput => this.generateId<M>(collectionName, resourceInput))
-      .filter((id): id is string => id !== undefined);
+    const resourceInputIds = input[collectionName].map(
+      resourceInput => this.generateId<M>(collectionName, resourceInput) || ""
+    );
 
     const resourceInputById = input[collectionName]
       .map((resourceInput, index) => ({


### PR DESCRIPTION
Fix `add()` and `update()` methods to properly return results one-to-one with inputs.