### PR TITLE
Internal improvement: Use `async-retry` in source-fetcher for retry logic

### DIFF
--- a/packages/source-fetcher/package.json
+++ b/packages/source-fetcher/package.json
@@ -26,11 +26,13 @@
   },
   "types": "dist/index.d.ts",
   "dependencies": {
+    "async-retry": "^1.3.1",
     "axios": "^0.21.1",
     "debug": "^4.3.1",
     "web3-utils": "1.5.1"
   },
   "devDependencies": {
+    "@types/async-retry": "^1.4.3",
     "@types/debug": "^4.1.5",
     "@types/node": "^15.0.1",
     "typescript": "^4.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3845,6 +3845,13 @@
   resolved "https://registry.yarnpkg.com/@types/assert/-/assert-1.4.3.tgz#c3b68c062a2375647d1b9efc41e57f8286bb30fe"
   integrity sha512-491hfOvNr0+BGOHT2m36xJ+LK68IuOshvxV0VIrKOnzBDL11WlDa3PwO+drTYkwCdfzJRN9REcDPZVVcrx1ucw==
 
+"@types/async-retry@^1.4.3":
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/@types/async-retry/-/async-retry-1.4.3.tgz#8b78f6ce88d97e568961732cdd9e5325cdc8c246"
+  integrity sha512-B3C9QmmNULVPL2uSJQ088eGWTNPIeUk35hca6CV8rRDJ8GXuQJP5CCVWA1ZUCrb9xYP7Js/RkLqnNNwKhe+Zsw==
+  dependencies:
+    "@types/retry" "*"
+
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.10"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.10.tgz#ca58fc195dd9734e77e57c6f2df565623636ab40"
@@ -4651,6 +4658,11 @@
   dependencies:
     "@types/node" "*"
     safe-buffer "*"
+
+"@types/retry@*":
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.1.tgz#d8f1c0d0dc23afad6dc16a9e993a0865774b4065"
+  integrity sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==
 
 "@types/retry@^0.12.0":
   version "0.12.0"
@@ -6272,7 +6284,7 @@ async-limiter@^1.0.0, async-limiter@~1.0.0:
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
-async-retry@^1.2.1:
+async-retry@^1.2.1, async-retry@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.3.1.tgz#139f31f8ddce50c0870b0ba558a6079684aaed55"
   integrity sha512-aiieFW/7h3hY0Bq5d+ktDBejxuwR78vRu9hDUdR8rNhSaQ29VzPL4AoIRG7D/c7tdenwOcKvgPM6tIxB3cB6HA==


### PR DESCRIPTION
Addresses #4231.

This PR makes it so that we use an external package, namely, `async-retry`, for the retry logic in source-fetcher, rather than rolling our own.  Whereas our retry logic was "just try it twice than give up", async-retry lets us do exponential backoff.

This is mostly pretty straightforward, but, some notes on this:
1. I went with 3 retries.  I think that means 3 retries past the initial one?
2. In the Etherscan fetcher, I had to decide on an initial timeout; I went with 1.5 times the timer delay?
3. I also had to decide on one for the Sourcify fetcher... I just left it at its default of 1 second.
4. In the Etherscan fetcher, I moved the wait/set timer logic from `getSuccessfulResponse` into `makeRequest`; note that during a retry this logic shouldn't be relevant (because the retry interval should be longer than the timer delay), but whatever.
5. The function passed as the first argument to `retry` optionally takes an argument which is a `bail` function; you can pass an error to this function to throw that error and *not* retry.  This functionality is used in the Sourcify fetcher to handle 404s (since we don't want to retry those).  (There's also an optional second argument, which is the number of retries so far; this functionality wasn't used in either fetcher.)
6. There's still no tests, I tested this manually. :P