### PR TITLE
Bug fix: Prevent Y from returning to non-error returns

### DIFF
--- a/packages/core/lib/debug/interpreter.js
+++ b/packages/core/lib/debug/interpreter.js
@@ -369,7 +369,7 @@ class DebugInterpreter {
       if (this.session.view(session.status.loaded)) {
         if (this.session.view(trace.finished)) {
           if (!this.session.view(evm.current.step.isExceptionalHalting)) {
-            const errorIndex = this.session.view(stacktrace.current.innerReturnIndex);
+            const errorIndex = this.session.view(stacktrace.current.innerErrorIndex);
             if (errorIndex !== null) {
               const stepSpinner = ora("Stepping...").start();
               await this.session.reset();
@@ -393,7 +393,7 @@ class DebugInterpreter {
     }
     if (cmd === "Y") {
       if (this.session.view(session.status.loaded)) {
-        const errorIndex = this.session.view(stacktrace.current.innerReturnIndex);
+        const errorIndex = this.session.view(stacktrace.current.innerErrorIndex);
         if (errorIndex !== null) {
           const stepSpinner = ora("Stepping...").start();
           await this.session.reset();

--- a/packages/debugger/lib/stacktrace/reducers.js
+++ b/packages/debugger/lib/stacktrace/reducers.js
@@ -129,7 +129,7 @@ function innerReturnStatus(state = null, action) {
   }
 }
 
-function innerReturnIndex(state = null, action) {
+function innerErrorIndex(state = null, action) {
   switch (action.type) {
     case actions.EXTERNAL_RETURN:
       //we use index null to mean don't update
@@ -148,7 +148,7 @@ const proc = combineReducers({
   lastPosition,
   innerReturnPosition,
   innerReturnStatus,
-  innerReturnIndex
+  innerErrorIndex
 });
 
 const reducer = combineReducers({

--- a/packages/debugger/lib/stacktrace/selectors/index.js
+++ b/packages/debugger/lib/stacktrace/selectors/index.js
@@ -146,12 +146,12 @@ let stacktrace = createSelectorTree({
     ),
 
     /**
-     * stacktrace.current.innerReturnIndex
+     * stacktrace.current.innerErrorIndex
      * Index of the most recent error (but not this)
      */
-    innerReturnIndex: createLeaf(
+    innerErrorIndex: createLeaf(
       ["/state"],
-      state => state.proc.innerReturnIndex
+      state => state.proc.innerErrorIndex
     ),
 
     ...createMultistepSelectors(solidity.current),
@@ -169,11 +169,12 @@ let stacktrace = createSelectorTree({
      * initial index for that error)
      * 2. we're not on the last step (we don't want to accidentally
      * save the final step as the last error, it would be confusing)
+     * 3. the return status is actually false
      */
     updateIndex: createLeaf(
-      ["./returnCounter", trace.stepsRemaining],
-      (returnCounter, stepsRemaining) =>
-        returnCounter === 0 && stepsRemaining > 1
+      ["./returnCounter", trace.stepsRemaining, "./returnStatus"],
+      (returnCounter, stepsRemaining, returnStatus) =>
+        returnCounter === 0 && stepsRemaining > 1 && !returnStatus
     ),
 
     /**


### PR DESCRIPTION
Oops!  The `y` command (#4029) had nothing to make sure it only returned to *errors*.  Now we check the return status when checking whether to update the index.

Also I renamed `innerReturnIndex` to `innerErrorIndex` to match this change in behavior.  That'd be a breaking change if we had released `y`, but we hadn't yet, so whatever. :)