### PR TITLE
Add London support (minus access lists) to Truffle Contract

### DIFF
--- a/packages/contract/lib/utils/index.js
+++ b/packages/contract/lib/utils/index.js
@@ -11,6 +11,8 @@ const allowedTxParams = new Set([
   "to",
   "gas",
   "gasPrice",
+  "maxFeePerGas",
+  "maxPriorityFeePerGas",
   "value",
   "data",
   "nonce",


### PR DESCRIPTION
This PR adds support for London transactions, minus access lists, to Truffle Contract.

This PR is a draft because it needs to be tested.  Unfortunately, it can't be tested with Ganache at the moment, because Ganache doesn't support London yet.

Obviously, prefer to wait until Ganache supports London before doing this, but London is coming soon and after discussing things with @gnidan we decided this is important enough not to wait.  Access lists are less important, so for now we're still going to wait on that one.