### PR TITLE
Dependency update: Update highlightjs-solidity to 2.0.1

### DIFF
--- a/packages/debug-utils/package.json
+++ b/packages/debug-utils/package.json
@@ -23,7 +23,7 @@
     "bn.js": "^5.1.3",
     "chalk": "^2.4.2",
     "debug": "^4.3.1",
-    "highlightjs-solidity": "^2.0.0"
+    "highlightjs-solidity": "^2.0.1"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14502,10 +14502,10 @@ highlight.js@^10.4.1:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.4.1.tgz#d48fbcf4a9971c4361b3f95f302747afe19dbad0"
   integrity sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg==
 
-highlightjs-solidity@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/highlightjs-solidity/-/highlightjs-solidity-2.0.0.tgz#37150fe2823b9313f1477197217f37da403f3cb3"
-  integrity sha512-104Nitqem7ntqVR4FyF+a+whp7C15g5moC/K7eHWyet09+wjUVCWcSm2dcaVKOIPAHGiW8X7knq+ZGwkg3aq+A==
+highlightjs-solidity@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/highlightjs-solidity/-/highlightjs-solidity-2.0.1.tgz#ee1beb6f353d4503aa3a011bbb86577976365b59"
+  integrity sha512-9YY+HQpXMTrF8HgRByjeQhd21GXAz2ktMPTcs6oWSj5HJR52fgsNoelMOmgigwcpt9j4tu4IVSaWaJB2n2TbvQ==
 
 hkts@^0.3.1:
   version "0.3.1"


### PR DESCRIPTION
A pretty small part of the 0.8.8 updates, but an easy one. :)  Updates our syntax highlighting for 0.8.8. :)  (Of course, it won't do much good until I actually make the debugger *support* those new parts of 0.8.8 that need highlighting, but, whatever, I did this first anyway.)