### PR TITLE
Bug fix: Fix printing of events with no arguments

### DIFF
--- a/packages/core/lib/testing/TestRunner.js
+++ b/packages/core/lib/testing/TestRunner.js
@@ -126,6 +126,7 @@ class TestRunner {
     }
 
     function printEvent(decoding, indentation = 0, initialPrefix = "") {
+      debug("raw event: %O", decoding);
       const anonymousPrefix =
         decoding.kind === "anonymous" ? "<anonymous> " : "";
       const className = decoding.definedIn
@@ -150,7 +151,7 @@ class TestRunner {
         )})`;
         return namePrefix + indexedPrefix + displayValue + typeString + ",";
       });
-      {
+      if (eventArgs.length > 0) {
         const len = eventArgs.length - 1;
         eventArgs[len] = eventArgs[len].slice(0, -1); // remove the final comma
       }


### PR DESCRIPTION
I didn't notice this before -- printing of events with no arguments was broken due to some code that assumed that events must have arguments.  It looks like this was supposed to be an `if` block or something, it was just a bare block?  Anyway I added the missing conditional and now it doesn't crash...