### PR TITLE
Bug fix: If --log is passed with truffle develop, leave the process open

### DIFF
--- a/packages/core/lib/commands/develop.js
+++ b/packages/core/lib/commands/develop.js
@@ -123,9 +123,11 @@ const command = {
       config.logger.log();
     }
 
-    if (!options.log) {
-      return await command.runConsole(config, ganacheOptions);
+    if (options.log) {
+      // leave the process open so that logging can take place
+      return new Promise(() => {});
     }
+    return await command.runConsole(config, ganacheOptions);
   }
 };
 


### PR DESCRIPTION
As reported by @cds-amal in [this issue](https://github.com/trufflesuite/truffle/issues/3909), the `--log` option for `truffle develop` has been broken. It is currently exiting after connecting to the existing develop session. This PR returns an unresolved `Promise` if `--log` is used so that logging can occur.