### PR TITLE
Internal improvement: Have txlog ignore returns from functions we shouldn't be in

### DIFF
--- a/packages/debugger/lib/txlog/sagas/index.js
+++ b/packages/debugger/lib/txlog/sagas/index.js
@@ -57,7 +57,9 @@ function* updateTransactionLogSaga() {
       }
     } else if (jumpDirection === "o") {
       const internal = yield select(txlog.current.inInternalSourceOrYul); //don't log jumps out of internal sources or Yul
-      if (!internal) {
+      const astMatchesTxLog = yield select(txlog.current.currentFunctionIsAsExpected); //don't log returns from the wrong function...?
+      //(I've added this second check due to a strange case Amal found, hopefully this doesn't screw anything up)
+      if (!internal && astMatchesTxLog) {
         //in this case, we have to do decoding & fn identification
         const newPointer = yield select(txlog.current.internalReturnPointer);
         const outputAllocations = yield select(

--- a/packages/debugger/lib/txlog/selectors/index.js
+++ b/packages/debugger/lib/txlog/selectors/index.js
@@ -207,6 +207,31 @@ let txlog = createSelectorTree({
     ),
 
     /**
+     * txlog.current.currentFunctionIsAsExpected
+     *
+     * Does the function we're currently in according to the AST,
+     * match the function we're currently in according to the txlog?
+     * (if we're in a modifier we'll ignore this check)
+     */
+    currentFunctionIsAsExpected: createLeaf(
+      ["./node", data.current.function, data.current.contract],
+      (txlogNode, currentFunction, contractNode) =>
+      currentFunction && 
+      (
+        currentFunction.nodeType === "ContractDefinition" ||
+        currentFunction.nodeType === "ModifierDefinition" ||
+        (
+          currentFunction.nodeType === "FunctionDefinition" &&
+          currentFunction.name === txlogNode.functionName &&
+          (
+            txlogNode.kind === "callexternal" ||
+            (contractNode && contractNode.name === txlogNode.contractName)
+          )
+        )
+      )
+    ),
+
+    /**
      * txlog.current.compilationId
      */
     compilationId: createLeaf([data.current.compilationId], identity),


### PR DESCRIPTION
So, @cds-amal found a case where `txlog` recorded a return value for a function that has no return values.  Obviously the optimizer is to blame, but what exactly happened here?

Something crazy, that's what.  What we have here is a case where a function `f` jumps to the contract node, which then jumps to a function `g` (which was never actually called, to be clear, and there's no jump-in marking here), but then `g` returns (complete with jump-out marking, unbalancing the callstack), and since `g` has a return value, that return value gets attributed to `f`.

So to fix this, to the extent that we can, I added a check -- we won't process returns from functions we're not supposed to be in.  Specifically, when processing a return, we check, does the function we're currently in match the function that txlog says we're in?

Now, I wanted to be careful here -- I did not want any false negatives -- so I checked what function we're returning from by looking at `data.current.function` rather than the current AST node per se.  Also, I turned off the check if we're somehow returning from a modifier (which shouldn't happen, but I want to be careful), or if we're outside a function entirely (say we're in a getter... I didn't want to deal with that case).  But if we're returning from the body of an actual function, then we check that the function name matches the function name the txlog says we're in; and if the txlog says we're in an internal call, then we additional check that the contract name matches too (we determine the current contract name with `data.current.contract`).

This is something of a hack, but, well, that's how dealing with the optimizer goes.

Unfortunately the particular transaction that led to this still has problems, due to the unbalanced jumps, but at least now that just manifests as some spurious `unwind`s.  Unfortunately doing anything about unbalanced jumps is harder.