### PR TITLE
Add support for custom config in db-kit

### DIFF
--- a/packages/db-kit/src/cli/App.tsx
+++ b/packages/db-kit/src/cli/App.tsx
@@ -12,17 +12,19 @@ import { Menu } from "./menu";
 
 export interface Props {
   network?: Pick<Resources.Resource<"networks">, "name">;
+  configPath?: string;
 }
 
 export const App = ({
   network = {
     name: "development"
-  }
+  },
+  configPath
 }: Props) => {
   const { exit } = useApp();
   const [shouldQuit, setShouldQuit] = useState<boolean>(false);
 
-  const config = useConfig({ network });
+  const config = useConfig({ network, configPath });
   const { db, project, error } = useDb({ config });
 
   useEffect(() => {
@@ -54,8 +56,10 @@ export const App = ({
             {" Reading truffle-config and connecting to network..."}
           </Text>
         )}
-      {error &&
-      error instanceof DbNotEnabledError && <ActivationInstructions /> // specific error case
+      {
+        error && error instanceof DbNotEnabledError && (
+          <ActivationInstructions />
+        ) // specific error case
       }
       {error &&
       !(error instanceof DbNotEnabledError) && ( // unknown error case

--- a/packages/db-kit/src/cli/hooks/useConfig.ts
+++ b/packages/db-kit/src/cli/hooks/useConfig.ts
@@ -6,14 +6,18 @@ import type { Resources } from "@truffle/db";
 
 export interface UseConfigOptions {
   network: Pick<Resources.Resource<"networks">, "name">;
+  configPath?: string;
 }
 
-export function useConfig({ network: { name } }) {
+export function useConfig({ network: { name }, configPath }) {
   const [config, setConfig] = useState<TruffleConfig | undefined>(undefined);
 
   useEffect(() => {
     setImmediate(() => {
-      const config = TruffleConfig.detect({ network: name });
+      const config = TruffleConfig.detect({
+        network: name,
+        config: configPath
+      });
 
       Environment.detect(config).then(() => setConfig(config));
     });

--- a/packages/db-kit/src/cli/index.ts
+++ b/packages/db-kit/src/cli/index.ts
@@ -11,10 +11,14 @@ const cli = meow(
 
       Options
         --network  Name of network to connect to
+        --config Path to configuration file
 `,
   {
     flags: {
       network: {
+        type: "string"
+      },
+      config: {
         type: "string"
       }
     }
@@ -22,13 +26,14 @@ const cli = meow(
 );
 
 export async function start() {
-  const { network: name } = cli.flags;
+  const { network: name, config: configPath } = cli.flags;
 
   const { waitUntilExit } = render(
     React.createElement(App, {
       network: {
         name
-      }
+      },
+      configPath
     })
   );
 


### PR DESCRIPTION
This was all @gnidan's work, just pushing it so we can get it in develop. We are adding support for a custom config when using `db-kit`, accessed with `--config <your-custom-file>.js`. 