### PR TITLE
Bug fix: Add maxRedirects field to axios requests

### DIFF
--- a/packages/box/lib/utils/unbox.ts
+++ b/packages/box/lib/utils/unbox.ts
@@ -26,7 +26,10 @@ async function verifyVCSURL(url: string) {
       .replace(/#.*/, "")}/master/truffle-box.json`
   );
   try {
-    await axios.head(`https://${configURL.host}${configURL.path}`);
+    await axios.head(
+      `https://${configURL.host}${configURL.path}`,
+      { maxRedirects: 50 }
+    );
   } catch (error) {
     if (error.response.status === 404) {
       throw new Error(

--- a/packages/compile-solidity/compilerSupplier/loadingStrategies/Docker.js
+++ b/packages/compile-solidity/compilerSupplier/loadingStrategies/Docker.js
@@ -36,7 +36,7 @@ class Docker extends LoadingStrategy {
   }
 
   getDockerTags() {
-    return axios.get(this.config.dockerTagsUrl)
+    return axios.get(this.config.dockerTagsUrl, { maxRedirects: 50 })
       .then(response => response.data.results.map(item => item.name))
       .catch(error => {
         throw this.errors("noRequest", this.config.dockerTagsUrl, error);

--- a/packages/compile-solidity/compilerSupplier/loadingStrategies/VersionRange.js
+++ b/packages/compile-solidity/compilerSupplier/loadingStrategies/VersionRange.js
@@ -102,7 +102,10 @@ class VersionRange extends LoadingStrategy {
       attemptNumber: index + 1
     });
     try {
-      const response = await axios.get(url);
+      const response = await axios.get(
+        url,
+        { maxRedirects: 50 }
+      );
       events.emit("downloadCompiler:succeed");
       this.addFileToCache(response.data, fileName);
       return this.compilerFromString(response.data);
@@ -147,7 +150,7 @@ class VersionRange extends LoadingStrategy {
 
     // trim trailing slashes from compilerRoot
     const url = `${compilerRoots[index].replace(/\/+$/, "")}/list.json`;
-    return axios.get(url)
+    return axios.get(url, { maxRedirects: 50 })
       .then(response => {
         events.emit("fetchSolcList:succeed");
         return response.data;

--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -100,7 +100,8 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
           address,
           apikey: this.apiKey
         },
-        responseType: "json"
+        responseType: "json",
+        maxRedirects: 50
       }
     );
     if (response.data.status === "0") {

--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -97,7 +97,8 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
       return await this.requestWithRetries<Types.SolcMetadata>({
         url: `https://${this.domain}/contracts/full_match/${this.networkId}/${address}/metadata.json`,
         method: "get",
-        responseType: "json"
+        responseType: "json",
+        maxRedirects: 50
       });
     } catch (error) {
       //is this a 404 error? if so just return null
@@ -117,7 +118,8 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     return await this.requestWithRetries<string>({
       url: `https://${this.domain}/contracts/full_match/${this.networkId}/${address}/sources/${sourcePath}`,
       responseType: "text",
-      method: "get"
+      method: "get",
+      maxRedirects: 50
     });
   }
 


### PR DESCRIPTION
A user reported [here](https://github.com/trufflesuite/truffle/issues/4016) that they were experiencing issues with making http requests while using Truffle from behind a proxy. It seemed reasonable to assume this had something to do with switching axios in for the deprecated request library (see https://github.com/trufflesuite/truffle/pull/3997). After a small amount of investigation I discovered that axios has an option for `maxRedirects` that defaults to 5. In an attempt to fix this http request issue, this PR increases `maxRedirects` to 50.