### PR TITLE
Internal improvement: Eth adapter

### DIFF
--- a/packages/decoder/lib/ProviderAdapter.ts
+++ b/packages/decoder/lib/ProviderAdapter.ts
@@ -144,7 +144,6 @@ export class ProviderAdapter {
     if (!this.provider) {
       throw new Error("There is not a valid provider present.");
     }
-<<<<<<< HEAD
     let result;
     if (isEip1193Provider(this.provider)) {
       result = await this.provider.request({ method, params });

--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -163,7 +163,7 @@ export class ProjectDecoder {
       return "pending";
     }
 
-    return parseInt((await this.providerAdapter.getBlockByNumber(block)).number);
+    return (await this.providerAdapter.getBlockByNumber(block)).number;
   }
 
   /**


### PR DESCRIPTION
This PR performs some formatting for the provider adapter in decoder. This adds an argument to the method responsible for sending so that each method responsible for an rpc call can specify its own formatter to use before returning the value. This will help maintain parity with the types that web3 returns (web3 transforms/formats a lot of the rpc response values) and hopefully make it easier to switch out in favor of this utility eventually.