### PR TITLE
Internal improvement: Add new, compatible nativize function and some missing codec/decoder functions

### DIFF
--- a/packages/codec/lib/conversion.ts
+++ b/packages/codec/lib/conversion.ts
@@ -46,6 +46,14 @@ export function toSignedBN(bytes: Uint8Array): BN {
   }
 }
 
+export function toBigInt(value: BN): BigInt {
+  //BN is binary-based, so we convert by means of a hex string in order
+  //to avoid having to do a binary-decimal conversion and back :P
+  return !value.isNeg()
+    ? BigInt("0x" + value.toString(16))
+    : -BigInt("0x" + value.neg().toString(16)); //can't directly make negative BigInt from hex string
+}
+
 export function toBig(value: BN | number): Big {
   //note: going through string may seem silly but it's actually not terrible here,
   //since BN (& number) is binary-based and Big is decimal-based

--- a/packages/codec/lib/export.ts
+++ b/packages/codec/lib/export.ts
@@ -1,0 +1,199 @@
+import debugModule from "debug";
+const debug = debugModule("codec:export");
+
+import * as Abify from "./abify";
+import * as Format from "@truffle/codec/format";
+import {
+  LogDecoding,
+  ReturndataDecoding
+} from "@truffle/codec/types";
+
+import { ResultInspector, nativize } from "@truffle/codec/format/utils/inspect";
+export { ResultInspector, nativize };
+
+type NumberFormatter = (n: BigInt) => any //not parameterized since we output any anyway
+
+/**
+ * This function is similar to [[Format.Utils.Inspect.nativize|nativize]], but
+ * is intended to match the way that Truffle Contract currently returns values
+ * (based on the Ethers decoder).  As such, it only handles ABI types, and in
+ * addition does not handle the types fixed, ufixed, or function.  Note that in
+ * these cases it returns `undefined` rather than throwing, as we want this
+ * function to be used in contexts where it had better not throw.  It also does
+ * not handle circularities, for similar reasons.
+ *
+ * To handle numeric types, this function takes an optional second argument,
+ * numberFormatter, that tells it how to handle numbers; this function should
+ * take a BigInt as input.  By default, this function will be the identity,
+ * and so numbers will be represented as BigInts.
+ *
+ * Note that this function begins by calling abify, so out-of-range enums (that
+ * aren't so out-of-range as to be padding errors) will not return `undefined`.
+ * Out-of-range booleans similarly will return true rather than `undefined`.
+ * However, other range errors may return `undefined`; this may technically be a
+ * slight incompatibility with existing behavior, but should not be relevant
+ * except in quite unusual cases.
+ *
+ * In order to match the behavior for tuples, tuples will be transformed into
+ * arrays, but named entries will additionally be keyed by name.  Moreover,
+ * indexed variables of reference type will be nativized to an undecoded hex
+ * string.
+ */
+export function compatibleNativize(
+  result: Format.Values.Result,
+  userDefinedTypes: Format.Types.TypesById,
+  numberFormatter: NumberFormatter = x => x
+): any {
+  return compatibleNativizeAbified(
+    Abify.abifyResult(result, userDefinedTypes),
+    numberFormatter
+  );
+}
+
+//HACK; this was going to be parameterized
+//but TypeScript didn't like that, so, whatever
+interface MixedArray extends Array<any> {
+  [key: string]: any
+}
+
+function compatibleNativizeAbified(
+  result: Format.Values.Result,
+  numberFormatter: NumberFormatter
+): any {
+  if (result.kind === "error") {
+    switch (result.error.kind) {
+      case "IndexedReferenceTypeError":
+        //strictly speaking for arrays ethers will fail to decode
+        //rather than do this, but, eh
+        return result.error.raw;
+      default:
+        return undefined;
+    }
+  }
+  switch (result.type.typeClass) {
+    case "uint":
+    case "int":
+      const asBN = (<Format.Values.UintValue | Format.Values.IntValue>(
+        result
+      )).value.asBN;
+      //BN is binary-based, so we convert by means of a hex string in order
+      //to avoid having to do a binary-decimal conversion and back :P
+      const asBigInt = !asBN.isNeg()
+        ? BigInt("0x" + asBN.toString(16))
+        : -BigInt("0x" + asBN.neg().toString(16)); //can't directly make negative BigInt from hex string
+      return numberFormatter(asBigInt);
+    case "bool":
+      return (<Format.Values.BoolValue>result).value.asBoolean;
+    case "bytes":
+      return (<Format.Values.BytesValue>result).value.asHex;
+    case "address":
+      return (<Format.Values.AddressValue>result).value.asAddress;
+    case "string": {
+      let coercedResult = <Format.Values.StringValue>result;
+      switch (coercedResult.value.kind) {
+        case "valid":
+          return coercedResult.value.asString;
+        case "malformed":
+          // this will turn malformed utf-8 into replacement characters (U+FFFD) (WARNING)
+          // note we need to cut off the 0x prefix
+          return Buffer.from(
+            coercedResult.value.asHex.slice(2),
+            "hex"
+          ).toString();
+      }
+    }
+    case "array":
+      return (<Format.Values.ArrayValue>result).value.map(value =>
+        compatibleNativizeAbified(value, numberFormatter)
+      );
+    case "tuple":
+      //in this case, we need the result to be an array, but also
+      //to have the field names (where extant) as keys
+      const nativized: MixedArray = [];
+      for (const { name, value } of (<Format.Values.TupleValue>result).value) {
+        const nativizedValue = compatibleNativizeAbified(value, numberFormatter);
+        nativized.push(nativizedValue);
+        if (name) {
+          nativized[name] = nativizedValue;
+        }
+      }
+      return nativized;
+    case "fixed":
+    case "ufixed":
+    case "function":
+      return undefined;
+  }
+}
+
+/**
+ * This function is similar to [[compatibleNativize]], but takes
+ * a [[ReturndataDecoding]].  If there's only one returned value, it
+ * will be run through compatibleNativize but otherwise unaltered;
+ * otherwise the results will be put in an object.
+ *
+ * Note that if the ReturndataDecoding is not a [[ReturnDecoding]],
+ * this will just return `undefined`.
+ */
+export function compatibleNativizeReturn(
+  decoding: ReturndataDecoding,
+  userDefinedTypes: Format.Types.TypesById,
+  numberFormatter: NumberFormatter = x => x
+): any {
+  if (decoding.kind !== "return") {
+    return undefined;
+  }
+  if (decoding.arguments.length === 1) {
+    return compatibleNativize(
+      decoding.arguments[0].value,
+      userDefinedTypes,
+      numberFormatter
+    );
+  }
+  const result: any = {};
+  for (let i = 0; i < decoding.arguments.length; i++) {
+    const { name, value } = decoding.arguments[i];
+    const nativized = compatibleNativize(
+      value,
+      userDefinedTypes,
+      numberFormatter
+    );
+    result[i] = nativized;
+    if (name) {
+      result[name] = nativized;
+    }
+  }
+  return result;
+}
+
+/**
+ * This function is similar to [[compatibleNativize]], but takes
+ * a [[LogDecoding]], and puts the results in an object.  Note
+ * that this does not return the entire event info, but just the
+ * `args` for the event.
+ */
+export function compatibleNativizeEventArgs(
+  decoding: LogDecoding,
+  userDefinedTypes: Format.Types.TypesById,
+  numberFormatter: NumberFormatter = x => x
+): any {
+  const result: any = {};
+  for (let i = 0; i < decoding.arguments.length; i++) {
+    const { name, value } = decoding.arguments[i];
+    const nativized = compatibleNativize(
+      value,
+      userDefinedTypes,
+      numberFormatter
+    );
+    result[i] = nativized;
+    if (name) {
+      result[name] = nativized;
+    }
+  }
+  //note: if you have an argument named __length__, what ethers
+  //actually does is... weird.  we're just going to do this instead,
+  //which is simpler and probably more useful, even if it's not strictly
+  //the same (I *seriously* doubt anyone was relying on the old behavior,
+  //because it's, uh, not very useful)
+  result.__length__ = decoding.arguments.length;
+  return result;
+}

--- a/packages/codec/lib/export.ts
+++ b/packages/codec/lib/export.ts
@@ -125,7 +125,7 @@ function ethersCompatibleNativize(
         case "contract":
           return (<Format.Values.ContractValue>result).value.address;
         case "string": {
-          let coercedResult = <Format.Values.StringValue>result;
+          const coercedResult = <Format.Values.StringValue>result;
           switch (coercedResult.value.kind) {
             case "valid":
               return coercedResult.value.asString;
@@ -156,9 +156,19 @@ function ethersCompatibleNativize(
             }
           }
           return nativized;
+        case "function":
+          switch (result.type.visibility) {
+            case "external":
+              const coercedResult = <Format.Values.FunctionExternalValue>result;
+              //ethers per se doesn't handle this, but web3's hacked version will
+              //sometimes decode these as just a bytes24, so let's do that
+              return coercedResult.value.contract.address.toLowerCase() +
+                coercedResult.value.selector.slice(2);
+            case "internal":
+              return undefined;
+          }
         case "fixed":
         case "ufixed":
-        case "function":
         default:
           return undefined;
       }

--- a/packages/codec/lib/index.ts
+++ b/packages/codec/lib/index.ts
@@ -280,7 +280,11 @@ export {
 } from "./types";
 export * from "./common";
 
-export { abifyCalldataDecoding, abifyLogDecoding } from "./abify";
+export {
+  abifyCalldataDecoding,
+  abifyLogDecoding,
+  abifyReturndataDecoding
+} from "./abify";
 
 // data locations - common
 import * as Basic from "./basic";
@@ -394,3 +398,6 @@ export { Pointer };
 
 import * as Evm from "./evm";
 export { Evm };
+
+import * as Export from "./export";
+export { Export };

--- a/packages/debugger/test/data/calldata.js
+++ b/packages/debugger/test/data/calldata.js
@@ -144,7 +144,7 @@ describe("Calldata Decoding", function () {
 
     await bugger.continueUntilBreakpoint();
 
-    const variables = Codec.Format.Utils.Inspect.nativizeVariables(
+    const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
     );
 
@@ -174,7 +174,7 @@ describe("Calldata Decoding", function () {
 
     await bugger.continueUntilBreakpoint();
 
-    const variables = Codec.Format.Utils.Inspect.nativizeVariables(
+    const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
     );
 
@@ -202,7 +202,7 @@ describe("Calldata Decoding", function () {
 
     await bugger.continueUntilBreakpoint();
 
-    const variables = Codec.Format.Utils.Inspect.nativizeVariables(
+    const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
     );
 
@@ -235,7 +235,7 @@ describe("Calldata Decoding", function () {
 
     await bugger.continueUntilBreakpoint();
 
-    const variables = Codec.Format.Utils.Inspect.nativizeVariables(
+    const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
     );
 
@@ -266,7 +266,7 @@ describe("Calldata Decoding", function () {
 
     await bugger.continueUntilBreakpoint();
 
-    const variables = Codec.Format.Utils.Inspect.nativizeVariables(
+    const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
     );
 
@@ -297,7 +297,7 @@ describe("Calldata Decoding", function () {
 
     await bugger.continueUntilBreakpoint();
 
-    const variables = Codec.Format.Utils.Inspect.nativizeVariables(
+    const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
     );
 
@@ -328,7 +328,7 @@ describe("Calldata Decoding", function () {
 
     await bugger.continueUntilBreakpoint();
 
-    const variables = Codec.Format.Utils.Inspect.nativizeVariables(
+    const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
     );
 

--- a/packages/debugger/test/data/codex.js
+++ b/packages/debugger/test/data/codex.js
@@ -119,7 +119,7 @@ describe("Codex", function () {
     await bugger.continueUntilBreakpoint(); //run till end
     debug("made it to end of transaction");
 
-    const surface = Codec.Format.Utils.Inspect.nativize(
+    const surface = Codec.Format.Utils.Inspect.unsafeNativize(
       await bugger.variable("surface")
     );
 
@@ -136,7 +136,7 @@ describe("Codex", function () {
 
     await bugger.continueUntilBreakpoint(); //run till end
 
-    const x = Codec.Format.Utils.Inspect.nativize(await bugger.variable("x"));
+    const x = Codec.Format.Utils.Inspect.unsafeNativize(await bugger.variable("x"));
 
     assert.equal(x, 1);
   });
@@ -151,7 +151,7 @@ describe("Codex", function () {
 
     await bugger.continueUntilBreakpoint(); //run till end
 
-    const x = Codec.Format.Utils.Inspect.nativize(await bugger.variable("x"));
+    const x = Codec.Format.Utils.Inspect.unsafeNativize(await bugger.variable("x"));
 
     assert.equal(x, 1);
   });

--- a/packages/debugger/test/data/function-decoding.js
+++ b/packages/debugger/test/data/function-decoding.js
@@ -206,7 +206,7 @@ describe("Function Pointer Decoding", function () {
 
     await bugger.continueUntilBreakpoint();
 
-    const variables = Codec.Format.Utils.Inspect.nativizeVariables(
+    const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
     );
 
@@ -241,7 +241,7 @@ describe("Function Pointer Decoding", function () {
 
     await bugger.continueUntilBreakpoint();
 
-    const variables = Codec.Format.Utils.Inspect.nativizeVariables(
+    const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
     );
 

--- a/packages/debugger/test/data/global-const.js
+++ b/packages/debugger/test/data/global-const.js
@@ -66,7 +66,7 @@ describe("Globally-defined constants", function () {
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
     //file-level constants should be available right away
-    const variables = Codec.Format.Utils.Inspect.nativizeVariables(
+    const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
     );
 

--- a/packages/debugger/test/data/global.js
+++ b/packages/debugger/test/data/global.js
@@ -182,7 +182,7 @@ describe("Globally-available variables", function () {
 
     await bugger.continueUntilBreakpoint(); //run till end
 
-    const variables = Codec.Format.Utils.Inspect.nativizeVariables(
+    const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
     );
 
@@ -208,7 +208,7 @@ describe("Globally-available variables", function () {
     });
     await bugger.continueUntilBreakpoint();
 
-    const variables = Codec.Format.Utils.Inspect.nativizeVariables(
+    const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
     );
 
@@ -234,7 +234,7 @@ describe("Globally-available variables", function () {
     });
     await bugger.continueUntilBreakpoint();
 
-    const variables = Codec.Format.Utils.Inspect.nativizeVariables(
+    const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
     );
 
@@ -260,7 +260,7 @@ describe("Globally-available variables", function () {
     });
     await bugger.continueUntilBreakpoint();
 
-    const variables = Codec.Format.Utils.Inspect.nativizeVariables(
+    const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
     );
 
@@ -278,7 +278,7 @@ describe("Globally-available variables", function () {
 
     await bugger.continueUntilBreakpoint(); //run till end
 
-    const variables = Codec.Format.Utils.Inspect.nativizeVariables(
+    const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
     );
 
@@ -304,7 +304,7 @@ describe("Globally-available variables", function () {
     });
     await bugger.continueUntilBreakpoint();
 
-    const variables = Codec.Format.Utils.Inspect.nativizeVariables(
+    const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
     );
 
@@ -330,7 +330,7 @@ describe("Globally-available variables", function () {
     });
     await bugger.continueUntilBreakpoint();
 
-    const variables = Codec.Format.Utils.Inspect.nativizeVariables(
+    const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
     );
 

--- a/packages/debugger/test/data/helpers.js
+++ b/packages/debugger/test/data/helpers.js
@@ -80,7 +80,7 @@ async function prepareDebugger(testName, sources) {
 }
 
 async function decode(name) {
-  return Codec.Format.Utils.Inspect.nativize(await this.session.variable(name));
+  return Codec.Format.Utils.Inspect.unsafeNativize(await this.session.variable(name));
 }
 
 export function describeDecoding(testName, fixtures, selector, generateSource) {

--- a/packages/debugger/test/data/ids.js
+++ b/packages/debugger/test/data/ids.js
@@ -224,7 +224,7 @@ describe("Variable IDs", function () {
     await bugger.continueUntilBreakpoint();
     while (!bugger.view(trace.finished)) {
       values.push(
-        Codec.Format.Utils.Inspect.nativize(await bugger.variable("nbang"))
+        Codec.Format.Utils.Inspect.unsafeNativize(await bugger.variable("nbang"))
       );
       await bugger.continueUntilBreakpoint();
     }
@@ -259,10 +259,10 @@ describe("Variable IDs", function () {
     await bugger.continueUntilBreakpoint();
     while (!bugger.view(trace.finished)) {
       xValues.push(
-        Codec.Format.Utils.Inspect.nativize(await bugger.variable("x"))
+        Codec.Format.Utils.Inspect.unsafeNativize(await bugger.variable("x"))
       );
       tempValues.push(
-        Codec.Format.Utils.Inspect.nativize(await bugger.variable("temp"))
+        Codec.Format.Utils.Inspect.unsafeNativize(await bugger.variable("temp"))
       );
       await bugger.continueUntilBreakpoint();
     }

--- a/packages/debugger/test/data/immutable.js
+++ b/packages/debugger/test/data/immutable.js
@@ -98,7 +98,7 @@ describe("Immutable state variables", function () {
 
     await bugger.continueUntilBreakpoint();
 
-    const variables = Codec.Format.Utils.Inspect.nativizeVariables(
+    const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
     );
 
@@ -134,7 +134,7 @@ describe("Immutable state variables", function () {
 
     await bugger.continueUntilBreakpoint();
 
-    const variables = Codec.Format.Utils.Inspect.nativizeVariables(
+    const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
     );
 

--- a/packages/debugger/test/data/more-decoding.js
+++ b/packages/debugger/test/data/more-decoding.js
@@ -341,7 +341,7 @@ describe("Further Decoding", function () {
 
     await bugger.continueUntilBreakpoint();
 
-    const variables = Codec.Format.Utils.Inspect.nativizeVariables(
+    const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
     );
 
@@ -378,7 +378,7 @@ describe("Further Decoding", function () {
 
     await bugger.continueUntilBreakpoint();
 
-    const variables = Codec.Format.Utils.Inspect.nativizeVariables(
+    const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
     );
     debug("variables %O", variables);
@@ -418,7 +418,7 @@ describe("Further Decoding", function () {
 
     await bugger.continueUntilBreakpoint();
 
-    const variables = Codec.Format.Utils.Inspect.nativizeVariables(
+    const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
     );
 
@@ -447,7 +447,7 @@ describe("Further Decoding", function () {
     //we're only testing storage so run till end
     await bugger.continueUntilBreakpoint();
 
-    const variables = Codec.Format.Utils.Inspect.nativizeVariables(
+    const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
     );
 
@@ -505,7 +505,7 @@ describe("Further Decoding", function () {
 
     await bugger.continueUntilBreakpoint(); //run till end
 
-    const variables = Codec.Format.Utils.Inspect.nativizeVariables(
+    const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
     );
     debug("variables %O", variables);
@@ -528,7 +528,7 @@ describe("Further Decoding", function () {
 
     await bugger.continueUntilBreakpoint(); //run till end
 
-    const variables = Codec.Format.Utils.Inspect.nativizeVariables(
+    const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
     );
     debug("variables %O", variables);
@@ -559,7 +559,7 @@ describe("Further Decoding", function () {
 
     await bugger.continueUntilBreakpoint();
 
-    const circular = Codec.Format.Utils.Inspect.nativize(
+    const circular = Codec.Format.Utils.Inspect.unsafeNativize(
       await bugger.variable("circular")
     );
 
@@ -586,7 +586,7 @@ describe("Further Decoding", function () {
 
       await bugger.continueUntilBreakpoint();
 
-      const variables = Codec.Format.Utils.Inspect.nativizeVariables(
+      const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
         await bugger.variables()
       );
       debug("variables %O", variables);
@@ -616,7 +616,7 @@ describe("Further Decoding", function () {
 
       await bugger.continueUntilBreakpoint();
 
-      const variables = Codec.Format.Utils.Inspect.nativizeVariables(
+      const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
         await bugger.variables()
       );
       debug("variables %O", variables);
@@ -646,7 +646,7 @@ describe("Further Decoding", function () {
 
       await bugger.continueUntilBreakpoint();
 
-      const variables = Codec.Format.Utils.Inspect.nativizeVariables(
+      const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
         await bugger.variables()
       );
       debug("variables %O", variables);

--- a/packages/debugger/test/data/returnvalue.js
+++ b/packages/debugger/test/data/returnvalue.js
@@ -110,7 +110,7 @@ describe("Return value decoding", function () {
     assert.strictEqual(outputs[0].name, "x");
     assert.isUndefined(outputs[1].name);
     const values = outputs.map(({ value }) =>
-      Codec.Format.Utils.Inspect.nativize(value)
+      Codec.Format.Utils.Inspect.unsafeNativize(value)
     );
     assert.deepEqual(values, [-1, -2]);
   });
@@ -138,7 +138,7 @@ describe("Return value decoding", function () {
     assert.strictEqual(immutables[0].name, "minus");
     assert.strictEqual(immutables[0].class.typeName, "ReturnValues");
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(immutables[0].value),
+      Codec.Format.Utils.Inspect.unsafeNativize(immutables[0].value),
       -1
     );
   });
@@ -187,7 +187,7 @@ describe("Return value decoding", function () {
     assert.strictEqual(immutables[0].name, "minus");
     assert.strictEqual(immutables[0].class.typeName, "Default");
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(immutables[0].value),
+      Codec.Format.Utils.Inspect.unsafeNativize(immutables[0].value),
       -1
     );
   });
@@ -241,7 +241,7 @@ describe("Return value decoding", function () {
     assert.strictEqual(decoding.abi.name, "Error");
     const outputs = decoding.arguments;
     assert.lengthOf(outputs, 1);
-    const message = Codec.Format.Utils.Inspect.nativize(outputs[0].value);
+    const message = Codec.Format.Utils.Inspect.unsafeNativize(outputs[0].value);
     assert.strictEqual(message, "Noise!");
   });
 
@@ -270,7 +270,7 @@ describe("Return value decoding", function () {
     assert.strictEqual(decoding.abi.name, "Panic");
     const outputs = decoding.arguments;
     assert.lengthOf(outputs, 1);
-    const panicCode = Codec.Format.Utils.Inspect.nativize(outputs[0].value);
+    const panicCode = Codec.Format.Utils.Inspect.unsafeNativize(outputs[0].value);
     assert.strictEqual(panicCode, 1);
   });
 });

--- a/packages/debugger/test/data/yul.js
+++ b/packages/debugger/test/data/yul.js
@@ -101,7 +101,7 @@ describe("Assembly decoding", function () {
       );
 
     let variables = numberize(
-      Codec.Format.Utils.Inspect.nativizeVariables(await bugger.variables())
+      Codec.Format.Utils.Inspect.unsafeNativizeVariables(await bugger.variables())
     );
 
     let expectedResult = {
@@ -119,7 +119,7 @@ describe("Assembly decoding", function () {
     await bugger.continueUntilBreakpoint();
 
     variables = numberize(
-      Codec.Format.Utils.Inspect.nativizeVariables(await bugger.variables())
+      Codec.Format.Utils.Inspect.unsafeNativizeVariables(await bugger.variables())
     );
 
     expectedResult = {
@@ -138,7 +138,7 @@ describe("Assembly decoding", function () {
     await bugger.continueUntilBreakpoint();
 
     variables = numberize(
-      Codec.Format.Utils.Inspect.nativizeVariables(await bugger.variables())
+      Codec.Format.Utils.Inspect.unsafeNativizeVariables(await bugger.variables())
     );
 
     expectedResult = {

--- a/packages/debugger/test/endstate.js
+++ b/packages/debugger/test/endstate.js
@@ -90,7 +90,7 @@ describe("End State", function () {
     await bugger.continueUntilBreakpoint(); //no breakpoints set so advances to end
 
     assert.ok(bugger.view(evm.transaction.status));
-    const variables = Codec.Format.Utils.Inspect.nativizeVariables(
+    const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
     );
     assert.include(variables, { x: 107 });

--- a/packages/debugger/test/load.js
+++ b/packages/debugger/test/load.js
@@ -66,7 +66,7 @@ describe("Loading and unloading transactions", function () {
     await bugger.load(txHash);
     assert.isTrue(bugger.view(trace.loaded));
     await bugger.continueUntilBreakpoint(); //continue to end
-    const variables = Codec.Format.Utils.Inspect.nativizeVariables(
+    const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
     );
     const expected = { x: 1 };
@@ -89,7 +89,7 @@ describe("Loading and unloading transactions", function () {
 
     assert.isTrue(bugger.view(trace.loaded));
     await bugger.continueUntilBreakpoint(); //continue to end
-    let variables = Codec.Format.Utils.Inspect.nativizeVariables(
+    let variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
     );
     let expected = { x: 1 };
@@ -99,7 +99,7 @@ describe("Loading and unloading transactions", function () {
     await bugger.load(txHash2);
     assert.isTrue(bugger.view(trace.loaded));
     await bugger.continueUntilBreakpoint(); //continue to end
-    variables = Codec.Format.Utils.Inspect.nativizeVariables(
+    variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
     );
     expected = { y: 2 };

--- a/packages/debugger/test/reset.js
+++ b/packages/debugger/test/reset.js
@@ -73,22 +73,22 @@ describe("Reset Button", function () {
     });
 
     variables[0].push(
-      Codec.Format.Utils.Inspect.nativizeVariables(await bugger.variables())
+      Codec.Format.Utils.Inspect.unsafeNativizeVariables(await bugger.variables())
     );
     await bugger.continueUntilBreakpoint(); //advance to line 10
     variables[0].push(
-      Codec.Format.Utils.Inspect.nativizeVariables(await bugger.variables())
+      Codec.Format.Utils.Inspect.unsafeNativizeVariables(await bugger.variables())
     );
     await bugger.continueUntilBreakpoint(); //advance to the end
     variables[0].push(
-      Codec.Format.Utils.Inspect.nativizeVariables(await bugger.variables())
+      Codec.Format.Utils.Inspect.unsafeNativizeVariables(await bugger.variables())
     );
 
     //now, reset and do it again
     await bugger.reset();
 
     variables[1].push(
-      Codec.Format.Utils.Inspect.nativizeVariables(await bugger.variables())
+      Codec.Format.Utils.Inspect.unsafeNativizeVariables(await bugger.variables())
     );
     await bugger.addBreakpoint({
       sourceId,
@@ -96,11 +96,11 @@ describe("Reset Button", function () {
     });
     await bugger.continueUntilBreakpoint(); //advance to line 10
     variables[1].push(
-      Codec.Format.Utils.Inspect.nativizeVariables(await bugger.variables())
+      Codec.Format.Utils.Inspect.unsafeNativizeVariables(await bugger.variables())
     );
     await bugger.continueUntilBreakpoint(); //advance to the end
     variables[1].push(
-      Codec.Format.Utils.Inspect.nativizeVariables(await bugger.variables())
+      Codec.Format.Utils.Inspect.unsafeNativizeVariables(await bugger.variables())
     );
 
     assert.deepEqual(variables[1], variables[0]);

--- a/packages/debugger/test/txlog.js
+++ b/packages/debugger/test/txlog.js
@@ -153,14 +153,14 @@ describe("Transaction log (visualizer)", function () {
     assert.equal(call.contractName, "VizTest");
     assert.equal(call.returnKind, "return");
     debug("arguments: %O", call.arguments);
-    let inputs = Codec.Format.Utils.Inspect.nativizeVariables(
+    let inputs = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       byName(call.arguments)
     );
     debug("nativized: %O", inputs);
     assert.deepEqual(inputs, {
       x: 108
     });
-    let outputs = Codec.Format.Utils.Inspect.nativizeVariables(
+    let outputs = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       byName(call.returnValues)
     );
     assert.deepEqual(outputs, {
@@ -172,13 +172,13 @@ describe("Transaction log (visualizer)", function () {
     assert.equal(call.functionName, "called");
     assert.equal(call.contractName, "VizTest");
     assert.equal(call.returnKind, "return");
-    inputs = Codec.Format.Utils.Inspect.nativizeVariables(
+    inputs = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       byName(call.arguments)
     );
     assert.deepEqual(inputs, {
       x: 108
     });
-    outputs = Codec.Format.Utils.Inspect.nativizeVariables(
+    outputs = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       byName(call.returnValues)
     );
     assert.deepEqual(outputs, {
@@ -208,14 +208,14 @@ describe("Transaction log (visualizer)", function () {
     assert.isUndefined(call.functionName);
     assert.equal(call.contractName, "Secondary");
     assert.equal(call.returnKind, "return");
-    let inputs = Codec.Format.Utils.Inspect.nativizeVariables(
+    let inputs = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       byName(call.arguments)
     );
     assert.deepEqual(inputs, {
       y: 108
     });
     debug("immuts: %O", call.returnImmutables);
-    let outputs = Codec.Format.Utils.Inspect.nativizeVariables(
+    let outputs = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       byName(call.returnImmutables)
     );
     assert.deepEqual(outputs, {
@@ -229,7 +229,7 @@ describe("Transaction log (visualizer)", function () {
     assert.equal(call.contractName, "Secondary");
     assert.equal(call.returnKind, "return");
     assert.lengthOf(call.arguments, 0);
-    outputs = Codec.Format.Utils.Inspect.nativizeVariables(
+    outputs = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       byName(call.returnValues)
     );
     assert.include(outputs, {
@@ -272,13 +272,13 @@ describe("Transaction log (visualizer)", function () {
     assert.equal(call.functionName, "loudIncrement");
     assert.equal(call.contractName, "VizLibrary");
     assert.equal(call.returnKind, "return");
-    let inputs = Codec.Format.Utils.Inspect.nativizeVariables(
+    let inputs = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       byName(call.arguments)
     );
     assert.deepEqual(inputs, {
       x: 1
     });
-    let outputs = Codec.Format.Utils.Inspect.nativizeVariables(
+    let outputs = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       byName(call.returnValues)
     );
     assert.deepEqual(outputs, {
@@ -350,13 +350,13 @@ describe("Transaction log (visualizer)", function () {
     assert.equal(call.functionName, "called");
     assert.equal(call.contractName, "VizTest");
     assert.equal(call.returnKind, "return");
-    let inputs = Codec.Format.Utils.Inspect.nativizeVariables(
+    let inputs = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       byName(call.arguments)
     );
     assert.deepEqual(inputs, {
       x: 4
     });
-    let outputs = Codec.Format.Utils.Inspect.nativizeVariables(
+    let outputs = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       byName(call.returnValues)
     );
     assert.deepEqual(outputs, {
@@ -405,7 +405,7 @@ describe("Transaction log (visualizer)", function () {
     assert.equal(call.error.kind, "revert");
     assert.lengthOf(call.error.arguments, 1);
     assert.equal(
-      Codec.Format.Utils.Inspect.nativize(call.error.arguments[0].value),
+      Codec.Format.Utils.Inspect.unsafeNativize(call.error.arguments[0].value),
       "Oops!"
     );
   });

--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -505,6 +505,19 @@ export class WireDecoder {
     return Codec.abifyLogDecoding(decoding, this.userDefinedTypes);
   }
 
+  /**
+   * Takes a [[ReturndataDecoding]], which may have been produced in full mode
+   * or ABI mode, and converts it to its ABI mode equivalent.  See the README
+   * for more information.
+   *
+   * Please only use on decodings produced by this same decoder instance; use
+   * on decodings produced by other instances may not work consistently.
+   * @param decoding The decoding to abify
+   */
+  public abifyReturndataDecoding(decoding: ReturndataDecoding): ReturndataDecoding {
+    return Codec.abifyReturndataDecoding(decoding, this.userDefinedTypes);
+  }
+
   //normally, this function gets the code of the given address at the given block,
   //and checks this against the known contexts to determine the contract type
   //however, if this fails and constructorBinary is passed in, it will then also
@@ -1020,6 +1033,13 @@ export class ContractDecoder {
    */
   public abifyLogDecoding(decoding: LogDecoding): LogDecoding {
     return this.wireDecoder.abifyLogDecoding(decoding);
+  }
+
+  /**
+   * See [[WireDecoder.abifyReturndataDecoding]].
+   */
+  public abifyReturndataDecoding(decoding: ReturndataDecoding): ReturndataDecoding {
+    return this.wireDecoder.abifyReturndataDecoding(decoding);
   }
 
   //the following functions are for internal use
@@ -1691,6 +1711,13 @@ export class ContractInstanceDecoder {
    */
   public abifyLogDecoding(decoding: LogDecoding): LogDecoding {
     return this.wireDecoder.abifyLogDecoding(decoding);
+  }
+
+  /**
+   * See [[WireDecoder.abifyReturndataDecoding]].
+   */
+  public abifyReturndataDecoding(decoding: ReturndataDecoding): ReturndataDecoding {
+    return this.wireDecoder.abifyReturndataDecoding(decoding);
   }
 
   /**

--- a/packages/decoder/lib/utils.ts
+++ b/packages/decoder/lib/utils.ts
@@ -15,13 +15,13 @@ const { Shims } = require("@truffle/compile-common");
 //NOTE: Definitely do not use this in real code!  For tests only!
 //for convenience: invokes the nativize method on all the given variables, and changes them to
 //the old format
-export function nativizeDecoderVariables(
+export function unsafeNativizeDecoderVariables(
   variables: Types.StateVariable[]
 ): { [name: string]: any } {
   return Object.assign(
     {},
     ...variables.map(({ name, value }) => ({
-      [name]: Codec.Format.Utils.Inspect.nativize(value)
+      [name]: Codec.Format.Utils.Inspect.unsafeNativize(value)
     }))
   );
   //note that the assignments are processed in order, so if multiple have same name, later

--- a/packages/decoder/test/current/contracts/CompatibleTest.sol
+++ b/packages/decoder/test/current/contracts/CompatibleTest.sol
@@ -36,4 +36,8 @@ contract CompatibleNativizeTest {
   function emitStringPair() public {
     emit StringPair(Pair("hello", "goodbye"));
   }
+
+  function returnFunction() public view returns (function() external) {
+    return this.emitString;
+  }
 }

--- a/packages/decoder/test/current/contracts/CompatibleTest.sol
+++ b/packages/decoder/test/current/contracts/CompatibleTest.sol
@@ -1,0 +1,39 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+contract CompatibleNativizeTest {
+
+  struct Pair {
+    string x;
+    string y;
+  }
+
+  event String(string z);
+  event TwoStrings(string w, string z);
+  event StringPair(Pair z);
+
+  function returnString() public pure returns (string memory z) {
+    return "hello";
+  }
+
+  function emitString() public {
+    emit String("hello");
+  }
+
+  function returnTwoStrings() public pure returns (string memory w, string memory z) {
+    return ("hello", "goodbye");
+  }
+
+  function emitTwoStrings() public {
+    emit TwoStrings("hello", "goodbye");
+  }
+
+  function returnStringPair() public pure returns (Pair memory z) {
+    return Pair("hello", "goodbye");
+  }
+
+  function emitStringPair() public {
+    emit StringPair(Pair("hello", "goodbye"));
+  }
+}

--- a/packages/decoder/test/current/test/compatible-nativize.js
+++ b/packages/decoder/test/current/test/compatible-nativize.js
@@ -1,0 +1,121 @@
+const debug = require("debug")("decoder:test:compatible-nativize");
+const assert = require("chai").assert;
+const BN = require("bn.js");
+const Ganache = require("ganache-core");
+const path = require("path");
+const Web3 = require("web3");
+
+const Decoder = require("../../..");
+const Codec = require("@truffle/codec");
+
+const { prepareContracts } = require("../../helpers");
+
+describe("compatibleNativize", function () {
+
+  let provider;
+  let abstractions;
+  let compilations;
+  let web3;
+
+  let Contracts;
+
+  before("Create Provider", async function () {
+    provider = Ganache.provider({seed: "decoder", gasLimit: 7000000});
+    web3 = new Web3(provider);
+  });
+
+  before("Prepare contracts and artifacts", async function () {
+    this.timeout(30000);
+
+    const prepared = await prepareContracts(provider, path.resolve(__dirname, ".."));
+    abstractions = prepared.abstractions;
+    compilations = prepared.compilations;
+
+    Contracts = [abstractions.CompatibleNativizeTest];
+  });
+
+  it("should compatibly nativize return values and event arguments", async function () {
+    const { CompatibleNativizeTest } = abstractions;
+    const instance = await CompatibleNativizeTest.new();
+
+    const decoder = await Decoder.forContract(CompatibleNativizeTest);
+
+    const keyedArray = ["hello", "goodbye"];
+    keyedArray.w = "hello";
+    keyedArray.z = "goodbye";
+
+    let expected = {
+      returnString: "hello",
+      emitString: {
+        '0': "hello",
+        z: "hello",
+        __length__: 1
+      },
+      returnTwoStrings: {
+        '0': "hello",
+        w: "hello",
+        '1': "goodbye",
+        z: "goodbye"
+      },
+      emitTwoStrings: {
+        '0': "hello",
+        w: "hello",
+        '1': "goodbye",
+        z: "goodbye",
+        __length__: 2
+      },
+      returnStringPair: keyedArray,
+      emitStringPair: {
+        '0': keyedArray,
+        z: keyedArray,
+        __length__: 1
+      }
+    };
+    expected.returnStringPair.w = "hello";
+    expected.returnStringPair.z = "goodbye";
+
+    for (const entry of CompatibleNativizeTest.abi) {
+      if (entry.type === "function") {
+        const selector = web3.eth.abi.encodeFunctionSignature(entry);
+        if (
+          entry.stateMutability === "view" || entry.stateMutability === "pure"
+        ) {
+          //do a call, decode the return value
+          //we need the raw return data, and contract.call() does not exist yet,
+          //so we're going to have to use web3.eth.call()
+          const data = await web3.eth.call({
+            to: instance.address,
+            data: selector //no arguments
+          });
+          const decodings = await decoder.decodeReturnValue(entry, data);
+          assert.lengthOf(decodings, 1);
+          const decoding = decodings[0];
+          const nativized = Codec.Export.compatibleNativizeReturn(
+            decoding,
+            decoder.getWireDecoder().getUserDefinedTypes() //hack?
+          );
+          assert.deepEqual(nativized, expected[entry.name]);
+        } else {
+          //send a transaction, decode the events
+          const accounts = await web3.eth.getAccounts();
+          const receipt = await web3.eth.sendTransaction({
+            from: accounts[0],
+            to: instance.address,
+            data: selector //no arguments
+          });
+          const logs = receipt.logs;
+          assert.lengthOf(logs, 1);
+          const log = logs[0];
+          const decodings = await decoder.decodeLog(log);
+          assert.lengthOf(decodings, 1);
+          const decoding = decodings[0];
+          const nativized = Codec.Export.compatibleNativizeEventArgs(
+            decoding,
+            decoder.getWireDecoder().getUserDefinedTypes() //hack?
+          );
+          assert.deepEqual(nativized, expected[entry.name]);
+        }
+      }
+    }
+  });
+});

--- a/packages/decoder/test/current/test/compatible-nativize.js
+++ b/packages/decoder/test/current/test/compatible-nativize.js
@@ -91,8 +91,7 @@ describe("compatibleNativize", function () {
           assert.lengthOf(decodings, 1);
           const decoding = decodings[0];
           const nativized = Codec.Export.compatibleNativizeReturn(
-            decoding,
-            decoder.getWireDecoder().getUserDefinedTypes() //hack?
+            decoding
           );
           assert.deepEqual(nativized, expected[entry.name]);
         } else {
@@ -110,8 +109,7 @@ describe("compatibleNativize", function () {
           assert.lengthOf(decodings, 1);
           const decoding = decodings[0];
           const nativized = Codec.Export.compatibleNativizeEventArgs(
-            decoding,
-            decoder.getWireDecoder().getUserDefinedTypes() //hack?
+            decoding
           );
           assert.deepEqual(nativized, expected[entry.name]);
         }

--- a/packages/decoder/test/current/test/compatible-nativize.js
+++ b/packages/decoder/test/current/test/compatible-nativize.js
@@ -44,6 +44,11 @@ describe("nativize (ethers format)", function () {
     keyedArray.w = "hello";
     keyedArray.z = "goodbye";
 
+    const emitStringSelector = Web3.utils.soliditySha3({
+      type: "string",
+      value: "emitString()"
+    }).slice(2, 10); //I've sliced off the 0x
+
     let expected = {
       returnString: "hello",
       emitString: {
@@ -69,7 +74,8 @@ describe("nativize (ethers format)", function () {
         '0': keyedArray,
         z: keyedArray,
         __length__: 1
-      }
+      },
+      returnFunction: instance.address.toLowerCase() + emitStringSelector
     };
     expected.returnStringPair.w = "hello";
     expected.returnStringPair.z = "goodbye";

--- a/packages/decoder/test/current/test/compatible-nativize.js
+++ b/packages/decoder/test/current/test/compatible-nativize.js
@@ -10,7 +10,7 @@ const Codec = require("@truffle/codec");
 
 const { prepareContracts } = require("../../helpers");
 
-describe("compatibleNativize", function () {
+describe("nativize (ethers format)", function () {
 
   let provider;
   let abstractions;
@@ -90,7 +90,7 @@ describe("compatibleNativize", function () {
           const decodings = await decoder.decodeReturnValue(entry, data);
           assert.lengthOf(decodings, 1);
           const decoding = decodings[0];
-          const nativized = Codec.Export.compatibleNativizeReturn(
+          const nativized = Codec.Export.nativizeReturn(
             decoding
           );
           assert.deepEqual(nativized, expected[entry.name]);
@@ -108,7 +108,7 @@ describe("compatibleNativize", function () {
           const decodings = await decoder.decodeLog(log);
           assert.lengthOf(decodings, 1);
           const decoding = decodings[0];
-          const nativized = Codec.Export.compatibleNativizeEventArgs(
+          const nativized = Codec.Export.nativizeEventArgs(
             decoding
           );
           assert.deepEqual(nativized, expected[entry.name]);

--- a/packages/decoder/test/current/test/decoding-test.js
+++ b/packages/decoder/test/current/test/decoding-test.js
@@ -4,7 +4,7 @@ const Ganache = require("ganache-core");
 const path = require("path");
 
 const Decoder = require("../../..");
-const { nativizeDecoderVariables } = require("../../../dist/utils");
+const { unsafeNativizeDecoderVariables } = require("../../../dist/utils");
 const { prepareContracts } = require("../../helpers");
 
 describe("State variable decoding", function () {
@@ -49,7 +49,7 @@ describe("State variable decoding", function () {
 
     assert.equal(initialState.class.typeName, "DecodingSample");
 
-    const variables = nativizeDecoderVariables(initialVariables);
+    const variables = unsafeNativizeDecoderVariables(initialVariables);
 
     assert.notStrictEqual(typeof variables.varUint, "undefined");
 
@@ -152,7 +152,7 @@ describe("State variable decoding", function () {
     );
 
     const initialVariables = await decoder.variables();
-    const variables = nativizeDecoderVariables(initialVariables);
+    const variables = unsafeNativizeDecoderVariables(initialVariables);
 
     assert.equal(variables.varString, "two");
   });

--- a/packages/decoder/test/current/test/downgrade-test.js
+++ b/packages/decoder/test/current/test/downgrade-test.js
@@ -338,14 +338,14 @@ describe("Graceful degradation when information is missing", function() {
     assert.strictEqual(decoding.decodingMode, "full");
     assert.lengthOf(decoding.arguments, 2);
     assert.deepEqual(
-      Codec.Format.Utils.Inspect.nativize(decoding.arguments[0].value),
+      Codec.Format.Utils.Inspect.unsafeNativize(decoding.arguments[0].value),
       {
         x: 107,
         y: 683
       }
     );
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(decoding.arguments[1].value),
+      Codec.Format.Utils.Inspect.unsafeNativize(decoding.arguments[1].value),
       "DowngradeTest.Ternary.No"
     );
   });
@@ -361,28 +361,28 @@ function verifyAbiDecoding(decoding, address) {
   //first argument: {{x: 7, y: 5}, z: 3}
   assert.strictEqual(decoding.arguments[0].value.type.typeClass, "tuple");
   assert.deepEqual(
-    Codec.Format.Utils.Inspect.nativize(decoding.arguments[0].value),
+    Codec.Format.Utils.Inspect.unsafeNativize(decoding.arguments[0].value),
     [[7, 5], 3]
   );
   //second argument: No (i.e. 1)
   assert.strictEqual(decoding.arguments[1].value.type.typeClass, "uint");
   assert.strictEqual(decoding.arguments[1].value.type.bits, 8);
   assert.deepEqual(
-    Codec.Format.Utils.Inspect.nativize(decoding.arguments[1].value),
+    Codec.Format.Utils.Inspect.unsafeNativize(decoding.arguments[1].value),
     1
   );
   //third argument: the contract (i.e. its address)
   assert.strictEqual(decoding.arguments[2].value.type.typeClass, "address");
   assert.strictEqual(decoding.arguments[2].value.type.kind, "general");
   assert.deepEqual(
-    Codec.Format.Utils.Inspect.nativize(decoding.arguments[2].value),
+    Codec.Format.Utils.Inspect.unsafeNativize(decoding.arguments[2].value),
     address
   );
   //fourth argument: the same thing
   assert.strictEqual(decoding.arguments[3].value.type.typeClass, "address");
   assert.strictEqual(decoding.arguments[3].value.type.kind, "general");
   assert.deepEqual(
-    Codec.Format.Utils.Inspect.nativize(decoding.arguments[3].value),
+    Codec.Format.Utils.Inspect.unsafeNativize(decoding.arguments[3].value),
     address
   );
 }
@@ -498,7 +498,7 @@ async function runEnumTestBody(mangledCompilations) {
   assert.strictEqual(decoyDecoding1.abi.name, "EnumSilliness1"); //also let's verify this is the right event
   assert.strictEqual(decoyDecoding1.decodingMode, "abi");
   let nativizedArguments1 = decoyDecoding1.arguments.map(({ value }) =>
-    Codec.Format.Utils.Inspect.nativize(value)
+    Codec.Format.Utils.Inspect.unsafeNativize(value)
   );
   assert.deepStrictEqual(nativizedArguments1, swappedTxArguments);
 
@@ -508,7 +508,7 @@ async function runEnumTestBody(mangledCompilations) {
   assert.strictEqual(decoyDecoding2.abi.name, "EnumSilliness2"); //also let's verify this is the right event
   assert.strictEqual(decoyDecoding2.decodingMode, "abi");
   let nativizedArguments2 = decoyDecoding2.arguments.map(({ value }) =>
-    Codec.Format.Utils.Inspect.nativize(value)
+    Codec.Format.Utils.Inspect.unsafeNativize(value)
   );
   assert.deepStrictEqual(nativizedArguments2, swappedTxArguments);
 }

--- a/packages/decoder/test/current/test/wire-test.js
+++ b/packages/decoder/test/current/test/wire-test.js
@@ -124,21 +124,21 @@ describe("Over-the-wire decoding", function () {
     assert.lengthOf(constructorDecoding.arguments, 3);
     assert.strictEqual(constructorDecoding.arguments[0].name, "status");
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         constructorDecoding.arguments[0].value
       ),
       true
     );
     assert.strictEqual(constructorDecoding.arguments[1].name, "info");
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         constructorDecoding.arguments[1].value
       ),
       "0xdeadbeef"
     );
     assert.strictEqual(constructorDecoding.arguments[2].name, "whoknows");
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         constructorDecoding.arguments[2].value
       ),
       "WireTest.Ternary.MaybeSo"
@@ -150,17 +150,17 @@ describe("Over-the-wire decoding", function () {
     assert.lengthOf(emitStuffDecoding.arguments, 3);
     assert.strictEqual(emitStuffDecoding.arguments[0].name, "p");
     assert.deepEqual(
-      Codec.Format.Utils.Inspect.nativize(emitStuffDecoding.arguments[0].value),
+      Codec.Format.Utils.Inspect.unsafeNativize(emitStuffDecoding.arguments[0].value),
       emitStuffArgs[0]
     );
     assert.strictEqual(emitStuffDecoding.arguments[1].name, "precompiles");
     assert.deepEqual(
-      Codec.Format.Utils.Inspect.nativize(emitStuffDecoding.arguments[1].value),
+      Codec.Format.Utils.Inspect.unsafeNativize(emitStuffDecoding.arguments[1].value),
       emitStuffArgs[1]
     );
     assert.strictEqual(emitStuffDecoding.arguments[2].name, "strings");
     assert.deepEqual(
-      Codec.Format.Utils.Inspect.nativize(emitStuffDecoding.arguments[2].value),
+      Codec.Format.Utils.Inspect.unsafeNativize(emitStuffDecoding.arguments[2].value),
       emitStuffArgs[2]
     );
 
@@ -170,12 +170,12 @@ describe("Over-the-wire decoding", function () {
     assert.lengthOf(moreStuffDecoding.arguments, 2);
     assert.strictEqual(moreStuffDecoding.arguments[0].name, "notThis");
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(moreStuffDecoding.arguments[0].value),
+      Codec.Format.Utils.Inspect.unsafeNativize(moreStuffDecoding.arguments[0].value),
       moreStuffArgs[0]
     );
     assert.strictEqual(moreStuffDecoding.arguments[1].name, "bunchOfInts");
     assert.deepEqual(
-      Codec.Format.Utils.Inspect.nativize(moreStuffDecoding.arguments[1].value),
+      Codec.Format.Utils.Inspect.unsafeNativize(moreStuffDecoding.arguments[1].value),
       moreStuffArgs[1]
     );
 
@@ -185,14 +185,14 @@ describe("Over-the-wire decoding", function () {
     assert.lengthOf(globalTestDecoding.arguments, 2);
     assert.strictEqual(globalTestDecoding.arguments[0].name, "s");
     assert.deepEqual(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         globalTestDecoding.arguments[0].value
       ),
       globalTestArgs[0]
     );
     assert.strictEqual(globalTestDecoding.arguments[1].name, "e");
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         globalTestDecoding.arguments[1].value
       ),
       "GlobalEnum.Yes"
@@ -204,7 +204,7 @@ describe("Over-the-wire decoding", function () {
     assert.lengthOf(inheritedDecoding.arguments, 1);
     assert.isUndefined(inheritedDecoding.arguments[0].name);
     assert.deepEqual(
-      Codec.Format.Utils.Inspect.nativize(inheritedDecoding.arguments[0].value),
+      Codec.Format.Utils.Inspect.unsafeNativize(inheritedDecoding.arguments[0].value),
       inheritedArg
     );
 
@@ -221,12 +221,12 @@ describe("Over-the-wire decoding", function () {
     assert.lengthOf(getterDecoding1.arguments, 2);
     assert.isUndefined(getterDecoding1.arguments[0].name);
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(getterDecoding1.arguments[0].value),
+      Codec.Format.Utils.Inspect.unsafeNativize(getterDecoding1.arguments[0].value),
       getter1Args[0]
     );
     assert.isUndefined(getterDecoding1.arguments[1].name);
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(getterDecoding1.arguments[1].value),
+      Codec.Format.Utils.Inspect.unsafeNativize(getterDecoding1.arguments[1].value),
       getter1Args[1]
     );
 
@@ -236,12 +236,12 @@ describe("Over-the-wire decoding", function () {
     assert.lengthOf(getterDecoding2.arguments, 2);
     assert.isUndefined(getterDecoding2.arguments[0].name);
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(getterDecoding2.arguments[0].value),
+      Codec.Format.Utils.Inspect.unsafeNativize(getterDecoding2.arguments[0].value),
       getter2Args[0]
     );
     assert.isUndefined(getterDecoding2.arguments[1].name);
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(getterDecoding2.arguments[1].value),
+      Codec.Format.Utils.Inspect.unsafeNativize(getterDecoding2.arguments[1].value),
       getter2Args[1]
     );
 
@@ -341,21 +341,21 @@ describe("Over-the-wire decoding", function () {
     assert.lengthOf(constructorEventDecoding.arguments, 3);
     assert.strictEqual(constructorEventDecoding.arguments[0].name, "bit");
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         constructorEventDecoding.arguments[0].value
       ),
       true
     );
     assert.isUndefined(constructorEventDecoding.arguments[1].name);
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         constructorEventDecoding.arguments[1].value
       ),
       "0xdeadbeef"
     );
     assert.isUndefined(constructorEventDecoding.arguments[2].name);
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         constructorEventDecoding.arguments[2].value
       ),
       "WireTest.Ternary.MaybeSo"
@@ -368,21 +368,21 @@ describe("Over-the-wire decoding", function () {
     assert.lengthOf(emitStuffEventDecoding.arguments, 3);
     assert.isUndefined(emitStuffEventDecoding.arguments[0].name);
     assert.deepEqual(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         emitStuffEventDecoding.arguments[0].value
       ),
       emitStuffArgs[0]
     );
     assert.isUndefined(emitStuffEventDecoding.arguments[1].name);
     assert.deepEqual(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         emitStuffEventDecoding.arguments[1].value
       ),
       emitStuffArgs[1]
     );
     assert.isUndefined(emitStuffEventDecoding.arguments[2].name);
     assert.deepEqual(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         emitStuffEventDecoding.arguments[2].value
       ),
       emitStuffArgs[2]
@@ -395,14 +395,14 @@ describe("Over-the-wire decoding", function () {
     assert.lengthOf(moreStuffEventDecoding.arguments, 2);
     assert.isUndefined(moreStuffEventDecoding.arguments[0].name);
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         moreStuffEventDecoding.arguments[0].value
       ),
       moreStuffArgs[0]
     );
     assert.strictEqual(moreStuffEventDecoding.arguments[1].name, "data");
     assert.deepEqual(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         moreStuffEventDecoding.arguments[1].value
       ),
       moreStuffArgs[1]
@@ -415,14 +415,14 @@ describe("Over-the-wire decoding", function () {
     assert.lengthOf(globalTestEventDecoding.arguments, 2);
     assert.isUndefined(globalTestEventDecoding.arguments[0].name);
     assert.deepEqual(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         globalTestEventDecoding.arguments[0].value
       ),
       globalTestArgs[0]
     );
     assert.isUndefined(globalTestEventDecoding.arguments[1].name);
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         globalTestEventDecoding.arguments[1].value
       ),
       "GlobalEnum.Yes"
@@ -444,34 +444,34 @@ describe("Over-the-wire decoding", function () {
     assert.lengthOf(indexTestEventDecoding.arguments, 5);
     assert.isUndefined(indexTestEventDecoding.arguments[0].name);
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         indexTestEventDecoding.arguments[0].value
       ),
       indexTestArgs[0]
     );
     assert.isUndefined(indexTestEventDecoding.arguments[1].name);
     assert.deepEqual(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         indexTestEventDecoding.arguments[1].value
       ),
       indexTestArgs[1]
     );
     assert.isUndefined(indexTestEventDecoding.arguments[2].name);
     assert.deepEqual(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         indexTestEventDecoding.arguments[2].value
       ),
       indexTestArgs[2]
     );
     assert.isUndefined(indexTestEventDecoding.arguments[3].name);
     assert.isUndefined(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         indexTestEventDecoding.arguments[3].value
       ) //can't decode indexed reference type!
     );
     assert.isUndefined(indexTestEventDecoding.arguments[4].name);
     assert.deepEqual(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         indexTestEventDecoding.arguments[4].value
       ),
       indexTestArgs[4]
@@ -490,7 +490,7 @@ describe("Over-the-wire decoding", function () {
     assert.lengthOf(libraryTestEventDecoding.arguments, 1);
     assert.isUndefined(libraryTestEventDecoding.arguments[0].name);
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         libraryTestEventDecoding.arguments[0].value
       ),
       libraryTestArg
@@ -501,7 +501,7 @@ describe("Over-the-wire decoding", function () {
     assert.lengthOf(dangerEventDecoding.arguments, 1);
     assert.isUndefined(dangerEventDecoding.arguments[0].name);
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         dangerEventDecoding.arguments[0].value
       ),
       `WireTest(${address}).danger`
@@ -553,12 +553,12 @@ describe("Over-the-wire decoding", function () {
     );
     assert.lengthOf(ambiguityTestContractDecoding.arguments, 2);
     assert.isUndefined(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         ambiguityTestContractDecoding.arguments[0].value
       )
     );
     assert.deepEqual(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         ambiguityTestContractDecoding.arguments[1].value
       ),
       [32, 3, 17, 18, 19]
@@ -572,13 +572,13 @@ describe("Over-the-wire decoding", function () {
     );
     assert.lengthOf(ambiguityTestLibraryDecoding.arguments, 2);
     assert.deepEqual(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         ambiguityTestLibraryDecoding.arguments[0].value
       ),
       [17, 18, 19]
     );
     assert.isUndefined(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         ambiguityTestLibraryDecoding.arguments[1].value
       )
     );
@@ -591,12 +591,12 @@ describe("Over-the-wire decoding", function () {
     assert.strictEqual(unambiguousDecodings[0].class.typeName, "WireTest");
     assert.lengthOf(unambiguousDecodings[0].arguments, 2);
     assert.isUndefined(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         unambiguousDecodings[0].arguments[0].value
       )
     );
     assert.deepEqual(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         unambiguousDecodings[0].arguments[1].value
       ),
       [32, 1e12, 17, 18, 19]
@@ -605,12 +605,12 @@ describe("Over-the-wire decoding", function () {
     assert.strictEqual(unambiguousDecodings[1].class.typeName, "WireTest");
     assert.lengthOf(unambiguousDecodings[1].arguments, 2);
     assert.isUndefined(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         unambiguousDecodings[1].arguments[0].value
       )
     );
     assert.deepEqual(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         unambiguousDecodings[1].arguments[1].value
       ),
       [32, 3, 257, 257, 257]
@@ -619,12 +619,12 @@ describe("Over-the-wire decoding", function () {
     assert.strictEqual(unambiguousDecodings[2].class.typeName, "WireTest");
     assert.lengthOf(unambiguousDecodings[2].arguments, 2);
     assert.isUndefined(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         unambiguousDecodings[2].arguments[0].value
       )
     );
     assert.deepEqual(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         unambiguousDecodings[2].arguments[1].value
       ),
       [64, 0, 2, 1, 1]
@@ -636,13 +636,13 @@ describe("Over-the-wire decoding", function () {
     );
     assert.lengthOf(unambiguousDecodings[3].arguments, 2);
     assert.deepEqual(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         unambiguousDecodings[3].arguments[0].value
       ),
       [107]
     );
     assert.isUndefined(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         unambiguousDecodings[3].arguments[1].value
       )
     );
@@ -683,7 +683,7 @@ describe("Over-the-wire decoding", function () {
     assert.lengthOf(anonymousTestEvents[0].decodings[0].arguments, 4);
     assert.deepEqual(
       anonymousTestEvents[0].decodings[0].arguments.map(({ value }) =>
-        Codec.Format.Utils.Inspect.nativize(value)
+        Codec.Format.Utils.Inspect.unsafeNativize(value)
       ),
       [257, 1, 1, 1]
     );
@@ -701,7 +701,7 @@ describe("Over-the-wire decoding", function () {
     assert.lengthOf(anonymousTestEvents[1].decodings[0].arguments, 4);
     assert.deepEqual(
       anonymousTestEvents[1].decodings[0].arguments.map(({ value }) =>
-        Codec.Format.Utils.Inspect.nativize(value)
+        Codec.Format.Utils.Inspect.unsafeNativize(value)
       ),
       [1, 2, 3, 4]
     );
@@ -717,7 +717,7 @@ describe("Over-the-wire decoding", function () {
     assert.lengthOf(anonymousTestEvents[1].decodings[1].arguments, 4);
     assert.deepEqual(
       anonymousTestEvents[1].decodings[1].arguments.map(({ value }) =>
-        Codec.Format.Utils.Inspect.nativize(value)
+        Codec.Format.Utils.Inspect.unsafeNativize(value)
       ),
       [1, 2, 3, 4]
     );
@@ -732,7 +732,7 @@ describe("Over-the-wire decoding", function () {
     assert.lengthOf(anonymousTestEvents[2].decodings[0].arguments, 3);
     assert.deepEqual(
       anonymousTestEvents[2].decodings[0].arguments.map(({ value }) =>
-        Codec.Format.Utils.Inspect.nativize(value)
+        Codec.Format.Utils.Inspect.unsafeNativize(value)
       ),
       [1, 2, 3]
     );
@@ -750,7 +750,7 @@ describe("Over-the-wire decoding", function () {
     assert.deepEqual(
       anonymousTestEvents[2].decodings[1].arguments
         .slice(1)
-        .map(({ value }) => Codec.Format.Utils.Inspect.nativize(value)),
+        .map(({ value }) => Codec.Format.Utils.Inspect.unsafeNativize(value)),
       [1, 2, 3]
     );
     assert(
@@ -771,7 +771,7 @@ describe("Over-the-wire decoding", function () {
     );
     assert.lengthOf(anonymousTestEvents[3].decodings[0].arguments, 1);
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         anonymousTestEvents[3].decodings[0].arguments[0].value
       ),
       "0xfe"
@@ -788,7 +788,7 @@ describe("Over-the-wire decoding", function () {
     assert.lengthOf(specifiedNameDecoding.arguments, 4);
     assert.deepEqual(
       specifiedNameDecoding.arguments.map(({ value }) =>
-        Codec.Format.Utils.Inspect.nativize(value)
+        Codec.Format.Utils.Inspect.unsafeNativize(value)
       ),
       [1, 2, 3, 4]
     );
@@ -892,7 +892,7 @@ describe("Over-the-wire decoding", function () {
     assert.strictEqual(decoding.decodingMode, "full");
     assert.lengthOf(decoding.arguments, 2);
     assert.deepEqual(
-      Codec.Format.Utils.Inspect.nativize(decoding.arguments[0].value),
+      Codec.Format.Utils.Inspect.unsafeNativize(decoding.arguments[0].value),
       {
         x: -1,
         y: "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
@@ -900,7 +900,7 @@ describe("Over-the-wire decoding", function () {
       }
     );
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(decoding.arguments[1].value),
+      Codec.Format.Utils.Inspect.unsafeNativize(decoding.arguments[1].value),
       "WireTest.Ternary.No"
     );
 
@@ -957,7 +957,7 @@ describe("Over-the-wire decoding", function () {
     assert.strictEqual(decoding.decodingMode, "full");
     assert.lengthOf(decoding.arguments, 1);
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(decoding.arguments[0].value),
+      Codec.Format.Utils.Inspect.unsafeNativize(decoding.arguments[0].value),
       1
     );
 
@@ -988,7 +988,7 @@ describe("Over-the-wire decoding", function () {
     assert.strictEqual(decoding.decodingMode, "full");
     assert.lengthOf(decoding.arguments, 1);
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(decoding.arguments[0].value),
+      Codec.Format.Utils.Inspect.unsafeNativize(decoding.arguments[0].value),
       2
     );
   });
@@ -1022,7 +1022,7 @@ function testSomeWithoutExtras(decodings) {
   assert.strictEqual(decoding.decodingMode, "full");
   assert.deepEqual(
     decoding.arguments.map(({ value }) =>
-      Codec.Format.Utils.Inspect.nativize(value)
+      Codec.Format.Utils.Inspect.unsafeNativize(value)
     ),
     [1, 2]
   );
@@ -1039,7 +1039,7 @@ function testSomeWithExtras(decodings) {
   assert.strictEqual(decoding.decodingMode, "full");
   assert.deepEqual(
     decoding.arguments.map(({ value }) =>
-      Codec.Format.Utils.Inspect.nativize(value)
+      Codec.Format.Utils.Inspect.unsafeNativize(value)
     ),
     [1, 2]
   );
@@ -1051,7 +1051,7 @@ function testSomeWithExtras(decodings) {
   assert.strictEqual(extraDecoding.decodingMode, "full");
   assert.deepEqual(
     extraDecoding.arguments.map(({ value }) =>
-      Codec.Format.Utils.Inspect.nativize(value)
+      Codec.Format.Utils.Inspect.unsafeNativize(value)
     ),
     [2, 1]
   );

--- a/packages/decoder/test/legacy/test/shadow-test.js
+++ b/packages/decoder/test/legacy/test/shadow-test.js
@@ -53,37 +53,37 @@ describe("Shadowed storage variables", function() {
 
     let decodedX = await decoder.variable("x");
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(decodedX),
+      Codec.Format.Utils.Inspect.unsafeNativize(decodedX),
       expectedDerivedX
     );
     let decodedY = await decoder.variable("y");
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(decodedY),
+      Codec.Format.Utils.Inspect.unsafeNativize(decodedY),
       expectedBaseY
     );
     let decodedZ = await decoder.variable("z");
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(decodedZ),
+      Codec.Format.Utils.Inspect.unsafeNativize(decodedZ),
       expectedDerivedZ
     );
     let decodedBaseX = await decoder.variable("ShadowBase.x");
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(decodedBaseX),
+      Codec.Format.Utils.Inspect.unsafeNativize(decodedBaseX),
       expectedBaseX
     );
     let decodedDerivedX = await decoder.variable("ShadowDerived.x");
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(decodedDerivedX),
+      Codec.Format.Utils.Inspect.unsafeNativize(decodedDerivedX),
       expectedDerivedX
     );
     let decodedBaseY = await decoder.variable("ShadowBase.y");
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(decodedBaseY),
+      Codec.Format.Utils.Inspect.unsafeNativize(decodedBaseY),
       expectedBaseY
     );
     let decodedDerivedZ = await decoder.variable("ShadowDerived.z");
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(decodedDerivedZ),
+      Codec.Format.Utils.Inspect.unsafeNativize(decodedDerivedZ),
       expectedDerivedZ
     );
   });

--- a/packages/decoder/test/legacy/test/wire-test.js
+++ b/packages/decoder/test/legacy/test/wire-test.js
@@ -85,7 +85,7 @@ describe("Over-the-wire decoding (legacy features)", function () {
     );
     assert.lengthOf(overrideTestEvents[1].decodings[0].arguments, 1);
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         overrideTestEvents[1].decodings[0].arguments[0].value
       ),
       107
@@ -107,7 +107,7 @@ describe("Over-the-wire decoding (legacy features)", function () {
     );
     assert.lengthOf(overrideTestEvents[2].decodings[0].arguments, 1);
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         overrideTestEvents[2].decodings[0].arguments[0].value
       ),
       683
@@ -129,7 +129,7 @@ describe("Over-the-wire decoding (legacy features)", function () {
     );
     assert.lengthOf(overrideTestEvents[3].decodings[0].arguments, 1);
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         overrideTestEvents[3].decodings[0].arguments[0].value
       ),
       107
@@ -151,7 +151,7 @@ describe("Over-the-wire decoding (legacy features)", function () {
     );
     assert.lengthOf(overrideTestEvents[4].decodings[0].arguments, 1);
     assert.strictEqual(
-      Codec.Format.Utils.Inspect.nativize(
+      Codec.Format.Utils.Inspect.unsafeNativize(
         overrideTestEvents[4].decodings[0].arguments[0].value
       ),
       683


### PR DESCRIPTION
**This PR is a breaking change to `@truffle/codec`.**

Redo of #3783 because it accidentally got merged early.  Please see description and all comments there.