### PR TITLE
Bug fix: Disallow absolute import paths not beginning with project root (for real)

### DIFF
--- a/packages/compile-common/src/sources.ts
+++ b/packages/compile-common/src/sources.ts
@@ -18,6 +18,10 @@ export function collectSources(
   replacement: string = "/"
 ): CollectedSources {
   const mappedResults = Object.entries(originalSources)
+    .filter(([originalSourcePath, _]) =>
+      !path.isAbsolute(originalSourcePath) ||
+      originalSourcePath.startsWith(baseDirectory)
+    )
     .map(([originalSourcePath, contents]) => ({
       originalSourcePath,
       contents,

--- a/packages/compile-solidity/test/test_nonrelative.js
+++ b/packages/compile-solidity/test/test_nonrelative.js
@@ -4,6 +4,9 @@ const { Compile } = require("@truffle/compile-solidity");
 const assert = require("assert");
 const Resolver = require("@truffle/resolver");
 const process = require("process");
+const tmp = require("tmp");
+tmp.setGracefulCleanup();
+const fs = require("fs");
 
 describe("Non-relative non-absolute file paths", function () {
   this.timeout(5000); // solc
@@ -57,5 +60,60 @@ describe("Non-relative non-absolute file paths", function () {
 
   after("Reset working directory", function () {
     process.chdir(originalWorkingDirectory);
+  });
+});
+
+describe("Non-canonical absolute file paths", function () {
+  this.timeout(5000); // solc
+  let tmpdir;
+  let options;
+
+  before("Set up temporary directory and project", async function () {
+    tmpdir = tmp.dirSync({ unsafeCleanup: true }).name; //tmp uses callbacks, not promises, so using sync
+    await fs.promises.mkdir(path.join(tmpdir, "./contracts"));
+    const contracts_directory = path.join(tmpdir, "./contracts");
+    options = {
+      working_directory: tmpdir,
+      contracts_directory,
+      contracts_build_directory: path.join(tmpdir, "./build/contracts"), //nothing is actually written, but resolver demands it
+      compilers: {
+        solc: {
+          version: "0.8.6",
+          settings: {
+            optimizer: {
+              enabled: false,
+              runs: 200
+            }
+          }
+        }
+      },
+      quiet: true
+    };
+    options.resolver = new Resolver(options);
+    const importedPath = path.join(options.contracts_directory, "Imported.sol");
+    const importerPath = path.join(options.contracts_directory, "DoubleSlash.sol");
+    await fs.promises.copyFile(
+      path.join(__dirname, "./sources/badSources/Imported.sol"),
+      importedPath
+    );
+    await fs.promises.writeFile(
+      importerPath,
+      `import "/${importedPath}";` //note the extra slash
+    );
+  });
+
+  it("Refuses to compile non-canonical absolute paths", async function () {
+    this.timeout(150000);
+
+    try {
+      await Compile.all(options);
+      assert.fail("Compilation should have failed");
+    } catch (error) {
+      debug("error: %O", error);
+      if(!error.message.match(/Source "\/\/[^"]*" not found/)) {
+        throw error; //rethrow errors that aren't the one we expect
+      }
+      //otherwise, we're good
+    }
   });
 });


### PR DESCRIPTION
Addresses #4165.

So, the actual effect of this PR isn't actually to require things to be in the project directory (that was already typically the case);
rather it's to bar getting around it by starting your import path with `"//"` or the like.  Issue #4165 was followed because you could import absolute paths if you just started them with `"//"`.  This PR ends that loophole -- all paths passed to the Solidity compiler have to be either relative, or begin with the project directory (as a string; no starting with `"//"`).  So, now such imports will fail, because their source got filtered out.

Note: @cameel raises the point that we might want to test this with Windows.  It's possible that due to the normalization, we should actually be checking for an an initial `"/"` rather than using `path.isAbsolute`.  @cds-amal would you possibly be willing to test that...?