### PR TITLE
Only remove listeners left around by soljson

### DIFF
--- a/packages/compile-solidity/compilerSupplier/loadingStrategies/LoadingStrategy.js
+++ b/packages/compile-solidity/compilerSupplier/loadingStrategies/LoadingStrategy.js
@@ -77,16 +77,22 @@ class LoadingStrategy {
     );
   }
 
-  /**
-   * Cleans up error listeners set (by solc?) when requiring it. (This code inherited from
-   * previous implementation, note to self - ask Tim about this)
-   */
-  removeListener() {
-    const listeners = process.listeners("uncaughtException");
-    const execeptionHandler = listeners[listeners.length - 1];
+  markListeners() {
+    return new Set(process.listeners("uncaughtException"));
+  }
 
-    if (execeptionHandler) {
-      process.removeListener("uncaughtException", execeptionHandler);
+  /**
+   * Cleans up error listeners left by older versions of soljson (pre-0.5.1).
+   * Use with `markListeners()`
+   */
+  removeListener(markedListeners) {
+    const listeners = process.listeners("uncaughtException");
+    const newListeners = listeners.filter(
+      listener => !markedListeners.has(listener)
+    );
+
+    for (const listener of newListeners) {
+      process.removeListener("uncaughtException", listener);
     }
   }
 

--- a/packages/compile-solidity/compilerSupplier/loadingStrategies/LoadingStrategy.js
+++ b/packages/compile-solidity/compilerSupplier/loadingStrategies/LoadingStrategy.js
@@ -78,21 +78,26 @@ class LoadingStrategy {
   }
 
   markListeners() {
-    return new Set(process.listeners("uncaughtException"));
+    return {
+      uncaughtException: new Set(process.listeners("uncaughtException")),
+      unhandledRejection: new Set(process.listeners("unhandledRejection")),
+    };
   }
 
   /**
-   * Cleans up error listeners left by older versions of soljson (pre-0.5.1).
+   * Cleans up error listeners left by soljson
    * Use with `markListeners()`
    */
   removeListener(markedListeners) {
-    const listeners = process.listeners("uncaughtException");
-    const newListeners = listeners.filter(
-      listener => !markedListeners.has(listener)
-    );
+    for (const eventName of ["uncaughtException", "unhandledRejection"]) {
+      const listeners = process.listeners(eventName);
+      const newListeners = listeners.filter(
+        (listener) => !markedListeners[eventName].has(listener),
+      );
 
-    for (const listener of newListeners) {
-      process.removeListener("uncaughtException", listener);
+      for (const listener of newListeners) {
+        process.removeListener(eventName, listener);
+      }
     }
   }
 

--- a/packages/compile-solidity/compilerSupplier/loadingStrategies/LoadingStrategy.js
+++ b/packages/compile-solidity/compilerSupplier/loadingStrategies/LoadingStrategy.js
@@ -89,14 +89,12 @@ class LoadingStrategy {
    * Use with `markListeners()`
    */
   removeListener(markedListeners) {
-    for (const eventName of ["uncaughtException", "unhandledRejection"]) {
-      const listeners = process.listeners(eventName);
-      const newListeners = listeners.filter(
-        (listener) => !markedListeners[eventName].has(listener),
-      );
-
-      for (const listener of newListeners) {
-        process.removeListener(eventName, listener);
+    for (const eventName in markedListeners) {
+      const marked = markedListeners[eventName];
+      for (const listener of process.listeners(eventName)) {
+        if (!marked.has(listener)) {
+          process.removeListener(eventName, listener);
+        }
       }
     }
   }

--- a/packages/compile-solidity/compilerSupplier/loadingStrategies/Local.js
+++ b/packages/compile-solidity/compilerSupplier/loadingStrategies/Local.js
@@ -9,6 +9,8 @@ class Local extends LoadingStrategy {
   }
 
   getLocalCompiler(localPath) {
+    const markedListeners = this.markListeners();
+
     let soljson, compilerPath, wrapped;
     compilerPath = path.isAbsolute(localPath)
       ? localPath
@@ -21,7 +23,8 @@ class Local extends LoadingStrategy {
     }
     //HACK: if it has a compile function, assume it's already wrapped
     wrapped = soljson.compile ? soljson : solcWrap(soljson);
-    this.removeListener();
+
+    this.removeListener(markedListeners);
     return wrapped;
   }
 }

--- a/packages/compile-solidity/compilerSupplier/loadingStrategies/Local.js
+++ b/packages/compile-solidity/compilerSupplier/loadingStrategies/Local.js
@@ -10,22 +10,23 @@ class Local extends LoadingStrategy {
 
   getLocalCompiler(localPath) {
     const markedListeners = this.markListeners();
-
-    let soljson, compilerPath, wrapped;
-    compilerPath = path.isAbsolute(localPath)
-      ? localPath
-      : path.resolve(process.cwd(), localPath);
-
     try {
-      soljson = originalRequire(compilerPath);
-    } catch (error) {
-      throw this.errors("noPath", localPath, error);
-    }
-    //HACK: if it has a compile function, assume it's already wrapped
-    wrapped = soljson.compile ? soljson : solcWrap(soljson);
+      let soljson, compilerPath, wrapped;
+      compilerPath = path.isAbsolute(localPath)
+        ? localPath
+        : path.resolve(process.cwd(), localPath);
 
-    this.removeListener(markedListeners);
-    return wrapped;
+      try {
+        soljson = originalRequire(compilerPath);
+      } catch (error) {
+        throw this.errors("noPath", localPath, error);
+      }
+      //HACK: if it has a compile function, assume it's already wrapped
+      wrapped = soljson.compile ? soljson : solcWrap(soljson);
+      return wrapped;
+    } finally {
+      this.removeListener(markedListeners);
+    }
   }
 }
 

--- a/packages/compile-solidity/compilerSupplier/loadingStrategies/Local.js
+++ b/packages/compile-solidity/compilerSupplier/loadingStrategies/Local.js
@@ -22,8 +22,7 @@ class Local extends LoadingStrategy {
         throw this.errors("noPath", localPath, error);
       }
       //HACK: if it has a compile function, assume it's already wrapped
-      wrapped = soljson.compile ? soljson : solcWrap(soljson);
-      return wrapped;
+      return soljson.compile ? soljson : solcWrap(soljson);
     } finally {
       this.removeListener(markedListeners);
     }

--- a/packages/compile-solidity/compilerSupplier/loadingStrategies/VersionRange.js
+++ b/packages/compile-solidity/compilerSupplier/loadingStrategies/VersionRange.js
@@ -10,10 +10,13 @@ const LoadingStrategy = require("./LoadingStrategy");
 class VersionRange extends LoadingStrategy {
   compilerFromString(code) {
     const markedListeners = this.markListeners();
-    const soljson = requireFromString(code);
-    const wrapped = solcWrap(soljson);
-    this.removeListener(markedListeners);
-    return wrapped;
+    try {
+      const soljson = requireFromString(code);
+      const wrapped = solcWrap(soljson);
+      return wrapped;
+    } finally {
+      this.removeListener(markedListeners);
+    }
   }
 
   findNewestValidVersion(version, allVersions) {
@@ -34,12 +37,15 @@ class VersionRange extends LoadingStrategy {
 
   getCachedSolcByFileName(fileName) {
     const markedListeners = this.markListeners();
-    const filePath = this.resolveCache(fileName);
-    const soljson = originalRequire(filePath);
-    debug("soljson %o", soljson);
-    const wrapped = solcWrap(soljson);
-    this.removeListener(markedListeners);
-    return wrapped;
+    try {
+      const filePath = this.resolveCache(fileName);
+      const soljson = originalRequire(filePath);
+      debug("soljson %o", soljson);
+      const wrapped = solcWrap(soljson);
+      return wrapped;
+    } finally {
+      this.removeListener(markedListeners);
+    }
   }
 
   // Range can also be a single version specification like "0.5.0"

--- a/packages/compile-solidity/compilerSupplier/loadingStrategies/VersionRange.js
+++ b/packages/compile-solidity/compilerSupplier/loadingStrategies/VersionRange.js
@@ -9,9 +9,10 @@ const LoadingStrategy = require("./LoadingStrategy");
 
 class VersionRange extends LoadingStrategy {
   compilerFromString(code) {
+    const markedListeners = this.markListeners();
     const soljson = requireFromString(code);
     const wrapped = solcWrap(soljson);
-    this.removeListener();
+    this.removeListener(markedListeners);
     return wrapped;
   }
 
@@ -32,11 +33,12 @@ class VersionRange extends LoadingStrategy {
   }
 
   getCachedSolcByFileName(fileName) {
+    const markedListeners = this.markListeners();
     const filePath = this.resolveCache(fileName);
     const soljson = originalRequire(filePath);
     debug("soljson %o", soljson);
     const wrapped = solcWrap(soljson);
-    this.removeListener();
+    this.removeListener(markedListeners);
     return wrapped;
   }
 
@@ -102,10 +104,7 @@ class VersionRange extends LoadingStrategy {
       attemptNumber: index + 1
     });
     try {
-      const response = await axios.get(
-        url,
-        { maxRedirects: 50 }
-      );
+      const response = await axios.get(url, { maxRedirects: 50 });
       events.emit("downloadCompiler:succeed");
       this.addFileToCache(response.data, fileName);
       return this.compilerFromString(response.data);
@@ -150,7 +149,8 @@ class VersionRange extends LoadingStrategy {
 
     // trim trailing slashes from compilerRoot
     const url = `${compilerRoots[index].replace(/\/+$/, "")}/list.json`;
-    return axios.get(url, { maxRedirects: 50 })
+    return axios
+      .get(url, { maxRedirects: 50 })
       .then(response => {
         events.emit("fetchSolcList:succeed");
         return response.data;

--- a/packages/compile-solidity/compilerSupplier/loadingStrategies/VersionRange.js
+++ b/packages/compile-solidity/compilerSupplier/loadingStrategies/VersionRange.js
@@ -12,8 +12,7 @@ class VersionRange extends LoadingStrategy {
     const markedListeners = this.markListeners();
     try {
       const soljson = requireFromString(code);
-      const wrapped = solcWrap(soljson);
-      return wrapped;
+      return solcWrap(soljson);
     } finally {
       this.removeListener(markedListeners);
     }
@@ -41,8 +40,7 @@ class VersionRange extends LoadingStrategy {
       const filePath = this.resolveCache(fileName);
       const soljson = originalRequire(filePath);
       debug("soljson %o", soljson);
-      const wrapped = solcWrap(soljson);
-      return wrapped;
+      return solcWrap(soljson);
     } finally {
       this.removeListener(markedListeners);
     }

--- a/packages/core/lib/command.js
+++ b/packages/core/lib/command.js
@@ -144,6 +144,26 @@ class Command {
       version: bundled || "(unbundled) " + core
     });
 
+    const unhandledRejections = new Map();
+
+    process.on('unhandledRejection', (reason, promise) => {
+      unhandledRejections.set(promise, reason);
+    });
+
+    process.on('rejectionHandled', (promise) => {
+      unhandledRejections.delete(promise);
+    });
+
+    process.on('exit', (_) => {
+      const log = options.logger ? (options.logger.log || options.logger.debug): console.log;
+      if (unhandledRejections.size) {
+        log('UnhandledRejections detected');
+        unhandledRejections.forEach((reason, promise) => {
+          log(promise, reason);
+        });
+      }
+    });
+
     return await result.command.run(newOptions);
   }
 

--- a/packages/truffle/test/scenarios/migrations/unhandled-rejection.js
+++ b/packages/truffle/test/scenarios/migrations/unhandled-rejection.js
@@ -1,0 +1,38 @@
+const MemoryLogger = require("../memorylogger");
+const CommandRunner = require("../commandrunner");
+const path = require("path");
+const assert = require("assert");
+const Server = require("../server");
+const Reporter = require("../reporter");
+const sandbox = require("../sandbox");
+
+describe.only("unhandledRejection detection", function () {
+  let config;
+  const project = path.join(
+    __dirname,
+    "../../sources/migrations/unhandled-rejection"
+  );
+  const logger = new MemoryLogger();
+
+  before(done => Server.start(done));
+  after(done => Server.stop(done));
+
+  before(async function () {
+    this.timeout(10000);
+    config = await sandbox.create(project);
+    config.network = "development";
+    config.logger = logger;
+    config.mocha = {
+      reporter: new Reporter(logger)
+    };
+  });
+
+  it("should detect unhandled-rejection", async function () {
+    this.timeout(70000);
+
+    await CommandRunner.run("migrate", config);
+    const output = logger.contents();
+    assert(output.includes("UnhandledRejections detected"));
+    assert(output.includes("Promise { <rejected> 4242 } 4242"));
+  });
+});

--- a/packages/truffle/test/sources/migrations/unhandled-rejection/contracts/Migrations.sol
+++ b/packages/truffle/test/sources/migrations/unhandled-rejection/contracts/Migrations.sol
@@ -1,0 +1,23 @@
+pragma solidity ^0.5.0;
+
+contract Migrations {
+  address public owner;
+  uint public last_completed_migration;
+
+  constructor() public {
+    owner = msg.sender;
+  }
+
+  modifier restricted() {
+    if (msg.sender == owner) _;
+  }
+
+  function setCompleted(uint completed) public restricted {
+    last_completed_migration = completed;
+  }
+
+  function upgrade(address new_address) public restricted {
+    Migrations upgraded = Migrations(new_address);
+    upgraded.setCompleted(last_completed_migration);
+  }
+}

--- a/packages/truffle/test/sources/migrations/unhandled-rejection/migrations/1_initial_migration.js
+++ b/packages/truffle/test/sources/migrations/unhandled-rejection/migrations/1_initial_migration.js
@@ -1,0 +1,6 @@
+var Migrations = artifacts.require("./Migrations.sol");
+
+module.exports = function(deployer) {
+  Promise.reject(4242);
+  deployer.deploy(Migrations);
+};

--- a/packages/truffle/test/sources/migrations/unhandled-rejection/truffle-config.js
+++ b/packages/truffle/test/sources/migrations/unhandled-rejection/truffle-config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  // See <http://trufflesuite.com/docs/advanced/configuration>
+  // to customize your Truffle configuration!
+  networks: {
+    development: {
+      host: "127.0.0.1",
+      port: 8545,
+      network_id: "*",
+      gas: 4700000,
+      gasPrice: 20000000000
+    }
+  }
+};


### PR DESCRIPTION
So, here's a hypothesis for the `uncaughtException` business in compile-solidity.

Solidity upgraded Emscripten from v1.35.4 to v1.37.21 in solc v0.5.1 (in [this PR](https://github.com/ethereum/solidity/pull/4486)). Inspecting the Emscripten changelog, [this issue](https://github.com/emscripten-core/emscripten/issues/4392) was closed as part of v1.36.6. Looks like the fix here may have changed buggy behavior that left `uncaughtException`s to linger.

Since we support old Solidity and need to handle pre-v0.5.1 behavior, this PR proposes that we alter the listener removal by first capturing the listeners that existed before loading solc and then removing only those listeners that are new after loading solc.

This is a different proposed solution than #4091... I haven't done any digging re: that PR's hypothesis that we must remove listeners for `unhandledRejection`, but I suspect that may be a red herring. This PR should address the "exits violently" part of #4090 (as well as many other issues over the past however-long)