### PR TITLE
Remove listeners for `unhandledRejection` after loading soljson, rather than `uncaughtException`

### DIFF
--- a/packages/compile-solidity/compilerSupplier/loadingStrategies/LoadingStrategy.js
+++ b/packages/compile-solidity/compilerSupplier/loadingStrategies/LoadingStrategy.js
@@ -82,11 +82,11 @@ class LoadingStrategy {
    * previous implementation, note to self - ask Tim about this)
    */
   removeListener() {
-    const listeners = process.listeners("uncaughtException");
+    const listeners = process.listeners("unhandledRejection");
     const execeptionHandler = listeners[listeners.length - 1];
 
     if (execeptionHandler) {
-      process.removeListener("uncaughtException", execeptionHandler);
+      process.removeListener("unhandledRejection", execeptionHandler);
     }
   }
 


### PR DESCRIPTION
Some time in the past soljson registered for `uncaughtException` and we adapted it. the most recent listens for `unhandledRejection` and aborts. 

It may be related to #4090