### PR TITLE
Bug fix: Sanitize network name for graphql query in db

### DIFF
--- a/packages/db/src/project/assignNames/getCurrent.ts
+++ b/packages/db/src/project/assignNames/getCurrent.ts
@@ -40,7 +40,7 @@ export const process = Batch.configure<{
         "projects",
         id,
         gql`
-        fragment Resolve_${type}_${name} on Project {
+        fragment Resolve_${type}_${name.replace(/[^0-9a-zA-Z_]/, "")} on Project {
           resolve(type: "${type}", name: "${name}") {
             id
             resource {


### PR DESCRIPTION
Inspired by https://github.com/trufflesuite/truffle/issues/3981

This PR fixes a bug caused by network names with characters that, when inserted into a GraphQL query, would break the query. For example, the network name "my-network" would break the query due to the "-". The PR sanitizes the name with a regex.