### PR TITLE
Bug fix: Skip import processing for sources that don't exist

### DIFF
--- a/packages/compile-common/src/profiler/requiredSources.ts
+++ b/packages/compile-common/src/profiler/requiredSources.ts
@@ -124,11 +124,13 @@ export async function requiredSources({
     debug("filesToProcess: %O", filesToProcess);
     const file = filesToProcess.shift();
     debug("file: %s", file);
-    required.push(file);
-    for (const importPath of resolved[file].imports) {
-      debug("importPath: %s", importPath);
-      if (!required.includes(importPath)) { //don't go into a loop!
-        filesToProcess.push(importPath);
+    if (resolved[file]) {
+      required.push(file);
+      for (const importPath of resolved[file].imports) {
+        debug("importPath: %s", importPath);
+        if (!required.includes(importPath)) { //don't go into a loop!
+          filesToProcess.push(importPath);
+        }
       }
     }
   }


### PR DESCRIPTION
Addresses #3798.

Seems the problem was that if an imported source didn't exist, it would get added to the list of sources needing import processing, which would then fail because the source didn't exist.  This PR makes it so we just skip those.

Now, such situations will result in a Solidity compile error, like they should, rather than Truffle crashing.

(This one is my fault, sorry.  May have been an unnoticed interaction between two other changes I made...)