### PR TITLE
Allow Project.contractInstance lookup by address+network

### DIFF
--- a/packages/db/src/resources/projects/index.ts
+++ b/packages/db/src/resources/projects/index.ts
@@ -29,7 +29,8 @@ export const projects: Definition<"projects"> = {
       networks: [Network!]!
 
       contractInstance(
-        contract: ResourceNameInput!
+        contract: ResourceNameInput
+        address: Address
         network: ResourceNameInput!
       ): ContractInstance
       contractInstances(

--- a/packages/db/src/resources/projects/resolveContractInstances.ts
+++ b/packages/db/src/resources/projects/resolveContractInstances.ts
@@ -26,6 +26,7 @@ export async function resolveContractInstances(
   project: IdObject<"projects">,
   inputs: {
     contract?: DataModel.ResourceNameInput;
+    address?: string;
     network?: DataModel.ResourceNameInput;
   },
   context: {
@@ -111,7 +112,13 @@ export async function resolveContractInstances(
     contractInstances.push(...stepContractInstances);
   }
 
-  return contractInstances;
+  if (!inputs.address) {
+    return contractInstances;
+  } else {
+    return contractInstances.filter(
+      contractInstance => contractInstance.address === inputs.address
+    );
+  }
 }
 
 /**


### PR DESCRIPTION
This PR adds the ability to look up a Project's single contract instance by address+network, rather than by contract+network.

This is a bit of an expedient hack; a better solution might be to generalize the filtering here, but I've avoided doing that now since this approach won't incur much of a performance penalty and minimizes the risk of breaking the existing mechanisms.