### PR TITLE
Fix Truffle build on Windows.

### DIFF
--- a/packages/preserve/package.json
+++ b/packages/preserve/package.json
@@ -11,7 +11,7 @@
     "build": "tsc",
     "prepare": "yarn build && yarn docs",
     "test": "jest --verbose --detectOpenHandles",
-    "docs": "../../node_modules/typedoc/bin/typedoc --options ./docs/typedoc.json"
+    "docs": "typedoc --options ./docs/typedoc.json"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Windows cannot reference paths with `../..`.   Reference the command directly as `typedoc` is a preserve dependency and should be available for a script.
