### PR TITLE
Internal improvement: Replace always-true expression with true

### DIFF
--- a/packages/core/lib/debug/cli.js
+++ b/packages/core/lib/debug/cli.js
@@ -152,7 +152,7 @@ class CLIDebugger {
         {
           provider: this.config.provider,
           compilations,
-          lightMode: this.config.fetchExternal
+          lightMode: true
         }
       ); //note: may throw!
       await this.fetchExternalSources(bugger); //note: mutates bugger!


### PR DESCRIPTION
This expression, `this.config.fetchExternal`, is always true due to being in an `else` block for an `if (!this.config.fetchExternal)`.  So, I just replaced it with `true`.  Presumably this is here because there didn't used to be a branch there, but now there is, so, yeah, this can now be simplified.