### PR TITLE
Update to proper Yul highlighting

### DIFF
--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -785,14 +785,8 @@ var DebugUtils = {
       case "Solidity":
         return chromafi(code, options);
       case "Yul":
-        //HACK: stick the code in an assembly block since we don't
-        //have a separate Yul language for HLJS at the moment,
-        //colorize it there, then extract it after colorization
-        const wrappedCode = "assembly {\n" + code + "\n}";
-        const colorizedWrapped = chromafi(wrappedCode, options);
-        const firstNewLine = colorizedWrapped.indexOf("\n");
-        const lastNewLine = colorizedWrapped.lastIndexOf("\n");
-        return colorizedWrapped.slice(firstNewLine + 1, lastNewLine);
+        options.lang = "yul"; //registered along with Solidity :)
+        return chromafi(code, options);
       case "Vyper":
         options.lang = "python"; //HACK -- close enough for now!
         return chromafi(code, options);

--- a/packages/debug-utils/package.json
+++ b/packages/debug-utils/package.json
@@ -24,7 +24,7 @@
     "chalk": "^2.4.2",
     "debug": "^4.3.1",
     "highlight.js": "^10.4.0",
-    "highlightjs-solidity": "^1.0.22"
+    "highlightjs-solidity": "^1.1.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14070,10 +14070,10 @@ highlight.js@^9.15.8:
   dependencies:
     handlebars "^4.5.3"
 
-highlightjs-solidity@^1.0.22:
-  version "1.0.22"
-  resolved "https://registry.yarnpkg.com/highlightjs-solidity/-/highlightjs-solidity-1.0.22.tgz#da3537cfcd4d49505bdc56700132422f403f5924"
-  integrity sha512-Ha1TDrtOwCDCSa+D99CMCdm2fOlpMqcEzC45rpwyr6SOPvor69tqhecolUA7TjnfHU8zJswH3lnxI1ti0tLmFw==
+highlightjs-solidity@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/highlightjs-solidity/-/highlightjs-solidity-1.1.0.tgz#bdf0adba6deffdb1651f8fa63bee4dacc3dc4e00"
+  integrity sha512-LtH7uuoe+FOmtQd41ozAZKLJC2chqdqs461FJcWAx00R3VcBhSQTRFfzRGtTQqu2wsVIEdHiyynrPrEDDWyIMw==
 
 hkts@^0.3.1:
   version "0.3.1"


### PR DESCRIPTION
I recently altered `highlightjs-solidity` so that instead of just registering a `solidity` language, it registers both `solidity` and `yul`.  The `yul` highlighting includes highlighting for things that don't appear in the Solidity assembly version of Yul, but appear only in the standalone version of Yul, and which previously would not have been highlighted.

So, this PR updates us to that, so we can now have proper highlighting for Yul.  It also gets rid of the hack we used to highlight Yul previously, now that Yul exists as a proper language for highlighting.