### PR TITLE
Bug fix: Don't change backslashes to slashes on Linux

### DIFF
--- a/packages/compile-common/src/sources.ts
+++ b/packages/compile-common/src/sources.ts
@@ -64,10 +64,9 @@ export function collectSources(
  * @private
  */
 function getPortableSourcePath(sourcePath: string): string {
-  // Turn all backslashes into forward slashes
   let replacement = sourcePath;
+  //on Windows, replace backslashes with forward slashes
   if (path.sep === '\\') {
-    //don't replace backslashes on Linux!
     replacement = sourcePath.replace(/\\/g, "/");
   }
 

--- a/packages/compile-common/src/sources.ts
+++ b/packages/compile-common/src/sources.ts
@@ -65,7 +65,11 @@ export function collectSources(
  */
 function getPortableSourcePath(sourcePath: string): string {
   // Turn all backslashes into forward slashes
-  var replacement = sourcePath.replace(/\\/g, "/");
+  let replacement = sourcePath;
+  if (path.sep === '\\') {
+    //don't replace backslashes on Linux!
+    replacement = sourcePath.replace(/\\/g, "/");
+  }
 
   // Turn G:/.../ into /G/.../ for Windows
   if (replacement.length >= 2 && replacement[1] === ":") {


### PR DESCRIPTION
Addresses #4166.  To avoid having to create regexes on the fly (which requires escaping), I just used the simpler method of skipping the replacement if `path.sep === '//'`.

I left in the code below for dealing with Windows drives just as a just-in-case thing, even though we can probably get rid of that now what with the `project:/` thing.