### PR TITLE
Internal improvement: Remove source-map-support from most packages, add it to db-kit

### DIFF
--- a/packages/abi-utils/package.json
+++ b/packages/abi-utils/package.json
@@ -45,7 +45,6 @@
   "dependencies": {
     "change-case": "3.0.2",
     "faker": "^5.3.1",
-    "fast-check": "^2.12.1",
-    "source-map-support": "^0.5.19"
+    "fast-check": "^2.12.1"
   }
 }

--- a/packages/artifactor/index.ts
+++ b/packages/artifactor/index.ts
@@ -1,4 +1,3 @@
-import "source-map-support/register";
 import Schema from "@truffle/contract-schema";
 import fse from "fs-extra";
 import path from "path";

--- a/packages/artifactor/package.json
+++ b/packages/artifactor/package.json
@@ -17,8 +17,7 @@
     "@truffle/contract-schema": "^3.3.4",
     "fs-extra": "^9.1.0",
     "lodash.assign": "^4.2.0",
-    "lodash.merge": "^4.6.2",
-    "source-map-support": "^0.5.19"
+    "lodash.merge": "^4.6.2"
   },
   "devDependencies": {
     "@truffle/contract": "^4.3.10",

--- a/packages/blockchain-utils/index.ts
+++ b/packages/blockchain-utils/index.ts
@@ -1,4 +1,3 @@
-import "source-map-support/register";
 import { Provider, Callback, JsonRPCResponse } from "web3/providers";
 import { parsedUriObject } from "typings";
 

--- a/packages/blockchain-utils/package.json
+++ b/packages/blockchain-utils/package.json
@@ -16,9 +16,7 @@
     "test": "mocha --exit -r ts-node/register test/**/*.test.ts"
   },
   "types": "./typings/index.d.ts",
-  "dependencies": {
-    "source-map-support": "^0.5.19"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@types/assert": "^1.4.2",
     "@types/mocha": "^5.2.7",

--- a/packages/box/box.ts
+++ b/packages/box/box.ts
@@ -1,4 +1,3 @@
-import "source-map-support/register";
 import utils from "./lib/utils";
 import tmp from "tmp";
 import path from "path";

--- a/packages/box/package.json
+++ b/packages/box/package.json
@@ -20,7 +20,6 @@
     "inquirer": "^7.0.0",
     "request": "^2.85.0",
     "request-promise-native": "^1.0.9",
-    "source-map-support": "^0.5.19",
     "tmp": "^0.2.1",
     "vcsurl": "^0.1.1"
   },

--- a/packages/code-utils/package.json
+++ b/packages/code-utils/package.json
@@ -13,8 +13,7 @@
   },
   "types": "./dist/src/index.d.ts",
   "dependencies": {
-    "cbor": "^5.1.0",
-    "source-map-support": "^0.5.19"
+    "cbor": "^5.1.0"
   },
   "devDependencies": {
     "@types/cbor": "^5.0.1",

--- a/packages/code-utils/src/index.ts
+++ b/packages/code-utils/src/index.ts
@@ -1,4 +1,3 @@
-import "source-map-support/register";
 import parseOpcode from "./opcodes";
 import { Instruction, OpcodeTable, opcodeObject, opcodes } from "./types";
 export { Instruction, OpcodeTable, opcodeObject, opcodes };

--- a/packages/codec/lib/index.ts
+++ b/packages/codec/lib/index.ts
@@ -60,8 +60,6 @@
  * @module @truffle/codec
  */ /** */
 
-import "source-map-support/register";
-
 //So, what shall codec export...?
 
 //First: export the data format

--- a/packages/codec/package.json
+++ b/packages/codec/package.json
@@ -30,7 +30,6 @@
     "lodash.partition": "^4.6.0",
     "lodash.sum": "^4.0.2",
     "semver": "^7.3.4",
-    "source-map-support": "^0.5.19",
     "utf8": "^3.0.0",
     "web3-utils": "1.2.9"
   },

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -25,8 +25,7 @@
     "lodash.assignin": "^4.2.0",
     "lodash.merge": "^4.6.2",
     "module": "^1.2.5",
-    "original-require": "^1.0.1",
-    "source-map-support": "^0.5.19"
+    "original-require": "^1.0.1"
   },
   "devDependencies": {
     "@types/configstore": "^4.0.0",

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,4 +1,3 @@
-import "source-map-support/register";
 import path from "path";
 import assignIn from "lodash.assignin";
 import merge from "lodash.merge";

--- a/packages/contract/index.js
+++ b/packages/contract/index.js
@@ -1,4 +1,3 @@
-require("source-map-support/register");
 const Schema = require("@truffle/contract-schema");
 const Contract = require("./lib/contract");
 const truffleContractVersion = require("./package.json").version;

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -25,7 +25,6 @@
     "bignumber.js": "^7.2.1",
     "ethereum-ens": "^0.8.0",
     "ethers": "^4.0.32",
-    "source-map-support": "^0.5.19",
     "web3": "1.2.9",
     "web3-core-helpers": "1.2.9",
     "web3-core-promievent": "1.2.9",

--- a/packages/db-kit/bin/cli.ts
+++ b/packages/db-kit/bin/cli.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import "source-map-support/register";
 import { start } from "@truffle/db-kit/cli";
 
 async function main() {

--- a/packages/db-kit/package.json
+++ b/packages/db-kit/package.json
@@ -71,6 +71,7 @@
     "ink-syntax-highlight": "^1.0.1",
     "ink-text-input": "^4.0.1",
     "meow": "^9.0.0",
-    "react": "^17.0.1"
+    "react": "^17.0.1",
+    "source-map-support": "^0.5.19"
   }
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -53,7 +53,6 @@
     "pouchdb-adapter-node-websql": "^7.0.0",
     "pouchdb-debug": "^7.1.1",
     "pouchdb-find": "^7.0.0",
-    "source-map-support": "^0.5.19",
     "web3-utils": "1.2.9"
   },
   "devDependencies": {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -263,8 +263,6 @@
 import debugModule from "debug";
 const debug = debugModule("db");
 
-require("source-map-support/register");
-
 import * as Network from "./network";
 export { Network };
 

--- a/packages/debugger/debugger.js
+++ b/packages/debugger/debugger.js
@@ -1,4 +1,3 @@
-require("source-map-support/register");
 var Debugger = require("./lib/debugger").default;
 
 module.exports = Debugger;

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -37,7 +37,6 @@
     "remote-redux-devtools": "^0.5.12",
     "reselect-tree": "^1.3.4",
     "semver": "^7.3.4",
-    "source-map-support": "^0.5.19",
     "web3": "1.2.9",
     "web3-eth-abi": "1.2.9"
   },

--- a/packages/decoder/lib/index.ts
+++ b/packages/decoder/lib/index.ts
@@ -136,8 +136,6 @@ documentation for these individual functions.
  * @module @truffle/decoder
  */ /** */
 
-import "source-map-support/register";
-
 import {
   ContractDecoder,
   ContractInstanceDecoder,

--- a/packages/decoder/package.json
+++ b/packages/decoder/package.json
@@ -27,7 +27,6 @@
     "@truffle/source-map-utils": "^1.3.35",
     "bn.js": "^5.1.3",
     "debug": "^4.3.1",
-    "source-map-support": "^0.5.19",
     "web3": "1.2.9"
   },
   "devDependencies": {

--- a/packages/hdwallet-provider/package.json
+++ b/packages/hdwallet-provider/package.json
@@ -24,8 +24,7 @@
     "ethereum-protocol": "^1.0.1",
     "ethereumjs-tx": "^1.0.0",
     "ethereumjs-util": "^6.1.0",
-    "ethereumjs-wallet": "^1.0.1",
-    "source-map-support": "^0.5.19"
+    "ethereumjs-wallet": "^1.0.1"
   },
   "devDependencies": {
     "@types/bip39": "^2.4.2",

--- a/packages/hdwallet-provider/src/index.ts
+++ b/packages/hdwallet-provider/src/index.ts
@@ -1,4 +1,3 @@
-import "source-map-support/register";
 import * as bip39 from "ethereum-cryptography/bip39";
 import { wordlist } from "ethereum-cryptography/bip39/wordlists/english";
 import * as EthUtil from "ethereumjs-util";

--- a/packages/interface-adapter/lib/index.ts
+++ b/packages/interface-adapter/lib/index.ts
@@ -1,3 +1,2 @@
-import "source-map-support/register";
 export { Web3Shim } from "./shim";
 export { createInterfaceAdapter, InterfaceAdapterOptions } from "./adapter";

--- a/packages/interface-adapter/package.json
+++ b/packages/interface-adapter/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "bn.js": "^5.1.3",
     "ethers": "^4.0.32",
-    "source-map-support": "^0.5.19",
     "web3": "1.2.9"
   },
   "devDependencies": {

--- a/packages/resolver/lib/index.ts
+++ b/packages/resolver/lib/index.ts
@@ -1,5 +1,3 @@
-import "source-map-support/register";
-
 import { Resolver } from "./resolver";
 import { ResolverSource, ResolvedSource } from "./source";
 

--- a/packages/resolver/package.json
+++ b/packages/resolver/package.json
@@ -30,7 +30,6 @@
     "detect-installed": "^2.0.4",
     "get-installed-path": "^4.0.8",
     "glob": "^7.1.6",
-    "source-map-support": "^0.5.19",
     "supports-color": "^7.1.0"
   },
   "devDependencies": {

--- a/packages/source-fetcher/lib/index.ts
+++ b/packages/source-fetcher/lib/index.ts
@@ -1,5 +1,3 @@
-import "source-map-support/register";
-
 import {Fetcher, FetcherConstructor} from "./types";
 import {InvalidNetworkError} from "./common";
 export {Fetcher, FetcherConstructor, InvalidNetworkError};

--- a/packages/source-fetcher/package.json
+++ b/packages/source-fetcher/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "debug": "^4.3.1",
     "request-promise-native": "^1.0.9",
-    "source-map-support": "^0.5.19",
     "web3-utils": "1.2.9"
   },
   "devDependencies": {


### PR DESCRIPTION
Addresses #3924.  This removes `source-map-support` from everywhere that isn't a top-level CLI application/script.  So it's removed from all packages from `core` (where it's used in `cli.js`) and `environment` (where it's used in `chain.js`).  In addition, I added it to `db-kit`, adding the registration in `bin/cli.ts`.