### PR TITLE
Internal improvement: Speed up and simplify yarncheck

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
       - run: npm install -g yarn
       - run: yarn install --ignore-scripts --frozen-lockfile
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -19,8 +19,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
       - run: npm install -g yarn
-      - run: yarn bootstrap
-      - run: test -z "$(git diff)" || (echo 'Please run yarn and commit all changes to yarn.lock'; false)
+      - run: yarn install --ignore-scripts --frozen-lockfile
 
 
   build:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,10 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
       - run: npm install -g yarn
-      - run: yarn install --ignore-scripts --frozen-lockfile
+      - run: yarn install --ignore-scripts --frozen-lockfile --ignore-engines
 
 
   build:


### PR DESCRIPTION
The `yarncheck` job takes a while.  This PR aims to speed it up, and also to simplify it by removing the jury-rigged mechanism I came up with for it.

To speed it up, we can pass the `--ignore-scripts` option, so that it will only do the `yarn install` part of things, and not run all the prepare scripts.  (Thanks to @gnidan for finding this option; I missed it.)

But also, we can pass the `--frozen-lockfile` option, which makes it so that if the lockfile needs to be modified, instead it fails -- exactly what we want!  So we can remove my jury-rigged mechanism for seeing if the lockfile changed; yarn will do that for us.

So yay, it's simpler now and should be faster too!

I also removed my custom error message, we'll see if I need to add that back in. :P

**Edit**: ~~I hit an engine problem; I decided to specify Node 12 rather than specifying `--ignore-engines`, but the latter would also be a possibility.~~  Yeah OK I changed it to just use `--ignore-engines` because I realized there's a potential for confusing errors otherwise.