### PR TITLE
Revert "Revert "Upgrade @ethereumjs/common to ^2.4.0 and @ethereumjs/tx to ^3.3.0""

### DIFF
--- a/packages/hdwallet-provider/package.json
+++ b/packages/hdwallet-provider/package.json
@@ -25,8 +25,8 @@
     "eth-sig-util": "^3.0.1",
     "ethereum-cryptography": "^0.1.3",
     "ethereum-protocol": "^1.0.1",
-    "ethereumjs-common": "^1.5.0",
-    "ethereumjs-tx": "^2.1.2",
+    "@ethereumjs/common": "^2.4.0",
+    "@ethereumjs/tx": "^3.3.0",
     "ethereumjs-util": "^6.1.0",
     "ethereumjs-wallet": "^1.0.1"
   },

--- a/packages/hdwallet-provider/src/index.ts
+++ b/packages/hdwallet-provider/src/index.ts
@@ -3,8 +3,8 @@ import { wordlist } from "ethereum-cryptography/bip39/wordlists/english";
 import * as EthUtil from "ethereumjs-util";
 import ethJSWallet from "ethereumjs-wallet";
 import { hdkey as EthereumHDKey } from "ethereumjs-wallet";
-import { Transaction } from "ethereumjs-tx";
-import Common from "ethereumjs-common";
+import { Transaction } from "@ethereumjs/tx";
+import Common from "@ethereumjs/common";
 
 // @ts-ignore
 import ProviderEngine from "@trufflesuite/web3-provider-engine";
@@ -157,21 +157,22 @@ class HDWalletProvider {
           const KNOWN_CHAIN_IDS = new Set([1, 3, 4, 5, 42]);
           let txOptions;
           if (typeof chain !== "undefined" && KNOWN_CHAIN_IDS.has(chain)) {
-            txOptions = { chain };
+            txOptions = { common: new Common({ chain }) };
           } else if (typeof chain !== "undefined") {
-            const common = Common.forCustomChain(
-              1,
-              {
-                name: "custom chain",
-                chainId: chain
-              },
-              self.hardfork
-            );
-            txOptions = { common };
+            txOptions = {
+              common: Common.forCustomChain(
+                1,
+                {
+                  name: "custom chain",
+                  chainId: chain
+                },
+                self.hardfork
+              )
+            };
           }
-          const tx = new Transaction(txParams, txOptions);
-          tx.sign(pkey as Buffer);
-          const rawTx = `0x${tx.serialize().toString("hex")}`;
+          const tx = Transaction.fromTxData(txParams, txOptions);
+          const signedTx = tx.sign(pkey as Buffer);
+          const rawTx = `0x${signedTx.serialize().toString("hex")}`;
           cb(null, rawTx);
         },
         signMessage({ data, from }: any, cb: any) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1027,6 +1027,14 @@
     "@ethereumjs/common" "^2.3.1"
     ethereumjs-util "^7.0.10"
 
+"@ethereumjs/tx@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/tx/-/tx-3.3.0.tgz#14ed1b7fa0f28e1cd61e3ecbdab824205f6a4378"
+  integrity sha512-yTwEj2lVzSMgE6Hjw9Oa1DZks/nKTWM8Wn4ykDNapBPua2f4nXO3qKnni86O6lgDj5fVNRqbDsD0yy7/XNGDEA==
+  dependencies:
+    "@ethereumjs/common" "^2.4.0"
+    ethereumjs-util "^7.1.0"
+
 "@ethersproject/abi@5.0.0-beta.153":
   version "5.0.0-beta.153"
   resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.0.0-beta.153.tgz#43a37172b33794e4562999f6e2d555b7599a8eee"


### PR DESCRIPTION
Do not merge this PR until October when support for Node.js version 10 is discontinued. 

This PR updates @ethereumjs/common and @ethereumjs/tx in @truffle/hdwallet-provider.

Reverts trufflesuite/truffle#4271