### PR TITLE
Make minor edit to db help output

### DIFF
--- a/packages/core/lib/commands/db/index.js
+++ b/packages/core/lib/commands/db/index.js
@@ -4,12 +4,9 @@ const serveCommand = require("./commands/serve");
 const usage =
   "truffle db <sub-command> [options]" +
   OS.EOL +
-  OS.EOL +
   "  Available sub-commands: " +
   OS.EOL +
-  OS.EOL +
-  "  serve \tStart the GraphQL server" +
-  OS.EOL;
+  "                serve \tStart the GraphQL server";
 
 const command = {
   command: "db",


### PR DESCRIPTION
This edits the help output for the db command. This is an attempt to format it more similarly to the output for the other commands. I'm not attached to the changes made in this PR so we can close it if people don't like this as much. I'll post some screenshots to show the comparison. Here is the output with the changes made in this PR 
<img width="1285" alt="Screen Shot 2021-02-26 at 10 45 12 AM" src="https://user-images.githubusercontent.com/14827965/109322315-2893e600-7820-11eb-9937-7d5a66f98662.png">
