### PR TITLE
Bug fix: Prevent error from missing error.response in source-fetcher

### DIFF
--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -115,7 +115,7 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     } catch (error) {
       //is this a 404 error? if so just return null
       debug("error: %O", error);
-      if (error.response.status === 404) {
+      if (error.response && error.response.status === 404) {
         return null;
       }
       //otherwise, we've got a problem; rethrow the error
@@ -151,7 +151,7 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     } catch (error) {
       //is this a 404 error? if so just return undefined
       debug("error: %O", error);
-      if (error.response.status === 404) {
+      if (error.response && error.response.status === 404) {
         return undefined;
       }
       //otherwise, we've got a problem; rethrow the error
@@ -169,7 +169,7 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
         return (await axios(requestObject)).data;
       } catch (error) {
         //check: is this a 404 error? if so give up
-        if (error.response.status === 404) {
+        if (error.response && error.response.status === 404) {
           throw error;
         }
         //otherwise, just go back to the top of the loop to retry


### PR DESCRIPTION
On seeing #4046, I realized we ought to be doing the same thing in the Sourcify source-fetcher as well, since it also checks for 404s.  I also checked for other places we might need to make this change, but there don't seem to be any others, so it's just this.