### PR TITLE
Add support for Solidity 0.8.8's user-defined value types, and other changes to support 0.8.8 and 0.8.9

### DIFF
--- a/packages/codec/lib/abi-data/allocate/index.ts
+++ b/packages/codec/lib/abi-data/allocate/index.ts
@@ -196,6 +196,7 @@ function abiSizeAndAllocate(
     case "fixed":
     case "ufixed":
     case "enum":
+    case "userDefinedValueType":
       return {
         size: Evm.Utils.WORD_SIZE,
         dynamic: false,
@@ -367,6 +368,7 @@ function allocateCalldataAndReturndata(
   let inputParametersAbi: Abi.Parameter[];
   let outputParametersAbi: Abi.Parameter[];
   let offset: number; //refers to INPUT offset; output offset is always 0
+  debug("allocating calldata and returndata");
   switch (abiEntry.type) {
     case "constructor":
       if (!constructorContext) {
@@ -405,6 +407,7 @@ function allocateCalldataAndReturndata(
             ),
           contractNode
         ).node; //may be undefined!  that's OK!
+        debug("found node: %o", Boolean(node));
       }
       break;
   }
@@ -463,6 +466,7 @@ function allocateCalldataAndReturndata(
     compiler
     //note no offset
   );
+  debug("modes: %s in, %s out", inputMode, outputMode);
   //finally: transform the allocation appropriately
   let inputArgumentsAllocation = abiAllocationInput.members.map(member => ({
     ...member,
@@ -546,6 +550,7 @@ function allocateDataArguments(
       )[id];
     } catch {
       //if something goes wrong, switch to ABI mdoe
+      debug("falling back to ABI due to exception!");
       allocationMode = "abi";
     }
   }

--- a/packages/codec/lib/abify.ts
+++ b/packages/codec/lib/abify.ts
@@ -90,7 +90,7 @@ export function abifyType(
       };
     }
     case "userDefinedValueType": {
-      const fullType = <Format.Types.UDVTType>(
+      const fullType = <Format.Types.UdvtType>(
         Format.Types.fullType(dataType, userDefinedTypes)
       );
       if (!fullType.underlyingType) {
@@ -224,7 +224,7 @@ export function abifyResult(
       }
     }
     case "userDefinedValueType": {
-      const coercedResult = <Format.Values.UDVTResult>result;
+      const coercedResult = <Format.Values.UdvtResult>result;
       switch (coercedResult.kind) {
         case "value":
           return abifyResult(coercedResult.value, userDefinedTypes);

--- a/packages/codec/lib/abify.ts
+++ b/packages/codec/lib/abify.ts
@@ -229,7 +229,7 @@ export function abifyResult(
         case "value":
           return abifyResult(coercedResult.value, userDefinedTypes);
         case "error":
-          return <Format.Errors.BuiltInValueTypeErrorResult>{ //I have no idea what TS is thinking here
+          return <Format.Errors.BuiltInValueErrorResult>{ //I have no idea what TS is thinking here
             ...coercedResult,
             type: abifyType(result.type, userDefinedTypes)
           };

--- a/packages/codec/lib/abify.ts
+++ b/packages/codec/lib/abify.ts
@@ -90,7 +90,7 @@ export function abifyType(
       };
     }
     case "userDefinedValueType": {
-      const fullType = <Format.Types.UdvtType>(
+      const fullType = <Format.Types.UserDefinedValueTypeType>(
         Format.Types.fullType(dataType, userDefinedTypes)
       );
       if (!fullType.underlyingType) {
@@ -224,7 +224,7 @@ export function abifyResult(
       }
     }
     case "userDefinedValueType": {
-      const coercedResult = <Format.Values.UdvtResult>result;
+      const coercedResult = <Format.Values.UserDefinedValueTypeResult>result;
       switch (coercedResult.kind) {
         case "value":
           return abifyResult(coercedResult.value, userDefinedTypes);

--- a/packages/codec/lib/ast/types.ts
+++ b/packages/codec/lib/ast/types.ts
@@ -13,6 +13,7 @@ export interface AstNode {
   canonicalName?: string;
   linearizedBaseContracts?: number[];
   members?: AstNode[];
+  underlyingType?: AstNode;
   nodes?: AstNode[];
   nodeType: string;
   ast_type?: string; //HACK: Vyper equivalent of nodeType

--- a/packages/codec/lib/ast/utils.ts
+++ b/packages/codec/lib/ast/utils.ts
@@ -746,19 +746,33 @@ function toAbiType(node: AstNode, referenceDeclarations: AstNodes): string {
       return "address";
     case "struct":
       return "tuple"; //the more detailed checking will be handled elsewhere
-    case "enum":
-      let referenceId = typeId(node);
-      let referenceDeclaration = referenceDeclarations[referenceId];
+    case "enum": {
+      const referenceId = typeId(node);
+      const referenceDeclaration = referenceDeclarations[referenceId];
       if (referenceDeclaration === undefined) {
-        let typeToDisplay = typeString(node);
+        const typeToDisplay = typeString(node);
         throw new Common.UnknownUserDefinedTypeError(
           referenceId.toString(),
           typeToDisplay
         );
       }
-      let numOptions = referenceDeclaration.members.length;
-      let bits = 8 * Math.ceil(Math.log2(numOptions) / 8);
+      const numOptions = referenceDeclaration.members.length;
+      const bits = 8 * Math.ceil(Math.log2(numOptions) / 8);
       return `uint${bits}`;
+    }
+    case "userDefinedValueType": {
+      const referenceId = typeId(node);
+      const referenceDeclaration = referenceDeclarations[referenceId];
+      if (referenceDeclaration === undefined) {
+        const typeToDisplay = typeString(node);
+        throw new Common.UnknownUserDefinedTypeError(
+          referenceId.toString(),
+          typeToDisplay
+        );
+      }
+      const underlyingType = referenceDeclaration.underlyingType;
+      return toAbiType(underlyingType, referenceDeclarations);
+    }
     default:
       return basicType;
     //note that: int/uint/fixed/ufixed/bytes will have their size and such left on;

--- a/packages/codec/lib/ast/utils.ts
+++ b/packages/codec/lib/ast/utils.ts
@@ -482,6 +482,18 @@ export function functionKind(node: AstNode): string | undefined {
   return node.name === "" ? "fallback" : "function";
 }
 
+//this is kind of a weird one, it exposes some Solidity internals.
+//for internal functions it'll return "internal".
+//for external functions it'll return "external".
+//for library functions it'll return "delegatecall".
+//and for builtin functions, it'll return an internal name for
+//that particular builtin function.
+//(there are more possibilities but I'm not going to list them all here)
+export function functionClass(node: AstNode): string | undefined {
+  const match = typeIdentifier(node).match(/^t_function_([^_]+)_/);
+  return match ? match[1] : undefined;
+}
+
 /**
  * similar compatibility function for mutability for pre-0.4.16 versions
  * returns undefined if you don't give it a FunctionDefinition or

--- a/packages/codec/lib/ast/utils.ts
+++ b/packages/codec/lib/ast/utils.ts
@@ -216,6 +216,8 @@ export function contractKind(definition: AstNode): Common.ContractKind {
 
 /**
  * stack size, in words, of a given type
+ * note: this function assumes that UDVTs only ever take up
+ * a single word, which is currently true
  * @category Definition Reading
  */
 export function stackSize(definition: AstNode): number {

--- a/packages/codec/lib/basic/allocate/index.ts
+++ b/packages/codec/lib/basic/allocate/index.ts
@@ -30,18 +30,6 @@ export function byteLength(
       }
     case "bytes": //we assume we're in the static case
       return (<Format.Types.BytesTypeStatic>dataType).length;
-    case "userDefinedValueType": {
-      const storedType = <Format.Types.UDVTType>userDefinedTypes[dataType.id];
-      if (!storedType.underlyingType) {
-        throw new Common.UnknownUserDefinedTypeError(
-          dataType.id,
-          Format.Types.typeString(dataType)
-        );
-      }
-      const underlyingType = storedType.underlyingType;
-      return byteLength(underlyingType, userDefinedTypes);
-      //strictly spekaing, we could omit userDefinedTypes there, but let's not
-    }
     case "enum": { //the only complex case!
       const storedType = <Format.Types.EnumType>userDefinedTypes[dataType.id];
       if (!storedType.options) {

--- a/packages/codec/lib/basic/allocate/index.ts
+++ b/packages/codec/lib/basic/allocate/index.ts
@@ -1,7 +1,6 @@
 import debugModule from "debug";
 const debug = debugModule("codec:basic:allocate");
 
-import * as Compiler from "@truffle/codec/compiler";
 import * as Common from "@truffle/codec/common";
 import * as Evm from "@truffle/codec/evm";
 import * as Format from "@truffle/codec/format";
@@ -9,8 +8,7 @@ import * as Format from "@truffle/codec/format";
 //only for direct types!
 export function byteLength(
   dataType: Format.Types.Type,
-  userDefinedTypes?: Format.Types.TypesById,
-  compiler?: Compiler.CompilerVersion
+  userDefinedTypes?: Format.Types.TypesById
 ): number {
   switch (dataType.typeClass) {
     case "bool":
@@ -51,16 +49,8 @@ export function byteLength(
           Format.Types.typeString(dataType)
         );
       }
-      switch (Compiler.Utils.solidityFamily(compiler)) {
-        case "0.8.7+":
-          //UDVTs were introduced in Solidity 0.8.8.  However, in that version,
-          //and that version only, they have a bug where they always take up a
-          //full word in storage regardless of the size of the underlying type.
-          return Evm.Utils.ADDRESS_SIZE;;
-        default:
-          const { underlyingType } = storedType;
-          return byteLength(underlyingType, userDefinedTypes, compiler);
-      }
+      const { underlyingType } = storedType;
+      return byteLength(underlyingType, userDefinedTypes);
     }
   }
 }

--- a/packages/codec/lib/basic/allocate/index.ts
+++ b/packages/codec/lib/basic/allocate/index.ts
@@ -30,7 +30,19 @@ export function byteLength(
       }
     case "bytes": //we assume we're in the static case
       return (<Format.Types.BytesTypeStatic>dataType).length;
-    case "enum": //the only complex case!
+    case "userDefinedValueType": {
+      const storedType = <Format.Types.UDVTType>userDefinedTypes[dataType.id];
+      if (!storedType.underlyingType) {
+        throw new Common.UnknownUserDefinedTypeError(
+          dataType.id,
+          Format.Types.typeString(dataType)
+        );
+      }
+      const underlyingType = storedType.underlyingType;
+      return byteLength(underlyingType, userDefinedTypes);
+      //strictly spekaing, we could omit userDefinedTypes there, but let's not
+    }
+    case "enum": { //the only complex case!
       const storedType = <Format.Types.EnumType>userDefinedTypes[dataType.id];
       if (!storedType.options) {
         throw new Common.UnknownUserDefinedTypeError(
@@ -40,5 +52,6 @@ export function byteLength(
       }
       const numValues = storedType.options.length;
       return Math.ceil(Math.log2(numValues) / 8);
+    }
   }
 }

--- a/packages/codec/lib/basic/allocate/index.ts
+++ b/packages/codec/lib/basic/allocate/index.ts
@@ -42,7 +42,7 @@ export function byteLength(
       return Math.ceil(Math.log2(numValues) / 8);
     }
     case "userDefinedValueType": {
-      const storedType = <Format.Types.UdvtType>userDefinedTypes[dataType.id];
+      const storedType = <Format.Types.UserDefinedValueTypeType>userDefinedTypes[dataType.id];
       if (!storedType || !storedType.underlyingType) {
         throw new Common.UnknownUserDefinedTypeError(
           dataType.id,

--- a/packages/codec/lib/basic/allocate/index.ts
+++ b/packages/codec/lib/basic/allocate/index.ts
@@ -42,7 +42,7 @@ export function byteLength(
       return Math.ceil(Math.log2(numValues) / 8);
     }
     case "userDefinedValueType": {
-      const storedType = <Format.Types.UDVTType>userDefinedTypes[dataType.id];
+      const storedType = <Format.Types.UdvtType>userDefinedTypes[dataType.id];
       if (!storedType || !storedType.underlyingType) {
         throw new Common.UnknownUserDefinedTypeError(
           dataType.id,

--- a/packages/codec/lib/basic/decode/index.ts
+++ b/packages/codec/lib/basic/decode/index.ts
@@ -37,7 +37,7 @@ export function* decodeBasic(
 
   switch (dataType.typeClass) {
     case "userDefinedValueType": {
-      const fullType = <Format.Types.UdvtType>(
+      const fullType = <Format.Types.UserDefinedValueTypeType>(
         Format.Types.fullType(dataType, info.userDefinedTypes)
       );
       if (!fullType.underlyingType) {
@@ -64,7 +64,7 @@ export function* decodeBasic(
       switch (underlyingResult.kind) { //yes this switch is a little unnecessary :P
         case "value":
           //wrap the value and return
-          return <Format.Values.UdvtValue>{ //no idea why need coercion here
+          return <Format.Values.UserDefinedValueTypeValue>{ //no idea why need coercion here
             type: fullType,
             kind: "value" as const,
             value: underlyingResult
@@ -76,7 +76,7 @@ export function* decodeBasic(
           //does not cause an error in the whole thing, but to do that here
           //would cause problems for the type system :-/
           //so we'll just be inconsistent
-          return <Format.Errors.UdvtErrorResult>{ //TS is being bad again :-/
+          return <Format.Errors.UserDefinedValueTypeErrorResult>{ //TS is being bad again :-/
             type: fullType,
             kind: "error" as const,
             error: {

--- a/packages/codec/lib/basic/decode/index.ts
+++ b/packages/codec/lib/basic/decode/index.ts
@@ -704,7 +704,7 @@ function checkPadding(
   userDefinedTypes?: Format.Types.TypesById
 ): boolean {
   const length = byteLength(dataType, userDefinedTypes);
-  let paddingType = getPaddingType(dataType, paddingMode);
+  const paddingType = getPaddingType(dataType, paddingMode);
   if (paddingMode === "permissive") {
     switch (dataType.typeClass) {
       case "bool":
@@ -737,11 +737,10 @@ function removePaddingDirect(
   paddingType: PaddingType
 ) {
   switch (paddingType) {
-    case "left":
-    case "signed":
-      return bytes.slice(-length);
     case "right":
       return bytes.slice(0, length);
+    default:
+      return bytes.slice(-length);
   }
 }
 
@@ -757,6 +756,8 @@ function checkPaddingDirect(
       return checkPaddingRight(bytes, length);
     case "signed":
       return checkPaddingSigned(bytes, length);
+    case "signedOrLeft":
+      return checkPaddingSigned(bytes, length) || checkPaddingLeft(bytes, length);
   }
 }
 
@@ -770,9 +771,14 @@ function getPaddingType(
     case "default":
     case "permissive":
       return defaultPaddingType(dataType);
-    case "zero":
-      let defaultType = defaultPaddingType(dataType);
+    case "zero": {
+      const defaultType = defaultPaddingType(dataType);
       return defaultType === "signed" ? "left" : defaultType;
+    }
+    case "defaultOrZero": {
+      const defaultType = defaultPaddingType(dataType);
+      return defaultType === "signed" ? "signedOrLeft" : defaultType;
+    }
   }
 }
 

--- a/packages/codec/lib/basic/decode/index.ts
+++ b/packages/codec/lib/basic/decode/index.ts
@@ -37,7 +37,7 @@ export function* decodeBasic(
 
   switch (dataType.typeClass) {
     case "userDefinedValueType": {
-      const fullType = <Format.Types.UDVTType>(
+      const fullType = <Format.Types.UdvtType>(
         Format.Types.fullType(dataType, info.userDefinedTypes)
       );
       if (!fullType.underlyingType) {
@@ -64,7 +64,7 @@ export function* decodeBasic(
       switch (underlyingResult.kind) { //yes this switch is a little unnecessary :P
         case "value":
           //wrap the value and return
-          return <Format.Values.UDVTValue>{ //no idea why need coercion here
+          return <Format.Values.UdvtValue>{ //no idea why need coercion here
             type: fullType,
             kind: "value" as const,
             value: underlyingResult
@@ -76,7 +76,7 @@ export function* decodeBasic(
           //does not cause an error in the whole thing, but to do that here
           //would cause problems for the type system :-/
           //so we'll just be inconsistent
-          return <Format.Errors.UDVTErrorResult>{ //TS is being bad again :-/
+          return <Format.Errors.UdvtErrorResult>{ //TS is being bad again :-/
             type: fullType,
             kind: "error" as const,
             error: {

--- a/packages/codec/lib/basic/encode/index.ts
+++ b/packages/codec/lib/basic/encode/index.ts
@@ -16,7 +16,7 @@ export function encodeBasic(input: Format.Values.Value): Uint8Array {
   let bytes: Uint8Array;
   switch (input.type.typeClass) {
     case "userDefinedValueType":
-      return encodeBasic((<Format.Values.UdvtValue>input).value);
+      return encodeBasic((<Format.Values.UserDefinedValueTypeValue>input).value);
     case "uint":
     case "int":
       return Conversion.toBytes(

--- a/packages/codec/lib/basic/encode/index.ts
+++ b/packages/codec/lib/basic/encode/index.ts
@@ -15,6 +15,8 @@ import * as Evm from "@truffle/codec/evm";
 export function encodeBasic(input: Format.Values.Value): Uint8Array {
   let bytes: Uint8Array;
   switch (input.type.typeClass) {
+    case "userDefinedValueType":
+      return encodeBasic((<Format.Values.UDVTValue>input).value);
     case "uint":
     case "int":
       return Conversion.toBytes(

--- a/packages/codec/lib/basic/encode/index.ts
+++ b/packages/codec/lib/basic/encode/index.ts
@@ -16,7 +16,7 @@ export function encodeBasic(input: Format.Values.Value): Uint8Array {
   let bytes: Uint8Array;
   switch (input.type.typeClass) {
     case "userDefinedValueType":
-      return encodeBasic((<Format.Values.UDVTValue>input).value);
+      return encodeBasic((<Format.Values.UdvtValue>input).value);
     case "uint":
     case "int":
       return Conversion.toBytes(

--- a/packages/codec/lib/common/types.ts
+++ b/packages/codec/lib/common/types.ts
@@ -18,16 +18,17 @@ export type ContractKind = "contract" | "library" | "interface";
 /**
  * @Category Enumerations
  */
-export type PaddingMode = "default" | "permissive" | "zero" | "right";
+export type PaddingMode = "default" | "permissive" | "zero" | "right" | "defaultOrZero";
 //default: check padding; the type of padding is determined by the type
 //permissive: like default, but turns off the check on certain types
 //zero: forces zero-padding even on signed types
 //right: forces right-padding on all types
+//defaultOrZero: allows either default or zero
 
 /**
  * @Category Enumerations
  */
-export type PaddingType = "left" | "right" | "signed";
+export type PaddingType = "left" | "right" | "signed" | "signedOrLeft";
 
 
 /**

--- a/packages/codec/lib/compilations/utils.ts
+++ b/packages/codec/lib/compilations/utils.ts
@@ -489,6 +489,7 @@ export function collectUserDefinedTypesAndTaggedOutputs(
           if (
             node.nodeType === "StructDefinition" ||
             node.nodeType === "EnumDefinition" ||
+            node.nodeType === "UserDefinedValueTypeDefinition" ||
             node.nodeType === "ContractDefinition"
           ) {
             references[compilation.id][node.id] = node;
@@ -510,7 +511,8 @@ export function collectUserDefinedTypesAndTaggedOutputs(
             for (const subNode of node.nodes) {
               if (
                 subNode.nodeType === "StructDefinition" ||
-                subNode.nodeType === "EnumDefinition"
+                subNode.nodeType === "EnumDefinition" ||
+                subNode.nodeType === "UserDefinedValueTypeDefinition"
               ) {
                 references[compilation.id][subNode.id] = subNode;
                 //we don't have all the references yet, but we only need the

--- a/packages/codec/lib/compiler/types.ts
+++ b/packages/codec/lib/compiler/types.ts
@@ -8,4 +8,10 @@ export interface CompilerVersion {
 //NOTE: Families 0.5.0 and up will be named by the lowest version that
 //fits in the given family.  So e.g. 0.5.x covers 0.5.x-0.7.x;
 //0.8.x covers 0.8.0-0.8.6; 0.8.7+ covers 0.8.7 to current (as I write this)
-export type SolidityFamily = "unknown" | "pre-0.5.0" | "0.5.x" | "0.8.x" | "0.8.7+";
+export type SolidityFamily =
+  | "unknown"
+  | "pre-0.5.0"
+  | "0.5.x"
+  | "0.8.x"
+  | "0.8.7+"
+  | "0.8.9+";

--- a/packages/codec/lib/compiler/utils.ts
+++ b/packages/codec/lib/compiler/utils.ts
@@ -9,6 +9,12 @@ export function solidityFamily(compiler: CompilerVersion): SolidityFamily {
     return "unknown";
   }
   if (
+    semver.satisfies(compiler.version, ">=0.8.9", {
+      includePrerelease: true
+    })
+  ) {
+    return "0.8.9+";
+  } else if (
     semver.satisfies(compiler.version, ">=0.8.7", {
       includePrerelease: true
     })

--- a/packages/codec/lib/core.ts
+++ b/packages/codec/lib/core.ts
@@ -5,7 +5,6 @@ import type * as Abi from "@truffle/abi-utils";
 import * as Ast from "@truffle/codec/ast";
 import * as AbiData from "@truffle/codec/abi-data";
 import * as Compiler from "@truffle/codec/compiler";
-import type { PaddingMode } from "@truffle/codec/common";
 import * as Topic from "@truffle/codec/topic";
 import type * as Pointer from "@truffle/codec/pointer";
 import type {
@@ -848,25 +847,11 @@ function* decodeBytecode(
     for (const variable of allocation.immutables) {
       const dataType = variable.type; //we don't conditioning on decodingMode here because we know it
       let value: Format.Values.Result;
-      let paddingMode: PaddingMode; //how immutables are padded depends on the Solidity version :-/
-      switch (Compiler.Utils.solidityFamily(context.compiler)) {
-        case "0.5.x":
-        case "0.8.x":
-        case "0.8.7+":
-          //from their introduction until 0.8.8, they were always zero-padded,
-          //regardless of sign
-          paddingMode = "zero";
-          break;
-        default:
-          //now they're padded normally
-          paddingMode = "default";
-          break;
-      }
       try {
         value = yield* decode(dataType, variable.pointer, info, {
           allowRetry: true, //we know we're in full mode
           strictAbiMode: true,
-          paddingMode
+          paddingMode: "defaultOrZero"
         });
       } catch (error) {
         if (error instanceof StopDecodingError && error.allowRetry) {

--- a/packages/codec/lib/decode.ts
+++ b/packages/codec/lib/decode.ts
@@ -63,20 +63,12 @@ function* decodeDispatch(
     case "nowhere":
       //currently only basic types can go in code, so we'll dispatch directly to decodeBasic
       //(if it's a nowhere pointer, this will return an error result, of course)
-      //also: on types with immutables but before 0.8.9, we force zero-padding!
-      debug("compiler: %o", info.currentContext.compiler);
-      debug("options: %o", options);
-      switch (Compiler.Utils.solidityFamily(info.currentContext.compiler)) {
-        case "0.5.x":
-        case "0.8.x":
-        case "0.8.7+":
-          return yield* Basic.Decode.decodeBasic(dataType, pointer, info, {
-            ...options,
-            paddingMode: "zero"
-          });
-        default:
-          return yield* Basic.Decode.decodeBasic(dataType, pointer, info, options);
-      }
+      //(also, Solidity <0.8.9 would always zero-pad immutables regardless of type,
+      //so we have to set the padding mode appropriately to allow for this)
+      return yield* Basic.Decode.decodeBasic(dataType, pointer, info, {
+        ...options,
+        paddingMode: "defaultOrZero"
+      });
 
     case "memory":
       //this case -- decoding something that resides *directly* in memory,

--- a/packages/codec/lib/export.ts
+++ b/packages/codec/lib/export.ts
@@ -141,7 +141,7 @@ function ethersCompatibleNativize(
         }
         case "userDefinedValueType":
           return ethersCompatibleNativize(
-            (<Format.Values.UdvtValue>result).value,
+            (<Format.Values.UserDefinedValueTypeValue>result).value,
             numberFormatter
           );
         case "array":

--- a/packages/codec/lib/export.ts
+++ b/packages/codec/lib/export.ts
@@ -139,6 +139,11 @@ function ethersCompatibleNativize(
               ).toString();
           }
         }
+        case "userDefinedValueType":
+          return ethersCompatibleNativize(
+            (<Format.Values.UDVTValue>result).value,
+            numberFormatter
+          );
         case "array":
           return (<Format.Values.ArrayValue>result).value.map(value =>
             ethersCompatibleNativize(value, numberFormatter)

--- a/packages/codec/lib/export.ts
+++ b/packages/codec/lib/export.ts
@@ -141,7 +141,7 @@ function ethersCompatibleNativize(
         }
         case "userDefinedValueType":
           return ethersCompatibleNativize(
-            (<Format.Values.UDVTValue>result).value,
+            (<Format.Values.UdvtValue>result).value,
             numberFormatter
           );
         case "array":

--- a/packages/codec/lib/format/elementary.ts
+++ b/packages/codec/lib/format/elementary.ts
@@ -19,7 +19,17 @@ export type ElementaryValue =
   | FixedValue
   | UfixedValue
   | EnumValue
+  | UDVTValue
   | ContractValue;
+
+export type BuiltInValueTypeValue =
+  | UintValue
+  | IntValue
+  | BoolValue
+  | BytesStaticValue
+  | AddressValue
+  | FixedValue
+  | UfixedValue;
 
 /**
  * A bytestring value (static or dynamic)
@@ -206,6 +216,17 @@ export interface EnumValue {
      */
     numericAsBN: BN;
   };
+}
+
+/**
+ * A UDVT value
+ *
+ * @Category User-defined elementary types
+ */
+export interface UDVTValue {
+  type: Types.UDVTType;
+  kind: "value";
+  value: BuiltInValueTypeValue;
 }
 
 /**

--- a/packages/codec/lib/format/elementary.ts
+++ b/packages/codec/lib/format/elementary.ts
@@ -22,7 +22,7 @@ export type ElementaryValue =
   | UserDefinedValueTypeValue
   | ContractValue;
 
-export type BuiltInValueTypeValue =
+export type BuiltInValueValue =
   | UintValue
   | IntValue
   | BoolValue
@@ -226,7 +226,7 @@ export interface EnumValue {
 export interface UserDefinedValueTypeValue {
   type: Types.UserDefinedValueTypeType;
   kind: "value";
-  value: BuiltInValueTypeValue;
+  value: BuiltInValueValue;
 }
 
 /**

--- a/packages/codec/lib/format/elementary.ts
+++ b/packages/codec/lib/format/elementary.ts
@@ -19,7 +19,7 @@ export type ElementaryValue =
   | FixedValue
   | UfixedValue
   | EnumValue
-  | UDVTValue
+  | UdvtValue
   | ContractValue;
 
 export type BuiltInValueTypeValue =
@@ -223,8 +223,8 @@ export interface EnumValue {
  *
  * @Category User-defined elementary types
  */
-export interface UDVTValue {
-  type: Types.UDVTType;
+export interface UdvtValue {
+  type: Types.UdvtType;
   kind: "value";
   value: BuiltInValueTypeValue;
 }

--- a/packages/codec/lib/format/elementary.ts
+++ b/packages/codec/lib/format/elementary.ts
@@ -19,7 +19,7 @@ export type ElementaryValue =
   | FixedValue
   | UfixedValue
   | EnumValue
-  | UdvtValue
+  | UserDefinedValueTypeValue
   | ContractValue;
 
 export type BuiltInValueTypeValue =
@@ -223,8 +223,8 @@ export interface EnumValue {
  *
  * @Category User-defined elementary types
  */
-export interface UdvtValue {
-  type: Types.UdvtType;
+export interface UserDefinedValueTypeValue {
+  type: Types.UserDefinedValueTypeType;
   kind: "value";
   value: BuiltInValueTypeValue;
 }

--- a/packages/codec/lib/format/errors.ts
+++ b/packages/codec/lib/format/errors.ts
@@ -80,7 +80,7 @@ export type DecoderError =
   | TypeErrorUnion
   | TupleError
   | EnumError
-  | UDVTError
+  | UdvtError
   | ContractError
   | FunctionExternalError
   | FunctionInternalError
@@ -105,7 +105,7 @@ export type ElementaryErrorResult =
   | FixedErrorResult
   | UfixedErrorResult
   | EnumErrorResult
-  | UDVTErrorResult
+  | UdvtErrorResult
   | ContractErrorResult;
 
 /**
@@ -465,10 +465,10 @@ export interface EnumNotFoundDecodingError {
  *
  * @Category User-defined elementary types
  */
-export interface UDVTErrorResult {
-  type: Types.UDVTType;
+export interface UdvtErrorResult {
+  type: Types.UdvtType;
   kind: "error";
-  error: GenericError | UDVTError;
+  error: GenericError | UdvtError;
 }
 
 /**
@@ -476,7 +476,7 @@ export interface UDVTErrorResult {
  *
  * @Category User-defined elementary types
  */
-export type UDVTError = WrappedError;
+export type UdvtError = WrappedError;
 
 /**
  * An error result representing something going wrong decoding

--- a/packages/codec/lib/format/errors.ts
+++ b/packages/codec/lib/format/errors.ts
@@ -62,6 +62,7 @@ export type DecoderError =
   | TypeErrorUnion
   | TupleError
   | EnumError
+  | UDVTError
   | ContractError
   | FunctionExternalError
   | FunctionInternalError
@@ -86,7 +87,22 @@ export type ElementaryErrorResult =
   | FixedErrorResult
   | UfixedErrorResult
   | EnumErrorResult
+  | UDVTErrorResult
   | ContractErrorResult;
+
+/**
+ * An error result for a built-in value type
+ *
+ * @Category Elementary types
+ */
+export type BuiltInValueTypeErrorResult =
+  | UintErrorResult
+  | IntErrorResult
+  | BoolErrorResult
+  | BytesStaticErrorResult
+  | AddressErrorResult
+  | FixedErrorResult
+  | UfixedErrorResult;
 
 /**
  * An error result for a bytestring
@@ -427,6 +443,35 @@ export interface EnumNotFoundDecodingError {
 }
 
 /**
+ * An error result for a user-defined value type
+ *
+ * @Category User-defined elementary types
+ */
+export interface UDVTErrorResult {
+  type: Types.UDVTType;
+  kind: "error";
+  error: GenericError | UDVTError;
+}
+
+/**
+ * A UDVT-specific error
+ *
+ * @Category User-defined elementary types
+ */
+export type UDVTError = WrappedError;
+
+/**
+ * An error result representing something going wrong decoding
+ * the underlying type when decoding a UDVT
+ *
+ * @Category User-defined elementary types
+ */
+export interface WrappedError {
+  kind: "WrappedError";
+  error: BuiltInValueTypeErrorResult;
+}
+
+/**
  * An error result for a contract
  *
  * @Category User-defined elementary types
@@ -719,6 +764,7 @@ export type GenericError =
   | UserDefinedTypeNotFoundError
   | IndexedReferenceTypeError
   | ReadError;
+
 /**
  * A read error
  *
@@ -730,6 +776,7 @@ export type ReadError =
   | ReadErrorBytes
   | ReadErrorStorage
   | UnusedImmutableError;
+
 /**
  * An error resulting from overlarge length or pointer values
  *

--- a/packages/codec/lib/format/errors.ts
+++ b/packages/codec/lib/format/errors.ts
@@ -80,7 +80,7 @@ export type DecoderError =
   | TypeErrorUnion
   | TupleError
   | EnumError
-  | UdvtError
+  | UserDefinedValueTypeError
   | ContractError
   | FunctionExternalError
   | FunctionInternalError
@@ -105,7 +105,7 @@ export type ElementaryErrorResult =
   | FixedErrorResult
   | UfixedErrorResult
   | EnumErrorResult
-  | UdvtErrorResult
+  | UserDefinedValueTypeErrorResult
   | ContractErrorResult;
 
 /**
@@ -465,10 +465,10 @@ export interface EnumNotFoundDecodingError {
  *
  * @Category User-defined elementary types
  */
-export interface UdvtErrorResult {
-  type: Types.UdvtType;
+export interface UserDefinedValueTypeErrorResult {
+  type: Types.UserDefinedValueTypeType;
   kind: "error";
-  error: GenericError | UdvtError;
+  error: GenericError | UserDefinedValueTypeError;
 }
 
 /**
@@ -476,7 +476,7 @@ export interface UdvtErrorResult {
  *
  * @Category User-defined elementary types
  */
-export type UdvtError = WrappedError;
+export type UserDefinedValueTypeError = WrappedError;
 
 /**
  * An error result representing something going wrong decoding

--- a/packages/codec/lib/format/errors.ts
+++ b/packages/codec/lib/format/errors.ts
@@ -113,7 +113,7 @@ export type ElementaryErrorResult =
  *
  * @Category Elementary types
  */
-export type BuiltInValueTypeErrorResult =
+export type BuiltInValueErrorResult =
   | UintErrorResult
   | IntErrorResult
   | BoolErrorResult
@@ -486,7 +486,7 @@ export type UserDefinedValueTypeError = WrappedError;
  */
 export interface WrappedError {
   kind: "WrappedError";
-  error: BuiltInValueTypeErrorResult;
+  error: BuiltInValueErrorResult;
 }
 
 /**

--- a/packages/codec/lib/format/errors.ts
+++ b/packages/codec/lib/format/errors.ts
@@ -40,6 +40,24 @@ export type ErrorResult =
   | FunctionInternalErrorResult;
 
 /**
+ * An error result for an ABI type
+ *
+ * @Category General categories
+ */
+export type AbiErrorResult =
+  | UintErrorResult
+  | IntErrorResult
+  | BoolErrorResult
+  | BytesErrorResult
+  | AddressErrorResult
+  | FixedErrorResult
+  | UfixedErrorResult
+  | StringErrorResult
+  | ArrayErrorResult
+  | FunctionExternalErrorResult
+  | TupleErrorResult;
+
+/**
  * One of the underlying errors contained in an [[ErrorResult]]
  *
  * @Category General categories

--- a/packages/codec/lib/format/types.ts
+++ b/packages/codec/lib/format/types.ts
@@ -46,7 +46,7 @@ export type Type =
   | FunctionType
   | StructType
   | EnumType
-  | UDVTType
+  | UdvtType
   | ContractType
   | MagicType
   | TypeType
@@ -228,7 +228,7 @@ export type ElementaryType =
   | AddressType
   | StringType
   | EnumType
-  | UDVTType
+  | UdvtType
   | ContractType;
 
 /**
@@ -341,7 +341,7 @@ export interface FunctionExternalTypeGeneral {
 export type ContractDefinedType =
   | StructTypeLocal
   | EnumTypeLocal
-  | UDVTTypeLocal;
+  | UdvtTypeLocal;
 
 /**
  * User-defined types
@@ -353,7 +353,7 @@ export type UserDefinedType =
   | ContractTypeNative
   | StructTypeGlobal
   | EnumTypeGlobal
-  | UDVTTypeGlobal;
+  | UdvtTypeGlobal;
 
 /**
  * Type of a struct
@@ -533,14 +533,14 @@ export interface ContractTypeForeign {
  *
  * @Category User-defined elementary types
  */
-export type UDVTType = UDVTTypeLocal | UDVTTypeGlobal;
+export type UdvtType = UdvtTypeLocal | UdvtTypeGlobal;
 
 /**
  * Local UDVT (defined in a contract)
  *
  * @Category User-defined elementary types
  */
-export interface UDVTTypeLocal {
+export interface UdvtTypeLocal {
   typeClass: "userDefinedValueType";
   kind: "local";
   /**
@@ -558,7 +558,7 @@ export interface UDVTTypeLocal {
  *
  * @Category User-defined elementary types
  */
-export interface UDVTTypeGlobal {
+export interface UdvtTypeGlobal {
   typeClass: "userDefinedValueType";
   kind: "global";
   /**
@@ -860,5 +860,5 @@ export function isContractDefinedType(
 ): anyType is ContractDefinedType {
   const contractDefinedTypes = ["enum", "struct", "userDefinedValueType"];
   return contractDefinedTypes.includes(anyType.typeClass)
-    && (<EnumType|StructType|UDVTType>anyType).kind === "local";
+    && (<EnumType|StructType|UdvtType>anyType).kind === "local";
 }

--- a/packages/codec/lib/format/types.ts
+++ b/packages/codec/lib/format/types.ts
@@ -245,6 +245,24 @@ export type BuiltInValueType =
   | AddressTypeSpecific; //UDVTs only exist on 0.8.8 and later
 
 /**
+ * Types that can go in the ABI
+ *
+ * @Category General categories
+ */
+export type AbiType =
+  | UintType
+  | IntType
+  | BoolType
+  | BytesType
+  | AddressTypeGeneral
+  | FixedType
+  | UfixedType
+  | StringType
+  | ArrayType
+  | FunctionExternalTypeGeneral
+  | TupleType;
+
+/**
  * Type of a mapping
  *
  * @Category Container types

--- a/packages/codec/lib/format/types.ts
+++ b/packages/codec/lib/format/types.ts
@@ -46,7 +46,7 @@ export type Type =
   | FunctionType
   | StructType
   | EnumType
-  | UdvtType
+  | UserDefinedValueTypeType
   | ContractType
   | MagicType
   | TypeType
@@ -228,7 +228,7 @@ export type ElementaryType =
   | AddressType
   | StringType
   | EnumType
-  | UdvtType
+  | UserDefinedValueTypeType
   | ContractType;
 
 /**
@@ -341,7 +341,7 @@ export interface FunctionExternalTypeGeneral {
 export type ContractDefinedType =
   | StructTypeLocal
   | EnumTypeLocal
-  | UdvtTypeLocal;
+  | UserDefinedValueTypeTypeLocal;
 
 /**
  * User-defined types
@@ -353,7 +353,7 @@ export type UserDefinedType =
   | ContractTypeNative
   | StructTypeGlobal
   | EnumTypeGlobal
-  | UdvtTypeGlobal;
+  | UserDefinedValueTypeTypeGlobal;
 
 /**
  * Type of a struct
@@ -533,14 +533,14 @@ export interface ContractTypeForeign {
  *
  * @Category User-defined elementary types
  */
-export type UdvtType = UdvtTypeLocal | UdvtTypeGlobal;
+export type UserDefinedValueTypeType = UserDefinedValueTypeTypeLocal | UserDefinedValueTypeTypeGlobal;
 
 /**
  * Local UDVT (defined in a contract)
  *
  * @Category User-defined elementary types
  */
-export interface UdvtTypeLocal {
+export interface UserDefinedValueTypeTypeLocal {
   typeClass: "userDefinedValueType";
   kind: "local";
   /**
@@ -558,7 +558,7 @@ export interface UdvtTypeLocal {
  *
  * @Category User-defined elementary types
  */
-export interface UdvtTypeGlobal {
+export interface UserDefinedValueTypeTypeGlobal {
   typeClass: "userDefinedValueType";
   kind: "global";
   /**
@@ -860,5 +860,5 @@ export function isContractDefinedType(
 ): anyType is ContractDefinedType {
   const contractDefinedTypes = ["enum", "struct", "userDefinedValueType"];
   return contractDefinedTypes.includes(anyType.typeClass)
-    && (<EnumType|StructType|UdvtType>anyType).kind === "local";
+    && (<EnumType|StructType|UserDefinedValueTypeType>anyType).kind === "local";
 }

--- a/packages/codec/lib/format/types.ts
+++ b/packages/codec/lib/format/types.ts
@@ -25,6 +25,7 @@ const debug = debugModule("codec:format:types");
 
 import type BN from "bn.js";
 import type { ContractKind, Location, Mutability } from "@truffle/codec/common";
+import type { CompilerVersion } from "@truffle/codec/compiler";
 
 /**
  * Object representing a type
@@ -631,6 +632,22 @@ export type ReferenceType =
 
 export interface TypesById {
   [id: string]: UserDefinedType;
+}
+
+export interface TypesByCompilationAndId {
+  [compilationId: string]: {
+    compiler: CompilerVersion;
+    types: TypesById;
+  };
+}
+
+export function forgetCompilations(
+  typesByCompilation: TypesByCompilationAndId
+): TypesById {
+  return Object.assign(
+    {},
+    ...Object.values(typesByCompilation).map(({ types }) => types)
+  );
 }
 
 function isUserDefinedType(anyType: Type): anyType is UserDefinedType {

--- a/packages/codec/lib/format/utils/inspect.ts
+++ b/packages/codec/lib/format/utils/inspect.ts
@@ -152,7 +152,7 @@ export class ResultInspector {
           }
           case "userDefinedValueType": {
             const typeName = Format.Types.typeStringWithoutLocation(this.result.type);
-            const coercedResult = <Format.Values.UdvtValue>this.result;
+            const coercedResult = <Format.Values.UserDefinedValueTypeValue>this.result;
             const inspectOfUnderlying = util.inspect(
               new ResultInspector(coercedResult.value),
               options
@@ -544,7 +544,7 @@ function unsafeNativizeWithTable(
       }
     }
     case "userDefinedValueType": {
-      return unsafeNativize((<Format.Values.UdvtValue>result).value);
+      return unsafeNativize((<Format.Values.UserDefinedValueTypeValue>result).value);
     }
     case "mapping":
       return Object.assign(

--- a/packages/codec/lib/format/utils/inspect.ts
+++ b/packages/codec/lib/format/utils/inspect.ts
@@ -2,7 +2,7 @@ import debugModule from "debug";
 const debug = debugModule("codec:format:utils:inspect");
 
 import util from "util";
-import type * as Format from "@truffle/codec/format/common";
+import * as Format from "@truffle/codec/format/common";
 import * as Exception from "./exception";
 
 //we'll need to write a typing for the options type ourself, it seems; just
@@ -150,6 +150,15 @@ export class ResultInspector {
               options
             );
           }
+          case "userDefinedValueType": {
+            const typeName = Format.Types.typeStringWithoutLocation(this.result.type);
+            const coercedResult = <Format.Values.UDVTValue>this.result;
+            const inspectOfUnderlying = util.inspect(
+              new ResultInspector(coercedResult.value),
+              options
+            );
+            return `${typeName}.wrap(${inspectOfUnderlying})`; //note only the underlying part is stylized
+          }
           case "tuple": {
             let coercedResult = <Format.Values.TupleValue>this.result;
             //if everything is named, do same as with struct.
@@ -291,6 +300,11 @@ export class ResultInspector {
         debug("this.result: %O", this.result);
         let errorResult = <Format.Errors.ErrorResult>this.result; //the hell?? why couldn't it make this inference??
         switch (errorResult.error.kind) {
+          case "WrappedError":
+            return util.inspect(
+              new ResultInspector(errorResult.error.error),
+              options
+            );
           case "UintPaddingError":
             return `Uint has incorrect padding (expected padding: ${errorResult.error.paddingType}) (raw value ${errorResult.error.raw})`;
           case "IntPaddingError":
@@ -383,7 +397,7 @@ class ContractInfoInspector {
   }
 }
 
-function enumTypeName(enumType: Format.Types.EnumType) {
+function enumTypeName(enumType: Format.Types.EnumType): string {
   return (
     (enumType.kind === "local" ? enumType.definingContractName + "." : "") +
     enumType.typeName
@@ -528,6 +542,9 @@ function unsafeNativizeWithTable(
       } else {
         return seenSoFar[coercedResult.reference - 1];
       }
+    }
+    case "userDefinedValueType": {
+      return unsafeNativize((<Format.Values.UDVTValue>result).value);
     }
     case "mapping":
       return Object.assign(

--- a/packages/codec/lib/format/utils/inspect.ts
+++ b/packages/codec/lib/format/utils/inspect.ts
@@ -152,7 +152,7 @@ export class ResultInspector {
           }
           case "userDefinedValueType": {
             const typeName = Format.Types.typeStringWithoutLocation(this.result.type);
-            const coercedResult = <Format.Values.UDVTValue>this.result;
+            const coercedResult = <Format.Values.UdvtValue>this.result;
             const inspectOfUnderlying = util.inspect(
               new ResultInspector(coercedResult.value),
               options
@@ -544,7 +544,7 @@ function unsafeNativizeWithTable(
       }
     }
     case "userDefinedValueType": {
-      return unsafeNativize((<Format.Values.UDVTValue>result).value);
+      return unsafeNativize((<Format.Values.UdvtValue>result).value);
     }
     case "mapping":
       return Object.assign(

--- a/packages/codec/lib/format/values.ts
+++ b/packages/codec/lib/format/values.ts
@@ -32,7 +32,7 @@ import type {
   FixedValue,
   UfixedValue,
   EnumValue,
-  UdvtValue,
+  UserDefinedValueTypeValue,
   ContractValue,
   ContractValueInfoKnown,
   ContractValueInfoUnknown
@@ -136,7 +136,7 @@ export type ElementaryResult =
   | FixedResult
   | UfixedResult
   | EnumResult
-  | UdvtResult
+  | UserDefinedValueTypeResult
   | ContractResult;
 
 /**
@@ -229,7 +229,7 @@ export type EnumResult = EnumValue | Errors.EnumErrorResult;
  *
  * @Category User-defined elementary types
  */
-export type UdvtResult = UdvtValue | Errors.UdvtErrorResult;
+export type UserDefinedValueTypeResult = UserDefinedValueTypeValue | Errors.UserDefinedValueTypeErrorResult;
 
 /**
  * A contract value or error

--- a/packages/codec/lib/format/values.ts
+++ b/packages/codec/lib/format/values.ts
@@ -31,6 +31,7 @@ import type {
   FixedValue,
   UfixedValue,
   EnumValue,
+  UDVTValue,
   ContractValue,
   ContractValueInfoKnown,
   ContractValueInfoUnknown
@@ -98,6 +99,7 @@ export type ElementaryResult =
   | FixedResult
   | UfixedResult
   | EnumResult
+  | UDVTResult
   | ContractResult;
 
 /**
@@ -184,6 +186,13 @@ export type UfixedResult = UfixedValue | Errors.UfixedErrorResult;
  * @Category User-defined elementary types
  */
 export type EnumResult = EnumValue | Errors.EnumErrorResult;
+
+/**
+ * A UDVT value or error
+ *
+ * @Category User-defined elementary types
+ */
+export type UDVTResult = UDVTValue | Errors.UDVTErrorResult;
 
 /**
  * A contract value or error

--- a/packages/codec/lib/format/values.ts
+++ b/packages/codec/lib/format/values.ts
@@ -32,7 +32,7 @@ import type {
   FixedValue,
   UfixedValue,
   EnumValue,
-  UDVTValue,
+  UdvtValue,
   ContractValue,
   ContractValueInfoKnown,
   ContractValueInfoUnknown
@@ -136,7 +136,7 @@ export type ElementaryResult =
   | FixedResult
   | UfixedResult
   | EnumResult
-  | UDVTResult
+  | UdvtResult
   | ContractResult;
 
 /**
@@ -229,7 +229,7 @@ export type EnumResult = EnumValue | Errors.EnumErrorResult;
  *
  * @Category User-defined elementary types
  */
-export type UDVTResult = UDVTValue | Errors.UDVTErrorResult;
+export type UdvtResult = UdvtValue | Errors.UdvtErrorResult;
 
 /**
  * A contract value or error

--- a/packages/codec/lib/format/values.ts
+++ b/packages/codec/lib/format/values.ts
@@ -26,6 +26,7 @@ import type {
   BoolValue,
   BytesStaticValue,
   BytesDynamicValue,
+  BytesValue,
   AddressValue,
   StringValue,
   FixedValue,
@@ -75,6 +76,42 @@ export type Value =
   | TypeValue
   | FunctionExternalValue
   | FunctionInternalValue;
+
+/**
+ * A value that can go in the ABI
+ *
+ * @Category General categories
+ */
+export type AbiValue =
+  | UintValue
+  | IntValue
+  | BoolValue
+  | BytesValue
+  | AddressValue
+  | FixedValue
+  | UfixedValue
+  | StringValue
+  | ArrayValue
+  | FunctionExternalValue
+  | TupleValue;
+
+/**
+ * A result for an ABI type
+ *
+ * @Category General categories
+ */
+export type AbiResult =
+  | UintResult
+  | IntResult
+  | BoolResult
+  | BytesResult
+  | AddressResult
+  | FixedResult
+  | UfixedResult
+  | StringResult
+  | ArrayResult
+  | FunctionExternalResult
+  | TupleResult;
 
 /*
  * SECTION 2: Built-in elementary types

--- a/packages/codec/lib/special/decode/index.ts
+++ b/packages/codec/lib/special/decode/index.ts
@@ -168,6 +168,7 @@ function coinbaseType(
     case "0.5.x":
     case "0.8.x":
     case "0.8.7+":
+    case "0.8.9+":
       return {
         typeClass: "address",
         kind: "specific",

--- a/packages/codec/lib/storage/allocate/index.ts
+++ b/packages/codec/lib/storage/allocate/index.ts
@@ -541,6 +541,16 @@ function storageSizeAndAllocate(
       };
     }
 
+    case "userDefinedValueType": {
+      //surprisingly, these always take up a full word in storage,
+      //regardless of their underlying type!  So I'm handling
+      //them here rather than in byteLength
+      return {
+        size: { words: 1 },
+        allocations: existingAllocations
+      };
+    }
+
     default:
       //otherwise, it's a direct type
       return {

--- a/packages/debugger/lib/ast/sagas/index.js
+++ b/packages/debugger/lib/ast/sagas/index.js
@@ -50,6 +50,7 @@ function* handleEnter(sourceId, sourceIndex, node, pointer, parentId) {
     case "ContractDefinition":
     case "StructDefinition":
     case "EnumDefinition":
+    case "UserDefinedValueTypeDefinition":
       debug("%s recording type %o", pointer, node);
       yield* data.defineType(node, sourceId);
       break;

--- a/packages/debugger/lib/data/sagas/index.js
+++ b/packages/debugger/lib/data/sagas/index.js
@@ -1120,9 +1120,11 @@ export function* reset() {
 export function* recordAllocations() {
   const contracts = yield select(data.views.contractAllocationInfo);
   const referenceDeclarations = yield select(data.views.referenceDeclarations);
+  const userDefinedTypesByCompilation =
+    yield select(data.views.userDefinedTypesByCompilation);
   const userDefinedTypes = yield select(data.views.userDefinedTypes);
   const storageAllocations = Codec.Storage.Allocate.getStorageAllocations(
-    userDefinedTypes
+    userDefinedTypesByCompilation
   );
   const memoryAllocations = Codec.Memory.Allocate.getMemoryAllocations(
     userDefinedTypes

--- a/packages/debugger/lib/data/sagas/index.js
+++ b/packages/debugger/lib/data/sagas/index.js
@@ -990,6 +990,8 @@ function* decodeMappingKeyCore(indexDefinition, keyDefinition) {
 
     const indexReference = (currentAssignments[fullIndexId] || {}).ref;
 
+    debug("indexDefinition.nodeType: %o", indexDefinition.nodeType);
+    debug("indexDefinition.kind: %o", indexDefinition.kind);
     if (Codec.Ast.Utils.isSimpleConstant(indexDefinition)) {
       //while the main case is the next one, where we look for a prior
       //assignment, we need this case (and need it first) for two reasons:
@@ -1068,7 +1070,11 @@ function* decodeMappingKeyCore(indexDefinition, keyDefinition) {
     //(note that this case is last for a reason; if this were earlier, it
     //would catch *non*-silent type conversions, which we want to just read
     //off the stack)
-    else if (indexDefinition.kind === "typeConversion") {
+    else if (
+      indexDefinition.nodeType === "FunctionCall" &&
+      indexDefinition.kind === "typeConversion"
+    ) {
+      debug("type conversion case");
       indexDefinition = indexDefinition.arguments[0];
     }
     //...also prior to 0.5.0, unary + was legal, which needs to be accounted
@@ -1077,7 +1083,20 @@ function* decodeMappingKeyCore(indexDefinition, keyDefinition) {
       indexDefinition.nodeType === "UnaryOperation" &&
       indexDefinition.operator === "+"
     ) {
+      debug("unary + case");
       indexDefinition = indexDefinition.subExpression;
+    }
+    //...and starting in 0.8.8, we'd better handle wrap and unwrap as well for
+    //the same reason!
+    else if (
+      indexDefinition.nodeType === "FunctionCall" &&
+      indexDefinition.kind === "functionCall" &&
+      ["wrap", "unwrap"].includes(
+        Codec.Ast.Utils.functionClass(indexDefinition.expression)
+      )
+    ) {
+      debug("wrap/unwrap case");
+      indexDefinition = indexDefinition.arguments[0];
     }
     //otherwise, we've just totally failed to decode it, so we mark
     //indexValue as null (as distinct from undefined) to indicate this.  In
@@ -1085,10 +1104,12 @@ function* decodeMappingKeyCore(indexDefinition, keyDefinition) {
     //not quite there yet, sorry (because we can't yet handle all constant
     //state variables)
     else {
+      debug("we failed");
       return null;
     }
+    debug("retrying");
     //now, as mentioned, retry in the typeConversion case
-    //(or unary + case)
+    //(or unary + case, or wrap/unwrap case)
   }
 }
 

--- a/packages/debugger/test/data/immutable.js
+++ b/packages/debugger/test/data/immutable.js
@@ -13,7 +13,7 @@ import * as Codec from "@truffle/codec";
 import solidity from "lib/solidity/selectors";
 
 const __IMMUTABLE = `
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.8;
 
 contract Base {
   int8 immutable base = -37;
@@ -24,11 +24,14 @@ contract ImmutableTest is Base {
     Red, Green, Blue
   }
 
+  type MyInt is int8;
+
   Color immutable background;
   bool immutable truth;
   address immutable self;
   bytes1 immutable secret;
   uint8 immutable trulySecret;
+  MyInt immutable obscured;
 
   event Done();
 
@@ -38,6 +41,7 @@ contract ImmutableTest is Base {
     self = address(this);
     secret = 0x88;
     trulySecret = 23;
+    obscured = MyInt.wrap(-1);
     emit Done(); //BREAK CONSTRUCTOR
   }
 
@@ -53,6 +57,7 @@ contract ImmutableTest is Base {
     emit Bool(truth);
     emit Address(self);
     emit Byte(secret);
+    emit Number(MyInt.unwrap(obscured));
     emit Done(); //BREAK DEPLOYED
   }
 }
@@ -107,7 +112,8 @@ describe("Immutable state variables", function () {
       background: "ImmutableTest.Color.Blue",
       truth: true,
       self: address,
-      secret: "0x88"
+      secret: "0x88",
+      obscured: -1
     };
 
     assert.deepInclude(variables, expectedResult);
@@ -144,7 +150,8 @@ describe("Immutable state variables", function () {
       truth: true,
       self: address,
       secret: "0x88",
-      trulySecret: 23
+      trulySecret: 23,
+      obscured: -1
     };
 
     assert.deepInclude(variables, expectedResult);

--- a/packages/debugger/test/data/more-decoding.js
+++ b/packages/debugger/test/data/more-decoding.js
@@ -74,13 +74,15 @@ contract ContainersTest {
 `;
 
 const __KEYSANDBYTES = `
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.8;
 
 contract ElementaryTest {
 
   event Done(); //makes a useful breakpoint
 
   enum Ternary { Red, Green, Blue }
+
+  type MyInt is int8;
 
   //storage variables to be tested
   mapping(bool => bool) boolMap;
@@ -92,6 +94,7 @@ contract ElementaryTest {
   mapping(address => address) addressMap;
   mapping(ElementaryTest => ElementaryTest) contractMap;
   mapping(Ternary => Ternary) enumMap;
+  mapping(MyInt => MyInt) wrapMap;
 
   //constant state variables to try as mapping keys
   uint constant two = 2;
@@ -125,6 +128,8 @@ contract ElementaryTest {
     contractMap[this] = this;
 
     enumMap[Ternary.Blue] = Ternary.Blue;
+
+    wrapMap[MyInt.wrap(-2)] = MyInt.wrap(-2);
 
     emit Done(); //break here
   }
@@ -393,6 +398,7 @@ describe("Further Decoding", function () {
       addressMap: { [address]: address },
       contractMap: { [address]: address },
       enumMap: { "ElementaryTest.Ternary.Blue": "ElementaryTest.Ternary.Blue" },
+      wrapMap: { "-2": -2 },
       oneByte: "0xff",
       severalBytes: ["0xff"]
     };

--- a/packages/debugger/test/helpers.js
+++ b/packages/debugger/test/helpers.js
@@ -26,7 +26,7 @@ export async function prepareContracts(provider, sources = {}, migrations) {
 
   config.compilers = {
     solc: {
-      version: "0.8.7",
+      version: "0.8.8",
       settings: {
         optimizer: { enabled: false, runs: 200 },
         evmVersion: "london"

--- a/packages/debugger/test/helpers.js
+++ b/packages/debugger/test/helpers.js
@@ -26,7 +26,7 @@ export async function prepareContracts(provider, sources = {}, migrations) {
 
   config.compilers = {
     solc: {
-      version: "0.8.8",
+      version: "0.8.9",
       settings: {
         optimizer: { enabled: false, runs: 200 },
         evmVersion: "london"

--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -1707,7 +1707,10 @@ export class ContractInstanceDecoder {
         break;
       case "mapping":
         let keyType = parentType.keyType;
-        if (keyType.typeClass === "enum") {
+        if (
+          keyType.typeClass === "enum" ||
+          keyType.typeClass === "userDefinedValueType"
+        ) {
           keyType = <Format.Types.EnumType>(
             Format.Types.fullType(keyType, this.userDefinedTypes)
           );

--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -53,6 +53,7 @@ export class ProjectDecoder {
   private contractsAndContexts: AbiData.Allocate.ContractAndContexts[] = [];
 
   private referenceDeclarations: { [compilationId: string]: Ast.AstNodes };
+  private userDefinedTypesByCompilation: Format.Types.TypesByCompilationAndId;
   private userDefinedTypes: Format.Types.TypesById;
   private allocations: Evm.AllocationInfo;
 
@@ -78,6 +79,7 @@ export class ProjectDecoder {
 
     ({
       definitions: this.referenceDeclarations,
+      typesByCompilation: this.userDefinedTypesByCompilation,
       types: this.userDefinedTypes
     } = Compilations.Utils.collectUserDefinedTypesAndTaggedOutputs(this.compilations));
 
@@ -93,7 +95,7 @@ export class ProjectDecoder {
       this.userDefinedTypes
     );
     this.allocations.storage = Storage.Allocate.getStorageAllocations(
-      this.userDefinedTypes
+      this.userDefinedTypesByCompilation
     ); //not used by project decoder itself, but used by contract decoder
     this.allocations.calldata = AbiData.Allocate.getCalldataAllocations(
       allocationInfo,

--- a/packages/decoder/lib/utils.ts
+++ b/packages/decoder/lib/utils.ts
@@ -7,7 +7,7 @@ import BN from "bn.js";
 import type * as Codec from "@truffle/codec";
 
 //Function for wrapping a value as an ElementaryValue
-//(note: assumes any enum types are the full type)
+//(note: assumes any enum types & UDVTs are the full type)
 //WARNING: this function does not check its inputs! Please check before using!
 //How to use:
 //numbers may be BN, number, or numeric string
@@ -116,6 +116,8 @@ export function wrapElementaryValue(
           numericAsBN: numeric
         }
       };
+    case "userDefinedValueType":
+      return wrapElementaryValue(value, dataType.underlyingType);
     //fixed and ufixed are not handled for now!
   }
 }

--- a/packages/decoder/test/current/contracts/CompatibleTest.sol
+++ b/packages/decoder/test/current/contracts/CompatibleTest.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.8;
 pragma experimental ABIEncoderV2;
 
 contract CompatibleNativizeTest {
@@ -8,6 +8,8 @@ contract CompatibleNativizeTest {
     string x;
     string y;
   }
+
+  type MyBool is bool;
 
   event String(string z);
   event TwoStrings(string w, string z);
@@ -43,5 +45,9 @@ contract CompatibleNativizeTest {
 
   function returnBytes() public pure returns (bytes memory) {
     return hex"";
+  }
+
+  function returnCustom() public pure returns (MyBool) {
+    return MyBool.wrap(true);
   }
 }

--- a/packages/decoder/test/current/contracts/DecodingSample.sol
+++ b/packages/decoder/test/current/contracts/DecodingSample.sol
@@ -1,7 +1,10 @@
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.8;
 
 contract DecodingSample {
+
+  type MyInt is int8;
+
   enum E {
     EnumValZero,
     EnumValOne,
@@ -31,11 +34,14 @@ contract DecodingSample {
   bytes   varBytes;
   E       varEnum;
   S       varStructS;
+  MyInt   varCustom1;
+  MyInt   varCustom2;
 
   mapping(uint => uint) varMapping;
   mapping(address => uint) varAddressMapping;
   mapping(DecodingSample => uint) varContractMapping;
   mapping(E => uint) varEnumMapping;
+  mapping(MyInt => MyInt) varWrapMapping;
 
   uint immutable immutableUint;
 
@@ -84,6 +90,8 @@ contract DecodingSample {
     varStructS.structS2.structTwoDynamicArrayUint[0] = 4;
     varStructS.structS2.structTwoDynamicArrayUint[1] = 8;
     varStructS.structS2.structTwoDynamicArrayUint[2] = 12;
+    varCustom1 = MyInt.wrap(-1);
+    varCustom2 = MyInt.wrap(-2);
 
     immutableUint = 16;
 
@@ -132,6 +140,7 @@ contract DecodingSample {
     varEnumMapping[E.EnumValTwo] = 2;
     varEnumMapping[E.EnumValThree] = 3;
     varEnumMapping[E.EnumValFour] = 4;
+    varWrapMapping[MyInt.wrap(-3)] = MyInt.wrap(-3);
 
     functionInternal = example;
   }

--- a/packages/decoder/test/current/contracts/DowngradeTest.sol
+++ b/packages/decoder/test/current/contracts/DowngradeTest.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.8;
 pragma experimental ABIEncoderV2;
 
 contract DowngradeTestParent {
@@ -10,9 +10,11 @@ contract DowngradeTest is DowngradeTestParent {
 
   //structs; enums; contracts; address payable; functions
 
+  type MyInt is int16;
+
   struct Pair {
     uint x;
-    uint y;
+    MyInt y;
   }
 
   struct AsymmetricTriple {
@@ -72,13 +74,13 @@ contract DowngradeTest is DowngradeTestParent {
   }
 
   function returnsStuff() public pure returns (Pair memory, Ternary) {
-    return (Pair(107, 683), Ternary.No);
+    return (Pair(107, MyInt.wrap(683)), Ternary.No);
   }
 
   error CustomError(Pair pair);
 
   function throwCustom() public pure {
-    revert CustomError(Pair(1, 2));
+    revert CustomError(Pair(1, MyInt.wrap(2)));
   }
 }
 

--- a/packages/decoder/test/current/contracts/WireTest.sol
+++ b/packages/decoder/test/current/contracts/WireTest.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.8.4;
+pragma solidity ^0.8.8;
 pragma experimental ABIEncoderV2;
 
 contract WireTestParent {
@@ -36,6 +36,8 @@ enum GlobalEnum {
 
 contract WireTest is WireTestParent, WireTestAbstract {
 
+  type MyInt is int8;
+
   function notImplemented() public {
     emit Done();
   } //just a dummy function, not 
@@ -70,10 +72,10 @@ contract WireTest is WireTestParent, WireTestAbstract {
     Yes, No, MaybeSo
   }
 
-  event EmitStuff(Triple, address[2], string[]);
+  event EmitStuff(Triple, address[2], string[], MyInt);
 
-  function emitStuff(Triple memory p, address[2] memory precompiles, string[] memory strings) public {
-    emit EmitStuff(p, precompiles, strings);
+  function emitStuff(Triple memory p, address[2] memory precompiles, string[] memory strings, MyInt x) public {
+    emit EmitStuff(p, precompiles, strings, x);
   }
 
   event MoreStuff(WireTest, uint[] data);
@@ -167,8 +169,16 @@ contract WireTest is WireTestParent, WireTestAbstract {
   mapping(string => Triple[]) public deepStruct;
   mapping(string => string)[] public deepString;
 
-  function returnsStuff() public pure returns (Triple memory, Ternary) {
-    return (Triple(-1, 0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef, hex"deadbeef"), Ternary.No);
+  function returnsStuff() public pure returns (Triple memory, Ternary, MyInt) {
+    return (
+      Triple(
+        -1,
+        0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef,
+        hex"deadbeef"
+      ),
+      Ternary.No,
+      MyInt.wrap(-1)
+    );
   }
 
   function overriddenReturn() public pure override returns (uint) {

--- a/packages/decoder/test/current/test/compatible-nativize.js
+++ b/packages/decoder/test/current/test/compatible-nativize.js
@@ -76,7 +76,8 @@ describe("nativize (ethers format)", function () {
         __length__: 1
       },
       returnFunction: instance.address.toLowerCase() + emitStringSelector,
-      returnBytes: null
+      returnBytes: null,
+      returnCustom: true
     };
     expected.returnStringPair.w = "hello";
     expected.returnStringPair.z = "goodbye";

--- a/packages/decoder/test/current/test/decoding-test.js
+++ b/packages/decoder/test/current/test/decoding-test.js
@@ -43,6 +43,7 @@ describe("State variable decoding", function () {
     await decoder.watchMappingKey("varEnumMapping", "EnumValTwo");
     await decoder.watchMappingKey("varEnumMapping", "3");
     await decoder.watchMappingKey("varEnumMapping", 4);
+    await decoder.watchMappingKey("varWrapMapping", -3);
 
     const initialState = await decoder.state();
     const initialVariables = await decoder.variables();
@@ -66,6 +67,8 @@ describe("State variable decoding", function () {
     assert.equal(variables.varBytes, "0x01030307");
     assert.equal(typeof variables.varEnum, "string");
     assert.equal(variables.varEnum, "DecodingSample.E.EnumValTwo");
+    assert.equal(variables.varCustom1, -1);
+    assert.equal(variables.varCustom2, -2);
 
     const struct = variables.varStructS;
     validateStructS(struct, [
@@ -134,6 +137,7 @@ describe("State variable decoding", function () {
     assert.equal(variables.varEnumMapping["DecodingSample.E.EnumValTwo"], 2);
     assert.equal(variables.varEnumMapping["DecodingSample.E.EnumValThree"], 3);
     assert.equal(variables.varEnumMapping["DecodingSample.E.EnumValFour"], 4);
+    assert.equal(variables.varWrapMapping[-3], -3);
 
     assert.equal(
       variables.functionExternal,

--- a/packages/decoder/test/current/test/downgrade-test.js
+++ b/packages/decoder/test/current/test/downgrade-test.js
@@ -411,11 +411,11 @@ function verifyAbiDecoding(decoding, address) {
   assert.lengthOf(decoding.arguments, 4);
   //we'll skip verifying the names as well
 
-  //first argument: {{x: 7, y: 5}, z: 3}
+  //first argument: {{x: 7, y: -5}, z: 3}
   assert.strictEqual(decoding.arguments[0].value.type.typeClass, "tuple");
   assert.deepEqual(
     Codec.Format.Utils.Inspect.unsafeNativize(decoding.arguments[0].value),
-    [[7, 5], 3]
+    [[7, -5], 3]
   );
   //second argument: No (i.e. 1)
   assert.strictEqual(decoding.arguments[1].value.type.typeClass, "uint");
@@ -478,7 +478,7 @@ async function runTestBody(
   let deployedContract = await abstractions.DowngradeTest.new();
   let address = deployedContract.address;
 
-  let result = await deployedContract.run([[7, 5], 3], 1, address, address);
+  let result = await deployedContract.run([[7, -5], 3], 1, address, address);
   let resultHash = result.tx;
   let resultTx = await web3.eth.getTransaction(resultHash);
   let resultLog = result.receipt.rawLogs[0];
@@ -505,7 +505,7 @@ async function runTestBody(
     //still getting it.  weird.  well, whatever...
     try {
       await deployedContract.causeTrouble();
-    } catch (_) {
+    } catch {
       //do nothing, get the result a different way
     }
     //HACK

--- a/packages/decoder/test/current/test/wire-test.js
+++ b/packages/decoder/test/current/test/wire-test.js
@@ -71,7 +71,8 @@ describe("Over-the-wire decoding", function () {
         "0x0000000000000000000000000000000000000001",
         "0x0000000000000000000000000000000000000002"
       ],
-      ["hello", "hi", "hooblypoob"]
+      ["hello", "hi", "hooblypoob"],
+      -1
     ];
     let emitStuff = await deployedContract.emitStuff(...emitStuffArgs);
     let emitStuffHash = emitStuff.tx;
@@ -131,6 +132,7 @@ describe("Over-the-wire decoding", function () {
     );
 
     assert.strictEqual(constructorDecoding.kind, "constructor");
+    assert.strictEqual(constructorDecoding.decodingMode, "full");
     assert.strictEqual(constructorDecoding.class.typeName, "WireTest");
     assert.lengthOf(constructorDecoding.arguments, 3);
     assert.strictEqual(constructorDecoding.arguments[0].name, "status");
@@ -156,9 +158,10 @@ describe("Over-the-wire decoding", function () {
     );
 
     assert.strictEqual(emitStuffDecoding.kind, "function");
+    assert.strictEqual(emitStuffDecoding.decodingMode, "full");
     assert.strictEqual(emitStuffDecoding.abi.name, "emitStuff");
     assert.strictEqual(emitStuffDecoding.class.typeName, "WireTest");
-    assert.lengthOf(emitStuffDecoding.arguments, 3);
+    assert.lengthOf(emitStuffDecoding.arguments, 4);
     assert.strictEqual(emitStuffDecoding.arguments[0].name, "p");
     assert.deepEqual(
       Codec.Format.Utils.Inspect.unsafeNativize(
@@ -180,8 +183,16 @@ describe("Over-the-wire decoding", function () {
       ),
       emitStuffArgs[2]
     );
+    assert.strictEqual(emitStuffDecoding.arguments[3].name, "x");
+    assert.strictEqual(
+      Codec.Format.Utils.Inspect.unsafeNativize(
+        emitStuffDecoding.arguments[3].value
+      ),
+      emitStuffArgs[3]
+    );
 
     assert.strictEqual(moreStuffDecoding.kind, "function");
+    assert.strictEqual(moreStuffDecoding.decodingMode, "full");
     assert.strictEqual(moreStuffDecoding.abi.name, "moreStuff");
     assert.strictEqual(moreStuffDecoding.class.typeName, "WireTest");
     assert.lengthOf(moreStuffDecoding.arguments, 2);
@@ -201,6 +212,7 @@ describe("Over-the-wire decoding", function () {
     );
 
     assert.strictEqual(globalTestDecoding.kind, "function");
+    assert.strictEqual(globalTestDecoding.decodingMode, "full");
     assert.strictEqual(globalTestDecoding.abi.name, "globalTest");
     assert.strictEqual(globalTestDecoding.class.typeName, "WireTest");
     assert.lengthOf(globalTestDecoding.arguments, 2);
@@ -220,6 +232,7 @@ describe("Over-the-wire decoding", function () {
     );
 
     assert.strictEqual(inheritedDecoding.kind, "function");
+    assert.strictEqual(inheritedDecoding.decodingMode, "full");
     assert.strictEqual(inheritedDecoding.abi.name, "inherited");
     assert.strictEqual(inheritedDecoding.class.typeName, "WireTest"); //NOT WireTestParent
     assert.lengthOf(inheritedDecoding.arguments, 1);
@@ -232,6 +245,7 @@ describe("Over-the-wire decoding", function () {
     );
 
     assert.strictEqual(defaultConstructorDecoding.kind, "constructor");
+    assert.strictEqual(defaultConstructorDecoding.decodingMode, "full");
     assert.strictEqual(
       defaultConstructorDecoding.class.typeName,
       "WireTestParent"
@@ -239,6 +253,7 @@ describe("Over-the-wire decoding", function () {
     assert.isEmpty(defaultConstructorDecoding.arguments);
 
     assert.strictEqual(getterDecoding1.kind, "function");
+    assert.strictEqual(getterDecoding1.decodingMode, "full");
     assert.strictEqual(getterDecoding1.abi.name, "deepStruct");
     assert.strictEqual(getterDecoding1.class.typeName, "WireTest");
     assert.lengthOf(getterDecoding1.arguments, 2);
@@ -258,6 +273,7 @@ describe("Over-the-wire decoding", function () {
     );
 
     assert.strictEqual(getterDecoding2.kind, "function");
+    assert.strictEqual(getterDecoding2.decodingMode, "full");
     assert.strictEqual(getterDecoding2.abi.name, "deepString");
     assert.strictEqual(getterDecoding2.class.typeName, "WireTest");
     assert.lengthOf(getterDecoding2.arguments, 2);
@@ -366,6 +382,7 @@ describe("Over-the-wire decoding", function () {
     let dangerEventDecoding = dangerEventDecodings[0];
 
     assert.strictEqual(constructorEventDecoding.kind, "event");
+    assert.strictEqual(constructorEventDecoding.decodingMode, "full");
     assert.strictEqual(constructorEventDecoding.class.typeName, "WireTest");
     assert.strictEqual(constructorEventDecoding.definedIn.typeName, "WireTest");
     assert.strictEqual(constructorEventDecoding.abi.name, "ConstructorEvent");
@@ -393,10 +410,11 @@ describe("Over-the-wire decoding", function () {
     );
 
     assert.strictEqual(emitStuffEventDecoding.kind, "event");
+    assert.strictEqual(emitStuffEventDecoding.decodingMode, "full");
     assert.strictEqual(emitStuffEventDecoding.abi.name, "EmitStuff");
     assert.strictEqual(emitStuffEventDecoding.class.typeName, "WireTest");
     assert.strictEqual(emitStuffEventDecoding.definedIn.typeName, "WireTest");
-    assert.lengthOf(emitStuffEventDecoding.arguments, 3);
+    assert.lengthOf(emitStuffEventDecoding.arguments, 4);
     assert.isUndefined(emitStuffEventDecoding.arguments[0].name);
     assert.deepEqual(
       Codec.Format.Utils.Inspect.unsafeNativize(
@@ -418,8 +436,16 @@ describe("Over-the-wire decoding", function () {
       ),
       emitStuffArgs[2]
     );
+    assert.isUndefined(emitStuffEventDecoding.arguments[3].name);
+    assert.strictEqual(
+      Codec.Format.Utils.Inspect.unsafeNativize(
+        emitStuffEventDecoding.arguments[3].value
+      ),
+      emitStuffArgs[3]
+    );
 
     assert.strictEqual(moreStuffEventDecoding.kind, "event");
+    assert.strictEqual(moreStuffEventDecoding.decodingMode, "full");
     assert.strictEqual(moreStuffEventDecoding.abi.name, "MoreStuff");
     assert.strictEqual(moreStuffEventDecoding.class.typeName, "WireTest");
     assert.strictEqual(moreStuffEventDecoding.definedIn.typeName, "WireTest");
@@ -440,6 +466,7 @@ describe("Over-the-wire decoding", function () {
     );
 
     assert.strictEqual(globalTestEventDecoding.kind, "event");
+    assert.strictEqual(globalTestEventDecoding.decodingMode, "full");
     assert.strictEqual(globalTestEventDecoding.abi.name, "Globals");
     assert.strictEqual(globalTestEventDecoding.class.typeName, "WireTest");
     assert.strictEqual(globalTestEventDecoding.definedIn.typeName, "WireTest");
@@ -460,6 +487,7 @@ describe("Over-the-wire decoding", function () {
     );
 
     assert.strictEqual(inheritedEventDecoding.kind, "event");
+    assert.strictEqual(inheritedEventDecoding.decodingMode, "full");
     assert.strictEqual(inheritedEventDecoding.abi.name, "Done");
     assert.strictEqual(inheritedEventDecoding.class.typeName, "WireTest");
     assert.strictEqual(
@@ -469,6 +497,7 @@ describe("Over-the-wire decoding", function () {
     assert.isEmpty(inheritedEventDecoding.arguments);
 
     assert.strictEqual(indexTestEventDecoding.kind, "event");
+    assert.strictEqual(indexTestEventDecoding.decodingMode, "full");
     assert.strictEqual(indexTestEventDecoding.abi.name, "HasIndices");
     assert.strictEqual(indexTestEventDecoding.class.typeName, "WireTest");
     assert.strictEqual(indexTestEventDecoding.definedIn.typeName, "WireTest");
@@ -509,6 +538,7 @@ describe("Over-the-wire decoding", function () {
     );
 
     assert.strictEqual(libraryTestEventDecoding.kind, "event");
+    assert.strictEqual(libraryTestEventDecoding.decodingMode, "full");
     assert.strictEqual(libraryTestEventDecoding.abi.name, "LibraryEvent");
     assert.strictEqual(
       libraryTestEventDecoding.class.typeName,
@@ -528,6 +558,7 @@ describe("Over-the-wire decoding", function () {
     );
 
     assert.strictEqual(dangerEventDecoding.kind, "event");
+    assert.strictEqual(dangerEventDecoding.decodingMode, "full");
     assert.strictEqual(dangerEventDecoding.abi.name, "Danger");
     assert.lengthOf(dangerEventDecoding.arguments, 1);
     assert.isUndefined(dangerEventDecoding.arguments[0].name);
@@ -930,7 +961,7 @@ describe("Over-the-wire decoding", function () {
     let decoding = decodings[0];
     assert.strictEqual(decoding.kind, "return");
     assert.strictEqual(decoding.decodingMode, "full");
-    assert.lengthOf(decoding.arguments, 2);
+    assert.lengthOf(decoding.arguments, 3);
     assert.deepEqual(
       Codec.Format.Utils.Inspect.unsafeNativize(decoding.arguments[0].value),
       {
@@ -942,6 +973,10 @@ describe("Over-the-wire decoding", function () {
     assert.strictEqual(
       Codec.Format.Utils.Inspect.unsafeNativize(decoding.arguments[1].value),
       "WireTest.Ternary.No"
+    );
+    assert.strictEqual(
+      Codec.Format.Utils.Inspect.unsafeNativize(decoding.arguments[2].value),
+      -1
     );
 
     //now: let's try decoding a self-destruct :D

--- a/packages/decoder/test/current/truffle-config.js
+++ b/packages/decoder/test/current/truffle-config.js
@@ -56,7 +56,7 @@ module.exports = {
   // Configure your compilers
   compilers: {
     solc: {
-      version: "0.8.4" // Fetch exact version from solc-bin (default: truffle's version)
+      version: "0.8.8" // Fetch exact version from solc-bin (default: truffle's version)
       // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
       // settings: {          // See the solidity docs for advice about optimization and evmVersion
       //  optimizer: {

--- a/packages/decoder/test/current/truffle-config.js
+++ b/packages/decoder/test/current/truffle-config.js
@@ -56,7 +56,7 @@ module.exports = {
   // Configure your compilers
   compilers: {
     solc: {
-      version: "0.8.8" // Fetch exact version from solc-bin (default: truffle's version)
+      version: "0.8.9" // Fetch exact version from solc-bin (default: truffle's version)
       // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
       // settings: {          // See the solidity docs for advice about optimization and evmVersion
       //  optimizer: {


### PR DESCRIPTION
This PR adds support for Solidity 0.8.8's user-defined value types.  Most of this is fairly straightforward, there's just a lot of places in the code that needed to be touched.

The biggest change is that of course a whole new typeclass, `"userDefinedValueType"`, had to be added to the type system, oh boy!  These work mostly like you expect, but I have a few notes on them.

Firstly, I had to have these work a bit differently from arrays/structs/mappings in terms of how they handle errors in the underlying thing.  See, with an array (for instance), the array can decode to a `Value`, but have individual elements that decode to `ErrorResult`s instead.  By contrast, with UDVTs, I made it so that if the underlying value decodes to an `ErrorResult`, then so does the UDVT value itself.

Why?  Well, uh, to avoid circular imports.  See, UDVTs can be used as mapping keys.  This means they have to be defined in `elementary.ts`.  But in order for a `Value` to be able to hold an `ErrorResult`, they'd have to be defined in `value.ts`.  So, I just made it so that a `Value` cannot hold an `ErrorResult`.  This is inconsistent with how we handle container types, but, oh well, whatever.  (Also it means that we don't have to worry about seemingly valid mapping keys that aren't actually valid mapping keys...)

Also, I added a few more collections of types (`BuiltInValueType`, `AbiType`) to the type system in order to make a few things work.  These aren't used very extensively, and they don't necessarily work completely well, but, oh well, at least they're there?

Another thing that has to be noted is the storage allocation of UDVTs.  Solidity 0.8.8 has a bug where these always take up a full word regardless of the size of the underlying type!  So, uh, that's how we allocate them.  We'll have to change this later when Solidity 0.8.9 comes out; this will unfortunately require an explicit version switch, as much as we try to avoid those.  I could add that to this PR if you think that's warranted, to be ready for it, but for now I've left it out.  (There's also a Solidity 0.8.8 bug where UDVTs are missing the `canonicalName` field in the AST, but that's easy to work around.)

One unexpected complication came from handling mapping keys!  Remember the no-op problem, that mapping keys given by expressions whose outermost layer was a no-op at the EVM level wouldn't be picked up?  Well, if `T` is a UDVT, then `T.wrap` and `T.unwrap` are both no-ops!  So, special handling had to be added for these in the debugger, alongside the other no-ops.

It's also worth noting how I chose to display such types in `ResultInspector`.  I made it so that, e.g., if you wrap `-1` in a type called `MyInt` defined in a contract `C`, it will display in the debugger (or anything using `ResultInspector`) as `C.MyInt.wrap(-1)` (and the `-1` will of course be colorized).  I think that conveys what's going on pretty well. :)

I also added support for UDVTs in `wrapElementaryValue` (and `constructSlot`), even though that'll be going away once #4142 is merged.  (And obviously once this PR is merged I'll have to update that one!)

One caveat to all this: Due to the way we handle `constant`s, it's unlikely that any UDVTs declared as `constant` will be decodeable.  But I see that as a minor problem, and something we can go back and do something about later if we really want.  We're already pretty limited in what `constant`s we can decode.

I also fixed up a few other things while I was at it, including factoring some repetitive code in `ast/import/index.ts`, and a bug in `isContractDefinedType`; I won't detail all these changes though, a number of them are just like changing some `let`s to `const`s. :P

Finally, of course, I added tests.  I decided not to add any specific new tests of UDVTs, but rather just sprinkled them into some existing tests.  I think it should be sufficient.  Some of the stuff not covered by these tests I checked manually.

And that's it!  Until Solidity 0.8.9, anyway.  (Or until I go back and do that work now in preparation for it. :P )