### PR TITLE
Add support for block.basefee in debugger, and fix a bug with internal function pointers

### DIFF
--- a/packages/codec/lib/ast/import/index.ts
+++ b/packages/codec/lib/ast/import/index.ts
@@ -47,8 +47,7 @@ export function definitionToType(
             kind: "general",
             typeHint
           };
-        case "0.5.x":
-        case "0.8.x":
+        default:
           return {
             typeClass,
             kind: "specific",

--- a/packages/codec/lib/compiler/types.ts
+++ b/packages/codec/lib/compiler/types.ts
@@ -7,5 +7,5 @@ export interface CompilerVersion {
 
 //NOTE: Families 0.5.0 and up will be named by the lowest version that
 //fits in the given family.  So e.g. 0.5.x covers 0.5.x-0.7.x;
-//0.8.x covers 0.8.x-current (as I write this)
-export type SolidityFamily = "unknown" | "pre-0.5.0" | "0.5.x" | "0.8.x";
+//0.8.x covers 0.8.0-0.8.6; 0.8.7+ covers 0.8.7 to current (as I write this)
+export type SolidityFamily = "unknown" | "pre-0.5.0" | "0.5.x" | "0.8.x" | "0.8.7+";

--- a/packages/codec/lib/compiler/utils.ts
+++ b/packages/codec/lib/compiler/utils.ts
@@ -9,11 +9,17 @@ export function solidityFamily(compiler: CompilerVersion): SolidityFamily {
     return "unknown";
   }
   if (
+    semver.satisfies(compiler.version, ">=0.8.7", {
+      includePrerelease: true
+    })
+  ) {
+    return "0.8.7+";
+  } else if (
+    //see comment below about the weird-looking condition
     semver.satisfies(compiler.version, "~0.8 || >=0.8.0", {
       includePrerelease: true
     })
   ) {
-    //see comment below about the weird-looking condition
     return "0.8.x";
   } else if (
     semver.satisfies(compiler.version, "~0.5 || >=0.5.0", {

--- a/packages/codec/lib/special/decode/index.ts
+++ b/packages/codec/lib/special/decode/index.ts
@@ -109,6 +109,9 @@ export function* decodeMagic(
       if (solidityVersionHasChainId(info.currentContext.compiler)) {
         variables.push("chainid");
       }
+      if (solidityVersionHasBaseFee(info.currentContext.compiler)) {
+        variables.push("basefee");
+      }
       for (let variable of variables) {
         block[variable] = yield* Basic.Decode.decodeBasic(
           {
@@ -143,7 +146,7 @@ function senderType(
         kind: "specific",
         payable: true
       };
-    case "0.8.x":
+    default:
       return {
         typeClass: "address",
         kind: "specific",
@@ -164,6 +167,7 @@ function coinbaseType(
       };
     case "0.5.x":
     case "0.8.x":
+    case "0.8.7+":
       return {
         typeClass: "address",
         kind: "specific",
@@ -180,7 +184,21 @@ function solidityVersionHasChainId(
     case "pre-0.5.0":
     case "0.5.x":
       return false;
+    default:
+      return true;
+  }
+}
+
+function solidityVersionHasBaseFee(
+  compiler: Compiler.CompilerVersion
+): boolean {
+  switch (Compiler.Utils.solidityFamily(compiler)) {
+    case "unknown":
+    case "pre-0.5.0":
+    case "0.5.x":
     case "0.8.x":
+      return false;
+    default:
       return true;
   }
 }

--- a/packages/debugger/lib/evm/reducers.js
+++ b/packages/debugger/lib/evm/reducers.js
@@ -94,7 +94,8 @@ const DEFAULT_BLOCK = {
   gaslimit: new BN(0),
   number: new BN(0),
   timestamp: new BN(0),
-  chainid: new BN(0)
+  chainid: new BN(0),
+  basefee: new BN(0)
 };
 
 function block(state = DEFAULT_BLOCK, action) {

--- a/packages/debugger/lib/web3/sagas/index.js
+++ b/packages/debugger/lib/web3/sagas/index.js
@@ -74,7 +74,10 @@ function* fetchTransactionInfo(adapter, { txHash }) {
     gaslimit: new BN(block.gasLimit),
     number: new BN(block.number),
     timestamp: new BN(block.timestamp),
-    chainid: new BN(chainId) //key is lowercase because that's what Solidity does
+    chainid: new BN(chainId), //key is lowercase because that's what Solidity does
+    basefee: new BN(parseInt(block.baseFeePerGas)) //will be 0 if pre-London [new BN(NaN) yields 0]
+    //note we need parseInt on basefee because some web3 versions return it as a hex string,
+    //and BN doesn't allow for hex strings as input
   };
 
   if (tx.to != null) {

--- a/packages/debugger/test/data/global.js
+++ b/packages/debugger/test/data/global.js
@@ -189,7 +189,7 @@ describe("Globally-available variables", function () {
     assert.equal(variables.this, variables._this);
     assert.deepEqual(variables.msg, variables._msg);
     assert.deepEqual(variables.tx, variables._tx);
-    assert.deepEqual(variables.block, variables._block);
+    assert.deepEqual(variables.block, withBaseFeeZero(variables._block));
   });
 
   it("Gets globals correctly in nested call", async function () {
@@ -215,7 +215,7 @@ describe("Globally-available variables", function () {
     assert.equal(variables.this, variables._this);
     assert.deepEqual(variables.msg, variables._msg);
     assert.deepEqual(variables.tx, variables._tx);
-    assert.deepEqual(variables.block, variables._block);
+    assert.deepEqual(variables.block, withBaseFeeZero(variables._block));
   });
 
   it("Gets globals correctly in static call", async function () {
@@ -241,7 +241,7 @@ describe("Globally-available variables", function () {
     assert.equal(variables.this, variables.__this);
     assert.deepEqual(variables.msg, variables.__msg);
     assert.deepEqual(variables.tx, variables.__tx);
-    assert.deepEqual(variables.block, variables.__block);
+    assert.deepEqual(variables.block, withBaseFeeZero(variables.__block));
   });
 
   it("Gets globals correctly in library call", async function () {
@@ -260,13 +260,15 @@ describe("Globally-available variables", function () {
     });
     await bugger.continueUntilBreakpoint();
 
+    debug("variables: %O", await bugger.variables());
+
     const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
     );
 
     assert.deepEqual(variables.msg, variables.__msg);
     assert.deepEqual(variables.tx, variables.__tx);
-    assert.deepEqual(variables.block, variables.__block);
+    assert.deepEqual(variables.block, withBaseFeeZero(variables.__block));
   });
 
   it("Gets globals correctly in simple creation", async function () {
@@ -285,7 +287,7 @@ describe("Globally-available variables", function () {
     assert.equal(variables.this, variables._this);
     assert.deepEqual(variables.msg, variables._msg);
     assert.deepEqual(variables.tx, variables._tx);
-    assert.deepEqual(variables.block, variables._block);
+    assert.deepEqual(variables.block, withBaseFeeZero(variables._block));
   });
 
   it("Gets globals correctly in nested creation", async function () {
@@ -311,7 +313,7 @@ describe("Globally-available variables", function () {
     assert.equal(variables.this, variables._this);
     assert.deepEqual(variables.msg, variables._msg);
     assert.deepEqual(variables.tx, variables._tx);
-    assert.deepEqual(variables.block, variables._block);
+    assert.deepEqual(variables.block, withBaseFeeZero(variables._block));
   });
 
   it("Gets globals correctly in failed CREATE2", async function () {
@@ -337,6 +339,14 @@ describe("Globally-available variables", function () {
     assert.equal(variables.this, variables._this);
     assert.deepEqual(variables.msg, variables._msg);
     assert.deepEqual(variables.tx, variables._tx);
-    assert.deepEqual(variables.block, variables._block);
+    assert.deepEqual(variables.block, withBaseFeeZero(variables._block));
   });
 });
+
+//HACK for testing until Ganache supports london
+function withBaseFeeZero(block) {
+  return {
+    ...block,
+    basefee: 0
+  };
+}

--- a/packages/debugger/test/helpers.js
+++ b/packages/debugger/test/helpers.js
@@ -26,10 +26,10 @@ export async function prepareContracts(provider, sources = {}, migrations) {
 
   config.compilers = {
     solc: {
-      version: "0.8.4",
+      version: "0.8.7",
       settings: {
         optimizer: { enabled: false, runs: 200 },
-        evmVersion: "istanbul"
+        evmVersion: "london"
       }
     }
   };

--- a/packages/debugger/test/stacktrace.js
+++ b/packages/debugger/test/stacktrace.js
@@ -328,18 +328,19 @@ describe("Stack tracing", function () {
       undefined,
       "run1",
       "runInternal",
-      undefined
+      undefined,
+      "panic_error_0x51"
     ]);
     let contractNames = report.map(({ contractName }) => contractName);
     assert.isUndefined(contractNames[contractNames.length - 1]);
-    contractNames.pop();
-    assert(contractNames.every(name => name === "StacktraceTest"));
+    assert.isUndefined(contractNames[contractNames.length - 2]);
+    assert(contractNames.slice(0,-2).every(name => name === "StacktraceTest"));
     let addresses = report.map(({ address }) => address);
     assert(addresses.every(address => address === instance.address));
     let status = report[report.length - 1].status;
     assert.isFalse(status);
-    let location = report[report.length - 2].location; //note, -2 because of undefined on top
-    let prevLocation = report[report.length - 3].location; //similar
+    let location = report[report.length - 3].location; //note, -2 because of panic & undefined on top
+    let prevLocation = report[report.length - 4].location; //similar
     assert.strictEqual(location.sourceRange.lines.start.line, failLine);
     assert.strictEqual(prevLocation.sourceRange.lines.start.line, callLine);
   });

--- a/packages/decoder/test/current/test/compatible-nativize.js
+++ b/packages/decoder/test/current/test/compatible-nativize.js
@@ -25,7 +25,7 @@ describe("nativize (ethers format)", function () {
   });
 
   before("Prepare contracts and artifacts", async function () {
-    this.timeout(30000);
+    this.timeout(45000);
 
     const prepared = await prepareContracts(provider, path.resolve(__dirname, ".."));
     abstractions = prepared.abstractions;


### PR DESCRIPTION
This PR does two things, which are basically unrelated, except that (for reasons you'll see) I had to do the second to get the tests passing for the first.

The main thing this PR does is to add support in the debugger for Solidity's `block.basefee` builtin, introduced in Solidity 0.8.7, because I forgot to do this when Solidity 0.8.7 came out.  Note that this builtin will only be displayed on Solidity versions 0.8.7 or later; on older versions it won't show up.  This involved adding a new value to the `SolidityFamily` type in `codec`.

Speaking of which, I got tired of updating all the `case` statements there, so I updated most of them to only list out earlier versions of Solidity that behaved differently, and have all versions with the current behavior just be `default`.  That way most of these just won't need to be updated in the future anymore.  I did leave one of them explicit because I expect it might still change in the future.

Note that if you have a transaction in a pre-London block, and its code was nonetheless compiled with Solidity 0.8.7 or later, then we'll show `block.basefee` as being zero.  Its "actual" value is, well, not defined; I figure 0 is an OK substitute.  Better perhaps would be to exclude it to display, but that would require a new mechanism to do that, and I didn't want to bother with that.

Testing this change was a bit of a pain -- since stable Ganache doesn't support London yet, I had to do my real tests manually.  But I did update the globally-available tests to keep them from breaking, even if "updating" them here just meant checking that basefee comes out as 0 in a pre-London block, rather than checking that it comes out as the correct value in a post-London block.

However, in doing this update, I encountered a problem: Our tests were on Solidity version 0.8.4... and upgrading them to 0.8.5 or later broke the tests that involved uninitialized internal function pointers.  Turns out, they changed the way those work *again* in Solidity 0.8.5.  (I'm going to have to update "Data Representation in Solidity" again!  I didn't know about that!)

With one of the broken tests, the debugger wasn't actually doing anything wrong, I just had to update the tests.  But for the other two, I had to update `source-map-utils` so that the new style (or, I guess, the *new* new style) of uninitialized internal function pointers would be recognized as such by the debugger.

Basically, the Solidity 0.8.4 way was to have them point to the `panic_error_0x51` function (although at the time it wasn't named).  Now instead they point to a function that just jumps *to* the `panic_error_0x51` function.  So we have to detect that, and I updated `source-map-utils` to do so.

Actually, hm, wait, I just realized... currently we detect whether a function is `panic_error_0x51` by checking its bytecode.  However, I could also add a check to check its AST `nodeType` and name too, since we have that information.  We wouldn't want to rely solely on that, of course, but...?  Well, I dunno.  I'm going to put this up for review, and if you think that should be changed, let me know!  (Or maybe I'll just go back and make the change anyway. :P )