### PR TITLE
Added an explicit debugger method to run to the end

### DIFF
--- a/packages/contract/lib/promievent.js
+++ b/packages/contract/lib/promievent.js
@@ -16,7 +16,7 @@ function PromiEvent(justPromise, bugger = undefined, isDeploy = false) {
       getSolidityStackTrace = async () => {
         try {
           await bugger.load(this.txHash);
-          await bugger.continueUntilBreakpoint();
+          await bugger.runToEnd();
           const report = bugger.stacktrace();
           await bugger.unload();
           return DebugUtils.formatStacktrace(report, 4); //indent 4 to match node's stacktraces

--- a/packages/debugger/lib/controller/actions/index.js
+++ b/packages/debugger/lib/controller/actions/index.js
@@ -33,6 +33,13 @@ export function interrupt() {
   return { type: INTERRUPT };
 }
 
+export const RUN_TO_END = "CONTROLLER_RUN_TO_END";
+export function runToEnd() {
+  return {
+    type: RUN_TO_END
+  };
+}
+
 export const CONTINUE = "CONTROLLER_CONTINUE";
 export function continueUntilBreakpoint(breakpoints) {
   //"continue" is not a legal name
@@ -70,7 +77,7 @@ export function setInternalStepping(status) {
   return {
     type: SET_INTERNAL_STEPPING,
     status
-  }
+  };
 }
 
 export const START_STEPPING = "CONTROLLER_START_STEPPING";

--- a/packages/debugger/lib/controller/sagas/index.js
+++ b/packages/debugger/lib/controller/sagas/index.js
@@ -216,15 +216,11 @@ function* stepOver() {
  * runToEnd - run the debugger till the end
  */
 function* runToEnd() {
-  var finished;
+  let finished;
 
   do {
     yield* advance();
-
     finished = yield select(controller.current.trace.finished);
-    if (finished) {
-      break; //can break immediately if finished
-    }
   } while (!finished);
 }
 

--- a/packages/debugger/lib/controller/sagas/index.js
+++ b/packages/debugger/lib/controller/sagas/index.js
@@ -213,28 +213,19 @@ function* stepOver() {
 }
 
 /**
- * runToEnd - run the debugger till the end without breakpoints
+ * runToEnd - run the debugger till the end
  */
 function* runToEnd() {
-  let breakpointHit = false;
-  let currentLocation = yield select(controller.current.location);
-  let currentSourceId = currentLocation.source.id;
+  var finished;
 
   do {
-    yield* advance(); //note: this avoids using stepNext in order to
-    //allow breakpoints in internal sources to work properly
+    yield* advance();
 
-    currentLocation = yield select(controller.current.location);
-    let finished = yield select(controller.current.trace.finished);
+    finished = yield select(controller.current.trace.finished);
     if (finished) {
       break; //can break immediately if finished
     }
-
-    currentSourceId = currentLocation.source.id;
-    if (currentSourceId === undefined) {
-      continue; //never stop on an unmapped instruction
-    }
-  } while (!breakpointHit);
+  } while (!finished);
 }
 
 /**

--- a/packages/debugger/lib/session/index.js
+++ b/packages/debugger/lib/session/index.js
@@ -419,6 +419,11 @@ export default class Session {
     return await this._runSaga(controllerSagas.reset);
   }
 
+  //Run the debugger till the end
+  async runToEnd() {
+    return await this.dispatch(controller.runToEnd());
+  }
+
   //NOTE: breakpoints is an OPTIONAL argument for if you want to supply your
   //own list of breakpoints; leave it out to use the internal one (as
   //controlled by the functions below)

--- a/packages/debugger/test/data/calldata.js
+++ b/packages/debugger/test/data/calldata.js
@@ -341,7 +341,7 @@ describe("Calldata Decoding", function () {
 
     assert.deepInclude(variables, expectedResult);
 
-    await bugger.continueUntilBreakpoint(); //continue to end
+    await bugger.runToEnd();
 
     const decodings = await bugger.returnValue();
 

--- a/packages/debugger/test/data/codex.js
+++ b/packages/debugger/test/data/codex.js
@@ -116,7 +116,7 @@ describe("Codex", function () {
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
     debug("starting stepping");
-    await bugger.continueUntilBreakpoint(); //run till end
+    await bugger.runToEnd();
     debug("made it to end of transaction");
 
     const surface = Codec.Format.Utils.Inspect.unsafeNativize(
@@ -134,7 +134,7 @@ describe("Codex", function () {
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-    await bugger.continueUntilBreakpoint(); //run till end
+    await bugger.runToEnd();
 
     const x = Codec.Format.Utils.Inspect.unsafeNativize(await bugger.variable("x"));
 
@@ -149,7 +149,7 @@ describe("Codex", function () {
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-    await bugger.continueUntilBreakpoint(); //run till end
+    await bugger.runToEnd();
 
     const x = Codec.Format.Utils.Inspect.unsafeNativize(await bugger.variable("x"));
 

--- a/packages/debugger/test/data/global.js
+++ b/packages/debugger/test/data/global.js
@@ -180,7 +180,7 @@ describe("Globally-available variables", function () {
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-    await bugger.continueUntilBreakpoint(); //run till end
+    await bugger.runToEnd();
 
     const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
@@ -278,7 +278,7 @@ describe("Globally-available variables", function () {
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-    await bugger.continueUntilBreakpoint(); //run till end
+    await bugger.runToEnd();
 
     const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()

--- a/packages/debugger/test/data/more-decoding.js
+++ b/packages/debugger/test/data/more-decoding.js
@@ -451,7 +451,7 @@ describe("Further Decoding", function () {
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
     //we're only testing storage so run till end
-    await bugger.continueUntilBreakpoint();
+    await bugger.runToEnd();
 
     const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()

--- a/packages/debugger/test/data/more-decoding.js
+++ b/packages/debugger/test/data/more-decoding.js
@@ -509,7 +509,7 @@ describe("Further Decoding", function () {
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-    await bugger.continueUntilBreakpoint(); //run till end
+    await bugger.runToEnd();
 
     const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
@@ -532,7 +532,7 @@ describe("Further Decoding", function () {
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-    await bugger.continueUntilBreakpoint(); //run till end
+    await bugger.runToEnd();
 
     const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()

--- a/packages/debugger/test/data/returnvalue.js
+++ b/packages/debugger/test/data/returnvalue.js
@@ -175,7 +175,7 @@ describe("Return value decoding", function () {
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-    await bugger.continueUntilBreakpoint(); //run till end
+    await bugger.runToEnd();
 
     const decodings = await bugger.returnValue();
     assert.lengthOf(decodings, 1);
@@ -201,7 +201,7 @@ describe("Return value decoding", function () {
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
     debug("about to run!");
-    await bugger.continueUntilBreakpoint(); //run till end
+    await bugger.runToEnd();
     debug("ran!");
 
     const decodings = await bugger.returnValue();
@@ -229,7 +229,7 @@ describe("Return value decoding", function () {
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
     debug("about to run!");
-    await bugger.continueUntilBreakpoint(); //run till end
+    await bugger.runToEnd();
     debug("ran!");
 
     const decodings = await bugger.returnValue();
@@ -250,7 +250,7 @@ describe("Return value decoding", function () {
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
     debug("about to run!");
-    await bugger.continueUntilBreakpoint(); //run till end
+    await bugger.runToEnd();
     debug("ran!");
 
     const decodings = await bugger.returnValue();
@@ -284,7 +284,7 @@ describe("Return value decoding", function () {
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-    await bugger.continueUntilBreakpoint(); //run till end
+    await bugger.runToEnd();
 
     const decodings = await bugger.returnValue();
     assert.lengthOf(decodings, 1);
@@ -308,7 +308,7 @@ describe("Return value decoding", function () {
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-    await bugger.continueUntilBreakpoint(); //run till end
+    await bugger.runToEnd();
 
     const decodings = await bugger.returnValue();
     assert.lengthOf(decodings, 1);
@@ -339,7 +339,7 @@ describe("Return value decoding", function () {
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-    await bugger.continueUntilBreakpoint(); //run till end
+    await bugger.runToEnd();
 
     const decodings = await bugger.returnValue();
     assert.lengthOf(decodings, 1);
@@ -371,7 +371,7 @@ describe("Return value decoding", function () {
   
       let bugger = await Debugger.forTx(txHash, { provider, compilations });
   
-      await bugger.continueUntilBreakpoint(); //run till end
+      await bugger.runToEnd();
   
       const decodings = await bugger.returnValue();
       assert.lengthOf(decodings, 1);
@@ -410,7 +410,7 @@ describe("Return value decoding", function () {
   
       let bugger = await Debugger.forTx(txHash, { provider, compilations });
   
-      await bugger.continueUntilBreakpoint(); //run till end
+      await bugger.runToEnd();
   
       const decodings = await bugger.returnValue();
       assert.lengthOf(decodings, 1);
@@ -439,7 +439,7 @@ describe("Return value decoding", function () {
   
       let bugger = await Debugger.forTx(txHash, { provider, compilations });
   
-      await bugger.continueUntilBreakpoint(); //run till end
+      await bugger.runToEnd();
   
       const decodings = await bugger.returnValue();
       assert.lengthOf(decodings, 1);
@@ -468,7 +468,7 @@ describe("Return value decoding", function () {
   
       let bugger = await Debugger.forTx(txHash, { provider, compilations });
   
-      await bugger.continueUntilBreakpoint(); //run till end
+      await bugger.runToEnd();
   
       const decodings = await bugger.returnValue();
       assert.lengthOf(decodings, 1);
@@ -497,7 +497,7 @@ describe("Return value decoding", function () {
   
       let bugger = await Debugger.forTx(txHash, { provider, compilations });
   
-      await bugger.continueUntilBreakpoint(); //run till end
+      await bugger.runToEnd();
   
       const decodings = await bugger.returnValue();
       assert.lengthOf(decodings, 1);
@@ -526,7 +526,7 @@ describe("Return value decoding", function () {
   
       let bugger = await Debugger.forTx(txHash, { provider, compilations });
   
-      await bugger.continueUntilBreakpoint(); //run till end
+      await bugger.runToEnd();
   
       const decodings = await bugger.returnValue();
       assert.lengthOf(decodings, 1);
@@ -560,7 +560,7 @@ describe("Return value decoding", function () {
   
       let bugger = await Debugger.forTx(txHash, { provider, compilations });
   
-      await bugger.continueUntilBreakpoint(); //run till end
+      await bugger.runToEnd();
   
       const decodings = await bugger.returnValue();
       assert.lengthOf(decodings, 1);

--- a/packages/debugger/test/endstate.js
+++ b/packages/debugger/test/endstate.js
@@ -86,8 +86,8 @@ describe("End State", function () {
       provider,
       compilations
     });
-
-    await bugger.continueUntilBreakpoint(); //no breakpoints set so advances to end
+    
+    await bugger.runToEnd();
 
     assert.ok(bugger.view(evm.transaction.status));
     const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(

--- a/packages/debugger/test/load.js
+++ b/packages/debugger/test/load.js
@@ -65,7 +65,7 @@ describe("Loading and unloading transactions", function () {
     assert.isFalse(bugger.view(trace.loaded));
     await bugger.load(txHash);
     assert.isTrue(bugger.view(trace.loaded));
-    await bugger.continueUntilBreakpoint(); //continue to end
+    await bugger.runToEnd();
     const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
     );
@@ -88,7 +88,7 @@ describe("Loading and unloading transactions", function () {
     });
 
     assert.isTrue(bugger.view(trace.loaded));
-    await bugger.continueUntilBreakpoint(); //continue to end
+    await bugger.runToEnd();
     let variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
     );
@@ -98,7 +98,7 @@ describe("Loading and unloading transactions", function () {
     assert.isFalse(bugger.view(trace.loaded));
     await bugger.load(txHash2);
     assert.isTrue(bugger.view(trace.loaded));
-    await bugger.continueUntilBreakpoint(); //continue to end
+    await bugger.runToEnd();
     variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
       await bugger.variables()
     );

--- a/packages/debugger/test/reset.js
+++ b/packages/debugger/test/reset.js
@@ -79,7 +79,7 @@ describe("Reset Button", function () {
     variables[0].push(
       Codec.Format.Utils.Inspect.unsafeNativizeVariables(await bugger.variables())
     );
-    await bugger.continueUntilBreakpoint(); //advance to the end
+    await bugger.runToEnd();
     variables[0].push(
       Codec.Format.Utils.Inspect.unsafeNativizeVariables(await bugger.variables())
     );
@@ -98,7 +98,7 @@ describe("Reset Button", function () {
     variables[1].push(
       Codec.Format.Utils.Inspect.unsafeNativizeVariables(await bugger.variables())
     );
-    await bugger.continueUntilBreakpoint(); //advance to the end
+    await bugger.runToEnd();
     variables[1].push(
       Codec.Format.Utils.Inspect.unsafeNativizeVariables(await bugger.variables())
     );

--- a/packages/debugger/test/stacktrace.js
+++ b/packages/debugger/test/stacktrace.js
@@ -138,8 +138,8 @@ describe("Stack tracing", function () {
     let source = bugger.view(solidity.current.source);
     let failLine = lineOf("REQUIRE", source.source);
     let callLine = lineOf("CALL", source.source);
-
-    await bugger.continueUntilBreakpoint(); //run till end
+    
+    await bugger.runToEnd();
 
     let report = bugger.view(stacktrace.current.finalReport);
     let functionNames = report.map(({ functionName }) => functionName);
@@ -265,7 +265,7 @@ describe("Stack tracing", function () {
     let failLine = lineOf("PAY", source.source);
     let callLine = lineOf("CALL", source.source);
 
-    await bugger.continueUntilBreakpoint(); //run till end
+    await bugger.runToEnd();
 
     let report = bugger.view(stacktrace.current.finalReport);
     let functionNames = report.map(({ functionName }) => functionName);
@@ -315,7 +315,7 @@ describe("Stack tracing", function () {
     let failLine = lineOf("GARBAGE", source.source);
     let callLine = lineOf("CALL", source.source);
 
-    await bugger.continueUntilBreakpoint(); //run till end
+    await bugger.runToEnd();
 
     let report = bugger.view(stacktrace.current.finalReport);
     let functionNames = report.map(({ functionName }) => functionName);
@@ -369,7 +369,7 @@ describe("Stack tracing", function () {
     let callLine = lineOf("UHOH", source.source);
     let prevCallLine = lineOf("CALL", source.source);
 
-    await bugger.continueUntilBreakpoint(); //run till end
+    await bugger.runToEnd();
 
     let report = bugger.view(stacktrace.current.finalReport);
     let functionNames = report.map(({ functionName }) => functionName);

--- a/packages/debugger/test/txlog.js
+++ b/packages/debugger/test/txlog.js
@@ -141,7 +141,7 @@ describe("Transaction log (visualizer)", function () {
       compilations
     });
 
-    await bugger.continueUntilBreakpoint(); //run till end
+    await bugger.runToEnd();
 
     const root = bugger.view(txlog.views.transactionLog);
     assert.equal(root.type, "transaction");
@@ -197,7 +197,7 @@ describe("Transaction log (visualizer)", function () {
       compilations
     });
 
-    await bugger.continueUntilBreakpoint(); //run till end
+    await bugger.runToEnd();
 
     const root = bugger.view(txlog.views.transactionLog);
     assert.equal(root.type, "transaction");
@@ -250,7 +250,7 @@ describe("Transaction log (visualizer)", function () {
       compilations
     });
 
-    await bugger.continueUntilBreakpoint(); //run till end
+    await bugger.runToEnd();
 
     const root = bugger.view(txlog.views.transactionLog);
     assert.equal(root.type, "transaction");
@@ -298,7 +298,7 @@ describe("Transaction log (visualizer)", function () {
       compilations
     });
 
-    await bugger.continueUntilBreakpoint(); //run till end
+    await bugger.runToEnd();
 
     const root = bugger.view(txlog.views.transactionLog);
     assert.equal(root.type, "transaction");
@@ -333,7 +333,7 @@ describe("Transaction log (visualizer)", function () {
       compilations
     });
 
-    await bugger.continueUntilBreakpoint(); //run till end
+    await bugger.runToEnd();
 
     const root = bugger.view(txlog.views.transactionLog);
     assert.equal(root.type, "transaction");
@@ -384,7 +384,7 @@ describe("Transaction log (visualizer)", function () {
       compilations
     });
 
-    await bugger.continueUntilBreakpoint(); //run till end
+    await bugger.runToEnd();
 
     const root = bugger.view(txlog.views.transactionLog);
     assert.equal(root.type, "transaction");
@@ -423,7 +423,7 @@ describe("Transaction log (visualizer)", function () {
       compilations
     });
 
-    await bugger.continueUntilBreakpoint(); //run till end
+    await bugger.runToEnd();
     await bugger.reset();
 
     const root = bugger.view(txlog.views.transactionLog);


### PR DESCRIPTION
### ISSUE
The  debugger runs to the end with continueUntilBreakpoint method without specifying the breakpoints. See issue #3834 

### SOLUTION
Added an explicit runToEnd method and use that method in the debugger tests.