### PR TITLE
Pass config file value to console if it exists

### DIFF
--- a/packages/core/lib/console-child.js
+++ b/packages/core/lib/console-child.js
@@ -9,7 +9,11 @@ const inputStrings = input[1];
 
 //detect config so we can get the provider and resolver without having to serialize
 //and deserialize them
-const detectedConfig = Config.detect({network: yargs(input[0]).argv.network});
+const args = yargs(input[0]).argv;
+const detectedConfig = Config.detect({
+  network: args.network,
+  config: args.config
+});
 const customConfig = detectedConfig.networks.develop || {};
 
 //need host and port for provider url
@@ -25,7 +29,7 @@ detectedConfig.networks.develop = {
   port: customConfig.port || 9545,
   network_id: customConfig.network_id || 5777,
   provider: function () {
-    return new Web3.providers.HttpProvider(url, {keepAlive: false});
+    return new Web3.providers.HttpProvider(url, { keepAlive: false });
   }
 };
 

--- a/packages/core/lib/console-child.js
+++ b/packages/core/lib/console-child.js
@@ -9,11 +9,8 @@ const inputStrings = input[1];
 
 //detect config so we can get the provider and resolver without having to serialize
 //and deserialize them
-const args = yargs(input[0]).argv;
-const detectedConfig = Config.detect({
-  network: args.network,
-  config: args.config
-});
+const { network, config } = yargs(input[0]).argv;
+const detectedConfig = Config.detect({ network, config });
 const customConfig = detectedConfig.networks.develop || {};
 
 //need host and port for provider url

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -161,18 +161,12 @@ class Console extends EventEmitter {
     // errors/warnings in child process - specifically the error re: having
     // multiple config files
     const spawnOptions = { stdio: ["inherit", "inherit", "pipe"] };
-    let spawnInput;
-    if (options.config) {
-      spawnInput =
-        "--config " +
-        options.config +
-        " --network " +
-        options.network +
-        " -- " +
-        inputStrings;
-    } else {
-      spawnInput = "--network " + options.network + " -- " + inputStrings;
-    }
+    const settings = ["config", "network"]
+      .filter(setting => options[setting])
+      .map(setting => `--${setting} ${options[setting]}`)
+      .join(" ");
+
+    const spawnInput = `${settings} -- ${inputStrings}`;
 
     const spawnResult = spawnSync(
       "node",

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -161,8 +161,19 @@ class Console extends EventEmitter {
     // errors/warnings in child process - specifically the error re: having
     // multiple config files
     const spawnOptions = { stdio: ["inherit", "inherit", "pipe"] };
+    let spawnInput;
+    if (options.config) {
+      spawnInput =
+        "--config " +
+        options.config +
+        " --network " +
+        options.network +
+        " -- " +
+        inputStrings;
+    } else {
+      spawnInput = "--network " + options.network + " -- " + inputStrings;
+    }
 
-    const spawnInput = "--network " + options.network + " -- " + inputStrings;
     const spawnResult = spawnSync(
       "node",
       ["--no-deprecation", childPath, spawnInput],
@@ -170,9 +181,9 @@ class Console extends EventEmitter {
     );
 
     if (spawnResult.stderr) {
-      // Theoretically stderr can contain multiple errors. 
+      // Theoretically stderr can contain multiple errors.
       // So let's just print it instead of throwing through
-      // the error handling mechanism. Bad call? 
+      // the error handling mechanism. Bad call?
       console.log(spawnResult.stderr.toString());
     }
 


### PR DESCRIPTION
This PR passes along the config to `truffle console` when the `--config` flag is used. This is useful for using the console with a custom config file. 