### PR TITLE
Dependency update: Bump solc to 0.6.0 in contract-schema

### DIFF
--- a/packages/compile-solidity/package.json
+++ b/packages/compile-solidity/package.json
@@ -28,7 +28,7 @@
     "request-promise": "^4.2.2",
     "require-from-string": "^2.0.2",
     "semver": "^7.3.4",
-    "solc": "^0.6.0"
+    "solc": "0.6.0"
   },
   "devDependencies": {
     "@truffle/artifactor": "^4.0.101",

--- a/packages/compile-solidity/test/test_supplier.js
+++ b/packages/compile-solidity/test/test_supplier.js
@@ -18,6 +18,7 @@ describe("CompilerSupplier", function () {
     let oldPragmaFloatSource; // ^0.4.15
     let version4PragmaSource; // ^0.4.21
     let version5PragmaSource; // ^0.5.0
+    let version6PragmaSource; // ^0.6.0
     let versionLatestPragmaSource; // Currently: ^0.8.0
     let compileConfig;
 
@@ -44,7 +45,10 @@ describe("CompilerSupplier", function () {
         path.join(__dirname, "./sources/v0.5.x/Version5Pragma.sol"),
         "utf-8"
       );
-
+      const version6Pragma = await fse.readFile(
+        path.join(__dirname, "./sources/v0.6.x/Version6Pragma.sol"),
+        "utf-8"
+      );
       const versionLatestPragma = await fse.readFile(
         path.join(__dirname, "./sources/v0.8.x/Version8Pragma.sol"), //update when necessary
         "utf-8"
@@ -54,6 +58,7 @@ describe("CompilerSupplier", function () {
       oldPragmaFloatSource = { "OldPragmaFloat.sol": oldPragmaFloat };
       version4PragmaSource = { "NewPragma.sol": version4Pragma };
       version5PragmaSource = { "Version5Pragma.sol": version5Pragma };
+      version6PragmaSource = { "Version6Pragma.sol": version6Pragma };
       versionLatestPragmaSource = { "Version8Pragma.sol": versionLatestPragma }; //update when necessary
     });
 
@@ -128,14 +133,14 @@ describe("CompilerSupplier", function () {
       const localPathOptions = Config.default().merge(options);
 
       const { compilations } = await Compile.sources({
-        sources: version5PragmaSource,
+        sources: version6PragmaSource,
         options: localPathOptions
       });
-      const Version5Pragma = findOne(
-        "Version5Pragma",
+      const Version6Pragma = findOne(
+        "Version6Pragma",
         compilations[0].contracts
       );
-      assert(Version5Pragma.contractName === "Version5Pragma");
+      assert(Version6Pragma.contractName === "Version6Pragma");
     });
 
     it("caches releases and uses them if available", async function () {

--- a/packages/contract-schema/package.json
+++ b/packages/contract-schema/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "json-schema-to-typescript": "^5.5.0",
     "mocha": "8.1.2",
-    "solc": "0.5.16"
+    "solc": "^0.6.0"
   },
   "keywords": [
     "artifacts",

--- a/packages/contract-schema/package.json
+++ b/packages/contract-schema/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "json-schema-to-typescript": "^5.5.0",
     "mocha": "8.1.2",
-    "solc": "^0.6.0"
+    "solc": "0.6.0"
   },
   "keywords": [
     "artifacts",

--- a/packages/contract-schema/test/solc.js
+++ b/packages/contract-schema/test/solc.js
@@ -3,8 +3,8 @@ const solc = require("solc");
 const Schema = require("../");
 const debug = require("debug")("test:solc");
 
-describe("solc", function() {
-  const exampleSolidity = `pragma solidity ^0.5.0;
+describe("solc", function () {
+  const exampleSolidity = `pragma solidity ^0.6.0;
 
 contract A {
   uint x;
@@ -19,7 +19,7 @@ contract B {
 }
 `;
 
-  it("processes solc standard JSON output correctly", function() {
+  it("processes solc standard JSON output correctly", function () {
     this.timeout(5000);
 
     const solcIn = JSON.stringify({
@@ -42,10 +42,7 @@ contract B {
               "devdoc",
               "userdoc"
             ],
-            "": [
-              "ast",
-              "legacyAST"
-            ]
+            "": ["ast", "legacyAST"]
           }
         }
       }
@@ -73,7 +70,7 @@ contract B {
       userdoc: rawA.userdoc
     };
 
-    Object.keys(expected).forEach(function(key) {
+    Object.keys(expected).forEach(function (key) {
       const expectedValue = expected[key];
       const actualValue = A[key];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -25410,6 +25410,20 @@ socks@~2.3.2:
     ip "1.1.5"
     smart-buffer "^4.1.0"
 
+solc@0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.6.0.tgz#061a36075087b5ca16e1c4fc4fad565aa2851fe4"
+  integrity sha512-fYVRKbJLbg0oETBuAJN/ts0X/hj2YgOAl3ly3nrm/qhleVr22ecl3OSXW3hRmOWvH81hJ2KHRYRQWgqioK6d0A==
+  dependencies:
+    command-exists "^1.2.8"
+    commander "3.0.2"
+    fs-extra "^0.30.0"
+    js-sha3 "0.8.0"
+    memorystream "^0.3.1"
+    require-from-string "^2.0.0"
+    semver "^5.5.0"
+    tmp "0.0.33"
+
 solc@^0.4.20:
   version "0.4.26"
   resolved "https://registry.yarnpkg.com/solc/-/solc-0.4.26.tgz#5390a62a99f40806b86258c737c1cf653cc35cb5"
@@ -25420,20 +25434,6 @@ solc@^0.4.20:
     require-from-string "^1.1.0"
     semver "^5.3.0"
     yargs "^4.7.1"
-
-solc@^0.6.0:
-  version "0.6.12"
-  resolved "https://registry.yarnpkg.com/solc/-/solc-0.6.12.tgz#48ac854e0c729361b22a7483645077f58cba080e"
-  integrity sha512-Lm0Ql2G9Qc7yPP2Ba+WNmzw2jwsrd3u4PobHYlSOxaut3TtUbj9+5ZrT6f4DUpNPEoBaFUOEg9Op9C0mk7ge9g==
-  dependencies:
-    command-exists "^1.2.8"
-    commander "3.0.2"
-    fs-extra "^0.30.0"
-    js-sha3 "0.8.0"
-    memorystream "^0.3.1"
-    require-from-string "^2.0.0"
-    semver "^5.5.0"
-    tmp "0.0.33"
 
 sonic-boom@^1.0.2:
   version "1.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -25410,20 +25410,6 @@ socks@~2.3.2:
     ip "1.1.5"
     smart-buffer "^4.1.0"
 
-solc@0.5.16:
-  version "0.5.16"
-  resolved "https://registry.yarnpkg.com/solc/-/solc-0.5.16.tgz#6c8d710a3792ccc79db924606b558a1149b1c603"
-  integrity sha512-weEtRtisJyf+8UjELs7S4ST1KK7UIq6SRB7tpprfJBL9b5mTrZAT7m4gJKi2h6MiBpuSWfnraK8BnkyWzuTMRA==
-  dependencies:
-    command-exists "^1.2.8"
-    commander "3.0.2"
-    fs-extra "^0.30.0"
-    js-sha3 "0.8.0"
-    memorystream "^0.3.1"
-    require-from-string "^2.0.0"
-    semver "^5.5.0"
-    tmp "0.0.33"
-
 solc@^0.4.20:
   version "0.4.26"
   resolved "https://registry.yarnpkg.com/solc/-/solc-0.4.26.tgz#5390a62a99f40806b86258c737c1cf653cc35cb5"


### PR DESCRIPTION
So that Truffle uses the same version of Solidity that compile-solidity uses, this PR bumps the version in contract-schema and updates a test.

I hope this makes CI just a little bit faster.