### PR TITLE
Bug fix: Remove gasLimit line from default ganache config in tests

### DIFF
--- a/packages/core/lib/commands/test/index.js
+++ b/packages/core/lib/commands/test/index.js
@@ -190,7 +190,6 @@ const command = {
         network_id: 4447,
         mnemonic:
           "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat",
-        gasLimit: config.gas,
         time: config.genesis_time,
         _chainId: 1337 //temporary until Ganache v3!
       };


### PR DESCRIPTION
When testing Truffle projects, a default ganache configuration is set up when users do not have a network configuration they wish to use. That configuration, set up in `truffle/packages/core/lib/commands/test`, erroneously set the gasLimit to the same as `gas`. Later in executing migrations, the gasLimit is actually set to be the blockLimit. This can lead to unintended errors and is ultimately unnecessary because Truffle will query ganache for the blockLimit when it is needed in gas estimation. 

This PR removes the `gasLimit` line in the default ganacheOptions for testing. 