### PR TITLE
Use @truffle/supplier to rewrite @truffle/compile-solidity's CompilerSupplier

### DIFF
--- a/packages/compile-solidity/package.json
+++ b/packages/compile-solidity/package.json
@@ -23,6 +23,7 @@
     "@truffle/config": "^1.3.4",
     "@truffle/contract-sources": "^0.1.12",
     "@truffle/expect": "^0.0.18",
+    "@truffle/supplier": "^0.1.0-0",
     "axios": "^0.21.1",
     "axios-retry": "^3.1.9",
     "debug": "^4.3.1",
@@ -34,7 +35,8 @@
     "original-require": "^1.0.1",
     "require-from-string": "^2.0.2",
     "semver": "^7.3.4",
-    "solc": "0.6.9"
+    "solc": "0.6.9",
+    "ts-mixer": "^6.0.0"
   },
   "devDependencies": {
     "@truffle/artifactor": "^4.0.118",

--- a/packages/compile-solidity/src/compileWithPragmaAnalysis.js
+++ b/packages/compile-solidity/src/compileWithPragmaAnalysis.js
@@ -1,4 +1,4 @@
-const { CompilerSupplier } = require("./compilerSupplier");
+const { createCompilerSupplier } = require("./compilerSupplier");
 const Config = require("@truffle/config");
 const semver = require("semver");
 const Profiler = require("./profiler");
@@ -72,10 +72,11 @@ const compileWithPragmaAnalysis = async ({ paths, options }) => {
     events: options.events,
     solcConfig: {
       ...options.compilers.solc,
+      version: undefined,
       docker: false
     }
   };
-  const compilerSupplier = new CompilerSupplier(supplierOptions);
+  const compilerSupplier = createCompilerSupplier(supplierOptions);
   const { releases } = await compilerSupplier.list();
 
   // collect sources by the version of the Solidity compiler that they require

--- a/packages/compile-solidity/src/compilerSupplier/Cache.ts
+++ b/packages/compile-solidity/src/compilerSupplier/Cache.ts
@@ -34,4 +34,12 @@ export class Cache {
   resolve(fileName) {
     return path.resolve(this.compilerCachePath, fileName);
   }
-};
+}
+
+export class HasCache {
+  protected cache: Cache;
+
+  constructor() {
+    this.cache = new Cache();
+  }
+}

--- a/packages/compile-solidity/src/compilerSupplier/defaults.ts
+++ b/packages/compile-solidity/src/compilerSupplier/defaults.ts
@@ -1,0 +1,1 @@
+export const solcVersion = "0.5.16";

--- a/packages/compile-solidity/src/compilerSupplier/index.ts
+++ b/packages/compile-solidity/src/compilerSupplier/index.ts
@@ -32,18 +32,28 @@ export const createCompilerSupplier = forDefinition<
       solcConfig: { docker = false, version }
     } = options;
 
+    // docker case: simple flag
     if (docker) {
       return "docker";
     }
 
+    // native case: version passed as string literal `"native"`
     if (version === "native") {
       return "native";
     }
 
-    if (version && fileExists(version)) {
+    // local soljson case: version is arguably a path
+    if (version && (
+      // an absolute path is definitely a path
+      path.isAbsolute(version) ||
+      // interpret version string as path if its point to real file on disk
+      fs.existsSync(version)
+    )) {
       return "local";
     }
 
+    // remote soljson case: version is unspecified or conforms to semver
+    // (default case)
     if (!version || semver.validRange(version)) {
       return "version-range";
     }
@@ -65,7 +75,3 @@ export const createCompilerSupplier = forDefinition<
     "version-range": VersionRange
   }
 });
-
-function fileExists(localPath) {
-  return fs.existsSync(localPath) || path.isAbsolute(localPath);
-}

--- a/packages/compile-solidity/src/compilerSupplier/index.ts
+++ b/packages/compile-solidity/src/compilerSupplier/index.ts
@@ -3,7 +3,7 @@ import fs from "fs";
 import semver from "semver";
 
 import type { Results } from "./types";
-import { forDefinition } from "@truffle/supplier";
+import { Supplier, forDefinition } from "@truffle/supplier";
 import { Docker, Local, Native, VersionRange } from "./loadingStrategies";
 
 export namespace CompilerSupplier {
@@ -23,6 +23,12 @@ export namespace CompilerSupplier {
     };
   };
 }
+
+export type CreateCompilerSupplierOptions =
+  Supplier.Options<
+    CompilerSupplier.Specification,
+    Supplier.StrategyName<CompilerSupplier.Specification>
+  >;
 
 export const createCompilerSupplier = forDefinition<
   CompilerSupplier.Specification
@@ -58,14 +64,7 @@ export const createCompilerSupplier = forDefinition<
       return "version-range";
     }
 
-    const message =
-      `Could not find a compiler version matching ${version}. ` +
-      `compilers.solc.version option must be a string specifying:\n` +
-      `   - a path to a locally installed solcjs\n` +
-      `   - a solc version or range (ex: '0.4.22' or '^0.5.0')\n` +
-      `   - a docker image name (ex: 'stable')\n` +
-      `   - 'native' to use natively installed solc\n`;
-    throw new Error(message);
+    throw new UnknownStrategyError(options);
   },
 
   strategyConstructors: {
@@ -75,3 +74,22 @@ export const createCompilerSupplier = forDefinition<
     "version-range": VersionRange
   }
 });
+
+export class UnknownStrategyError extends Error {
+  constructor(options: CreateCompilerSupplierOptions) {
+    const {
+      solcConfig: {
+        version
+      }
+    } = options;
+
+    super(
+      `Could not find a compiler version matching ${version}. ` +
+      `compilers.solc.version option must be a string specifying:\n` +
+      `   - a path to a locally installed solcjs\n` +
+      `   - a solc version or range (ex: '0.4.22' or '^0.5.0')\n` +
+      `   - a docker image name (ex: 'stable')\n` +
+      `   - 'native' to use natively installed solc\n`
+    );
+  }
+}

--- a/packages/compile-solidity/src/compilerSupplier/rangeUtils.ts
+++ b/packages/compile-solidity/src/compilerSupplier/rangeUtils.ts
@@ -2,23 +2,23 @@ import path from "path";
 import fs from "fs-extra";
 import semver from "semver";
 import { Native, Local } from "./loadingStrategies";
-import { CompilerSupplier } from "./index";
+import * as defaults from "./defaults";
 
 /**
  * takes a version string which may be native or local, and resolves
  * it to one which is (presumably) either a version or a version range
  */
-export function resolveToRange(version?: string): string {
+export async function resolveToRange(version?: string): Promise<string> {
   if (!version) {
-    return CompilerSupplier.getDefaultVersion();
+    return defaults.solcVersion;
   }
 
   //if version was native or local, must determine what version that
   //actually corresponds to
   if (version === "native") {
-    return new Native().load().version();
+    return (await new Native().load()).solc.version();
   } else if (fs.existsSync(version) && path.isAbsolute(version)) {
-    return new Local().load(version).version();
+    return (await new Local().load(version)).solc.version();
   }
   return version;
 }

--- a/packages/compile-solidity/src/compilerSupplier/types.ts
+++ b/packages/compile-solidity/src/compilerSupplier/types.ts
@@ -1,0 +1,15 @@
+export namespace Results {
+  export type Specification = {
+    load: Promise<{
+      solc: {
+        compile(...args: any[]): any;
+        version(): string;
+      };
+    }>;
+    list: Promise<{
+      latestRelease: string | undefined;
+      releases: AsyncIterableIterator<string> | string[];
+      prereleases: AsyncIterableIterator<string> | string[];
+    }>;
+  };
+}

--- a/packages/compile-solidity/src/index.js
+++ b/packages/compile-solidity/src/index.js
@@ -2,7 +2,7 @@ const debug = require("debug")("compile");
 const findContracts = require("@truffle/contract-sources");
 const Config = require("@truffle/config");
 const Profiler = require("./profiler");
-const { CompilerSupplier } = require("./compilerSupplier");
+const { createCompilerSupplier } = require("./compilerSupplier");
 const { run } = require("./run");
 const { normalizeOptions } = require("./normalizeOptions");
 const { compileWithPragmaAnalysis } = require("./compileWithPragmaAnalysis");
@@ -170,5 +170,5 @@ const Compile = {
 
 module.exports = {
   Compile,
-  CompilerSupplier
+  createCompilerSupplier
 };

--- a/packages/compile-solidity/src/profiler/loadParser.js
+++ b/packages/compile-solidity/src/profiler/loadParser.js
@@ -1,4 +1,4 @@
-const { CompilerSupplier } = require("../compilerSupplier");
+const { createCompilerSupplier } = require("../compilerSupplier");
 const Parser = require("../parser");
 const semver = require("semver");
 
@@ -16,7 +16,7 @@ const semver = require("semver");
 async function loadParser({ events, compilers: { solc: solcConfig } }) {
   const { parser } = solcConfig;
 
-  const supplier = new CompilerSupplier({ events, solcConfig });
+  const supplier = createCompilerSupplier({ events, solcConfig });
   const { solc } = await supplier.load();
 
   // if no parser is specified, just use the normal solc
@@ -33,7 +33,7 @@ async function loadParser({ events, compilers: { solc: solcConfig } }) {
 
   // determine normal solc version and then load that version as solcjs
   const { version } = semver.coerce(solc.version());
-  const parserSupplier = new CompilerSupplier({
+  const parserSupplier = createCompilerSupplier({
     events,
     solcConfig: {
       ...solcConfig,

--- a/packages/compile-solidity/src/run.js
+++ b/packages/compile-solidity/src/run.js
@@ -2,7 +2,7 @@ const debug = require("debug")("compile:run");
 const OS = require("os");
 const semver = require("semver");
 const Common = require("@truffle/compile-common");
-const { CompilerSupplier } = require("./compilerSupplier");
+const { createCompilerSupplier } = require("./compilerSupplier");
 
 // this function returns a Compilation - legacy/index.js and ./index.js
 // both check to make sure rawSources exist before calling this method
@@ -221,7 +221,7 @@ async function invokeCompiler({ compilerInput, options }) {
     events: options.events,
     solcConfig: options.compilers.solc
   };
-  const supplier = new CompilerSupplier(supplierOptions);
+  const supplier = createCompilerSupplier(supplierOptions);
   const { solc } = await supplier.load();
   const solcVersion = solc.version();
 

--- a/packages/compile-solidity/test/compileWithPragmaAnalysis.js
+++ b/packages/compile-solidity/test/compileWithPragmaAnalysis.js
@@ -1,8 +1,8 @@
 const assert = require("assert");
 const Config = require("@truffle/config");
-const {CompilerSupplier} = require("../dist/index");
 const Resolver = require("@truffle/resolver");
 const sinon = require("sinon");
+const { VersionRange } = require("../dist/compilerSupplier/loadingStrategies");
 const {compileWithPragmaAnalysis} = require("../dist/compileWithPragmaAnalysis");
 const path = require("path");
 let paths = [];
@@ -74,10 +74,10 @@ config.resolver = new Resolver(config);
 
 describe("compileWithPragmaAnalysis", function () {
   before(function () {
-    sinon.stub(CompilerSupplier.prototype, "list").returns(releases);
+    sinon.stub(VersionRange.prototype, "list").returns(Promise.resolve(releases));
   });
   after(function () {
-    CompilerSupplier.prototype.list.restore();
+    VersionRange.prototype.list.restore();
   });
 
   describe("solidity files with no imports", function () {

--- a/packages/compile-solidity/test/test_metadata.js
+++ b/packages/compile-solidity/test/test_metadata.js
@@ -2,7 +2,7 @@ const debug = require("debug")("compile:test:test_metadata");
 const fs = require("fs");
 const path = require("path");
 const { Compile } = require("@truffle/compile-solidity");
-const { CompilerSupplier } = require("../dist/compilerSupplier");
+const { createCompilerSupplier } = require("../dist/compilerSupplier");
 const assert = require("assert");
 const { findOne } = require("./helpers");
 const workingDirectory = "/home/fakename/truffleproject";
@@ -36,7 +36,7 @@ describe("Compile - solidity ^0.4.0", function () {
   before("get solc", async function () {
     this.timeout(40000);
 
-    const supplier = new CompilerSupplier(supplierOptions);
+    const supplier = createCompilerSupplier(supplierOptions);
     ({ solc } = await supplier.load());
   });
 

--- a/packages/compile-solidity/test/test_ordering.js
+++ b/packages/compile-solidity/test/test_ordering.js
@@ -2,7 +2,7 @@ const debug = require("debug")("compile:test:test_ordering");
 const fs = require("fs");
 const path = require("path");
 const { Compile } = require("@truffle/compile-solidity");
-const { CompilerSupplier } = require("../dist/compilerSupplier");
+const { createCompilerSupplier } = require("../dist/compilerSupplier");
 const assert = require("assert");
 const { findOne } = require("./helpers");
 let compileOptions = {
@@ -53,7 +53,7 @@ describe("Compile - solidity ^0.4.0", function () {
   before("get solc", async function () {
     this.timeout(40000);
 
-    const supplier = new CompilerSupplier(supplierOptions);
+    const supplier = createCompilerSupplier(supplierOptions);
     ({ solc } = await supplier.load());
   });
 

--- a/packages/compile-solidity/test/test_parser.js
+++ b/packages/compile-solidity/test/test_parser.js
@@ -1,7 +1,7 @@
 const fs = require("fs");
 const path = require("path");
 const Parser = require("../dist/parser");
-const { CompilerSupplier } = require("../dist/compilerSupplier");
+const { createCompilerSupplier } = require("../dist/compilerSupplier");
 const assert = require("assert");
 
 describe("Parser", () => {
@@ -26,10 +26,10 @@ describe("Parser", () => {
     );
 
     supplierOptions = {
-      solcConfig: { version: null },
+      solcConfig: { },
       events: { emit: () => {} }
     };
-    const supplier = new CompilerSupplier(supplierOptions);
+    const supplier = createCompilerSupplier(supplierOptions);
     ({ solc } = await supplier.load());
   });
 
@@ -48,7 +48,7 @@ describe("Parser", () => {
       events: { emit: () => {} },
       solcConfig: { version: "native" }
     };
-    const nativeSupplier = new CompilerSupplier(options);
+    const nativeSupplier = createCompilerSupplier(options);
 
     nativeSupplier.load().then(({ solc }) => {
       const imports = Parser.parseImports(source, solc);
@@ -68,7 +68,7 @@ describe("Parser", () => {
         version: "0.4.25"
       }
     };
-    const dockerSupplier = new CompilerSupplier(options);
+    const dockerSupplier = createCompilerSupplier(options);
 
     dockerSupplier.load().then(({ solc }) => {
       const imports = Parser.parseImports(source, solc);

--- a/packages/compile-solidity/test/test_supplier.js
+++ b/packages/compile-solidity/test/test_supplier.js
@@ -288,30 +288,6 @@ describe("CompilerSupplier", function () {
         );
       });
 
-      it("errors if running dockerized solc without specifying an image", async function () {
-        options.compilers = {
-          solc: {
-            version: undefined,
-            docker: true,
-            settings: {}
-          }
-        };
-        compileConfig = Config.default().merge(options);
-
-        let error;
-        try {
-          await Compile.sources({
-            sources: version4PragmaSource,
-            options: compileConfig
-          });
-        } catch (err) {
-          error = err;
-        }
-
-        assert(error);
-        assert(error.message.includes("option must be"));
-      });
-
       it("errors if running dockerized solc when image does not exist locally", async function () {
         const imageName = "fantasySolc.7777555";
 

--- a/packages/core/lib/commands/compile.js
+++ b/packages/core/lib/commands/compile.js
@@ -96,10 +96,10 @@ const command = {
   },
 
   listVersions: async function (options) {
-    const { CompilerSupplier } = require("@truffle/compile-solidity");
+    const { createCompilerSupplier } = require("@truffle/compile-solidity");
     const { asyncTake } = require("iter-tools");
 
-    const supplier = new CompilerSupplier({
+    const supplier = createCompilerSupplier({
       solcConfig: {
         ...options.compilers.solc,
         // HACK to force use of the VersionRange or Docker strategy

--- a/packages/core/lib/commands/compile.js
+++ b/packages/core/lib/commands/compile.js
@@ -102,10 +102,10 @@ const command = {
     const supplier = createCompilerSupplier({
       solcConfig: {
         ...options.compilers.solc,
-        // HACK to force use of the VersionRange or Docker strategy
-        // as implemented, Docker requires a version to be specified, and so
-        // we can't simply remove this field entirely.
-        version: "0.5.16",
+        // override+omit version to prevent case where project is configured
+        // to use a path to a local soljson file / case where project is
+        // configured to use a native `solc` bin from the PATH
+        version: undefined,
         docker: options.list === "docker"
       },
       events: options.events

--- a/packages/core/lib/commands/obtain.js
+++ b/packages/core/lib/commands/obtain.js
@@ -32,7 +32,7 @@ module.exports = {
   },
 
   downloadAndCacheSolc: async ({config, options}) => {
-    const { CompilerSupplier } = require("@truffle/compile-solidity");
+    const { createCompilerSupplier } = require("@truffle/compile-solidity");
     const semver = require("semver");
     const { events } = config;
 
@@ -45,7 +45,7 @@ module.exports = {
     }
 
     try {
-      const supplier = new CompilerSupplier({
+      const supplier = createCompilerSupplier({
         events,
         solcConfig: {
           ...config.compilers.solc,

--- a/packages/core/lib/testing/SolidityTest.js
+++ b/packages/core/lib/testing/SolidityTest.js
@@ -108,7 +108,7 @@ const SolidityTest = {
     debug("compiling");
     const config = runner.config;
     let solcVersion = config.compilers.solc.version;
-    solcVersion = RangeUtils.resolveToRange(solcVersion);
+    solcVersion = await RangeUtils.resolveToRange(solcVersion);
 
     const truffleLibraries = [
       "truffle/Assert.sol",

--- a/packages/core/lib/testing/Test.js
+++ b/packages/core/lib/testing/Test.js
@@ -207,7 +207,7 @@ const Test = {
     });
     if (config.compileAllDebug) {
       let versionString = ((compileConfig.compilers || {}).solc || {}).version;
-      versionString = RangeUtils.resolveToRange(versionString);
+      versionString = await RangeUtils.resolveToRange(versionString);
       if (RangeUtils.rangeContainsAtLeast(versionString, "0.6.3")) {
         compileConfig = compileConfig.merge({
           compilers: {

--- a/packages/core/lib/version.js
+++ b/packages/core/lib/version.js
@@ -1,5 +1,5 @@
 const pkg = require("../package.json");
-const { CompilerSupplier } = require("@truffle/compile-solidity");
+const { createCompilerSupplier } = require("@truffle/compile-solidity");
 const Config = require("@truffle/config");
 
 const info = config => {
@@ -18,7 +18,7 @@ const info = config => {
     const solcConfig = compilers.solc;
     supplierOptions = { events, solcConfig };
   }
-  const supplier = new CompilerSupplier(supplierOptions);
+  const supplier = createCompilerSupplier(supplierOptions);
 
   return {
     core: pkg.version,

--- a/packages/core/test/lib/commands/obtain.js
+++ b/packages/core/test/lib/commands/obtain.js
@@ -1,27 +1,25 @@
 const assert = require("chai").assert;
 const command = require("../../../lib/commands/obtain");
 const sinon = require("sinon");
-const CompilerSupplier = require("@truffle/compile-solidity").CompilerSupplier;
+const {
+  VersionRange
+} = require("@truffle/compile-solidity/dist/compilerSupplier/loadingStrategies");
 let options, solc;
 
 describe("obtain", () => {
   describe(".run(options)", function () {
     beforeEach(() => {
-      options = {solc: "0.5.3"};
-      solc = {version: () => "0.5.3"};
-      sinon
-        .stub(CompilerSupplier.prototype, "load")
-        .returns({ solc });
+      options = { solc: "0.5.3" };
+      solc = { version: () => "0.5.3" };
+      sinon.stub(VersionRange.prototype, "load").returns({ solc });
     });
     afterEach(() => {
-      CompilerSupplier.prototype.load.restore();
+      VersionRange.prototype.load.restore();
     });
 
     it("calls supplier.load()", async function () {
       await command.run(options);
-      assert(
-        CompilerSupplier.prototype.load.calledWith()
-      );
+      assert(VersionRange.prototype.load.calledWith());
     });
 
     describe("when options.solc is not present", async function () {
@@ -29,7 +27,7 @@ describe("obtain", () => {
         options.solc = undefined;
       });
 
-      it("throws an error", async function() {
+      it("throws an error", async function () {
         try {
           await command.run(options);
           assert.fail("The run command should have failed");

--- a/packages/resolver/lib/sources/truffle/Deployed.ts
+++ b/packages/resolver/lib/sources/truffle/Deployed.ts
@@ -7,10 +7,10 @@ type solcOptionsArg = {
 };
 
 export class Deployed {
-  static makeSolidityDeployedAddressesLibrary(
+  static async makeSolidityDeployedAddressesLibrary(
     mapping: { [key: string]: string | false },
     { solc: { version } }: solcOptionsArg
-  ): string {
+  ): Promise<string> {
     let source = "";
     source +=
       "//SPDX-License-Identifier: MIT\n" +
@@ -37,7 +37,7 @@ export class Deployed {
 
     source += "}";
 
-    version = RangeUtils.resolveToRange(version);
+    version = await RangeUtils.resolveToRange(version);
     if (!RangeUtils.rangeContainsAtLeast(version, "0.5.0")) {
       //remove "payable"s in types if we're before 0.5.0
       source = source.replace(/address payable/g, "address");

--- a/packages/resolver/lib/sources/truffle/index.ts
+++ b/packages/resolver/lib/sources/truffle/index.ts
@@ -63,7 +63,7 @@ export class Truffle implements ResolverSource {
         mapping[name] = address;
       });
 
-      const addressSource = Deployed.makeSolidityDeployedAddressesLibrary(
+      const addressSource = await Deployed.makeSolidityDeployedAddressesLibrary(
         mapping,
         this.options.compilers
       );


### PR DESCRIPTION
Follows from #4223 (for TS support in @truffle/compile-solidity) and #4224 (for @truffle/supplier)

This PR removes the `CompilerSupplier` class defined in @truffle/compile-solidity and replaces it with a `createCompilerSupplier` function, built via the mechanisms provided by #4224. This new function behaves largely the same as the prior class constructor.

Some notable changes here:
- Docker no longer requires a version upfront; if you don't specify a version but you specify `docker: true`, then it'll use the default solc verson (same as how VersionRange works)
- RangeUtils relies on the common interface for `list()`, which returns a promise, so `resolveToRange()` now is `async`.
- I've added `allowsLoadingSpecificVersion()` and `allowsListingVersions()` type guards to each of the loading strategies
- Each of the loading strategies now returns `{ solc }` instead of `solc`. **(Should we change this to remove the extra wrapping?)**
