### PR TITLE
Standardize option aliases

### DIFF
--- a/packages/core/lib/commands/console.js
+++ b/packages/core/lib/commands/console.js
@@ -4,7 +4,7 @@ const command = {
     "Run a console with contract abstractions and commands available",
   builder: {},
   help: {
-    usage: "truffle console [--verbose-rpc] [(--require|-r) <file>]",
+    usage: "truffle console [--verbose-rpc] [--require|-r <file>]",
     options: [
       {
         option: "--verbose-rpc",
@@ -12,7 +12,7 @@ const command = {
           "Log communication between Truffle and the Ethereum client."
       },
       {
-        option: "(--require|-r) <file>",
+        option: "--require|-r <file>",
         description: "Preload console environment from required JavaScript " +
           "file. The default export must be an object with named keys that " +
           "will be used\n                    to populate the console environment."

--- a/packages/core/lib/commands/debug.js
+++ b/packages/core/lib/commands/debug.js
@@ -30,8 +30,8 @@ const command = {
   },
   help: {
     usage:
-      "truffle debug [<transaction_hash>] [(--fetch-external|-x)]" + OS.EOL +
-      "                             [(--compile-tests|--compile-all|--compile-none)]",
+      "truffle debug [<transaction_hash>] [--fetch-external|-x]" + OS.EOL +
+      "                             [--compile-tests|--compile-all|--compile-none]",
     options: [
       {
         option: "<transaction_hash>",
@@ -39,7 +39,7 @@ const command = {
           "Transaction ID to use for debugging.  Mandatory if --fetch-external is passed."
       },
       {
-        option: "(--fetch-external|-x)",
+        option: "--fetch-external|-x",
         description:
           "Allows debugging of external contracts with verified sources."
       },

--- a/packages/core/lib/commands/debug.js
+++ b/packages/core/lib/commands/debug.js
@@ -30,8 +30,8 @@ const command = {
   },
   help: {
     usage:
-      "truffle debug [<transaction_hash>] [--fetch-external]" + OS.EOL +
-      "                             [--compile-tests|--compile-all|--compile-none]",
+      "truffle debug [<transaction_hash>] [(--fetch-external|-x)]" + OS.EOL +
+      "                             [(--compile-tests|--compile-all|--compile-none)]",
     options: [
       {
         option: "<transaction_hash>",
@@ -39,7 +39,7 @@ const command = {
           "Transaction ID to use for debugging.  Mandatory if --fetch-external is passed."
       },
       {
-        option: "--fetch-external|-x",
+        option: "(--fetch-external|-x)",
         description:
           "Allows debugging of external contracts with verified sources."
       },

--- a/packages/core/lib/commands/debug.js
+++ b/packages/core/lib/commands/debug.js
@@ -39,9 +39,9 @@ const command = {
           "Transaction ID to use for debugging.  Mandatory if --fetch-external is passed."
       },
       {
-        option: "--fetch-external",
+        option: "--fetch-external|-x",
         description:
-          "Allows debugging of external contracts with verified sources.  Alias: -x"
+          "Allows debugging of external contracts with verified sources."
       },
       {
         option: "--compile-tests",

--- a/packages/core/lib/commands/develop.js
+++ b/packages/core/lib/commands/develop.js
@@ -11,7 +11,7 @@ const command = {
     }
   },
   help: {
-    usage: "truffle develop [--log] [(--require|-r) <file>]",
+    usage: "truffle develop [--log] [--require|-r <file>]",
     options: [
       {
         option: `--log`,
@@ -21,7 +21,7 @@ const command = {
           `different Truffle develop or console session to interact via the repl.`
       },
       {
-        option: "(--require|-r) <file>",
+        option: "--require|-r <file>",
         description: "Preload console environment from required JavaScript " +
           "file. The default export must be an object with named keys that " +
           "will be used\n                    to populate the console environment."

--- a/packages/core/lib/commands/test/index.js
+++ b/packages/core/lib/commands/test/index.js
@@ -50,8 +50,8 @@ const command = {
       `truffle test [<test_file>] [--compile-all[-debug]] [--compile-none] ` +
       `[--network <name>]${OS.EOL}                             ` +
       `[--verbose-rpc] [--show-events] [--debug] ` +
-      `[--debug-global <identifier>] [(--bail)]${OS.EOL}                      ` +
-      `       [--stacktrace[-extra]] [(--grep|-g) <regex>]`,
+      `[--debug-global <identifier>] [--bail|-b]${OS.EOL}                      ` +
+      `       [--stacktrace[-extra]] [--grep|-g <regex>]`,
     options: [
       {
         option: "<test_file>",
@@ -100,7 +100,7 @@ const command = {
         description: "Suppress all output except for test runner output."
       },
       {
-        option: "(--bail|-b)",
+        option: "--bail|-b",
         description: "Bail after first test failure."
       },
       {
@@ -115,7 +115,7 @@ const command = {
         description: "Shortcut for --stacktrace --compile-all-debug."
       },
       {
-        option: "(--grep|-g)",
+        option: "--grep|-g",
         description: "Use mocha's \"grep\" option while running tests. This " +
           "option only runs tests that match the supplied regex/string."
       }


### PR DESCRIPTION
This PR continues work from https://github.com/trufflesuite/truffle/pull/4179 and standardizes the format in which options are listed in the command files' help.