### PR TITLE
Mark abi-utils as dependency of codec

### DIFF
--- a/packages/codec/package.json
+++ b/packages/codec/package.json
@@ -25,6 +25,7 @@
   },
   "types": "dist/lib/index.d.ts",
   "dependencies": {
+    "@truffle/abi-utils": "^0.2.3",
     "@truffle/compile-common": "^0.7.15",
     "big.js": "^5.2.2",
     "bn.js": "^5.1.3",
@@ -39,7 +40,6 @@
     "web3-utils": "1.5.1"
   },
   "devDependencies": {
-    "@truffle/abi-utils": "^0.2.3",
     "@truffle/contract-schema": "^3.4.2",
     "@trufflesuite/typedoc-default-themes": "^0.6.1",
     "@types/big.js": "^4.0.5",


### PR DESCRIPTION
Addresses #4251.  Abi-utils was classified as only a devDependency, presumably because that was true at one point, and this never got corrected.  This fixes it.