### PR TITLE
fix inferLanguage error with undefined sourcePath

### DIFF
--- a/packages/codec/lib/compilations/utils.ts
+++ b/packages/codec/lib/compilations/utils.ts
@@ -355,6 +355,7 @@ function inferLanguage(
     if (compiler.name === "vyper") {
       return "Vyper";
     } else if (compiler.name === "solc") {
+      //assuming sources compiled with solc without sourcePath are Solidity
       if (sourcePath && sourcePath.endsWith(".yul")) {
         return "Yul";
       } else {

--- a/packages/codec/lib/compilations/utils.ts
+++ b/packages/codec/lib/compilations/utils.ts
@@ -355,7 +355,7 @@ function inferLanguage(
     if (compiler.name === "vyper") {
       return "Vyper";
     } else if (compiler.name === "solc") {
-      if (sourcePath.endsWith(".yul")) {
+      if (sourcePath && sourcePath.endsWith(".yul")) {
         return "Yul";
       } else {
         return "Solidity";


### PR DESCRIPTION
when sourcePath is `undefined`, `inferLanguage` throws `TypeError: Cannot read property 'endsWith' of undefined`.