### PR TITLE
Update highlightjs-solidity to 1.2.1

### DIFF
--- a/packages/debug-utils/package.json
+++ b/packages/debug-utils/package.json
@@ -23,7 +23,7 @@
     "bn.js": "^5.1.3",
     "chalk": "^2.4.2",
     "debug": "^4.3.1",
-    "highlightjs-solidity": "^1.2.0"
+    "highlightjs-solidity": "^1.2.1"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14433,10 +14433,10 @@ highlight.js@^10.4.1:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.4.1.tgz#d48fbcf4a9971c4361b3f95f302747afe19dbad0"
   integrity sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg==
 
-highlightjs-solidity@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/highlightjs-solidity/-/highlightjs-solidity-1.2.0.tgz#742ac2eacbd0f1d4aacea39704e58b76b4eb12e3"
-  integrity sha512-KXYcVzBRof3CBWHsxGffsSEAJF0YsPaOk1jgIYv2xSzrBSxkfNUJFXrlE2oZEWvYQKbPqLe4qprJyNbSDV+LZA==
+highlightjs-solidity@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/highlightjs-solidity/-/highlightjs-solidity-1.2.1.tgz#61de8c33a8fbb12b31244a4fb76a195ef3df2cf0"
+  integrity sha512-zHs/nxHt6Se59xvEHHDoBC1R2zAIStIFxJHRvnqjH7vRRoW2E6GKZ68mUqaDSOQkG79b3rN6E0i/923ij1183Q==
 
 hkts@^0.3.1:
   version "0.3.1"


### PR DESCRIPTION
Addresses #4235.

Updates highlightjs-solidity to a version that includes [this](https://github.com/highlightjs/highlightjs-solidity/pull/51) PR.  So, we'll fix highlighting problems, at the expense of no longer having punctuation highlighting.