### PR TITLE
Bug fix: Fix sourcify support in source-fetcher

### DIFF
--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -29,7 +29,7 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
   private readonly networkName: string; //not really used as a class member atm
   //but may be in the future
 
-  private readonly domain: string = "contractrepo.komputing.org";
+  private readonly domain: string = "repo.sourcify.dev";
 
   constructor(networkId: number) {
     this.networkId = networkId;
@@ -53,7 +53,9 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     address: string
   ): Promise<Types.SourceInfo | null> {
     const metadata = await this.getMetadata(address);
+    debug("metadata: %O", metadata);
     if (!metadata) {
+      debug("no metadata");
       return null;
     }
     let sources: Types.SourcesByPath;
@@ -93,11 +95,12 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
   ): Promise<Types.SolcMetadata | null> {
     try {
       return await this.requestWithRetries<Types.SolcMetadata>({
-        uri: `https://${this.domain}/contract/${this.networkId}/${address}/metadata.json`,
+        uri: `https://${this.domain}/contracts/full_match/${this.networkId}/${address}/metadata.json`,
         json: true //turns on auto-parsing
       });
     } catch (error) {
       //is this a 404 error? if so just return null
+      debug("error: %O", error);
       if (error.statusCode === 404) {
         return null;
       }
@@ -111,7 +114,7 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     sourcePath: string
   ): Promise<string> {
     return await this.requestWithRetries<string>({
-      uri: `https://${this.domain}/contract/${this.networkId}/${address}/sources/${sourcePath}`
+      uri: `https://${this.domain}/contracts/full_match/${this.networkId}/${address}/sources/${sourcePath}`
     });
   }
 


### PR DESCRIPTION
This PR fixes the sourcify source-fetcher since they broke their interface and we have to update to match it.  Sorry there are no tests for source-fetcher at the moment; I tested it manually.

This PR does not add support for constructor arguments in the sourcify source fetcher.  I was going to, but I'm not entirely certain of the details, so I'm leaving it out for now and we can add it later; more important I think to just get this fixed first.