### PR TITLE
Feature: Add `--grep` option to `truffle test`

### DIFF
--- a/packages/config/src/configDefaults.ts
+++ b/packages/config/src/configDefaults.ts
@@ -43,7 +43,10 @@ export const getInitialConfig = ({
       enabled: false,
       registryAddress: null
     },
-    mocha: {},
+    mocha: {
+      bail: false,
+      grep: null
+    },
     compilers: {
       solc: {
         settings: {

--- a/packages/config/src/configDefaults.ts
+++ b/packages/config/src/configDefaults.ts
@@ -43,6 +43,7 @@ export const getInitialConfig = ({
       enabled: false,
       registryAddress: null
     },
+    mocha: {},
     compilers: {
       solc: {
         settings: {
@@ -94,6 +95,7 @@ export const configProps = ({
     compilers() {},
     ens() {},
     console() {},
+    mocha() {},
 
     build_directory: {
       default: () => path.join(configObject.working_directory, "build"),

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -121,7 +121,6 @@ class TruffleConfig {
     propertyNames.forEach(key => {
       try {
         if (typeof clone[key] === "object" && this._deepCopy.includes(key)) {
-
           this[key] = merge(this[key], clone[key]);
         } else {
           this[key] = clone[key];

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -23,7 +23,7 @@ class TruffleConfig {
     workingDirectory?: string,
     network?: any
   ) {
-    this._deepCopy = ["compilers"];
+    this._deepCopy = ["compilers", "mocha"];
     this._values = getInitialConfig({
       truffleDirectory,
       workingDirectory,
@@ -121,6 +121,7 @@ class TruffleConfig {
     propertyNames.forEach(key => {
       try {
         if (typeof clone[key] === "object" && this._deepCopy.includes(key)) {
+
           this[key] = merge(this[key], clone[key]);
         } else {
           this[key] = clone[key];

--- a/packages/core/lib/command.js
+++ b/packages/core/lib/command.js
@@ -114,12 +114,17 @@ class Command {
 
     const allValidOptions = [...result.command.help.options, ...allowedGlobalOptions];
 
-    const validOptions = allValidOptions
-      .map(item => {
-        let opt = item.option.split(" ")[0];
-        return opt.startsWith("--") ? opt : null;
-      })
-      .filter(item => item != null);
+    const validOptions = allValidOptions.reduce((a, item) => {
+      // we split the options off from the arguments
+      // and then we split to handle options of the form --<something>|-<s>
+      let options = item.option.split(" ")[0].split("|");
+      return [
+        ...a,
+        ...(options.filter(
+          option => option.startsWith("--") || option.startsWith("-")
+        ))
+      ];
+    }, []);
 
     let invalidOptions = inputOptions.filter(
       opt => !validOptions.includes(opt)
@@ -130,7 +135,7 @@ class Command {
       if (options.logger) {
         const log = options.logger.log || options.logger.debug;
         log(
-          "> Warning: possible unsupported (undocumented in help) command line option: " +
+          "> Warning: possible unsupported (undocumented in help) command line option(s): " +
             invalidOptions
         );
       }

--- a/packages/core/lib/commands/test/index.js
+++ b/packages/core/lib/commands/test/index.js
@@ -51,7 +51,7 @@ const command = {
       `[--network <name>]${OS.EOL}                             ` +
       `[--verbose-rpc] [--show-events] [--debug] ` +
       `[--debug-global <identifier>] [--bail]${OS.EOL}                      ` +
-      `       [--stacktrace[-extra]]`,
+      `       [--stacktrace[-extra]] [--grep|-g <regex>]`,
     options: [
       {
         option: "<test_file>",
@@ -113,6 +113,11 @@ const command = {
       {
         option: "--stacktrace-extra",
         description: "Shortcut for --stacktrace --compile-all-debug."
+      },
+      {
+        option: "--grep|-g",
+        description: "Use mocha's \"grep\" option while running tests. This " +
+          "option only runs tests whose descriptions match the supplied regex."
       }
     ],
     allowedGlobalOptions: ["network", "config"]

--- a/packages/core/lib/commands/test/index.js
+++ b/packages/core/lib/commands/test/index.js
@@ -100,8 +100,8 @@ const command = {
         description: "Suppress all output except for test runner output."
       },
       {
-        option: "--bail",
-        description: "Bail after first test failure.  Alias: -b"
+        option: "--bail|-b",
+        description: "Bail after first test failure."
       },
       {
         option: "--stacktrace",
@@ -124,12 +124,21 @@ const command = {
   },
   run: async function (options) {
     const Config = require("@truffle/config");
-    const {Environment, Develop} = require("@truffle/environment");
-    const {copyArtifactsToTempDir} = require("./copyArtifactsToTempDir");
-    const {determineTestFilesToRun} = require("./determineTestFilesToRun");
-    const {prepareConfigAndRunTests} = require("./prepareConfigAndRunTests");
+    const { Environment, Develop } = require("@truffle/environment");
+    const { copyArtifactsToTempDir } = require("./copyArtifactsToTempDir");
+    const { determineTestFilesToRun } = require("./determineTestFilesToRun");
+    const { prepareConfigAndRunTests } = require("./prepareConfigAndRunTests");
 
-    const config = Config.detect(options);
+    // parse out command line flags to merge in to the config
+    const grep = options.grep || options.g;
+    const bail = options.bail || options.b;
+
+    const config = Config.detect(options).merge({
+      mocha: {
+        grep,
+        bail
+      }
+    });
 
     // if "development" exists, default to using that for testing
     if (!config.network && config.networks.development) {

--- a/packages/core/lib/commands/test/index.js
+++ b/packages/core/lib/commands/test/index.js
@@ -122,6 +122,17 @@ const command = {
     ],
     allowedGlobalOptions: ["network", "config"]
   },
+  parseCommandLineFlags: options => {
+    // parse out command line flags to merge in to the config
+    const grep = options.grep || options.g;
+    const bail = options.bail || options.b;
+    return {
+      mocha: {
+        grep,
+        bail
+      }
+    };
+  },
   run: async function (options) {
     const Config = require("@truffle/config");
     const { Environment, Develop } = require("@truffle/environment");
@@ -129,16 +140,8 @@ const command = {
     const { determineTestFilesToRun } = require("./determineTestFilesToRun");
     const { prepareConfigAndRunTests } = require("./prepareConfigAndRunTests");
 
-    // parse out command line flags to merge in to the config
-    const grep = options.grep || options.g;
-    const bail = options.bail || options.b;
-
-    const config = Config.detect(options).merge({
-      mocha: {
-        grep,
-        bail
-      }
-    });
+    const optionsToMerge = this.parseCommandLineFlags(options);
+    const config = Config.detect(options).merge(optionsToMerge);
 
     // if "development" exists, default to using that for testing
     if (!config.network && config.networks.development) {

--- a/packages/core/lib/commands/test/index.js
+++ b/packages/core/lib/commands/test/index.js
@@ -50,8 +50,8 @@ const command = {
       `truffle test [<test_file>] [--compile-all[-debug]] [--compile-none] ` +
       `[--network <name>]${OS.EOL}                             ` +
       `[--verbose-rpc] [--show-events] [--debug] ` +
-      `[--debug-global <identifier>] [--bail]${OS.EOL}                      ` +
-      `       [--stacktrace[-extra]] [--grep|-g <regex>]`,
+      `[--debug-global <identifier>] [(--bail)]${OS.EOL}                      ` +
+      `       [--stacktrace[-extra]] [(--grep|-g) <regex>]`,
     options: [
       {
         option: "<test_file>",
@@ -100,7 +100,7 @@ const command = {
         description: "Suppress all output except for test runner output."
       },
       {
-        option: "--bail|-b",
+        option: "(--bail|-b)",
         description: "Bail after first test failure."
       },
       {
@@ -115,7 +115,7 @@ const command = {
         description: "Shortcut for --stacktrace --compile-all-debug."
       },
       {
-        option: "--grep|-g",
+        option: "(--grep|-g)",
         description: "Use mocha's \"grep\" option while running tests. This " +
           "option only runs tests that match the supplied regex/string."
       }

--- a/packages/core/lib/commands/test/index.js
+++ b/packages/core/lib/commands/test/index.js
@@ -117,7 +117,7 @@ const command = {
       {
         option: "--grep|-g",
         description: "Use mocha's \"grep\" option while running tests. This " +
-          "option only runs tests whose descriptions match the supplied regex."
+          "option only runs tests that match the supplied regex/string."
       }
     ],
     allowedGlobalOptions: ["network", "config"]

--- a/packages/core/test/commands.js
+++ b/packages/core/test/commands.js
@@ -70,7 +70,7 @@ describe("Commander", function () {
     } finally {
       assert.equal(
         warning,
-        "> Warning: possible unsupported (undocumented in help) command line option: --unsupportedflag,--unsupportedflag2",
+        "> Warning: possible unsupported (undocumented in help) command line option(s): --unsupportedflag,--unsupportedflag2",
       );
     }
   });


### PR DESCRIPTION
This PR adds a `--grep|-g` command line option to `truffle test` and it works exactly like the `--grep` option for mocha. [See the mocha docs](https://mochajs.org/api/mocha). Basically you can provide a regex for mocha to search the test descriptions. It will then only run the tests whose descriptions match.

One thing to note with this PR is that there is an order of precedence when it comes to setting parameters in the `truffle-config.js` and on the command line with flags (`--bail`). We have decided to let the command line flags take precedence over the settings in `truffle-config.js`. So in other words if you set `bail = false` in your `truffle-config.js` and pass it `--bail` on the command line, `bail` will be set to `true`.

One other note here, I am trying to make it a convention in the command files to write options and their aliases in the form `--<option>|-o`. I have altered the algorithm that parses the options to determine whether the user is possibly passing in an unsupported option to deal with separating them.

This feature was suggested in [this issue](https://github.com/trufflesuite/truffle/issues/2080).