### PR TITLE
Bug fix: Fix ethers-compatible nativization of empty bytestring

### DIFF
--- a/packages/codec/lib/export.ts
+++ b/packages/codec/lib/export.ts
@@ -119,7 +119,8 @@ function ethersCompatibleNativize(
         case "bool":
           return (<Format.Values.BoolValue>result).value.asBoolean;
         case "bytes":
-          return (<Format.Values.BytesValue>result).value.asHex;
+          const asHex = (<Format.Values.BytesValue>result).value.asHex;
+          return asHex !== "0x" ? asHex : null;
         case "address":
           return (<Format.Values.AddressValue>result).value.asAddress;
         case "contract":

--- a/packages/decoder/test/current/contracts/CompatibleTest.sol
+++ b/packages/decoder/test/current/contracts/CompatibleTest.sol
@@ -40,4 +40,8 @@ contract CompatibleNativizeTest {
   function returnFunction() public view returns (function() external) {
     return this.emitString;
   }
+
+  function returnBytes() public pure returns (bytes memory) {
+    return hex"";
+  }
 }

--- a/packages/decoder/test/current/test/compatible-nativize.js
+++ b/packages/decoder/test/current/test/compatible-nativize.js
@@ -75,7 +75,8 @@ describe("nativize (ethers format)", function () {
         z: keyedArray,
         __length__: 1
       },
-      returnFunction: instance.address.toLowerCase() + emitStringSelector
+      returnFunction: instance.address.toLowerCase() + emitStringSelector,
+      returnBytes: null
     };
     expected.returnStringPair.w = "hello";
     expected.returnStringPair.z = "goodbye";


### PR DESCRIPTION
So, the new `nativize` function in codec (as opposed to the old unsafe one) is supposed to match ethers's behavior, right?  Well, um, turns out ethers has a special behavior for the empty bytestring that I didn't realize... instead of being nativized as `"0x"`, it's rendered as `null`!  This is seems to me to be pretty dumb, but, well, the point is to be compatible, so, uh, yeah, I've changed it. :-/  (Fortunately this isn't yet actually used anywhere...)

I didn't bother adding a test of this, but I could if people think it's necessary.