### PR TITLE
Fix/testy rejections

### DIFF
--- a/packages/artifactor/test/methods.js
+++ b/packages/artifactor/test/methods.js
@@ -47,12 +47,19 @@ describe("Artifactor.saveAll", () => {
         },
       ])
       .then(() => {
-        assert.isTrue(consoleWarnSpy.called, "No warning emitted");
-        assert.isTrue(
+        assert.fail("This should have failed because of bad path");
+      })
+      .catch((err) => {
+        assert(consoleWarnSpy.called, "No warning emitted");
+        assert(
           consoleWarnSpy.calledWithMatch(/Duplicate contract names/),
           "Wrong warning message"
         );
-      });
+
+        // Note, we expect saveAll to fail after checking for warnings above
+        // because `Destination "/some/path" doesn't exist!`);
+        assert(/".some.path" doesn't exist!/i.test(err.message));
+      })
   });
 
   it("throws if this.destination doesn't exist", () => {

--- a/packages/core/test/commands.js
+++ b/packages/core/test/commands.js
@@ -3,48 +3,48 @@ const commands = require("../lib/commands");
 const commander = new Command(commands);
 const assert = require("assert");
 
-describe("Commander", function() {
-  before("assert preconditions", function() {
+describe("Commander", function () {
+  before("assert preconditions", function () {
     // These commands are expected to exist in tests.
     assert.notEqual(commands.migrate, null);
     assert.notEqual(commands.compile, null);
     assert.notEqual(commands.console, null);
   });
 
-  it("will infer commands based on initial letters entered", function() {
+  it("will infer commands based on initial letters entered", function () {
     var actualCommand = commander.getCommand("m").command;
     assert.equal(actualCommand, commands.migrate);
   });
 
-  it("will infer commands based on initial letters entered, even when typos exist later", function() {
+  it("will infer commands based on initial letters entered, even when typos exist later", function () {
     var actualCommand = commander.getCommand("complie").command;
     assert.equal(actualCommand, commands.compile);
   });
 
-  it("will NOT infer a command if not given enough information", function() {
+  it("will NOT infer a command if not given enough information", function () {
     // Note: "co" matches "console" and "compile"
     var actualCommand = commander.getCommand("co");
     assert.equal(actualCommand, null);
   });
 
-  it("will infer commands based on initial letters entered, given matches for shorter substrings", function() {
+  it("will infer commands based on initial letters entered, given matches for shorter substrings", function () {
     // Note: "co" matches "console" and "compile"
     var actualCommand = commander.getCommand("com").command;
     assert.equal(actualCommand, commands.compile);
   });
 
-  it("will ignore inferring if full command is specified", function() {
+  it("will ignore inferring if full command is specified", function () {
     var actualCommand = commander.getCommand("console").command;
     assert.equal(actualCommand, commands.console);
   });
 
-  it("will warn and display error for unsupported flags in commands", function() {
+  it("will warn and display error for unsupported flags in commands", async function () {
     var actualCommand = commander.getCommand("mig").command;
     assert.equal(actualCommand, commands.migrate);
 
     const originalLog = console.log || console.debug;
     let warning = "";
-    console.log = function(msg) {
+    console.log = function (msg) {
       console.log = originalLog;
       warning = msg;
     };

--- a/packages/core/test/commands.js
+++ b/packages/core/test/commands.js
@@ -49,25 +49,29 @@ describe("Commander", function () {
       warning = msg;
     };
 
-    commander.run(
-      [
-        "migrate",
-        "--network",
-        "localhost",
-        "--unsupportedflag",
-        "invalidoption",
-        "--unsupportedflag2",
-        "invalidflag2"
-      ],
-      { noAliases: true, logger: console },
-      function() {
-        //ignore. not part of test
-      }
-    );
-
-    assert.equal(
-      warning,
-      "> Warning: possible unsupported (undocumented in help) command line option: --unsupportedflag,--unsupportedflag2"
-    );
+    try {
+      await commander.run(
+        [
+          "migrate",
+          "--network",
+          "localhost",
+          "--unsupportedflag",
+          "invalidoption",
+          "--unsupportedflag2",
+          "invalidflag2",
+        ],
+        { noAliases: true, logger: console },
+        function () {
+          //ignore. not part of test
+        },
+      );
+    } catch (error) {
+      console.log("error", error);
+    } finally {
+      assert.equal(
+        warning,
+        "> Warning: possible unsupported (undocumented in help) command line option: --unsupportedflag,--unsupportedflag2",
+      );
+    }
   });
 });


### PR DESCRIPTION
This PR fixes two tests that didn't account for unhandled promise rejections. I found this when a build failed and flagged these [tests for failing CI](https://github.com/trufflesuite/truffle/runs/2841780353)

```
2021-06-16T18:00:09.1609218Z @truffle/core: UnhandledRejections detected
2021-06-16T18:00:09.1626964Z @truffle/core: Promise {
2021-06-16T18:00:09.1628102Z @truffle/core:   <rejected> ExtendableError: Could not find suitable configuration file.
2021-06-16T18:00:09.1629778Z @truffle/core:       at Function.detect (/home/runner/work/truffle/truffle/packages/config/src/index.ts:185:13)
2021-06-16T18:00:09.1631596Z @truffle/core:       at Object.run (/home/runner/work/truffle/truffle/packages/core/lib/commands/migrate.js:194:25)
2021-06-16T18:00:09.1633948Z @truffle/core:       at Command.run (/home/runner/work/truffle/truffle/packages/core/lib/command.js:167:33)
2021-06-16T18:00:09.1635235Z @truffle/core:       at Context.<anonymous> (/home/runner/work/truffle/truffle/packages/core/test/commands.js:52:15)
2021-06-16T18:00:09.1636611Z @truffle/core:       at callFn (/home/runner/work/truffle/truffle/node_modules/mocha/lib/runnable.js:358:21)
2021-06-16T18:00:09.1638602Z @truffle/core:       at Test.Runnable.run (/home/runner/work/truffle/truffle/node_modules/mocha/lib/runnable.js:346:5)
2021-06-16T18:00:09.1640194Z @truffle/core:       at Runner.runTest (/home/runner/work/truffle/truffle/node_modules/mocha/lib/runner.js:621:10)
2021-06-16T18:00:09.1641587Z @truffle/core:       at /home/runner/work/truffle/truffle/node_modules/mocha/lib/runner.js:745:12
2021-06-16T18:00:09.1642861Z @truffle/core:       at next (/home/runner/work/truffle/truffle/node_modules/mocha/lib/runner.js:538:14)
2021-06-16T18:00:09.1643944Z @truffle/core:       at /home/runner/work/truffle/truffle/node_modules/mocha/lib/runner.js:548:7
2021-06-16T18:00:09.1645023Z @truffle/core:       at next (/home/runner/work/truffle/truffle/node_modules/mocha/lib/runner.js:430:14)
2021-06-16T18:00:09.1646245Z @truffle/core:       at Immediate.<anonymous> (/home/runner/work/truffle/truffle/node_modules/mocha/lib/runner.js:516:5)
2021-06-16T18:00:09.1647317Z @truffle/core:       at processImmediate (internal/timers.js:462:21)
2021-06-16T18:00:09.1648312Z @truffle/core: } ExtendableError: Could not find suitable configuration file.
2021-06-16T18:00:09.1649892Z @truffle/core:     at Function.detect (/home/runner/work/truffle/truffle/packages/config/src/index.ts:185:13)
2021-06-16T18:00:09.1651227Z @truffle/core:     at Object.run (/home/runner/work/truffle/truffle/packages/core/lib/commands/migrate.js:194:25)
2021-06-16T18:00:09.1654304Z @truffle/core:     at Command.run (/home/runner/work/truffle/truffle/packages/core/lib/command.js:167:33)
2021-06-16T18:00:09.1655830Z @truffle/core:     at Context.<anonymous> (/home/runner/work/truffle/truffle/packages/core/test/commands.js:52:15)
2021-06-16T18:00:09.1657131Z @truffle/core:     at callFn (/home/runner/work/truffle/truffle/node_modules/mocha/lib/runnable.js:358:21)
2021-06-16T18:00:09.1659374Z @truffle/core:     at Test.Runnable.run (/home/runner/work/truffle/truffle/node_modules/mocha/lib/runnable.js:346:5)
2021-06-16T18:00:09.1660861Z @truffle/core:     at Runner.runTest (/home/runner/work/truffle/truffle/node_modules/mocha/lib/runner.js:621:10)
2021-06-16T18:00:09.1662196Z @truffle/core:     at /home/runner/work/truffle/truffle/node_modules/mocha/lib/runner.js:745:12
2021-06-16T18:00:09.1663520Z @truffle/core:     at next (/home/runner/work/truffle/truffle/node_modules/mocha/lib/runner.js:538:14)
2021-06-16T18:00:09.1664591Z @truffle/core:     at /home/runner/work/truffle/truffle/node_modules/mocha/lib/runner.js:548:7
2021-06-16T18:00:09.1665682Z @truffle/core:     at next (/home/runner/work/truffle/truffle/node_modules/mocha/lib/runner.js:430:14)
2021-06-16T18:00:09.1666873Z @truffle/core:     at Immediate.<anonymous> (/home/runner/work/truffle/truffle/node_modules/mocha/lib/runner.js:516:5)
2021-06-16T18:00:09.1667945Z @truffle/core:     at processImmediate (internal/timers.js:462:21)
2021-06-16T18:00:09.2150790Z @truffle/core: error Command failed with exit code 1.
```