### PR TITLE
Internal improvement: Fix yarncheck

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -19,7 +19,8 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
       - run: npm install -g yarn
-      - run: yarn install --ignore-scripts --frozen-lockfile --ignore-engines
+      - run: yarn install --ignore-scripts --ignore-engines
+      - run: test -z "$(git diff)" || (echo 'Please run yarn and commit all changes to yarn.lock'; false)
 
 
   build:


### PR DESCRIPTION
Turns out I accidentally broke yarncheck, and the lockfile got out of sync!  This PR fixes it.

I thought that `--frozen-lockfile` meant that `yarn` would error out if the lockfile needed to be updated.  No, turns out it means it just doesn't update it.  Oops.

So, this PR changes yarncheck back to working the old way.  Of course, I left in the `--ignore-scripts` flag so it'll still be fast.