### PR TITLE
Fix/console globals

### DIFF
--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -61,22 +61,31 @@ class Console extends EventEmitter {
 
   async start() {
     try {
-      // we calculate the context before calling `start`  so that the context
-      // variables are available as early as possible after the repl starts
-      const context = { ...(await this.calculateTruffleAndUserGlobals()) };
-      // we set up this.repl here because `this.provision` sets values on
-      // this.repl.context - this will finish setting up the environment
-      this.repl = { context };
-      // this hydrates the environment with the user's contracts
-      this.provision();
-
+      // start the repl with an empty prompt and show a proper one when
+      // the repl has set up its context and is ready to accept input
       this.repl = repl.start({
-        prompt: "truffle(" + this.options.network + ")> ",
+        prompt: "",
+        ignoreUndefined: true,
         eval: this.interpret.bind(this)
       });
-      this.repl.context = context;
 
-      //want repl to exit when it receives an exit command
+      // Get and set Truffle and User Globals
+      const truffleAndUserGlobals = await this.calculateTruffleAndUserGlobals() ;
+      Object.entries(truffleAndUserGlobals).forEach(([key, value]) => {
+        Object.defineProperty(this.repl.context, key, {
+          configurable: false,
+          enumerable: true,
+          value,
+        });
+      });
+
+      // repl is ready - set and display prompt
+      this.repl.setPrompt("truffle(" + this.options.network + ")> ");
+      this.repl.displayPrompt();
+
+      // hydrate the environment with the user's contracts
+      this.provision();
+
       this.repl.on("exit", () => {
         process.exit();
       });

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -71,11 +71,7 @@ class Console extends EventEmitter {
       // Get and set Truffle and User Globals
       const truffleAndUserGlobals = await this.calculateTruffleAndUserGlobals() ;
       Object.entries(truffleAndUserGlobals).forEach(([key, value]) => {
-        Object.defineProperty(this.repl.context, key, {
-          configurable: false,
-          enumerable: true,
-          value,
-        });
+        this.repl.context[key] = value;
       });
 
       // repl is ready - set and display prompt

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -65,7 +65,6 @@ class Console extends EventEmitter {
       // the repl has set up its context and is ready to accept input
       this.repl = repl.start({
         prompt: "",
-        ignoreUndefined: true,
         eval: this.interpret.bind(this)
       });
 

--- a/packages/truffle/test/scenarios/commands/develop.js
+++ b/packages/truffle/test/scenarios/commands/develop.js
@@ -38,8 +38,7 @@ describe("truffle develop", function () {
 
     [
       'clearInterval',      'clearTimeout',       
-      'setInterval',
-      'setTimeout',         'queueMicrotask',
+      'setInterval',        'setTimeout',
       'clearImmediate',     'setImmediate',
       '__core-js_shared__', 'regeneratorRuntime',
     ].forEach(property => {

--- a/packages/truffle/test/scenarios/commands/develop.js
+++ b/packages/truffle/test/scenarios/commands/develop.js
@@ -43,6 +43,7 @@ describe("truffle develop", function () {
       '__core-js_shared__', 'regeneratorRuntime',
     ].forEach(property => {
       it(`has ${property}`, function () {
+        this.timeout(70000);
         assert(
           output.includes(property),
           `${property} is missing from globals.\n${formatLines(output)}`

--- a/packages/truffle/test/scenarios/commands/develop.js
+++ b/packages/truffle/test/scenarios/commands/develop.js
@@ -28,6 +28,42 @@ describe("truffle develop", function () {
     };
   });
 
+  describe("Globals", () => {
+    let output;
+    before(async() => {
+      const input = "Object.keys(global)";
+      await CommandRunner.runInDevelopEnvironment([input], config);
+      output = logger.contents();
+    });
+
+    [
+      'clearInterval',      'clearTimeout',       
+      'setInterval',
+      'setTimeout',         'queueMicrotask',
+      'clearImmediate',     'setImmediate',
+      '__core-js_shared__', 'regeneratorRuntime',
+    ].forEach(property => {
+      it(`has ${property}`, function () {
+        assert(
+          output.includes(property),
+          `${property} is missing from globals.\n${formatLines(output)}`
+        );
+      });
+    });
+  })
+
+  it("handles awaits", async function () {
+    this.timeout(70000);
+    const input = "await Promise.resolve(`${6*7} is probably not a prime`)";
+    await CommandRunner.runInDevelopEnvironment([input], config);
+    const output = logger.contents();
+    const expectedValue = "42 is probably not a prime";
+    assert(
+      output.includes(expectedValue),
+      `Expected "${expectedValue}" in output:\n${formatLines(output)}`
+    );
+  });
+
   it("loads snippets", async function () {
     this.timeout(70000);
     await CommandRunner.runInDevelopEnvironment(["breakfast"], config);

--- a/packages/truffle/test/scenarios/commands/develop.js
+++ b/packages/truffle/test/scenarios/commands/develop.js
@@ -8,6 +8,13 @@ const sandbox = require("../sandbox");
 const logger = new MemoryLogger();
 let config, project;
 
+//prepare a helpful message to standout in CI log noise
+const formatLines = lines =>
+  lines
+    .split("\n")
+    .map(line => `\t---truffle develop log---\t${line}`)
+    .join("\n");
+
 describe("truffle develop", function () {
   project = path.join(__dirname, "../../sources/develop");
 
@@ -23,16 +30,8 @@ describe("truffle develop", function () {
 
   it("loads snippets", async function () {
     this.timeout(70000);
-
     await CommandRunner.runInDevelopEnvironment(["breakfast"], config);
     const output = logger.contents();
-
-    //prepare a helpful message to standout in CI log noise
-    const formatLines = lines =>
-      lines
-        .split("\n")
-        .map(line => `\t---truffle develop log---\t${line}`)
-        .join("\n");
     const expectedValue = "eggs and sausage, and a side of toast";
     assert(
       output.includes(expectedValue),
@@ -46,12 +45,6 @@ describe("truffle develop", function () {
     await CommandRunner.runInDevelopEnvironment(["twoAccounts"], config);
     const output = logger.contents();
 
-    //prepare a helpful message to standout in CI log noise
-    const formatLines = lines =>
-      lines
-        .split("\n")
-        .map(line => `\t---truffle develop log---\t${line}`)
-        .join("\n");
     // `twoAccounts` is the concatenation of the first 2 accounts in `accounts`
     // this matches two concatenated accounts
     const addressesRegex = new RegExp(/(0x[0-9a-f]{40}){2}/, "gi");


### PR DESCRIPTION
This PR
  - changes how the REPL context is instantiated and. 
  - removes annoying `undefined` from REPL output. (See [docs](https://nodejs.org/dist/latest-v14.x/docs/api/repl.html#repl_repl_start_options))
  - adds tests using the new framework @eggplantzzz introduced.
  - should resolve 
    - #4238 
    - #4239 

This is necessary to capture the globals that the REPL includes in the context, which needed for a good user experience. Being able to `console.log` contributes to good experience.

The motivation for the previous change was to allow the truffle context variables to be hydrated before processing user input which is needed for our tests.  This PR still allows for that by coordinating when to send the input from tests. The sequence of events is as follows:

Child Process:
  1. REPL starts with nodes context and prompt = ''
  1. REPL loads truffle specific variables into context
  1. REPL sets the prompt to '(develop)>'

Test runner:
  1. Scans child's sdtout looking for '(develop)>' before sending input