### PR TITLE
Fix truffle resolve on windows

### DIFF
--- a/packages/resolver/lib/sources/truffle/index.ts
+++ b/packages/resolver/lib/sources/truffle/index.ts
@@ -13,7 +13,7 @@ export class Truffle implements ResolverSource {
   }
 
   async resolve(importPath: string) {
-    if (importPath === "truffle/DeployedAddresses.sol") {
+    if (importPath === `truffle${path.sep}DeployedAddresses.sol`) {
       const sourceFiles = await findContracts(this.options.contracts_directory);
 
       const buildDirFiles: string[] =
@@ -88,7 +88,7 @@ export class Truffle implements ResolverSource {
     ];
 
     for (const lib of truffleLibraries) {
-      if (importPath === `truffle/${lib}.sol`) {
+      if (importPath === `truffle${path.sep}${lib}.sol`) {
         const actualImportPath =
           // @ts-ignore
           typeof BUNDLE_VERSION !== "undefined"

--- a/packages/resolver/package.json
+++ b/packages/resolver/package.json
@@ -21,7 +21,9 @@
   "scripts": {
     "build": "tsc",
     "prepare": "yarn build",
-    "test": "mocha -r ts-node/register test/*.ts"
+    "test:ts": "mocha -r ts-node/register test/*.ts",
+    "test:js": "mocha test/*.js",
+    "test": "yarn test:ts && yarn test:js"
   },
   "types": "dist/lib/index.d.ts",
   "dependencies": {

--- a/packages/resolver/test/truffle.js
+++ b/packages/resolver/test/truffle.js
@@ -1,0 +1,43 @@
+const assert = require("assert");
+const path = require("path");
+
+// Use transpiled output to properly test the path manipulation
+// truffle resolver utilizes
+const { Truffle } = require("../dist/lib/sources/truffle");
+const resolver = new Truffle({});
+
+describe("truffle resolve [ @win ]", function () {
+
+  describe("assertion contracts", () => {
+    [
+      "Assert",
+      "AssertAddress",
+      "AssertAddressArray",
+      "AssertBalance",
+      "AssertBool",
+      "AssertBytes32",
+      "AssertBytes32Array",
+      "AssertGeneral",
+      "AssertInt",
+      "AssertIntArray",
+      "AssertString",
+      "AssertUint",
+      "AssertUintArray",
+      "SafeSend",
+    ].forEach(lib => {
+      it(`resolves truffle/${lib}.sol`, async () => {
+        const dependency = path.join("truffle", `${lib}.sol`);
+        let result = await resolver.resolve(dependency);
+        assert(
+          result.filePath.includes(dependency),
+          `should have resovled 'truffle${path.sep}${lib}.sol'`
+        );
+      })
+    })
+  });
+
+  describe.skip("DeployedAddresses Contracts", () => {
+    // "DeployedAddresses"
+    // TODO: Not sure how to set this up
+  })
+});

--- a/packages/resolver/test/truffle.js
+++ b/packages/resolver/test/truffle.js
@@ -6,7 +6,7 @@ const path = require("path");
 const { Truffle } = require("../dist/lib/sources/truffle");
 const resolver = new Truffle({});
 
-describe("truffle resolve [ @win ]", function () {
+describe("truffle resolve", function () {
 
   describe("assertion contracts", () => {
     [
@@ -35,9 +35,4 @@ describe("truffle resolve [ @win ]", function () {
       })
     })
   });
-
-  describe.skip("DeployedAddresses Contracts", () => {
-    // "DeployedAddresses"
-    // TODO: Not sure how to set this up
-  })
 });


### PR DESCRIPTION
This PR fixes truffle solidity imports on Windows  (`import truffle/Assert.sol`). 

See: #400 , and [windows CI test results](https://github.com/trufflesuite/truffle/runs/3157919036#step:6:283). This branch is working towards getting a windows CI workflow.
 
Note: couldn't figure out a way to test resolving `DeployedAddress`