### PR TITLE
Allow ContractInstances in @truffle/db without transactionHash information

### DIFF
--- a/packages/db/src/network/index.ts
+++ b/packages/db/src/network/index.ts
@@ -307,7 +307,10 @@ export class Network {
 
     debug("latest %O", latest);
 
-    if (latest.historicBlock.height > this._knownLatest.historicBlock.height) {
+    if (
+      latest &&
+      latest.historicBlock.height > this._knownLatest.historicBlock.height
+    ) {
       this._knownLatest = latest;
     }
 
@@ -345,7 +348,7 @@ export class Network {
     };
   }): Promise<{
     networks: (NetworkResource | undefined)[];
-    latest: NetworkResource;
+    latest: NetworkResource | undefined;
   }> {
     if (options.blocks.length === 0) {
       throw new Error("Zero blocks provided.");
@@ -374,20 +377,22 @@ export class Network {
     const definedNetworks = networks.filter(
       (network): network is NetworkResource => !!network
     );
-    const loadedLatest = definedNetworks
+    const loadedLatest: NetworkResource | undefined = definedNetworks
       .slice(1)
       .reduce(
         (a, b) => (a.historicBlock.height > b.historicBlock.height ? a : b),
         definedNetworks[0]
       );
 
-    const latest = skipKnownLatest
+    const latest = !loadedLatest
+      ? undefined
+      : skipKnownLatest
       ? loadedLatest
       : await run(Fetch.KnownLatest.process, { network: loadedLatest });
 
     return {
       networks,
-      latest: latest || loadedLatest
+      latest
     };
   }
 

--- a/packages/db/src/resources/contractInstances.ts
+++ b/packages/db/src/resources/contractInstances.ts
@@ -60,7 +60,7 @@ export const contractInstances: Definition<"contractInstances"> = {
     }
 
     input ContractInstanceCreationInput {
-      transactionHash: TransactionHash!
+      transactionHash: TransactionHash
       constructor: ConstructorInput!
     }
 

--- a/packages/db/src/resources/contractInstances.ts
+++ b/packages/db/src/resources/contractInstances.ts
@@ -15,7 +15,7 @@ export const contractInstances: Definition<"contractInstances"> = {
     ResourcesMutate: "ContractInstancesAdd"
   },
   createIndexes: [{ fields: ["contract.id"] }],
-  idFields: ["address", "network"],
+  idFields: ["contract", "address", "creation"],
   typeDefs: gql`
     type ContractInstance implements Resource {
       address: Address!
@@ -29,7 +29,6 @@ export const contractInstances: Definition<"contractInstances"> = {
 
     type ContractInstanceCreation {
       transactionHash: TransactionHash
-      constructorArguments: [ConstructorArgument]
       constructor: Constructor
     }
 
@@ -39,6 +38,7 @@ export const contractInstances: Definition<"contractInstances"> = {
 
     type Constructor {
       createBytecode: LinkedBytecode
+      calldata: Bytes
     }
 
     type LinkedBytecode {

--- a/packages/db/src/resources/types.ts
+++ b/packages/db/src/resources/types.ts
@@ -52,7 +52,7 @@ export type Collections = {
   contractInstances: {
     resource: DataModel.ContractInstance;
     input: DataModel.ContractInstanceInput;
-    idFields: ["address", "network"];
+    idFields: ["contract", "address", "creation"];
     names: {
       resource: "contractInstance";
       Resource: "ContractInstance";

--- a/packages/db/src/test/contractInstance.spec.ts
+++ b/packages/db/src/test/contractInstance.spec.ts
@@ -24,11 +24,29 @@ describe("Contract Instance", () => {
       hash: "0xcba0b90a5e65512202091c12a2e3b328f374715b9f1c8f32cb4600c726fe2aa6"
     });
 
-    expectedId = generateId("contractInstances", {
-      address: address,
-      network: { id: addNetworkResult.networksAdd.networks[0].id }
-    });
-    let shimmedBytecode = Shims.LegacyToNew.forBytecode(Migrations.bytecode);
+    const shimmedBytecode = Shims.LegacyToNew.forBytecode(Migrations.bytecode);
+    // @ts-ignore won't be undefined
+    const contract: IdObject<"contracts"> = {
+      id: generateId("contracts", {
+        name: Migrations.contractName,
+        abi: { json: JSON.stringify(Migrations.abi) },
+        processedSource: { index: 0 },
+        compilation: {
+          id:
+            "0x7f91bdeb02ae5fd772f829f41face7250ce9eada560e3e7fa7ed791c40d926bd"
+        }
+      })
+    };
+    const creation = {
+      transactionHash: Migrations.networks["5777"].transactionHash,
+      constructor: {
+        createBytecode: {
+          bytecode: {
+            id: generateId("bytecodes", shimmedBytecode) as string
+          }
+        }
+      }
+    };
 
     variables = [
       {
@@ -36,29 +54,16 @@ describe("Contract Instance", () => {
         network: {
           id: addNetworkResult.networksAdd.networks[0].id
         },
-        contract: {
-          id: generateId("contracts", {
-            name: Migrations.contractName,
-            abi: { json: JSON.stringify(Migrations.abi) },
-            processedSource: { index: 0 },
-            compilation: {
-              id:
-                "0x7f91bdeb02ae5fd772f829f41face7250ce9eada560e3e7fa7ed791c40d926bd"
-            }
-          })
-        },
-        creation: {
-          transactionHash: Migrations.networks["5777"].transactionHash,
-          constructor: {
-            createBytecode: {
-              bytecode: {
-                id: generateId("bytecodes", shimmedBytecode)
-              }
-            }
-          }
-        }
+        contract,
+        creation
       }
     ];
+
+    expectedId = generateId("contractInstances", {
+      contract,
+      address,
+      creation
+    });
   });
 
   test("can be added", async () => {


### PR DESCRIPTION
This PR removes the non-nullability requirement for ContractInstance.creation.transactionHash to accommodate situations where it may be infeasible to obtain this information. As a result, ContractInstance.network may now represent any Network on which this instance is available at the end of that Network's historicBlock.

This means a couple things:
- `network` can no longer be an ID field, since this looser constraint means `network` is no longer unique; use `contract` and `creation` when computing ContractInstance IDs (in addition to the unchanged `address`).
- When doing `project.loadMigrate()`, if any input artifacts are missing a transactionHash, load the latest block as a Network resource and use that for any such ContractInstances.