### PR TITLE
Add commented storage options for @truffle/db

### DIFF
--- a/packages/core/lib/commands/init/initSource/truffle-config.js
+++ b/packages/core/lib/commands/init/initSource/truffle-config.js
@@ -94,7 +94,7 @@ module.exports = {
   },
 
   // Truffle DB is currently disabled by default; to enable it, change enabled:
-  // false to enabled: true, the default storage location can also be
+  // false to enabled: true. The default storage location can also be
   // overridden by specifying the adapter settings.
   //
   // Note: your previously migrated contracts will not be available in

--- a/packages/core/lib/commands/init/initSource/truffle-config.js
+++ b/packages/core/lib/commands/init/initSource/truffle-config.js
@@ -99,7 +99,7 @@ module.exports = {
   //
   // Note: your previously migrated contracts will not be available in
   // truffle-db. We recommnd you backup your artifacts before utilizing Truffle
-  // DB the first time with:
+  // DB for the first time with:
   // $ truffle migrate --reset --compile-all
 
   db: {

--- a/packages/core/lib/commands/init/initSource/truffle-config.js
+++ b/packages/core/lib/commands/init/initSource/truffle-config.js
@@ -104,7 +104,7 @@ module.exports = {
 
   db: {
     enabled: false
-    //, adapter: {
+    // adapter: {
     //   name: "sqlite",
     //   settings: {
     //     directory: ".truffle-db"

--- a/packages/core/lib/commands/init/initSource/truffle-config.js
+++ b/packages/core/lib/commands/init/initSource/truffle-config.js
@@ -95,7 +95,7 @@ module.exports = {
 
   // Truffle DB is currently disabled by default; to enable it, change enabled:
   // false to enabled: true. The default storage location can also be
-  // overridden by specifying the adapter settings.
+  // overridden by specifying the adapter settings, as shown in the commented code below.
   //
   // Note: your previously migrated contracts will not be available in
   // truffle-db. We recommnd you backup your artifacts before utilizing Truffle

--- a/packages/core/lib/commands/init/initSource/truffle-config.js
+++ b/packages/core/lib/commands/init/initSource/truffle-config.js
@@ -97,8 +97,9 @@ module.exports = {
   // false to enabled: true, the default storage location can also be
   // overridden by specifying the adapter settings.
   //
-  // Note: if you migrated your contracts prior to enabling this field in your Truffle project and want
-  // those previously migrated contracts available in the .db directory, you will need to run the following:
+  // Note: your previously migrated contracts will not be available in
+  // truffle-db. We recommnd you backup your artifacts before utilizing Truffle
+  // DB the first time with:
   // $ truffle migrate --reset --compile-all
 
   db: {

--- a/packages/core/lib/commands/init/initSource/truffle-config.js
+++ b/packages/core/lib/commands/init/initSource/truffle-config.js
@@ -103,7 +103,7 @@ module.exports = {
   // $ truffle migrate --reset --compile-all
 
   db: {
-    enabled: false
+    enabled: false,
     // adapter: {
     //   name: "sqlite",
     //   settings: {

--- a/packages/core/lib/commands/init/initSource/truffle-config.js
+++ b/packages/core/lib/commands/init/initSource/truffle-config.js
@@ -97,9 +97,10 @@ module.exports = {
   // false to enabled: true. The default storage location can also be
   // overridden by specifying the adapter settings, as shown in the commented code below.
   //
-  // Note: your previously migrated contracts will not be available in
-  // truffle-db. We recommnd you backup your artifacts before utilizing Truffle
-  // DB for the first time with:
+  // NOTE: It is not possible to migrate your contracts to truffle DB and you should
+  // make a backup of your artifacts to a safe location before enabling this feature.
+  //
+  // After you backed up your artifacts you can utilize db by running migrate as follows: 
   // $ truffle migrate --reset --compile-all
 
   db: {

--- a/packages/core/lib/commands/init/initSource/truffle-config.js
+++ b/packages/core/lib/commands/init/initSource/truffle-config.js
@@ -93,7 +93,9 @@ module.exports = {
     }
   },
 
-  // Truffle DB is currently disabled by default; to enable it, change enabled: false to enabled: true
+  // Truffle DB is currently disabled by default; to enable it, change enabled:
+  // false to enabled: true, the default storage location can also be
+  // overridden by specifying the adapter settings.
   //
   // Note: if you migrated your contracts prior to enabling this field in your Truffle project and want
   // those previously migrated contracts available in the .db directory, you will need to run the following:
@@ -101,5 +103,11 @@ module.exports = {
 
   db: {
     enabled: false
+    //, adapter: {
+    //   name: "sqlite",
+    //   settings: {
+    //     directory: ".truffle-db"
+    //   }
+    // }
   }
 };

--- a/packages/core/lib/commands/init/initSource/truffle-config.js
+++ b/packages/core/lib/commands/init/initSource/truffle-config.js
@@ -102,14 +102,15 @@ module.exports = {
   //
   // After you backed up your artifacts you can utilize db by running migrate as follows: 
   // $ truffle migrate --reset --compile-all
-
-  db: {
-    enabled: false,
+  //
+  // db: {
+    // enabled: false,
+    // host: "127.0.0.1",
     // adapter: {
     //   name: "sqlite",
     //   settings: {
     //     directory: ".truffle-db"
     //   }
     // }
-  }
+  // }
 };


### PR DESCRIPTION
This PR adds commented db settings to `truffle-config.js` so that a developer can quickly enable and configure local db storage.