### PR TITLE
Enhancement: Look inside "build" folder when resolving artifacts

### DIFF
--- a/packages/resolver/lib/sources/npm.ts
+++ b/packages/resolver/lib/sources/npm.ts
@@ -27,20 +27,12 @@ export class NPM implements ResolverSource {
       if (!basePath) {
         continue;
       }
-      const expectedPath = path.join(
-        basePath,
-        "node_modules",
-        packageName,
-        "build",
-        "contracts",
-        contractName + ".json"
-      );
-      try {
-        const result = fs.readFileSync(expectedPath, "utf8");
-        return JSON.parse(result);
-      } catch (e) {
-        continue;
+      const result = this.resolveAndParse(basePath, packageName, contractName);
+      // result is null if it fails to resolve
+      if (result) {
+        return result;
       }
+      continue;
     }
     return null;
   }
@@ -66,6 +58,25 @@ export class NPM implements ResolverSource {
       }
     }
     return { body, filePath: import_path };
+  }
+
+  resolveAndParse(basePath: string, packageName: string, contractName: string) {
+    const packagePath = path.join(basePath, "node_modules", packageName);
+    const subDirs = [`build${path.sep}contracts`, "build"];
+    for (const subDir of subDirs) {
+      const possiblePath = path.join(
+        packagePath,
+        subDir,
+        `${contractName}.json`
+      );
+      try {
+        const result = fs.readFileSync(possiblePath, "utf8");
+        return JSON.parse(result);
+      } catch (e) {
+        continue;
+      }
+    }
+    return null;
   }
 
   // We're resolving package paths to other package paths, not absolute paths.

--- a/packages/resolver/test/fixtures/globalnpm/node_modules/otherPackage/build/OtherTest.json
+++ b/packages/resolver/test/fixtures/globalnpm/node_modules/otherPackage/build/OtherTest.json
@@ -1,0 +1,1 @@
+{ "wallace": "grommit" }

--- a/packages/resolver/test/fixtures/node_modules/package/build/SomeArtifact.json
+++ b/packages/resolver/test/fixtures/node_modules/package/build/SomeArtifact.json
@@ -1,0 +1,3 @@
+{
+  "hello": "mr. anderson"
+}

--- a/packages/resolver/test/globalnpm.ts
+++ b/packages/resolver/test/globalnpm.ts
@@ -27,17 +27,17 @@ describe("globalnpm", () => {
       getInstalledPathSyncStub.restore();
     });
 
-    it("should return null if the import_path starts with '.'", () => {
+    it("returns null if the import_path starts with '.'", () => {
       const result = globalNpm.require("./A.sol");
       assert.deepEqual(result, null);
     });
 
-    it("should return null if the import_path is absolute path", () => {
+    it("returns null if the import_path is absolute path", () => {
       const result = globalNpm.require("/A.sol");
       assert.deepEqual(result, null);
     });
 
-    it("should return the contents of json if the import_path exists", () => {
+    it("returns the contents of json (in build/contracts)", () => {
       syncStub.withArgs("package").returns(true);
       getInstalledPathSyncStub
         .withArgs("package")
@@ -45,12 +45,28 @@ describe("globalnpm", () => {
           path.resolve(__dirname, "fixtures/globalnpm/node_modules/package")
         );
 
-      const result = globalNpm.require("package/contracts/Test.sol");
+      const result = globalNpm.require("package/Test.sol");
 
       assert.deepEqual(result, {});
     });
 
-    it("should return undefined if the import_path does not exist", () => {
+    it("returns the contents of json (in build dir)", () => {
+      syncStub.withArgs("otherPackage").returns(true);
+      getInstalledPathSyncStub
+        .withArgs("otherPackage")
+        .returns(
+          path.resolve(
+            __dirname,
+            "fixtures/globalnpm/node_modules/otherPackage"
+          )
+        );
+
+      const result = globalNpm.require("otherPackage/OtherTest.sol");
+
+      assert.deepEqual(result.wallace, "grommit");
+    });
+
+    it("returns undefined if the import_path does not exist", () => {
       const read_file_sync_stub = sinon.stub(fs, "readFileSync");
 
       syncStub.withArgs("package").returns(false);
@@ -63,7 +79,7 @@ describe("globalnpm", () => {
       read_file_sync_stub.restore();
     });
 
-    it("should return null if readFileSync throws Error", () => {
+    it("returns null if readFileSync throws Error", () => {
       const readFileSyncStub = sinon.stub(fs, "readFileSync");
 
       syncStub.withArgs("package").returns(true);
@@ -99,7 +115,7 @@ describe("globalnpm", () => {
       getInstalledPathSyncStub.restore();
     });
 
-    it("should return the contents of solidity file if the import_path exists", async () => {
+    it("returns the contents of solidity file if the import_path exists", async () => {
       syncStub.withArgs("package").returns(true);
       getInstalledPathSyncStub
         .withArgs("package")
@@ -115,7 +131,7 @@ describe("globalnpm", () => {
       assert.strictEqual(filePath, "package/contracts/Test.sol");
     });
 
-    it("should return undefined body if the package does not exist", async () => {
+    it("returns undefined body if the package does not exist", async () => {
       syncStub.withArgs("package").returns(false);
       getInstalledPathSyncStub
         .withArgs("package")
@@ -131,7 +147,7 @@ describe("globalnpm", () => {
       assert.strictEqual(filePath, "package/contracts/Test.sol");
     });
 
-    it("should return undefined body if readFileSync throws Error", async () => {
+    it("returns undefined body if readFileSync throws Error", async () => {
       const readFileSyncStub = sinon.stub(fs, "readFileSync");
 
       syncStub.withArgs("package").returns(true);

--- a/packages/resolver/test/npm.ts
+++ b/packages/resolver/test/npm.ts
@@ -3,14 +3,17 @@ import assert from "assert";
 import { NPM } from "../lib/sources/npm";
 const npm = new NPM("");
 
-describe("npm", function() {
-  describe("#require()", function() {
-    it("reads package name", function() {
+describe("npm", function () {
+  describe("#require()", function () {
+    it("returns file contents from artifacts in build/contracts", function () {
       let result = npm.require("package/Test", "./test/fixtures");
       assert.deepEqual(result, {});
     });
-
-    it("reads package name with /", function() {
+    it("returns file contents from artifacts in build dir", function () {
+      let result = npm.require("package/SomeArtifact", "./test/fixtures");
+      assert.deepEqual(result.hello, "mr. anderson");
+    });
+    it("reads package name with /", function () {
       let result = npm.require("@org/package/Test", "./test/fixtures");
       assert.deepEqual(result, {});
     });


### PR DESCRIPTION
When checking npm packages for artifacts, Truffle currently expects that package to have the structure of a Truffle project (i.e. it looks in `build/contracts` for artifacts). This PR also checks the `build` folder in those packages. This was prompted by https://github.com/trufflesuite/truffle/issues/3951 where a Uniswap package had artifacts located in a `build` directory.