### PR TITLE
Feature: Run user-supplied scripts to populate the console

### DIFF
--- a/packages/config/src/configDefaults.ts
+++ b/packages/config/src/configDefaults.ts
@@ -59,6 +59,9 @@ export const getInitialConfig = ({
         settings: {}
       }
     },
+    console: {
+      require: null
+    },
     logger: console
   };
 };
@@ -90,6 +93,7 @@ export const configProps = ({
     logger() {},
     compilers() {},
     ens() {},
+    console() {},
 
     build_directory: {
       default: () => path.join(configObject.working_directory, "build"),

--- a/packages/core/lib/commands/console.js
+++ b/packages/core/lib/commands/console.js
@@ -16,6 +16,13 @@ const command = {
         description: "Preload console environment from required JavaScript " +
           "file. The default export must be an object with named keys that " +
           "will be used\n                    to populate the console environment."
+      },
+      {
+        option: "--require-none",
+        description: "Do not load any user-defined JavaScript into the " +
+          "console environment. This option takes precedence over --require, " +
+          "-r, and\n                    values provided in console.require in" +
+          " your project's truffle-config.js."
       }
     ],
     allowedGlobalOptions: ["network", "config"]

--- a/packages/core/lib/commands/console.js
+++ b/packages/core/lib/commands/console.js
@@ -21,8 +21,8 @@ const command = {
         option: "--require-none",
         description: "Do not load any user-defined JavaScript into the " +
           "console environment. This option takes precedence over --require, " +
-          "-r, and\n                    values provided in console.require in" +
-          " your project's truffle-config.js."
+          "-r, and\n                    values provided for console.require " +
+          "in your project's truffle-config.js."
       }
     ],
     allowedGlobalOptions: ["network", "config"]

--- a/packages/core/lib/commands/console.js
+++ b/packages/core/lib/commands/console.js
@@ -4,7 +4,7 @@ const command = {
     "Run a console with contract abstractions and commands available",
   builder: {},
   help: {
-    usage: "truffle console [--verbose-rpc] [--require|-r <file>]",
+    usage: "truffle console [--verbose-rpc] [(--require|-r) <file>]",
     options: [
       {
         option: "--verbose-rpc",
@@ -12,7 +12,7 @@ const command = {
           "Log communication between Truffle and the Ethereum client."
       },
       {
-        option: "--require|-r <file>",
+        option: "(--require|-r) <file>",
         description: "Preload console environment from required JavaScript " +
           "file. The default export must be an object with named keys that " +
           "will be used\n                    to populate the console environment."

--- a/packages/core/lib/commands/console.js
+++ b/packages/core/lib/commands/console.js
@@ -4,12 +4,18 @@ const command = {
     "Run a console with contract abstractions and commands available",
   builder: {},
   help: {
-    usage: "truffle console [--verbose-rpc]",
+    usage: "truffle console [--verbose-rpc] [--require|-r <file>]",
     options: [
       {
         option: "--verbose-rpc",
         description:
           "Log communication between Truffle and the Ethereum client."
+      },
+      {
+        option: "--require|-r <file>",
+        description: "Preload console environment from required JavaScript " +
+          "file. The default export must be an object with named keys that " +
+          "will be used\n                    to populate the console environment."
       }
     ],
     allowedGlobalOptions: ["network", "config"]

--- a/packages/core/lib/commands/develop.js
+++ b/packages/core/lib/commands/develop.js
@@ -25,6 +25,13 @@ const command = {
         description: "Preload console environment from required JavaScript " +
           "file. The default export must be an object with named keys that " +
           "will be used\n                    to populate the console environment."
+      },
+      {
+        option: "--require-none",
+        description: "Do not load any user-defined JavaScript into the " +
+          "console environment. This option takes precedence over --require, " +
+          "-r, and\n                    values provided in console.require in" +
+          " your project's truffle-config.js."
       }
     ],
     allowedGlobalOptions: ["config"]

--- a/packages/core/lib/commands/develop.js
+++ b/packages/core/lib/commands/develop.js
@@ -11,7 +11,7 @@ const command = {
     }
   },
   help: {
-    usage: "truffle develop [--log] [--require|-r <file>]",
+    usage: "truffle develop [--log] [(--require|-r) <file>]",
     options: [
       {
         option: `--log`,
@@ -21,7 +21,7 @@ const command = {
           `different Truffle develop or console session to interact via the repl.`
       },
       {
-        option: "--require|-r <file>",
+        option: "(--require|-r) <file>",
         description: "Preload console environment from required JavaScript " +
           "file. The default export must be an object with named keys that " +
           "will be used\n                    to populate the console environment."

--- a/packages/core/lib/commands/develop.js
+++ b/packages/core/lib/commands/develop.js
@@ -30,8 +30,8 @@ const command = {
         option: "--require-none",
         description: "Do not load any user-defined JavaScript into the " +
           "console environment. This option takes precedence over --require, " +
-          "-r, and\n                    values provided in console.require in" +
-          " your project's truffle-config.js."
+          "-r, and\n                    values provided for console.require " +
+          "in your project's truffle-config.js."
       }
     ],
     allowedGlobalOptions: ["config"]

--- a/packages/core/lib/commands/develop.js
+++ b/packages/core/lib/commands/develop.js
@@ -11,7 +11,7 @@ const command = {
     }
   },
   help: {
-    usage: "truffle develop [--log]",
+    usage: "truffle develop [--log] [--require|-r <file>]",
     options: [
       {
         option: `--log`,
@@ -19,6 +19,12 @@ const command = {
           `Start/Connect to a Truffle develop session and log all ` +
           `rpc activity. You will\n                    need to open a ` +
           `different Truffle develop or console session to interact via the repl.`
+      },
+      {
+        option: "--require|-r <file>",
+        description: "Preload console environment from required JavaScript " +
+          "file. The default export must be an object with named keys that " +
+          "will be used\n                    to populate the console environment."
       }
     ],
     allowedGlobalOptions: ["config"]

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -142,12 +142,12 @@ class Console extends EventEmitter {
       // to sign transactions (e.g. no reason to disallow debugging)
       accounts = [];
     }
+    // we load user variables first so as to not clobber ours
+    this.hydrateUserDefinedVariables();
 
     this.repl.context.web3 = this.web3;
     this.repl.context.interfaceAdapter = this.interfaceAdapter;
     this.repl.context.accounts = accounts;
-
-    this.hydrateUserDefinedVariables();
   }
 
   provision() {

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -86,12 +86,14 @@ class Console extends EventEmitter {
   }
 
   hydrateUserDefinedVariables() {
-    if (
-      (!this.options.console || !this.options.console.require) &&
-      !this.options.require &&
-      !this.options.r ||
-      this.options["require-none"]
-    ) return;
+  // exit if feature should be disabled
+  if (this.options["require-none"]) return;
+
+  // exit if no hydrate options are set
+  if (!this.options.console || !this.options.console.require) &&
+    !this.options.require &&
+    !this.options.r 
+  ) return;
 
     const requireFromPath = target => {
       return path.isAbsolute(target) ?

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -114,7 +114,7 @@ class Console extends EventEmitter {
       "either a string or an array. If you specify an array, its members " +
       "must be paths or objects containing at least a `path` property.";
 
-    const requireValue = this.options.require || this.options.console.require;
+    const requireValue = this.options.r || this.options.require || this.options.console.require;
 
     if (typeof requireValue === "string") {
       addToContext(requireFromPath(requireValue));

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -65,18 +65,7 @@ class Console extends EventEmitter {
         eval: this.interpret.bind(this)
       });
 
-      let accounts;
-      try {
-        accounts = await this.interfaceAdapter.getAccounts();
-      } catch {
-        // don't prevent Truffle from working if user doesn't provide some way
-        // to sign transactions (e.g. no reason to disallow debugging)
-        accounts = [];
-      }
-
-      this.repl.context.web3 = this.web3;
-      this.repl.context.interfaceAdapter = this.interfaceAdapter;
-      this.repl.context.accounts = accounts;
+      this.setUpEnvironment();
       this.provision();
 
       //want repl to exit when it receives an exit command
@@ -93,6 +82,21 @@ class Console extends EventEmitter {
       );
       this.options.logger.log(error.stack || error.message || error);
     }
+  }
+
+  setUpEnvironment() {
+    let accounts;
+    try {
+      accounts = await this.interfaceAdapter.getAccounts();
+    } catch {
+      // don't prevent Truffle from working if user doesn't provide some way
+      // to sign transactions (e.g. no reason to disallow debugging)
+      accounts = [];
+    }
+
+    this.repl.context.web3 = this.web3;
+    this.repl.context.interfaceAdapter = this.interfaceAdapter;
+    this.repl.context.accounts = accounts;
   }
 
   provision() {

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -97,6 +97,23 @@ class Console extends EventEmitter {
     this.repl.context.web3 = this.web3;
     this.repl.context.interfaceAdapter = this.interfaceAdapter;
     this.repl.context.accounts = accounts;
+
+    if (this.options.console && this.options.console.require) {
+      switch (typeof this.options.console.require) {
+        case "string":
+          const userDefined = require(this.options.console.require);
+          for (const key in userDefined) {
+            this.repl.context[key] = userDefined[key];
+          }
+          break;
+        case "object":
+        default:
+          const message = "You must specify the console.require property as " +
+            "either a string or an object. If you specify an object, it must " +
+            "contain at least a `path` property."
+          throw new Error
+      }
+    }
   }
 
   provision() {

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -65,7 +65,7 @@ class Console extends EventEmitter {
         eval: this.interpret.bind(this)
       });
 
-      this.setUpEnvironment();
+      await this.setUpEnvironment();
       this.provision();
 
       //want repl to exit when it receives an exit command
@@ -78,13 +78,14 @@ class Console extends EventEmitter {
       return new Promise(() => {});
     } catch (error) {
       this.options.logger.log(
-        "Unexpected error: Cannot provision contracts while instantiating the console."
+        "Unexpected error setting up the environment or provisioning " +
+        "contracts while instantiating the console."
       );
       this.options.logger.log(error.stack || error.message || error);
     }
   }
 
-  setUpEnvironment() {
+  async setUpEnvironment() {
     let accounts;
     try {
       accounts = await this.interfaceAdapter.getAccounts();
@@ -101,7 +102,9 @@ class Console extends EventEmitter {
     if (this.options.console && this.options.console.require) {
       switch (typeof this.options.console.require) {
         case "string":
-          const userDefined = require(this.options.console.require);
+          const userDefined = path.isAbsolute(this.options.console.require) ?
+            require(this.options.console.require) :
+            require(path.join(this.options.working_directory, this.options.console.require));
           for (const key in userDefined) {
             this.repl.context[key] = userDefined[key];
           }

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -86,15 +86,15 @@ class Console extends EventEmitter {
   }
 
   hydrateUserDefinedVariables() {
-  // exit if feature should be disabled
-  if (this.options["require-none"]) return;
+    // exit if feature should be disabled
+    if (this.options["require-none"]) return;
 
-  // exit if no hydrate options are set
-  if (
-    (!this.options.console || !this.options.console.require) &&
-    !this.options.require &&
-    !this.options.r
-  ) return;
+    // exit if no hydrate options are set
+    if (
+      (!this.options.console || !this.options.console.require) &&
+      !this.options.require &&
+      !this.options.r
+    ) return;
 
     const requireFromPath = target => {
       return path.isAbsolute(target) ?

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -90,10 +90,10 @@ class Console extends EventEmitter {
   if (this.options["require-none"]) return;
 
   // exit if no hydrate options are set
-  if (!this.options.console || !this.options.console.require) &&
+  if ((!this.options.console || !this.options.console.require) &&
     !this.options.require &&
-    !this.options.r 
-  ) return;
+    !this.options.r
+    ) return;
 
     const requireFromPath = target => {
       return path.isAbsolute(target) ?

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -86,7 +86,7 @@ class Console extends EventEmitter {
   }
 
   hydrateUserDefinedVariables() {
-    if (!this.options.console || !this.options.console.require) return;
+    if ((!this.options.console || !this.options.console.require) && !this.options.require) return;
 
     const requireFromPath = target => {
       return path.isAbsolute(target) ?
@@ -109,9 +109,11 @@ class Console extends EventEmitter {
       "either a string or an array. If you specify an array, its members " +
       "must be paths or objects containing at least a `path` property.";
 
-    if (typeof this.options.console.require === "string") {
-      addToContext(requireFromPath(this.options.console.require));
-    } else if (Array.isArray(this.options.console.require)) {
+    const requireValue = this.options.require || this.options.console.require;
+
+    if (typeof requireValue === "string") {
+      addToContext(requireFromPath(requireValue));
+    } else if (Array.isArray(requireValue)) {
       this.options.console.require.forEach(item => {
         if (typeof item === "string") {
           addToContext(requireFromPath(item));

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -90,10 +90,11 @@ class Console extends EventEmitter {
   if (this.options["require-none"]) return;
 
   // exit if no hydrate options are set
-  if ((!this.options.console || !this.options.console.require) &&
+  if (
+    (!this.options.console || !this.options.console.require) &&
     !this.options.require &&
     !this.options.r
-    ) return;
+  ) return;
 
     const requireFromPath = target => {
       return path.isAbsolute(target) ?

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -86,7 +86,12 @@ class Console extends EventEmitter {
   }
 
   hydrateUserDefinedVariables() {
-    if ((!this.options.console || !this.options.console.require) && !this.options.require) return;
+    if (
+      (!this.options.console || !this.options.console.require) &&
+      !this.options.require &&
+      !this.options.r ||
+      this.options["require-none"]
+    ) return;
 
     const requireFromPath = target => {
       return path.isAbsolute(target) ?

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -87,7 +87,8 @@
   "devDependencies": {
     "@truffle/blockchain-utils": "^0.0.30",
     "chai-as-promised": "^7.1.1",
-    "memorystream": "^0.3.1"
+    "memorystream": "^0.3.1",
+    "sinon": "^9.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/test/lib/console.js
+++ b/packages/core/test/lib/console.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const path = require("path");
 const Console = require("../../lib/console");
 const commands = require("../../lib/commands");
 const sinon = require("sinon");
@@ -25,27 +26,41 @@ const consoleCommands = Object.keys(commands).reduce((acc, name) => {
     ? Object.assign(acc, {[name]: commands[name]})
     : acc;
 }, {});
+
 let truffleConsole;
 
 describe("Console", function () {
-  beforeEach(function () {
-    truffleConsole = new Console(consoleCommands, consoleOptions);
-    // this is just a stub for the repl.context to check for variables added
-    truffleConsole.repl = { context: {} };
-    sinon.stub(truffleConsole.interfaceAdapter, "getAccounts").returns(["0x0"]);
-    sinon.stub(truffleConsole, "hydrateUserDefinedVariables");
-  });
-  afterEach(function () {
-    truffleConsole.interfaceAdapter.getAccounts.restore();
-    truffleConsole.hydrateUserDefinedVariables.restore();
-  });
 
   describe("Console.setUpEnvironment", function () {
+    beforeEach(function () {
+      const pathToUserJs = path.join(config.working_directory, "test/sources/userVariables.js");
+      const pathToMoreUserJs = path.join(config.working_directory, "test/sources/moreUserVariables.js");
+      consoleOptions.console.require = [
+        pathToUserJs,
+        { path: pathToMoreUserJs },
+        { path: pathToUserJs, as: "namespace" }
+      ];
+      truffleConsole = new Console(consoleCommands, consoleOptions);
+      // this is just a stub for the repl.context to check for variables added
+      truffleConsole.repl = { context: {} };
+      sinon.stub(truffleConsole.interfaceAdapter, "getAccounts").returns(["0x0"]);
+    });
+    afterEach(function () {
+      truffleConsole.interfaceAdapter.getAccounts.restore();
+    });
+
     it("sets web3, the interface adapter, and accounts variables", async function () {
       await truffleConsole.setUpEnvironment();
       assert(truffleConsole.repl.context.web3);
       assert(truffleConsole.repl.context.interfaceAdapter);
       assert.equal(truffleConsole.repl.context.accounts[0], "0x0");
+    });
+
+    it("adds the JS to the environment (repl.context)", async function () {
+      await truffleConsole.setUpEnvironment();
+      assert.equal(truffleConsole.repl.context.bingBam, "boom");
+      assert.equal(truffleConsole.repl.context.abraham, "lincoln");
+      assert.equal(truffleConsole.repl.context.namespace.bingBam, "boom");
     });
   });
 });

--- a/packages/core/test/lib/console.js
+++ b/packages/core/test/lib/console.js
@@ -1,0 +1,51 @@
+const assert = require("chai").assert;
+const Console = require("../../lib/console");
+const commands = require("../../lib/commands");
+const sinon = require("sinon");
+const Config = require("@truffle/config");
+const Web3 = require("web3");
+const Resolver = require("@truffle/resolver");
+const config = new Config();
+const consoleOptions = new Config().with({
+  network: "funTimeNetwork",
+  networks: {
+    funTimeNetwork: {
+      type: "ethereum"
+    }
+  },
+  network_id: 666,
+  provider: new Web3.providers.HttpProvider("http://localhost:666"),
+  resolver: new Resolver(config)
+});
+
+// Console uses the following for instantiation in packages/core/lib/console.js
+const excluded = new Set(["console", "init", "watch", "develop"]);
+const consoleCommands = Object.keys(commands).reduce((acc, name) => {
+  return !excluded.has(name)
+    ? Object.assign(acc, {[name]: commands[name]})
+    : acc;
+}, {});
+let truffleConsole;
+
+describe("Console", function () {
+  beforeEach(function () {
+    truffleConsole = new Console(consoleCommands, consoleOptions);
+    // this is just a stub for the repl.context to check for variables added
+    truffleConsole.repl = { context: {} };
+    sinon.stub(truffleConsole.interfaceAdapter, "getAccounts").returns(["0x0"]);
+    sinon.stub(truffleConsole, "hydrateUserDefinedVariables");
+  });
+  afterEach(function () {
+    truffleConsole.interfaceAdapter.getAccounts.restore();
+    truffleConsole.hydrateUserDefinedVariables.restore();
+  });
+
+  describe("Console.setUpEnvironment", function () {
+    it("sets web3, the interface adapter, and accounts variables", async function () {
+      await truffleConsole.setUpEnvironment();
+      assert(truffleConsole.repl.context.web3);
+      assert(truffleConsole.repl.context.interfaceAdapter);
+      assert.equal(truffleConsole.repl.context.accounts[0], "0x0");
+    });
+  });
+});

--- a/packages/core/test/lib/console.js
+++ b/packages/core/test/lib/console.js
@@ -7,17 +7,6 @@ const Config = require("@truffle/config");
 const Web3 = require("web3");
 const Resolver = require("@truffle/resolver");
 const config = new Config();
-const consoleOptions = new Config().with({
-  network: "funTimeNetwork",
-  networks: {
-    funTimeNetwork: {
-      type: "ethereum"
-    }
-  },
-  network_id: 666,
-  provider: new Web3.providers.HttpProvider("http://localhost:666"),
-  resolver: new Resolver(config)
-});
 
 // Console uses the following for instantiation in packages/core/lib/console.js
 const excluded = new Set(["console", "init", "watch", "develop"]);
@@ -26,13 +15,22 @@ const consoleCommands = Object.keys(commands).reduce((acc, name) => {
     ? Object.assign(acc, {[name]: commands[name]})
     : acc;
 }, {});
-
-let truffleConsole;
+let truffleConsole, otherTruffleConsole, consoleOptions, otherConsoleOptions;
 
 describe("Console", function () {
-
   describe("Console.setUpEnvironment", function () {
     beforeEach(function () {
+      consoleOptions = new Config().with({
+        network: "funTimeNetwork",
+        networks: {
+          funTimeNetwork: {
+            type: "ethereum"
+          }
+        },
+        network_id: 666,
+        provider: new Web3.providers.HttpProvider("http://localhost:666"),
+        resolver: new Resolver(config)
+      });
       const pathToUserJs = path.join(config.working_directory, "test/sources/userVariables.js");
       const pathToMoreUserJs = path.join(config.working_directory, "test/sources/moreUserVariables.js");
       consoleOptions.console.require = [
@@ -62,5 +60,32 @@ describe("Console", function () {
       assert.equal(truffleConsole.repl.context.abraham, "lincoln");
       assert.equal(truffleConsole.repl.context.namespace.bingBam, "boom");
     });
+
+    describe("when there are name conflicts with user-supplied variables", function () {
+      beforeEach(function () {
+        otherConsoleOptions = new Config().with({
+          network: "funTimeNetwork",
+          networks: {
+            funTimeNetwork: {
+              type: "ethereum"
+            }
+          },
+          network_id: 666,
+          provider: new Web3.providers.HttpProvider("http://localhost:666"),
+          resolver: new Resolver(config)
+        });
+        otherConsoleOptions.console.require = path.join(config.working_directory, "test/sources/nameConflicts.js");
+        otherTruffleConsole = new Console(consoleCommands, otherConsoleOptions);
+        // this is just a stub for the repl.context to check for variables added
+        otherTruffleConsole.repl = { context: {} };
+      });
+
+      it("won't let users clobber Truffle variables", async function () {
+        await otherTruffleConsole.setUpEnvironment();
+        assert.notEqual(otherTruffleConsole.repl.context.accounts, "0x666");
+        assert.notEqual(otherTruffleConsole.repl.context.web3, "fakeWeb3");
+        assert.notEqual(otherTruffleConsole.repl.context.interfaceAdapter, "fakeInterfaceAdapter");
+      });
+    })
   });
 });

--- a/packages/core/test/sources/moreUserVariables.js
+++ b/packages/core/test/sources/moreUserVariables.js
@@ -1,0 +1,3 @@
+module.exports = {
+  abraham: "lincoln"
+};

--- a/packages/core/test/sources/nameConflicts.js
+++ b/packages/core/test/sources/nameConflicts.js
@@ -1,0 +1,7 @@
+// this file will try to load variables named the same as Truffle-injected ones
+// Truffle should not allow it to clobber our own injected ones
+module.exports = {
+  accounts: [ "0x666" ],
+  web3: "fakeWeb3",
+  interfaceAdapter: "fakeInterfaceAdapter"
+}

--- a/packages/core/test/sources/userVariables.js
+++ b/packages/core/test/sources/userVariables.js
@@ -1,0 +1,3 @@
+module.exports = {
+  bingBam: "boom"
+};


### PR DESCRIPTION
In https://github.com/trufflesuite/truffle/issues/2472 it was suggested to add a way of providing Truffle with scripts to be run when starting the console environment. This PR provides the ability so specify paths to scripts in `truffle-config.js`. 

Users can now add a `console.require` property which will either be a string or an array. If the user supplies a string, it must be a path to a JS file that will be `require`d. The `module.exports` must be a JS object with named keys. The keys will be variables set in the console environment and they will be set to the value of their value. So for example, consider the case where the user supplies the following JS:
```
// user-specified JS file
module.exports = {
  breakfast: "yes please"
};
```
When the user starts up the console via `truffle console` or `truffle develop`, the environment should have the variable "breakfast" which will be equal to the string "yes please".

The other possible value for `console.require` is an array. Each member of the array must either be a string or an object that contains at least a `path` property. Strings will be treated exactly as described in the preceding paragraph. Objects must contain a `path` property (that will have a string value) that will once again specify a path to a file to be `require`d. It will be treated exactly like strings.

The only other member allowed for objects is a `as` property. The variables specified by the JS will then be namespaced under whatever string value is provided for `as`. The following is an example of specifying the `console.require` format when not using just a plain string.
```
// truffle-config.js
module.exports = {
  console: {
    require: [
      "../../food.js",
      { path: "./myStuff.js" },
      { path: "../someOtherStuff.js", as: "myVariables" }
    ]
  }
};
```

That configuration would load the variables found in "../../food.js", "./myStuff.js", and "../someOtherStuff.js". Furthermore, the variables found in "../someOtherStuff.js" would be available namespaced under `myVariables`.