### PR TITLE
Use gas estimate as default transaction gas limit

### DIFF
--- a/packages/config/src/configDefaults.ts
+++ b/packages/config/src/configDefaults.ts
@@ -78,11 +78,6 @@ export const configProps = ({
   const resolveDirectory = (value: string): string =>
     path.resolve(configObject.working_directory, value);
 
-  const defaultTXValues = {
-    gas: 6721975,
-    from: null
-  };
-
   return {
     // These are already set.
     truffle_directory() {},
@@ -158,7 +153,7 @@ export const configProps = ({
           config = {};
         }
 
-        config = assignIn({}, defaultTXValues, config);
+        config = assignIn({}, config);
 
         return config;
       },
@@ -173,7 +168,7 @@ export const configProps = ({
         try {
           return configObject.network_config.from;
         } catch (e) {
-          return defaultTXValues.from;
+          return null;
         }
       },
       set() {
@@ -187,7 +182,7 @@ export const configProps = ({
         try {
           return configObject.network_config.gas;
         } catch (e) {
-          return defaultTXValues.gas;
+          return null;
         }
       },
       set() {

--- a/packages/config/src/configDefaults.ts
+++ b/packages/config/src/configDefaults.ts
@@ -1,4 +1,3 @@
-import assignIn from "lodash.assignin";
 import * as path from "path";
 import Provider from "@truffle/provider";
 import TruffleConfig from "./";
@@ -152,8 +151,6 @@ export const configProps = ({
         if (config === null || config === undefined) {
           config = {};
         }
-
-        config = assignIn({}, config);
 
         return config;
       },

--- a/packages/contract/lib/execute.js
+++ b/packages/contract/lib/execute.js
@@ -18,7 +18,7 @@ const execute = {
    * @param  {Number} blockLimit  most recent network block.blockLimit
    * @return {Number}             gas estimate
    */
-  getGasEstimate: function (params, blockLimit) {
+  getGasEstimate: function (params, blockLimit, stacktrace = false) {
     const constructor = this;
     const interfaceAdapter = this.interfaceAdapter;
 
@@ -29,34 +29,32 @@ const execute = {
       if (!constructor.autoGas) return accept();
 
       interfaceAdapter
-        .estimateGas(params)
+        .estimateGas(params, stacktrace)
         .then(gas => {
           // there are situations where the web3 gas estimation function in interfaceAdapter
           // fails, specifically when a transaction will revert; we still want to continue
-          // the user flow for debugging purposes; so we provide a default gas for
-          // that situation, equal to half of the blockLimit for the latest block
-          const limit = utils.bigNumberify(blockLimit);
-          let bestEstimate;
+          // the user flow for debugging purposes if the user has enabled stacktraces; so we provide a
+          // default gas for that situation, equal to half of the blockLimit for the latest block
+          //
+          // note: this means if a transaction will revert but the user does not have stacktracing enabled,
+          // they will get an error from the gas estimation and be unable to proceed; we may need to revisit this
           if(gas === null) {
             const defaultGas = utils.bigNumberify(Math.floor(blockLimit/2));
-            bestEstimate = defaultGas;
+            accept(defaultGas.toHexString());
           } else {
+            const limit = utils.bigNumberify(blockLimit);
             // if we did get a numerical gas estimate from interfaceAdapter, we
             // multiply that estimate by the gasMultiplier to help ensure we
             // have enough gas for the transaction
-            bestEstimate = utils.multiplyBigNumberByDecimal(
+            const bestEstimate = utils.multiplyBigNumberByDecimal(
               utils.bigNumberify(gas),
               constructor.gasMultiplier
             );
+            // Check that we don't go over blockLimit
+            bestEstimate.gte(limit)
+              ? accept(limit.sub(1).toHexString())
+              : accept(bestEstimate.toHexString());
           }
-
-          // Check that we don't go over blockLimit
-          bestEstimate.gte(limit)
-            ? accept(limit.sub(1).toHexString())
-            : accept(bestEstimate.toHexString());
-
-          // We need to let txs that revert through.
-          // Often that's exactly what you are testing.
         })
         .catch(() => accept());
     });
@@ -204,11 +202,13 @@ const execute = {
             contract: constructor
           });
 
+          const stacktrace = promiEvent.debug ? promiEvent.debug : false;
           try {
             params.gas = await execute.getGasEstimate.call(
               constructor,
               params,
-              network.blockLimit
+              network.blockLimit,
+              stacktrace
             );
           } catch (error) {
             promiEvent.reject(error);
@@ -267,11 +267,13 @@ const execute = {
 
           const contract = new web3.eth.Contract(constructor.abi);
           params.data = contract.deploy(options).encodeABI();
+          const stacktrace = promiEvent.debug ? promiEvent.debug : false;
 
           params.gas = await execute.getGasEstimate.call(
             constructor,
             params,
-            blockLimit
+            blockLimit,
+            stacktrace
           );
 
           context.params = params;

--- a/packages/contract/lib/execute.js
+++ b/packages/contract/lib/execute.js
@@ -38,7 +38,7 @@ const execute = {
           //
           // note: this means if a transaction will revert but the user does not have stacktracing enabled,
           // they will get an error from the gas estimation and be unable to proceed; we may need to revisit this
-          if(gas === null) {
+          if (gas === null) {
             const defaultGas = utils.bigNumberify(Math.floor(blockLimit/2));
             accept(defaultGas.toHexString());
           } else {

--- a/packages/core/test/migrate.js
+++ b/packages/core/test/migrate.js
@@ -22,7 +22,7 @@ describe("migrate", function () {
   });
 
   function createProviderAndSetNetworkConfig(network) {
-    var provider = Ganache.provider({ seed: network, gasLimit: config.gas });
+    var provider = Ganache.provider({ seed: network });
     var web3 = new Web3(provider);
     return web3.eth.getAccounts().then(accs => {
       return web3.eth.net.getId().then(network_id => {

--- a/packages/interface-adapter/lib/adapter/types.ts
+++ b/packages/interface-adapter/lib/adapter/types.ts
@@ -40,7 +40,7 @@ export interface InterfaceAdapter {
   getBalance(address: string): Promise<string>;
   getCode(address: string): Promise<string>;
   getAccounts(): Promise<string[]>;
-  estimateGas(transactionConfig: Transaction): Promise<number>;
+  estimateGas(transactionConfig: Transaction): Promise<number> | null;
   getTransactionCostReport(receipt: TransactionReceipt): Promise<TransactionCostReport>;
   displayCost(value: BN): string;
 }

--- a/packages/interface-adapter/lib/adapter/types.ts
+++ b/packages/interface-adapter/lib/adapter/types.ts
@@ -40,7 +40,7 @@ export interface InterfaceAdapter {
   getBalance(address: string): Promise<string>;
   getCode(address: string): Promise<string>;
   getAccounts(): Promise<string[]>;
-  estimateGas(transactionConfig: Transaction): Promise<number> | null;
+  estimateGas(transactionConfig: Transaction, stacktrace: boolean): Promise<number> | null;
   getTransactionCostReport(receipt: TransactionReceipt): Promise<TransactionCostReport>;
   displayCost(value: BN): string;
 }

--- a/packages/interface-adapter/lib/adapter/web3/index.ts
+++ b/packages/interface-adapter/lib/adapter/web3/index.ts
@@ -49,8 +49,13 @@ export class Web3InterfaceAdapter implements InterfaceAdapter {
     return this.web3.eth.getAccounts();
   }
 
-  public estimateGas(transactionConfig: Transaction) {
-    return this.web3.eth.estimateGas(transactionConfig);
+  public async estimateGas(transactionConfig: Transaction) {
+    try {
+      const gasEstimate = await this.web3.eth.estimateGas(transactionConfig);
+      return gasEstimate;
+    } catch {
+      return null;
+    }
   }
 
   public getBlockNumber() {

--- a/packages/interface-adapter/lib/adapter/web3/index.ts
+++ b/packages/interface-adapter/lib/adapter/web3/index.ts
@@ -53,7 +53,7 @@ export class Web3InterfaceAdapter implements InterfaceAdapter {
     // web3 does not error gracefully when gas estimation fails due to a revert,
     // so in cases where we want to get past this (debugging/stacktracing), we must
     // catch the error and return null instead
-    if(stacktrace === true) {
+    if (stacktrace === true) {
       try {
         const gasEstimate = await this.web3.eth.estimateGas(transactionConfig);
         return gasEstimate;

--- a/packages/interface-adapter/lib/adapter/web3/index.ts
+++ b/packages/interface-adapter/lib/adapter/web3/index.ts
@@ -49,10 +49,20 @@ export class Web3InterfaceAdapter implements InterfaceAdapter {
     return this.web3.eth.getAccounts();
   }
 
-  public async estimateGas(transactionConfig: Transaction) {
-    const gasEstimate = await this.web3.eth.estimateGas(transactionConfig);
-
-    return gasEstimate;
+  public async estimateGas(transactionConfig: Transaction, stacktrace = false) {
+    // web3 does not error gracefully when gas estimation fails due to a revert,
+    // so in cases where we want to get past this (debugging/stacktracing), we must
+    // catch the error and return null instead
+    if(stacktrace === true) {
+      try {
+        const gasEstimate = await this.web3.eth.estimateGas(transactionConfig);
+        return gasEstimate;
+      } catch {
+        return null;
+      }
+    } else {
+      return this.web3.eth.estimateGas(transactionConfig);
+    }
   }
 
   public getBlockNumber() {

--- a/packages/interface-adapter/lib/adapter/web3/index.ts
+++ b/packages/interface-adapter/lib/adapter/web3/index.ts
@@ -50,12 +50,9 @@ export class Web3InterfaceAdapter implements InterfaceAdapter {
   }
 
   public async estimateGas(transactionConfig: Transaction) {
-    try {
-      const gasEstimate = await this.web3.eth.estimateGas(transactionConfig);
-      return gasEstimate;
-    } catch {
-      return null;
-    }
+    const gasEstimate = await this.web3.eth.estimateGas(transactionConfig);
+
+    return gasEstimate;
   }
 
   public getBlockNumber() {


### PR DESCRIPTION
This addresses the remaining part of #3992 

Prior to this PR, Truffle's `getGasEstimate()` function never actually estimated gas. There was a hardcoded default gas value in the configuration defaults that was added to the params before we hit the gas estimation function. The gas estimation function would check for gas in the params before estimating, and that value was never empty. 

A workaround was to add `gas: 0` to the config, which would force the estimation function to do the estimation. This was not ideal as it is not clear what is actually happening and why. This fix removes the default gas value to ensure that gas is estimated if the user does not provide their own gas in the transaction params.

*Note: user-provided gas params are still respected, and gas estimation will not occur if a non-zero integer is provided as the gas from the user's code*

*Note: gas estimation for transactions that will revert does not error gracefully, which in general Truffle's code is aware of, but we want to be able to continue the user flow in the case of debugging, so in that situation we provide a default gas of 1/2 the blockLimit*