### PR TITLE
Internal improvement: Cache chain ID to avoid extra network requests

### DIFF
--- a/packages/contract/lib/contract/constructorMethods.js
+++ b/packages/contract/lib/contract/constructorMethods.js
@@ -29,6 +29,9 @@ module.exports = Contract => ({
     // save properties
     this.currentProvider = provider;
     this.networkType = networkType;
+
+    //invalidate cached chain ID
+    this._chainId = undefined;
   },
 
   setProvider(provider) {

--- a/packages/contract/lib/execute.js
+++ b/packages/contract/lib/execute.js
@@ -527,8 +527,17 @@ const execute = {
   sendTransaction: async function (web3, params, promiEvent, context) {
     // get the chainId to be compliant with EIP-155
     // Geth wants this value in base 16 prefixed by "0x"
-    const chainId = await web3.eth.net.getId();
-    params.chainId = `0x${chainId.toString(16)}`;
+    let chainId;
+    if (context.contract._chainId) {
+      chainId = context.contract._chainId;
+    } else {
+      chainId = await web3.eth.net.getId();
+      chainId = `0x${chainId.toString(16)}`;
+      //cache it in a field on the contract
+      //(I'd do this in setProvider instead of here, but that's not async)
+      context.contract._chainId = chainId;
+    }
+    params.chainId = chainId;
 
     //if we don't need the debugger, let's not risk any errors on our part,
     //and just have web3 do everything


### PR DESCRIPTION
This PR is a follow-on to #3923.  That PR added an extra network request with each transaction sent, and I wanted to fix that.

So, this PR adds a chain ID field to contract constructor objects; I called it `_chainId` because I was slightly worried about naming conflicts, but we can change it if that's not what you think it should be named.

Anyway, now when we send transactions, we check that field, and use the chain ID from there if possible; if not we fetch the chain ID from the network and then store it there.

Note, the way I wanted to do this actually would be to get it once in, say, `setProvider`, but we can't do that because it's not `async`.  So, I did the caching where it's used instead.  However I did have `setProvider` (or more generally, `configureNetwork`) set `this._chainId` to `undefined` so we don't have this stale cache mucking things up should the network change.