### PR TITLE
Internal improvement: Add .eslintrc.json to Truffle projects in our source tree

### DIFF
--- a/.eslintrc.package.json
+++ b/.eslintrc.package.json
@@ -1,0 +1,28 @@
+{
+  "overrides": [
+    {
+      "files": ["./test/**/*.js"],
+      "env": {
+        "mocha": true
+      },
+      "globals": {
+        "interfaceAdapter": "readonly",
+        "web3": "readonly",
+        "assert": "readonly",
+        "expect": "readonly",
+        "artifacts": "readonly",
+        "config": "readonly",
+        "debug": "readonly",
+        "contract": "readonly"
+      }
+    },
+    {
+      "files": ["./migrations/**/*.js"],
+      "globals": {
+        "artifacts": "readonly",
+        "config": "readonly"
+      }
+    }
+  ]
+}
+

--- a/.eslintrc.test.json
+++ b/.eslintrc.test.json
@@ -1,0 +1,10 @@
+{
+  "overrides": [
+    {
+      "files": ["./test/**/*.js"],
+      "env": {
+        "mocha": true
+      }
+    }
+  ]
+}

--- a/packages/artifactor/.eslintrc.json
+++ b/packages/artifactor/.eslintrc.json
@@ -1,10 +1,3 @@
 {
-  "overrides": [
-    {
-      "files": ["./test/**/*.js"],
-      "env": {
-        "mocha": true
-      }
-    }
-  ]
+  "extends": ["../../.eslintrc.package.json"]
 }

--- a/packages/box/.eslintrc.json
+++ b/packages/box/.eslintrc.json
@@ -1,10 +1,3 @@
 {
-  "overrides": [
-    {
-      "files": ["./test/**/*.js"],
-      "env": {
-        "mocha": true
-      }
-    }
-  ]
+  "extends": ["../../.eslintrc.package.json"]
 }

--- a/packages/compile-solidity/.eslintrc.json
+++ b/packages/compile-solidity/.eslintrc.json
@@ -1,10 +1,3 @@
 {
-  "overrides": [
-    {
-      "files": ["./test/**/*.js"],
-      "env": {
-        "mocha": true
-      }
-    }
-  ]
+  "extends": ["../../.eslintrc.package.json"]
 }

--- a/packages/compile-vyper/.eslintrc.json
+++ b/packages/compile-vyper/.eslintrc.json
@@ -1,10 +1,3 @@
 {
-  "overrides": [
-    {
-      "files": ["./test/**/*.js"],
-      "env": {
-        "mocha": true
-      }
-    }
-  ]
+  "extends": ["../../.eslintrc.package.json"]
 }

--- a/packages/contract-schema/.eslintrc.json
+++ b/packages/contract-schema/.eslintrc.json
@@ -1,10 +1,3 @@
 {
-  "overrides": [
-    {
-      "files": ["./test/**/*.js"],
-      "env": {
-        "mocha": true
-      }
-    }
-  ]
+  "extends": ["../../.eslintrc.package.json"]
 }

--- a/packages/contract-tests/.eslintrc.json
+++ b/packages/contract-tests/.eslintrc.json
@@ -1,10 +1,3 @@
 {
-  "overrides": [
-    {
-      "files": ["./test/**/*.js"],
-      "env": {
-        "mocha": true
-      }
-    }
-  ]
+  "extends": ["../../.eslintrc.package.json"]
 }

--- a/packages/core/.eslintrc.json
+++ b/packages/core/.eslintrc.json
@@ -1,10 +1,3 @@
 {
-  "overrides": [
-    {
-      "files": ["./test/**/*.js"],
-      "env": {
-        "mocha": true
-      }
-    }
-  ]
+  "extends": ["../../.eslintrc.package.json"]
 }

--- a/packages/core/lib/commands/init/copyFiles.js
+++ b/packages/core/lib/commands/init/copyFiles.js
@@ -10,7 +10,8 @@ const copyFiles = async (destination, options) => {
   const destinationContents = fse.readdirSync(destination);
 
   const newContents = projectFiles.filter(
-    filename => !destinationContents.includes(filename)
+    filename => !filename.endsWith(".eslintrc.json") //exclude eslintrc.json
+    && !destinationContents.includes(filename)
   );
 
   const contentCollisions = projectFiles.filter(filename =>

--- a/packages/core/lib/commands/init/copyFiles.js
+++ b/packages/core/lib/commands/init/copyFiles.js
@@ -6,12 +6,13 @@ const copyFiles = async (destination, options) => {
   fse.ensureDirSync(destination);
   const { force, logger, events } = options;
   const sourcePath = path.join(__dirname, "initSource");
-  const projectFiles = fse.readdirSync(sourcePath);
+  const projectFiles = fse.readdirSync(sourcePath).filter(
+    filename => !filename.endsWith(".eslintrc.json") //exclude .eslintrc.json
+  );
   const destinationContents = fse.readdirSync(destination);
 
   const newContents = projectFiles.filter(
-    filename => !filename.endsWith(".eslintrc.json") //exclude eslintrc.json
-    && !destinationContents.includes(filename)
+    filename => !destinationContents.includes(filename)
   );
 
   const contentCollisions = projectFiles.filter(filename =>

--- a/packages/core/lib/commands/init/initSource/.eslintrc.json
+++ b/packages/core/lib/commands/init/initSource/.eslintrc.json
@@ -1,0 +1,28 @@
+{
+  "overrides": [
+    {
+      "files": ["./test/**/*.js"],
+      "env": {
+        "mocha": true
+      },
+      "globals": {
+        "interfaceAdapter": "readonly",
+        "web3": "readonly",
+        "assert": "readonly",
+        "expect": "readonly",
+        "artifacts": "readonly",
+        "config": "readonly",
+        "debug": "readonly",
+        "contract": "readonly"
+      }
+    },
+    {
+      "files": ["./migration/**/*.js"],
+      "globals": {
+        "artifacts": "readonly",
+        "config": "readonly"
+      }
+    }
+  ]
+}
+

--- a/packages/core/lib/commands/init/initSource/.eslintrc.json
+++ b/packages/core/lib/commands/init/initSource/.eslintrc.json
@@ -17,7 +17,7 @@
       }
     },
     {
-      "files": ["./migration/**/*.js"],
+      "files": ["./migrations/**/*.js"],
       "globals": {
         "artifacts": "readonly",
         "config": "readonly"
@@ -25,4 +25,3 @@
     }
   ]
 }
-

--- a/packages/core/lib/commands/init/initSource/.eslintrc.json
+++ b/packages/core/lib/commands/init/initSource/.eslintrc.json
@@ -1,27 +1,3 @@
 {
-  "overrides": [
-    {
-      "files": ["./test/**/*.js"],
-      "env": {
-        "mocha": true
-      },
-      "globals": {
-        "interfaceAdapter": "readonly",
-        "web3": "readonly",
-        "assert": "readonly",
-        "expect": "readonly",
-        "artifacts": "readonly",
-        "config": "readonly",
-        "debug": "readonly",
-        "contract": "readonly"
-      }
-    },
-    {
-      "files": ["./migrations/**/*.js"],
-      "globals": {
-        "artifacts": "readonly",
-        "config": "readonly"
-      }
-    }
-  ]
+  "extends": ["../../../../../../.eslintrc.truffle.json"]
 }

--- a/packages/db/src/project/test/compilationSources/.eslintrc.json
+++ b/packages/db/src/project/test/compilationSources/.eslintrc.json
@@ -1,0 +1,27 @@
+{
+  "overrides": [
+    {
+      "files": ["./test/**/*.js"],
+      "env": {
+        "mocha": true
+      },
+      "globals": {
+        "interfaceAdapter": "readonly",
+        "web3": "readonly",
+        "assert": "readonly",
+        "expect": "readonly",
+        "artifacts": "readonly",
+        "config": "readonly",
+        "debug": "readonly",
+        "contract": "readonly"
+      }
+    },
+    {
+      "files": ["./migration/**/*.js"],
+      "globals": {
+        "artifacts": "readonly",
+        "config": "readonly"
+      }
+    }
+  ]
+}

--- a/packages/db/src/project/test/compilationSources/.eslintrc.json
+++ b/packages/db/src/project/test/compilationSources/.eslintrc.json
@@ -17,7 +17,7 @@
       }
     },
     {
-      "files": ["./migration/**/*.js"],
+      "files": ["./migrations/**/*.js"],
       "globals": {
         "artifacts": "readonly",
         "config": "readonly"

--- a/packages/db/src/project/test/compilationSources/.eslintrc.json
+++ b/packages/db/src/project/test/compilationSources/.eslintrc.json
@@ -1,27 +1,3 @@
 {
-  "overrides": [
-    {
-      "files": ["./test/**/*.js"],
-      "env": {
-        "mocha": true
-      },
-      "globals": {
-        "interfaceAdapter": "readonly",
-        "web3": "readonly",
-        "assert": "readonly",
-        "expect": "readonly",
-        "artifacts": "readonly",
-        "config": "readonly",
-        "debug": "readonly",
-        "contract": "readonly"
-      }
-    },
-    {
-      "files": ["./migrations/**/*.js"],
-      "globals": {
-        "artifacts": "readonly",
-        "config": "readonly"
-      }
-    }
-  ]
+  "extends": ["../../../../../.eslintrc.truffle.json"]
 }

--- a/packages/db/test/truffle-projects/drizzle-box/.eslintrc.json
+++ b/packages/db/test/truffle-projects/drizzle-box/.eslintrc.json
@@ -1,0 +1,28 @@
+{
+  "overrides": [
+    {
+      "files": ["./test/**/*.js"],
+      "env": {
+        "mocha": true
+      },
+      "globals": {
+        "interfaceAdapter": "readonly",
+        "web3": "readonly",
+        "assert": "readonly",
+        "expect": "readonly",
+        "artifacts": "readonly",
+        "config": "readonly",
+        "debug": "readonly",
+        "contract": "readonly"
+      }
+    },
+    {
+      "files": ["./migration/**/*.js"],
+      "globals": {
+        "artifacts": "readonly",
+        "config": "readonly"
+      }
+    }
+  ]
+}
+

--- a/packages/db/test/truffle-projects/drizzle-box/.eslintrc.json
+++ b/packages/db/test/truffle-projects/drizzle-box/.eslintrc.json
@@ -17,7 +17,7 @@
       }
     },
     {
-      "files": ["./migration/**/*.js"],
+      "files": ["./migrations/**/*.js"],
       "globals": {
         "artifacts": "readonly",
         "config": "readonly"

--- a/packages/db/test/truffle-projects/drizzle-box/.eslintrc.json
+++ b/packages/db/test/truffle-projects/drizzle-box/.eslintrc.json
@@ -1,28 +1,3 @@
 {
-  "overrides": [
-    {
-      "files": ["./test/**/*.js"],
-      "env": {
-        "mocha": true
-      },
-      "globals": {
-        "interfaceAdapter": "readonly",
-        "web3": "readonly",
-        "assert": "readonly",
-        "expect": "readonly",
-        "artifacts": "readonly",
-        "config": "readonly",
-        "debug": "readonly",
-        "contract": "readonly"
-      }
-    },
-    {
-      "files": ["./migrations/**/*.js"],
-      "globals": {
-        "artifacts": "readonly",
-        "config": "readonly"
-      }
-    }
-  ]
+  "extends": ["../../../../../.eslintrc.truffle.json"]
 }
-

--- a/packages/debugger/.eslintrc.json
+++ b/packages/debugger/.eslintrc.json
@@ -1,10 +1,3 @@
 {
-  "overrides": [
-    {
-      "files": ["./test/**/*.js"],
-      "env": {
-        "mocha": true
-      }
-    }
-  ]
+  "extends": ["../../.eslintrc.package.json"]
 }

--- a/packages/decoder/.eslintrc.json
+++ b/packages/decoder/.eslintrc.json
@@ -1,10 +1,3 @@
 {
-  "overrides": [
-    {
-      "files": ["./test/**/*.js"],
-      "env": {
-        "mocha": true
-      }
-    }
-  ]
+  "extends": ["../../.eslintrc.package.json"]
 }

--- a/packages/decoder/test/current/.eslintrc.json
+++ b/packages/decoder/test/current/.eslintrc.json
@@ -1,0 +1,28 @@
+{
+  "overrides": [
+    {
+      "files": ["./test/**/*.js"],
+      "env": {
+        "mocha": true
+      },
+      "globals": {
+        "interfaceAdapter": "readonly",
+        "web3": "readonly",
+        "assert": "readonly",
+        "expect": "readonly",
+        "artifacts": "readonly",
+        "config": "readonly",
+        "debug": "readonly",
+        "contract": "readonly"
+      }
+    },
+    {
+      "files": ["./migration/**/*.js"],
+      "globals": {
+        "artifacts": "readonly",
+        "config": "readonly"
+      }
+    }
+  ]
+}
+

--- a/packages/decoder/test/current/.eslintrc.json
+++ b/packages/decoder/test/current/.eslintrc.json
@@ -17,7 +17,7 @@
       }
     },
     {
-      "files": ["./migration/**/*.js"],
+      "files": ["./migrations/**/*.js"],
       "globals": {
         "artifacts": "readonly",
         "config": "readonly"

--- a/packages/decoder/test/current/.eslintrc.json
+++ b/packages/decoder/test/current/.eslintrc.json
@@ -1,28 +1,3 @@
 {
-  "overrides": [
-    {
-      "files": ["./test/**/*.js"],
-      "env": {
-        "mocha": true
-      },
-      "globals": {
-        "interfaceAdapter": "readonly",
-        "web3": "readonly",
-        "assert": "readonly",
-        "expect": "readonly",
-        "artifacts": "readonly",
-        "config": "readonly",
-        "debug": "readonly",
-        "contract": "readonly"
-      }
-    },
-    {
-      "files": ["./migrations/**/*.js"],
-      "globals": {
-        "artifacts": "readonly",
-        "config": "readonly"
-      }
-    }
-  ]
+  "extends": ["../../../../.eslintrc.truffle.json"]
 }
-

--- a/packages/decoder/test/legacy/.eslintrc.json
+++ b/packages/decoder/test/legacy/.eslintrc.json
@@ -1,0 +1,28 @@
+{
+  "overrides": [
+    {
+      "files": ["./test/**/*.js"],
+      "env": {
+        "mocha": true
+      },
+      "globals": {
+        "interfaceAdapter": "readonly",
+        "web3": "readonly",
+        "assert": "readonly",
+        "expect": "readonly",
+        "artifacts": "readonly",
+        "config": "readonly",
+        "debug": "readonly",
+        "contract": "readonly"
+      }
+    },
+    {
+      "files": ["./migration/**/*.js"],
+      "globals": {
+        "artifacts": "readonly",
+        "config": "readonly"
+      }
+    }
+  ]
+}
+

--- a/packages/decoder/test/legacy/.eslintrc.json
+++ b/packages/decoder/test/legacy/.eslintrc.json
@@ -17,7 +17,7 @@
       }
     },
     {
-      "files": ["./migration/**/*.js"],
+      "files": ["./migrations/**/*.js"],
       "globals": {
         "artifacts": "readonly",
         "config": "readonly"

--- a/packages/decoder/test/legacy/.eslintrc.json
+++ b/packages/decoder/test/legacy/.eslintrc.json
@@ -1,28 +1,3 @@
 {
-  "overrides": [
-    {
-      "files": ["./test/**/*.js"],
-      "env": {
-        "mocha": true
-      },
-      "globals": {
-        "interfaceAdapter": "readonly",
-        "web3": "readonly",
-        "assert": "readonly",
-        "expect": "readonly",
-        "artifacts": "readonly",
-        "config": "readonly",
-        "debug": "readonly",
-        "contract": "readonly"
-      }
-    },
-    {
-      "files": ["./migrations/**/*.js"],
-      "globals": {
-        "artifacts": "readonly",
-        "config": "readonly"
-      }
-    }
-  ]
+  "extends": ["../../../../.eslintrc.truffle.json"]
 }
-

--- a/packages/deployer/.eslintrc.json
+++ b/packages/deployer/.eslintrc.json
@@ -1,10 +1,3 @@
 {
-  "overrides": [
-    {
-      "files": ["./test/**/*.js"],
-      "env": {
-        "mocha": true
-      }
-    }
-  ]
+  "extends": ["../../.eslintrc.package.json"]
 }

--- a/packages/expect/.eslintrc.json
+++ b/packages/expect/.eslintrc.json
@@ -1,10 +1,3 @@
 {
-  "overrides": [
-    {
-      "files": ["./test/**/*.js"],
-      "env": {
-        "mocha": true
-      }
-    }
-  ]
+  "extends": ["../../.eslintrc.package.json"]
 }

--- a/packages/external-compile/.eslintrc.json
+++ b/packages/external-compile/.eslintrc.json
@@ -1,10 +1,3 @@
 {
-  "overrides": [
-    {
-      "files": ["./test/**/*.js"],
-      "env": {
-        "mocha": true
-      }
-    }
-  ]
+  "extends": ["../../.eslintrc.package.json"]
 }

--- a/packages/migrate/.eslintrc.json
+++ b/packages/migrate/.eslintrc.json
@@ -1,10 +1,3 @@
 {
-  "overrides": [
-    {
-      "files": ["./test/**/*.js"],
-      "env": {
-        "mocha": true
-      }
-    }
-  ]
+  "extends": ["../../.eslintrc.package.json"]
 }

--- a/packages/provider/.eslintrc.json
+++ b/packages/provider/.eslintrc.json
@@ -1,10 +1,3 @@
 {
-  "overrides": [
-    {
-      "files": ["./test/**/*.js"],
-      "env": {
-        "mocha": true
-      }
-    }
-  ]
+  "extends": ["../../.eslintrc.package.json"]
 }

--- a/packages/require/.eslintrc.json
+++ b/packages/require/.eslintrc.json
@@ -1,10 +1,3 @@
 {
-  "overrides": [
-    {
-      "files": ["./test/**/*.js"],
-      "env": {
-        "mocha": true
-      }
-    }
-  ]
+  "extends": ["../../.eslintrc.package.json"]
 }

--- a/packages/truffle/test/sources/contract_names/.eslintrc.json
+++ b/packages/truffle/test/sources/contract_names/.eslintrc.json
@@ -1,0 +1,28 @@
+{
+  "overrides": [
+    {
+      "files": ["./test/**/*.js"],
+      "env": {
+        "mocha": true
+      },
+      "globals": {
+        "interfaceAdapter": "readonly",
+        "web3": "readonly",
+        "assert": "readonly",
+        "expect": "readonly",
+        "artifacts": "readonly",
+        "config": "readonly",
+        "debug": "readonly",
+        "contract": "readonly"
+      }
+    },
+    {
+      "files": ["./migration/**/*.js"],
+      "globals": {
+        "artifacts": "readonly",
+        "config": "readonly"
+      }
+    }
+  ]
+}
+

--- a/packages/truffle/test/sources/contract_names/.eslintrc.json
+++ b/packages/truffle/test/sources/contract_names/.eslintrc.json
@@ -17,7 +17,7 @@
       }
     },
     {
-      "files": ["./migration/**/*.js"],
+      "files": ["./migrations/**/*.js"],
       "globals": {
         "artifacts": "readonly",
         "config": "readonly"

--- a/packages/truffle/test/sources/contract_names/.eslintrc.json
+++ b/packages/truffle/test/sources/contract_names/.eslintrc.json
@@ -1,28 +1,3 @@
 {
-  "overrides": [
-    {
-      "files": ["./test/**/*.js"],
-      "env": {
-        "mocha": true
-      },
-      "globals": {
-        "interfaceAdapter": "readonly",
-        "web3": "readonly",
-        "assert": "readonly",
-        "expect": "readonly",
-        "artifacts": "readonly",
-        "config": "readonly",
-        "debug": "readonly",
-        "contract": "readonly"
-      }
-    },
-    {
-      "files": ["./migrations/**/*.js"],
-      "globals": {
-        "artifacts": "readonly",
-        "config": "readonly"
-      }
-    }
-  ]
+  "extends": ["../../../../../.eslintrc.truffle.json"]
 }
-

--- a/packages/truffle/test/sources/external_compile/.eslintrc.json
+++ b/packages/truffle/test/sources/external_compile/.eslintrc.json
@@ -1,0 +1,28 @@
+{
+  "overrides": [
+    {
+      "files": ["./test/**/*.js"],
+      "env": {
+        "mocha": true
+      },
+      "globals": {
+        "interfaceAdapter": "readonly",
+        "web3": "readonly",
+        "assert": "readonly",
+        "expect": "readonly",
+        "artifacts": "readonly",
+        "config": "readonly",
+        "debug": "readonly",
+        "contract": "readonly"
+      }
+    },
+    {
+      "files": ["./migration/**/*.js"],
+      "globals": {
+        "artifacts": "readonly",
+        "config": "readonly"
+      }
+    }
+  ]
+}
+

--- a/packages/truffle/test/sources/external_compile/.eslintrc.json
+++ b/packages/truffle/test/sources/external_compile/.eslintrc.json
@@ -17,7 +17,7 @@
       }
     },
     {
-      "files": ["./migration/**/*.js"],
+      "files": ["./migrations/**/*.js"],
       "globals": {
         "artifacts": "readonly",
         "config": "readonly"

--- a/packages/truffle/test/sources/external_compile/.eslintrc.json
+++ b/packages/truffle/test/sources/external_compile/.eslintrc.json
@@ -1,28 +1,3 @@
 {
-  "overrides": [
-    {
-      "files": ["./test/**/*.js"],
-      "env": {
-        "mocha": true
-      },
-      "globals": {
-        "interfaceAdapter": "readonly",
-        "web3": "readonly",
-        "assert": "readonly",
-        "expect": "readonly",
-        "artifacts": "readonly",
-        "config": "readonly",
-        "debug": "readonly",
-        "contract": "readonly"
-      }
-    },
-    {
-      "files": ["./migrations/**/*.js"],
-      "globals": {
-        "artifacts": "readonly",
-        "config": "readonly"
-      }
-    }
-  ]
+  "extends": ["../../../../../.eslintrc.truffle.json"]
 }
-

--- a/packages/truffle/test/sources/inheritance/.eslintrc.json
+++ b/packages/truffle/test/sources/inheritance/.eslintrc.json
@@ -1,0 +1,28 @@
+{
+  "overrides": [
+    {
+      "files": ["./test/**/*.js"],
+      "env": {
+        "mocha": true
+      },
+      "globals": {
+        "interfaceAdapter": "readonly",
+        "web3": "readonly",
+        "assert": "readonly",
+        "expect": "readonly",
+        "artifacts": "readonly",
+        "config": "readonly",
+        "debug": "readonly",
+        "contract": "readonly"
+      }
+    },
+    {
+      "files": ["./migration/**/*.js"],
+      "globals": {
+        "artifacts": "readonly",
+        "config": "readonly"
+      }
+    }
+  ]
+}
+

--- a/packages/truffle/test/sources/inheritance/.eslintrc.json
+++ b/packages/truffle/test/sources/inheritance/.eslintrc.json
@@ -17,7 +17,7 @@
       }
     },
     {
-      "files": ["./migration/**/*.js"],
+      "files": ["./migrations/**/*.js"],
       "globals": {
         "artifacts": "readonly",
         "config": "readonly"

--- a/packages/truffle/test/sources/inheritance/.eslintrc.json
+++ b/packages/truffle/test/sources/inheritance/.eslintrc.json
@@ -1,28 +1,3 @@
 {
-  "overrides": [
-    {
-      "files": ["./test/**/*.js"],
-      "env": {
-        "mocha": true
-      },
-      "globals": {
-        "interfaceAdapter": "readonly",
-        "web3": "readonly",
-        "assert": "readonly",
-        "expect": "readonly",
-        "artifacts": "readonly",
-        "config": "readonly",
-        "debug": "readonly",
-        "contract": "readonly"
-      }
-    },
-    {
-      "files": ["./migrations/**/*.js"],
-      "globals": {
-        "artifacts": "readonly",
-        "config": "readonly"
-      }
-    }
-  ]
+  "extends": ["../../../../../.eslintrc.truffle.json"]
 }
-

--- a/packages/truffle/test/sources/install/.eslintrc.json
+++ b/packages/truffle/test/sources/install/.eslintrc.json
@@ -1,0 +1,28 @@
+{
+  "overrides": [
+    {
+      "files": ["./test/**/*.js"],
+      "env": {
+        "mocha": true
+      },
+      "globals": {
+        "interfaceAdapter": "readonly",
+        "web3": "readonly",
+        "assert": "readonly",
+        "expect": "readonly",
+        "artifacts": "readonly",
+        "config": "readonly",
+        "debug": "readonly",
+        "contract": "readonly"
+      }
+    },
+    {
+      "files": ["./migration/**/*.js"],
+      "globals": {
+        "artifacts": "readonly",
+        "config": "readonly"
+      }
+    }
+  ]
+}
+

--- a/packages/truffle/test/sources/install/.eslintrc.json
+++ b/packages/truffle/test/sources/install/.eslintrc.json
@@ -17,7 +17,7 @@
       }
     },
     {
-      "files": ["./migration/**/*.js"],
+      "files": ["./migrations/**/*.js"],
       "globals": {
         "artifacts": "readonly",
         "config": "readonly"

--- a/packages/truffle/test/sources/install/.eslintrc.json
+++ b/packages/truffle/test/sources/install/.eslintrc.json
@@ -1,28 +1,3 @@
 {
-  "overrides": [
-    {
-      "files": ["./test/**/*.js"],
-      "env": {
-        "mocha": true
-      },
-      "globals": {
-        "interfaceAdapter": "readonly",
-        "web3": "readonly",
-        "assert": "readonly",
-        "expect": "readonly",
-        "artifacts": "readonly",
-        "config": "readonly",
-        "debug": "readonly",
-        "contract": "readonly"
-      }
-    },
-    {
-      "files": ["./migrations/**/*.js"],
-      "globals": {
-        "artifacts": "readonly",
-        "config": "readonly"
-      }
-    }
-  ]
+  "extends": ["../../../../../.eslintrc.truffle.json"]
 }
-

--- a/packages/truffle/test/sources/migrations/error/.eslintrc.json
+++ b/packages/truffle/test/sources/migrations/error/.eslintrc.json
@@ -1,0 +1,28 @@
+{
+  "overrides": [
+    {
+      "files": ["./test/**/*.js"],
+      "env": {
+        "mocha": true
+      },
+      "globals": {
+        "interfaceAdapter": "readonly",
+        "web3": "readonly",
+        "assert": "readonly",
+        "expect": "readonly",
+        "artifacts": "readonly",
+        "config": "readonly",
+        "debug": "readonly",
+        "contract": "readonly"
+      }
+    },
+    {
+      "files": ["./migration/**/*.js"],
+      "globals": {
+        "artifacts": "readonly",
+        "config": "readonly"
+      }
+    }
+  ]
+}
+

--- a/packages/truffle/test/sources/migrations/error/.eslintrc.json
+++ b/packages/truffle/test/sources/migrations/error/.eslintrc.json
@@ -1,28 +1,3 @@
 {
-  "overrides": [
-    {
-      "files": ["./test/**/*.js"],
-      "env": {
-        "mocha": true
-      },
-      "globals": {
-        "interfaceAdapter": "readonly",
-        "web3": "readonly",
-        "assert": "readonly",
-        "expect": "readonly",
-        "artifacts": "readonly",
-        "config": "readonly",
-        "debug": "readonly",
-        "contract": "readonly"
-      }
-    },
-    {
-      "files": ["./migrations/**/*.js"],
-      "globals": {
-        "artifacts": "readonly",
-        "config": "readonly"
-      }
-    }
-  ]
+  "extends": ["../../../../../../.eslintrc.truffle.json"]
 }
-

--- a/packages/truffle/test/sources/migrations/error/.eslintrc.json
+++ b/packages/truffle/test/sources/migrations/error/.eslintrc.json
@@ -17,7 +17,7 @@
       }
     },
     {
-      "files": ["./migration/**/*.js"],
+      "files": ["./migrations/**/*.js"],
       "globals": {
         "artifacts": "readonly",
         "config": "readonly"

--- a/packages/truffle/test/sources/migrations/fabric-evm/.eslintrc.json
+++ b/packages/truffle/test/sources/migrations/fabric-evm/.eslintrc.json
@@ -1,0 +1,28 @@
+{
+  "overrides": [
+    {
+      "files": ["./test/**/*.js"],
+      "env": {
+        "mocha": true
+      },
+      "globals": {
+        "interfaceAdapter": "readonly",
+        "web3": "readonly",
+        "assert": "readonly",
+        "expect": "readonly",
+        "artifacts": "readonly",
+        "config": "readonly",
+        "debug": "readonly",
+        "contract": "readonly"
+      }
+    },
+    {
+      "files": ["./migration/**/*.js"],
+      "globals": {
+        "artifacts": "readonly",
+        "config": "readonly"
+      }
+    }
+  ]
+}
+

--- a/packages/truffle/test/sources/migrations/fabric-evm/.eslintrc.json
+++ b/packages/truffle/test/sources/migrations/fabric-evm/.eslintrc.json
@@ -1,28 +1,3 @@
 {
-  "overrides": [
-    {
-      "files": ["./test/**/*.js"],
-      "env": {
-        "mocha": true
-      },
-      "globals": {
-        "interfaceAdapter": "readonly",
-        "web3": "readonly",
-        "assert": "readonly",
-        "expect": "readonly",
-        "artifacts": "readonly",
-        "config": "readonly",
-        "debug": "readonly",
-        "contract": "readonly"
-      }
-    },
-    {
-      "files": ["./migrations/**/*.js"],
-      "globals": {
-        "artifacts": "readonly",
-        "config": "readonly"
-      }
-    }
-  ]
+  "extends": ["../../../../../../.eslintrc.truffle.json"]
 }
-

--- a/packages/truffle/test/sources/migrations/fabric-evm/.eslintrc.json
+++ b/packages/truffle/test/sources/migrations/fabric-evm/.eslintrc.json
@@ -17,7 +17,7 @@
       }
     },
     {
-      "files": ["./migration/**/*.js"],
+      "files": ["./migrations/**/*.js"],
       "globals": {
         "artifacts": "readonly",
         "config": "readonly"

--- a/packages/truffle/test/sources/migrations/init/.eslintrc.json
+++ b/packages/truffle/test/sources/migrations/init/.eslintrc.json
@@ -1,0 +1,28 @@
+{
+  "overrides": [
+    {
+      "files": ["./test/**/*.js"],
+      "env": {
+        "mocha": true
+      },
+      "globals": {
+        "interfaceAdapter": "readonly",
+        "web3": "readonly",
+        "assert": "readonly",
+        "expect": "readonly",
+        "artifacts": "readonly",
+        "config": "readonly",
+        "debug": "readonly",
+        "contract": "readonly"
+      }
+    },
+    {
+      "files": ["./migration/**/*.js"],
+      "globals": {
+        "artifacts": "readonly",
+        "config": "readonly"
+      }
+    }
+  ]
+}
+

--- a/packages/truffle/test/sources/migrations/init/.eslintrc.json
+++ b/packages/truffle/test/sources/migrations/init/.eslintrc.json
@@ -1,28 +1,3 @@
 {
-  "overrides": [
-    {
-      "files": ["./test/**/*.js"],
-      "env": {
-        "mocha": true
-      },
-      "globals": {
-        "interfaceAdapter": "readonly",
-        "web3": "readonly",
-        "assert": "readonly",
-        "expect": "readonly",
-        "artifacts": "readonly",
-        "config": "readonly",
-        "debug": "readonly",
-        "contract": "readonly"
-      }
-    },
-    {
-      "files": ["./migrations/**/*.js"],
-      "globals": {
-        "artifacts": "readonly",
-        "config": "readonly"
-      }
-    }
-  ]
+  "extends": ["../../../../../../.eslintrc.truffle.json"]
 }
-

--- a/packages/truffle/test/sources/migrations/init/.eslintrc.json
+++ b/packages/truffle/test/sources/migrations/init/.eslintrc.json
@@ -17,7 +17,7 @@
       }
     },
     {
-      "files": ["./migration/**/*.js"],
+      "files": ["./migrations/**/*.js"],
       "globals": {
         "artifacts": "readonly",
         "config": "readonly"

--- a/packages/truffle/test/sources/migrations/production/.eslintrc.json
+++ b/packages/truffle/test/sources/migrations/production/.eslintrc.json
@@ -1,0 +1,28 @@
+{
+  "overrides": [
+    {
+      "files": ["./test/**/*.js"],
+      "env": {
+        "mocha": true
+      },
+      "globals": {
+        "interfaceAdapter": "readonly",
+        "web3": "readonly",
+        "assert": "readonly",
+        "expect": "readonly",
+        "artifacts": "readonly",
+        "config": "readonly",
+        "debug": "readonly",
+        "contract": "readonly"
+      }
+    },
+    {
+      "files": ["./migration/**/*.js"],
+      "globals": {
+        "artifacts": "readonly",
+        "config": "readonly"
+      }
+    }
+  ]
+}
+

--- a/packages/truffle/test/sources/migrations/production/.eslintrc.json
+++ b/packages/truffle/test/sources/migrations/production/.eslintrc.json
@@ -1,28 +1,3 @@
 {
-  "overrides": [
-    {
-      "files": ["./test/**/*.js"],
-      "env": {
-        "mocha": true
-      },
-      "globals": {
-        "interfaceAdapter": "readonly",
-        "web3": "readonly",
-        "assert": "readonly",
-        "expect": "readonly",
-        "artifacts": "readonly",
-        "config": "readonly",
-        "debug": "readonly",
-        "contract": "readonly"
-      }
-    },
-    {
-      "files": ["./migrations/**/*.js"],
-      "globals": {
-        "artifacts": "readonly",
-        "config": "readonly"
-      }
-    }
-  ]
+  "extends": ["../../../../../../.eslintrc.truffle.json"]
 }
-

--- a/packages/truffle/test/sources/migrations/production/.eslintrc.json
+++ b/packages/truffle/test/sources/migrations/production/.eslintrc.json
@@ -17,7 +17,7 @@
       }
     },
     {
-      "files": ["./migration/**/*.js"],
+      "files": ["./migrations/**/*.js"],
       "globals": {
         "artifacts": "readonly",
         "config": "readonly"

--- a/packages/truffle/test/sources/migrations/quorum/.eslintrc.json
+++ b/packages/truffle/test/sources/migrations/quorum/.eslintrc.json
@@ -1,0 +1,28 @@
+{
+  "overrides": [
+    {
+      "files": ["./test/**/*.js"],
+      "env": {
+        "mocha": true
+      },
+      "globals": {
+        "interfaceAdapter": "readonly",
+        "web3": "readonly",
+        "assert": "readonly",
+        "expect": "readonly",
+        "artifacts": "readonly",
+        "config": "readonly",
+        "debug": "readonly",
+        "contract": "readonly"
+      }
+    },
+    {
+      "files": ["./migration/**/*.js"],
+      "globals": {
+        "artifacts": "readonly",
+        "config": "readonly"
+      }
+    }
+  ]
+}
+

--- a/packages/truffle/test/sources/migrations/quorum/.eslintrc.json
+++ b/packages/truffle/test/sources/migrations/quorum/.eslintrc.json
@@ -1,28 +1,3 @@
 {
-  "overrides": [
-    {
-      "files": ["./test/**/*.js"],
-      "env": {
-        "mocha": true
-      },
-      "globals": {
-        "interfaceAdapter": "readonly",
-        "web3": "readonly",
-        "assert": "readonly",
-        "expect": "readonly",
-        "artifacts": "readonly",
-        "config": "readonly",
-        "debug": "readonly",
-        "contract": "readonly"
-      }
-    },
-    {
-      "files": ["./migrations/**/*.js"],
-      "globals": {
-        "artifacts": "readonly",
-        "config": "readonly"
-      }
-    }
-  ]
+  "extends": ["../../../../../../.eslintrc.truffle.json"]
 }
-

--- a/packages/truffle/test/sources/migrations/quorum/.eslintrc.json
+++ b/packages/truffle/test/sources/migrations/quorum/.eslintrc.json
@@ -17,7 +17,7 @@
       }
     },
     {
-      "files": ["./migration/**/*.js"],
+      "files": ["./migrations/**/*.js"],
       "globals": {
         "artifacts": "readonly",
         "config": "readonly"

--- a/packages/truffle/test/sources/migrations/success/.eslintrc.json
+++ b/packages/truffle/test/sources/migrations/success/.eslintrc.json
@@ -1,0 +1,28 @@
+{
+  "overrides": [
+    {
+      "files": ["./test/**/*.js"],
+      "env": {
+        "mocha": true
+      },
+      "globals": {
+        "interfaceAdapter": "readonly",
+        "web3": "readonly",
+        "assert": "readonly",
+        "expect": "readonly",
+        "artifacts": "readonly",
+        "config": "readonly",
+        "debug": "readonly",
+        "contract": "readonly"
+      }
+    },
+    {
+      "files": ["./migration/**/*.js"],
+      "globals": {
+        "artifacts": "readonly",
+        "config": "readonly"
+      }
+    }
+  ]
+}
+

--- a/packages/truffle/test/sources/migrations/success/.eslintrc.json
+++ b/packages/truffle/test/sources/migrations/success/.eslintrc.json
@@ -1,28 +1,3 @@
 {
-  "overrides": [
-    {
-      "files": ["./test/**/*.js"],
-      "env": {
-        "mocha": true
-      },
-      "globals": {
-        "interfaceAdapter": "readonly",
-        "web3": "readonly",
-        "assert": "readonly",
-        "expect": "readonly",
-        "artifacts": "readonly",
-        "config": "readonly",
-        "debug": "readonly",
-        "contract": "readonly"
-      }
-    },
-    {
-      "files": ["./migrations/**/*.js"],
-      "globals": {
-        "artifacts": "readonly",
-        "config": "readonly"
-      }
-    }
-  ]
+  "extends": ["../../../../../../.eslintrc.truffle.json"]
 }
-

--- a/packages/truffle/test/sources/migrations/success/.eslintrc.json
+++ b/packages/truffle/test/sources/migrations/success/.eslintrc.json
@@ -17,7 +17,7 @@
       }
     },
     {
-      "files": ["./migration/**/*.js"],
+      "files": ["./migrations/**/*.js"],
       "globals": {
         "artifacts": "readonly",
         "config": "readonly"

--- a/packages/truffle/test/sources/migrations/unhandled-rejection/.eslintrc.json
+++ b/packages/truffle/test/sources/migrations/unhandled-rejection/.eslintrc.json
@@ -1,0 +1,28 @@
+{
+  "overrides": [
+    {
+      "files": ["./test/**/*.js"],
+      "env": {
+        "mocha": true
+      },
+      "globals": {
+        "interfaceAdapter": "readonly",
+        "web3": "readonly",
+        "assert": "readonly",
+        "expect": "readonly",
+        "artifacts": "readonly",
+        "config": "readonly",
+        "debug": "readonly",
+        "contract": "readonly"
+      }
+    },
+    {
+      "files": ["./migration/**/*.js"],
+      "globals": {
+        "artifacts": "readonly",
+        "config": "readonly"
+      }
+    }
+  ]
+}
+

--- a/packages/truffle/test/sources/migrations/unhandled-rejection/.eslintrc.json
+++ b/packages/truffle/test/sources/migrations/unhandled-rejection/.eslintrc.json
@@ -1,28 +1,3 @@
 {
-  "overrides": [
-    {
-      "files": ["./test/**/*.js"],
-      "env": {
-        "mocha": true
-      },
-      "globals": {
-        "interfaceAdapter": "readonly",
-        "web3": "readonly",
-        "assert": "readonly",
-        "expect": "readonly",
-        "artifacts": "readonly",
-        "config": "readonly",
-        "debug": "readonly",
-        "contract": "readonly"
-      }
-    },
-    {
-      "files": ["./migrations/**/*.js"],
-      "globals": {
-        "artifacts": "readonly",
-        "config": "readonly"
-      }
-    }
-  ]
+  "extends": ["../../../../../../.eslintrc.truffle.json"]
 }
-

--- a/packages/truffle/test/sources/migrations/unhandled-rejection/.eslintrc.json
+++ b/packages/truffle/test/sources/migrations/unhandled-rejection/.eslintrc.json
@@ -17,7 +17,7 @@
       }
     },
     {
-      "files": ["./migration/**/*.js"],
+      "files": ["./migrations/**/*.js"],
       "globals": {
         "artifacts": "readonly",
         "config": "readonly"

--- a/packages/truffle/test/sources/networks/metacoin/.eslintrc.json
+++ b/packages/truffle/test/sources/networks/metacoin/.eslintrc.json
@@ -1,0 +1,28 @@
+{
+  "overrides": [
+    {
+      "files": ["./test/**/*.js"],
+      "env": {
+        "mocha": true
+      },
+      "globals": {
+        "interfaceAdapter": "readonly",
+        "web3": "readonly",
+        "assert": "readonly",
+        "expect": "readonly",
+        "artifacts": "readonly",
+        "config": "readonly",
+        "debug": "readonly",
+        "contract": "readonly"
+      }
+    },
+    {
+      "files": ["./migration/**/*.js"],
+      "globals": {
+        "artifacts": "readonly",
+        "config": "readonly"
+      }
+    }
+  ]
+}
+

--- a/packages/truffle/test/sources/networks/metacoin/.eslintrc.json
+++ b/packages/truffle/test/sources/networks/metacoin/.eslintrc.json
@@ -1,28 +1,3 @@
 {
-  "overrides": [
-    {
-      "files": ["./test/**/*.js"],
-      "env": {
-        "mocha": true
-      },
-      "globals": {
-        "interfaceAdapter": "readonly",
-        "web3": "readonly",
-        "assert": "readonly",
-        "expect": "readonly",
-        "artifacts": "readonly",
-        "config": "readonly",
-        "debug": "readonly",
-        "contract": "readonly"
-      }
-    },
-    {
-      "files": ["./migrations/**/*.js"],
-      "globals": {
-        "artifacts": "readonly",
-        "config": "readonly"
-      }
-    }
-  ]
+  "extends": ["../../../../../../.eslintrc.truffle.json"]
 }
-

--- a/packages/truffle/test/sources/networks/metacoin/.eslintrc.json
+++ b/packages/truffle/test/sources/networks/metacoin/.eslintrc.json
@@ -17,7 +17,7 @@
       }
     },
     {
-      "files": ["./migration/**/*.js"],
+      "files": ["./migrations/**/*.js"],
       "globals": {
         "artifacts": "readonly",
         "config": "readonly"

--- a/packages/workflow-compile/.eslintrc.json
+++ b/packages/workflow-compile/.eslintrc.json
@@ -1,10 +1,3 @@
 {
-  "overrides": [
-    {
-      "files": ["./test/**/*.js"],
-      "env": {
-        "mocha": true
-      }
-    }
-  ]
+  "extends": ["../../.eslintrc.package.json"]
 }


### PR DESCRIPTION
This is something of a follow-on to #4009.  Right now Husky is still broken (#3530), but once it's fixed, ESLint could potentially cause problems for `.js` files in Truffle projects that use Truffle-defined globals.  Specifically this would apply to test files that use globals, and migration scripts that use globals.

Since we have a bunch of those in our source tree, I added `.eslintrc.json` files to them that should take care of the problem.

There's one case I wasn't sure about, which is, what do we do about `initSource`?  If we put a `.eslintrc.json` in there, that means `truffle init` will create that file for people!  I went ahead and put it there anyway, but I did it in a separate commit since I wasn't so sure about it.  We could always change `truffle init` to ignore dotfiles, or something?