### PR TITLE
Internal improvement: Change Gitter link in issue template to Zendesk link

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-- [ ] I've asked for help in the [Truffle Gitter](http://gitter.im/Consensys/truffle) before filing this issue.
+- [ ] I've [opened a support ticket](https://trufflesuite.zendesk.com/hc/en-us/requests/new) before filing this issue.
 
 ---------------------------
 


### PR DESCRIPTION
I believe @CombsieZ was going to handle this as part of the website update, but since that seems to be taking a while and the issue came up again recently, I figured, why not do this now?

Feel free of course to nitpick the phrasing, but I thought I should at least put up a PR for this. :)