### PR TITLE
Internal improvement: only check permissions for monorepo packages

### DIFF
--- a/scripts/npm-access.js
+++ b/scripts/npm-access.js
@@ -14,7 +14,7 @@ const getMonorepoPackages = () => {
   return new Set(pkgs);
 }
 
-const orgs = ["trufflesuite", "truffle"];
+const orgs = ["truffle"];
 
 for (let org of orgs) {
   const permissions = getPkgPermissions(org);

--- a/scripts/npm-access.js
+++ b/scripts/npm-access.js
@@ -7,10 +7,10 @@ const getPkgPermissions = userOrOrg => {
 };
 
 const getMonorepoPackages = () => {
-  // get list of monorepo packages and remove lerna branding from output
-  const pkgs = execSync('$(yarn bin)/lerna ls | grep -v "^lerna"')
+  const pkgs = execSync('lerna ls')
     .toString()
-    .split("\n");
+    .split("\n")
+    .filter(ln => !/^lerna/.test(ln));
   return new Set(pkgs);
 }
 


### PR DESCRIPTION
- This PR will only check permissions for packages in the monorepo against **truffle** org. 
- It drops checking against the **trufflesuite** org because we're not publishing there on npmjs. 