### PR TITLE
Make spinners for 'unbox' repect the `--quiet` option

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -43,9 +43,7 @@ class TruffleConfig {
   public eventManagerOptions(config: TruffleConfig): any {
     let muteLogging;
     const { quiet, logger, subscribers } = config;
-
-    if (quiet) muteLogging = true;
-    return { logger, muteLogging, subscribers };
+    return { logger, quiet, subscribers };
   }
 
   public addProp(propertyName: string, descriptor: any): void {

--- a/packages/core/lib/commands/unbox.js
+++ b/packages/core/lib/commands/unbox.js
@@ -43,6 +43,8 @@ const command = {
     const fse = require("fs-extra");
 
     const config = Config.default().with({logger: console});
+    // we merge in the options so that options passed on the command line
+    // (for example --quiet) make it to the EventManager
     config.merge(options);
 
     let [url, destination] = options._;

--- a/packages/core/lib/commands/unbox.js
+++ b/packages/core/lib/commands/unbox.js
@@ -43,6 +43,7 @@ const command = {
     const fse = require("fs-extra");
 
     const config = Config.default().with({logger: console});
+    config.merge(options);
 
     let [url, destination] = options._;
 

--- a/packages/core/test/lib/commands/unbox.js
+++ b/packages/core/test/lib/commands/unbox.js
@@ -4,7 +4,7 @@ const Config = require("@truffle/config");
 const sinon = require("sinon");
 const tmp = require("tmp");
 tmp.setGracefulCleanup();
-let tempDir, mockConfig;
+let tempDir, config;
 
 describe("commands/unbox.js", () => {
   const invalidBoxFormats = ["bare-box//"];
@@ -25,14 +25,11 @@ describe("commands/unbox.js", () => {
       tempDir = tmp.dirSync({
         unsafeCleanup: true
       });
-      mockConfig = Config.default().with({
-        logger: {log: () => {}},
-        working_directory: tempDir.name
+      config = Config.default().with({
+        working_directory: tempDir.name,
+        quiet: true
       });
-      mockConfig.events = {
-        emit: () => {}
-      };
-      sinon.stub(Config, "default").returns({with: () => mockConfig});
+      sinon.stub(Config, "default").returns(config);
     });
     afterEach(() => {
       Config.default.restore();
@@ -44,7 +41,7 @@ describe("commands/unbox.js", () => {
         for (const path of invalidBoxFormats) {
           promises.push(
             unbox
-              .run({_: [`${path}`]})
+              .run({ _: [`${path}`] })
               .then(() => assert.fail())
               .catch(_error => assert(true))
           );
@@ -59,9 +56,9 @@ describe("commands/unbox.js", () => {
         validBoxInput.forEach(val => {
           promises.push(
             unbox
-              .run({_: [`${val}`], force: true})
+              .run({ _: [`${val}`], force: true })
               .then(() => assert(true))
-              .catch(_error => assert.fail())
+              .catch(assert.fail)
           );
         });
         return await Promise.all(promises);

--- a/packages/events/EventManager.js
+++ b/packages/events/EventManager.js
@@ -4,15 +4,14 @@ const defaultSubscribers = require("./defaultSubscribers");
 
 class EventManager {
   constructor(eventManagerOptions) {
-    let { logger, muteLogging, subscribers } = eventManagerOptions;
-
+    let { logger, quiet, subscribers } = eventManagerOptions;
     this.emitter = new Emittery();
     this.subscriberAggregators = [];
 
     this.initializationOptions = {
       emitter: this.emitter,
       logger,
-      muteLogging,
+      quiet,
       subscribers
     };
     this.initializeDefaultSubscribers(this.initializationOptions);

--- a/packages/events/Subscriber/index.js
+++ b/packages/events/Subscriber/index.js
@@ -2,14 +2,14 @@ const helpers = require("./helpers");
 const { createLookupTable, sortHandlers, validateOptions } = helpers;
 
 class Subscriber {
-  constructor({ emitter, options, logger }) {
+  constructor({ emitter, options, logger, quiet }) {
     validateOptions(options);
     const { initialization, handlers } = options;
 
     this.emitter = emitter;
     // Object for storing unsubscribe methods for non-globbed listeners
     this.unsubscribeListeners = {};
-
+    this.quiet = quiet;
     if (logger) this.logger = logger;
     if (initialization) initialization.bind(this)();
 
@@ -62,7 +62,8 @@ class Subscriber {
   }
 
   updateOptions(newOptions) {
-    const { logger } = newOptions;
+    const { logger, quiet } = newOptions;
+    if (quiet) this.quiet = true;
     if (logger) this.logger = logger;
   }
 }

--- a/packages/events/SubscriberAggregator.js
+++ b/packages/events/SubscriberAggregator.js
@@ -7,27 +7,25 @@ class SubscriberAggregator {
   }
 
   initializeSubscribers(initializationOptions) {
-    let { emitter, logger, muteLogging, subscribers } = initializationOptions;
-    if (muteLogging) logger = () => {};
+    let { emitter, logger, quiet, subscribers } = initializationOptions;
     for (let name in subscribers) {
       this.subscribers.push(
         new Subscriber({
           options: subscribers[name],
           emitter,
-          logger
+          logger,
+          quiet
         })
       );
     }
   }
 
   updateSubscriberOptions(newOptions) {
-    let { logger, muteLogging } = newOptions;
-    if (muteLogging) {
-      logger = { log: () => {} };
-    }
+    let { logger, quiet } = newOptions;
     this.subscribers.forEach(subscriber => {
       subscriber.updateOptions({
-        logger
+        logger,
+        quiet
       });
     });
   }

--- a/packages/events/defaultSubscribers/compile.js
+++ b/packages/events/defaultSubscribers/compile.js
@@ -7,12 +7,14 @@ module.exports = {
   handlers: {
     "compile:start": [
       function () {
+        if (this.quiet) return;
         this.logger.log(OS.EOL + `Compiling your contracts...`);
         this.logger.log(`===========================`);
       }
     ],
     "compile:succeed": [
       function ({ contractsBuildDirectory, compilers }) {
+        if (this.quiet) return;
         if (compilers.length > 0) {
           this.logger.log(`> Artifacts written to ${contractsBuildDirectory}`);
           this.logger.log(`> Compiled successfully using:`);
@@ -39,6 +41,7 @@ module.exports = {
     ],
     "compile:sourcesToCompile": [
       function ({ sourceFileNames }) {
+        if (this.quiet) return;
         if (!sourceFileNames) return;
         sourceFileNames.forEach(sourceFileName =>
           this.logger.log("> Compiling " + sourceFileName)
@@ -47,12 +50,14 @@ module.exports = {
     ],
     "compile:warnings": [
       function ({ warnings }) {
+        if (this.quiet) return;
         this.logger.log("> Compilation warnings encountered:");
         this.logger.log(`${OS.EOL}    ${warnings.join()}`);
       }
     ],
     "compile:nothingToCompile": [
       function () {
+        if (this.quiet) return;
         this.logger.log(
           `> Everything is up to date, there is nothing to compile.`
         );

--- a/packages/events/defaultSubscribers/unbox.js
+++ b/packages/events/defaultSubscribers/unbox.js
@@ -22,52 +22,62 @@ module.exports = {
   handlers: {
     "unbox:start": [
       function () {
+        if (this.quiet) return;
         this.logger.log(`${OS.EOL}Starting unbox...`);
         this.logger.log(`=================${OS.EOL}`);
       },
     ],
     "unbox:preparingToDownload:start": [
       function () {
+        if (this.quiet) return;
         this.spinner = this.ora("Preparing to download box").start();
       },
     ],
     "unbox:preparingToDownload:succeed": [
       function () {
+        if (this.quiet) return;
         this.spinner.succeed();
       },
     ],
     "unbox:downloadingBox:start": [
       function () {
+        if (this.quiet) return;
         this.spinner = this.ora("Downloading").start();
       },
     ],
     "unbox:downloadingBox:succeed": [
       function () {
+        if (this.quiet) return;
         this.spinner.succeed();
       },
     ],
     "unbox:cleaningTempFiles:start": [
       function () {
+        if (this.quiet) return;
         this.spinner = this.ora("Cleaning up temporary files").start();
       },
     ],
     "unbox:cleaningTempFiles:succeed": [
       function () {
+        if (this.quiet) return;
         this.spinner.succeed();
       },
     ],
     "unbox:settingUpBox:start": [
       function () {
+        if (this.quiet) return;
         this.spinner = this.ora("Setting up box").start();
       },
     ],
     "unbox:settingUpBox:succeed": [
       function () {
+        if (this.quiet) return;
         this.spinner.succeed();
       },
     ],
     "unbox:succeed": [
       function ({ boxConfig }) {
+        if (this.quiet) return;
         this.logger.log(`${OS.EOL}Unbox successful, sweet!${OS.EOL}`);
 
         const commandMessages = formatCommands(boxConfig.commands);
@@ -83,6 +93,7 @@ module.exports = {
     ],
     "unbox:fail": [
       function () {
+        if (this.quiet) return;
         this.spinner.fail();
         this.logger.log("Unbox failed!");
       },


### PR DESCRIPTION
**Note**: This is a breaking change for @truffle/events

This PR updates the EventManager to accept and pass a `quiet` parameter instead of `muteLogging`. `quiet` is used in the rest of Truffle and it will be up to the handlers themselves to decide what `quiet === true` means. In the case of unboxing, if this option is passed then it will not display any of the spinners and show no output.