### PR TITLE
Bug fix: Allow fetch-and-compile to compile sources with absolute paths

### DIFF
--- a/packages/compile-solidity/index.js
+++ b/packages/compile-solidity/index.js
@@ -20,7 +20,11 @@ async function compileYulPaths(yulPaths, options) {
     //for simplicity, since there are no imports to worry about)
     const yulSource = fs.readFileSync(path, { encoding: "utf8" });
     debug("Compiling Yul");
-    const compilation = await run({ [path]: yulSource }, yulOptions, "Yul");
+    const compilation = await run(
+      { [path]: yulSource },
+      yulOptions,
+      { language: "Yul" }
+    );
     debug("Yul compiled successfully");
 
     // returns CompilerResult - see @truffle/compile-common
@@ -40,6 +44,8 @@ async function compileYulPaths(yulPaths, options) {
 const Compile = {
   // this takes an object with keys being the name and values being source
   // material as well as an options object
+  // NOTE: this function does *not* transform the source path prefix to
+  // "project:/" before passing to the compiler!
   async sources({ sources, options }) {
     options = Config.default().merge(options);
     options = normalizeOptions(options);
@@ -55,7 +61,11 @@ const Compile = {
     let yulCompilations = [];
     if (solidityNames.length > 0) {
       debug("Compiling Solidity (specified sources)");
-      const compilation = await run(soliditySources, options);
+      const compilation = await run(
+        soliditySources,
+        options,
+        { noTransform: true }
+      );
       debug("Compiled Solidity");
       if (compilation.contracts.length > 0) {
         solidityCompilations = [compilation];
@@ -63,7 +73,11 @@ const Compile = {
     }
     for (const name of yulNames) {
       debug("Compiling Yul (specified sources)");
-      const compilation = await run({ [name]: sources[name] }, options, "Yul");
+      const compilation = await run(
+        { [name]: sources[name] },
+        options,
+        { language: "Yul", noTransform: true },
+      );
       debug("Compiled Yul");
       yulCompilations.push(compilation);
     }

--- a/packages/compile-solidity/run.js
+++ b/packages/compile-solidity/run.js
@@ -7,15 +7,18 @@ const CompilerSupplier = require("./compilerSupplier");
 // this function returns a Compilation - legacy/index.js and ./index.js
 // both check to make sure rawSources exist before calling this method
 // however, there is a check here that returns null if no sources exist
-async function run(rawSources, options, language = "Solidity") {
+async function run(rawSources, options, internalOptions = {}) {
   if (Object.keys(rawSources).length === 0) {
     return null;
   }
 
+  const language = internalOptions.language || "Solidity"; //could also be "Yul"
+  const noTransform = internalOptions.noTransform; //turns off project root transform
+
   // Ensure sources have operating system independent paths
   // i.e., convert backslashes to forward slashes; things like C: are left intact.
   // we also strip the project root (to avoid it appearing in metadata)
-  // and replace it with "project:/"
+  // and replace it with "project:/" (unless noTransform is set)
   const {
     sources,
     targets,
@@ -23,8 +26,8 @@ async function run(rawSources, options, language = "Solidity") {
   } = Common.Sources.collectSources(
     rawSources,
     options.compilationTargets,
-    options.working_directory,
-    "project:/"
+    noTransform ? "" : options.working_directory,
+    noTransform ? "" : "project:/"
   );
 
   // construct solc compiler input


### PR DESCRIPTION
This PR fixes a problem where fetch-and-compile would fail to compile sources that used absolute paths in their source paths.  This can't happen for sources in the single-file etherscan format, but it can happen for the other formats.  The problem was that, due to #4216, these sources would be filtered out by `collectSources`.

To address this, I added a `noTransform` option to `Compile.run()` (I also changed `language` to be a named rather than positional argument), which makes it so that `collectSources` will not filter the sources or rewrite their prefix (it'll still do its other usual transformations, of course).  I then made it so that `Compile.sources()` passes this option.  Note that I did *not* make any changes to compile-vyper; I'll discuss that more in a bit.

Now this may seem like a significant change, but actually, outside of tests, `Compile.sources()` is currently only used in fetch-and-compile, so it's not really a problem.  As for those tests, well, it turns out our test *of* that path transformation was using `Compile.sources()`, so I rewrote it to use `Compile.sourcesWithDependencies` instead.

So, compile-solidity will no longer apply the prefix transformation when using `Compile.sources()`.  However I left Vyper alone.  (Note that compile-vyper performs a different transformation than compile-solidity.)  This is basically because it's irrelevant at the moment.  First of all, compile-vyper's `sources()` isn't used anywhere.  But not only that, even once we add Vyper support to fetch-and-compile, it still won't immediately matter, because currently Sourcify doesn't support Vyper, and Etherscan only supports Vyper in single-source form, meaning there are no imports to worry about, so this sort of path-rewriting shouldn't have any effect.

Also, the transformation in compile-vyper (which predates the one in compile-solidity!) is mostly intended to make certain imports work (see #3720, sorry for the poor quality of the writing there); so while not changing it risks eventually breaking things (in the distant future :P ), changing it *also* risks breaking things in that distant future.  So I feel like this is a problem for then rather than now.

Anyway fetch-and-compile, including `truffle debug -x`, should now be fixed for these Solidity contracts!