### PR TITLE
Allow different blockchain network architectures in @truffle/reporters

### DIFF
--- a/packages/interface-adapter/lib/adapter/types.ts
+++ b/packages/interface-adapter/lib/adapter/types.ts
@@ -1,3 +1,4 @@
+import BN from "bn.js";
 import {
   Block as EvmBlock,
   BlockType as EvmBlockType,
@@ -18,6 +19,18 @@ export type BlockType = EvmBlockType | any;
 export type Transaction = EvmTransaction | any;
 export type TransactionReceipt = EvmTransactionReceipt | any;
 export type TxHash = string;
+export type TransactionReportData = {
+  timestamp: number;
+  from: string;
+  balance: string;
+  gasUnit: string;
+  gasPrice: string;
+  gas: BN;
+  mainUnit: string;
+  value: string;
+  cost: BN;
+  convertCost: (val: BN) => string;
+};
 
 export interface InterfaceAdapter {
   getNetworkId(): Promise<NetworkId>;
@@ -29,4 +42,5 @@ export interface InterfaceAdapter {
   getCode(address: string): Promise<string>;
   getAccounts(): Promise<string[]>;
   estimateGas(transactionConfig: Transaction): Promise<number>;
+  getTransactionReportData(receipt: TransactionReceipt): Promise<TransactionReportData>;
 }

--- a/packages/interface-adapter/lib/adapter/types.ts
+++ b/packages/interface-adapter/lib/adapter/types.ts
@@ -1,4 +1,4 @@
-import BN from "bn.js";
+import type BN from "bn.js";
 import {
   Block as EvmBlock,
   BlockType as EvmBlockType,

--- a/packages/interface-adapter/lib/adapter/types.ts
+++ b/packages/interface-adapter/lib/adapter/types.ts
@@ -19,17 +19,16 @@ export type BlockType = EvmBlockType | any;
 export type Transaction = EvmTransaction | any;
 export type TransactionReceipt = EvmTransactionReceipt | any;
 export type TxHash = string;
-export type TransactionReportData = {
+export type TransactionCostReport = {
   timestamp: number;
   from: string;
   balance: string;
   gasUnit: string;
   gasPrice: string;
   gas: BN;
-  mainUnit: string;
+  valueUnit: string;
   value: string;
   cost: BN;
-  convertCost: (val: BN) => string;
 };
 
 export interface InterfaceAdapter {
@@ -42,5 +41,6 @@ export interface InterfaceAdapter {
   getCode(address: string): Promise<string>;
   getAccounts(): Promise<string[]>;
   estimateGas(transactionConfig: Transaction): Promise<number>;
-  getTransactionReportData(receipt: TransactionReceipt): Promise<TransactionReportData>;
+  getTransactionCostReport(receipt: TransactionReceipt): Promise<TransactionCostReport>;
+  displayCost(value: BN): string;
 }

--- a/packages/interface-adapter/lib/adapter/web3/index.ts
+++ b/packages/interface-adapter/lib/adapter/web3/index.ts
@@ -6,7 +6,7 @@ import {
   Provider,
   Transaction,
   TransactionReceipt,
-  TransactionReportData
+  TransactionCostReport
 } from "../types";
 
 export interface Web3InterfaceAdapterOptions {
@@ -57,7 +57,7 @@ export class Web3InterfaceAdapter implements InterfaceAdapter {
     return this.web3.eth.getBlockNumber();
   }
 
-  public async getTransactionReportData(receipt: TransactionReceipt): Promise<TransactionReportData> {
+  public async getTransactionCostReport(receipt: TransactionReceipt): Promise<TransactionCostReport> {
     const tx = await this.getTransaction(receipt.transactionHash);
     const block = await this.getBlock(receipt.blockNumber);
 
@@ -76,10 +76,13 @@ export class Web3InterfaceAdapter implements InterfaceAdapter {
       gasUnit: "gwei",
       gasPrice: Web3Shim.utils.fromWei(gasPrice, "gwei"),
       gas,
-      mainUnit: "ETH",
+      valueUnit: "ETH",
       value: Web3Shim.utils.fromWei(value, "ether"),
-      cost,
-      convertCost: (val: BN) => Web3Shim.utils.fromWei(val, "ether")
+      cost
     };
+  }
+
+  public displayCost(value: BN) {
+    return Web3Shim.utils.fromWei(value, "ether");
   }
 }

--- a/packages/migrate/Migration.js
+++ b/packages/migrate/Migration.js
@@ -58,18 +58,19 @@ class Migration {
     // `migrateFn` might be sync or async. We negotiate that difference in
     // `execute` through the deployer API.
     const migrateFn = fn(deployer, options.network, accounts);
-    await this._deploy(options, deployer, resolver, migrateFn);
+    await this._deploy(options, context, deployer, resolver, migrateFn);
   }
 
   /**
    * Initiates deployer sequence, then manages migrations info
    * publication to chain / artifact saving.
    * @param  {Object}   options     config and command-line
+   * @param  {Object}   context     web3 & interfaceAdapter
    * @param  {Object}   deployer    truffle module
    * @param  {Object}   resolver    truffle module
    * @param  {[type]}   migrateFn   module.exports of a migrations.js
    */
-  async _deploy(options, deployer, resolver, migrateFn) {
+  async _deploy(options, context, deployer, resolver, migrateFn) {
     try {
       await deployer.start();
 
@@ -108,7 +109,12 @@ class Migration {
         }
       }
 
-      await this.emitter.emit("postMigrate", this.isLast);
+      const eventArgs = {
+        isLast: this.isLast,
+        interfaceAdapter: context.interfaceAdapter
+      };
+
+      await this.emitter.emit("postMigrate", eventArgs);
 
       let artifacts = resolver
         .contracts()

--- a/packages/reporters/reporters/migrations-V5/messages.js
+++ b/packages/reporters/reporters/migrations-V5/messages.js
@@ -278,9 +278,9 @@ class MigrationsMessages {
           `   > ${"account:".padEnd(20)} ${data.from}\n` +
           `   > ${"balance:".padEnd(20)} ${data.balance}\n` +
           `   > ${"gas used:".padEnd(20)} ${self.decAndHex(data.gas)}\n` +
-          `   > ${"gas price:".padEnd(20)} ${data.gasPrice} gwei\n` +
-          `   > ${"value sent:".padEnd(20)} ${data.value} ETH\n` +
-          `   > ${"total cost:".padEnd(20)} ${data.cost} ETH\n`;
+          `   > ${"gas price:".padEnd(20)} ${data.gasPrice} ${data.gasUnit}\n` +
+          `   > ${"value sent:".padEnd(20)} ${data.value} ${data.mainUnit}\n` +
+          `   > ${"total cost:".padEnd(20)} ${data.cost} ${data.mainUnit}\n`;
 
         if (reporter.confirmations !== 0)
           output += self.underline(
@@ -415,7 +415,7 @@ class MigrationsMessages {
         output +=
           self.underline(37) +
           "\n" +
-          `   > ${"Total cost:".padEnd(15)} ${data.cost.padStart(15)} ETH\n`;
+          `   > ${"Total cost:".padEnd(15)} ${data.cost.padStart(15)} ${data.mainUnit}\n`;
 
         if (self.describeJson) {
           output +=
@@ -437,7 +437,7 @@ class MigrationsMessages {
           self.doubleline("Summary") +
           "\n" +
           `> ${"Total deployments:".padEnd(20)} ${data.totalDeployments}\n` +
-          `> ${"Final cost:".padEnd(20)} ${data.finalCost} ETH\n`;
+          `> ${"Final cost:".padEnd(20)} ${data.finalCost} ${data.mainUnit}\n`;
 
         if (self.describeJson) {
           output +=

--- a/packages/reporters/reporters/migrations-V5/messages.js
+++ b/packages/reporters/reporters/migrations-V5/messages.js
@@ -279,8 +279,8 @@ class MigrationsMessages {
           `   > ${"balance:".padEnd(20)} ${data.balance}\n` +
           `   > ${"gas used:".padEnd(20)} ${self.decAndHex(data.gas)}\n` +
           `   > ${"gas price:".padEnd(20)} ${data.gasPrice} ${data.gasUnit}\n` +
-          `   > ${"value sent:".padEnd(20)} ${data.value} ${data.mainUnit}\n` +
-          `   > ${"total cost:".padEnd(20)} ${data.cost} ${data.mainUnit}\n`;
+          `   > ${"value sent:".padEnd(20)} ${data.value} ${data.valueUnit}\n` +
+          `   > ${"total cost:".padEnd(20)} ${data.cost} ${data.valueUnit}\n`;
 
         if (reporter.confirmations !== 0)
           output += self.underline(
@@ -415,7 +415,7 @@ class MigrationsMessages {
         output +=
           self.underline(37) +
           "\n" +
-          `   > ${"Total cost:".padEnd(15)} ${data.cost.padStart(15)} ${data.mainUnit}\n`;
+          `   > ${"Total cost:".padEnd(15)} ${data.cost.padStart(15)} ${data.valueUnit}\n`;
 
         if (self.describeJson) {
           output +=
@@ -437,7 +437,7 @@ class MigrationsMessages {
           self.doubleline("Summary") +
           "\n" +
           `> ${"Total deployments:".padEnd(20)} ${data.totalDeployments}\n` +
-          `> ${"Final cost:".padEnd(20)} ${data.finalCost} ${data.mainUnit}\n`;
+          `> ${"Final cost:".padEnd(20)} ${data.finalCost} ${data.valueUnit}\n`;
 
         if (self.describeJson) {
           output +=

--- a/packages/truffle/test/scenarios/migrations/describe-json.js
+++ b/packages/truffle/test/scenarios/migrations/describe-json.js
@@ -53,6 +53,8 @@ function verifyMigrationStatuses(statuses, deployingStatusString) {
     assert.equal(status.data.contract.address.slice(0, 2), "0x");
     assert.equal(status.data.contract.address.length, 42);
     assert.equal(status.data.deployed, true);
+    assert.equal(status.data.gasUnit, "gwei");
+    assert.equal(status.data.mainUnit, "ETH");
     cost = parseFloat(status.data.cost);
     assert(cost > 0);
     done();

--- a/packages/truffle/test/scenarios/migrations/describe-json.js
+++ b/packages/truffle/test/scenarios/migrations/describe-json.js
@@ -54,7 +54,7 @@ function verifyMigrationStatuses(statuses, deployingStatusString) {
     assert.equal(status.data.contract.address.length, 42);
     assert.equal(status.data.deployed, true);
     assert.equal(status.data.gasUnit, "gwei");
-    assert.equal(status.data.mainUnit, "ETH");
+    assert.equal(status.data.valueUnit, "ETH");
     cost = parseFloat(status.data.cost);
     assert(cost > 0);
     done();


### PR DESCRIPTION
This PR moves gas calculations and units from the reporter to the interface-adapter. That way we can bring a new architecture without branching code in the reporter.

In summary:
- Unit print values are no longer hardcoded in the message and have been added as part of the data passed.
- In order to operate with gas values to calculate totals, interface adapter returns BN values, as well as a method to convert the value to the final unit that we want to display. Conversion needs to occur at the end as BN does not support decimals.
- Added a couple of assertions to existing tests to verify that units are being added to the data payload.