### PR TITLE
Replace project directory in metadata with "project://"

### DIFF
--- a/packages/compile-common/src/sources.ts
+++ b/packages/compile-common/src/sources.ts
@@ -15,7 +15,7 @@ export function collectSources(
   originalSources: Sources,
   originalTargets: string[] = [],
   baseDirectory: string = "",
-  replacement: string = ""
+  replacement: string = "/"
 ): CollectedSources {
   const mappedResults = Object.entries(originalSources)
     .map(([originalSourcePath, contents]) => ({
@@ -81,9 +81,9 @@ function replaceRootDirectory(
   rootDirectory: string,
   replacement: string
 ): string {
-  //make sure root directory doesn't end in a separator
-  if (rootDirectory.endsWith(path.sep)) {
-    rootDirectory = rootDirectory.slice(0, -1); //remove last character
+  //make sure root directory ends in a separator
+  if (!rootDirectory.endsWith(path.sep)) {
+    rootDirectory = rootDirectory + path.sep;
   }
   return sourcePath.startsWith(rootDirectory)
     ? replacement + sourcePath.slice(rootDirectory.length) //remove prefix

--- a/packages/compile-common/src/sources.ts
+++ b/packages/compile-common/src/sources.ts
@@ -7,19 +7,22 @@ import * as path from "path";
  *
  * @param originalSources - { [originalSourcePath]: contents }
  * @param originalTargets - originalSourcePath[]
+ * @param baseDirectory - a directory to remove as a prefix
+ * @param replacement - what to replace it with
  * @return { sources, targets, originalSourcePaths }
  */
 export function collectSources(
   originalSources: Sources,
   originalTargets: string[] = [],
-  contractsDirectory: string = "" //only used by Vyper atm
+  baseDirectory: string = "",
+  replacement: string = ""
 ): CollectedSources {
   const mappedResults = Object.entries(originalSources)
     .map(([originalSourcePath, contents]) => ({
       originalSourcePath,
       contents,
       sourcePath: getPortableSourcePath(
-        removeRootDirectory(originalSourcePath, contractsDirectory)
+        replaceRootDirectory(originalSourcePath, baseDirectory, replacement)
       )
     }))
     .map(({ originalSourcePath, sourcePath, contents }) => ({
@@ -73,12 +76,16 @@ function getPortableSourcePath(sourcePath: string): string {
   return replacement;
 }
 
-function removeRootDirectory(sourcePath: string, rootDirectory: string): string {
+function replaceRootDirectory(
+  sourcePath: string,
+  rootDirectory: string,
+  replacement: string
+): string {
   //make sure root directory doesn't end in a separator
   if (rootDirectory.endsWith(path.sep)) {
     rootDirectory = rootDirectory.slice(0, -1); //remove last character
   }
   return sourcePath.startsWith(rootDirectory)
-    ? sourcePath.slice(rootDirectory.length) //remove prefix
+    ? replacement + sourcePath.slice(rootDirectory.length) //remove prefix
     : sourcePath;
 }

--- a/packages/compile-solidity/run.js
+++ b/packages/compile-solidity/run.js
@@ -14,11 +14,18 @@ async function run(rawSources, options, language = "Solidity") {
 
   // Ensure sources have operating system independent paths
   // i.e., convert backslashes to forward slashes; things like C: are left intact.
+  // we also strip the project root (to avoid it appearing in metadata)
+  // and replace it with "project://"
   const {
     sources,
     targets,
     originalSourcePaths
-  } = Common.Sources.collectSources(rawSources, options.compilationTargets);
+  } = Common.Sources.collectSources(
+    rawSources,
+    options.compilationTargets,
+    options.working_directory,
+    "project:/" //only one slash, other will already be present
+  );
 
   // construct solc compiler input
   const compilerInput = prepareCompilerInput({

--- a/packages/compile-solidity/run.js
+++ b/packages/compile-solidity/run.js
@@ -24,7 +24,7 @@ async function run(rawSources, options, language = "Solidity") {
     rawSources,
     options.compilationTargets,
     options.working_directory,
-    "project:/" //only one slash, other will already be present
+    "project://"
   );
 
   // construct solc compiler input

--- a/packages/compile-solidity/test/test_metadata.js
+++ b/packages/compile-solidity/test/test_metadata.js
@@ -1,0 +1,72 @@
+const debug = require("debug")("compile:test:test_metadata");
+const fs = require("fs");
+const path = require("path");
+const { Compile } = require("@truffle/compile-solidity");
+const CompilerSupplier = require("../compilerSupplier");
+const assert = require("assert");
+const { findOne } = require("./helpers");
+const workingDirectory = "/home/fakename/truffleproject";
+const compileOptions = {
+  working_directory: workingDirectory,
+  compilers: {
+    solc: {
+      version: "0.4.25",
+      settings: {
+        optimizer: {
+          enabled: false,
+          runs: 200
+        }
+      }
+    }
+  },
+  quiet: true
+};
+const supplierOptions = {
+  solcConfig: compileOptions.compilers.solc,
+  events: {
+    emit: () => {}
+  }
+};
+
+describe("Compile - solidity ^0.4.0", function () {
+  this.timeout(5000); // solc
+  let source = null;
+  let solc = null; // gets loaded via supplier
+
+  before("get solc", async function () {
+    this.timeout(40000);
+
+    const supplier = new CompilerSupplier(supplierOptions);
+    ({ solc } = await supplier.load());
+  });
+
+  describe("Metadata", function () {
+    before("get code", function () {
+      source = fs.readFileSync(
+        path.join(__dirname, "./sources/v0.4.x/SimpleOrdered.sol"),
+        "utf-8"
+      );
+    });
+
+    it("does not include absolute paths in metadata", async function () {
+      const sourcePath = `${workingDirectory}/contracts/SimpleOrdered.sol`;
+      const sources = { [sourcePath]: source };
+
+      const { compilations } = await Compile.sources({
+        sources,
+        options: compileOptions
+      });
+
+      const SimpleOrdered = findOne("SimpleOrdered", compilations[0].contracts);
+      const metadata = JSON.parse(SimpleOrdered.metadata);
+      const metadataSources = Object.keys(metadata.sources);
+      const metadataTargets = Object.keys(metadata.settings.compilationTarget);
+      const metadataPaths = metadataSources.concat(metadataTargets);
+      debug("metadataPaths: %O", metadataPaths);
+      assert(metadataPaths.every(
+        sourcePath => sourcePath.startsWith("project://") &&
+          !sourcePath.includes(workingDirectory)
+      ));
+    });
+  });
+});

--- a/packages/compile-vyper/vyper-json.js
+++ b/packages/compile-vyper/vyper-json.js
@@ -12,6 +12,10 @@ const partition = require("lodash.partition");
 function compileJson({ sources: rawSources, options, version, command }) {
   const compiler = { name: "vyper", version };
 
+  //in order to better support absolute Vyper imports, we pretend that
+  //the contracts directory is the root directory.  note this means that
+  //if an imported source from somewhere other than FS uses an absolute
+  //import to refer to its own project root, it won't work.  But, oh well.
   const {
     sources,
     targets,
@@ -32,11 +36,6 @@ function compileJson({ sources: rawSources, options, version, command }) {
         targets.includes(sourcePath)
       : sourcePath => !sourcePath.endsWith(".json")
   );
-
-  //in order to better support absolute Vyper imports, we pretend that
-  //the contracts directory is the root directory.  note this means that
-  //if an imported source from somewhere other than FS uses an absolute
-  //import to refer to its own project root, it won't work.  But, oh well.
 
   const properSources = Object.assign(
     {},


### PR DESCRIPTION
Addresses #4119.

Per discussion there, this PR changes our input to the Solidity compiler so that the Truffle project directory will be replaced (in input to the Solidity compiler) with `"project://"`.  In addition to affecting the metadata, this also affects the `absolutePath` field on the AST, although we don't currently using that.  It does *not* affect the `sourcePath` field in the artifacts.

Note that this only affects sources that live in the project directory.  Sources imported from, e.g., NPM, will be unaffected.  However, since sources imported from NPM will be given by an NPM path rather than an absolute file path, this is fine.

What about FS sources living outside the project directory?  Well, those probably just won't work anymore, as the compiler won't be able to find them.

To implement this, I reused existing functionality from `compile-vyper`.  (Well, the functionality lives in `compile-common`, but it was added for Vyper purposes.)  We already do something similar for Vyper, although slightly differently and for different reasons.  I just expanded the functionality to cover replacing a prefix instead of just removing a prefix, and invoked it in `compile-solidity` as well.

I also added a test, and moved a comment I noticed was in the wrong place.