### PR TITLE
Bug fix: Fix incorrect variable name

### DIFF
--- a/packages/core/lib/commands/init/copyFiles.js
+++ b/packages/core/lib/commands/init/copyFiles.js
@@ -19,7 +19,7 @@ const copyFiles = async (destination, options) => {
 
   let shouldCopy;
   if (force) {
-    shouldCopy = boxContents;
+    shouldCopy = projectFiles;
   } else {
     const overwriteContents = await promptOverwrites(contentCollisions, logger);
     shouldCopy = [...newContents, ...overwriteContents];


### PR DESCRIPTION
This file refers to `boxContents`, but no such variable exists.  It looks like `projectFiles` was meant.