### PR TITLE
Internal improvement: Add `returnData` to txlog

### DIFF
--- a/packages/debugger/lib/txlog/actions/index.js
+++ b/packages/debugger/lib/txlog/actions/index.js
@@ -134,12 +134,13 @@ export function instantCreate(
 }
 
 export const EXTERNAL_RETURN = "TXLOG_EXTERNAL_RETURN";
-export function externalReturn(pointer, newPointer, decodings) {
+export function externalReturn(pointer, newPointer, decodings, returnData) {
   return {
     type: EXTERNAL_RETURN,
     pointer,
     newPointer,
-    decodings
+    decodings,
+    returnData
   };
 }
 

--- a/packages/debugger/lib/txlog/reducers.js
+++ b/packages/debugger/lib/txlog/reducers.js
@@ -239,30 +239,29 @@ function transactionLog(state = DEFAULT_TX_LOG, action) {
       if (!finalNode.returnKind) {
         finalNode.returnKind = "unwind";
       }
-      //now let's set its return variables (or return data) if applicable.
+      //now let's set its return variables if applicable.
       if (
+        finalNode.kind === "function" &&
         action.type === actions.EXTERNAL_RETURN &&
         action.decodings
       ) {
-        if (finalNode.kind === "function") {
-          //functions get returnValues
-          const decoding = action.decodings.find(
-            decoding => decoding.kind === "return"
-          );
-          if (decoding) {
-            //we'll trust this method over the method resulting from an internal return,
-            //*if* it produces a valid return-value decoding.  if it doesn't, we ignore it.
-            finalNode.returnValues = decoding.arguments;
-          }
-        } else if (finalNode.kind === "message") {
-          //messages get returnData
-          const decoding = action.decodings.find(
-            decoding => decoding.kind === "returnmessage"
-          );
-          if (decoding) {
-            finalNode.returnData = decoding.data;
-          }
+        //functions get returnValues
+        const decoding = action.decodings.find(
+          decoding => decoding.kind === "return"
+        );
+        if (decoding) {
+          //we'll trust this method over the method resulting from an internal return,
+          //*if* it produces a valid return-value decoding.  if it doesn't, we ignore it.
+          finalNode.returnValues = decoding.arguments;
         }
+      }
+      //and we'll set raw return data if applicable
+      //(we don't use codec here to increase robustness)
+      if (
+        finalNode.kind === "message" &&
+        action.type === actions.EXTERNAL_RETURN
+      ) {
+        finalNode.returnData = action.returnData;
       }
       //also, set immutables if applicable -- note that we do *not* attempt to set
       //these the internal way, as we don't have a reliable way of doing that

--- a/packages/debugger/lib/txlog/sagas/index.js
+++ b/packages/debugger/lib/txlog/sagas/index.js
@@ -31,8 +31,11 @@ function* updateTransactionLogSaga() {
         yield put(actions.selfdestruct(pointer, newPointer, beneficiary));
       } else {
         const decodings = yield* data.decodeReturnValue();
+        const rawData = yield select(txlog.current.returnData);
         debug("external return: %o %o", pointer, newPointer);
-        yield put(actions.externalReturn(pointer, newPointer, decodings));
+        yield put(
+          actions.externalReturn(pointer, newPointer, decodings, rawData)
+        );
       }
     } else {
       const error = (yield* data.decodeReturnValue())[0]; //NOTE: we will do this a better way in the future!

--- a/packages/debugger/lib/txlog/selectors/index.js
+++ b/packages/debugger/lib/txlog/selectors/index.js
@@ -348,6 +348,11 @@ let txlog = createSelectorTree({
     beneficiary: createLeaf([evm.current.step.beneficiary], identity),
 
     /**
+     * txlog.current.returnData
+     */
+    returnData: createLeaf([evm.current.step.returnValue], identity),
+
+    /**
      * txlog.current.inputParameterAllocations
      */
     inputParameterAllocations: createLeaf(

--- a/packages/debugger/test/txlog.js
+++ b/packages/debugger/test/txlog.js
@@ -36,8 +36,9 @@ contract VizTest {
     payable(tx.origin).transfer(1);
   }
 
-  fallback() external {
-    called(msg.data.length);
+  fallback(bytes calldata input) external returns (bytes memory) {
+    called(input.length);
+    return hex"beefdead";
   }
 
   function testRevert() public {
@@ -344,6 +345,7 @@ describe("Transaction log (visualizer)", function () {
     assert.equal(call.contractName, "VizTest");
     assert.equal(call.data, "0xdeadbeef");
     assert.equal(call.returnKind, "return");
+    assert.equal(call.returnData, "0xbeefdead");
     assert.lengthOf(call.actions, 1);
     call = call.actions[0];
     assert.equal(call.type, "callinternal");


### PR DESCRIPTION
Addresses #3822.  However I called the field `returnData` rather than `returndata`.

In more detail:

The original version of txlog would track return values for functions, as well as revert messages, but it wouldn't track raw binary returned from a fallback function.  That's because the ability to do this in Solidity was only introduced in 0.7.6!  So we didn't track it as it wasn't something that should ordinarily happen.

So, now we do that.  This didn't require any big code changes, because for fallback functions that can return data, `codec` already includes the raw data as a possible return decoding.  So we do it the same way we do `returnValues`, just instead of looking for the `function` call type and the `return` decoding type, we look for the `message` call type and the `returnmessage` decoding type.

The one thing I worry about here is that this approach will *only* work for fallback functions that are supposed to be able for return data, not for anything else.  We might want to make sure this works more broadly, which would require doing things slightly differently.  Not that different though; this still wouldn't be that hard.  Let me know if you think that's worth doing.

**Edit**: Actually I did go back and redo it this more robust way, see comment below.