### PR TITLE
Update typings for hdwallet-provider

### DIFF
--- a/packages/hdwallet-provider/package.json
+++ b/packages/hdwallet-provider/package.json
@@ -26,6 +26,9 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@trufflesuite/web3-provider-engine": "15.0.13-1",
+    "@types/ethereumjs-util": "^5.2.0",
+    "@types/ethereum-protocol": "^1.0.0",
+    "@types/web3-provider-engine": "^14.0.0",
     "any-promise": "^1.3.0",
     "bindings": "^1.5.0",
     "ethereum-cryptography": "^0.1.3",
@@ -37,11 +40,7 @@
   },
   "devDependencies": {
     "@types/bip39": "^2.4.2",
-    "@types/ethereum-protocol": "^1.0.0",
-    "@types/ethereumjs-util": "^5.2.0",
     "@types/mocha": "^5.2.7",
-    "@types/web3": "^1.0.20",
-    "@types/web3-provider-engine": "^14.0.0",
     "ganache-core": "2.13.0",
     "mocha": "8.1.2",
     "ts-node": "^9.0.0",

--- a/packages/hdwallet-provider/package.json
+++ b/packages/hdwallet-provider/package.json
@@ -17,7 +17,11 @@
   "scripts": {
     "build": "tsc",
     "prepare": "yarn build",
-    "test": "yarn build && mocha --exit -r ts-node/register test/**/*.test.ts"
+    "test": "yarn build && mocha --exit -r ts-node/register test/**/*.test.ts",
+    "test:types": "tsd"
+  },
+  "tsd": {
+    "directory": "test"
   },
   "types": "dist/index.d.ts",
   "dependencies": {
@@ -41,6 +45,7 @@
     "ganache-core": "2.13.0",
     "mocha": "8.1.2",
     "ts-node": "^9.0.0",
+    "tsd": "^0.17.0",
     "typescript": "^4.1.4"
   },
   "keywords": [

--- a/packages/hdwallet-provider/test/typings.test-d.ts
+++ b/packages/hdwallet-provider/test/typings.test-d.ts
@@ -1,0 +1,4 @@
+import { expectType } from "tsd";
+import HDWalletProvider from "../dist/index";
+
+expectType<HDWalletProvider>(new HDWalletProvider("", ""));

--- a/packages/hdwallet-provider/tsconfig.json
+++ b/packages/hdwallet-provider/tsconfig.json
@@ -21,7 +21,7 @@
       "./typings",
       "../../node_modules/@types/mocha",
       "../../node_modules/@types/node",
-      "../../node_modules/@types/web3"
+      "../../node_modules/@types/ethereumjs-util"
     ]
   },
   "include": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3820,6 +3820,11 @@
     xhr "^2.2.0"
     xtend "^4.0.1"
 
+"@tsd/typescript@~4.3.2":
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/@tsd/typescript/-/typescript-4.3.5.tgz#0e0669bbd82a399a06c825c22dc63d56debe70a2"
+  integrity sha512-Xwxv8bIwyI3ggPz9bwoWEoiaz79MJs+VGf27S1N2tapfDVo60Lz741j5diL9RwszZSXt6IkTAuw7Lai7jSXRJg==
+
 "@types/accepts@*", "@types/accepts@^1.3.5":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/accepts/-/accepts-1.3.5.tgz#c34bec115cfc746e04fe5a059df4ce7e7b391575"
@@ -27458,6 +27463,18 @@ tsd@^0.15.1:
     path-exists "^4.0.0"
     read-pkg-up "^7.0.0"
     update-notifier "^4.1.0"
+
+tsd@^0.17.0:
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/tsd/-/tsd-0.17.0.tgz#e5aa66d6598d0b66628784ecb4c0c27795b47317"
+  integrity sha512-+HUwya2NgoP/g9t2gRCC3I8VtGu65NgG9Lv75vNzMaxjMFo+0VXF9c4sj3remSzJYeBHLNKzWMbFOinPqrL20Q==
+  dependencies:
+    "@tsd/typescript" "~4.3.2"
+    eslint-formatter-pretty "^4.0.0"
+    globby "^11.0.1"
+    meow "^9.0.0"
+    path-exists "^4.0.0"
+    read-pkg-up "^7.0.0"
 
 tslib@^1.10.0, tslib@^1.9.0, tslib@^1.9.3:
   version "1.10.0"


### PR DESCRIPTION
This provides dependent types for hdwallet-provider. It should address issues #3777 and #4143 

## Testing

You'll need two terminals
In terminal 1
  1. `npm install @truffle/hdwallet-provider web3`
  1. Put inside src/index.ts:
      ```
      import HDWalletProvider from "@truffle/hdwallet-provider";
      console.log("Hello world!")
      ```
 
  1. Verify failure. There are tsc error messages and no `src/index.js`
      `npx typescript --esModuleInterop src/index.ts`
   1. In terminal 2, cd into your built packages/hdwallet-provider folder to link
      `yarn link`
   1. in terminal 1
      `yarn link @truffle/hdwallet-provider`
   1. Test again
      `npx typescript --esModuleInterop src/index.ts`
   1. Verify success. There are no tsc errors and there is a `src/index.js`
 