### PR TITLE
Bug fix: Add missing variable in fetch-external error handling

### DIFF
--- a/packages/core/lib/debug/cli.js
+++ b/packages/core/lib/debug/cli.js
@@ -46,7 +46,11 @@ class CLIDebugger {
     const fetchSpinner = ora(
       "Getting and compiling external sources..."
     ).start();
-    const { badAddresses, badFetchers } = await new DebugExternalHandler(
+    const {
+      badAddresses,
+      badFetchers,
+      badCompilationAddresses
+    } = await new DebugExternalHandler(
       bugger,
       this.config
     ).fetch(); //note: mutates bugger!


### PR DESCRIPTION
Oops, this variable never got declared/defined...