### PR TITLE
Internal improvement: Implement reset for txlog

### DIFF
--- a/packages/debugger/lib/evm/sagas/index.js
+++ b/packages/debugger/lib/evm/sagas/index.js
@@ -215,7 +215,7 @@ export function* callstackAndCodexSaga() {
 }
 
 export function* reset() {
-  let initialCall = yield select(evm.transaction.initialCall);
+  const initialCall = yield select(evm.transaction.initialCall);
   yield put(actions.reset());
   yield put(initialCall);
 }

--- a/packages/debugger/lib/txlog/sagas/index.js
+++ b/packages/debugger/lib/txlog/sagas/index.js
@@ -236,7 +236,9 @@ function callKind(context, calldata, instant) {
 }
 
 export function* reset() {
+  const initialCall = yield select(txlog.transaction.initialCall);
   yield put(actions.reset());
+  yield put(initialCall);
 }
 
 export function* unload() {

--- a/packages/debugger/lib/txlog/selectors/index.js
+++ b/packages/debugger/lib/txlog/selectors/index.js
@@ -70,6 +70,11 @@ let txlog = createSelectorTree({
     origin: createLeaf([evm.transaction.globals.tx], tx => tx.origin),
 
     /**
+     * txlog.transaction.initialCall
+     */
+    initialCall: createLeaf(["/state"], state => state.transaction.initialCall),
+
+    /**
      * txlog.transaction.absorbFirstInternalCall
      */
     absorbFirstInternalCall: createLeaf(

--- a/packages/debugger/test/txlog.js
+++ b/packages/debugger/test/txlog.js
@@ -409,4 +409,41 @@ describe("Transaction log (visualizer)", function () {
       "Oops!"
     );
   });
+
+  it("Resets properly", async function () {
+    this.timeout(12000);
+    let instance = await abstractions.VizTest.deployed();
+    let receipt = await instance.testCall(108);
+    let txHash = receipt.tx;
+
+    let bugger = await Debugger.forTx(txHash, {
+      provider,
+      compilations
+    });
+
+    await bugger.continueUntilBreakpoint(); //run till end
+    await bugger.reset();
+
+    const root = bugger.view(txlog.views.transactionLog);
+    assert.equal(root.type, "transaction");
+    assert.isDefined(root.origin); //not going to bother checking specific address
+    assert.lengthOf(root.actions, 1);
+    let call = root.actions[0];
+    assert.equal(call.type, "callexternal");
+    assert.equal(call.kind, "function");
+    assert.equal(call.address, instance.address);
+    assert.equal(call.functionName, "testCall");
+    assert.equal(call.contractName, "VizTest");
+    assert.notProperty(call, "returnKind");
+    let inputs = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
+      byName(call.arguments)
+    );
+    assert.deepEqual(inputs, {
+      x: 108
+    });
+    assert.notProperty(call, "returnValues");
+    assert.lengthOf(call.actions, 0);
+    assert.isTrue(call.waitingForFunctionDefinition);
+    assert.isTrue(call.absorbNextInternalCall);
+  });
 });


### PR DESCRIPTION
Somehow when writing `txlog` I forgot to implement resetting it.  This has been a pain when trying to debug problems with txlog.

Unfortunately txlog is complicated enough that directly resetting it wasn't practical, so I reused a hack from `evm`: We store the initial call, and in order to reset, rather than attempting to directly reset to after the initial call, we reset to just *before* the initial call and then replay that call.  (At the beginning, there are normally two `txlog` actions; one to set the origin, the other to do the initial call.  We reset to inbetween these two, so we do keep the origin.)

Note this doesn't really alter the end result of `txlog`, but it will make debugging it substantially easier in the future.

I also added a test of this functionality.  Also as you can see I also made some style changes. :P  (Husky still isn't running, but...)