### PR TITLE
github(action): remove node 10.x from test matrix

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x]
         env: [GETH=true, PACKAGES=true, INTEGRATION=true]
     runs-on: ${{ matrix.platform }}
 


### PR DESCRIPTION
Truffle no longer supports node 10