### PR TITLE
Minor corrections for Tezos compiler upgrade

### DIFF
--- a/packages/artifactor/index.ts
+++ b/packages/artifactor/index.ts
@@ -47,15 +47,16 @@ class Artifactor {
     if (Array.isArray(artifactObjects)) {
       const tmpArtifactArray = artifactObjects;
       tmpArtifactArray.forEach(artifactObj => {
-        if (newArtifactObjects[artifactObj.contract_name || artifactObj.contractName]) {
+        const contractName = artifactObj.contract_name || artifactObj.contractName;
+        if (newArtifactObjects[contractName]) {
           console.warn(
             `${OS.EOL}> Duplicate contract names found for ${
-              artifactObj.contract_name
+              contractName
             }.${OS.EOL}` +
               `> This can cause errors and unknown behavior. Please rename one of your contracts.`
           );
         }
-        newArtifactObjects[artifactObj.contract_name || artifactObj.contractName] = artifactObj;
+        newArtifactObjects[contractName] = artifactObj;
       });
     } else {
       newArtifactObjects = artifactObjects;

--- a/packages/artifactor/tsconfig.json
+++ b/packages/artifactor/tsconfig.json
@@ -9,7 +9,7 @@
     "sourceMap": true,
     "outDir": "dist",
     "baseUrl": ".",
-    "lib": ["es2017"],
+    "lib": ["es2017","dom"],
     "paths": {
       "web3": [
         "../../node_modules/@types/web3/index",

--- a/packages/artifactor/tsconfig.json
+++ b/packages/artifactor/tsconfig.json
@@ -9,7 +9,7 @@
     "sourceMap": true,
     "outDir": "dist",
     "baseUrl": ".",
-    "lib": ["es2017","dom"],
+    "lib": ["es2017"],
     "paths": {
       "web3": [
         "../../node_modules/@types/web3/index",

--- a/packages/compile-common/src/profiler/getImports.ts
+++ b/packages/compile-common/src/profiler/getImports.ts
@@ -23,7 +23,7 @@ export async function getImports({
   shouldIncludePath,
   parseImports
 }: GetImportsOptions): Promise<string[]> {
-  if (!shouldIncludePath(filePath)) return [];
+  if (!shouldIncludePath(filePath) || !parseImports) return [];
 
   debug("filePath: %s", filePath);
 

--- a/packages/compile-common/src/profiler/profiler.ts
+++ b/packages/compile-common/src/profiler/profiler.ts
@@ -10,8 +10,8 @@ import { requiredSources, RequiredSourcesOptions } from "./requiredSources";
 import { convertToAbsolutePaths } from "./convertToAbsolutePaths";
 
 export interface ProfilerConfig {
-  parseImports: RequiredSourcesOptions["parseImports"];
-  shouldIncludePath: RequiredSourcesOptions["shouldIncludePath"];
+  parseImports?: RequiredSourcesOptions["parseImports"];
+  shouldIncludePath?: RequiredSourcesOptions["shouldIncludePath"];
 }
 
 export class Profiler {
@@ -73,7 +73,7 @@ export class Profiler {
           throw error;
         }
       }
-    }
+    };
 
     const updatedPaths = convertToAbsolutePaths(paths, basePath);
     const allPaths = convertToAbsolutePaths(


### PR DESCRIPTION
- @truffle/artifactor: Minor refactor to remove code duplication and show warning if `contract_name` is missing but `contractName` is present.
- @truffle/compile-common: Make properties from `ProfilerConfig` type optional, as they are currently not being passed in some instances of @truffle/compile-vyper.

None of these are breaking changes.