### PR TITLE
Bug fix: Prevent (extremely unlikely) crash from cbor null

### DIFF
--- a/packages/codec/lib/contexts/utils.ts
+++ b/packages/codec/lib/contexts/utils.ts
@@ -272,7 +272,7 @@ function extractCborInfo(binary: string): CborInfo | null {
 }
 
 function isObjectWithHash(decoded: any): boolean {
-  if (typeof decoded !== "object") {
+  if (typeof decoded !== "object" || decoded === null) {
     return false;
   }
   //cbor sometimes returns maps and sometimes objects,
@@ -290,7 +290,7 @@ function isObjectWithHash(decoded: any): boolean {
 //(if it detects solc but no version, it will not return
 //a partial result, just undefined)
 function detectCompilerInfo(decoded: any): CompilerVersion | undefined {
-  if (typeof decoded !== "object") {
+  if (typeof decoded !== "object" || decoded === null) {
     return undefined;
   }
   //cbor sometimes returns maps and sometimes objects,


### PR DESCRIPTION
Quick followup to #4094, I just realized that I forgot to account for the case of `null` (which is an object, but which you better not try to access the properties of).  Mind you, this should never actually happen, barring an extremely unlikely coincidence, but just to be safe, I'm putting in checks for it here.  (I mean, a number of the cases I check for here should never happen...)