### PR TITLE
Bug fix (internal improvement?): Allow txlog to process internal calls happening at end of tx

### DIFF
--- a/packages/debugger/lib/txlog/selectors/index.js
+++ b/packages/debugger/lib/txlog/selectors/index.js
@@ -202,10 +202,8 @@ let txlog = createSelectorTree({
         (ready || stepsRemaining <= 2) && //HACK: see below
         node &&
         node.nodeType === "FunctionDefinition" &&
-        (!isNextInternal || stepsRemaining <= 1) //need to make sure we're not just jumping to a generated source or unmapped code
-        //however if there are no steps remaining that will trip isNextInternal which we don't want,
-        //so we have to account for that too
-        //we also account for this up top because the last step will never be processed, so...
+        !isNextInternal //need to make sure we're not just jumping to a generated source or unmapped code
+        //hack above: the last step doesn't get processed, so...
     ),
 
     /**

--- a/packages/debugger/lib/txlog/selectors/index.js
+++ b/packages/debugger/lib/txlog/selectors/index.js
@@ -5,6 +5,7 @@ import { createSelectorTree, createLeaf } from "reselect-tree";
 
 import data from "lib/data/selectors";
 import evm from "lib/evm/selectors";
+import trace from "lib/trace/selectors";
 import solidity from "lib/solidity/selectors";
 
 import * as Codec from "@truffle/codec";
@@ -196,12 +197,15 @@ let txlog = createSelectorTree({
      * txlog.current.onFunctionDefinition
      */
     onFunctionDefinition: createLeaf(
-      ["./astNode", "./isSourceRangeFinal", "/next/inInternalSourceOrYul"],
-      (node, ready, isNextInternal) =>
-        ready &&
+      ["./astNode", "./isSourceRangeFinal", "/next/inInternalSourceOrYul", trace.stepsRemaining],
+      (node, ready, isNextInternal, stepsRemaining) =>
+        (ready || stepsRemaining <= 2) && //HACK: see below
         node &&
         node.nodeType === "FunctionDefinition" &&
-        !isNextInternal //need to make sure we're not just jumping to a generated source or unmapped code
+        (!isNextInternal || stepsRemaining <= 1) //need to make sure we're not just jumping to a generated source or unmapped code
+        //however if there are no steps remaining that will trip isNextInternal which we don't want,
+        //so we have to account for that too
+        //we also account for this up top because the last step will never be processed, so...
     ),
 
     /**


### PR DESCRIPTION
So txlog had a problem where internal calls at the very end of a transaction wouldn't have their info properly recorded.  (I'm a little unclear on why this happens, or if the info we get is really meaningful, but we should at least include it.)  The problem was twofold:

1. Because it occurred at the very end, and rather than checking the jump location we check what's after the function definition node, this would get processed as a jump into internal sources (which it's not), so I had to special-case that;
2. Because it happend on the very last step, it would never get processed, as we don't update things happening after the last step!  So I had to special case that.

This is a bit of a hack, but the info is there now at least?