### PR TITLE
Bug fix: Add header to single sources downloaded from Etherscan

### DIFF
--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -14,6 +14,12 @@ import {
 } from "./common";
 import axios from "axios";
 
+const etherscanCommentHeader = `/**
+ *Submitted for verification at Etherscan.io on 20XX-XX-XX
+*/
+
+`; //note we include that final newline
+
 //this looks awkward but the TS docs actually suggest this :P
 const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
   implements Fetcher {
@@ -167,7 +173,10 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
     return {
       contractName: result.ContractName,
       sources: {
-        [filename]: result.SourceCode
+        //we prepend this header comment so that line numbers in the debugger
+        //will match up with what's displayed on the website; note that other
+        //cases don't display a similar header on the website
+        [filename]: etherscanCommentHeader + result.SourceCode
       },
       options: {
         language: "Solidity",


### PR DESCRIPTION
Addresses #4071.  See that issue for why I'm doing this.

The header is only added in the single-source Solidity case, because that's the only case where Etherscan adds a header on the website.

I tested this manually and with this change the line numbers now match up.

Note that the header we're using contains a generic placeholder in place of the date, since there doesn't seem to be any way for us to get the submission date from the API (and even if we could I'm not sure it would be so important to do!).