### PR TITLE
Add support for compilation notices

### DIFF
--- a/packages/events/defaultSubscribers/compile.js
+++ b/packages/events/defaultSubscribers/compile.js
@@ -55,6 +55,13 @@ module.exports = {
         this.logger.log(`${OS.EOL}    ${warnings.join()}`);
       }
     ],
+    "compile:infos": [
+      function ({ infos }) {
+        if (this.quiet) return;
+        this.logger.log("> Compilation notices encountered:");
+        this.logger.log(`${OS.EOL}    ${infos.join()}`);
+      }
+    ],
     "compile:nothingToCompile": [
       function () {
         if (this.quiet) return;

--- a/packages/truffle/test/scenarios/commands/install.js
+++ b/packages/truffle/test/scenarios/commands/install.js
@@ -19,5 +19,5 @@ describe("truffle install [ @standalone ]", () => {
       path.join(config.working_directory, "installed_contracts")
     );
     assert(theInstallDirExists);
-  }).timeout(30000);
+  }).timeout(45000);
 });


### PR DESCRIPTION
This PR adds support for compilation notices, coming in Solidity 0.8.8.  It doesn't add very much support, but it adds enough to ensure they won't break things.  Note that since Solidity 0.8.8 isn't out yet I didn't add any tests; I did test it manually with the soljson linked [here](https://github.com/ethereum/solidity/issues/11508#issuecomment-908397096).  (A danger of working ahead!)

Basically, as of Solidity 0.8.8, instead of just compilation warnings (with severity `"warning"`) and errors (with severity `"error"`), there will also be compilation notices, with severity `"info"`.  These would cause a problem for our existing code, in that in our existing code, when getting the errors, rather than checking for severity *equal to* `"error"`, we instead check for severity *not* equal to `"warning"`.  Since `"info"` is not equal to `"warning"`, it would be treated as an error!  So, obviously, I changed that.

I then more generally added support for obtaining and printing notices in addition to warnings and errors, including a default subscriber for them in the events system.

Note that currently notices will always be printed (unless `quiet` is on, of course).  We don't necessarily want this; I believe part of the design intent of notices was that the user might want to silence them (without silencing warnings).  However, I figure that support for that sort of thing can be added later in a separate PR.