### PR TITLE
Internal improvement: Make consistent use of `import type` in most TS packages

### DIFF
--- a/packages/abi-utils/lib/arbitrary.ts
+++ b/packages/abi-utils/lib/arbitrary.ts
@@ -2,7 +2,7 @@ import * as fc from "fast-check";
 import faker from "faker";
 import { camelCase, pascalCase } from "change-case";
 
-import * as Types from "./types";
+import type * as Types from "./types";
 
 export const Parameter = () =>
   fc

--- a/packages/abi-utils/lib/normalize.ts
+++ b/packages/abi-utils/lib/normalize.ts
@@ -1,5 +1,5 @@
-import { Abi as SchemaAbi } from "@truffle/contract-schema/spec";
-import { Abi, Entry, StateMutability } from "./types";
+import type { Abi as SchemaAbi } from "@truffle/contract-schema/spec";
+import type { Abi, Entry, StateMutability } from "./types";
 
 export const normalize = (looseAbi: SchemaAbi | Abi): Abi =>
   (looseAbi as SchemaAbi).map(normalizeEntry);

--- a/packages/artifactor/utils.ts
+++ b/packages/artifactor/utils.ts
@@ -1,7 +1,7 @@
 import fse from "fs-extra";
 import merge from "lodash.merge";
 import assign from "lodash.assign";
-import { ContractObject } from "@truffle/contract-schema";
+import type { ContractObject } from "@truffle/contract-schema";
 
 export function writeArtifact(
   completeArtifact: ContractObject,

--- a/packages/blockchain-utils/index.ts
+++ b/packages/blockchain-utils/index.ts
@@ -1,5 +1,5 @@
-import { Provider, Callback, JsonRPCResponse } from "web3/providers";
-import { parsedUriObject } from "typings";
+import type { Provider, Callback, JsonRPCResponse } from "web3/providers";
+import type { parsedUriObject } from "typings";
 
 const Blockchain = {
   getBlockByNumber(

--- a/packages/box/lib/config.ts
+++ b/packages/box/lib/config.ts
@@ -1,5 +1,5 @@
 import fse from "fs-extra";
-import { boxConfig } from "typings";
+import type { boxConfig } from "typings";
 
 function setDefaults(config: any = {}): boxConfig {
   const hooks = config.hooks || {};

--- a/packages/box/lib/utils/index.ts
+++ b/packages/box/lib/utils/index.ts
@@ -5,7 +5,7 @@ import tmp from "tmp";
 import process from "process";
 const cwd = require("process").cwd();
 import path from "path";
-import { boxConfig, unboxOptions } from "typings";
+import type { boxConfig, unboxOptions } from "typings";
 
 export = {
   downloadBox: async (source: string, destination: string, events: any) => {

--- a/packages/box/lib/utils/unbox.ts
+++ b/packages/box/lib/utils/unbox.ts
@@ -6,7 +6,7 @@ import vcsurl from "vcsurl";
 import { parse as parseURL } from "url";
 import { execSync } from "child_process";
 import inquirer from "inquirer";
-import { boxConfig, unboxOptions } from "typings";
+import type { boxConfig, unboxOptions } from "typings";
 import { promisify } from "util";
 import ignore from "ignore";
 

--- a/packages/code-utils/src/index.ts
+++ b/packages/code-utils/src/index.ts
@@ -1,6 +1,6 @@
 import parseOpcode from "./opcodes";
-import { Instruction, OpcodeTable, opcodeObject, opcodes } from "./types";
-export { Instruction, OpcodeTable, opcodeObject, opcodes };
+import type { Instruction, OpcodeTable, opcodeObject, opcodes } from "./types";
+export type { Instruction, OpcodeTable, opcodeObject, opcodes };
 import * as cbor from "cbor";
 
 /**

--- a/packages/code-utils/src/opcodes.ts
+++ b/packages/code-utils/src/opcodes.ts
@@ -1,4 +1,4 @@
-import { OpcodeTable } from "./types";
+import type { OpcodeTable } from "./types";
 
 const codes: OpcodeTable = {
   0x00: "STOP",

--- a/packages/compile-common/src/profiler/profiler.ts
+++ b/packages/compile-common/src/profiler/profiler.ts
@@ -5,7 +5,7 @@ const expect = require("@truffle/expect");
 
 import type TruffleConfig from "@truffle/config";
 import { updated } from "./updated";
-import { UnresolvedSource } from "./resolveAllSources";
+import type { UnresolvedSource } from "./resolveAllSources";
 import { requiredSources, RequiredSourcesOptions } from "./requiredSources";
 import { convertToAbsolutePaths } from "./convertToAbsolutePaths";
 

--- a/packages/compile-common/src/profiler/updated.ts
+++ b/packages/compile-common/src/profiler/updated.ts
@@ -1,7 +1,7 @@
 import * as path from "path";
 import * as fse from "fs-extra";
 
-import { ContractObject } from "@truffle/contract-schema/spec";
+import type { ContractObject } from "@truffle/contract-schema/spec";
 
 export interface UpdatedOptions {
   paths: string[];

--- a/packages/compile-common/src/shims/LegacyToNew.ts
+++ b/packages/compile-common/src/shims/LegacyToNew.ts
@@ -1,4 +1,4 @@
-import { Bytecode, CompiledContract, LinkReference } from "../types";
+import type { Bytecode, CompiledContract, LinkReference } from "../types";
 
 export function forContracts(contracts: any[]): CompiledContract[] {
   // convert to list

--- a/packages/compile-common/src/shims/NewToLegacy.ts
+++ b/packages/compile-common/src/shims/NewToLegacy.ts
@@ -1,4 +1,4 @@
-import { LinkReference, CompiledContract } from "../types";
+import type { LinkReference, CompiledContract } from "../types";
 
 export function forContract(contract: CompiledContract): any {
   const {

--- a/packages/compile-common/src/sources.ts
+++ b/packages/compile-common/src/sources.ts
@@ -1,4 +1,4 @@
-import { Sources, CollectedSources } from "./types";
+import type { Sources, CollectedSources } from "./types";
 import * as path from "path";
 
 /**

--- a/packages/compile-common/src/types.ts
+++ b/packages/compile-common/src/types.ts
@@ -1,4 +1,4 @@
-import { Abi, ImmutableReferences } from "@truffle/contract-schema/spec";
+import type { Abi, ImmutableReferences } from "@truffle/contract-schema/spec";
 
 export type Compilation = {
   sourceIndexes: string[]; //note: does not include internal sources

--- a/packages/hdwallet-provider/src/constructor/Constructor.ts
+++ b/packages/hdwallet-provider/src/constructor/Constructor.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   Mnemonic,
   MnemonicPhrase,
   PrivateKey,

--- a/packages/hdwallet-provider/src/constructor/ConstructorArguments.ts
+++ b/packages/hdwallet-provider/src/constructor/ConstructorArguments.ts
@@ -1,5 +1,5 @@
-import * as LegacyConstructor from "./LegacyConstructor";
-import * as Constructor from "./Constructor";
+import type * as LegacyConstructor from "./LegacyConstructor";
+import type * as Constructor from "./Constructor";
 
 /*
  * top-level polymorphic type

--- a/packages/hdwallet-provider/src/constructor/LegacyConstructor.ts
+++ b/packages/hdwallet-provider/src/constructor/LegacyConstructor.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   MnemonicPhrase,
   PrivateKey,
   ProviderOrUrl,

--- a/packages/hdwallet-provider/src/constructor/getMnemonic.ts
+++ b/packages/hdwallet-provider/src/constructor/getMnemonic.ts
@@ -1,5 +1,5 @@
-import { SigningAuthority } from "./Constructor";
-import { Mnemonic } from "./types";
+import type { SigningAuthority } from "./Constructor";
+import type { Mnemonic } from "./types";
 
 // extract the mnemonic if that's the style used, or return undefined
 export const getMnemonic = (

--- a/packages/hdwallet-provider/src/constructor/getOptions.ts
+++ b/packages/hdwallet-provider/src/constructor/getOptions.ts
@@ -1,7 +1,7 @@
-import { MnemonicPhrase, PrivateKey } from "./types";
-import { ConstructorArguments } from "./ConstructorArguments";
-import * as Constructor from "./Constructor";
-import * as LegacyConstructor from "./LegacyConstructor";
+import type { MnemonicPhrase, PrivateKey } from "./types";
+import type { ConstructorArguments } from "./ConstructorArguments";
+import type * as Constructor from "./Constructor";
+import type * as LegacyConstructor from "./LegacyConstructor";
 import { validateMnemonic } from "ethereum-cryptography/bip39";
 import { wordlist } from "ethereum-cryptography/bip39/wordlists/english";
 

--- a/packages/hdwallet-provider/src/constructor/getPrivateKeys.ts
+++ b/packages/hdwallet-provider/src/constructor/getPrivateKeys.ts
@@ -1,5 +1,5 @@
-import { PrivateKey } from "./types";
-import { SigningAuthority } from "./Constructor";
+import type { PrivateKey } from "./types";
+import type { SigningAuthority } from "./Constructor";
 
 // extract the private keys if that's the style used, or return undefined
 export const getPrivateKeys = (

--- a/packages/hdwallet-provider/src/index.ts
+++ b/packages/hdwallet-provider/src/index.ts
@@ -18,13 +18,13 @@ import RpcProvider from "@trufflesuite/web3-provider-engine/subproviders/rpc";
 import WebsocketProvider from "@trufflesuite/web3-provider-engine/subproviders/websocket";
 
 import Url from "url";
-import { JSONRPCRequestPayload, JSONRPCErrorCallback, JSONRPCResponsePayload } from "ethereum-protocol";
-import { Callback, JsonRPCResponse } from "web3/providers";
-import { ConstructorArguments } from "./constructor/ConstructorArguments";
+import type { JSONRPCRequestPayload, JSONRPCErrorCallback, JSONRPCResponsePayload } from "ethereum-protocol";
+import type { Callback, JsonRPCResponse } from "web3/providers";
+import type { ConstructorArguments } from "./constructor/ConstructorArguments";
 import { getOptions } from "./constructor/getOptions";
 import { getPrivateKeys } from "./constructor/getPrivateKeys";
 import { getMnemonic } from "./constructor/getMnemonic";
-import { ChainId, ChainSettings, Hardfork } from "./constructor/types";
+import type { ChainId, ChainSettings, Hardfork } from "./constructor/types";
 
 // Important: do not use debug module. Reason: https://github.com/trufflesuite/truffle/issues/2374#issuecomment-536109086
 

--- a/packages/interface-adapter/lib/adapter/index.ts
+++ b/packages/interface-adapter/lib/adapter/index.ts
@@ -1,6 +1,6 @@
 import { Web3InterfaceAdapter, Web3InterfaceAdapterOptions } from "./web3";
 
-import { InterfaceAdapter } from "./types";
+import type { InterfaceAdapter } from "./types";
 
 export type InterfaceAdapterOptions = Web3InterfaceAdapterOptions;
 

--- a/packages/interface-adapter/lib/adapter/types.ts
+++ b/packages/interface-adapter/lib/adapter/types.ts
@@ -1,10 +1,10 @@
 import type BN from "bn.js";
-import {
+import type {
   Block as EvmBlock,
   BlockType as EvmBlockType,
   Tx as EvmTransaction
 } from "web3/eth/types";
-import { TransactionReceipt as EvmTransactionReceipt } from "web3-eth/types";
+import type { TransactionReceipt as EvmTransactionReceipt } from "web3-eth/types";
 
 export {
   Block as EvmBlock,

--- a/packages/interface-adapter/lib/adapter/web3/index.ts
+++ b/packages/interface-adapter/lib/adapter/web3/index.ts
@@ -1,6 +1,6 @@
 import BN from "bn.js";
 import { Web3Shim } from "../../shim";
-import {
+import type {
   InterfaceAdapter,
   EvmBlockType,
   Provider,

--- a/packages/interface-adapter/lib/shim/index.ts
+++ b/packages/interface-adapter/lib/shim/index.ts
@@ -1,5 +1,5 @@
 import Web3 from "web3";
-import { Provider } from "web3/providers";
+import type { Provider } from "web3/providers";
 
 import { EthereumDefinition } from "./overloads/ethereum";
 import { QuorumDefinition } from "./overloads/quorum";

--- a/packages/interface-adapter/lib/shim/overloads/ethereum.ts
+++ b/packages/interface-adapter/lib/shim/overloads/ethereum.ts
@@ -1,6 +1,6 @@
 import BN from "bn.js";
-import { Web3Shim } from "..";
-import {
+import type { Web3Shim } from "..";
+import type {
   BlockType,
   EvmTransaction,
   EvmTransactionReceipt

--- a/packages/interface-adapter/lib/shim/overloads/fabric-evm.ts
+++ b/packages/interface-adapter/lib/shim/overloads/fabric-evm.ts
@@ -1,5 +1,5 @@
-import { Web3Shim } from "..";
-import { NetworkId } from "../../adapter/types";
+import type { Web3Shim } from "..";
+import type { NetworkId } from "../../adapter/types";
 
 export const FabricEvmDefinition = {
   async initNetworkType(web3: Web3Shim) {

--- a/packages/interface-adapter/lib/shim/overloads/quorum.ts
+++ b/packages/interface-adapter/lib/shim/overloads/quorum.ts
@@ -1,6 +1,6 @@
 import BN from "bn.js";
-import { Web3Shim } from "..";
-import { EvmTransaction } from "../../adapter/types";
+import type { Web3Shim } from "..";
+import type { EvmTransaction } from "../../adapter/types";
 import { AbiCoder as EthersAbi } from "ethers/utils/abi-coder";
 
 export const QuorumDefinition = {

--- a/packages/interface-adapter/lib/shim/overloads/web3js.ts
+++ b/packages/interface-adapter/lib/shim/overloads/web3js.ts
@@ -1,4 +1,4 @@
-import { Web3Shim } from "..";
+import type { Web3Shim } from "..";
 
 // We simply return plain ol' Web3.js
 export const Web3JsDefinition = {

--- a/packages/plugins/lib/Plugin.ts
+++ b/packages/plugins/lib/Plugin.ts
@@ -1,7 +1,7 @@
 const TruffleError = require("@truffle/error");
 const originalRequire = require("original-require");
 import path from "path";
-import { PluginConstructorOptions, PluginDefinition } from "./types";
+import type { PluginConstructorOptions, PluginDefinition } from "./types";
 
 export class Plugin {
   constructor({ module, definition }: PluginConstructorOptions) {

--- a/packages/plugins/lib/Plugins.ts
+++ b/packages/plugins/lib/Plugins.ts
@@ -1,7 +1,7 @@
 const TruffleError = require("@truffle/error");
 const originalRequire = require("original-require");
 import path from "path";
-import { PluginConfig, PluginDefinitions, TruffleConfig } from "./types";
+import type { PluginConfig, PluginDefinitions, TruffleConfig } from "./types";
 import { Plugin } from "./Plugin";
 import { normalizeConfigPlugins } from "./utils";
 

--- a/packages/plugins/lib/utils.ts
+++ b/packages/plugins/lib/utils.ts
@@ -1,4 +1,4 @@
-import { PluginConfig, RawPluginConfig } from "./types";
+import type { PluginConfig, RawPluginConfig } from "./types";
 
 const TruffleError = require("@truffle/error");
 const originalRequire = require("original-require");

--- a/packages/preserve-fs/lib/fs.ts
+++ b/packages/preserve-fs/lib/fs.ts
@@ -1,8 +1,8 @@
 import fs from "fs";
 import { join as joinPath } from "path";
 
-import * as Preserve from "@truffle/preserve";
-import { TargetPathOptions, PathEntryOptions } from "./types";
+import type * as Preserve from "@truffle/preserve";
+import type { TargetPathOptions, PathEntryOptions } from "./types";
 
 export async function* targetPath(
   options: TargetPathOptions

--- a/packages/preserve-fs/lib/index.ts
+++ b/packages/preserve-fs/lib/index.ts
@@ -2,7 +2,7 @@
  * @module @truffle/preserve-fs
  */ /** */
 
-import * as Preserve from "@truffle/preserve";
+import type * as Preserve from "@truffle/preserve";
 
 import { targetPath } from "./fs";
 

--- a/packages/preserve-fs/lib/types.ts
+++ b/packages/preserve-fs/lib/types.ts
@@ -1,4 +1,4 @@
-import * as Preserve from "@truffle/preserve";
+import type * as Preserve from "@truffle/preserve";
 
 export interface TargetPathOptions {
   controls: Preserve.Controls | Preserve.Control.StepsController;

--- a/packages/preserve-fs/package.json
+++ b/packages/preserve-fs/package.json
@@ -28,7 +28,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@truffle/preserve": "^0.2.2",
     "@types/fs-extra": "^9.0.1",
     "@types/jest": "^26.0.0",
     "@types/node": "^14.0.13",
@@ -37,5 +36,8 @@
     "tmp-promise": "^3.0.2",
     "ts-jest": "^26.1.0",
     "typescript": "^4.1.4"
+  },
+  "dependencies": {
+    "@truffle/preserve": "^0.2.2"
   }
 }

--- a/packages/preserve-fs/package.json
+++ b/packages/preserve-fs/package.json
@@ -28,6 +28,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@truffle/preserve": "^0.2.2",
     "@types/fs-extra": "^9.0.1",
     "@types/jest": "^26.0.0",
     "@types/node": "^14.0.13",
@@ -36,8 +37,5 @@
     "tmp-promise": "^3.0.2",
     "ts-jest": "^26.1.0",
     "typescript": "^4.1.4"
-  },
-  "dependencies": {
-    "@truffle/preserve": "^0.2.2"
   }
 }

--- a/packages/preserve-to-buckets/lib/clear.ts
+++ b/packages/preserve-to-buckets/lib/clear.ts
@@ -1,5 +1,5 @@
-import * as Preserve from "@truffle/preserve";
-import { Buckets } from "@textile/hub";
+import type * as Preserve from "@truffle/preserve";
+import type { Buckets } from "@textile/hub";
 
 export interface ClearOptions {
   controls: Preserve.Controls;

--- a/packages/preserve-to-buckets/lib/connect.ts
+++ b/packages/preserve-to-buckets/lib/connect.ts
@@ -1,4 +1,4 @@
-import * as Preserve from "@truffle/preserve";
+import type * as Preserve from "@truffle/preserve";
 import { Buckets } from "@textile/hub";
 
 export interface ConnectOptions {

--- a/packages/preserve-to-buckets/lib/index.ts
+++ b/packages/preserve-to-buckets/lib/index.ts
@@ -3,7 +3,7 @@
  */ /** */
 
 import * as Preserve from "@truffle/preserve";
-import CID from "cids";
+import type CID from "cids";
 import { clear } from "./clear";
 import { connect } from "./connect";
 import { upload } from "./upload";

--- a/packages/preserve-to-buckets/lib/ipfs-adapter.ts
+++ b/packages/preserve-to-buckets/lib/ipfs-adapter.ts
@@ -1,4 +1,4 @@
-import * as Preserve from "@truffle/preserve";
+import type * as Preserve from "@truffle/preserve";
 import createIpfsHttpClient from "ipfs-http-client";
 
 // extract the typing for an IIPFS client from the default export of "ipfs-http-client"

--- a/packages/preserve-to-buckets/lib/search.ts
+++ b/packages/preserve-to-buckets/lib/search.ts
@@ -1,5 +1,5 @@
 import * as Preserve from "@truffle/preserve";
-import { FileObject } from "./ipfs-adapter";
+import type { FileObject } from "./ipfs-adapter";
 
 export type SearchOptions = {
   source: Preserve.Targets.Normalized.Source;

--- a/packages/preserve-to-buckets/lib/upload.ts
+++ b/packages/preserve-to-buckets/lib/upload.ts
@@ -1,9 +1,9 @@
 import CID from "cids";
 
-import * as Preserve from "@truffle/preserve";
+import type * as Preserve from "@truffle/preserve";
 import { search } from "./search";
 import { asyncToArray } from "iter-tools";
-import { Buckets, Root } from "@textile/hub";
+import type { Buckets, Root } from "@textile/hub";
 
 export interface UploadOptions {
   controls: Preserve.Controls;

--- a/packages/preserve-to-filecoin/lib/connect.ts
+++ b/packages/preserve-to-filecoin/lib/connect.ts
@@ -3,7 +3,7 @@ import {
   WsJsonRpcConnector,
   HttpJsonRpcConnector
 } from "filecoin.js";
-import * as Preserve from "@truffle/preserve";
+import type * as Preserve from "@truffle/preserve";
 
 export interface ConnectOptions {
   url: string;

--- a/packages/preserve-to-filecoin/lib/index.ts
+++ b/packages/preserve-to-filecoin/lib/index.ts
@@ -2,7 +2,7 @@
  * @module @truffle/preserve-to-filecoin
  */ /** */
 
-import CID from "cids";
+import type CID from "cids";
 import * as Preserve from "@truffle/preserve";
 
 import { connect } from "./connect";

--- a/packages/preserve-to-filecoin/lib/miners.ts
+++ b/packages/preserve-to-filecoin/lib/miners.ts
@@ -1,5 +1,5 @@
-import * as Preserve from "@truffle/preserve";
-import { LotusClient } from "filecoin.js";
+import type * as Preserve from "@truffle/preserve";
+import type { LotusClient } from "filecoin.js";
 
 export interface GetMinersOptions {
   client: LotusClient;

--- a/packages/preserve-to-filecoin/lib/storage.ts
+++ b/packages/preserve-to-filecoin/lib/storage.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import CID from "cids";
-import * as Preserve from "@truffle/preserve";
-import { LotusClient } from "filecoin.js";
+import type * as Preserve from "@truffle/preserve";
+import type { LotusClient } from "filecoin.js";
 
 export interface StorageDealOptions {
   walletAddress?: string;

--- a/packages/preserve-to-filecoin/lib/wait.ts
+++ b/packages/preserve-to-filecoin/lib/wait.ts
@@ -1,9 +1,9 @@
-import CID from "cids";
-import * as Preserve from "@truffle/preserve";
+import type CID from "cids";
+import type * as Preserve from "@truffle/preserve";
 import { terminalStates, DealState } from "./dealstates";
-import { LotusClient } from "filecoin.js";
+import type { LotusClient } from "filecoin.js";
 import delay from "delay";
-import { DealInfo } from "filecoin.js/builds/dist/providers/Types";
+import type { DealInfo } from "filecoin.js/builds/dist/providers/Types";
 
 export interface WaitOptions {
   client: LotusClient;

--- a/packages/preserve-to-ipfs/lib/connect.ts
+++ b/packages/preserve-to-ipfs/lib/connect.ts
@@ -1,6 +1,6 @@
 import createIpfsClient from "ipfs-http-client";
-import * as Preserve from "@truffle/preserve";
-import { IpfsClient } from "./ipfs-adapter";
+import type * as Preserve from "@truffle/preserve";
+import type { IpfsClient } from "./ipfs-adapter";
 
 export interface ConnectOptions {
   controls: Preserve.Controls;

--- a/packages/preserve-to-ipfs/lib/index.ts
+++ b/packages/preserve-to-ipfs/lib/index.ts
@@ -2,7 +2,7 @@
  * @module @truffle/preserve-to-ipfs
  */ /** */
 
-import CID from "cids";
+import type CID from "cids";
 import * as Preserve from "@truffle/preserve";
 
 import { connect } from "./connect";

--- a/packages/preserve-to-ipfs/lib/ipfs-adapter.ts
+++ b/packages/preserve-to-ipfs/lib/ipfs-adapter.ts
@@ -1,4 +1,4 @@
-import * as Preserve from "@truffle/preserve";
+import type * as Preserve from "@truffle/preserve";
 import createIpfsHttpClient from "ipfs-http-client";
 
 // extract the typing for an IIPFS client from the default export of "ipfs-http-client"

--- a/packages/preserve-to-ipfs/lib/search.ts
+++ b/packages/preserve-to-ipfs/lib/search.ts
@@ -1,5 +1,5 @@
 import * as Preserve from "@truffle/preserve";
-import { FileObject } from "./ipfs-adapter";
+import type { FileObject } from "./ipfs-adapter";
 
 export type SearchOptions = {
   source: Preserve.Targets.Normalized.Source;

--- a/packages/preserve-to-ipfs/lib/upload.ts
+++ b/packages/preserve-to-ipfs/lib/upload.ts
@@ -1,8 +1,8 @@
 import chalk from "chalk";
-import CID from "cids";
+import type CID from "cids";
 
 import * as Preserve from "@truffle/preserve";
-import { IpfsClient } from "./ipfs-adapter";
+import type { IpfsClient } from "./ipfs-adapter";
 import { search } from "./search";
 import { asyncToArray } from "iter-tools";
 

--- a/packages/preserve-to-ipfs/package.json
+++ b/packages/preserve-to-ipfs/package.json
@@ -31,6 +31,7 @@
     "@ganache/filecoin": "^0.1.2",
     "@types/jest": "^26.0.20",
     "@types/node": "^14.14.22",
+    "cids": "^1.1.5",
     "ganache": "^3.0.0-filecoin.3",
     "jest": "^26.6.3",
     "semver": "^7.3.4",
@@ -39,7 +40,6 @@
   },
   "dependencies": {
     "@truffle/preserve": "^0.2.2",
-    "cids": "^1.1.5",
     "ipfs-http-client": "^48.2.2",
     "iter-tools": "^7.0.2"
   }

--- a/packages/preserve/lib/control/controllers/BaseController.ts
+++ b/packages/preserve/lib/control/controllers/BaseController.ts
@@ -1,5 +1,5 @@
-import { Event } from "../events";
-import { Scope } from "../scopes";
+import type { Event } from "../events";
+import type { Scope } from "../scopes";
 import { State } from "../types";
 
 export interface ConstructorOptions {

--- a/packages/preserve/lib/control/controllers/ErrorController.ts
+++ b/packages/preserve/lib/control/controllers/ErrorController.ts
@@ -1,4 +1,4 @@
-import { Events } from "../events";
+import type { Events } from "../events";
 import { Process, State } from "../types";
 import {
   BaseController,

--- a/packages/preserve/lib/control/controllers/StepsController.ts
+++ b/packages/preserve/lib/control/controllers/StepsController.ts
@@ -3,7 +3,7 @@ import {
   ConstructorOptions as ErrorControllerConstructorOptions,
   IErrorController
 } from "./ErrorController";
-import { Events } from "../events";
+import type { Events } from "../events";
 import {
   IValueResolutionController,
   ValueResolutionController

--- a/packages/preserve/lib/control/controllers/ValueResolutionController.ts
+++ b/packages/preserve/lib/control/controllers/ValueResolutionController.ts
@@ -1,4 +1,4 @@
-import { Events } from "../events";
+import type { Events } from "../events";
 import { Process, State } from "../types";
 import { transitionToState, validStates } from "./decorators";
 import {

--- a/packages/preserve/lib/control/controllers/decorators.ts
+++ b/packages/preserve/lib/control/controllers/decorators.ts
@@ -1,4 +1,4 @@
-import { State } from "../types";
+import type { State } from "../types";
 
 export const validStates = (states: State[]) => (
   target: Object,

--- a/packages/preserve/lib/control/events.ts
+++ b/packages/preserve/lib/control/events.ts
@@ -1,4 +1,4 @@
-import { Scope } from "./scopes";
+import type { Scope } from "./scopes";
 
 export type EventName =
   | "fail"

--- a/packages/preserve/lib/control/types.ts
+++ b/packages/preserve/lib/control/types.ts
@@ -1,5 +1,5 @@
-import { StepsController } from "./controllers";
-import { Event } from "./events";
+import type { StepsController } from "./controllers";
+import type { Event } from "./events";
 
 export enum State {
   Pending = "pending",

--- a/packages/preserve/lib/index.ts
+++ b/packages/preserve/lib/index.ts
@@ -13,6 +13,6 @@ export { Target } from "./targets";
 import * as Targets from "./targets";
 export { Targets };
 
-export { Recipe } from "./recipes";
-import * as Recipes from "./recipes";
+export type { Recipe } from "./recipes";
+import type * as Recipes from "./recipes";
 export { Recipes };

--- a/packages/preserve/lib/preserve.ts
+++ b/packages/preserve/lib/preserve.ts
@@ -1,4 +1,4 @@
-import { Recipe } from "./recipes";
+import type { Recipe } from "./recipes";
 import { control, Event } from "./control";
 const TruffleError = require("@truffle/error");
 

--- a/packages/preserve/lib/recipes.ts
+++ b/packages/preserve/lib/recipes.ts
@@ -1,4 +1,4 @@
-import { Process, Controls } from "./control";
+import type { Process, Controls } from "./control";
 
 export interface ConstructorOptions {}
 

--- a/packages/preserve/lib/targets/sources/index.ts
+++ b/packages/preserve/lib/targets/sources/index.ts
@@ -1,5 +1,5 @@
 export * from "./types";
 
-export { Content } from "./contents";
+export type { Content } from "./contents";
 import * as Contents from "./contents";
 export { Contents };

--- a/packages/preserve/lib/targets/sources/types.ts
+++ b/packages/preserve/lib/targets/sources/types.ts
@@ -1,4 +1,4 @@
-import { Content } from "./contents";
+import type { Content } from "./contents";
 
 export interface Entry {
   path: string;

--- a/packages/preserve/lib/targets/types.ts
+++ b/packages/preserve/lib/targets/types.ts
@@ -1,4 +1,4 @@
-import { Source } from "./sources";
+import type { Source } from "./sources";
 
 export interface Target {
   source: Source;

--- a/packages/provisioner/src/index.ts
+++ b/packages/provisioner/src/index.ts
@@ -1,4 +1,4 @@
-import TruffleConfig from "@truffle/config";
+import type TruffleConfig from "@truffle/config";
 
 const provision = (contractAbstraction: any, truffleConfig: TruffleConfig) => {
   if (truffleConfig.provider) {

--- a/packages/resolver/lib/index.ts
+++ b/packages/resolver/lib/index.ts
@@ -1,5 +1,5 @@
 import { Resolver } from "./resolver";
-import { ResolverSource, ResolvedSource } from "./source";
+import type { ResolverSource, ResolvedSource } from "./source";
 
 export { Resolver, ResolverSource, ResolvedSource };
 

--- a/packages/resolver/lib/resolver.ts
+++ b/packages/resolver/lib/resolver.ts
@@ -5,7 +5,7 @@ const contract = require("@truffle/contract");
 const expect = require("@truffle/expect");
 const provision = require("@truffle/provisioner");
 
-import { ResolverSource, ResolvedSource } from "./source";
+import type { ResolverSource, ResolvedSource } from "./source";
 import { EthPMv1, NPM, GlobalNPM, FS, Truffle, ABI, Vyper } from "./sources";
 
 export interface ResolverOptions {

--- a/packages/resolver/lib/source.ts
+++ b/packages/resolver/lib/source.ts
@@ -1,4 +1,4 @@
-import { ContractObject } from "@truffle/contract-schema/spec";
+import type { ContractObject } from "@truffle/contract-schema/spec";
 
 export interface ResolverSource {
   require(importPath: string, searchPath?: string): ContractObject | null;

--- a/packages/resolver/lib/sources/abi.ts
+++ b/packages/resolver/lib/sources/abi.ts
@@ -1,7 +1,7 @@
 import path from "path";
-import { ContractObject } from "@truffle/contract-schema/spec";
+import type { ContractObject } from "@truffle/contract-schema/spec";
 import { generateSolidity } from "abi-to-sol";
-import { ResolverSource } from "../source";
+import type { ResolverSource } from "../source";
 
 export class ABI {
 

--- a/packages/resolver/lib/sources/ethpm-v1.ts
+++ b/packages/resolver/lib/sources/ethpm-v1.ts
@@ -1,8 +1,8 @@
 import path from "path";
 import fs from "fs";
 
-import { ContractObject } from "@truffle/contract-schema/spec";
-import { ResolverSource } from "../source";
+import type { ContractObject } from "@truffle/contract-schema/spec";
+import type { ResolverSource } from "../source";
 
 export class EthPMv1 implements ResolverSource {
   workingDirectory: string;

--- a/packages/resolver/lib/sources/fs.ts
+++ b/packages/resolver/lib/sources/fs.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import fs from "fs";
 
-import { ResolverSource } from "../source";
+import type { ResolverSource } from "../source";
 
 export class FS implements ResolverSource {
   workingDirectory: string;

--- a/packages/resolver/lib/sources/globalnpm.ts
+++ b/packages/resolver/lib/sources/globalnpm.ts
@@ -3,7 +3,7 @@ import fs from "fs";
 const detectInstalled: any = require("detect-installed");
 const getInstalledPath: any = require("get-installed-path");
 
-import { ResolverSource } from "../source";
+import type { ResolverSource } from "../source";
 
 export class GlobalNPM implements ResolverSource {
   require(importPath: string) {

--- a/packages/resolver/lib/sources/npm.ts
+++ b/packages/resolver/lib/sources/npm.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import fs from "fs";
 
-import { ResolverSource } from "../source";
+import type { ResolverSource } from "../source";
 
 export class NPM implements ResolverSource {
   workingDirectory: string;

--- a/packages/resolver/lib/sources/truffle/index.ts
+++ b/packages/resolver/lib/sources/truffle/index.ts
@@ -2,7 +2,7 @@ import path from "path";
 import fse from "fs-extra";
 import { Deployed } from "./Deployed";
 import findContracts from "@truffle/contract-sources";
-import { ResolverSource } from "../../source";
+import type { ResolverSource } from "../../source";
 const contract = require("@truffle/contract");
 
 export class Truffle implements ResolverSource {

--- a/packages/resolver/lib/sources/vyper.ts
+++ b/packages/resolver/lib/sources/vyper.ts
@@ -1,8 +1,8 @@
 import debugModule from "debug";
 const debug = debugModule("resolver:sources:vyper");
 import path from "path";
-import { ContractObject } from "@truffle/contract-schema/spec";
-import { ResolverSource, SourceResolution } from "../source";
+import type { ContractObject } from "@truffle/contract-schema/spec";
+import type { ResolverSource, SourceResolution } from "../source";
 
 export class Vyper implements ResolverSource {
   contractsDirectory: string;

--- a/packages/source-fetcher/lib/common.ts
+++ b/packages/source-fetcher/lib/common.ts
@@ -1,7 +1,7 @@
 //these imports aren't actually necessary, but why not :)
 import util from "util";
 import { setTimeout } from "timers";
-import * as Types from "./types";
+import type * as Types from "./types";
 
 export const networksById: { [id: number]: string } = {
   1: "mainnet",

--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -3,8 +3,8 @@ const debug = debugModule("source-fetcher:etherscan");
 // untyped import since no @types/web3-utils exists
 const Web3Utils = require("web3-utils");
 
-import { Fetcher, FetcherConstructor } from "./types";
-import * as Types from "./types";
+import type { Fetcher, FetcherConstructor } from "./types";
+import type * as Types from "./types";
 import {
   networksById,
   makeFilename,

--- a/packages/source-fetcher/lib/index.ts
+++ b/packages/source-fetcher/lib/index.ts
@@ -1,6 +1,6 @@
-import {Fetcher, FetcherConstructor} from "./types";
-import {InvalidNetworkError} from "./common";
-export {Fetcher, FetcherConstructor, InvalidNetworkError};
+import type { Fetcher, FetcherConstructor } from "./types";
+import { InvalidNetworkError } from "./common";
+export { Fetcher, FetcherConstructor, InvalidNetworkError };
 
 import EtherscanFetcher from "./etherscan";
 import SourcifyFetcher from "./sourcify";

--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -1,8 +1,8 @@
 import debugModule from "debug";
 const debug = debugModule("source-fetcher:sourcify");
 
-import { Fetcher, FetcherConstructor } from "./types";
-import * as Types from "./types";
+import type { Fetcher, FetcherConstructor } from "./types";
+import type * as Types from "./types";
 import { networksById, removeLibraries, InvalidNetworkError } from "./common";
 import axios from "axios";
 


### PR DESCRIPTION
In our Typescript packages, we've often been using `import` when we could be using `import type`.  This PR is the start of an attempt at fixing that.  Basically I went over most of the TS packages and replaced every `import` I could find that was only importing types with `import type` (I also did the same thing with exports where it seemed appropriate).

I did not touch `codec` or `decoder` because #3974 is still outstanding and I don't want even more merge conflicts.

I did not touch `db` or `db-kit` because they're large and confusing and I don't know them well, and I'm hoping someone else can handle those.  **Edit**: According to @gnidan, these packages already do this properly, so I don't need to do anything there!  Hooray!

I did not touch testing code, because I did not really see a need.

While doing this, I also noticed that:
1. Outside of testing, `@truffle/preserve-fs` only uses `@truffle/preserve` for types, and
2. Outside of testing, `@truffle/preserve-to-ipfs` only uses `cids` for types

So I reclassified both of those dependencies as devDependencies.  The former seems a little weird, but that's what the code says!  I don't know these packages really.