### PR TITLE
Internal improvement: Add missing typescript devDependency

### DIFF
--- a/packages/fetch-and-compile/package.json
+++ b/packages/fetch-and-compile/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@truffle/compile-common": "^0.7.14",
-    "@truffle/config": "^1.3.2"
+    "@truffle/config": "^1.3.2",
+    "typescript": "^4.1.4"
   }
 }


### PR DESCRIPTION
The `fetch-and-compile` package uses Typescript, but we forgot to include it as a devDependency!  This PR adds it.