### PR TITLE
Internal improvement: Add/update repository field and other missing fields

### DIFF
--- a/packages/abi-utils/package.json
+++ b/packages/abi-utils/package.json
@@ -20,7 +20,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/trufflesuite/truffle.git"
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/abi-utils"
   },
   "scripts": {
     "prepare": "tsc",

--- a/packages/artifactor/package.json
+++ b/packages/artifactor/package.json
@@ -4,13 +4,17 @@
   "description": "A contract packager for Ethereum and Javascript",
   "license": "MIT",
   "author": "Tim Coulter",
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/artifactor",
   "version": "4.0.103",
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
     "prepare": "yarn build",
     "test": "mocha"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/artifactor"
   },
   "types": "dist/index.d.ts",
   "dependencies": {

--- a/packages/blockchain-utils/package.json
+++ b/packages/blockchain-utils/package.json
@@ -4,7 +4,11 @@
   "license": "MIT",
   "author": "Tim Coulter <tim@trufflesuite.com>",
   "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/blockchain-utils#readme",
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/blockchain-utils",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/blockchain-utils"
+  },
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"
   },

--- a/packages/box/package.json
+++ b/packages/box/package.json
@@ -3,7 +3,11 @@
   "description": "Truffle project boilerplate utility",
   "license": "MIT",
   "author": "g. nicholas d'andrea <gnidan@trufflesuite.com>",
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/box",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/box"
+  },
   "version": "2.1.10",
   "main": "dist/box.js",
   "scripts": {

--- a/packages/code-utils/package.json
+++ b/packages/code-utils/package.json
@@ -3,7 +3,11 @@
   "description": "Utilities for parsing and managing EVM-compatible bytecode",
   "license": "MIT",
   "author": "",
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/code-utils",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/code-utils"
+  },
   "version": "1.2.26",
   "main": "dist/src/index.js",
   "scripts": {

--- a/packages/codec/package.json
+++ b/packages/codec/package.json
@@ -4,7 +4,11 @@
   "license": "MIT",
   "author": "",
   "homepage": "https://github.com/trufflesuite/truffle#readme",
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/codec",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/codec"
+  },
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"
   },

--- a/packages/compile-common/package.json
+++ b/packages/compile-common/package.json
@@ -4,7 +4,11 @@
   "description": "Common compiler integration support infrastructure for Truffle",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
-  "repository": "https://github.com/trufflesuite/truffle/tree/develop/packages/compile-common",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/compile-common"
+  },
   "license": "MIT",
   "scripts": {
     "build": "tsc",

--- a/packages/compile-solidity/package.json
+++ b/packages/compile-solidity/package.json
@@ -4,7 +4,11 @@
   "license": "MIT",
   "author": "Tim Coulter <tim@trufflesuite.com>",
   "homepage": "https://github.com/trufflesuite/compile-solidity#readme",
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/compile-solidity",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/compile-solidity"
+  },
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"
   },

--- a/packages/compile-vyper/package.json
+++ b/packages/compile-vyper/package.json
@@ -3,7 +3,11 @@
   "description": "Vyper compiler support",
   "license": "MIT",
   "author": "Evgeniy Filatov <evgeniyfilatov@gmail.com>",
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/compile-vyper",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/compile-vyper"
+  },
   "version": "3.1.6",
   "main": "index.js",
   "scripts": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -4,7 +4,11 @@
   "license": "MIT",
   "author": "Tim Coulter <tim@trufflesuite.com>",
   "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/config#readme",
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/config",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/config"
+  },
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"
   },

--- a/packages/contract-schema/package.json
+++ b/packages/contract-schema/package.json
@@ -4,7 +4,11 @@
   "license": "MIT",
   "author": "Tim Coulter <tim@trufflesuite.com>",
   "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/contract-schema#readme",
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/contract-schema",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/contract-schema"
+  },
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"
   },

--- a/packages/contract-sources/package.json
+++ b/packages/contract-sources/package.json
@@ -6,7 +6,11 @@
   "scripts": {
     "prepare": "exit 0"
   },
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/contract-sources",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/contract-sources"
+  },
   "keywords": [
     "ethereum",
     "contracts",

--- a/packages/contract-tests/package.json
+++ b/packages/contract-tests/package.json
@@ -7,7 +7,8 @@
   "homepage": "https://github.com/trufflesuite/truffle#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/trufflesuite/truffle.git"
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/contract-tests"
   },
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -4,7 +4,11 @@
   "license": "MIT",
   "author": "Tim Coulter <tim@trufflesuite.com>",
   "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/contract#readme",
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/contract",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/contract"
+  },
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,11 @@
   "description": "Core code for Truffle command line tool",
   "author": "consensys.net",
   "homepage": "https://github.com/trufflesuite/truffle#readme",
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/core",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/core"
+  },
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"
   },

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -6,7 +6,8 @@
   "homepage": "https://github.com/trufflesuite/truffle#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/trufflesuite/truffle.git"
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/db"
   },
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"

--- a/packages/debug-utils/package.json
+++ b/packages/debug-utils/package.json
@@ -4,7 +4,11 @@
   "license": "MIT",
   "author": "Truffle Suite <inquiry@trufflesuite.com>",
   "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/debug-utils#readme",
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/debug-utils",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/debug-utils"
+  },
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"
   },

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -4,7 +4,11 @@
   "license": "MIT",
   "author": "Tim Coulter <tim@trufflesuite.com>",
   "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/debugger#readme",
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/debugger",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/debugger"
+  },
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"
   },

--- a/packages/decoder/package.json
+++ b/packages/decoder/package.json
@@ -4,7 +4,11 @@
   "license": "MIT",
   "author": "Mike Seese and Harry Altman",
   "homepage": "https://github.com/trufflesuite/truffle#readme",
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/codec",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/decoder"
+  },
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"
   },

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -4,7 +4,11 @@
   "license": "MIT",
   "author": "Tim Coulter <tim@trufflesuite.com>",
   "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/deployer#readme",
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/deployer",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/deployer"
+  },
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"
   },

--- a/packages/environment/package.json
+++ b/packages/environment/package.json
@@ -5,7 +5,11 @@
   "license": "MIT",
   "author": "Faina Shalts",
   "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/environment#readme",
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/environment",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/environment"
+  },
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"
   },

--- a/packages/error/package.json
+++ b/packages/error/package.json
@@ -11,7 +11,11 @@
     "build": "tsc",
     "prepare": "yarn build"
   },
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/error",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/error"
+  },
   "keywords": [
     "ethereum",
     "truffle",

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -6,6 +6,15 @@
   "keywords": [],
   "author": "Nick D'Andrea and Tyler Feickert",
   "license": "ISC",
+  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/events#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/events"
+  },
+  "bugs": {
+    "url": "https://github.com/trufflesuite/truffle/issues"
+  },
   "scripts": {
     "prepare": "exit 0"
   },

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -4,7 +4,11 @@
   "license": "MIT",
   "author": "Tim Coulter <tim@trufflesuite.com>",
   "homepage": "https://github.com/trufflesuite/truffle/blob/master/packages/expect#readme",
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/expect",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/expect"
+  },
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"
   },

--- a/packages/external-compile/package.json
+++ b/packages/external-compile/package.json
@@ -4,7 +4,11 @@
   "license": "MIT",
   "author": "g. nicholas d'andrea <gnidan@users.noreply.github.com>",
   "homepage": "https://github.com/trufflesuite/truffle#readme",
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/external-compile",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/external-compile"
+  },
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"
   },

--- a/packages/hdwallet-provider/package.json
+++ b/packages/hdwallet-provider/package.json
@@ -4,7 +4,11 @@
   "license": "MIT",
   "author": "Tim Coulter <tim@trufflesuite.com>",
   "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/hdwallet-provider#readme",
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/hdwallet-provider",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/hdwallet-provider"
+  },
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"
   },

--- a/packages/interface-adapter/package.json
+++ b/packages/interface-adapter/package.json
@@ -3,7 +3,11 @@
   "description": "A library that provides an adapter layer for Truffle to interace with different types of networks/ledgers.",
   "license": "MIT",
   "homepage": "https://github.com/trufflesuite/truffle#readme",
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/interface-adapter",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/interface-adapter"
+  },
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"
   },

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -4,7 +4,11 @@
   "license": "MIT",
   "author": "Tim Coulter <tim@trufflesuite.com>",
   "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/migrate#readme",
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/migrate",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/migrate"
+  },
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"
   },

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -12,7 +12,15 @@
     "prepare": "yarn build",
     "test": "jest --verbose --detectOpenHandles"
   },
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/plugins",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/plugins"
+  },
+  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/plugins#readme",
+  "bugs": {
+    "url": "https://github.com/trufflesuite/truffle/issues"
+  },
   "author": "g. nicholas d'andrea <gnidan@trufflesuite.com>",
   "license": "MIT",
   "publishConfig": {

--- a/packages/preserve-fs/package.json
+++ b/packages/preserve-fs/package.json
@@ -13,7 +13,15 @@
     "prepare": "yarn build",
     "test": "jest --verbose --detectOpenHandles"
   },
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/preserve-directory",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/preserve-fs"
+  },
+  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/preserve-fs#readme",
+  "bugs": {
+    "url": "https://github.com/trufflesuite/truffle/issues"
+  },
   "author": "g. nicholas d'andrea <gnidan@trufflesuite.com>",
   "license": "MIT",
   "publishConfig": {

--- a/packages/preserve-to-buckets/package.json
+++ b/packages/preserve-to-buckets/package.json
@@ -13,7 +13,15 @@
     "prepare": "yarn build",
     "test": "./scripts/test.sh"
   },
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/preserve-to-buckets",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/preserve-to-buckets"
+  },
+  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/preserve-to-buckets#readme",
+  "bugs": {
+    "url": "https://github.com/trufflesuite/truffle/issues"
+  },
   "author": "Rosco Kalis <roscokalis@gmail.com>",
   "license": "MIT",
   "publishConfig": {

--- a/packages/preserve-to-filecoin/package.json
+++ b/packages/preserve-to-filecoin/package.json
@@ -13,7 +13,15 @@
     "prepare": "yarn build",
     "test": "./scripts/test.sh"
   },
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/preserve-to-filecoin",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/preserve-to-filecoin"
+  },
+  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/preserve-to-filecoin#readme",
+  "bugs": {
+    "url": "https://github.com/trufflesuite/truffle/issues"
+  },
   "author": "g. nicholas d'andrea <gnidan@trufflesuite.com>",
   "license": "MIT",
   "publishConfig": {

--- a/packages/preserve-to-ipfs/package.json
+++ b/packages/preserve-to-ipfs/package.json
@@ -13,7 +13,15 @@
     "prepare": "yarn build",
     "test": "./scripts/test.sh"
   },
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/preserve-to-ipfs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/preserve-to-ipfs"
+  },
+  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/preserve-to-ipfs#readme",
+  "bugs": {
+    "url": "https://github.com/trufflesuite/truffle/issues"
+  },
   "author": "g. nicholas d'andrea <gnidan@trufflesuite.com>",
   "license": "MIT",
   "publishConfig": {

--- a/packages/preserve/package.json
+++ b/packages/preserve/package.json
@@ -13,7 +13,15 @@
     "test": "jest --verbose --detectOpenHandles",
     "docs": "../../node_modules/typedoc/bin/typedoc --options ./docs/typedoc.json"
   },
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/preserve",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/preserve"
+  },
+  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/preserve#readme",
+  "bugs": {
+    "url": "https://github.com/trufflesuite/truffle/issues"
+  },
   "author": "g. nicholas d'andrea <gnidan@trufflesuite.com>",
   "license": "MIT",
   "publishConfig": {

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -4,7 +4,11 @@
   "license": "MIT",
   "author": "Tim Coulter <tim@trufflesuite.com>",
   "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/provider#readme",
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/provider",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/provider"
+  },
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"
   },

--- a/packages/provisioner/package.json
+++ b/packages/provisioner/package.json
@@ -11,7 +11,11 @@
     "build": "tsc",
     "prepare": "yarn build"
   },
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/provisioner",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/provisioner"
+  },
   "keywords": [
     "ethereum",
     "truffle",

--- a/packages/reporters/package.json
+++ b/packages/reporters/package.json
@@ -3,7 +3,15 @@
   "description": "Reporters for Truffle modules",
   "license": "MIT",
   "author": "",
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/reporters",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/reporters"
+  },
+  "bugs": {
+    "url": "https://github.com/trufflesuite/truffle/issues"
+  },
+  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/provisioner#reporters",
   "version": "1.1.3",
   "main": "index.js",
   "scripts": {

--- a/packages/require/package.json
+++ b/packages/require/package.json
@@ -4,7 +4,11 @@
   "license": "MIT",
   "author": "Tim Coulter <tim@trufflesuite.com>",
   "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/require#readme",
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/require",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/require"
+  },
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"
   },

--- a/packages/resolver/package.json
+++ b/packages/resolver/package.json
@@ -4,7 +4,11 @@
   "license": "MIT",
   "author": "Tim Coulter <tim@trufflesuite.com>",
   "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/resolver#readme",
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/resolver",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/resolver"
+  },
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"
   },

--- a/packages/source-fetcher/package.json
+++ b/packages/source-fetcher/package.json
@@ -4,7 +4,11 @@
   "license": "MIT",
   "author": "Harry Altman <harry@trufflesuite.com>",
   "homepage": "https://github.com/trufflesuite/truffle#readme",
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/source-fetcher",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/source-fetcher"
+  },
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"
   },

--- a/packages/source-map-utils/package.json
+++ b/packages/source-map-utils/package.json
@@ -6,7 +6,11 @@
   "scripts": {
     "prepare": "exit 0"
   },
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/source-map-utils",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/source-map-utils"
+  },
   "keywords": [
     "ethereum",
     "truffle",

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -6,7 +6,8 @@
   "homepage": "https://github.com/trufflesuite/truffle/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/trufflesuite/truffle.git"
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/truffle"
   },
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -4,7 +4,10 @@
   "description": "Truffle - Simple development framework for Ethereum",
   "author": "consensys.net",
   "homepage": "https://github.com/trufflesuite/truffle/",
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git"
+  },
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"
   },

--- a/packages/workflow-compile/package.json
+++ b/packages/workflow-compile/package.json
@@ -4,7 +4,11 @@
   "license": "MIT",
   "author": "Truffle Suite <inquiry@trufflesuite.com>",
   "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/workflow-compile#readme",
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/workflow-compile",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/workflow-compile"
+  },
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"
   },


### PR DESCRIPTION
Addresses #3998.

This PR updates all package's `package.json` files to all use the same format for the `repository` field, with explicit `directory` specified.  I also added the `homepage` and `bugs` fields wherever I noticed them missing.