### PR TITLE
Check if error.response exists

### DIFF
--- a/packages/box/lib/utils/unbox.ts
+++ b/packages/box/lib/utils/unbox.ts
@@ -31,7 +31,7 @@ async function verifyVCSURL(url: string) {
       { maxRedirects: 50 }
     );
   } catch (error) {
-    if (error.response.status === 404) {
+    if (error.response && error.response.status === 404) {
       throw new Error(
         `Truffle Box at URL ${url} doesn't exist. If you believe this is an error, please contact Truffle support.`
       );


### PR DESCRIPTION
If you cannot access `raw.githubusercontent.com` in China, then `error.response` does not exist. 
So we need to check `error.response` first, and then judge `error.response.status` in [here](https://github.com/trufflesuite/truffle/blob/develop/packages/box/lib/utils/unbox.ts#L34).
Otherwise you will get the following error.
```
$ truffle unbox metacoin-box

Starting unbox...
=================

✔ Preparing to download box
✖ Downloading
Unbox failed!
✖ Downloading
Unbox failed!
TypeError: Cannot read property 'status' of undefined
    at /usr/local/lib/node_modules/truffle/build/webpack:/packages/box/dist/lib/utils/unbox.js:41:1
    at Generator.throw (<anonymous>)
    at rejected (/usr/local/lib/node_modules/truffle/build/webpack:/packages/box/dist/lib/utils/unbox.js:6:41)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
Truffle v5.3.6 (core: 5.3.6)
Node v14.17.0
```