### PR TITLE
Enhancement: Add `y` and `Y` commands to debugger to return to last error

### DIFF
--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -56,7 +56,9 @@ const commandReference = {
   "T": "unload transaction",
   "s": "print stacktrace",
   "g": "turn on generated sources",
-  "G": "turn off generated sources except via `;`"
+  "G": "turn off generated sources except via `;`",
+  "y": "(if at end) reset & continue to final error",
+  "Y": "reset & continue to previous error"
 };
 
 const shortCommandReference = {
@@ -82,7 +84,9 @@ const shortCommandReference = {
   "T": "unload",
   "s": "stacktrace",
   "g": "turn on generated sources",
-  "G": "turn off generated sources"
+  "G": "turn off generated sources",
+  "y": "reset & go to final error",
+  "Y": "reset & go to previous error"
 };
 
 const truffleColors = {
@@ -336,7 +340,8 @@ var DebugUtils = {
 
     var commandSections = [
       ["o", "i", "u", "n"],
-      ["c"],
+      ["c", "Y"],
+      ["y"],
       [";"],
       ["g", "G"],
       ["p"],

--- a/packages/debugger/lib/stacktrace/actions/index.js
+++ b/packages/debugger/lib/stacktrace/actions/index.js
@@ -27,12 +27,13 @@ export function externalCall(location, context, address) {
 }
 
 export const EXTERNAL_RETURN = "STACKTRACE_EXTERNAL_RETURN";
-export function externalReturn(from, status, location) {
+export function externalReturn(from, status, location, index) {
   return {
     type: EXTERNAL_RETURN,
     from,
     status,
     location,
+    index
   };
 }
 

--- a/packages/debugger/lib/stacktrace/reducers.js
+++ b/packages/debugger/lib/stacktrace/reducers.js
@@ -129,12 +129,26 @@ function innerReturnStatus(state = null, action) {
   }
 }
 
+function innerReturnIndex(state = null, action) {
+  switch (action.type) {
+    case actions.EXTERNAL_RETURN:
+      //we use index null to mean don't update
+      return action.index !== null ? action.index : state;
+    case actions.RESET:
+    case actions.UNLOAD_TRANSACTION:
+      return null;
+    default:
+      return state;
+  }
+}
+
 const proc = combineReducers({
   callstack,
   returnCounter,
   lastPosition,
   innerReturnPosition,
-  innerReturnStatus
+  innerReturnStatus,
+  innerReturnIndex
 });
 
 const reducer = combineReducers({

--- a/packages/debugger/lib/stacktrace/sagas/index.js
+++ b/packages/debugger/lib/stacktrace/sagas/index.js
@@ -29,8 +29,15 @@ function* stacktraceSaga() {
   //first: are we returning?
   if (yield select(stacktrace.current.willReturn)) {
     const status = yield select(stacktrace.current.returnStatus);
+    const index = yield select(stacktrace.current.index);
+    const updateIndex = yield select(stacktrace.current.updateIndex);
     debug("returning!");
-    yield put(actions.externalReturn(lastLocation, status, currentLocation));
+    yield put(actions.externalReturn(
+      lastLocation,
+      status,
+      currentLocation,
+      updateIndex ? index : null //we use null to mean don't update
+    ));
     positionUpdated = true;
   } else if (
     //next: are we *executing* a return?


### PR DESCRIPTION
This is sort of a primitive hack to address #4026; not sure it should be considered a full resolution of it.

This PR adds two commands to the debugger CLI, and adds selectors to the debugger library to support this.  The `Y` command returns to the last place an error was through.  The `y` command, only usable at the end of the trace, returns to the final error, and does nothing if the trace ends on the final error.

Since the debugger doesn't currently step backwards (#3854), this is done inefficiently by resetting and then stepping to the required step.  But, it'll do for now?

In order to do this, I've added `innerReturnIndex` to the `stacktrace` state.  It keeps track of the index of the last error.  Note that unlike `innerReturnPosition` and `innerReturnStatus`, it's only set to `null` when there is no previous error; it tracks the index of the *last* error, not the index of the *current* error.  So we need to know when to update it; it's only updated when we're not already processing an error (`returnCounter === 0`).  Otherwise, it's left alone.

Note that the `y` command has to manually check if we're at a final revert, because if there is one, it won't affect `innerReturnIndex`.