### PR TITLE
Bug fix: Filter out fake import at end rather than start (fix compile errors)

### DIFF
--- a/packages/compile-solidity/parser.js
+++ b/packages/compile-solidity/parser.js
@@ -46,9 +46,10 @@ module.exports = {
       ({ message }) => !message.includes(preReleaseCompilerWarning)
     );
 
+    debug("errors: %O", errors);
+
     // Filter out our forced import, then get the import paths of the rest.
     const imports = errors
-      .filter(({ message }) => !message.includes(failingImportFileName))
       .map(({ formattedMessage, message }) => {
         // Multiline import check which works for solcjs and solc
         // solcjs: ^ (Relevant source part starts here and spans across multiple lines)
@@ -71,7 +72,7 @@ module.exports = {
           if (matches) return matches[2];
         }
       })
-      .filter(match => match !== undefined);
+      .filter(match => match !== undefined && match !== failingImportFileName);
 
     return imports;
   }


### PR DESCRIPTION
This PR should hopefully address #3798, which has been plaguing us for a while.  (Hopefully there isn't some other second bug lurking causing the problem, and we won't have to reopen the issue later...?  But I fixed the one that @fainashalts managed to reproduce.)

The problem (or this problem, anyway) was in the Solidity import parser.  If the fake import was inserted at a spot where it couldn't legally go, the resulting compilation error would contain the fake import in its formatted message, but the error message wouldn't be about a bad import.  This meant that the error wouldn't get filtered out, and the fake import would get processed as a real import, causing the problem.

Now, the right solution to this might be to make sure that we have the correct type of error.  However I didn't want to do that since I'm not familiar with the exact error messages (and we can't rely on numeric error codes because Solidity only started including those in 0.6.10.)  So instead I took a simpler approach: Instead of filtering out certain error messages at the beginning, I filtered out the fake import at the end.  That's obviously more robust anyway.

Anyway, with that done, the problem appears to be solved.  Let's hope that really is it and we don't need to reopen the issue once again!