### PR TITLE
Internal improvement: Turn on no-undef ESlint option

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,6 +21,7 @@
     "@typescript-eslint/semi": [ "error", "always" ],
     "no-mixed-operators": "warn",
     "no-tabs": "warn",
-    "no-useless-escape": "warn"
+    "no-useless-escape": "warn",
+    "no-undef": ["error", { "typeof": true }]
   }
 }


### PR DESCRIPTION
We didn't have the ESlint option turned on to prevent one from using undeclared variables.  It's annoying -- ESlint should catch undeclared variables!  So I'm turning that on.  I've also set `typeof: true` because by default, without that, it'll allow undeclared variables as an argument to `typeof`, and, well, we shouldn't have that either.

Note that this rule doesn't need a special `typescript-eslint` version, we just use the eslint version.

Of course, due to #3530, this will frequently have no effect at the moment, but, well, better than not having it, right? :-/