### PR TITLE
Bug fix: Allow maxFeePerGas and maxPriorityFeePerGas for transactions

### DIFF
--- a/packages/config/src/configDefaults.ts
+++ b/packages/config/src/configDefaults.ts
@@ -23,6 +23,8 @@ export const getInitialConfig = ({
     verboseRpc: false,
     gas: null,
     gasPrice: null,
+    maxFeePerGas: null,
+    maxPriorityFeePerGas: null,
     from: null,
     confirmations: 0,
     timeoutBlocks: 0,
@@ -199,6 +201,34 @@ export const configProps = ({
       set() {
         throw new Error(
           "Don't set config.gasPrice directly. Instead, set config.networks and then config.networks[<network name>].gasPrice"
+        );
+      }
+    },
+    maxFeePerGas: {
+      get() {
+        try {
+          return configObject.network_config.maxFeePerGas;
+        } catch (e) {
+          return null;
+        }
+      },
+      set() {
+        throw new Error(
+          "Don't set config.maxFeePerGas directly. Instead, set config.networks and then config.networks[<network name>].maxFeePerGas"
+        );
+      }
+    },
+    maxPriorityFeePerGas: {
+      get() {
+        try {
+          return configObject.network_config.maxPriorityFeePerGas;
+        } catch (e) {
+          return null;
+        }
+      },
+      set() {
+        throw new Error(
+          "Don't set config.maxPriorityFeePerGas directly. Instead, set config.networks and then config.networks[<network name>].maxPriorityFeePerGas"
         );
       }
     },

--- a/packages/provisioner/src/index.ts
+++ b/packages/provisioner/src/index.ts
@@ -23,7 +23,7 @@ const provision = (contractAbstraction: any, truffleConfig: TruffleConfig) => {
 
   contractAbstraction.ens = truffleConfig.ens;
 
-  ["from", "gas", "gasPrice"].forEach(key => {
+  ["from", "gas", "gasPrice", "maxFeePerGas", "maxPriorityFeePerGas"].forEach(key => {
     if (truffleConfig[key]) {
       const obj: any = {};
       obj[key] = truffleConfig[key];


### PR DESCRIPTION
When providing values for `maxFeePerGas` and `maxPriorityFeePerGas` in `truffle-config.js`, those values were not being passed along to @truffle/contract so that they could be provided to `web3.eth.sendTransaction`. This PR provides defaults for them in Truffle Config and adds them to the whitelisted parameters in @truffle/provisioner so as to make them available on the contract object.

To test:

Mostly all transactions from contracts are passed to `web3.eth.sendTransaction` in the `sendTransaction` method in `packages/contract/execute.js`. You can verify that this change whitelists `maxFeePerGas` and `maxPriorityFeePerGas` by logging out the `params` variable here https://github.com/trufflesuite/truffle/blob/develop/packages/contract/lib/execute.js#L548.