### PR TITLE
Bug fix: Fix watch command

### DIFF
--- a/packages/core/lib/commands/watch.js
+++ b/packages/core/lib/commands/watch.js
@@ -59,6 +59,7 @@ const command = {
     config.logger.log(
       colors.green("Watching for a change in project files...")
     );
+    return new Promise(() => {});
   }
 };
 


### PR DESCRIPTION
Currently the process is not being left open when `truffle watch` is executed and so "watching" does not actually happen. This PR returns an unresolved Promise so that the process stays open and "watching" will occur :)