### PR TITLE
Internal improvement: Up timeout in debugger test

### DIFF
--- a/packages/debugger/test/ast.js
+++ b/packages/debugger/test/ast.js
@@ -57,7 +57,7 @@ describe("AST", function () {
   });
 
   before("Prepare contracts and artifacts", async function () {
-    this.timeout(30000);
+    this.timeout(50000);
 
     let prepared = await prepareContracts(provider, sources);
     abstractions = prepared.abstractions;


### PR DESCRIPTION
This test has been timing out a bunch lately, upping it.