### PR TITLE
Enhancement: Add syntax highlighting for operators and punctuation (in debugger)

### DIFF
--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -123,6 +123,8 @@ const trufflePalette = {
   "class": truffleColors.orange,
   "comment": truffleColors.comment,
   "doctag": truffleColors.comment,
+  "operator": truffleColors.blue,
+  "punctuation": truffleColors.purple,
   /* classes it might soon use! */
   "meta": truffleColors.pink,
   "metaString": truffleColors.green,
@@ -132,6 +134,7 @@ const trufflePalette = {
   "symbol": truffleColors.orange,
   "metaKeyword": truffleColors.mint,
   "meta-keyword": truffleColors.mint, //again, to be sure
+  "property": chalk, //not putting any highlighting here for now
   /* classes that don't make sense for Solidity */
   "regexp": chalk, //solidity does not have regexps
   "subst": chalk, //or string interpolation

--- a/packages/debug-utils/package.json
+++ b/packages/debug-utils/package.json
@@ -24,7 +24,7 @@
     "chalk": "^2.4.2",
     "debug": "^4.3.1",
     "highlight.js": "^10.4.0",
-    "highlightjs-solidity": "^1.1.1"
+    "highlightjs-solidity": "^1.2.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14418,10 +14418,10 @@ highlight.js@^10.4.1:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.4.1.tgz#d48fbcf4a9971c4361b3f95f302747afe19dbad0"
   integrity sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg==
 
-highlightjs-solidity@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/highlightjs-solidity/-/highlightjs-solidity-1.1.1.tgz#ed0f246d0f8cba647291baff68fb131252067424"
-  integrity sha512-NNcuj6GC0OP8qIrXVaqUA33d/nQoGvwRPS3FR2juIT+I1LAcNkebLbEp1AxzH0TiQ9InPxG62P/FnON8Ns15sQ==
+highlightjs-solidity@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/highlightjs-solidity/-/highlightjs-solidity-1.2.0.tgz#742ac2eacbd0f1d4aacea39704e58b76b4eb12e3"
+  integrity sha512-KXYcVzBRof3CBWHsxGffsSEAJF0YsPaOk1jgIYv2xSzrBSxkfNUJFXrlE2oZEWvYQKbPqLe4qprJyNbSDV+LZA==
 
 hkts@^0.3.1:
   version "0.3.1"


### PR DESCRIPTION
I recently published highlightjs-solidity 1.2.0, which adds syntax highlighting for operators and punctuation.

This PR updates us to that version of highlightjs-solidity, and adds colors in `trufflePalette` for operators and punctuation.  (And also the lack of a color for `property`, in case that gets added in the future.)

I went with blue for operators and purple for punctuation, and, well, it looked fine when I tried it so I didn't revise it any further.