### PR TITLE
Internal improvement: Move debug to dependencies from devDependencies in `contract`

### DIFF
--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -28,6 +28,7 @@
     "@truffle/error": "^0.0.14",
     "@truffle/interface-adapter": "^0.5.8",
     "bignumber.js": "^7.2.1",
+    "debug": "^4.3.1",
     "ethers": "^4.0.32",
     "web3": "1.5.3",
     "web3-core-helpers": "1.5.3",
@@ -37,7 +38,6 @@
   },
   "devDependencies": {
     "browserify": "^17.0.0",
-    "debug": "^4.3.1",
     "exorcist": "^2.0.0",
     "uglify-es": "^3.3.9"
   },


### PR DESCRIPTION
I only just noticed -- Truffle Contract has debugging output, but `debug` isn't listed as a dependency, only a devDependency.  So, I put up this PR.

Note: It's possible that we don't want to do this and instead we want to remove the debugging output from `contract`?  Well, I went ahead and put up this PR, and I can let the reviewers tell me if that's what we want to do instead. :P