### PR TITLE
Bug fix: Turn on quiet option in fetch-and-compile

### DIFF
--- a/packages/fetch-and-compile/lib/fetch.ts
+++ b/packages/fetch-and-compile/lib/fetch.ts
@@ -123,7 +123,7 @@ async function tryFetchAndCompileAddress(
     let compileResult: WorkflowCompileResult;
     try {
       compileResult = await Compile.sources({
-        options: externalConfig,
+        options: externalConfig.with({ quiet: true }),
         sources
       });
     } catch (error) {


### PR DESCRIPTION
So, uh, turns out that issue #4237 was never actually a real issue.  Sorry about that.  Actually `quiet` works just fine!

The real issue was that in pulling out `fetch-and-compile` into its own package, the `quiet` option went missing.  This PR adds it back in.

Notionally we could just add it where `fetch-and-compile` is invoked, rather than inside `fetch-and-compile` itself in case people want to occasionally use it non-quiet?  But I figured I'd do it this way for now as this is easier and I can't think of such a use case.