### PR TITLE
Convert @truffle/expect to TypeScript

### DIFF
--- a/packages/expect/.gitignore
+++ b/packages/expect/.gitignore
@@ -1,3 +1,4 @@
+dist
 node_modules
 yarn.lock
 package-lock.json

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -13,13 +13,24 @@
     "url": "https://github.com/trufflesuite/truffle/issues"
   },
   "version": "0.0.16",
-  "main": "index.js",
+  "main": "dist/src/index.js",
   "scripts": {
-    "prepare": "exit 0",
+    "build": "yarn build:dist",
+    "clean": "rm -rf ./dist",
+    "prepare": "yarn build",
+    "build:dist": "ttsc",
     "test": "mocha"
   },
+  "types": "dist/src/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "devDependencies": {
-    "mocha": "8.1.2"
+    "@types/node": "12.12.21",
+    "mocha": "8.1.2",
+    "ttypescript": "^1.5.7",
+    "typescript": "^4.1.4",
+    "typescript-transform-paths": "^2.1.0"
   },
   "keywords": [
     "ethereum",

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -19,7 +19,9 @@
     "clean": "rm -rf ./dist",
     "prepare": "yarn build",
     "build:dist": "ttsc",
-    "test": "mocha"
+    "test:code": "mocha",
+    "test:types": "tsd",
+    "test": "yarn test:types && yarn test:code"
   },
   "types": "dist/src/index.d.ts",
   "files": [
@@ -28,6 +30,7 @@
   "devDependencies": {
     "@types/node": "12.12.21",
     "mocha": "8.1.2",
+    "tsd": "^0.15.1",
     "ttypescript": "^1.5.7",
     "typescript": "^4.1.4",
     "typescript-transform-paths": "^2.1.0"

--- a/packages/expect/src/index.ts
+++ b/packages/expect/src/index.ts
@@ -1,35 +1,72 @@
-const Expect = {
-  options(options, expected_keys) {
-    expected_keys.forEach(key => {
-      if (options[key] == null) {
-        throw new Error(`Expected parameter '${key}' not passed to function.`);
-      }
-    });
-  },
+/**
+ * Object type O that includes non-nullable keys K
+ */
+export type Has<O extends {}, K extends string> = O &
+  Required<NonNullable<Pick<O, K & keyof O>>>;
 
-  one(options, expected_keys) {
-    const found: number[] = [];
+/**
+ * Object type O that includes exactly one non-nullable value among keys K
+ */
+export type HasOne<O extends {}, K extends string> = O &
+  {
+    [N in K]: Has<O, N>;
+  }[K];
 
-    expected_keys.forEach(key => {
-      if (options[key] != null) {
-        found.push(1);
-      } else {
-        found.push(0);
-      }
-    });
+/**
+ * Asserts at runtime that `options` contains `key`
+ */
+export function has<O extends {}, K extends string>(
+  options: O,
+  key: K
+): asserts options is Has<O, K> {
+  // @ts-ignore to get around the fact that we know nothing about O
+  if (options[key] == null) {
+    throw new Error(`Expected parameter '${key}' not passed to function.`);
+  }
+}
 
-    const total = found.reduce((t, value) => t + value);
+/**
+ * Asserts at runtime that `options` contains all `expectedKeys`
+ */
+export function options<O extends {}, K extends string>(
+  options: O,
+  expectedKeys: K[]
+): asserts options is Has<O, K> {
+  for (const key of expectedKeys) {
+    has(options, key);
+  }
+}
 
-    // If this doesn't work in all cases, perhaps we should
-    // create an expect.onlyOne() function.
-    if (total < 1) {
-      throw new Error(
-        `Expected one of the following parameters, but found none: ${expected_keys.join(
-          ", "
-        )}`
-      );
+/**
+ * Asserts at runtime that `options` contains at least one of `expectedKeys`
+ *
+ * Post-condition: this narrows type of `options` to include _exactly one_ of
+ * `expectedKeys`, even though at runtime this accepts more than one key.
+ */
+export function one<O extends {}, K extends string>(
+  options: O,
+  expectedKeys: K[]
+): asserts options is HasOne<O, K> {
+  let found = false;
+
+  for (const key of expectedKeys) {
+    try {
+      has(options, key);
+
+      found = true;
+      break;
+    } catch {
+      continue;
     }
   }
-};
 
-export default Expect;
+  // If this doesn't work in all cases, perhaps we should
+  // create an expect.onlyOne() function.
+  if (!found) {
+    throw new Error(
+      `Expected one of the following parameters, but found none: ${expectedKeys.join(
+        ", "
+      )}`
+    );
+  }
+}

--- a/packages/expect/src/index.ts
+++ b/packages/expect/src/index.ts
@@ -8,7 +8,7 @@ const Expect = {
   },
 
   one(options, expected_keys) {
-    const found = [];
+    const found: number[] = [];
 
     expected_keys.forEach(key => {
       if (options[key] != null) {
@@ -32,4 +32,4 @@ const Expect = {
   }
 };
 
-module.exports = Expect;
+export default Expect;

--- a/packages/expect/src/index.ts
+++ b/packages/expect/src/index.ts
@@ -47,18 +47,23 @@ export function one<O extends {}, K extends string>(
   options: O,
   expectedKeys: K[]
 ): asserts options is HasOne<O, K> {
-  let found = false;
-
-  for (const key of expectedKeys) {
+  const found = expectedKeys.some(key => {
     try {
       has(options, key);
 
-      found = true;
-      break;
-    } catch {
-      continue;
+      return true;
+    } catch (error) {
+      if (
+        !error.message.includes(
+          `Expected parameter '${key}' not passed to function.`
+        )
+      ) {
+        throw error;
+      }
+
+      return false;
     }
-  }
+  });
 
   // If this doesn't work in all cases, perhaps we should
   // create an expect.onlyOne() function.

--- a/packages/expect/test-d/index.ts
+++ b/packages/expect/test-d/index.ts
@@ -85,3 +85,20 @@ interface Options {
     expectNotType<number>(quantity);
   }
 }
+
+// expect.one with more than one
+{
+  const options: Options = { size: "small", design: "neon", quantity: 5 };
+  expect.one(options, ["size", "quantity"]);
+
+  expectAssignable<{ size: string } | { quantity: number }>(options);
+  expectNotAssignable<{ size: string; quantity: number }>(options);
+
+  {
+    expect.has(options, "size");
+    const { size, quantity } = options;
+
+    expectType<string>(size);
+    expectNotType<number>(quantity);
+  }
+}

--- a/packages/expect/test-d/index.ts
+++ b/packages/expect/test-d/index.ts
@@ -1,0 +1,87 @@
+import {
+  expectAssignable,
+  expectNotAssignable,
+  expectType,
+  expectNotType
+} from "tsd";
+
+import * as expect from "..";
+
+interface Options {
+  size?: string;
+  design?: "original" | "neon";
+  quantity?: number;
+}
+
+// expect.has
+{
+  const options: Options = { size: "medium", design: "original" };
+
+  // assert we have size
+  expect.has(options, "size");
+
+  // check that we can assign asserted
+  expectAssignable<{ size: string }>(options);
+
+  // check that we can't assign not-asserted
+  expectNotAssignable<{ size: string; design: "original" | "neon" }>(options);
+
+  {
+    const { size, design } = options;
+
+    // check destructured properties
+    expectType<string>(size);
+    expectNotType<"original" | "neon">(design);
+  }
+
+  // add additional assertion now
+  expect.has(options, "design");
+
+  // check that assignment now holds
+  expectAssignable<{ design: "original" | "neon" }>(options);
+
+  {
+    // and check destructuring again
+    const { design } = options;
+    expectType<"original" | "neon">(design);
+  }
+}
+
+// expect.options
+{
+  const options: Options = { size: "medium", design: "original" };
+
+  // assert two properties
+  expect.options(options, ["size", "design"]);
+
+  // check both properties
+  expectAssignable<{ size: string; design: "original" | "neon" }>(options);
+
+  // check that we can't assign other properties
+  expectNotAssignable<{ quantity: number }>(options);
+
+  {
+    // check destructuring
+    const { size, design, quantity } = options;
+    expectType<string>(size);
+    expectType<"original" | "neon">(design);
+    expectNotType<number>(quantity);
+  }
+}
+
+// expect.one
+{
+  const options: Options = { design: "original", quantity: 5 };
+  expect.one(options, ["size", "quantity"]);
+
+  expectAssignable<{ size: string } | { quantity: number }>(options);
+  expectNotAssignable<{ size: string; quantity: number }>(options);
+
+  {
+    expect.has(options, "size");
+    const { size, quantity } = options;
+
+    expectType<string>(size);
+    expectNotType<number>(quantity);
+  }
+}

--- a/packages/expect/test/index.js
+++ b/packages/expect/test/index.js
@@ -1,4 +1,4 @@
-const expect = require("../index");
+const expect = require("../");
 const assert = require("assert");
 
 // object being testing

--- a/packages/expect/tsconfig.json
+++ b/packages/expect/tsconfig.json
@@ -1,0 +1,39 @@
+{
+  "compilerOptions": {
+    "sourceMap": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "lib": ["esnext"],
+    "skipLibCheck": true,
+    "target": "es6",
+    "moduleResolution": "node",
+    "downlevelIteration": true,
+    "allowSyntheticDefaultImports": true,
+    "module": "commonjs",
+    "outDir": "./dist",
+    "strictBindCallApply": true,
+    "strictNullChecks": true,
+    "paths": {
+      "@truffle/expect": ["./src"],
+      "@truffle/expect/*": ["./src/*"],
+      "test/*": ["./test/*"]
+    },
+    "rootDir": ".",
+    "baseUrl": ".",
+    "types": [
+      "node"
+    ],
+    "plugins": [
+      { "transform": "typescript-transform-paths" },
+      { "transform": "typescript-transform-paths", "afterDeclarations": true }
+    ]
+  },
+  "include": [
+    "src/**/*",
+    "bin/**/*",
+    "test/**/*"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7196,6 +7196,20 @@ borc@^2.1.2:
     json-text-sequence "~0.1.0"
     readable-stream "^3.6.0"
 
+boxen@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/boxen/-/boxen-4.2.0.tgz#e411b62357d6d6d36587c8ac3d5d974daa070e64"
+  integrity sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==
+  dependencies:
+    ansi-align "^3.0.0"
+    camelcase "^5.3.1"
+    chalk "^3.0.0"
+    cli-boxes "^2.2.0"
+    string-width "^4.1.0"
+    term-size "^2.1.0"
+    type-fest "^0.8.1"
+    widest-line "^3.1.0"
+
 boxen@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/boxen/-/boxen-5.0.0.tgz#64fe9b16066af815f51057adcc800c3730120854"
@@ -10879,10 +10893,28 @@ esdoc@^1.0.4:
     minimist "1.2.0"
     taffydb "2.7.3"
 
+eslint-formatter-pretty@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-formatter-pretty/-/eslint-formatter-pretty-4.0.0.tgz#dc15f3bf4fb51b7ba5fbedb77f57ba8841140ce2"
+  integrity sha512-QgdeZxQwWcN0TcXXNZJiS6BizhAANFhCzkE7Yl9HKB7WjElzwED6+FbbZB2gji8ofgJTGPqKm6VRCNT3OGCeEw==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^4.1.0"
+    eslint-rule-docs "^1.1.5"
+    log-symbols "^4.0.0"
+    plur "^4.0.0"
+    string-width "^4.2.0"
+    supports-hyperlinks "^2.0.0"
+
 eslint-plugin-react-hooks@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz#8c229c268d468956334c943bb45fc860280f5556"
   integrity sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==
+
+eslint-rule-docs@^1.1.5:
+  version "1.1.226"
+  resolved "https://registry.yarnpkg.com/eslint-rule-docs/-/eslint-rule-docs-1.1.226.tgz#5778f20065109ab7c5604100776af089f76f9ca0"
+  integrity sha512-Wnn0ETzE2v2UT0OdRCcdMNPkQtbzyZr3pPPXnkreP0l6ZJaKqnl88dL1DqZ6nCCZZwDGBAnN0Y+nCvGxxLPQLQ==
 
 eslint-scope@^4.0.3:
   version "4.0.3"
@@ -13335,6 +13367,13 @@ glob@^5.0.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+global-dirs@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-2.1.0.tgz#e9046a49c806ff04d6c1825e196c8f0091e8df4d"
+  integrity sha512-MG6kdOUh/xBnyo9cJFeIKkLEc1AyFq42QTU4XiX51i2NEdxLxLWXIjEjmqKeSuKR7pAZjTqUVoT2b2huxVLgYQ==
+  dependencies:
+    ini "1.3.7"
+
 global-dirs@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-3.0.0.tgz#70a76fe84ea315ab37b1f5576cbde7d48ef72686"
@@ -14492,6 +14531,11 @@ inherits@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
+
+ini@1.3.7:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.7.tgz#a09363e1911972ea16d7a8851005d84cf09a9a84"
+  integrity sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==
 
 ini@2.0.0:
   version "2.0.0"
@@ -15698,6 +15742,11 @@ ipns@^0.8.0:
     timestamp-nano "^1.0.0"
     uint8arrays "^2.0.5"
 
+irregular-plurals@^3.2.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/irregular-plurals/-/irregular-plurals-3.3.0.tgz#67d0715d4361a60d9fd9ee80af3881c631a31ee2"
+  integrity sha512-MVBLKUTangM3EfRPFROhmWQQKRDsrgI83J8GS3jXy+OwYqiR2/aoWndYQ5416jLE3uaGgLH7ncme3X9y09gZ3g==
+
 is-absolute@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-absolute/-/is-absolute-1.0.0.tgz#395e1ae84b11f26ad1795e73c17378e48a301576"
@@ -15983,6 +16032,14 @@ is-hex-prefixed@1.0.0:
   resolved "https://registry.yarnpkg.com/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz#7d8d37e6ad77e5d127148913c573e082d777f554"
   integrity sha1-fY035q135dEnFIkTxXPggtd39VQ=
 
+is-installed-globally@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.3.2.tgz#fd3efa79ee670d1187233182d5b0a1dd00313141"
+  integrity sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==
+  dependencies:
+    global-dirs "^2.0.1"
+    is-path-inside "^3.0.1"
+
 is-installed-globally@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.4.0.tgz#9a0fd407949c30f86eb6959ef1b7994ed0b7b520"
@@ -16042,6 +16099,11 @@ is-negative-zero@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.1.tgz#3de746c18dda2319241a53675908d8f766f11c24"
   integrity sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==
+
+is-npm@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-4.0.0.tgz#c90dd8380696df87a7a6d823c20d0b12bbe3c84d"
+  integrity sha512-96ECIfh9xtDDlPylNPXhzjsykHsMJZ18ASpaWzQyBr4YRTcVjUvzaHayDAES2oU/3KpljhHUjtSRNiDwi0F0ig==
 
 is-npm@^5.0.0:
   version "5.0.0"
@@ -16129,6 +16191,11 @@ is-path-inside@^2.1.0:
   integrity sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==
   dependencies:
     path-is-inside "^1.0.2"
+
+is-path-inside@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
+  integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
 
 is-path-inside@^3.0.2:
   version "3.0.2"
@@ -17920,7 +17987,7 @@ labeled-stream-splicer@^2.0.0:
     inherits "^2.0.1"
     stream-splicer "^2.0.0"
 
-latest-version@^5.1.0:
+latest-version@^5.0.0, latest-version@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-5.1.0.tgz#119dfe908fe38d15dfa43ecd13fa12ec8832face"
   integrity sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==
@@ -19780,6 +19847,23 @@ meow@^5.0.0:
     redent "^2.0.0"
     trim-newlines "^2.0.0"
     yargs-parser "^10.0.0"
+
+meow@^7.0.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/meow/-/meow-7.1.1.tgz#7c01595e3d337fcb0ec4e8eed1666ea95903d306"
+  integrity sha512-GWHvA5QOcS412WCo8vwKDlTelGLsCGBVevQB5Kva961rmNfun0PCbv5+xta2kUMFJyR8/oWnn7ddeKdosbAPbA==
+  dependencies:
+    "@types/minimist" "^1.2.0"
+    camelcase-keys "^6.2.2"
+    decamelize-keys "^1.1.0"
+    hard-rejection "^2.1.0"
+    minimist-options "4.1.0"
+    normalize-package-data "^2.5.0"
+    read-pkg-up "^7.0.1"
+    redent "^3.0.0"
+    trim-newlines "^3.0.0"
+    type-fest "^0.13.1"
+    yargs-parser "^18.1.3"
 
 meow@^9.0.0:
   version "9.0.0"
@@ -22486,6 +22570,13 @@ please-upgrade-node@^3.1.1, please-upgrade-node@^3.2.0:
   dependencies:
     semver-compare "^1.0.0"
 
+plur@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/plur/-/plur-4.0.0.tgz#729aedb08f452645fe8c58ef115bf16b0a73ef84"
+  integrity sha512-4UGewrYgqDFw9vV6zNV+ADmPAUAfJPKtGvb/VdpQAx25X5f3xXdGdyOEVFwkl8Hl/tl7+xbeHqSEM+D5/TirUg==
+  dependencies:
+    irregular-plurals "^3.2.0"
+
 pluralize@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
@@ -23271,7 +23362,7 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-pupa@^2.1.1:
+pupa@^2.0.1, pupa@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/pupa/-/pupa-2.1.1.tgz#f5e8fd4afc2c5d97828faa523549ed8744a20d62"
   integrity sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==
@@ -23506,7 +23597,7 @@ read-pkg-up@^4.0.0:
     find-up "^3.0.0"
     read-pkg "^3.0.0"
 
-read-pkg-up@^7.0.1:
+read-pkg-up@^7.0.0, read-pkg-up@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-7.0.1.tgz#f3a6135758459733ae2b95638056e1854e7ef507"
   integrity sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==
@@ -26350,6 +26441,11 @@ temp@~0.4.0:
   resolved "https://registry.yarnpkg.com/temp/-/temp-0.4.0.tgz#671ad63d57be0fe9d7294664b3fc400636678a60"
   integrity sha1-ZxrWPVe+D+nXKUZks/xABjZnimA=
 
+term-size@^2.1.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/term-size/-/term-size-2.2.1.tgz#2a6a54840432c2fb6320fea0f415531e90189f54"
+  integrity sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==
+
 terminal-link@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/terminal-link/-/terminal-link-2.1.1.tgz#14a64a27ab3c0df933ea546fba55f2d078edc994"
@@ -27015,6 +27111,18 @@ tsconfig@^7.0.0:
     strip-bom "^3.0.0"
     strip-json-comments "^2.0.0"
 
+tsd@^0.15.1:
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/tsd/-/tsd-0.15.1.tgz#d0c733c623d59de52f180ae7af66a1fde9e6c533"
+  integrity sha512-8ADO2rPntfNiJV4KiqJiiiitfkXLxCbKEFN672JgwNiaEIuiyurTc1+w3InZ+0DqBz73B6Z3UflZcNGw5xMaDA==
+  dependencies:
+    eslint-formatter-pretty "^4.0.0"
+    globby "^11.0.1"
+    meow "^7.0.1"
+    path-exists "^4.0.0"
+    read-pkg-up "^7.0.0"
+    update-notifier "^4.1.0"
+
 tslib@^1.10.0, tslib@^1.9.0, tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
@@ -27124,6 +27232,11 @@ type-fest@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.12.0.tgz#f57a27ab81c68d136a51fd71467eff94157fa1ee"
   integrity sha512-53RyidyjvkGpnWPMF9bQgFtWp+Sl8O2Rp13VavmJgfAP9WWG6q6TkrKU8iyJdnwnfgHI6k2hTlgqH4aSdjoTbg==
+
+type-fest@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.13.1.tgz#0172cb5bce80b0bd542ea348db50c7e21834d934"
+  integrity sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==
 
 type-fest@^0.15.1:
   version "0.15.1"
@@ -27596,6 +27709,25 @@ upath@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
   integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
+
+update-notifier@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-4.1.3.tgz#be86ee13e8ce48fb50043ff72057b5bd598e1ea3"
+  integrity sha512-Yld6Z0RyCYGB6ckIjffGOSOmHXj1gMeE7aROz4MG+XMkmixBX4jUngrGXNYz7wPKBmtoD4MnBa2Anu7RSKht/A==
+  dependencies:
+    boxen "^4.2.0"
+    chalk "^3.0.0"
+    configstore "^5.0.1"
+    has-yarn "^2.1.0"
+    import-lazy "^2.1.0"
+    is-ci "^2.0.0"
+    is-installed-globally "^0.3.1"
+    is-npm "^4.0.0"
+    is-yarn-global "^0.3.0"
+    latest-version "^5.0.0"
+    pupa "^2.0.1"
+    semver-diff "^3.1.1"
+    xdg-basedir "^4.0.0"
 
 update-notifier@^5.0.0:
   version "5.1.0"
@@ -30082,7 +30214,7 @@ yargs-parser@^15.0.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^18.1.2:
+yargs-parser@^18.1.2, yargs-parser@^18.1.3:
   version "18.1.3"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
   integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==


### PR DESCRIPTION
**:information_source: This is a minor release for @truffle/expect**

This PR converts @truffle/expect in order to offer type-safe guarantees of the post-conditions of using `expect.options`, etc.

This also adds `expect.has(options: {}, key: string)`, as a more simple form of `expect.options(options: {}, key: string[])`.

**Note**: for `expect.one()`, which is designed for either-or cases, the type guard asserts _exactly one_ key so as to facilitate likely usage (`expect.one(options, ["a", "b"]); const x = "a" in options ? options.a : options.b`), and also because taking the combination of all allowable expected values is just kind of excessive work for the type-checker. We may want to change the runtime behavior here, assuming it won't cause hard-to-fix breakages.

Post conditions for the asserted types here are tested using [tsd](https://github.com/SamVerschueren/tsd)