### PR TITLE
Fixed bug in command line description of truffle unbox

### DIFF
--- a/packages/core/lib/commands/unbox.js
+++ b/packages/core/lib/commands/unbox.js
@@ -12,7 +12,7 @@ const command = {
   description: "Download a Truffle Box, a pre-built Truffle project",
   builder: {},
   help: {
-    usage: "truffle unbox [destination] [<box_name>] [--force]",
+    usage: "truffle unbox [<box_name>] [destination] [--force]",
     options: [
       {
         option: "destination",


### PR DESCRIPTION
The actual command line parses:

`truffle unbox [<box_name>] [destination] [--force]`  

But the command line help shows: 

` truffle unbox [destination] [<box_name>] [--force]`