### PR TITLE
Remove unnecessary awaits & simplify associated test

### DIFF
--- a/packages/box/box.ts
+++ b/packages/box/box.ts
@@ -190,7 +190,7 @@ const Box = {
       const normalizedSourcePath = normalizeSourcePath(url);
 
       await Box.checkDir(options, destination);
-      const tempDir = await utils.setUpTempDirectory(events);
+      const tempDir = utils.setUpTempDirectory(events);
       const tempDirPath = tempDir.path;
       tempDirCleanup = tempDir.cleanupCallback;
 
@@ -209,7 +209,7 @@ const Box = {
       tempDirCleanup();
       events.emit("unbox:cleaningTempFiles:succeed");
 
-      await utils.setUpBox(boxConfig, destination, events);
+      utils.setUpBox(boxConfig, destination, events);
 
       return boxConfig;
     } catch (error) {

--- a/packages/box/test/box.js
+++ b/packages/box/test/box.js
@@ -120,14 +120,10 @@ describe("@truffle/box Box", () => {
       beforeEach(() => {
         cleanupCallback = sinon.spy();
         sinon.stub(utils, "downloadBox").throws();
-        sinon.stub(utils, "setUpTempDirectory").returns(
-          new Promise((resolve) => {
-            resolve({
-              path: destination,
-              cleanupCallback,
-            });
-          }),
-        );
+        sinon.stub(utils, "setUpTempDirectory").returns({
+          path: destination,
+          cleanupCallback,
+        });
       });
 
       afterEach(() => {
@@ -138,6 +134,7 @@ describe("@truffle/box Box", () => {
       it("calls the cleanup function if it is available", async () => {
         try {
           await Box.unbox(TRUFFLE_BOX_DEFAULT, destination, {}, config);
+          assert.fail("Box.unbox(...) should have thrown");
         } catch (_) {
           assert(cleanupCallback.called);
         }


### PR DESCRIPTION
  - don't await `setupTempDirectory`. The await promise seems to be
    necessary for one test, which is rewritten to work without promise
    complexity.

  - don't await `setUpBox`. It is a synchronous function and the awaited
    value is not used.
