### PR TITLE
Fix unbox to remove repo name restriction

### DIFF
--- a/packages/box/box.ts
+++ b/packages/box/box.ts
@@ -135,9 +135,12 @@ export const normalizeSourcePath = (url = defaultPath) => {
       throw new Error("Box specified with invalid format");
     }
 
-    // repo should have`-box` suffix
     let repo = groups["repo"];
-    repo = repo.endsWith("-box") ? repo : `${repo}-box`;
+
+    // Official Truffle boxes should have a `-box` suffix
+    if (org.toLowerCase().startsWith("truffle-box")) {
+        repo = repo.endsWith("-box") ? repo : `${repo}-box`;
+    }
 
     const result = `https://github.com:${org}${repo}${branch}`;
 

--- a/packages/box/test/normalizeSourcePath.js
+++ b/packages/box/test/normalizeSourcePath.js
@@ -185,4 +185,55 @@ describe("@truffle/box.normalizeSourcePath unit tests", () => {
       });
     });
   });
+
+  describe("handles -box suffix", () => {
+    [
+      {
+        input: "bare-box",
+        expected: "https://github.com:truffle-box/bare-box",
+        description: "No org with box suffix"
+
+      },
+      {
+        input: "bare",
+        expected: "https://github.com:truffle-box/bare-box",
+        description: "No org without box suffix"
+
+      },
+      {
+        input: "truffle-box/bare-box",
+        expected: "https://github.com:truffle-box/bare-box",
+        description: "truffle-box with box suffix"
+
+      },
+      {
+        input: "truffle-box/bare",
+        expected: "https://github.com:truffle-box/bare-box",
+        description: "truffle-box without box suffix"
+
+      },
+      {
+        input: "acme/bare-box",
+        expected: "https://github.com:acme/bare-box",
+        description: "not truffle-box with box suffix"
+
+      },
+      {
+        input: "acme/bare",
+        expected: "https://github.com:acme/bare",
+        description: "not truffle-box without box suffix"
+
+      },
+      ,
+    ].forEach(({ input, description, expected }) => {
+        it(`handles: \`${description}\``, () => {
+          assert.strictEqual(
+            normalize(input),
+            expected,
+            `should process: [${input}]`,
+          );
+        });
+    });
+  });
+
 });


### PR DESCRIPTION
This PR allows users to name their boxes without constraints and enforces rules for repos in the `truffle-box` org.

  - `truffle-box` repos must end in `-box`, this allows for `truffle unbox bare`
  - non `truffle-box` repos can be any valid repo name
  
## How to test

Unboxing these two should work:
1. `truffle unbox azure-samples/Blockchain-Ethereum-Template`
1. `truffle unbox smartcontractkit/box`

