### PR TITLE
Bug fix: Fix two debugger/decoder crashes

### DIFF
--- a/packages/codec/lib/abi-data/allocate/index.ts
+++ b/packages/codec/lib/abi-data/allocate/index.ts
@@ -1100,7 +1100,7 @@ function getReturndataAllocationsForContract(
       ));
     }
   }
-  if (!useAst) { //deliberately *not* an else!
+  if (!useAst && abi) { //deliberately *not* an else!
     return abi
       .filter((abiEntry: Abi.Entry) => abiEntry.type === "error")
       .filter(
@@ -1117,6 +1117,8 @@ function getReturndataAllocationsForContract(
         compiler
       ));
   }
+  //otherwise just return nothing
+  return [];
 }
 
 export function getReturndataAllocations(

--- a/packages/debugger/lib/data/selectors/index.js
+++ b/packages/debugger/lib/data/selectors/index.js
@@ -1032,7 +1032,7 @@ const data = createSelectorTree({
      */
     errorNodeId: createLeaf(
       [stacktrace.current.innerReturnPosition, stacktrace.current.lastPosition],
-      (innerLocation, lastLocation) => ((innerLocation || lastLocation).node || {}).id
+      (innerLocation, lastLocation) => ((innerLocation || lastLocation || {}).node || {}).id
     ),
 
     /**


### PR DESCRIPTION
This PR fixes two debugger/decoder crashes, one of which I accidentally introduced in #4015, the other of which I accidentally introduced in #4029.