### PR TITLE
Fix/quiet option

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -28,6 +28,7 @@
     "find-up": "^2.1.0",
     "lodash.assignin": "^4.2.0",
     "lodash.merge": "^4.6.2",
+    "lodash.pick": "^4.4.0",
     "module": "^1.2.5",
     "original-require": "^1.0.1"
   },

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -37,6 +37,7 @@
     "@types/find-up": "^2.1.0",
     "@types/lodash.assignin": "^4.2.6",
     "@types/lodash.merge": "^4.6.6",
+    "@types/lodash.pick": "^4.4.6",
     "@types/node": "12.12.21",
     "@types/sinon": "^9.0.10",
     "mocha": "8.1.2",

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -42,7 +42,7 @@ class TruffleConfig {
   }
 
   private eventManagerOptions(
-    options: TruffleConfig | { quiet?: boolean, logger?: any, subscribers?: any[] }
+    options: TruffleConfig | Pick<TruffleConfig, "quiet" | "logger" | "subscribers">
   ): any {
     const optionsWhitelist = ["quiet", "logger", "subscribers"];
     return pick(options, optionsWhitelist);

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -43,7 +43,7 @@ class TruffleConfig {
 
   private eventManagerOptions(
     options: TruffleConfig | Partial<Pick<TruffleConfig, "quiet" | "logger" | "subscribers">>
-  ): any {
+  ): Partial<TruffleConfig> {
     const optionsWhitelist = ["quiet", "logger", "subscribers"];
     return pick(options, optionsWhitelist);
   }

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -40,9 +40,8 @@ class TruffleConfig {
     );
   }
 
-  public eventManagerOptions(config: TruffleConfig): any {
-    let muteLogging;
-    const { quiet, logger, subscribers } = config;
+  public eventManagerOptions(options: any): any {
+    const { quiet, logger, subscribers } = options;
     return { logger, quiet, subscribers };
   }
 
@@ -102,8 +101,12 @@ class TruffleConfig {
     const current = this.normalize(this);
     const normalized = this.normalize(obj);
 
-    let eventsOptions = this.eventManagerOptions(this);
-    this.events.updateSubscriberOptions(eventsOptions);
+    const currentEventsOptions = this.eventManagerOptions(this);
+    const optionsToMerge = this.eventManagerOptions(obj);
+    this.events.updateSubscriberOptions({
+      ...currentEventsOptions,
+      ...optionsToMerge
+    });
 
     return assignIn(
       Object.create(TruffleConfig.prototype),

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -42,8 +42,8 @@ class TruffleConfig {
   }
 
   private eventManagerOptions(
-    options: TruffleConfig | Partial<Pick<TruffleConfig, "quiet" | "logger" | "subscribers">>
-  ): Partial<TruffleConfig> {
+    options: Partial<TruffleConfig>
+  ): Partial<Pick<TruffleConfig, "quiet" | "logger" | "subscribers">> {
     const optionsWhitelist = ["quiet", "logger", "subscribers"];
     return pick(options, optionsWhitelist);
   }

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -42,7 +42,15 @@ class TruffleConfig {
 
   public eventManagerOptions(options: any): any {
     const { quiet, logger, subscribers } = options;
-    return { logger, quiet, subscribers };
+    const eventManagerOptions: any = { quiet, logger, subscribers };
+    // filter undefined values
+    return Object.keys(eventManagerOptions)
+      .reduce((a: any, key: string) => {
+        if (typeof eventManagerOptions[key] !== "undefined") {
+          a[key] = eventManagerOptions[key];
+        }
+        return a;
+      }, {});
   }
 
   public addProp(propertyName: string, descriptor: any): void {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -42,7 +42,7 @@ class TruffleConfig {
   }
 
   private eventManagerOptions(
-    options: TruffleConfig | Pick<TruffleConfig, "quiet" | "logger" | "subscribers">
+    options: TruffleConfig | Partial<Pick<TruffleConfig, "quiet" | "logger" | "subscribers">>
   ): any {
     const optionsWhitelist = ["quiet", "logger", "subscribers"];
     return pick(options, optionsWhitelist);

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -44,7 +44,7 @@ class TruffleConfig {
   private eventManagerOptions(
     options: TruffleConfig | { quiet?: boolean, logger?: any, subscribers?: any[] }
   ): any {
-    const optionsWhitelist = ["quiet", "logger", "subscribers"] as const;
+    const optionsWhitelist = ["quiet", "logger", "subscribers"];
     return pick(options, optionsWhitelist);
   }
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,6 +1,7 @@
 import path from "path";
 import assignIn from "lodash.assignin";
 import merge from "lodash.merge";
+import pick from "lodash.pick";
 import Module from "module";
 import findUp from "find-up";
 import Configstore from "configstore";
@@ -40,17 +41,11 @@ class TruffleConfig {
     );
   }
 
-  public eventManagerOptions(options: any): any {
-    const { quiet, logger, subscribers } = options;
-    const eventManagerOptions: any = { quiet, logger, subscribers };
-    // filter undefined values
-    return Object.keys(eventManagerOptions)
-      .reduce((a: any, key: string) => {
-        if (typeof eventManagerOptions[key] !== "undefined") {
-          a[key] = eventManagerOptions[key];
-        }
-        return a;
-      }, {});
+  private eventManagerOptions(
+    options: TruffleConfig | { quiet?: boolean, logger?: any, subscribers?: any[] }
+  ): any {
+    const optionsWhitelist = ["quiet", "logger", "subscribers"] as const;
+    return pick(options, optionsWhitelist);
   }
 
   public addProp(propertyName: string, descriptor: any): void {

--- a/packages/core/lib/command-options.js
+++ b/packages/core/lib/command-options.js
@@ -8,6 +8,10 @@ const options = {
     option: "--config <file>",
     description:
       "Specify configuration file to be used. The default is truffle-config.js"
+  },
+  quiet: {
+    option: "--quiet",
+    description: "Suppress excess logging output."
   }
 };
  module.exports = options;

--- a/packages/core/lib/commands/compile.js
+++ b/packages/core/lib/commands/compile.js
@@ -39,10 +39,6 @@ const command = {
           "prereleases,\n                    releases, latestRelease or docker."
       },
       {
-        option: "--quiet",
-        description: "Suppress all compilation output."
-      },
-      {
         option: "--compiler <compiler-name>",
         description:
           "Specify a single compiler to use (e.g. `--compiler=solc`). Specify `none` to skip compilation."
@@ -54,7 +50,7 @@ const command = {
           "Save the raw compiler results into <output-file>, overwriting any existing content."
       },
     ],
-    allowedGlobalOptions: ["config"]
+    allowedGlobalOptions: ["config", "quiet"]
   },
   run: async function (options) {
     const TruffleError = require("@truffle/error");

--- a/packages/core/lib/commands/obtain.js
+++ b/packages/core/lib/commands/obtain.js
@@ -9,7 +9,7 @@ module.exports = {
         description: `Download and cache a version of the solc compiler. (required)`
       }
     ],
-    allowedGlobalOptions: []
+    allowedGlobalOptions: ["quiet"]
   },
   run: async function (options) {
     const SUPPORTED_COMPILERS = ["--solc"];

--- a/packages/core/lib/commands/unbox.js
+++ b/packages/core/lib/commands/unbox.js
@@ -35,7 +35,7 @@ const command = {
           "that exist in the directory.",
       },
     ],
-    allowedGlobalOptions: []
+    allowedGlobalOptions: ["quiet"]
   },
   async run(options) {
     const Config = require("@truffle/config");

--- a/packages/events/defaultSubscribers/obtain.js
+++ b/packages/events/defaultSubscribers/obtain.js
@@ -9,12 +9,14 @@ module.exports = {
   handlers: {
     "obtain:start": [
       function() {
+        if (this.quiet) return;
         this.logger.log(`${OS.EOL}Starting obtain...`);
         this.logger.log(`==================${OS.EOL}`);
       }
     ],
     "obtain:succeed": [
       function({ compiler }) {
+        if (this.quiet) return;
         const { name, version } = compiler;
         this.logger.log(
           `    > successfully downloaded and cached version ${version} ` +
@@ -24,6 +26,7 @@ module.exports = {
     ],
     "obtain:fail": [
       function() {
+        if (this.quiet) return;
         if (this.spinner.isSpinning) this.spinner.fail();
         this.logger.log("Unbox failed!");
       }
@@ -31,6 +34,7 @@ module.exports = {
 
     "downloadCompiler:start": [
       function({ attemptNumber }) {
+        if (this.quiet) return;
         this.spinner = this.ora({
           text: `Downloading compiler. Attempt #${attemptNumber}.`,
           color: "red"
@@ -39,12 +43,13 @@ module.exports = {
     ],
     "downloadCompiler:succeed": [
       function() {
+        if (this.quiet) return;
         this.spinner.succeed();
       }
     ],
-
     "fetchSolcList:start": [
       function({ attemptNumber }) {
+        if (this.quiet) return;
         this.spinner = this.ora({
           text: `Fetching solc version list from solc-bin. Attempt #${attemptNumber}`,
           color: "yellow"

--- a/packages/events/defaultSubscribers/obtain.js
+++ b/packages/events/defaultSubscribers/obtain.js
@@ -58,11 +58,13 @@ module.exports = {
     ],
     "fetchSolcList:succeed": [
       function() {
+        if (this.quiet) return;
         if (this.spinner.isSpinning) this.spinner.succeed();
       }
     ],
     "fetchSolcList:fail": [
       function() {
+        if (this.quiet) return;
         if (this.spinner.isSpinning) this.spinner.fail();
       }
     ]

--- a/packages/truffle/test/scenarios/commands/obtain.js
+++ b/packages/truffle/test/scenarios/commands/obtain.js
@@ -1,0 +1,62 @@
+const MemoryLogger = require("../MemoryLogger");
+const CommandRunner = require("../commandRunner");
+const Config = require("@truffle/config");
+const fse = require("fs-extra");
+const path = require("path");
+const assert = require("assert");
+const sandbox = require("../sandbox");
+
+let logger, config, project, expectedPath;
+
+describe("truffle obtain", function () {
+  project = path.join(__dirname, "../../sources/develop");
+
+  beforeEach(async function () {
+    expectedPath = path.join(
+      Config.getTruffleDataDirectory(),
+      "compilers",
+      "node_modules",
+      "soljson-v0.7.2+commit.51b20bc0.js"
+    );
+    this.timeout(10000);
+    config = await sandbox.create(project);
+    logger = new MemoryLogger();
+    config.logger = logger;
+  });
+
+  it("fetches the solc version specified", async function () {
+    this.timeout(70000);
+    // ensure the compiler does not yet exist
+    try {
+      fse.unlinkSync(expectedPath);
+    } catch (error) {
+      // unlink throws when file doesn't exist
+      if (error.code !== "ENOENT") {
+        throw error;
+      }
+    }
+    await CommandRunner.run("obtain --solc=0.7.2", config);
+    assert(fse.statSync(expectedPath), "The compiler was not obtained!");
+    fse.unlinkSync(expectedPath);
+  });
+
+  it("respects the `quiet` option", async function () {
+    this.timeout(70000);
+    // ensure the compiler does not yet exist
+    try {
+      fse.unlinkSync(expectedPath);
+    } catch (error) {
+      // unlink throws when file doesn't exist
+      if (error.code !== "ENOENT") {
+        throw error;
+      }
+    }
+    await CommandRunner.run("obtain --solc=0.7.2 --quiet", config);
+    const output = logger.contents();
+    assert(
+      !output.includes("successfully downloaded and cached"),
+      "The command logged to the console when it shouldn't have."
+    );
+    fse.unlinkSync(expectedPath);
+  });
+});

--- a/packages/truffle/test/scenarios/commands/obtain.js
+++ b/packages/truffle/test/scenarios/commands/obtain.js
@@ -9,7 +9,7 @@ const sandbox = require("../sandbox");
 let logger, config, project, expectedPath;
 
 describe("truffle obtain", function () {
-  project = path.join(__dirname, "../../sources/develop");
+  project = path.join(__dirname, "../../sources/obtain");
 
   beforeEach(async function () {
     expectedPath = path.join(

--- a/packages/truffle/test/scenarios/commands/obtain.js
+++ b/packages/truffle/test/scenarios/commands/obtain.js
@@ -52,9 +52,10 @@ describe("truffle obtain", function () {
       }
     }
     await CommandRunner.run("obtain --solc=0.7.2 --quiet", config);
-    const output = logger.contents();
+    // logger.contents() returns false as long as nothing is written to the
+    // stream that is used for logging in MemoryLogger
     assert(
-      !output.includes("successfully downloaded and cached"),
+      !logger.contents(),
       "The command logged to the console when it shouldn't have."
     );
     fse.unlinkSync(expectedPath);

--- a/packages/truffle/test/sources/obtain/truffle-config.js
+++ b/packages/truffle/test/sources/obtain/truffle-config.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -19530,7 +19530,7 @@ lodash.partition@^4.6.0:
   resolved "https://registry.yarnpkg.com/lodash.partition/-/lodash.partition-4.6.0.tgz#a38e46b73469e0420b0da1212e66d414be364ba4"
   integrity sha1-o45GtzRp4EILDaEhLmbUFL42S6Q=
 
-lodash.pick@^4.2.1:
+lodash.pick@^4.2.1, lodash.pick@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
   integrity sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=

--- a/yarn.lock
+++ b/yarn.lock
@@ -4324,6 +4324,13 @@
   dependencies:
     "@types/lodash" "*"
 
+"@types/lodash.pick@^4.4.6":
+  version "4.4.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.pick/-/lodash.pick-4.4.6.tgz#ae4e8f109e982786313bb6aac4b1a73aefa6e9be"
+  integrity sha512-u8bzA16qQ+8dY280z3aK7PoWb3fzX5ATJ0rJB6F+uqchOX2VYF02Aqa+8aYiHiHgPzQiITqCgeimlyKFy4OA6g==
+  dependencies:
+    "@types/lodash" "*"
+
 "@types/lodash.sum@^4.0.6":
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/@types/lodash.sum/-/lodash.sum-4.0.6.tgz#acae9c8b24390a974667565acf17288e98dcdb8e"


### PR DESCRIPTION
After looking into https://github.com/trufflesuite/truffle/issues/4237, I discovered that Truffle Config's `with` method wasn't updating the events system properly if an option pertaining to it was passed. This PR fixes the way Truffle Config merges in properties and updates the event system when doing so. 

In addition this PR adds guards into the obtain subscriber so that it won't log (mostly via ora) when `--quiet` is `true`.