### PR TITLE
Make source not found error clearer

### DIFF
--- a/packages/compile-solidity/run.js
+++ b/packages/compile-solidity/run.js
@@ -258,7 +258,12 @@ function detectErrors({
     );
 
   // extract messages
-  let errors = rawErrors.map(({ formattedMessage }) => formattedMessage).join();
+  let errors = rawErrors.map(
+    ({ formattedMessage }) => formattedMessage.replace(
+      /: File import callback not supported/g, //remove this confusing message suffix
+      ""
+    )
+  ).join();
   const warnings = rawWarnings.map(({ formattedMessage }) => formattedMessage);
 
   if (errors.includes("requires different compiler version")) {


### PR DESCRIPTION
So, ever since we stopped throwing our own source-not-found errors and exposing the Solidity ones, there's been this annoyance that the Solidity source-not-found errors end with this confusing "File import callback not supported" message.  What does that mean?  The error would be clearer if it were just stripped off.  Well, today I realized we can just, y'know, do that!  So I made this PR to strip off that suffix when we see it.