### PR TITLE
Bug fix: Fix in-test debugging

### DIFF
--- a/packages/core/lib/debug/mocha.js
+++ b/packages/core/lib/debug/mocha.js
@@ -1,3 +1,6 @@
+const debugModule = require("debug");
+const debug = debugModule("lib:debug:mocha");
+
 const colors = require("colors");
 const util = require("util");
 
@@ -18,12 +21,14 @@ class CLIDebugHook {
     this.disableTimeout();
 
     const { txHash, result, method } = await this.invoke(operation);
+    debug("txHash: %o", txHash);
 
     this.printStartTestHook(method);
 
     const interpreter = await new CLIDebugger(this.config, {
-      compilations: this.compilations
-    }).run(txHash);
+      compilations: this.compilations,
+      txHash
+    }).run();
     await interpreter.start();
 
     this.printStopTestHook();


### PR DESCRIPTION
Addresses #4150.

Seems we accidentally broke this a while back when we changed out `CLIDebugger` is invoked, and nobody noticed.  Updated in-test debugging to use the new invocation and now it works fine.