### PR TITLE
Bug fix: Prevent function argument corruption after bare block

### DIFF
--- a/packages/debugger/lib/data/sagas/index.js
+++ b/packages/debugger/lib/data/sagas/index.js
@@ -363,6 +363,15 @@ function* variablesAndMappingsSaga() {
       //the rest hopefully will be caught by the modifier preamble
       //(in fact they won't all be, but...)
 
+      //HACK: prevent parameter allocation while popping
+      //sometimes Solidity's sourcemapping will jump back to the function
+      //definition after a bare block while it pops the stack a bit.
+      //we don't want to allocate then, so we'll break out if the current
+      //instruction is a POP.
+      if (yield select(data.current.isPop)) {
+        break;
+      }
+
       //HACK: filter out some garbage
       //this filters out the case where we're really in an invocation of a
       //modifier or base constructor, but have temporarily hit the definition

--- a/packages/debugger/lib/data/selectors/index.js
+++ b/packages/debugger/lib/data/selectors/index.js
@@ -1507,7 +1507,12 @@ const data = createSelectorTree({
     callContext: createLeaf(
       [evm.current.step.callContext],
       debuggerContextToDecoderContext
-    )
+    ),
+
+    /**
+     * data.current.isPop
+     */
+    isPop: createLeaf([evm.current.step.isPop], identity)
   },
 
   /**

--- a/packages/debugger/lib/evm/selectors/index.js
+++ b/packages/debugger/lib/evm/selectors/index.js
@@ -157,7 +157,13 @@ function createStepSelectors(step, state = null) {
     touchesStorage: createLeaf(
       ["./isStore", "isLoad"],
       (stores, loads) => stores || loads
-    )
+    ),
+
+    /*
+     * .isPop
+     * used by data
+     */
+    isPop: createLeaf(["./trace"], step => step.op === "POP")
   };
 
   if (state) {


### PR DESCRIPTION
Addresses #4055.

This PR solves a problem where function arguments would appear to be corrupted after the use of a bare block (a block not part of a control structure such as an `if` or a `while`) that declares local variables.  After such a block, Solidity has to pop its local variables from the stack.  However, if the block is not part of any control structure, this popping, for whatever reason, gets sourcemapped to the function definition.

This means we hit the function definition again, so the debugger thinks that the function's arguments are now at the top of the stack, and it overwrites their previous location with an incorrect location, thus leading to the incorrect values seen for them.

There were two possible ways to fix this.  The more robust way would be to make sure that function argument locations can't just be overwritten like that, but this is a little trickier than it sounds.  It's likely doable, but, well, I didn't want to deal with the potential for edge cases, so instead I took a more targeted approach that just attempts to fix this specifically.  Namely: We do not assign function argument locations if the current instruction is a `POP`.

Anyway hopefully that doesn't screw anything up, but all the tests are passing, so, yeah.  (Also I added a test of this too.)  Regardless this should be fixed now.