### PR TITLE
environment.develop overwrite config options

### DIFF
--- a/packages/environment/environment.js
+++ b/packages/environment/environment.js
@@ -71,6 +71,7 @@ const Environment = {
     const url = `http://${ganacheOptions.host}:${ganacheOptions.port}/`;
 
     config.networks[network] = {
+      ...config.networks[network],
       network_id: ganacheOptions.network_id,
       provider: function () {
         return new Web3.providers.HttpProvider(url, { keepAlive: false });

--- a/packages/environment/package.json
+++ b/packages/environment/package.json
@@ -16,7 +16,8 @@
   "version": "0.2.75",
   "main": "index.js",
   "scripts": {
-    "prepare": "exit 0"
+    "prepare": "exit 0",
+    "test": "mocha ./test/** ./test/**/*"
   },
   "dependencies": {
     "@truffle/artifactor": "^4.0.126",

--- a/packages/environment/test/develop.js
+++ b/packages/environment/test/develop.js
@@ -1,0 +1,60 @@
+const assert = require("chai").assert;
+const { default: Box } = require("@truffle/box");
+const { Environment } = require("@truffle/environment");
+const sinon = require("sinon");
+
+describe("Environment develop", function () {
+  let config;
+
+  const expectedNetwork = {
+    port: 8545,
+    network_id: 1342,
+    gas: 90000
+  };
+
+  const testOptions = {
+    port: 5678,
+    network_id: expectedNetwork.network_id,
+    gas: 7000
+  };
+
+  beforeEach("Create a sandbox", async function () {
+    this.timeout(5000);
+    config = await Box.sandbox("default");
+    config.network = "network";
+    config.networks = {
+      network: {
+        port: expectedNetwork.port,
+        network_id: 4321,
+        gas: expectedNetwork.gas
+      }
+    };
+    sinon.stub(Environment, "detect");
+  });
+
+  afterEach("Restore Environment detect", async function () {
+    Environment.detect.restore();
+  });
+
+  it("Environment.develop overwrites the network_id of the network", async function() {
+    await Environment.develop(config, testOptions);
+    const mutatedNetwork = config.networks[config.network];
+
+    assert.equal(
+      mutatedNetwork.port,
+      expectedNetwork.port,
+      "The port of the network should be unchanged."
+    );
+    assert.equal(
+      mutatedNetwork.network_id,
+      expectedNetwork.network_id,
+      "The network_id of the network should be overwritten."
+    );
+    assert.equal(
+      mutatedNetwork.gas,
+      expectedNetwork.gas,
+      "The gas of the network should be unchanged."
+    );
+  });
+
+}).timeout(10000);


### PR DESCRIPTION
This PR fixes issue #4335 that config network is overwritten
with a custom, barebones network config.