### PR TITLE
Dependency update: Update syntax highlighting for 0.8.5

### DIFF
--- a/packages/debug-utils/package.json
+++ b/packages/debug-utils/package.json
@@ -24,7 +24,7 @@
     "chalk": "^2.4.2",
     "debug": "^4.3.1",
     "highlight.js": "^10.4.0",
-    "highlightjs-solidity": "^1.1.0"
+    "highlightjs-solidity": "^1.1.1"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14394,10 +14394,10 @@ highlight.js@^9.15.8:
   dependencies:
     handlebars "^4.5.3"
 
-highlightjs-solidity@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/highlightjs-solidity/-/highlightjs-solidity-1.1.0.tgz#bdf0adba6deffdb1651f8fa63bee4dacc3dc4e00"
-  integrity sha512-LtH7uuoe+FOmtQd41ozAZKLJC2chqdqs461FJcWAx00R3VcBhSQTRFfzRGtTQqu2wsVIEdHiyynrPrEDDWyIMw==
+highlightjs-solidity@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/highlightjs-solidity/-/highlightjs-solidity-1.1.1.tgz#ed0f246d0f8cba647291baff68fb131252067424"
+  integrity sha512-NNcuj6GC0OP8qIrXVaqUA33d/nQoGvwRPS3FR2juIT+I1LAcNkebLbEp1AxzH0TiQ9InPxG62P/FnON8Ns15sQ==
 
 hkts@^0.3.1:
   version "0.3.1"


### PR DESCRIPTION
I've made it so that highlightjs-solidity 1.1.1 highlights the `verbatim` builtin new in Solidity assembly in 0.8.5, this PR updates us to use that.