### PR TITLE
Preserve non 404 errors when unboxing

### DIFF
--- a/packages/box/lib/utils/unbox.ts
+++ b/packages/box/lib/utils/unbox.ts
@@ -25,9 +25,11 @@ async function verifyVCSURL(url: string) {
       .replace("github.com", "raw.githubusercontent.com")
       .replace(/#.*/, "")}/master/truffle-box.json`
   );
+
+  const testUrl = `https://${configURL.host}${configURL.path}`;
   try {
     await axios.head(
-      `https://${configURL.host}${configURL.path}`,
+      testUrl,
       { maxRedirects: 50 }
     );
   } catch (error) {
@@ -36,9 +38,9 @@ async function verifyVCSURL(url: string) {
         `Truffle Box at URL ${url} doesn't exist. If you believe this is an error, please contact Truffle support.`
       );
     } else {
-      throw new Error(
-        "Error connecting to github.com. Please check your internet connection and try again."
-      );
+      const prefix = `Error connecting to ${testUrl}. Please check your internet connection and try again.`;
+      error.message = `${prefix}\n\n${error.message || ''}`;
+      throw error;
     }
   }
 }
@@ -156,5 +158,6 @@ export = {
   fetchRepository,
   installBoxDependencies,
   prepareToCopyFiles,
-  verifySourcePath
+  verifySourcePath,
+  verifyVCSURL
 };

--- a/packages/box/lib/utils/unbox.ts
+++ b/packages/box/lib/utils/unbox.ts
@@ -26,10 +26,10 @@ async function verifyVCSURL(url: string) {
       .replace(/#.*/, "")}/master/truffle-box.json`
   );
 
-  const testUrl = `https://${configURL.host}${configURL.path}`;
+  const repoUrl = `https://${configURL.host}${configURL.path}`;
   try {
     await axios.head(
-      testUrl,
+      repoUrl,
       { maxRedirects: 50 }
     );
   } catch (error) {
@@ -38,7 +38,7 @@ async function verifyVCSURL(url: string) {
         `Truffle Box at URL ${url} doesn't exist. If you believe this is an error, please contact Truffle support.`
       );
     } else {
-      const prefix = `Error connecting to ${testUrl}. Please check your internet connection and try again.`;
+      const prefix = `Error connecting to ${repoUrl}. Please check your internet connection and try again.`;
       error.message = `${prefix}\n\n${error.message || ''}`;
       throw error;
     }

--- a/packages/box/test/utils-unbox.js
+++ b/packages/box/test/utils-unbox.js
@@ -1,5 +1,7 @@
 const assert = require("assert");
 const utils = require("../dist/lib/utils/unbox");
+const axios = require("axios");
+const sinon = require("sinon");
 
 describe("utils", () => {
   describe("installBoxDependencies", () => {
@@ -31,4 +33,33 @@ describe("utils", () => {
       }, "should have rejected!");
     });
   });
+
+  describe("verifySourcePath", async() => {
+    const errorStatus = 401;
+    const errorMessage = "Network error: oh noes!";
+    const authError = {
+      response: {
+        status: errorStatus
+      },
+      message: errorMessage
+    };
+
+    before(async() => {
+      url = "https://github.com/truffle-box/bare-box";
+      sinon.stub(axios, 'head').throws(authError);
+    });
+
+    it("Includes network error message on non 404 failure", async () => {
+      try {
+        await utils.verifyVCSURL(url);
+        assert(false, "verifyVCSURL should have thrown!");
+      } catch (error) {
+        const { response, message } = error;
+        assert.equal(response.status, errorStatus); 
+        assert(message.endsWith(errorMessage), "Axios error message should be the suffix");
+      }
+    })
+
+  });
+
 });


### PR DESCRIPTION
This PR preserves `axios` errors that could occur during box validation. Previously all non 404 errors were assumed to be a network issue. Hopefully we'll have better information to support issues like #4152 