### PR TITLE
Dependency update: Bump TypeScript to ^4.1.4

### DIFF
--- a/packages/artifactor/package.json
+++ b/packages/artifactor/package.json
@@ -33,7 +33,7 @@
     "sinon": "^9.0.2",
     "tmp": "^0.2.1",
     "ts-node": "^9.0.0",
-    "typescript": "3.9.8",
+    "typescript": "^4.1.4",
     "web3": "1.3.5"
   },
   "publishConfig": {

--- a/packages/blockchain-utils/package.json
+++ b/packages/blockchain-utils/package.json
@@ -23,7 +23,7 @@
     "@types/web3": "^1.0.20",
     "mocha": "8.1.2",
     "ts-node": "^9.0.0",
-    "typescript": "3.9.8"
+    "typescript": "^4.1.4"
   },
   "keywords": [
     "blockchain",

--- a/packages/box/package.json
+++ b/packages/box/package.json
@@ -31,7 +31,7 @@
     "mocha": "8.1.2",
     "sinon": "^9.0.2",
     "ts-node": "^9.0.0",
-    "typescript": "3.9.8"
+    "typescript": "^4.1.4"
   },
   "keywords": [
     "boilerplate",

--- a/packages/code-utils/package.json
+++ b/packages/code-utils/package.json
@@ -21,7 +21,7 @@
     "@types/node": "12.12.21",
     "mocha": "8.1.2",
     "ts-node": "^9.0.0",
-    "typescript": "3.9.8"
+    "typescript": "^4.1.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/codec/package.json
+++ b/packages/codec/package.json
@@ -53,7 +53,7 @@
     "ttypescript": "^1.5.7",
     "typedoc": "0.15.0",
     "typedoc-plugin-external-module-name": "^2.1.0",
-    "typescript": "3.9.8"
+    "typescript": "^4.1.4"
   },
   "keywords": [
     "abi",

--- a/packages/compile-common/package.json
+++ b/packages/compile-common/package.json
@@ -17,7 +17,7 @@
     "@truffle/contract-schema": "^3.3.4",
     "@types/fs-extra": "^8.1.0",
     "@types/mocha": "^5.2.7",
-    "typescript": "3.9.8"
+    "typescript": "^4.1.4"
   },
   "dependencies": {
     "@truffle/contract-sources": "^0.1.11",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -37,7 +37,7 @@
     "mocha": "8.1.2",
     "sinon": "^9.0.2",
     "ts-node": "^9.0.0",
-    "typescript": "3.9.8"
+    "typescript": "^4.1.4"
   },
   "keywords": [
     "config",

--- a/packages/db-kit/package.json
+++ b/packages/db-kit/package.json
@@ -48,7 +48,7 @@
     "tsconfig-paths": "^3.9.0",
     "ttypescript": "^1.5.7",
     "typedoc": "^0.20.19",
-    "typescript": "^4.1.3",
+    "typescript": "^4.1.4",
     "typescript-transform-paths": "^2.1.0"
   },
   "bugs": {

--- a/packages/decoder/package.json
+++ b/packages/decoder/package.json
@@ -44,7 +44,7 @@
     "lodash.clonedeep": "^4.5.0",
     "lodash.flatten": "^4.4.0",
     "tmp": "^0.2.1",
-    "typescript": "3.9.8"
+    "typescript": "^4.1.4"
   },
   "keywords": [
     "abi",

--- a/packages/error/package.json
+++ b/packages/error/package.json
@@ -28,6 +28,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "typescript": "^3.9.8"
+    "typescript": "^4.1.4"
   }
 }

--- a/packages/hdwallet-provider/package.json
+++ b/packages/hdwallet-provider/package.json
@@ -37,7 +37,7 @@
     "ganache-core": "2.13.0",
     "mocha": "8.1.2",
     "ts-node": "^9.0.0",
-    "typescript": "3.9.8"
+    "typescript": "^4.1.4"
   },
   "keywords": [
     "etheruem",

--- a/packages/interface-adapter/package.json
+++ b/packages/interface-adapter/package.json
@@ -31,7 +31,7 @@
     "ganache-core": "2.13.0",
     "mocha": "8.1.2",
     "ts-node": "^9.0.0",
-    "typescript": "3.9.8"
+    "typescript": "^4.1.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/interface-adapter/test/fabric-evm-getId.test.ts
+++ b/packages/interface-adapter/test/fabric-evm-getId.test.ts
@@ -31,34 +31,16 @@ async function prepareGanache(
 
 describe("fabric-evm getId Overload", function() {
   it("returns networkID as valid string instead of number w/ fabric-evm=true", async function() {
-    return new Promise(async (resolve, reject) => {
-      let preparedGanache;
-      try {
-        preparedGanache = await prepareGanache(true);
-        const networkID = await preparedGanache.interfaceAdapter.getNetworkId();
-        assert(typeof networkID === "string");
-        preparedGanache.server.close(resolve);
-      } catch (e) {
-        preparedGanache.server.close(() => {
-          reject(e);
-        });
-      }
-    });
+    const preparedGanache = await prepareGanache(true);
+    const networkID = await preparedGanache.interfaceAdapter.getNetworkId();
+    assert(typeof networkID === "string");
+    await preparedGanache.server.close();
   });
 
   it("returns networkID as number w/ fabric-evm=false", async function() {
-    return new Promise(async (resolve, reject) => {
-      let preparedGanache;
-      try {
-        preparedGanache = await prepareGanache(false);
-        const networkID = await preparedGanache.interfaceAdapter.getNetworkId();
-        assert(typeof networkID === "number");
-        preparedGanache.server.close(resolve);
-      } catch (e) {
-        preparedGanache.server.close(() => {
-          reject(e);
-        });
-      }
-    });
+    const preparedGanache = await prepareGanache(false);
+    const networkID = await preparedGanache.interfaceAdapter.getNetworkId();
+    assert(typeof networkID === "number");
+    await preparedGanache.server.close();
   });
 });

--- a/packages/interface-adapter/test/quorum-decodeParameters.test.ts
+++ b/packages/interface-adapter/test/quorum-decodeParameters.test.ts
@@ -33,23 +33,14 @@ const emptyByte = "";
 
 describe("Quorum decodeParameters Overload", function() {
   it("decodes an empty byte to a '0' string value w/ quorum=true", async function() {
-    return new Promise(async (resolve, reject) => {
-      let preparedGanache;
-      try {
-        preparedGanache = await prepareGanache(true);
-        const result = await preparedGanache.web3Shim.eth.abi.decodeParameters(
-          expectedOutput,
-          emptyByte
-        );
-        assert(result);
-        assert(result.retVal === "0");
-        preparedGanache.server.close(resolve);
-      } catch (e) {
-        preparedGanache.server.close(() => {
-          reject(e);
-        });
-      }
-    });
+    const preparedGanache = await prepareGanache(true);
+    const result = await preparedGanache.web3Shim.eth.abi.decodeParameters(
+      expectedOutput,
+      emptyByte
+    );
+    assert(result);
+    assert(result.retVal === "0");
+    await preparedGanache.server.close();
   });
 
   // ganache-core uses web3@1.0.0-beta.35 which doesn't include the 'Out of Gas?' decoder guard!

--- a/packages/interface-adapter/test/quorum-getBlock.test.ts
+++ b/packages/interface-adapter/test/quorum-getBlock.test.ts
@@ -35,39 +35,21 @@ async function prepareGanache(
 
 describe("Quorum getBlock Overload", function() {
   it("recovers block timestamp as hexstring instead of number w/ quorum=true", async function() {
-    return new Promise(async (resolve, reject) => {
-      let preparedGanache;
-      try {
-        preparedGanache = await prepareGanache(true);
-        const block = await preparedGanache.interfaceAdapter.getBlock(0);
-        const expectedBlockTime = new BN(genesisBlockTime.getTime()).divn(1000);
-        assert.strictEqual(
-          block.timestamp,
-          "0x" + expectedBlockTime.toString(16)
-        );
-        preparedGanache.server.close(resolve);
-      } catch (e) {
-        preparedGanache.server.close(() => {
-          reject(e);
-        });
-      }
-    });
+    const preparedGanache = await prepareGanache(true);
+    const block = await preparedGanache.interfaceAdapter.getBlock(0);
+    const expectedBlockTime = new BN(genesisBlockTime.getTime()).divn(1000);
+    assert.strictEqual(
+      block.timestamp,
+      "0x" + expectedBlockTime.toString(16)
+    );
+    await preparedGanache.server.close();
   });
 
   it("recovers block timestamp as number w/ quorum=false", async function() {
-    return new Promise(async (resolve, reject) => {
-      let preparedGanache;
-      try {
-        preparedGanache = await prepareGanache(false);
-        const block = await preparedGanache.interfaceAdapter.getBlock(0);
-        const expectedBlockTime = new BN(genesisBlockTime.getTime()).divn(1000);
-        assert.strictEqual(block.timestamp, expectedBlockTime.toNumber());
-        preparedGanache.server.close(resolve);
-      } catch (e) {
-        preparedGanache.server.close(() => {
-          reject(e);
-        });
-      }
-    });
+    const preparedGanache = await prepareGanache(false);
+    const block = await preparedGanache.interfaceAdapter.getBlock(0);
+    const expectedBlockTime = new BN(genesisBlockTime.getTime()).divn(1000);
+    assert.strictEqual(block.timestamp, expectedBlockTime.toNumber());
+    await preparedGanache.server.close();
   });
 });

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -23,7 +23,7 @@
     "@types/node": "^14.0.13",
     "jest": "^26.0.1",
     "ts-jest": "^26.1.0",
-    "typescript": "^3.8.3"
+    "typescript": "^4.1.4"
   },
   "dependencies": {
     "@truffle/error": "^0.0.8",

--- a/packages/preserve-fs/package.json
+++ b/packages/preserve-fs/package.json
@@ -27,7 +27,7 @@
     "jest": "^26.0.1",
     "tmp-promise": "^3.0.2",
     "ts-jest": "^26.1.0",
-    "typescript": "^3.8.3"
+    "typescript": "^4.1.4"
   },
   "dependencies": {
     "@truffle/preserve": "^0.2.0"

--- a/packages/preserve-to-buckets/package.json
+++ b/packages/preserve-to-buckets/package.json
@@ -26,7 +26,7 @@
     "ipfsd-ctl": "^7.2.0",
     "jest": "^26.6.3",
     "ts-jest": "^26.5.0",
-    "typescript": "^4.1.3"
+    "typescript": "^4.1.4"
   },
   "dependencies": {
     "@textile/hub": "^6.0.2",

--- a/packages/preserve-to-filecoin/package.json
+++ b/packages/preserve-to-filecoin/package.json
@@ -27,7 +27,7 @@
     "ganache": "^3.0.0-filecoin.3",
     "jest": "^26.6.3",
     "ts-jest": "^26.5.0",
-    "typescript": "^4.1.3"
+    "typescript": "^4.1.4"
   },
   "dependencies": {
     "@truffle/preserve": "^0.2.0",

--- a/packages/preserve-to-ipfs/package.json
+++ b/packages/preserve-to-ipfs/package.json
@@ -27,7 +27,7 @@
     "jest": "^26.6.3",
     "semver": "^7.3.4",
     "ts-jest": "^26.5.0",
-    "typescript": "^4.1.3"
+    "typescript": "^4.1.4"
   },
   "dependencies": {
     "@truffle/preserve": "^0.2.0",

--- a/packages/preserve/package.json
+++ b/packages/preserve/package.json
@@ -26,7 +26,7 @@
     "jest": "^26.0.1",
     "ts-jest": "^26.1.0",
     "typedoc": "^0.20.34",
-    "typescript": "^3.8.3"
+    "typescript": "^4.1.4"
   },
   "dependencies": {
     "spinnies": "^0.5.1"

--- a/packages/provisioner/package.json
+++ b/packages/provisioner/package.json
@@ -28,7 +28,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "typescript": "^3.9.8"
+    "typescript": "^4.1.4"
   },
   "dependencies": {
     "@truffle/config": "^1.2.37"

--- a/packages/resolver/package.json
+++ b/packages/resolver/package.json
@@ -38,7 +38,7 @@
     "mocha": "8.1.2",
     "sinon": "^9.0.2",
     "ts-node": "^9.0.0",
-    "typescript": "3.9.8"
+    "typescript": "^4.1.4"
   },
   "keywords": [
     "dependencies",

--- a/packages/source-fetcher/package.json
+++ b/packages/source-fetcher/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@types/debug": "^4.1.5",
     "@types/request-promise-native": "^1.0.17",
-    "typescript": "3.9.8"
+    "typescript": "^4.1.4"
   },
   "keywords": [
     "ethereum",

--- a/yarn.lock
+++ b/yarn.lock
@@ -27394,11 +27394,6 @@ typescript@^3.0.3, typescript@^3.7.5, typescript@^3.8.3, typescript@^3.9.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
-typescript@^4.1.3:
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.5.tgz#123a3b214aaff3be32926f0d8f1f6e704eb89a72"
-  integrity sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==
-
 typescript@^4.1.4:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.4.tgz#f058636e2f4f83f94ddaae07b20fd5e14598432f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -27384,7 +27384,7 @@ typescript@3.6.x:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.4.tgz#b18752bb3792bc1a0281335f7f6ebf1bbfc5b91d"
   integrity sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==
 
-typescript@3.9.8, typescript@^3.9.8:
+typescript@3.9.8:
   version "3.9.8"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.8.tgz#7d937ba4e4044af7fa83d127b982f8f61ca816a4"
   integrity sha512-nDbnFkUZZjkQ92qwKX+C+jtk4OGfU8H9toSEs3uAsl8cxLjG2sqQm6leF/pLWvm9FAEJ6KHkYMAbHYaY2ITeVg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -27384,11 +27384,6 @@ typescript@3.6.x:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.4.tgz#b18752bb3792bc1a0281335f7f6ebf1bbfc5b91d"
   integrity sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==
 
-typescript@3.9.8:
-  version "3.9.8"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.8.tgz#7d937ba4e4044af7fa83d127b982f8f61ca816a4"
-  integrity sha512-nDbnFkUZZjkQ92qwKX+C+jtk4OGfU8H9toSEs3uAsl8cxLjG2sqQm6leF/pLWvm9FAEJ6KHkYMAbHYaY2ITeVg==
-
 typescript@^3.0.3, typescript@^3.7.5, typescript@^3.8.3, typescript@^3.9.5:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"


### PR DESCRIPTION
Truffle currently uses 5 different versions of TS. This PR bumps all packages to use ^4.1.4.