### PR TITLE
Remove default gasPrice

### DIFF
--- a/packages/config/src/configDefaults.ts
+++ b/packages/config/src/configDefaults.ts
@@ -189,7 +189,11 @@ export const configProps = ({
     },
     gasPrice: {
       get() {
-        return configObject.network_config.gasPrice;
+        try {
+          return configObject.network_config.gasPrice;
+        } catch (e) {
+          return null;
+        }
       },
       set() {
         throw new Error(

--- a/packages/config/src/configDefaults.ts
+++ b/packages/config/src/configDefaults.ts
@@ -73,7 +73,6 @@ export const configProps = ({
 
   const defaultTXValues = {
     gas: 6721975,
-    gasPrice: 20000000000, // 20 gwei,
     from: null
   };
 
@@ -190,11 +189,7 @@ export const configProps = ({
     },
     gasPrice: {
       get() {
-        try {
-          return configObject.network_config.gasPrice;
-        } catch (e) {
-          return defaultTXValues.gasPrice;
-        }
+        return configObject.network_config.gasPrice;
       },
       set() {
         throw new Error(


### PR DESCRIPTION
Partially addresses https://github.com/trufflesuite/truffle/issues/3992

Removes default gasPrice when none is specified as part of the network config.

It will use the last few blocks median gas price instead, as per web3js documentation: https://web3js.readthedocs.io/en/v1.2.0/web3-eth.html#getgasprice