### PR TITLE
Bug fix: Allow node-based breakpoints to work without AST (fix sub-line breakpoints for Vyper and Yul)

### DIFF
--- a/packages/core/lib/debug/interpreter.js
+++ b/packages/core/lib/debug/interpreter.js
@@ -49,7 +49,8 @@ class DebugInterpreter {
     const currentLocation = this.session.view(controller.current.location);
     const breakpoints = this.session.view(controller.breakpoints);
 
-    const currentNode = currentLocation.astRef;
+    const currentStart = currentLocation.sourceRange.start;
+    const currentLength = currentLocation.sourceRange.length;
     const currentSourceId = currentLocation.source
       ? currentLocation.source.id
       : null;
@@ -64,12 +65,14 @@ class DebugInterpreter {
     if (args.length === 0) {
       //no arguments, want currrent node
       debug("node case");
-      if (currentNode === null) {
+      if (currentSourceId === null) {
         this.printer.print("Cannot determine current location.");
         return;
       }
-      breakpoint.node = currentNode;
-      breakpoint.line = currentLine;
+      breakpoint.start = currentStart;
+      breakpoint.line = currentLine; //this isn't necessary for the
+      //breakpoint to work, but we use it for printing messages
+      breakpoint.length = currentLength;
       breakpoint.sourceId = currentSourceId;
     }
 

--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -505,7 +505,7 @@ var DebugUtils = {
     sourceNames
   ) {
     let baseMessage;
-    if (breakpoint.node !== undefined) {
+    if (breakpoint.start !== undefined && breakpoint.length !== undefined) {
       baseMessage = here
         ? `this point in line ${breakpoint.line + 1}`
         : `a point in line ${breakpoint.line + 1}`;


### PR DESCRIPTION
Addresses #3827.  **Breaking change to `@truffle/debugger`** (at least technically).  (Note: I could go back and do this in a non-breaking way if people think that's important.)

This PR makes it so that sub-line breakpoints -- where you stop on a specific source location rather than a specific line, the sort you set by just pressing `b` rather than giving it an argument -- now work with Vyper and Yul.  Previously these didn't work because they were based around AST nodes, but we don't have ASTs for Vyper (OK, we have them, but we don't use them), and we only sometimes have ASTs for Yul.  This PR makes it so that instead of being based on AST nodes, these breakpoints are based on source ranges directly, with `start` and `length` fields replacing the old `node` field.  This obviously doesn't rely on an AST, so now these breakpoints will work for Vyper and work consistently for Yul.

(Note that line-based breakpoints, where you specify a line, already worked fine; this PR doesn't affect those.)

This is technically a breaking change, as now old-style `node` breakpoints will no longer work.