### PR TITLE
Internal improvement: Ensure all packages have homepage and bugs fields

### DIFF
--- a/packages/artifactor/package.json
+++ b/packages/artifactor/package.json
@@ -4,6 +4,10 @@
   "description": "A contract packager for Ethereum and Javascript",
   "license": "MIT",
   "author": "Tim Coulter",
+  "bugs": {
+    "url": "https://github.com/trufflesuite/truffle/issues"
+  },
+  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/artifactor#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/trufflesuite/truffle.git",

--- a/packages/box/package.json
+++ b/packages/box/package.json
@@ -3,10 +3,14 @@
   "description": "Truffle project boilerplate utility",
   "license": "MIT",
   "author": "g. nicholas d'andrea <gnidan@trufflesuite.com>",
+  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/box#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/trufflesuite/truffle.git",
     "directory": "packages/box"
+  },
+  "bugs": {
+    "url": "https://github.com/trufflesuite/truffle/issues"
   },
   "version": "2.1.28",
   "main": "dist/box.js",

--- a/packages/code-utils/package.json
+++ b/packages/code-utils/package.json
@@ -3,10 +3,14 @@
   "description": "Utilities for parsing and managing EVM-compatible bytecode",
   "license": "MIT",
   "author": "",
+  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/code-utils#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/trufflesuite/truffle.git",
     "directory": "packages/code-utils"
+  },
+  "bugs": {
+    "url": "https://github.com/trufflesuite/truffle/issues"
   },
   "version": "1.2.29",
   "main": "dist/src/index.js",

--- a/packages/codec/package.json
+++ b/packages/codec/package.json
@@ -3,7 +3,7 @@
   "description": "Library for encoding and decoding smart contract data",
   "license": "MIT",
   "author": "",
-  "homepage": "https://github.com/trufflesuite/truffle#readme",
+  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/codec#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/trufflesuite/truffle.git",

--- a/packages/compile-common/package.json
+++ b/packages/compile-common/package.json
@@ -4,10 +4,14 @@
   "description": "Common compiler integration support infrastructure for Truffle",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
+  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/compile-common#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/trufflesuite/truffle.git",
     "directory": "packages/compile-common"
+  },
+  "bugs": {
+    "url": "https://github.com/trufflesuite/truffle/issues"
   },
   "license": "MIT",
   "scripts": {

--- a/packages/compile-solidity/package.json
+++ b/packages/compile-solidity/package.json
@@ -3,7 +3,7 @@
   "description": "Compiler helper and artifact manager for Solidity files",
   "license": "MIT",
   "author": "Tim Coulter <tim@trufflesuite.com>",
-  "homepage": "https://github.com/trufflesuite/compile-solidity#readme",
+  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/compile-solidity#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/trufflesuite/truffle.git",

--- a/packages/compile-vyper/package.json
+++ b/packages/compile-vyper/package.json
@@ -3,6 +3,10 @@
   "description": "Vyper compiler support",
   "license": "MIT",
   "author": "Evgeniy Filatov <evgeniyfilatov@gmail.com>",
+  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/compile-vyper#readme",
+  "bugs": {
+    "url": "https://github.com/trufflesuite/truffle/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/trufflesuite/truffle.git",

--- a/packages/contract-tests/package.json
+++ b/packages/contract-tests/package.json
@@ -4,7 +4,7 @@
   "description": "Test suite for @truffle/contract smart contract abstraction (unpublished)",
   "license": "MIT",
   "author": "g. nicholas d'andrea <gnidan@trufflesuite.com>",
-  "homepage": "https://github.com/trufflesuite/truffle#readme",
+  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/contract-tests#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/trufflesuite/truffle.git",

--- a/packages/db-kit/package.json
+++ b/packages/db-kit/package.json
@@ -7,7 +7,7 @@
     "truffle"
   ],
   "author": "g. nicholas d'andrea <gnidan@trufflesuite.com>",
-  "homepage": "https://github.com/trufflesuite/truffle#readme",
+  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/db-kit#readme",
   "license": "MIT",
   "main": "dist/src/index.js",
   "directories": {

--- a/packages/db-loader/package.json
+++ b/packages/db-loader/package.json
@@ -3,7 +3,7 @@
   "description": "Utility for loading @truffle/db",
   "license": "MIT",
   "author": "tyler feickert <tyler.feickert@consensys.net>",
-  "homepage": "https://github.com/trufflesuite/truffle/blob/develop/packages/db-loader/README.md",
+  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/db-loader#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/trufflesuite/truffle.git",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -3,7 +3,7 @@
   "description": "Smart contract data aggregation",
   "license": "MIT",
   "author": "g. nicholas d'andrea <gnidan@users.noreply.github.com>",
-  "homepage": "https://github.com/trufflesuite/truffle#readme",
+  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/db#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/trufflesuite/truffle.git",

--- a/packages/decoder/package.json
+++ b/packages/decoder/package.json
@@ -3,7 +3,7 @@
   "description": "A decoder and encoder for Solidity variables of all sorts",
   "license": "MIT",
   "author": "Mike Seese and Harry Altman",
-  "homepage": "https://github.com/trufflesuite/truffle#readme",
+  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/decoder#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/trufflesuite/truffle.git",

--- a/packages/external-compile/package.json
+++ b/packages/external-compile/package.json
@@ -3,7 +3,7 @@
   "description": "Wrapper to compile Truffle contracts with arbitrary shell command",
   "license": "MIT",
   "author": "g. nicholas d'andrea <gnidan@users.noreply.github.com>",
-  "homepage": "https://github.com/trufflesuite/truffle#readme",
+  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/external-compile#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/trufflesuite/truffle.git",

--- a/packages/fetch-and-compile/package.json
+++ b/packages/fetch-and-compile/package.json
@@ -9,7 +9,7 @@
   },
   "author": "Harry Altman <harry@trufflesuite.com>",
   "license": "MIT",
-  "homepage": "https://github.com/trufflesuite/truffle#readme",
+  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/fetch-and-compile#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/trufflesuite/truffle.git",

--- a/packages/interface-adapter/package.json
+++ b/packages/interface-adapter/package.json
@@ -2,7 +2,7 @@
   "name": "@truffle/interface-adapter",
   "description": "A library that provides an adapter layer for Truffle to interace with different types of networks/ledgers.",
   "license": "MIT",
-  "homepage": "https://github.com/trufflesuite/truffle#readme",
+  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/interface-adapter#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/trufflesuite/truffle.git",

--- a/packages/profiler/package.json
+++ b/packages/profiler/package.json
@@ -9,6 +9,10 @@
     "url": "https://github.com/trufflesuite/truffle.git",
     "directory": "packages/profiler"
   },
+  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/profiler#readme",
+  "bugs": {
+    "url": "https://github.com/trufflesuite/truffle/issues"
+  },
   "license": "MIT",
   "scripts": {
     "build": "tsc",

--- a/packages/reporters/package.json
+++ b/packages/reporters/package.json
@@ -3,7 +3,7 @@
   "description": "Reporters for Truffle modules",
   "license": "MIT",
   "author": "",
-  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/provisioner#reporters",
+  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/reporters#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/trufflesuite/truffle.git",

--- a/packages/source-fetcher/package.json
+++ b/packages/source-fetcher/package.json
@@ -3,7 +3,7 @@
   "description": "Fetches verified source code from services such as Etherscan",
   "license": "MIT",
   "author": "Harry Altman <harry@trufflesuite.com>",
-  "homepage": "https://github.com/trufflesuite/truffle#readme",
+  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/source-fetcher#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/trufflesuite/truffle.git",

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -3,7 +3,7 @@
   "description": "Truffle - Simple development framework for Ethereum",
   "license": "MIT",
   "author": "consensys.net",
-  "homepage": "https://github.com/trufflesuite/truffle/",
+  "homepage": "https://github.com/trufflesuite/truffle#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/trufflesuite/truffle.git",


### PR DESCRIPTION
I noticed a bunch of the `package.json`s were missing the `bugs` and `homepage` fields.  So, I added them.

One question though: I noticed that the exsting packages are inconsistent about how they do `homepage`.  Some point to their specific package, while some point to Truffle as a whole.  We should probably figure out how we're doing this?

Like, should it be:
1. Every package's homepage points to that package?
2. Every package's homepage points to that package, except for `truffle` and `core`, which point to Truffle as a whole?
3. A package's homepage points to that package if it has a README, and otherwise points to Truffle as a whole?
4. Every package's homepage points to Truffle as a whole?
5. Something else?

My thinking is that we should go with (2), but really we should just agree on *something*.  (Or is there an existing consistent pattern and I simply missed it...?)