### PR TITLE
Bug fix: Fix debugger crash from cross-compilation revert

### DIFF
--- a/packages/debugger/lib/data/selectors/index.js
+++ b/packages/debugger/lib/data/selectors/index.js
@@ -1026,13 +1026,13 @@ const data = createSelectorTree({
     ),
 
     /**
-     * data.current.errorNodeId
+     * data.current.errorLocation
      * note: we can't get the actual node from stacktrace,
-     * it only stores the ID
+     * it doesn't store that
      */
-    errorNodeId: createLeaf(
+    errorLocation: createLeaf(
       [stacktrace.current.innerReturnPosition, stacktrace.current.lastPosition],
-      (innerLocation, lastLocation) => ((innerLocation || lastLocation || {}).node || {}).id
+      (innerLocation, lastLocation) => innerLocation || lastLocation || {}
     ),
 
     /**
@@ -1041,8 +1041,16 @@ const data = createSelectorTree({
      * it only stores the ID
      */
     errorNode: createLeaf(
-      ["./errorNodeId", "/current/scopes/inlined"],
-      (id, scopes) => id !== undefined ? scopes[id].definition : null
+      ["./errorLocation", "/views/scopes/inlined"],
+      (errorLocation, scopes) => {
+        const sourceId = (errorLocation.source || {}).id;
+        const astId = (errorLocation.node || {}).id;
+        if (sourceId !== undefined && astId !== undefined) {
+          return scopes[sourceId][astId].definition;
+        } else {
+          return null;
+        }
+      }
     ),
 
     /**


### PR DESCRIPTION
Addresses #4120.

This PR fixes a bug in how I implemented #4015.  In it, when decoding an error, we attempt to get the node where the error occurred from the stacktrace.  However, I attempted to look up the node, by its ID, in `data.current.scopes.inlined`.  This doesn't work, because `data.current.scopes.inlined` only contains information about the current compilation, and the error might have occurred in a different compilation.  So, instead, we have to look it up in `data.views.scopes.inlined`, which contains information about all compilations.  Looking it up in there requires knowing the source ID in addition to just the node ID, so we now get both the source ID and the node ID from the stacktrace, and then use those with `data.views.scopes.inlined` to get the actual node.  We then proceed as before.