### PR TITLE
Bug fix: Add crypto lib and method to silence warning

### DIFF
--- a/packages/core/lib/console-child.js
+++ b/packages/core/lib/console-child.js
@@ -4,6 +4,12 @@ const Config = require("@truffle/config");
 const Web3 = require("web3");
 const yargs = require("yargs");
 
+const crypto = require("crypto");
+global.crypto = crypto;
+// we need to make sure this function exists so ensjs doesn't complain
+// it requires getRandomValues for some functionalities
+global.crypto.getRandomValues = require("get-random-values");
+
 const input = process.argv[2].split(" -- ");
 const inputStrings = input[1];
 


### PR DESCRIPTION
To silence a warning that occurs whenever a command is run in the console, this PR includes the crypto library with the get-random-values package. This warning comes from a dependency of an ENS package used by Truffle which warns if there is not a good source for randomness.
<img width="1139" alt="Screen Shot 2021-06-21 at 5 04 44 PM" src="https://user-images.githubusercontent.com/14827965/122828105-38de3e00-d2b3-11eb-9569-6719f3686b20.png">

This PR prevents the above warning from displaying in these cases. This is identical to what is done in `cli.js` [here](https://github.com/trufflesuite/truffle/blob/develop/packages/core/cli.js#L6-L10).