### PR TITLE
Debugger/decoder support for custom errors; fix for assembly parameters in 0.8.4

### DIFF
--- a/packages/codec/lib/abi-data/allocate/index.ts
+++ b/packages/codec/lib/abi-data/allocate/index.ts
@@ -1070,8 +1070,8 @@ function getReturndataAllocationsForContract(
   compilationId: string,
   compiler: Compiler.CompilerVersion | undefined
 ): RevertReturndataAllocation[] {
-  let useAST = Boolean(contractNode && contractNode.usedErrors);
-  if (useAST) {
+  let useAst = Boolean(contractNode && contractNode.usedErrors);
+  if (useAst) {
     const errorNodes = contractNode.usedErrors.map(
       errorNodeId => referenceDeclarations[errorNodeId]
     );
@@ -1084,9 +1084,9 @@ function getReturndataAllocationsForContract(
         )
       );
     } catch {
-      useAST = false;
+      useAst = false;
     }
-    if (useAST) { //i.e. if the above operation succeeded
+    if (useAst) { //i.e. if the above operation succeeded
       return contractNode.usedErrors.map(
         errorNodeId => referenceDeclarations[errorNodeId]
       ).map((errorNode, index) => allocateError(
@@ -1100,7 +1100,7 @@ function getReturndataAllocationsForContract(
       ));
     }
   }
-  if (!useAST) { //deliberately *not* an else!
+  if (!useAst) { //deliberately *not* an else!
     return abi
       .filter((abiEntry: Abi.Entry) => abiEntry.type === "error")
       .filter(

--- a/packages/codec/lib/abi-data/allocate/types.ts
+++ b/packages/codec/lib/abi-data/allocate/types.ts
@@ -8,15 +8,15 @@ import { DecodingMode } from "@truffle/codec/types";
 import { ImmutableReferences } from "@truffle/contract-schema/spec";
 import * as Format from "@truffle/codec/format";
 
-//for passing to calldata/event/state allocation functions
+//for passing to calldata/returndata/event/state allocation functions
 export interface ContractAllocationInfo {
-  abi?: Abi.Abi; //needed for events & calldata
-  contractNode: Ast.AstNode; //needed for all 3
-  deployedContext?: Contexts.Context; //needed for events & calldata
-  constructorContext?: Contexts.Context; //needed for calldata
+  abi?: Abi.Abi; //needed for all but state
+  contractNode: Ast.AstNode; //needed for all
+  deployedContext?: Contexts.Context; //needed for all
+  constructorContext?: Contexts.Context; //needed for calldata & returndata; eventually will be needed for events
   immutableReferences?: ImmutableReferences; //needed for state
-  compiler: Compiler.CompilerVersion; //needed for all 3
-  compilationId?: string; //needed for all 3
+  compiler: Compiler.CompilerVersion; //needed for all
+  compilationId?: string; //needed for all
 }
 
 export interface AbiSizeInfo {
@@ -141,7 +141,9 @@ export interface EventArgumentAllocation {
 
 //now let's go back and fill in returndata
 export interface ReturndataAllocations {
-  [selector: string]: RevertReturndataAllocation[]
+  [contextHash: string]: { //NOTE: contextHash here can also be "" to represent no context
+    [selector: string]: RevertReturndataAllocation[];
+  };
 }
 
 export type ReturndataAllocation =

--- a/packages/codec/lib/ast/types.ts
+++ b/packages/codec/lib/ast/types.ts
@@ -53,6 +53,7 @@ export interface AstNode {
   anonymous?: boolean;
   contractKind?: Common.ContractKind;
   isConstructor?: boolean;
+  usedErrors?: number[];
   //Note: May need to add more in the future.
   //May also want to create a proper system of AstNode types
   //in the future, but sticking with this for now.

--- a/packages/codec/lib/ast/utils.ts
+++ b/packages/codec/lib/ast/utils.ts
@@ -541,6 +541,8 @@ export function definitionToAbi(
       }
     case "EventDefinition":
       return eventDefinitionToAbi(node, referenceDeclarations);
+    case "ErrorDefinition":
+      return errorDefinitionToAbi(node, referenceDeclarations);
     case "VariableDeclaration":
       if (node.visibility === "public") {
         return getterDefinitionToAbi(node, referenceDeclarations);
@@ -631,6 +633,22 @@ function eventDefinitionToAbi(
     inputs,
     name,
     anonymous
+  };
+}
+
+function errorDefinitionToAbi(
+  node: AstNode,
+  referenceDeclarations: AstNodes
+): Abi.ErrorEntry {
+  let inputs = parametersToAbi(
+    node.parameters.parameters,
+    referenceDeclarations
+  );
+  let name = node.name;
+  return {
+    type: "error",
+    inputs,
+    name
   };
 }
 

--- a/packages/codec/lib/basic/decode/index.ts
+++ b/packages/codec/lib/basic/decode/index.ts
@@ -6,12 +6,8 @@ import * as Conversion from "@truffle/codec/conversion";
 import * as Format from "@truffle/codec/format";
 import * as Contexts from "@truffle/codec/contexts";
 import * as Pointer from "@truffle/codec/pointer";
-import {
-  DecoderRequest,
-  DecoderOptions,
-  PaddingMode,
-  PaddingType
-} from "@truffle/codec/types";
+import { DecoderRequest, DecoderOptions } from "@truffle/codec/types";
+import { PaddingMode, PaddingType } from "@truffle/codec/common";
 import * as Evm from "@truffle/codec/evm";
 import { handleDecodingError, StopDecodingError } from "@truffle/codec/errors";
 import { byteLength } from "@truffle/codec/basic/allocate";

--- a/packages/codec/lib/common/types.ts
+++ b/packages/codec/lib/common/types.ts
@@ -16,6 +16,21 @@ export type Mutability = "pure" | "view" | "nonpayable" | "payable";
 export type ContractKind = "contract" | "library" | "interface";
 
 /**
+ * @Category Enumerations
+ */
+export type PaddingMode = "default" | "permissive" | "zero" | "right";
+//default: check padding; the type of padding is determined by the type
+//permissive: like default, but turns off the check on certain types
+//zero: forces zero-padding even on signed types
+//right: forces right-padding on all types
+
+/**
+ * @Category Enumerations
+ */
+export type PaddingType = "left" | "right" | "signed";
+
+
+/**
  * This error indicates that the decoder was unable to locate a user-defined
  * type (struct, enum, or contract type) via its ID.  Unfortunately, we can't
  * always avoid this at the moment; we're hoping to make this more robust in

--- a/packages/codec/lib/core.ts
+++ b/packages/codec/lib/core.ts
@@ -597,7 +597,9 @@ export function* decodeReturndata(
 ): Generator<DecoderRequest, ReturndataDecoding[], Uint8Array> {
   let possibleAllocations: AbiData.Allocate.ReturndataAllocation[];
   const selector = Conversion.toHexString(info.state.returndata.slice(0,4));
-  const customRevertAllocations = (info.allocations.returndata || { selector: [] })[selector] || [];
+  const contextHash = (info.currentContext || { context: "" }).context; //HACK: "" is used to represent no context
+  const customRevertAllocations =
+    (((info.allocations.returndata || { [contextHash]: {} })[contextHash]) || { [selector]: [] })[selector] || [];
   if (successAllocation === null) {
     possibleAllocations = [
       ...defaultRevertAllocations,

--- a/packages/codec/lib/core.ts
+++ b/packages/codec/lib/core.ts
@@ -457,17 +457,18 @@ export function* decodeEvent(
     }
     //if we've made it here, the allocation works!  hooray!
     debug("allocation accepted!");
+    let decoding: LogDecoding;
     if (allocation.abi.anonymous) {
-      decodings.push({
+      decoding = {
         kind: "anonymous",
         definedIn: contractType,
         class: emittingContractType,
         abi: allocation.abi,
         arguments: decodedArguments,
         decodingMode
-      });
+      };
     } else {
-      decodings.push({
+      decoding = {
         kind: "event",
         definedIn: contractType,
         class: emittingContractType,
@@ -475,7 +476,13 @@ export function* decodeEvent(
         arguments: decodedArguments,
         selector,
         decodingMode
-      });
+      };
+    }
+    decodings.push(decoding);
+    //if we've made this far (so this allocation works), and we were passed an
+    //ID, and it matches this ID, bail out & return this as the *only* decoding
+    if (options.id && allocation.id === options.id) {
+      return [decoding];
     }
   }
   return decodings;
@@ -495,7 +502,7 @@ const panicSelector: Uint8Array = Conversion.toBytes(
   })
 ).subarray(0, Evm.Utils.SELECTOR_SIZE);
 
-const defaultReturnAllocationsHighPriority: AbiData.Allocate.ReturndataAllocation[] = [
+const defaultRevertAllocations: AbiData.Allocate.ReturndataAllocation[] = [
   {
     kind: "revert" as const,
     allocationMode: "full" as const,
@@ -511,6 +518,7 @@ const defaultReturnAllocationsHighPriority: AbiData.Allocate.ReturndataAllocatio
         }
       ]
     },
+    definedIn: null,
     arguments: [
       {
         name: "",
@@ -541,6 +549,7 @@ const defaultReturnAllocationsHighPriority: AbiData.Allocate.ReturndataAllocatio
         }
       ]
     },
+    definedIn: null,
     arguments: [
       {
         name: "",
@@ -559,7 +568,7 @@ const defaultReturnAllocationsHighPriority: AbiData.Allocate.ReturndataAllocatio
   }
 ];
 
-const defaultReturnAllocationsLowPriority: AbiData.Allocate.ReturndataAllocation[] = [
+const defaultEmptyAllocations: AbiData.Allocate.ReturndataAllocation[] = [
   {
     kind: "failure" as const,
     allocationMode: "full" as const,
@@ -574,37 +583,51 @@ const defaultReturnAllocationsLowPriority: AbiData.Allocate.ReturndataAllocation
   }
 ];
 
-const defaultReturnAllocations = [
-  ...defaultReturnAllocationsHighPriority,
-  ...defaultReturnAllocationsLowPriority
-];
-
 /**
  * If there are multiple possibilities, they're always returned in
  * the order: return, revert, returnmessage, failure, empty, bytecode, unknownbytecode
+ * Moreover, within "revert", builtin ones are put above custom ones
  * @Category Decoding
  */
 export function* decodeReturndata(
   info: Evm.EvmInfo,
   successAllocation: AbiData.Allocate.ReturndataAllocation | null, //null here must be explicit
-  status?: boolean //you can pass this to indicate that you know the status
+  status?: boolean, //you can pass this to indicate that you know the status,
+  id?: string //useful when status = false
 ): Generator<DecoderRequest, ReturndataDecoding[], Uint8Array> {
   let possibleAllocations: AbiData.Allocate.ReturndataAllocation[];
+  const selector = Conversion.toHexString(info.state.returndata.slice(0,4));
+  const customRevertAllocations = (info.allocations.returndata || { selector: [] })[selector] || [];
   if (successAllocation === null) {
-    possibleAllocations = defaultReturnAllocations;
+    possibleAllocations = [
+      ...defaultRevertAllocations,
+      ...customRevertAllocations,
+      ...defaultEmptyAllocations
+    ];
   } else {
     switch (successAllocation.kind) {
       case "return":
-        possibleAllocations = [successAllocation, ...defaultReturnAllocations];
+        possibleAllocations = [
+          successAllocation,
+          ...defaultRevertAllocations,
+          ...customRevertAllocations,
+          ...defaultEmptyAllocations
+        ];
         break;
       case "bytecode":
-        possibleAllocations = [...defaultReturnAllocations, successAllocation];
+        possibleAllocations = [
+          ...defaultRevertAllocations,
+          ...customRevertAllocations,
+          ...defaultEmptyAllocations,
+          successAllocation
+        ];
         break;
       case "returnmessage":
         possibleAllocations = [
-          ...defaultReturnAllocationsHighPriority,
+          ...defaultRevertAllocations,
+          ...customRevertAllocations,
           successAllocation,
-          ...defaultReturnAllocationsLowPriority
+          ...defaultEmptyAllocations
         ];
         break;
       //Other cases shouldn't happen so I'm leaving them to cause errors!
@@ -745,11 +768,10 @@ export function* decodeReturndata(
     //if we've made it here, the allocation works!  hooray!
     debug("allocation accepted!");
     let decoding: ReturndataDecoding;
-    let kind = allocation.kind;
-    switch (kind) {
+    switch (allocation.kind) {
       case "return":
         decoding = {
-          kind,
+          kind: "return" as const,
           status: true as const,
           arguments: decodedArguments,
           decodingMode
@@ -757,8 +779,9 @@ export function* decodeReturndata(
         break;
       case "revert":
         decoding = {
-          kind,
+          kind: "revert" as const,
           abi: allocation.abi,
+          definedIn: allocation.definedIn,
           status: false as const,
           arguments: decodedArguments,
           decodingMode
@@ -766,20 +789,25 @@ export function* decodeReturndata(
         break;
       case "selfdestruct":
         decoding = {
-          kind,
+          kind: "selfdestruct" as const,
           status: true as const,
           decodingMode
         };
         break;
       case "failure":
         decoding = {
-          kind,
+          kind: "failure" as const,
           status: false as const,
           decodingMode
         };
         break;
     }
     decodings.push(decoding);
+    //if we've made this far (so this allocation works), and we were passed an
+    //ID, and it matches this ID, bail out & return this as the *only* decoding
+    if (id && allocation.kind === "revert" && allocation.id === id) {
+      return [decoding];
+    }
   }
   return decodings;
 }
@@ -806,9 +834,7 @@ function* decodeBytecode(
   const contractType = Contexts.Import.contextToType(context);
   //now: ignore original allocation (which we didn't even pass :) )
   //and lookup allocation by context
-  const allocation = <ConstructorReturndataAllocation>(
-    info.allocations.calldata.constructorAllocations[context.context].output
-  );
+  const allocation = info.allocations.calldata.constructorAllocations[context.context].output;
   debug("bytecode allocation: %O", allocation);
   //now: add immutables if applicable
   let immutables: StateVariable[] | undefined;

--- a/packages/codec/lib/evm/types.ts
+++ b/packages/codec/lib/evm/types.ts
@@ -9,6 +9,7 @@ import { MemoryAllocations } from "@truffle/codec/memory/allocate/types";
 import {
   AbiAllocations,
   CalldataAllocations,
+  ReturndataAllocations,
   EventAllocations
 } from "@truffle/codec/abi-data/allocate/types";
 import * as Contexts from "@truffle/codec/contexts/types";
@@ -47,6 +48,7 @@ export interface AllocationInfo {
   memory?: MemoryAllocations;
   abi?: AbiAllocations;
   calldata?: CalldataAllocations;
+  returndata?: ReturndataAllocations; //just for custom errors
   event?: EventAllocations;
   state?: StateAllocations;
 }

--- a/packages/codec/lib/format/errors.ts
+++ b/packages/codec/lib/format/errors.ts
@@ -11,7 +11,7 @@ import BN from "bn.js";
 import * as Types from "./types";
 import * as Ast from "@truffle/codec/ast/types";
 import * as Storage from "@truffle/codec/storage/types";
-import { PaddingType } from "@truffle/codec/types";
+import { PaddingType } from "@truffle/codec/common";
 
 /*
  * SECTION 1: Generic types for values in general (including errors).

--- a/packages/codec/lib/format/utils/exception.ts
+++ b/packages/codec/lib/format/utils/exception.ts
@@ -2,7 +2,7 @@ import debugModule from "debug";
 const debug = debugModule("codec:format:utils:exception");
 
 import * as Format from "@truffle/codec/format/common";
-import * as Ast from "@truffle/codec/ast";
+import * as AstUtils from "@truffle/codec/ast/utils";
 import * as Storage from "@truffle/codec/storage/types";
 
 //this function gives an error message
@@ -18,7 +18,7 @@ export function message(error: Format.Errors.ErrorForThrowing): string {
         error.type.id
       }`;
     case "UnsupportedConstantError":
-      return `Unsupported constant type ${Ast.Utils.typeClass(
+      return `Unsupported constant type ${AstUtils.typeClass(
         error.definition
       )}`;
     case "UnusedImmutableError":

--- a/packages/codec/lib/types.ts
+++ b/packages/codec/lib/types.ts
@@ -409,6 +409,14 @@ export interface RevertMessageDecoding {
    */
   abi: Abi.ErrorEntry;
   /**
+   * The class of the contract that (according to this decoding) defined the
+   * error type, as a Format.Types.ContractType.  This will be `null` if the
+   * error was defined outside of the contract or it's one of the builtin
+   * `Error(string)` or `Panic(uint)` types.
+   * May be omitted if we can't determine it, as may occur in ABI mode.
+   */
+  definedIn?: Format.Types.ContractType | null;
+  /**
    * Indicates that this kind of decoding indicates an unsuccessful return.
    */
   status: false;
@@ -597,4 +605,10 @@ export interface LogOptions {
    * the event -- should be returned.  Defaults to `"off"`.
    */
   extras?: ExtrasAllowed;
+  /**
+   * If passed, restricts to events with the given ID.  This is meant for
+   * internal use by Truffle Debugger; you probably don't want to bother
+   * with this option.
+   */
+  id?: string;
 }

--- a/packages/codec/lib/types.ts
+++ b/packages/codec/lib/types.ts
@@ -1,7 +1,9 @@
 import BN from "bn.js";
 
 import * as Abi from "@truffle/abi-utils";
-import * as Format from "@truffle/codec/format";
+import * as Types from "@truffle/codec/format/types";
+import * as Values from "@truffle/codec/format/values";
+import { PaddingMode } from "@truffle/codec/common";
 
 /**
  * A type representing a transaction (calldata) decoding.  As you can see, these come in five types,
@@ -61,11 +63,11 @@ export interface StateVariable {
    * Note that this class may differ from that of the contract being decoded, due
    * to inheritance.
    */
-  class: Format.Types.ContractType;
+  class: Types.ContractType;
   /**
    * The decoded value of the variable.  Note this is a Format.Values.Result, so it may be an error.
    */
-  value: Format.Values.Result;
+  value: Values.Result;
 }
 
 /**
@@ -81,7 +83,7 @@ export interface FunctionDecoding {
   /**
    * The class of contract that was called, as a Format.Types.ContractType.
    */
-  class: Format.Types.ContractType;
+  class: Types.ContractType;
   /**
    * The list of decoded arguments to the function.
    */
@@ -120,7 +122,7 @@ export interface ConstructorDecoding {
   /**
    * The class of contract being constructed, as a Format.Types.ContractType.
    */
-  class: Format.Types.ContractType;
+  class: Types.ContractType;
   /**
    * The list of decoded arguments to the constructor.  This will be empty for a
    * default constructor.
@@ -158,7 +160,7 @@ export interface MessageDecoding {
   /**
    * The class of contract that was called, as a Format.Types.ContractType.
    */
-  class: Format.Types.ContractType;
+  class: Types.ContractType;
   /**
    * The ABI entry for the contract's fallback or receive function that would
    * handle this message; will be null if there is none.
@@ -235,12 +237,12 @@ export interface EventDecoding {
    * having emitted the event, but we decode it as if the library emitted the event, for clarity.
    * (The address of the contract the EVM thinks emitted the event can of course be found in the original log.)
    */
-  class: Format.Types.ContractType;
+  class: Types.ContractType;
   /**
    * The class of the contract that (according to this decoding) defined the event, as a Format.Types.ContractType.
    * May be omitted if we can't determine it, as may occur in ABI mode.
    */
-  definedIn?: Format.Types.ContractType;
+  definedIn?: Types.ContractType;
   /**
    * The list of decoded arguments to the event.
    */
@@ -277,12 +279,12 @@ export interface AnonymousDecoding {
    * having emitted the event, but we decode it as if the library emitted the event, for clarity.
    * (The address of the contract the EVM thinks emitted the event can of course be found in the original log.)
    */
-  class: Format.Types.ContractType;
+  class: Types.ContractType;
   /**
    * The class of the contract that (according to this decoding) defined the event, as a Format.Types.ContractType.
    * May be omitted if we can't determine it, as may occur in ABI mode.
    */
-  definedIn?: Format.Types.ContractType;
+  definedIn?: Types.ContractType;
   /**
    * The list of decoded arguments to the event.
    */
@@ -415,7 +417,7 @@ export interface RevertMessageDecoding {
    * `Error(string)` or `Panic(uint)` types.
    * May be omitted if we can't determine it, as may occur in ABI mode.
    */
-  definedIn?: Format.Types.ContractType | null;
+  definedIn?: Types.ContractType | null;
   /**
    * Indicates that this kind of decoding indicates an unsuccessful return.
    */
@@ -459,7 +461,7 @@ export interface BytecodeDecoding {
   /**
    * The class of contract being constructed, as a Format.Types.ContractType.
    */
-  class: Format.Types.ContractType;
+  class: Types.ContractType;
   /**
    * Decodings for any immutable state variables the created contract contains.
    * Omitted in ABI mode.
@@ -528,7 +530,7 @@ export interface AbiArgument {
    * may contain errors (although event decodings should typically not contain errors;
    * see the [[DecodedLog]] documentation for why).
    */
-  value: Format.Values.Result;
+  value: Values.Result;
 }
 
 /**
@@ -555,14 +557,6 @@ export interface CodeRequest {
   type: "code";
   address: string;
 }
-
-export type PaddingMode = "default" | "permissive" | "zero" | "right";
-//default: check padding; the type of padding is determined by the type
-//permissive: like default, but turns off the check on certain types
-//zero: forces zero-padding even on signed types
-//right: forces right-padding on all types
-
-export type PaddingType = "left" | "right" | "signed";
 
 export interface DecoderOptions {
   paddingMode?: PaddingMode;

--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -695,9 +695,35 @@ var DebugUtils = {
       .join(OS.EOL);
   },
 
+  //note: only intended to be used for *custom* errors :)
+  formatCustomError: function (decoding, indent = 0) {
+    const name = decoding.definedIn
+      ? `${decoding.definedIn.typeName}.${decoding.abi.name}`
+      : decoding.abi.name;
+    if (decoding.arguments.length === 0) {
+      return `${name}()`;
+    }
+    const prefix = `${name}(`;
+    const formattedValues = decoding.arguments.map(
+      ({ name, value }) => {
+        const argumentPrefix = name
+          ? `${name}: `
+          : "";
+        const typeString = ` (type: ${Codec.Format.Types.typeStringWithoutLocation(
+          value.type
+        )})`;
+        return (DebugUtils.formatValue(value, argumentPrefix.length) + typeString + ",")
+          .split(/\r?\n/g)
+          .map(line => " ".repeat(indent) + line)
+          .join(OS.EOL);
+      }
+    );
+    return [prefix, ...formattedValues, ')'].join(OS.EOL);
+  },
+
   formatStacktrace: function (stacktrace, indent = 2) {
     //get message or panic code from stacktrace
-    const { message, panic } = stacktrace[0];
+    const { message, panic, custom } = stacktrace[0];
     //we want to print inner to outer, so first, let's
     //reverse
     stacktrace = stacktrace.slice().reverse(); //reverse is in-place so clone first
@@ -753,6 +779,10 @@ var DebugUtils = {
           : `Panic: ${DebugUtils.panicString(panic)} (code 0x${panic.toString(
               16
             )})`;
+      } else if (custom !== undefined) {
+        statusLine = status
+          ? `Error: Improper return (caused custom error)`
+          : `Error: Revert (custom error)`;
       } else {
         statusLine = status
           ? "Error: Improper return (may be an unexpected self-destruct)"

--- a/packages/debugger/lib/ast/sagas/index.js
+++ b/packages/debugger/lib/ast/sagas/index.js
@@ -56,7 +56,7 @@ function* handleEnter(sourceId, sourceIndex, node, pointer, parentId) {
     case "EventDefinition":
     case "ErrorDefinition":
       debug("%s recording type %o", pointer, node);
-      yield* data.defineEventOrError(node, sourceId);
+      yield* data.defineTaggedOutput(node, sourceId);
       break;
   }
 }

--- a/packages/debugger/lib/ast/sagas/index.js
+++ b/packages/debugger/lib/ast/sagas/index.js
@@ -53,6 +53,11 @@ function* handleEnter(sourceId, sourceIndex, node, pointer, parentId) {
       debug("%s recording type %o", pointer, node);
       yield* data.defineType(node, sourceId);
       break;
+    case "EventDefinition":
+    case "ErrorDefinition":
+      debug("%s recording type %o", pointer, node);
+      yield* data.defineEventOrError(node, sourceId);
+      break;
   }
 }
 

--- a/packages/debugger/lib/data/actions/index.js
+++ b/packages/debugger/lib/data/actions/index.js
@@ -61,10 +61,10 @@ export function defineType(node, sourceId) {
   };
 }
 
-export const DEFINE_EVENT_OR_ERROR = "DATA_DEFINE_EVENT_OR_ERROR";
-export function defineEventOrError(node, sourceId) {
+export const DEFINE_TAGGED_OUTPUT = "DATA_DEFINE_TAGGED_OUTPUT";
+export function defineTaggedOutput(node, sourceId) {
   return {
-    type: DEFINE_EVENT_OR_ERROR,
+    type: DEFINE_TAGGED_OUTPUT,
     node,
     sourceId
   };

--- a/packages/debugger/lib/data/actions/index.js
+++ b/packages/debugger/lib/data/actions/index.js
@@ -61,14 +61,24 @@ export function defineType(node, sourceId) {
   };
 }
 
+export const DEFINE_EVENT_OR_ERROR = "DATA_DEFINE_EVENT_OR_ERROR";
+export function defineEventOrError(node, sourceId) {
+  return {
+    type: DEFINE_EVENT_OR_ERROR,
+    node,
+    sourceId
+  };
+}
+
 export const ALLOCATE = "DATA_ALLOCATE";
-export function allocate(storage, memory, abi, calldata, state) {
+export function allocate(storage, memory, abi, calldata, returndata, state) {
   return {
     type: ALLOCATE,
     storage,
     memory,
     abi,
     calldata,
+    returndata,
     state
   };
 }

--- a/packages/debugger/lib/data/reducers.js
+++ b/packages/debugger/lib/data/reducers.js
@@ -83,10 +83,22 @@ function userDefinedTypes(state = [], action) {
   }
 }
 
+//just going to treat this like userDefinedTypes
+function eventsAndErrors(state = [], action) {
+  switch (action.type) {
+    case actions.DEFINE_EVENT_OR_ERROR:
+      return [...state, { id: action.node.id, sourceId: action.sourceId }];
+    default:
+      return state;
+  }
+}
+
 const DEFAULT_ALLOCATIONS = {
   storage: {},
   memory: {},
   abi: {},
+  calldata: {},
+  returndata: {},
   state: {}
 };
 
@@ -98,6 +110,7 @@ function allocations(state = DEFAULT_ALLOCATIONS, action) {
       memory: action.memory,
       abi: action.abi,
       calldata: action.calldata,
+      returndata: action.returndata,
       state: action.state
     };
   } else {
@@ -108,6 +121,7 @@ function allocations(state = DEFAULT_ALLOCATIONS, action) {
 const info = combineReducers({
   scopes,
   userDefinedTypes,
+  eventsAndErrors,
   allocations
 });
 

--- a/packages/debugger/lib/data/reducers.js
+++ b/packages/debugger/lib/data/reducers.js
@@ -84,9 +84,9 @@ function userDefinedTypes(state = [], action) {
 }
 
 //just going to treat this like userDefinedTypes
-function eventsAndErrors(state = [], action) {
+function taggedOutputs(state = [], action) {
   switch (action.type) {
-    case actions.DEFINE_EVENT_OR_ERROR:
+    case actions.DEFINE_TAGGED_OUTPUT:
       return [...state, { id: action.node.id, sourceId: action.sourceId }];
     default:
       return state;
@@ -121,7 +121,7 @@ function allocations(state = DEFAULT_ALLOCATIONS, action) {
 const info = combineReducers({
   scopes,
   userDefinedTypes,
-  eventsAndErrors,
+  taggedOutputs,
   allocations
 });
 

--- a/packages/debugger/lib/data/sagas/index.js
+++ b/packages/debugger/lib/data/sagas/index.js
@@ -60,6 +60,10 @@ export function* defineType(node, sourceId) {
   yield put(actions.defineType(node, sourceId));
 }
 
+export function* defineEventOrError(node, sourceId) {
+  yield put(actions.defineEventOrError(node, sourceId));
+}
+
 function* tickSaga() {
   yield* variablesAndMappingsSaga();
   yield* trace.signalTickSagaCompletion();
@@ -131,6 +135,7 @@ export function* decodeReturnValue() {
   const contexts = yield select(data.views.contexts);
   const status = yield select(data.current.returnStatus); //may be undefined
   const returnAllocation = yield select(data.current.returnAllocation); //may be null
+  const errorId = yield select(data.current.errorId);
   debug("returnAllocation: %O", returnAllocation);
 
   const decoder = Codec.decodeReturndata(
@@ -141,7 +146,8 @@ export function* decodeReturnValue() {
       contexts
     },
     returnAllocation,
-    status
+    status,
+    errorId
   );
 
   debug("beginning decoding");
@@ -1054,6 +1060,12 @@ export function* recordAllocations() {
     userDefinedTypes,
     abiAllocations
   );
+  const returndataAllocations = Codec.AbiData.Allocate.getReturndataAllocations(
+    contracts,
+    referenceDeclarations,
+    userDefinedTypes,
+    abiAllocations
+  );
   const stateAllocations = Codec.Storage.Allocate.getStateAllocations(
     contracts,
     referenceDeclarations,
@@ -1066,6 +1078,7 @@ export function* recordAllocations() {
       memoryAllocations,
       abiAllocations,
       calldataAllocations,
+      returndataAllocations,
       stateAllocations
     )
   );

--- a/packages/debugger/lib/data/sagas/index.js
+++ b/packages/debugger/lib/data/sagas/index.js
@@ -60,8 +60,8 @@ export function* defineType(node, sourceId) {
   yield put(actions.defineType(node, sourceId));
 }
 
-export function* defineEventOrError(node, sourceId) {
-  yield put(actions.defineEventOrError(node, sourceId));
+export function* defineTaggedOutput(node, sourceId) {
+  yield put(actions.defineTaggedOutput(node, sourceId));
 }
 
 function* tickSaga() {
@@ -426,7 +426,7 @@ function* variablesAndMappingsSaga() {
       //first inputs then outputs (and we skip handling the outputs),
       //yul parameters have the inputs go top to bottom,
       //and the outputs go bottom to top (again with the outputs on top)
-      //For Solidity <0.8.4, we needs we need to handle both inputs and outputs
+      //For Solidity <0.8.4, we need to handle both inputs and outputs
       //here; for Solidity >=0.8.4, we handle only inputs here and handle
       //outputs separately
       let returnSuffixes = [];

--- a/packages/debugger/lib/data/sagas/index.js
+++ b/packages/debugger/lib/data/sagas/index.js
@@ -133,6 +133,7 @@ export function* decodeReturnValue() {
   const state = yield select(data.next.state); //next state has the return data
   const allocations = yield select(data.info.allocations);
   const contexts = yield select(data.views.contexts);
+  const currentContext = yield select(data.current.context);
   const status = yield select(data.current.returnStatus); //may be undefined
   const returnAllocation = yield select(data.current.returnAllocation); //may be null
   const errorId = yield select(data.current.errorId);
@@ -143,7 +144,8 @@ export function* decodeReturnValue() {
       userDefinedTypes,
       state,
       allocations,
-      contexts
+      contexts,
+      currentContext
     },
     returnAllocation,
     status,

--- a/packages/debugger/lib/data/selectors/index.js
+++ b/packages/debugger/lib/data/selectors/index.js
@@ -11,6 +11,7 @@ import { stableKeccak256, makePath } from "lib/helpers";
 import trace from "lib/trace/selectors";
 import evm from "lib/evm/selectors";
 import solidity from "lib/solidity/selectors";
+import stacktrace from "lib/stacktrace/selectors";
 
 import * as Codec from "@truffle/codec";
 
@@ -338,11 +339,16 @@ const data = createSelectorTree({
      * for simplicity, we will assume that generated sources never define types!
      */
     referenceDeclarations: createLeaf(
-      ["./scopes/inlined", "/info/userDefinedTypes", solidity.views.sources],
-      (scopes, userDefinedTypes, sources) =>
+      [
+        "./scopes/inlined",
+        "/info/userDefinedTypes",
+        "/info/eventsAndErrors",
+        solidity.views.sources
+      ],
+      (scopes, userDefinedTypes, eventsAndErrors, sources) =>
         merge(
           {},
-          ...userDefinedTypes.map(({ id, sourceId }) => {
+          ...userDefinedTypes.concat(eventsAndErrors).map(({ id, sourceId }) => {
             const source = sources[sourceId];
             return source.internal
               ? {} //exclude these
@@ -449,7 +455,12 @@ const data = createSelectorTree({
       /*
        * data.info.allocations.calldata
        */
-      calldata: createLeaf(["/state"], state => state.info.allocations.calldata)
+      calldata: createLeaf(["/state"], state => state.info.allocations.calldata),
+
+      /*
+       * data.info.allocations.returndata
+       */
+      returndata: createLeaf(["/state"], state => state.info.allocations.returndata)
     },
 
     /**
@@ -458,6 +469,14 @@ const data = createSelectorTree({
     userDefinedTypes: createLeaf(
       ["/state"],
       state => state.info.userDefinedTypes
+    ),
+
+    /**
+     * data.info.eventsAndErrors
+     */
+    eventsAndErrors: createLeaf(
+      ["/state"],
+      state => state.info.eventsAndErrors
     )
   },
 
@@ -996,6 +1015,57 @@ const data = createSelectorTree({
       ["./context"],
       ({ abi }) => (Object.keys(abi).length > 0 ? 1 : 0)
       //note ABI here has been transformed to include functions only
+    ),
+
+    /**
+     * data.current.errorNodeId
+     * note: we can't get the actual node from stacktrace,
+     * it only stores the ID
+     */
+    errorNodeId: createLeaf(
+      [stacktrace.current.innerReturnPosition, stacktrace.current.lastPosition],
+      (innerLocation, lastLocation) => ((innerLocation || lastLocation).node || {}).id
+    ),
+
+    /**
+     * data.current.errorNode
+     * note: we can't get the actual node from stacktrace,
+     * it only stores the ID
+     */
+    errorNode: createLeaf(
+      ["./errorNodeId", "/current/scopes/inlined"],
+      (id, scopes) => id !== undefined ? scopes[id].definition : null
+    ),
+
+    /**
+     * data.current.errorId
+     * returns a codec-style ID, not just an AST ID
+     * does not assume that the error is on the correct node...
+     * this could be factored into two selectors (one that finds
+     * the node and one that makes the ID)
+     */
+    errorId: createLeaf(
+      ["./errorNode", "./compilationId"],
+      (errorNode, compilationId) => {
+        if (errorNode === null) {
+          return undefined;
+        }
+        switch (errorNode.nodeType) {
+          case "RevertStatement":
+            //I don't think this case should happen, but I'm including it
+            //for extra certainty
+            errorNode = errorNode.errorCall;
+            //DELIBERATE FALL-THROUGH
+          case "FunctionCall":
+            //this should work for both qualified & unqualified errors
+            const errorId = errorNode.expression.referencedDeclaration;
+            return Codec.Contexts.Import.makeTypeId(errorId, compilationId);
+          default:
+            //I'm not going to try to handle other cases that maybe could
+            //occur with the optimizer on
+            return undefined;
+        }
+      }
     ),
 
     /**

--- a/packages/debugger/lib/data/selectors/index.js
+++ b/packages/debugger/lib/data/selectors/index.js
@@ -342,13 +342,13 @@ const data = createSelectorTree({
       [
         "./scopes/inlined",
         "/info/userDefinedTypes",
-        "/info/eventsAndErrors",
+        "/info/taggedOutputs",
         solidity.views.sources
       ],
-      (scopes, userDefinedTypes, eventsAndErrors, sources) =>
+      (scopes, userDefinedTypes, taggedOutputs, sources) =>
         merge(
           {},
-          ...userDefinedTypes.concat(eventsAndErrors).map(({ id, sourceId }) => {
+          ...userDefinedTypes.concat(taggedOutputs).map(({ id, sourceId }) => {
             const source = sources[sourceId];
             return source.internal
               ? {} //exclude these
@@ -472,11 +472,19 @@ const data = createSelectorTree({
     ),
 
     /**
-     * data.info.eventsAndErrors
+     * data.info.taggedOutputs
+     * "Tagged outputs" means user-defined things that are output by a contract
+     * (not input to a contract), and which are distinguished by (potentially
+     * ambiguous) selectors.  So, events and custom errors are tagged outputs.  
+     * Function arguments are not tagged outputs (they're not outputs).
+     * Return values are not tagged outputs (they don't have a selector).
+     * Built-in errors (Error(string) and Panic(uint))... OK I guess those could
+     * be considered tagged outputs, but we're only looking at user-defined ones
+     * here.
      */
-    eventsAndErrors: createLeaf(
+    taggedOutputs: createLeaf(
       ["/state"],
-      state => state.info.eventsAndErrors
+      state => state.info.taggedOutputs
     )
   },
 

--- a/packages/debugger/lib/txlog/sagas/index.js
+++ b/packages/debugger/lib/txlog/sagas/index.js
@@ -35,7 +35,7 @@ function* updateTransactionLogSaga() {
         yield put(actions.externalReturn(pointer, newPointer, decodings));
       }
     } else {
-      const error = (yield* data.decodeReturnValue())[0]; //NOTE: we will do this a better way in the future!
+      const error = (yield* data.decodeReturnValue())[0];
       debug("revert: %o %o", pointer, newPointer);
       yield put(actions.revert(pointer, newPointer, error));
     }

--- a/packages/debugger/test/helpers.js
+++ b/packages/debugger/test/helpers.js
@@ -26,7 +26,7 @@ export async function prepareContracts(provider, sources = {}, migrations) {
 
   config.compilers = {
     solc: {
-      version: "0.8.0",
+      version: "0.8.4",
       settings: {
         optimizer: { enabled: false, runs: 200 },
         evmVersion: "istanbul"

--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -180,7 +180,7 @@ export class WireDecoder {
     debug("done with allocation");
   }
 
-  /**
+  /*
    * (comment copypasted from the debugger)
    * "Tagged outputs" means user-defined things that are output by a contract
    * (not input to a contract), and which are distinguished by (potentially

--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -959,7 +959,8 @@ export class ContractDecoder {
       },
       userDefinedTypes: this.userDefinedTypes,
       allocations: this.allocations,
-      contexts: { ...this.contexts, ...additionalContexts }
+      contexts: { ...this.contexts, ...additionalContexts },
+      currentContext: this.context
     };
 
     const decoder = decodeReturndata(info, allocation, status);

--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -126,7 +126,7 @@ export class WireDecoder {
     ({
       definitions: this.referenceDeclarations,
       types: this.userDefinedTypes
-    } = this.collectUserDefinedTypesEventsAndErrors());
+    } = this.collectUserDefinedTypesAndTaggedOutputs());
 
     const allocationInfo: AbiData.Allocate.ContractAllocationInfo[] = this.contractsAndContexts.map(
       ({
@@ -180,7 +180,18 @@ export class WireDecoder {
     debug("done with allocation");
   }
 
-  private collectUserDefinedTypesEventsAndErrors(): {
+  /**
+   * (comment copypasted from the debugger)
+   * "Tagged outputs" means user-defined things that are output by a contract
+   * (not input to a contract), and which are distinguished by (potentially
+   * ambiguous) selectors.  So, events and custom errors are tagged outputs.  
+   * Function arguments are not tagged outputs (they're not outputs).
+   * Return values are not tagged outputs (they don't have a selector).
+   * Built-in errors (Error(string) and Panic(uint))... OK I guess those could
+   * be considered tagged outputs, but we're only looking at user-defined ones
+   * here.
+   */
+  private collectUserDefinedTypesAndTaggedOutputs(): {
     definitions: { [compilationId: string]: Ast.AstNodes };
     types: Format.Types.TypesById;
   } {

--- a/packages/decoder/test/current/contracts/CompatibleTest.sol
+++ b/packages/decoder/test/current/contracts/CompatibleTest.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
 contract CompatibleNativizeTest {

--- a/packages/decoder/test/current/contracts/DecodingSample.sol
+++ b/packages/decoder/test/current/contracts/DecodingSample.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract DecodingSample {
   enum E {
@@ -44,7 +44,7 @@ contract DecodingSample {
   bool[2]    fixedArrayBool;
   address[2] fixedArrayAddress;
   bytes7[2]  fixedArrayBytes7;
-  byte[2]    fixedArrayByte;
+  bytes1[2]    fixedArrayByte;
   E[2]       fixedArrayEnum;
 
   uint[]    dynamicArrayUint;
@@ -52,7 +52,7 @@ contract DecodingSample {
   bool[]    dynamicArrayBool;
   address[] dynamicArrayAddress;
   bytes7[]  dynamicArrayBytes7;
-  byte[]    dynamicArrayByte;
+  bytes1[]    dynamicArrayByte;
   E[]       dynamicArrayEnum;
 
   function() external functionExternal = this.example;
@@ -117,7 +117,7 @@ contract DecodingSample {
     dynamicArrayBytes7 = new bytes7[](2);
     dynamicArrayBytes7[0] = hex"75754477331122";
     dynamicArrayBytes7[1] = hex"e7d14477331122";
-    dynamicArrayByte = new byte[](2);
+    dynamicArrayByte = new bytes1[](2);
     dynamicArrayByte[0] = 0x37;
     dynamicArrayByte[1] = 0xbe;
     dynamicArrayEnum = new E[](2);

--- a/packages/decoder/test/current/contracts/DowngradeTest.sol
+++ b/packages/decoder/test/current/contracts/DowngradeTest.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
 contract DowngradeTestParent {
@@ -73,6 +73,12 @@ contract DowngradeTest is DowngradeTestParent {
 
   function returnsStuff() public pure returns (Pair memory, Ternary) {
     return (Pair(107, 683), Ternary.No);
+  }
+
+  error CustomError(Pair pair);
+
+  function throwCustom() public pure {
+    revert CustomError(Pair(1, 2));
   }
 }
 

--- a/packages/decoder/test/current/contracts/MessageTest.sol
+++ b/packages/decoder/test/current/contracts/MessageTest.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract ReceiveTest {
 

--- a/packages/decoder/test/current/contracts/Migrations.sol
+++ b/packages/decoder/test/current/contracts/Migrations.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract Migrations {
   address public owner;

--- a/packages/decoder/test/current/contracts/SliceTest.sol
+++ b/packages/decoder/test/current/contracts/SliceTest.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.7.3;
+pragma solidity ^0.8.0;
 
 //This contract is purely here to make sure that
 //internal sources are generated, to make sure that the decoder

--- a/packages/decoder/test/current/contracts/WireTest.sol
+++ b/packages/decoder/test/current/contracts/WireTest.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.4;
 pragma experimental ABIEncoderV2;
 
 contract WireTestParent {
@@ -151,7 +151,7 @@ contract WireTest is WireTestParent, WireTestAbstract {
 
   event AnonUints(uint indexed, uint indexed, uint indexed, uint indexed) anonymous;
   event NonAnon(uint indexed, uint indexed, uint indexed);
-  event ObviouslyAnon(byte) anonymous;
+  event ObviouslyAnon(bytes1) anonymous;
 
   function anonymousTest() public {
     //first test: unambiguous
@@ -179,7 +179,7 @@ contract WireTest is WireTestParent, WireTestAbstract {
   }
 
   function boom() public returns (uint) {
-    selfdestruct(address(this));
+    selfdestruct(payable(address((this))));
   }
 
   event SemiAmbiguousEvent(uint indexed, uint);
@@ -192,6 +192,26 @@ contract WireTest is WireTestParent, WireTestAbstract {
     return test.delegatecall(
       abi.encodeWithSignature("run()")
     );
+  }
+
+  error UnambiguousError(int, int);
+
+  function throwUnambiguous() public pure {
+    revert UnambiguousError(-1, -2);
+  }
+
+  function callAndThrow() public pure {
+    WireTestLibrary.throwUnambiguous();
+  }
+
+  error h9316(bytes32);
+
+  function throwAmbiguous() public pure {
+    revert h9316(hex"");
+  }
+
+  function callAndThrowAmbiguous() public pure {
+    WireTestLibrary.throwAmbiguous();
   }
 
 }
@@ -213,6 +233,18 @@ library WireTestLibrary {
   }
 
   event AnonUint8s(uint8 indexed, uint8 indexed, uint8 indexed, uint8 indexed) anonymous;
+
+  error LibraryError();
+
+  function throwUnambiguous() external pure {
+    revert LibraryError();
+  }
+
+  error b27072(uint);
+
+  function throwAmbiguous() external pure {
+    revert b27072(0);
+  }
 }
 
 contract WireTestRedHerring {

--- a/packages/decoder/test/current/contracts/WireTest.sol
+++ b/packages/decoder/test/current/contracts/WireTest.sol
@@ -204,7 +204,7 @@ contract WireTest is WireTestParent, WireTestAbstract {
     WireTestLibrary.throwUnambiguous();
   }
 
-  error h9316(bytes32);
+  error h9316(bytes32); //ambiguous with b2072(uint)
 
   function throwAmbiguous() public pure {
     revert h9316(hex"");
@@ -240,7 +240,7 @@ library WireTestLibrary {
     revert LibraryError();
   }
 
-  error b27072(uint);
+  error b27072(uint); //ambiguous with h9316(bytes32)
 
   function throwAmbiguous() external pure {
     revert b27072(0);

--- a/packages/decoder/test/current/test/downgrade-test.js
+++ b/packages/decoder/test/current/test/downgrade-test.js
@@ -24,7 +24,11 @@ describe("Graceful degradation when information is missing", function() {
   let compilations;
 
   before("Create Provider", async function () {
-    provider = Ganache.provider({seed: "decoder", gasLimit: 7000000});
+    provider = Ganache.provider({
+      seed: "decoder",
+      gasLimit: 7000000,
+      vmErrorsOnRPCResponse: false
+    });
     web3 = new Web3(provider);
     accounts = await web3.eth.getAccounts();
   });
@@ -349,6 +353,53 @@ describe("Graceful degradation when information is missing", function() {
       "DowngradeTest.Ternary.No"
     );
   });
+
+  describe("Custom errors", function () {
+    it("Degrades correctly when no node", async function () {
+      let mangledCompilations = clonedeep(compilations);
+      let source = mangledCompilations[0].sources.find(x => x); //find defined source
+      source.ast = undefined;
+      await runErrorTestBody(mangledCompilations);
+    });
+    it("Degrades correctly when no usedErrors", async function () {
+      let mangledCompilations = clonedeep(compilations);
+      let source = mangledCompilations[0].sources.find(x => x); //find defined source
+      let contractNode = source.ast.nodes.find(
+        node =>
+          node.nodeType === "ContractDefinition" && node.name === "DowngradeTest"
+      );
+      contractNode.usedErrors = undefined;
+      await runErrorTestBody(mangledCompilations);
+    });
+    it("Degrades correctly on no error node", async function () {
+      let mangledCompilations = clonedeep(compilations);
+      let source = mangledCompilations[0].sources.find(x => x); //find defined source
+      let contractNode = source.ast.nodes.find(
+        node =>
+          node.nodeType === "ContractDefinition" && node.name === "DowngradeTest"
+      );
+      let errorNode = contractNode.nodes.find(
+        node => node.nodeType === "ErrorDefinition" && node.name === "CustomError"
+      );
+      errorNode.nodeType = "Ninja"; //fake node type which will prevent decoder
+      //from recognizing it
+      await runErrorTestBody(mangledCompilations);
+    });
+    it("Degrades correctly on error", async function () {
+      let mangledCompilations = clonedeep(compilations);
+      let source = mangledCompilations[0].sources.find(x => x); //find defined source
+      let contractNode = source.ast.nodes.find(
+        node =>
+          node.nodeType === "ContractDefinition" && node.name === "DowngradeTest"
+      );
+      let structNode = contractNode.nodes.find(
+        node => node.nodeType === "StructDefinition" && node.name === "Pair"
+      );
+      structNode.nodeType = "Ninja"; //fake node type which will prevent decoder
+      //from recognizing it
+      await runErrorTestBody(mangledCompilations);
+    });
+  });
 });
 
 //verify the decoding for run
@@ -511,4 +562,37 @@ async function runEnumTestBody(mangledCompilations) {
     Codec.Format.Utils.Inspect.unsafeNativize(value)
   );
   assert.deepStrictEqual(nativizedArguments2, swappedTxArguments);
+}
+
+async function runErrorTestBody(mangledCompilations) {
+  const deployedContract = await abstractions.DowngradeTest.new();
+  const decoder = await Decoder.forContract(abstractions.DowngradeTest, {
+    compilations: mangledCompilations
+  });
+  let abiEntry = abstractions.DowngradeTest.abi.find(
+    ({ type, name }) => type === "function" && name === "throwCustom"
+  );
+  let selector = web3.eth.abi.encodeFunctionSignature(abiEntry);
+
+  //we need the raw return data, and contract.call() does not exist yet,
+  //so we're going to have to use web3.eth.call()
+
+  let data = await web3.eth.call({
+    to: deployedContract.address,
+    data: selector
+  });
+
+  let decodings = await decoder.decodeReturnValue(abiEntry, data);
+  assert.lengthOf(decodings, 1);
+  let decoding = decodings[0];
+  assert.strictEqual(decoding.kind, "revert");
+  assert.strictEqual(decoding.decodingMode, "abi");
+  assert.strictEqual(decoding.abi.name, "CustomError");
+  assert.isUndefined(decoding.definedIn);
+  assert.lengthOf(decoding.arguments, 1);
+  assert.strictEqual(decoding.arguments[0].name, "pair");
+  assert.deepEqual(
+    Codec.Format.Utils.Inspect.unsafeNativize(decoding.arguments[0].value),
+    [1, 2]
+  );
 }

--- a/packages/decoder/test/current/test/wire-test.js
+++ b/packages/decoder/test/current/test/wire-test.js
@@ -20,7 +20,11 @@ describe("Over-the-wire decoding", function () {
   let Contracts;
 
   before("Create Provider", async function () {
-    provider = Ganache.provider({seed: "decoder", gasLimit: 7000000});
+    provider = Ganache.provider({
+      seed: "decoder",
+      gasLimit: 7000000,
+      vmErrorsOnRPCResponse: false
+    });
     web3 = new Web3(provider);
   });
 
@@ -991,6 +995,122 @@ describe("Over-the-wire decoding", function () {
       Codec.Format.Utils.Inspect.unsafeNativize(decoding.arguments[0].value),
       2
     );
+  });
+
+  describe("Custom error decoding", function () {
+    it("Decodes unambiguous custom errors", async function () {
+      const { WireTest } = abstractions;
+      const deployedContract = await WireTest.deployed();
+  
+      const decoder = await Decoder.forContract(WireTest, Contracts);
+  
+      let abiEntry = WireTest.abi.find(
+        ({ type, name }) => type === "function" && name === "throwUnambiguous"
+      );
+      let selector = web3.eth.abi.encodeFunctionSignature(abiEntry);
+  
+      //we need the raw return data, and contract.call() does not exist yet,
+      //so we're going to have to use web3.eth.call()
+  
+      let data = await web3.eth.call({
+        to: deployedContract.address,
+        data: selector
+      });
+
+      debug("data: %O", data);
+  
+      let decodings = await decoder.decodeReturnValue(abiEntry, data);
+      assert.lengthOf(decodings, 1);
+      let decoding = decodings[0];
+      assert.strictEqual(decoding.kind, "revert");
+      assert.strictEqual(decoding.decodingMode, "full");
+      assert.strictEqual(decoding.abi.name, "UnambiguousError");
+      assert.strictEqual(decoding.definedIn.typeName, "WireTest");
+      assert.lengthOf(decoding.arguments, 2);
+      assert.strictEqual(
+        Codec.Format.Utils.Inspect.unsafeNativize(decoding.arguments[0].value),
+        -1
+      );
+      assert.strictEqual(
+        Codec.Format.Utils.Inspect.unsafeNativize(decoding.arguments[1].value),
+        -2
+      );
+    });
+
+    it("Decodes unambiguous custom errors from external calls", async function () {
+      const { WireTest } = abstractions;
+      const deployedContract = await WireTest.deployed();
+  
+      const decoder = await Decoder.forContract(WireTest, Contracts);
+  
+      let abiEntry = WireTest.abi.find(
+        ({ type, name }) => type === "function" && name === "callAndThrow"
+      );
+      let selector = web3.eth.abi.encodeFunctionSignature(abiEntry);
+  
+      //we need the raw return data, and contract.call() does not exist yet,
+      //so we're going to have to use web3.eth.call()
+  
+      let data = await web3.eth.call({
+        to: deployedContract.address,
+        data: selector
+      });
+  
+      let decodings = await decoder.decodeReturnValue(abiEntry, data);
+      assert.lengthOf(decodings, 1);
+      let decoding = decodings[0];
+      assert.strictEqual(decoding.kind, "revert");
+      assert.strictEqual(decoding.decodingMode, "full");
+      assert.strictEqual(decoding.abi.name, "LibraryError");
+      assert.strictEqual(decoding.definedIn.typeName, "WireTestLibrary");
+      assert.lengthOf(decoding.arguments, 0);
+    });
+
+    it("Decodes ambiguous custom errors", async function () {
+      const { WireTest } = abstractions;
+      const deployedContract = await WireTest.deployed();
+  
+      const decoder = await Decoder.forContract(WireTest, Contracts);
+  
+      let abiEntry = WireTest.abi.find(
+        ({ type, name }) => type === "function" && name === "throwAmbiguous"
+      );
+      let selector = web3.eth.abi.encodeFunctionSignature(abiEntry);
+  
+      //we need the raw return data, and contract.call() does not exist yet,
+      //so we're going to have to use web3.eth.call()
+  
+      let data = await web3.eth.call({
+        to: deployedContract.address,
+        data: selector
+      });
+  
+      let decodings = await decoder.decodeReturnValue(abiEntry, data);
+      assert.lengthOf(decodings, 2);
+    });
+
+    it("Decodes ambiguous custom errors from external calls", async function () {
+      const { WireTest } = abstractions;
+      const deployedContract = await WireTest.deployed();
+  
+      const decoder = await Decoder.forContract(WireTest, Contracts);
+  
+      let abiEntry = WireTest.abi.find(
+        ({ type, name }) => type === "function" && name === "callAndThrowAmbiguous"
+      );
+      let selector = web3.eth.abi.encodeFunctionSignature(abiEntry);
+  
+      //we need the raw return data, and contract.call() does not exist yet,
+      //so we're going to have to use web3.eth.call()
+  
+      let data = await web3.eth.call({
+        to: deployedContract.address,
+        data: selector
+      });
+  
+      let decodings = await decoder.decodeReturnValue(abiEntry, data);
+      assert.lengthOf(decodings, 2);
+    });
   });
 });
 

--- a/packages/decoder/test/current/test/wire-test.js
+++ b/packages/decoder/test/current/test/wire-test.js
@@ -1087,6 +1087,24 @@ describe("Over-the-wire decoding", function () {
   
       let decodings = await decoder.decodeReturnValue(abiEntry, data);
       assert.lengthOf(decodings, 2);
+      assert.strictEqual(decodings[0].kind, "revert");
+      assert.strictEqual(decodings[0].decodingMode, "full");
+      assert.strictEqual(decodings[0].abi.name, "h9316");
+      assert.strictEqual(decodings[0].definedIn.typeName, "WireTest");
+      assert.lengthOf(decodings[0].arguments, 1);
+      assert.strictEqual(
+        Codec.Format.Utils.Inspect.unsafeNativize(decodings[0].arguments[0].value),
+        "0x0000000000000000000000000000000000000000000000000000000000000000"
+      );
+      assert.strictEqual(decodings[1].kind, "revert");
+      assert.strictEqual(decodings[1].decodingMode, "full");
+      assert.strictEqual(decodings[1].abi.name, "b27072");
+      assert.strictEqual(decodings[1].definedIn.typeName, "WireTestLibrary");
+      assert.lengthOf(decodings[1].arguments, 1);
+      assert.strictEqual(
+        Codec.Format.Utils.Inspect.unsafeNativize(decodings[1].arguments[0].value),
+        0
+      );
     });
 
     it("Decodes ambiguous custom errors from external calls", async function () {
@@ -1110,6 +1128,25 @@ describe("Over-the-wire decoding", function () {
   
       let decodings = await decoder.decodeReturnValue(abiEntry, data);
       assert.lengthOf(decodings, 2);
+      //note: what follows is copypasted from above
+      assert.strictEqual(decodings[0].kind, "revert");
+      assert.strictEqual(decodings[0].decodingMode, "full");
+      assert.strictEqual(decodings[0].abi.name, "h9316");
+      assert.strictEqual(decodings[0].definedIn.typeName, "WireTest");
+      assert.lengthOf(decodings[0].arguments, 1);
+      assert.strictEqual(
+        Codec.Format.Utils.Inspect.unsafeNativize(decodings[0].arguments[0].value),
+        "0x0000000000000000000000000000000000000000000000000000000000000000"
+      );
+      assert.strictEqual(decodings[1].kind, "revert");
+      assert.strictEqual(decodings[1].decodingMode, "full");
+      assert.strictEqual(decodings[1].abi.name, "b27072");
+      assert.strictEqual(decodings[1].definedIn.typeName, "WireTestLibrary");
+      assert.lengthOf(decodings[1].arguments, 1);
+      assert.strictEqual(
+        Codec.Format.Utils.Inspect.unsafeNativize(decodings[1].arguments[0].value),
+        0
+      );
     });
   });
 });

--- a/packages/decoder/test/current/truffle-config.js
+++ b/packages/decoder/test/current/truffle-config.js
@@ -57,7 +57,7 @@ module.exports = {
   // Configure your compilers
   compilers: {
     solc: {
-      version: "0.7.3" // Fetch exact version from solc-bin (default: truffle's version)
+      version: "0.8.4" // Fetch exact version from solc-bin (default: truffle's version)
       // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
       // settings: {          // See the solidity docs for advice about optimization and evmVersion
       //  optimizer: {


### PR DESCRIPTION
Partially addresses #3996.

This PR does two things.  Primarily, it adds support for custom errors in the debugger and the decoder (although for technical reasons it does *not* add proper support for them in stacktraces).  In addition, this PR also fixes the debugger's tracking of assembly function parameters (including return parameters) on Solidity 0.8.4.

(...also, I fixed an unrelated circular dependency while I was at it.)

The latter change, while not being the main point, is simpler, so I'll discuss it first.  (I made this change because I had to upgrade our debugger tests to Solidity 0.8.4, which broke our tests of assembly variables, so I had to fix that.)

### Assembly variable tracking in Solidity 0.8.4

So, the debugger doesn't always allocate parameters for Yul functions on hitting a `YulFunctionDefinition` node, because Yul will actually hit these nodes sometimes even when you're not actually entering the function, so the debugger does an additional check to see if you're actually entering the function body.  But Solidity 0.8.4 changed the behavior when there are return parameters.  Previously, the last step on the function definition would be after all parameters (input and output) had been allocated, and then it'd enter the function.  Now, the last step on the function definition would be after all input parameters are allocated, and then it steps onto the output parameters, one by one.  (Which is how it already worked for Solidity!)

So, to handle 0.8.4 in a backwards compatible manner (and without explicit version checks), we now check if you're about to step either into the function body, *or* onto the return parameters.  If the former, we use the old method.  If the latter, we only allocate input parameters, not output parameters.  Then, I added a separate `YulTypedName` case for allocating the output parameters (as this is the node type of the output parameters that it will step onto).  The latter also acts as potential future-proofing for if they ever change how ordinary variable declarations are handled.

## Custom errors

OK, so now for the main thing -- custom errors.  There are several parts to this.

Decoding custom errors isn't actually that hard; after all, we already decode errors, just not custom ones.  I didn't change this very much -- I could have changed it more to perhaps make it more efficient, but I figured it wasn't a big concern.  Just, now when we attempt to decode return data, which might be an error, we also check for custom errors.  Of course, those errors also have to get allocated at some point, and I'll get back to that later!

There is one truly new thing in error decoding though, and it's a change I've made to event decoding as well: The option to pass in an ID.  Full-mode errors and events now get IDs, the same way that user-defined types and contracts do.  This option is meant for use by the debugger -- it's not exposed in Truffle Decoder; IDs are supposed to be an internal matter, after all (I haven't even added them to the return format).  The idea is that the debugger can pass in an ID to help disambiguate in the case of ambiguous events or errors.  (The debugger doesn't currently decode events, but it will in the future, per #3824.)  If any of the possible decodings match that ID, only that decoding will be returned.  If none do, though, then they'll all be returned as normal, so that a bad ID (such as due to optimization, or due to the return data being anything other than a custom error!) doesn't cause a total decoding failure.

(For events, this is passed in as an option, whereas for errors, to keep compatibility, I added it as an additional positional argument; realistically you're not going to be passing this in unless you're also passing in a `status`, which is how the debugger does it, so I think this is fine.)

The fact that I didn't change much means there is some redundant selector checking, but, oh well.  I think it's fine.

Note that the debugger performs the decoding in the `data` module, but it uses the `stacktrace` module to find the error ID.  (Since it has to find where the error was originally thrown, not what contracts lower on the callstack might have forwarded it!)  So this means that `data` now depends on `stacktrace`, which it didn't previously.

Also note that because right now decoding of this -- as well as setting up the allocations -- is done in the `data` submodule, that means that `stacktrace` can't decode custom errors.  (Not sure how I'd format those, anyway. :P )  (And remember, `stacktrace` has to be able to run in light mode, with `data` turned off.)  So instead it just assumes that any error it can't decode is a custom error and just reports "Custom error". :shrug:  You want more information, you can use the debugger!

In addition to the actual decoding itself, of course, the debugger CLI and `debug-utils` now contain functions for formatting and printing these errors.

### Allocation

So now we come to the hard part: Allocation.  Both the debugger and decoder first have to obtain the needed information for allocation.  Which of course they were mostly already doing, but there's one new thing -- error and event definitions now go in `referenceDeclarations`.  Really we're only using this for errors at the moment, but I've included it for events as well because Solidity has been considering changes to the event ABI and AST that would make it useful in that case as well.  (In the debugger case, this has resulted in some new actions and state being added to the `data` module.)

But, that's just setup for allocation.  What about allocation itself?

As with other types of things, we split allocation into three levels: Allocating an individual error, collecting the error allocations for an individual contract, and collecting the error allocations for the entire project.

Allocating an individual error is pretty straightforward and largely reuses existing code via the `allocateDataArguments` function, so I don't have a lot to say about that.

The other two levels are where I perhaps took some shortcuts and should possibly redo things a little.

When it comes to collecting the error allocations for an individual contract, we encounter an oddity: Solidity has decided to include in the ABI not just the errors declared in a contract, but all the errors declared in there *or* that it could directly emit -- and contracts can emit errors declared anywhere, so these could come from any contract at all (or none, errors can be top-level!).  However they've also added a `usedErrors` property to the contract node on the AST, giving the IDs of these.

So, what I did is the following.  We try using `usedErrors` to allocate in full mode (for everything).  If however we run into a problem in the initial stages, we use just the ABI and fall back to ABI mode.

I'm not entirely happy with this because this can mean falling back to ABI mode for *all* of a contract's errors, even if something goes wrong with just *one* of them.  I may redo this.  However redoing this will I think require searching *every* contract in the compilation to find the corresponding error node.  I didn't do that because, well, I was wary of that, but, well, we actually already basically do that during allocation to find which contract a given error was defined in, so, um, yeah, maybe that's OK.  (Or, maybe I should get rid of the search there too...)  Anyway @gnidan I would like your opinion on whether I should redo this...

Then we come to collecting errors for the entire compilation, and here I took another shortcut.  Since any contract can notionally throw any error (since a contract can call any contract, and the called contract can throw whatever, and the caller will then forward it), I just tossed all errors with the same selector into a big pile, more or less.  That is to say, if for some reason an error is ambiguous, the decoder doesn't put first errors that could be thrown directly by the specific contract.  Again, I'm kind of uneasy with this, and am wondering if I should change it.  This would take a bit of work though.

Note that because of how Solidity is doing the error ABIs, we have this question of what counts as the same error, since an error declared in one place might show up in the ABIs of multiple contracts.  My approach was as follows: I considered full-mode errors declared in different places to be different, but all ABI-mode errors with matching signature to be the same.  If there are both full-mode and abi-mode allocations for the same signature, we toss out the abi-mode ones and keep just the full-mode ones.  Seems sensible to me?

Anyway yeah that's it.  @gnidan please let me know if I should redo the two things mentioned above.