### PR TITLE
Bug fix: Change "project://" to "project:/"

### DIFF
--- a/packages/compile-solidity/run.js
+++ b/packages/compile-solidity/run.js
@@ -15,7 +15,7 @@ async function run(rawSources, options, language = "Solidity") {
   // Ensure sources have operating system independent paths
   // i.e., convert backslashes to forward slashes; things like C: are left intact.
   // we also strip the project root (to avoid it appearing in metadata)
-  // and replace it with "project://"
+  // and replace it with "project:/"
   const {
     sources,
     targets,
@@ -24,7 +24,7 @@ async function run(rawSources, options, language = "Solidity") {
     rawSources,
     options.compilationTargets,
     options.working_directory,
-    "project://"
+    "project:/"
   );
 
   // construct solc compiler input

--- a/packages/compile-solidity/test/test_metadata.js
+++ b/packages/compile-solidity/test/test_metadata.js
@@ -64,7 +64,7 @@ describe("Compile - solidity ^0.4.0", function () {
       const metadataPaths = metadataSources.concat(metadataTargets);
       debug("metadataPaths: %O", metadataPaths);
       assert(metadataPaths.every(
-        sourcePath => sourcePath.startsWith("project://") &&
+        sourcePath => sourcePath.startsWith("project:/") &&
           !sourcePath.includes(workingDirectory)
       ));
     });

--- a/packages/truffle/test/scenarios/solidity_testing/ImportEverything.sol
+++ b/packages/truffle/test/scenarios/solidity_testing/ImportEverything.sol
@@ -3,6 +3,7 @@ pragma solidity >= 0.5.0 < 0.9.0;
 import "truffle/Assert.sol";
 import "truffle/DeployedAddresses.sol";
 import "truffle/SafeSend.sol";
+import "../contracts/Migrations.sol"
 
 contract TestWithBalance {
 


### PR DESCRIPTION
Alteration to #4137.  Double-slashes break the ability of contracts in `test` to import projects in `contract`.  Replacing with single slashes so that these imports can work.