### PR TITLE
Bug fix: Fix decoding of constant `bytesN` initialized as string literal

### DIFF
--- a/packages/codec/lib/conversion.ts
+++ b/packages/codec/lib/conversion.ts
@@ -67,7 +67,8 @@ export function toBig(value: BN | number): Big {
  */
 export function toHexString(
   bytes: Uint8Array | BN,
-  padLength: number = 0
+  padLength: number = 0,
+  padRight: boolean = false //pad on right instead of length
 ): string {
   if (BN.isBN(bytes)) {
     bytes = toBytes(bytes);
@@ -85,7 +86,13 @@ export function toHexString(
     let prior = bytes;
     bytes = new Uint8Array(padLength);
 
-    bytes.set(prior, padLength - prior.length);
+    if (padRight) {
+      //unusual case: pad on right
+      bytes.set(prior);
+    } else {
+      //usual case
+      bytes.set(prior, padLength - prior.length);
+    }
   }
 
   debug("bytes: %o", bytes);

--- a/packages/debugger/test/data/more-decoding.js
+++ b/packages/debugger/test/data/more-decoding.js
@@ -88,6 +88,7 @@ contract ElementaryTest {
   mapping(bool => bool) boolMap;
   mapping(bytes1 => bytes1) byteMap;
   mapping(bytes => bytes) bytesMap;
+  mapping(bytes4 => bytes4) selectorMap;
   mapping(uint => uint) uintMap;
   mapping(int => int) intMap;
   mapping(string => string) stringMap;
@@ -97,7 +98,11 @@ contract ElementaryTest {
   mapping(MyInt => MyInt) wrapMap;
 
   //constant state variables to try as mapping keys
+  //(and for testing on their own)
   uint constant two = 2;
+  string constant hello = "hello";
+  bytes4 constant hexConst = 0xdeadbeef;
+  bytes4 constant short = hex"ff";
 
   function run() public {
     //local variables to be tested
@@ -124,12 +129,17 @@ contract ElementaryTest {
 
     stringMap["0xdeadbeef"] = "0xdeadbeef";
     stringMap["12345"] = "12345";
+    stringMap[hello] = hello;
 
     contractMap[this] = this;
 
     enumMap[Ternary.Blue] = Ternary.Blue;
 
     wrapMap[MyInt.wrap(-2)] = MyInt.wrap(-2);
+
+    selectorMap[hexConst] = hexConst;
+    selectorMap[short] = short;
+    selectorMap[hex"f00f"] = hex"f00f";
 
     emit Done(); //break here
   }
@@ -394,13 +404,22 @@ describe("Further Decoding", function () {
       bytesMap: { "0x01": "0x01" },
       uintMap: { 1: 1, 2: 2 },
       intMap: { "-1": -1 },
-      stringMap: { "0xdeadbeef": "0xdeadbeef", "12345": "12345" },
+      stringMap: { "0xdeadbeef": "0xdeadbeef", "12345": "12345", "hello": "hello" },
       addressMap: { [address]: address },
       contractMap: { [address]: address },
       enumMap: { "ElementaryTest.Ternary.Blue": "ElementaryTest.Ternary.Blue" },
       wrapMap: { "-2": -2 },
       oneByte: "0xff",
-      severalBytes: ["0xff"]
+      severalBytes: ["0xff"],
+      two: 2,
+      hexConst: "0xdeadbeef",
+      short: "0xff000000",
+      hello: "hello",
+      selectorMap: {
+        "0xdeadbeef": "0xdeadbeef",
+        "0xff000000": "0xff000000",
+        "0xf00f0000": "0xf00f0000"
+      }
     };
 
     assert.deepInclude(variables, expectedResult);


### PR DESCRIPTION
When writing the code for decoding constants of type `bytesN`, I assumed that these would be initialized via hex numeric literals.  I didn't learn until later that string/hexstring literals can also be used as `bytesN`, and it turns out the code I wrote doesn't work for those.

Note that this problem didn't only apply to constants, but also applies to mapping keys of type `bytesN`, if you used a string/hexstring literal as a mapping key to a mapping which has `bytesN` for its key type.  Those wouldn't work properly, and this PR fixes that.  (It also affected constants used as mapping keys.)

So, I fixed that decoding to be a little more general.  I also expanded our testing of constants, of literals used as mapping keys, and constants used as mapping keys, to make sure this all works properly.