### PR TITLE
Report contractName in source-fetcher if possible

### DIFF
--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -162,6 +162,7 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
   ): Types.SourceInfo {
     const filename = makeFilename(result.ContractName);
     return {
+      contractName: result.ContractName,
       sources: {
         [filename]: result.SourceCode
       },
@@ -182,6 +183,7 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
     sources: Types.SolcSources
   ): Types.SourceInfo {
     return {
+      contractName: result.ContractName,
       sources: this.processSources(sources),
       options: {
         language: "Solidity",
@@ -200,6 +202,7 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
     jsonInput: Types.SolcInput
   ): Types.SourceInfo {
     return {
+      contractName: result.ContractName,
       sources: this.processSources(jsonInput.sources),
       options: {
         language: jsonInput.language,

--- a/packages/source-fetcher/lib/types.ts
+++ b/packages/source-fetcher/lib/types.ts
@@ -21,6 +21,7 @@ export interface FetcherOptions {
 }
 
 export interface SourceInfo {
+  contractName?: string;
   sources: SourcesByPath;
   options: CompilerOptions;
 }


### PR DESCRIPTION
@truffle/source-fetcher is great for obtaining all the sources that went into compiling the contract instance at a given address!

Unfortunately, it does not make it easy to figure out which resulting compiled contract it was that ended up getting to deployed to that address.

This PR adds that information as an optional field to the result type, since Etherscan provides us with this information but Sourcify does not. (In the future, perhaps there's a solution when fetching from Sourcify to do an `eth_getCode` and bytecode match?)