### PR TITLE
Bug fix: Use backslashes on Windows while resolving imports

### DIFF
--- a/packages/compile-common/src/profiler/getImports.ts
+++ b/packages/compile-common/src/profiler/getImports.ts
@@ -1,4 +1,5 @@
 import debugModule from "debug";
+import path from "path";
 const debug = debugModule("compile-common:profiler:getImports");
 
 //HACK: do *not* import ResolvedSource from @truffle/resolver because
@@ -36,5 +37,7 @@ export async function getImports({
   // here, that's now the responsibility of the individual resolverSource to check
   return (await Promise.all(imports.map(
     dependencyPath => source.resolveDependencyPath(filePath, dependencyPath)
-  ))).filter(path => path); //filter out Vyper failures
+  ))).filter(sourcePath => sourcePath) //filter out Vyper failures
+  .map(sourcePath => sourcePath.replace(/\//g, path.sep)); //make sure to use
+  //backslash on Windows (for same reason as in requiredSources.ts)
 }

--- a/packages/compile-common/src/profiler/requiredSources.ts
+++ b/packages/compile-common/src/profiler/requiredSources.ts
@@ -1,4 +1,5 @@
 import debugModule from "debug";
+import path from "path";
 const debug = debugModule("compile-common:profiler:requiredSources");
 
 import {
@@ -36,6 +37,13 @@ export async function requiredSources({
 
   debug("allPaths: %O", allPaths);
   debug("updatedPaths: %O", updatedPaths);
+
+  //before anything else: on Windows, make sure all paths are in native form
+  //(with backslashes) rather than slashes.  otherwise, resolution of relative
+  //paths can cause aliasing; you can end up with one source with slashes (as
+  //given) and one with backslashes (due to relative import resolution).
+  allPaths = allPaths.map(sourcePath => sourcePath.replace(/\//g, path.sep));
+  updatedPaths = updatedPaths.map(sourcePath => sourcePath.replace(/\//g, path.sep));
 
   // Solidity test files might have been injected. Include them in the known set.
   updatedPaths.forEach(_path => {


### PR DESCRIPTION
This PR is intended to address #4193.  **This needs to be tested on Windows!**  This is a quick PR that I think should resolve the problem, but I am working without actual testing here.

As best I can tell -- remember, I'm working without testing here -- the problem is that resolution of relative paths is causing aliasing of sources.  Because some paths are being given with slashes, but import resolution leads to the use of backslashes instead.

~Except, hm, we might need to apply this imports too, not just at the beginning?  Uh, I guess I need to go make more changes to this...~ OK, made that change.