### PR TITLE
Separate PouchDB adapter interface from existing Workspace interface in @truffle/db

### DIFF
--- a/packages/db/src/meta/collections.ts
+++ b/packages/db/src/meta/collections.ts
@@ -97,9 +97,11 @@ export type SavedInput<
   C extends Collections = Collections,
   N extends CollectionName<C> = CollectionName<C>
 > = {
-  [K in keyof Input<C, N> | "id"]: K extends keyof Input<C, N>
-    ? Input<C, N>[K]
-    : string;
+  [K in keyof Input<C, N> | "id"]: K extends "id"
+    ? string
+    : K extends keyof Input<C, N>
+      ? Input<C, N>[K]
+      : never;
 };
 
 export type IdFields<

--- a/packages/db/src/meta/data.ts
+++ b/packages/db/src/meta/data.ts
@@ -26,7 +26,7 @@ export interface Workspace<C extends Collections> {
   get<N extends CollectionName<C>>(
     collectionName: N,
     id: string | undefined
-  ): Promise<Historical<SavedInput<C, N>> | undefined>;
+  ): Promise<SavedInput<C, N> | undefined>;
 
   add<N extends CollectionName<C>>(
     collectionName: N,
@@ -43,13 +43,3 @@ export interface Workspace<C extends Collections> {
     input: MutationInput<C, M>
   ): Promise<void>;
 }
-
-export type History = Pick<PouchDB.Core.GetMeta, "_rev">;
-
-export type Historical<T> = {
-  [K in keyof T | keyof History]: K extends keyof History
-    ? History[K]
-    : K extends keyof T
-    ? T[K]
-    : never;
-};

--- a/packages/db/src/meta/data.ts
+++ b/packages/db/src/meta/data.ts
@@ -44,7 +44,7 @@ export interface Workspace<C extends Collections> {
   ): Promise<void>;
 }
 
-export type History = PouchDB.Core.IdMeta & PouchDB.Core.GetMeta;
+export type History = Pick<PouchDB.Core.GetMeta, "_rev">;
 
 export type Historical<T> = {
   [K in keyof T | keyof History]: K extends keyof History

--- a/packages/db/src/meta/pouch/adapters/base.ts
+++ b/packages/db/src/meta/pouch/adapters/base.ts
@@ -18,6 +18,11 @@ import type { Workspace, Historical } from "@truffle/db/meta/data";
 
 import type { Definition, Definitions } from "@truffle/db/meta/pouch/types";
 
+export interface DatabasesOptions<C extends Collections> {
+  definitions: Definitions<C>;
+  settings: any;
+}
+
 /**
  * Aggegrates logic for interacting wth a set of PouchDB databases identified
  * by resource collection name.
@@ -29,7 +34,7 @@ export abstract class Databases<C extends Collections> implements Workspace<C> {
 
   private ready: Promise<void>;
 
-  constructor(options) {
+  constructor(options: DatabasesOptions<C>) {
     this.setup(options.settings);
 
     this.definitions = options.definitions;

--- a/packages/db/src/meta/pouch/adapters/base.ts
+++ b/packages/db/src/meta/pouch/adapters/base.ts
@@ -100,7 +100,7 @@ export abstract class Databases<C extends Collections> implements Adapter<C> {
   public async retrieve<N extends CollectionName<C>, T>(
     collectionName: N,
     records: (Pick<Record<T>, "_id"> | undefined)[]
-  ) {
+  ): Promise<(SavedRecord<T> | undefined)[]> {
     await this.ready;
 
     const unorderedSavedRecords = await this.search<N, T>(collectionName, {
@@ -132,7 +132,7 @@ export abstract class Databases<C extends Collections> implements Adapter<C> {
   public async search<N extends CollectionName<C>, T>(
     collectionName: N,
     options: PouchDB.Find.FindRequest<{}>
-  ) {
+  ): Promise<SavedRecord<T>[]> {
     await this.ready;
 
     // allows searching with `id` instead of pouch's internal `_id`,
@@ -160,7 +160,7 @@ export abstract class Databases<C extends Collections> implements Adapter<C> {
     collectionName: N,
     records: (Record<T> | undefined)[],
     options: { overwrite?: boolean } = {}
-  ) {
+  ): Promise<(SavedRecord<T> | undefined)[]> {
     await this.ready;
 
     const { overwrite = false } = options;
@@ -231,7 +231,7 @@ export abstract class Databases<C extends Collections> implements Adapter<C> {
   public async delete<N extends CollectionName<C>, T>(
     collectionName: N,
     references: (RecordReference<T> | undefined)[]
-  ) {
+  ): Promise<void> {
     await this.ready;
 
     const savedRecords = await this.retrieve<N, T>(collectionName, references);

--- a/packages/db/src/meta/pouch/adapters/base.ts
+++ b/packages/db/src/meta/pouch/adapters/base.ts
@@ -19,7 +19,7 @@ import type {
 
 export interface DatabasesOptions<C extends Collections> {
   definitions: Definitions<C>;
-  settings: any;
+  settings: any; // subclasses define their own settings type
 }
 
 /**

--- a/packages/db/src/meta/pouch/adapters/base.ts
+++ b/packages/db/src/meta/pouch/adapters/base.ts
@@ -135,21 +135,7 @@ export abstract class Databases<C extends Collections> implements Adapter<C> {
   ): Promise<SavedRecord<T>[]> {
     await this.ready;
 
-    // allows searching with `id` instead of pouch's internal `_id`,
-    // since we call the field `id` externally, and this approach avoids
-    // an extra index
-    const fixIdSelector = (selector: PouchDB.Find.Selector) =>
-      Object.entries(selector)
-        .map(
-          ([field, predicate]): PouchDB.Find.Selector =>
-            field === "id" ? { _id: predicate } : { [field]: predicate }
-        )
-        .reduce((a, b) => ({ ...a, ...b }), {});
-
-    const { docs }: any = await this.collections[collectionName].find({
-      ...options,
-      selector: fixIdSelector(options.selector)
-    });
+    const { docs }: any = await this.collections[collectionName].find(options);
 
     const savedRecords: SavedRecord<T>[] = docs;
 

--- a/packages/db/src/meta/pouch/adapters/base.ts
+++ b/packages/db/src/meta/pouch/adapters/base.ts
@@ -228,7 +228,7 @@ export abstract class Databases<C extends Collections> implements Adapter<C> {
     return records.map(record => record && savedRecordById[record._id]);
   }
 
-  public async forget<N extends CollectionName<C>, T>(
+  public async delete<N extends CollectionName<C>, T>(
     collectionName: N,
     references: (RecordReference<T> | undefined)[]
   ) {

--- a/packages/db/src/meta/pouch/adapters/base.ts
+++ b/packages/db/src/meta/pouch/adapters/base.ts
@@ -142,7 +142,7 @@ export abstract class Databases<C extends Collections> implements Adapter<C> {
     return savedRecords;
   }
 
-  public async record<N extends CollectionName<C>, T>(
+  public async save<N extends CollectionName<C>, T>(
     collectionName: N,
     records: (Record<T> | undefined)[],
     options: { overwrite?: boolean } = {}

--- a/packages/db/src/meta/pouch/index.ts
+++ b/packages/db/src/meta/pouch/index.ts
@@ -1,14 +1,17 @@
 import { logger } from "@truffle/db/logger";
 const debug = logger("db:meta:pouch");
 
-export { Definition, Definitions } from "./types";
+import type { Collections } from "@truffle/db/meta/collections";
+import type { Workspace } from "@truffle/db/meta/data";
 
 import * as Adapters from "./adapters";
 export { Adapters };
 
-import type { Collections } from "@truffle/db/meta/collections";
-import type { Workspace } from "@truffle/db/meta/data";
-import type { Definitions } from "./types";
+import { AdapterWorkspace } from "./workspace";
+
+import type { Adapter, Definition, Definitions } from "./types";
+export { Adapter, Definition, Definitions };
+
 
 export const forDefinitions = <C extends Collections>(
   definitions: Definitions<C>
@@ -19,7 +22,12 @@ export const forDefinitions = <C extends Collections>(
 
   debug("Initializing workspace...");
   // @ts-ignore
-  const workspace = new constructor({ definitions, settings });
+  const adapter: Adapter<C> = new constructor({ definitions, settings });
+
+  const workspace = new AdapterWorkspace<C>({
+    adapter,
+    definitions
+  });
 
   return workspace;
 };

--- a/packages/db/src/meta/pouch/types.ts
+++ b/packages/db/src/meta/pouch/types.ts
@@ -4,7 +4,35 @@ const debug = logger("db:meta:pouch:types");
 import PouchDB from "pouchdb";
 
 import type { Collections, CollectionName } from "@truffle/db/meta/collections";
+import type { Historical } from "@truffle/db/meta/data";
 import type * as Id from "@truffle/db/meta/id";
+
+export interface Adapter<C extends Collections> {
+  every<N extends CollectionName<C>, I extends { id: string }>(
+    collectionName: N
+  ): Promise<Historical<I>[]>;
+
+  retrieve<N extends CollectionName<C>, I extends { id: string }>(
+    collectionName: N,
+    references: (Pick<I, "id"> | undefined)[]
+  ): Promise<(Historical<I> | undefined)[]>;
+
+  search<N extends CollectionName<C>, I extends { id: string }>(
+    collectionName: N,
+    options: PouchDB.Find.FindRequest<{}>
+  ): Promise<Historical<I>[]>;
+
+  record<N extends CollectionName<C>, I extends { id: string }>(
+    collectionName: N,
+    inputs: (I | undefined)[],
+    options: { overwrite?: boolean }
+  ): Promise<(Historical<I> | undefined)[]>;
+
+  forget<N extends CollectionName<C>, I extends { id: string }>(
+    collectionName: N,
+    references: (Pick<I, "id"> | undefined)[]
+  ): Promise<void>;
+}
 
 /**
  * @category Definitions

--- a/packages/db/src/meta/pouch/types.ts
+++ b/packages/db/src/meta/pouch/types.ts
@@ -75,7 +75,7 @@ export interface Adapter<C extends Collections> {
    *
    * @param references - Can be sparse
    */
-  forget<N extends CollectionName<C>, T>(
+  delete<N extends CollectionName<C>, T>(
     collectionName: N,
     references: (RecordReference<T> | undefined)[]
   ): Promise<void>;

--- a/packages/db/src/meta/pouch/types.ts
+++ b/packages/db/src/meta/pouch/types.ts
@@ -4,33 +4,36 @@ const debug = logger("db:meta:pouch:types");
 import PouchDB from "pouchdb";
 
 import type { Collections, CollectionName } from "@truffle/db/meta/collections";
-import type { Historical } from "@truffle/db/meta/data";
 import type * as Id from "@truffle/db/meta/id";
 
+export type History = PouchDB.Core.IdMeta & PouchDB.Core.GetMeta;
+
+export type Historical<T> = T & History;
+
 export interface Adapter<C extends Collections> {
-  every<N extends CollectionName<C>, I extends { id: string }>(
+  every<N extends CollectionName<C>, I extends PouchDB.Core.IdMeta>(
     collectionName: N
   ): Promise<Historical<I>[]>;
 
-  retrieve<N extends CollectionName<C>, I extends { id: string }>(
+  retrieve<N extends CollectionName<C>, I extends PouchDB.Core.IdMeta>(
     collectionName: N,
-    references: (Pick<I, "id"> | undefined)[]
+    references: (Pick<I, "_id"> | undefined)[]
   ): Promise<(Historical<I> | undefined)[]>;
 
-  search<N extends CollectionName<C>, I extends { id: string }>(
+  search<N extends CollectionName<C>, I extends PouchDB.Core.IdMeta>(
     collectionName: N,
     options: PouchDB.Find.FindRequest<{}>
   ): Promise<Historical<I>[]>;
 
-  record<N extends CollectionName<C>, I extends { id: string }>(
+  record<N extends CollectionName<C>, I extends PouchDB.Core.IdMeta>(
     collectionName: N,
     inputs: (I | undefined)[],
     options: { overwrite?: boolean }
   ): Promise<(Historical<I> | undefined)[]>;
 
-  forget<N extends CollectionName<C>, I extends { id: string }>(
+  forget<N extends CollectionName<C>, I extends PouchDB.Core.IdMeta>(
     collectionName: N,
-    references: (Pick<I, "id"> | undefined)[]
+    references: (Pick<I, "_id"> | undefined)[]
   ): Promise<void>;
 }
 

--- a/packages/db/src/meta/pouch/types.ts
+++ b/packages/db/src/meta/pouch/types.ts
@@ -64,7 +64,7 @@ export interface Adapter<C extends Collections> {
    * @param records - Can be sparse
    * @return - Items in list correspond to `records` by index (also sparse)
    */
-  record<N extends CollectionName<C>, T>(
+  save<N extends CollectionName<C>, T>(
     collectionName: N,
     records: (Record<T> | undefined)[],
     options: { overwrite?: boolean }

--- a/packages/db/src/meta/pouch/workspace.ts
+++ b/packages/db/src/meta/pouch/workspace.ts
@@ -1,0 +1,190 @@
+import { logger } from "@truffle/db/logger";
+const debug = logger("db:meta:pouch:workspace");
+
+import type PouchDB from "pouchdb";
+
+import type {
+  CollectionName,
+  Collections,
+  MutationInput,
+  MutationPayload,
+  MutableCollectionName,
+  Input,
+  SavedInput
+} from "@truffle/db/meta/collections";
+import * as Id from "@truffle/db/meta/id";
+import type { Workspace, Historical } from "@truffle/db/meta/data";
+
+import type { Adapter, Definitions } from "@truffle/db/meta/pouch/types";
+
+export interface AdapterWorkspaceConstructorOptions<C extends Collections> {
+  adapter: Adapter<C>;
+  definitions: Definitions<C>;
+}
+
+export class AdapterWorkspace<C extends Collections> implements Workspace<C> {
+  private adapter: Adapter<C>;
+  private generateId: Id.GenerateId<C>;
+
+  constructor({
+    adapter,
+    definitions
+  }: AdapterWorkspaceConstructorOptions<C>) {
+    this.adapter = adapter;
+    this.generateId = Id.forDefinitions(definitions);
+  }
+
+  public async all<N extends CollectionName<C>>(
+    collectionName: N
+  ): Promise<SavedInput<C, N>[]> {
+    const log = debug.extend(`${collectionName}:all`);
+    log("Fetching all...");
+
+    try {
+      const result = await this.adapter.every<N, SavedInput<C, N>>(collectionName);
+
+      log("Found.");
+      return result as SavedInput<C, N>[];
+    } catch (error) {
+      log("Error fetching all %s, got error: %O", collectionName, error);
+      throw error;
+    }
+  }
+
+  public async find<N extends CollectionName<C>>(
+    collectionName: N,
+    options: (Id.IdObject<C, N> | undefined)[] | PouchDB.Find.FindRequest<{}>
+  ): Promise<(SavedInput<C, N> | undefined)[]> {
+    const log = debug.extend(`${collectionName}:find`);
+    log("Finding...");
+
+    try {
+      // handle convenient interface for getting a bunch of IDs while preserving
+      // order of input request
+      if (Array.isArray(options)) {
+        const references = options;
+
+        return await this.adapter.retrieve<N, SavedInput<C, N>>(
+          collectionName,
+          references as (Pick<SavedInput<C, N>, "id"> | undefined)[]
+        ) as (SavedInput<C, N> | undefined)[];
+      }
+
+      const result = await this.adapter.search<N, SavedInput<C, N>>(
+        collectionName,
+        options
+      );
+
+      log("Found.");
+      return result as SavedInput<C, N>[];
+    } catch (error) {
+      log("Error fetching all %s, got error: %O", collectionName, error);
+      throw error;
+    }
+  }
+
+  public async get<N extends CollectionName<C>>(
+    collectionName: N,
+    id: string | undefined
+  ): Promise<Historical<SavedInput<C, N>> | undefined> {
+    if (typeof id === "undefined") {
+      return;
+    }
+    const [savedInput] = await this.adapter.retrieve<N, SavedInput<C, N>>(
+      collectionName,
+      [{ id }]
+    );
+
+    return savedInput;
+  }
+
+  public async add<N extends CollectionName<C>>(
+    collectionName: N,
+    input: MutationInput<C, N>
+  ): Promise<MutationPayload<C, N>> {
+    const log = debug.extend(`${collectionName}:add`);
+    log("Adding...");
+
+    const inputsWithIds = input[collectionName].map(
+      input => this.attachId(collectionName, input)
+    );
+
+    const addedInputs = await this.adapter.record<N, SavedInput<C, N>>(
+      collectionName,
+      inputsWithIds,
+      { overwrite: false }
+    );
+
+    log(
+      "Added ids: %o",
+      addedInputs
+        .filter((input): input is Historical<SavedInput<C, N>> => !!input)
+        .map(({ id }) => id)
+    );
+
+    return {
+      [collectionName]: addedInputs
+    } as MutationPayload<C, N>;
+  }
+
+  public async update<M extends MutableCollectionName<C>>(
+    collectionName: M,
+    input: MutationInput<C, M>
+  ): Promise<MutationPayload<C, M>> {
+    const log = debug.extend(`${collectionName}:update`);
+    log("Updating...");
+
+    const inputsWithIds = input[collectionName].map(
+      input => this.attachId(collectionName, input)
+    );
+
+    const updatedInputs = await this.adapter.record<M, SavedInput<C, M>>(
+      collectionName,
+      inputsWithIds,
+      { overwrite: true }
+    );
+
+    log(
+      "Updated ids: %o",
+      updatedInputs
+        .filter((input): input is Historical<SavedInput<C, M>> => !!input)
+        .map(({ id }) => id)
+    );
+
+    return {
+      [collectionName]: updatedInputs
+    } as MutationPayload<C, M>;
+  }
+
+  public async remove<M extends MutableCollectionName<C>>(
+    collectionName: M,
+    input: MutationInput<C, M>
+  ): Promise<void> {
+    const log = debug.extend(`${collectionName}:remove`);
+    log("Removing...");
+
+    const inputsWithIds = input[collectionName].map(
+      input => this.attachId(collectionName, input)
+    );
+
+    await this.adapter.forget(collectionName, inputsWithIds);
+
+    log("Removed.");
+  }
+
+  private attachId<N extends CollectionName<C>>(
+    collectionName: N,
+    input: Input<C, N> | undefined
+  ) {
+    const id = this.generateId<N>(collectionName, input);
+
+    if (typeof id === "undefined") {
+      return;
+    }
+
+    return {
+      ...input,
+      id
+    } as SavedInput<C, N>;
+  }
+}

--- a/packages/db/src/meta/pouch/workspace.ts
+++ b/packages/db/src/meta/pouch/workspace.ts
@@ -183,7 +183,7 @@ export class AdapterWorkspace<C extends Collections> implements Workspace<C> {
       input ? this.marshal(collectionName, input) : undefined
     );
 
-    await this.adapter.forget(collectionName, records);
+    await this.adapter.delete(collectionName, records);
 
     log("Removed.");
   }

--- a/packages/db/src/meta/pouch/workspace.ts
+++ b/packages/db/src/meta/pouch/workspace.ts
@@ -131,7 +131,7 @@ export class AdapterWorkspace<C extends Collections> implements Workspace<C> {
       input ? this.marshal(collectionName, input) : undefined
     );
 
-    const savedRecords = await this.adapter.record<N, Input<C, N>>(
+    const savedRecords = await this.adapter.save<N, Input<C, N>>(
       collectionName,
       records,
       { overwrite: false }
@@ -164,7 +164,7 @@ export class AdapterWorkspace<C extends Collections> implements Workspace<C> {
       input ? this.marshal(collectionName, input) : undefined
     );
 
-    const savedRecords = await this.adapter.record<M, Input<C, M>>(
+    const savedRecords = await this.adapter.save<M, Input<C, M>>(
       collectionName,
       records,
       { overwrite: true }


### PR DESCRIPTION
Currently, @truffle/db defines the [`Workspace<C>`](https://www.trufflesuite.com/docs/truffle/db/interfaces/meta.workspace.html) interface for use across many modules, implementing that workspace directly via the class hierarchy of PouchDB adapters (i.e., the base [`Databases<C>`](https://www.trufflesuite.com/docs/truffle/db/classes/meta.pouch.adapters.base.databases.html) class).

In order to support future work of allowing schema migrations, we can't abide the constraints defined by `Workspace<C>` - this interface accepts/returns data in _the current schema_. We need an interface that can read/write to our PouchDB adapter via _past versions of the schema_ as well.

This PR removes `implements Workspace<C>` from the PouchDB adapter classes, implementing instead the new `Adapter<C>` interface that provides weaker typing. It adds a new concrete class `AdapterWorkspace<C>`, to then translate an `Adapter<C>` into a `Workspace<C>`. Thus, existing code will continue to use `Workspace<C>`, but whatever future schema migration system can be built to use `Adapter<C>` directly.

To support this new Adapter interface, this PR also introduces some new naming: adapters now operate on Records, which have IDs (PouchDB's `_id` field), and SavedRecords, which have all the other Pouch fields (like `_rev`). The purpose of this new terminology is to distinguish these low-level types from the existing high-level types (e.g. `Input` and `SavedInput`), which are exposed by the Workspace interface and part of the current data model.