### PR TITLE
Update contract-schema and abi-utils for Solidity 0.8.4 (add error type)

### DIFF
--- a/packages/abi-utils/lib/arbitrary.test.ts
+++ b/packages/abi-utils/lib/arbitrary.test.ts
@@ -26,6 +26,10 @@ const arbitraries = {
     arbitrary: Arbitrary.EventEntry(),
     schema: withDefinitions(abiSchema.definitions.Event)
   },
+  ErrorEntry: {
+    arbitrary: Arbitrary.ErrorEntry(),
+    schema: withDefinitions(abiSchema.definitions.Error)
+  },
   FunctionEntry: {
     arbitrary: Arbitrary.FunctionEntry(),
     schema: withDefinitions(abiSchema.definitions.NormalFunction)

--- a/packages/abi-utils/lib/arbitrary.ts
+++ b/packages/abi-utils/lib/arbitrary.ts
@@ -42,6 +42,17 @@ export const EventEntry = () =>
     anonymous: fc.boolean()
   });
 
+export const ErrorEntry = () =>
+  fc.record({
+    type: fc.constant("error"),
+    name: ErrorName(),
+    inputs: fc.array(Parameter(), { maxLength: 10 }).filter(inputs => {
+      // names that are not blank should be unique
+      const names = inputs.map(({ name }) => name).filter(name => name !== "");
+      return names.length === new Set(names).size;
+    })
+  });
+
 export const FunctionEntry = () =>
   fc
     .tuple(
@@ -168,7 +179,7 @@ export const Abi = () =>
       ConstructorEntry(),
       FallbackEntry(),
       ReceiveEntry(),
-      fc.array(fc.oneof(FunctionEntry(), EventEntry()))
+      fc.array(fc.oneof(FunctionEntry(), EventEntry(), ErrorEntry()))
     )
     .chain(([constructor, fallback, receive, entries]) =>
       fc.shuffledSubarray([constructor, fallback, receive, ...entries])
@@ -277,6 +288,7 @@ const reservedWords = new Set([
   "else",
   "emit",
   "enum",
+  "error",
   "ether",
   "event",
   "external",
@@ -395,6 +407,8 @@ const ParameterName = () =>
   );
 const EventName = () =>
   fakerToArb("{{hacker.verb}} {{hacker.noun}}", pascalCase);
+const ErrorName = () =>
+  fakerToArb("{{hacker.noun}} {{hacker.noun}}", pascalCase);
 const FunctionName = () => fakerToArb("{{hacker.verb}} {{hacker.noun}}");
 
 const TypeRecord = (): fc.Arbitrary<any> =>

--- a/packages/abi-utils/lib/arbitrary.ts
+++ b/packages/abi-utils/lib/arbitrary.ts
@@ -146,7 +146,11 @@ export const ConstructorEntry = () =>
     .tuple(
       fc.record({
         type: fc.constant("constructor"),
-        inputs: fc.array(Parameter())
+        inputs: fc.array(Parameter(), { maxLength: 10 }).filter(inputs => {
+          // names that are not blank should be unique
+          const names = inputs.map(({ name }) => name).filter(name => name !== "");
+          return names.length === new Set(names).size;
+        })
       }),
       fc
         .tuple(

--- a/packages/abi-utils/lib/normalize.test.ts
+++ b/packages/abi-utils/lib/normalize.test.ts
@@ -41,12 +41,14 @@ describe("normalize", () => {
   );
 
   testProp(
-    `always includes "stateMutability" for entries that aren't events`,
+    `always includes "stateMutability" for entries that aren't events or errors`,
     [Arbitrary.Abi()],
     looseAbi => {
       const abi = normalize(looseAbi);
 
-      expect(abi.filter(({ type }) => type !== "event")).toSatisfyAll(
+      expect(
+        abi.filter(({ type }) => type !== "event" && type !== "error")
+      ).toSatisfyAll(
         entry => "stateMutability" in entry
       );
     }

--- a/packages/abi-utils/lib/normalize.ts
+++ b/packages/abi-utils/lib/normalize.ts
@@ -8,7 +8,7 @@ type Item<A> = A extends (infer I)[] ? I : never;
 
 export const normalizeEntry = (looseEntry: Item<SchemaAbi> | Entry): Entry => {
   if (looseEntry.type === "event" || looseEntry.type === "error") {
-    // nothing gets normalized for events or errorsright now
+    // nothing gets normalized for events or errors right now
     return looseEntry as Entry;
   }
 

--- a/packages/contract-schema/spec/abi.spec.json
+++ b/packages/contract-schema/spec/abi.spec.json
@@ -6,6 +6,7 @@
   "type": "array",
   "items": { "oneOf": [
     { "$ref": "#/definitions/Event" },
+    { "$ref": "#/definitions/Error" },
     { "$ref": "#/definitions/ConstructorFunction" },
     { "$ref": "#/definitions/FallbackFunction" },
     { "$ref": "#/definitions/ReceiveFunction" },
@@ -147,6 +148,23 @@
         "anonymous": { "type": "boolean" }
       },
       "required": ["type", "name", "inputs", "anonymous"],
+      "additionalProperties": false
+    },
+
+    "Error": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["error"]
+        },
+        "name": { "$ref": "#/definitions/Name" },
+        "inputs": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/Parameter" }
+        }
+      },
+      "required": ["type", "name", "inputs"],
       "additionalProperties": false
     },
 

--- a/packages/contract-schema/test/abi-schema.js
+++ b/packages/contract-schema/test/abi-schema.js
@@ -144,6 +144,128 @@ describe("ABI Schema", function() {
     });
   });
 
+  describe("error definition", function() {
+    it("validates with all fields valid", function() {
+      var abi = [
+        {
+          type: "error",
+          name: "InsufficientBalance",
+          inputs: [
+            {
+              name: "needed",
+              type: "uint256",
+            },
+            {
+              name: "actual",
+              type: "uint256",
+            }
+          ]
+        }
+      ];
+
+      assert(validate(abi));
+    });
+
+    it("cannot omit type", function() {
+      var abi = [
+        {
+          name: "InsufficientBalance",
+          inputs: [
+            {
+              name: "needed",
+              type: "uint256",
+            },
+            {
+              name: "actual",
+              type: "uint256",
+            }
+          ]
+        }
+      ];
+
+      assert(!validate(abi));
+    });
+
+    it("cannot omit name", function() {
+      var abi = [
+        {
+          type: "error",
+          inputs: [
+            {
+              name: "needed",
+              type: "uint256",
+            },
+            {
+              name: "actual",
+              type: "uint256",
+            }
+          ]
+        }
+      ];
+
+      assert(!validate(abi));
+    });
+
+    it("cannot omit inputs", function() {
+      var abi = [
+        {
+          type: "error",
+          name: "InsufficientBalance"
+        }
+      ];
+
+      assert(!validate(abi));
+    });
+  });
+
+  describe("normal function definition", function() {
+    it("can omit type, outputs, constant, and payable", function() {
+      var abi = [
+        {
+          name: "press",
+          inputs: [
+            {
+              name: "button",
+              type: "uint256"
+            }
+          ],
+          stateMutability: "nonpayable"
+        }
+      ];
+
+      assert(validate(abi));
+      assert.equal(abi[0].type, "function");
+      assert.equal(abi[0].stateMutability, "nonpayable");
+      assert.deepEqual(abi[0].outputs, []);
+    });
+
+    it("cannot omit name", function() {
+      var abi = [
+        {
+          type: "function",
+          outputs: [],
+          inputs: [],
+          stateMutability: "nonpayable"
+        }
+      ];
+
+      assert(!validate(abi));
+    });
+
+    it("cannot omit inputs", function() {
+      var abi = [
+        {
+          name: "pressButton",
+          type: "function",
+          outputs: [],
+          stateMutability: "nonpayable"
+        }
+      ];
+
+      assert(!validate(abi));
+    });
+  });
+
   describe("constructor function definition", function() {
     it("can omit constant, and payable", function() {
       var abi = [

--- a/packages/contract-schema/test/abi-schema.js
+++ b/packages/contract-schema/test/abi-schema.js
@@ -96,53 +96,6 @@ describe("ABI Schema", function() {
       assert(!validate(abi));
     });
   });
-  describe("normal function definition", function() {
-    it("can omit type, outputs, constant, and payable", function() {
-      var abi = [
-        {
-          name: "press",
-          inputs: [
-            {
-              name: "button",
-              type: "uint256"
-            }
-          ],
-          stateMutability: "nonpayable"
-        }
-      ];
-
-      assert(validate(abi));
-      assert.equal(abi[0].type, "function");
-      assert.equal(abi[0].stateMutability, "nonpayable");
-      assert.deepEqual(abi[0].outputs, []);
-    });
-
-    it("cannot omit name", function() {
-      var abi = [
-        {
-          type: "function",
-          outputs: [],
-          inputs: [],
-          stateMutability: "nonpayable"
-        }
-      ];
-
-      assert(!validate(abi));
-    });
-
-    it("cannot omit inputs", function() {
-      var abi = [
-        {
-          name: "pressButton",
-          type: "function",
-          outputs: [],
-          stateMutability: "nonpayable"
-        }
-      ];
-
-      assert(!validate(abi));
-    });
-  });
 
   describe("error definition", function() {
     it("validates with all fields valid", function() {


### PR DESCRIPTION
Solidity 0.8.4 introduces a new type of ABI entry: The error.  These basically look like events, except of course they're `"error"`, not `"event"`, and there's no `indexed` or `anonymous`.

This PR updates the contract-schema and abi-utils packages to account for this.  It adds the new type of ABI entry to the contract schema and adds appropriate tests.  It actually *doesn't* need to add the type to the abi-utils normalization, as this was actually already done earlier; but it does add it to the arbitraries.  (I went with a "noun noun" pattern for naming errors. :) )  And then of course I appropriately updated the tests of both normalization and the arbitraries.

I also added `"error"` to the list of keywords to avoid.

Also, while I was at it, I noticed that constructor parameters weren't being done quite parallel to other sorts of parameters (in particular they lacked the uniqueness check), so I made those line up.

That's all, pretty simple really!