### PR TITLE
Remove web3 types from hdwallet-provider

### DIFF
--- a/packages/hdwallet-provider/package.json
+++ b/packages/hdwallet-provider/package.json
@@ -34,7 +34,6 @@
     "@types/ethereum-protocol": "^1.0.0",
     "@types/ethereumjs-util": "^5.2.0",
     "@types/mocha": "^5.2.7",
-    "@types/web3": "^1.0.20",
     "@types/web3-provider-engine": "^14.0.0",
     "ganache-core": "2.13.0",
     "mocha": "8.1.2",

--- a/packages/hdwallet-provider/tsconfig.json
+++ b/packages/hdwallet-provider/tsconfig.json
@@ -21,7 +21,6 @@
       "./typings",
       "../../node_modules/@types/mocha",
       "../../node_modules/@types/node",
-      "../../node_modules/@types/web3"
     ]
   },
   "include": [


### PR DESCRIPTION
While working on hdwallet-provider I notices that the web3 types are not necessary in this package. This PR removes them from hdwallet-provider.