### PR TITLE
Bug fix: Disallow non-absolute non-relative FS imports

### DIFF
--- a/packages/compile-solidity/test/sources/badSources/Imported.sol
+++ b/packages/compile-solidity/test/sources/badSources/Imported.sol
@@ -1,0 +1,5 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract Imported {
+}

--- a/packages/compile-solidity/test/sources/badSources/Nonrelative.sol
+++ b/packages/compile-solidity/test/sources/badSources/Nonrelative.sol
@@ -1,0 +1,4 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "Imported.sol";

--- a/packages/compile-solidity/test/test_nonrelative.js
+++ b/packages/compile-solidity/test/test_nonrelative.js
@@ -1,0 +1,61 @@
+const debug = require("debug")("compile:test:test_nonrelative");
+const path = require("path");
+const { Compile } = require("@truffle/compile-solidity");
+const assert = require("assert");
+const Resolver = require("@truffle/resolver");
+const process = require("process");
+
+describe("Non-relative non-absolute file paths", function () {
+  this.timeout(5000); // solc
+
+  const options = {
+    working_directory: __dirname,
+    contracts_directory: path.join(__dirname, "./sources/badSources"),
+    contracts_build_directory: path.join(__dirname, "./does/not/matter"), //nothing is actually written, but resolver demands it
+    compilers: {
+      solc: {
+        version: "0.8.6",
+        settings: {
+          optimizer: {
+            enabled: false,
+            runs: 200
+          }
+        }
+      }
+    },
+    quiet: true
+  };
+  options.resolver = new Resolver(options);
+
+  before("Set working directory", function () {
+    originalWorkingDirectory = process.cwd();
+    process.chdir(options.contracts_directory);
+  });
+
+  it("Refuses to compile non-relative non-absolute paths", async function () {
+    this.timeout(150000);
+    const paths = [
+      "Nonrelative.sol",
+    ].map(filePath => path.join(options.contracts_directory, filePath));
+
+    debug("current dir: %s", process.cwd());
+
+    try {
+      await Compile.sourcesWithDependencies({
+        paths,
+        options
+      });
+      assert.fail("Compilation should have failed");
+    } catch (error) {
+      debug("error: %O", error);
+      if(!error.message.includes('Source "Imported.sol" not found')) {
+        throw error; //rethrow errors that aren't the one we expect
+      }
+      //otherwise, we're good
+    }
+  });
+
+  after("Reset working directory", function () {
+    process.chdir(originalWorkingDirectory);
+  });
+});

--- a/packages/resolver/lib/sources/fs.ts
+++ b/packages/resolver/lib/sources/fs.ts
@@ -57,7 +57,7 @@ export class FS implements ResolverSource {
     return path.basename(sourcePath, ".sol");
   }
 
-  async resolve(importPath: string, importedFrom?: string) {
+  async resolve(importPath: string, _importedFrom?: string) {
 
     if (!path.isAbsolute(importPath)) {
       //the FS resolver should only resolve absolute paths.


### PR DESCRIPTION
This PR addresses #4161, sort of, by just disallowing such imports.

So, the problem in #4161 regards what happens when you use FS-resolved direct imports that are neither absolute nor explicitly relative.  The problem is, there's not really any reasonable way to make these work.

Truffle tries to give each source a canonical path -- not necessarily a file path, but a path it's going to pass with it to solc.  Normally when making file-system imports, you use a relative path.  This works with Truffle and with Solidity; Truffle can find the source you're looking for to pass to solc, and Solidity can resolve the relative path among the sources you pass to it.  This also works with non-FS imports for the same reasons.

But what if you use a direct import?  In this case, Solidity performs no resolution of relative paths.

Now, if the direct import is absolute, or isn't FS-resolved at all, then this isn't a problem, because the imported path, being given in full, will match what we pass to solc.  (Although, absolute file imports might have problems, if, say you're on Windows; but you're not really supposed to use those in the first place although I haven't explicitly disallowed them here.)  But what if it's neither absolute, nor explicitly relative?

Then we get a mismatch: The path where Solidity looks for the import will be a shortened path, whereas the path we pass to solc for it will be the full path.  It won't find it!  Alternatively, we may end up passing it under *both* paths, which causes other problems.

There's not really any reasonable way for us to resolve this (unless we're willing to drop the `project:/` prefix, and have just e.g. `contracts/C.sol` instead of `project:/contracts/C.sol`).  Because regardless of what we do, solc **will** look at the short path, not the path we want.  So either we have to make the short path the canonical path (and drop `project:/` as just mentioned), or we have to disallow such things.  (Or we have to go to substantially more effort and try actually rewriting import statements or something, which I don't think we're about to do.)

Note that the existing behavior for such imports was for them to be resolved **relative to the directory the command was running in**, so they wouldn't have worked consistently anyway.  So, hopefully, this change isn't breaking anything anyone was relying on, because it shouldn't be breaking anything that consistently worked?

(Now we'll see if the tests pass. :P )