### PR TITLE
Add BASEFEE opcode to code-utils

### DIFF
--- a/packages/code-utils/src/opcodes.ts
+++ b/packages/code-utils/src/opcodes.ts
@@ -60,6 +60,7 @@ const codes: OpcodeTable = {
   0x45: "GASLIMIT",
   0x46: "CHAINID",
   0x47: "SELFBALANCE",
+  0x48: "BASEFEE",
 
   // 0x50 range - 'storage' and execution
   0x50: "POP",


### PR DESCRIPTION
Since London is already out on testnets.  This probably won't do very much at the moment, as I doubt many people are yet using this opcode (it's not in Yul yet), but, still, here it is.