### PR TITLE
Bug fix: Fix `fetchAndCompile()`

### DIFF
--- a/packages/fetch-and-compile/lib/recognizer.ts
+++ b/packages/fetch-and-compile/lib/recognizer.ts
@@ -59,10 +59,13 @@ export class SingleRecognizer implements Recognizer {
 
   addCompiledInfo(
     info: FetchAndCompileResult,
-    _address: string,
+    address: string,
     _fetcherName: string
   ): void {
     this.compileResult = info.compileResult;
     this.sourceInfo = info.sourceInfo;
+    if (address === this.address) { //I guess? this should never be false
+      this.recognized = true;
+    }
   }
 }


### PR DESCRIPTION
This function didn't actually work, because we never actually set `this.recognized` to true anywhere in `SingleRecognizer`.  Now we do!

...and yeah, this wasn't caught till now because the fetch-and-compile package has no tests (#3837)... :-/