### PR TITLE
Run all integration tests

### DIFF
--- a/packages/truffle/test/scenarios/commands/build.js
+++ b/packages/truffle/test/scenarios/commands/build.js
@@ -32,7 +32,7 @@ describe("truffle build [ @standalone ]", () => {
       await CommandRunner.run("build", config);
       const output = logger.contents();
       assert(output.includes("No build configuration found."));
-    });
+    }).timeout(30000);
   });
 
   describe("when there is a proper build config", () => {
@@ -50,7 +50,7 @@ describe("truffle build [ @standalone ]", () => {
       await CommandRunner.run("build", config);
       const output = logger.contents();
       assert(output.includes("'this is the build script'"));
-    });
+    }).timeout(30000);
   });
 
   describe("when there is an object in the build config", () => {

--- a/packages/truffle/test/scenarios/migrations/unhandled-rejection.js
+++ b/packages/truffle/test/scenarios/migrations/unhandled-rejection.js
@@ -6,7 +6,7 @@ const Server = require("../server");
 const Reporter = require("../reporter");
 const sandbox = require("../sandbox");
 
-describe.only("unhandledRejection detection", function () {
+describe("unhandledRejection detection", function () {
   let config;
   const project = path.join(
     __dirname,

--- a/packages/truffle/test/scenarios/solidity_testing/ImportEverything.sol
+++ b/packages/truffle/test/scenarios/solidity_testing/ImportEverything.sol
@@ -3,7 +3,7 @@ pragma solidity >= 0.5.0 < 0.9.0;
 import "truffle/Assert.sol";
 import "truffle/DeployedAddresses.sol";
 import "truffle/SafeSend.sol";
-import "../contracts/Migrations.sol"
+import "../contracts/Migrations.sol";
 
 contract TestWithBalance {
 

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -4,102 +4,102 @@
 set -o errexit
 
 run_geth() {
-  docker run \
-    -v /$PWD/scripts:/scripts \
-    -d \
-    -p 8545:8545 \
-    -p 8546:8546 \
-    -p 30303:30303 \
-    ethereum/client-go:stable \
-    --http \
-    --http.addr '0.0.0.0' \
-    --http.port 8545 \
-    --http.corsdomain '*' \
-    --ws \
-    --ws.addr '0.0.0.0' \
-    --ws.origins '*' \
-    --nodiscover \
-    --dev \
-    --dev.period 0 \
-    --allow-insecure-unlock \
-    js ./scripts/geth-accounts.js \
-    > /dev/null &
+	docker run \
+		-v /$PWD/scripts:/scripts \
+		-d \
+		-p 8545:8545 \
+		-p 8546:8546 \
+		-p 30303:30303 \
+		ethereum/client-go:stable \
+		--http \
+		--http.addr '0.0.0.0' \
+		--http.port 8545 \
+		--http.corsdomain '*' \
+		--ws \
+		--ws.addr '0.0.0.0' \
+		--ws.origins '*' \
+		--nodiscover \
+		--dev \
+		--dev.period 0 \
+		--allow-insecure-unlock \
+		js ./scripts/geth-accounts.js \
+		>/dev/null &
 }
 
 if [ "$INTEGRATION" = true ]; then
 
-  sudo add-apt-repository -y ppa:deadsnakes/ppa
-  sudo add-apt-repository -y ppa:ethereum/ethereum
-  sudo apt install -y jq python3.6 python3.6-dev python3.6-venv solc
-  wget https://bootstrap.pypa.io/get-pip.py
-  sudo python3.6 get-pip.py
-  sudo pip3 install vyper
-  lerna run --scope truffle test --stream
+	sudo add-apt-repository -y ppa:deadsnakes/ppa
+	sudo add-apt-repository -y ppa:ethereum/ethereum
+	sudo apt install -y jq python3.6 python3.6-dev python3.6-venv solc
+	wget https://bootstrap.pypa.io/get-pip.py
+	sudo python3.6 get-pip.py
+	sudo pip3 install vyper
+	lerna run --scope truffle test --stream
 
 elif [ "$GETH" = true ]; then
 
-  sudo apt install -y jq
-  docker pull ethereum/client-go:stable
-  run_geth
-  sleep 30
-  lerna run --scope truffle test --stream -- --exit
-  lerna run --scope @truffle/contract test --stream -- --exit
+	sudo apt install -y jq
+	docker pull ethereum/client-go:stable
+	run_geth
+	sleep 30
+	lerna run --scope truffle test --stream -- --exit
+	lerna run --scope @truffle/contract test --stream -- --exit
 
 elif [ "$FABRICEVM" = true ]; then
 
-  root=$(pwd)
-  sudo add-apt-repository -y ppa:rmescandon/yq
-  sudo apt update
-  sudo apt install -y yq
-  eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=1.12 bash)"
-  cd $GOPATH
-  mkdir -p src/github.com/hyperledger
-  cd src/github.com/hyperledger
-  git clone https://github.com/hyperledger/fabric-chaincode-evm
-  curl -sSL http://bit.ly/2ysbOFE | bash -s 1.4.1
-  cd fabric-samples/first-network
-  yq w -i docker-compose-cli.yaml "services.cli.volumes[+]" "./../../fabric-chaincode-evm:/opt/gopath/src/github.com/hyperledger/fabric-chaincode-evm"
-  yes Y | ./byfn.sh up
-  docker exec -it cli sh -c "peer chaincode install -n evmcc -l golang -v 0 -p github.com/hyperledger/fabric-chaincode-evm/evmcc &&
+	root=$(pwd)
+	sudo add-apt-repository -y ppa:rmescandon/yq
+	sudo apt update
+	sudo apt install -y yq
+	eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=1.12 bash)"
+	cd $GOPATH
+	mkdir -p src/github.com/hyperledger
+	cd src/github.com/hyperledger
+	git clone https://github.com/hyperledger/fabric-chaincode-evm
+	curl -sSL http://bit.ly/2ysbOFE | bash -s 1.4.1
+	cd fabric-samples/first-network
+	yq w -i docker-compose-cli.yaml "services.cli.volumes[+]" "./../../fabric-chaincode-evm:/opt/gopath/src/github.com/hyperledger/fabric-chaincode-evm"
+	yes Y | ./byfn.sh up
+	docker exec -it cli sh -c "peer chaincode install -n evmcc -l golang -v 0 -p github.com/hyperledger/fabric-chaincode-evm/evmcc &&
     peer chaincode instantiate -n evmcc -v 0 -C mychannel -c '{\"Args\":[]}' -o orderer.example.com:7050 --tls --cafile /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem"
-  cd ../../fabric-chaincode-evm
-  make fab3
-  # Environment Variables for Fab3:
-  export FAB3_CONFIG=${GOPATH}/src/github.com/hyperledger/fabric-chaincode-evm/examples/first-network-sdk-config.yaml
-  export FAB3_USER=User1
-  export FAB3_ORG=Org1
-  export FAB3_CHANNEL=mychannel
-  export FAB3_CCID=evmcc
-  export FAB3_PORT=5000
-  bin/fab3 &>/dev/null &
-  cd $root
-  lerna run --scope truffle test --stream -- --exit
+	cd ../../fabric-chaincode-evm
+	make fab3
+	# Environment Variables for Fab3:
+	export FAB3_CONFIG=${GOPATH}/src/github.com/hyperledger/fabric-chaincode-evm/examples/first-network-sdk-config.yaml
+	export FAB3_USER=User1
+	export FAB3_ORG=Org1
+	export FAB3_CHANNEL=mychannel
+	export FAB3_CCID=evmcc
+	export FAB3_PORT=5000
+	bin/fab3 &>/dev/null &
+	cd $root
+	lerna run --scope truffle test --stream -- --exit
 
 elif [ "$PACKAGES" = true ]; then
 
-  docker pull ethereum/solc:0.4.22
-  sudo add-apt-repository -y ppa:deadsnakes/ppa
-  sudo add-apt-repository -y ppa:ethereum/ethereum
-  sudo apt update
-  sudo apt install -y python3.6 python3.6-dev python3.6-venv solc
-  wget https://bootstrap.pypa.io/get-pip.py
-  sudo python3.6 get-pip.py
-  sudo pip3 install vyper
-  lerna run --ignore truffle test --stream --concurrency=1
+	docker pull ethereum/solc:0.4.22
+	sudo add-apt-repository -y ppa:deadsnakes/ppa
+	sudo add-apt-repository -y ppa:ethereum/ethereum
+	sudo apt update
+	sudo apt install -y python3.6 python3.6-dev python3.6-venv solc
+	wget https://bootstrap.pypa.io/get-pip.py
+	sudo python3.6 get-pip.py
+	sudo pip3 install vyper
+	lerna run --ignore truffle test --stream --concurrency=1
 
 elif [ "$COVERAGE" = true ]; then
 
-  docker pull ethereum/solc:0.4.22
-  sudo add-apt-repository -y ppa:deadsnakes/ppa
-  sudo add-apt-repository -y ppa:ethereum/ethereum
-  sudo apt update
-  sudo apt install -y jq python3.6 python3.6-dev python3.6-venv solc
-  wget https://bootstrap.pypa.io/get-pip.py
-  sudo python3.6 get-pip.py
-  sudo pip3 install vyper
-  cd packages/debugger && yarn test:coverage && \
-  cd ../../ && nyc lerna run --ignore debugger test && \
-  cat ./packages/debugger/coverage/lcov.info >> ./coverage/lcov.info && \
-  cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
+	docker pull ethereum/solc:0.4.22
+	sudo add-apt-repository -y ppa:deadsnakes/ppa
+	sudo add-apt-repository -y ppa:ethereum/ethereum
+	sudo apt update
+	sudo apt install -y jq python3.6 python3.6-dev python3.6-venv solc
+	wget https://bootstrap.pypa.io/get-pip.py
+	sudo python3.6 get-pip.py
+	sudo pip3 install vyper
+	cd packages/debugger && yarn test:coverage \
+		&& cd ../../ && nyc lerna run --ignore debugger test \
+		&& cat ./packages/debugger/coverage/lcov.info >>./coverage/lcov.info \
+		&& cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
 
 fi

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -10,7 +10,7 @@ run_geth() {
 		-p 8545:8545 \
 		-p 8546:8546 \
 		-p 30303:30303 \
-		ethereum/client-go:stable \
+		ethereum/client-go:v1.10.3 \
 		--http \
 		--http.addr '0.0.0.0' \
 		--http.port 8545 \
@@ -39,7 +39,7 @@ if [ "$INTEGRATION" = true ]; then
 elif [ "$GETH" = true ]; then
 
 	sudo apt install -y jq
-	docker pull ethereum/client-go:stable
+	docker pull ethereum/client-go:v1.10.3
 	run_geth
 	sleep 30
 	lerna run --scope truffle test --stream -- --exit

--- a/scripts/geth.sh
+++ b/scripts/geth.sh
@@ -3,21 +3,21 @@
 docker pull ethereum/client-go:stable
 
 docker run \
-    -v /$PWD/scripts:/scripts \
-    -i \
-    -p 8545:8545 \
-    -p 8546:8546 \
-    -p 30303:30303 \
-    ethereum/client-go:stable \
-    --http \
-    --http.addr '0.0.0.0' \
-    --http.port 8545 \
-    --http.corsdomain '*' \
-    --ws \
-    --ws.addr '0.0.0.0' \
-    --ws.origins '*' \
-    --nodiscover \
-    --dev \
-    --dev.period 0 \
-    --allow-insecure-unlock \
-    js ./scripts/geth-accounts.js
+	-v /$PWD/scripts:/scripts \
+	-i \
+	-p 8545:8545 \
+	-p 8546:8546 \
+	-p 30303:30303 \
+	ethereum/client-go:stable \
+	--http \
+	--http.addr '0.0.0.0' \
+	--http.port 8545 \
+	--http.corsdomain '*' \
+	--ws \
+	--ws.addr '0.0.0.0' \
+	--ws.origins '*' \
+	--nodiscover \
+	--dev \
+	--dev.period 0 \
+	--allow-insecure-unlock \
+	js ./scripts/geth-accounts.js

--- a/scripts/geth.sh
+++ b/scripts/geth.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-docker pull ethereum/client-go:stable
+docker pull ethereum/client-go:v1.10.3
 
 docker run \
 	-v /$PWD/scripts:/scripts \
@@ -8,7 +8,7 @@ docker run \
 	-p 8545:8545 \
 	-p 8546:8546 \
 	-p 30303:30303 \
-	ethereum/client-go:stable \
+	ethereum/client-go:v1.10.3 \
 	--http \
 	--http.addr '0.0.0.0' \
 	--http.port 8545 \


### PR DESCRIPTION
This PR allows CI to run all integration tests and follows web3's lead to pin GETH to v1.10.3. It should be noted that web3 didn't document a reason to pin and we should probably follow up with them (@gnidan ?)