### PR TITLE
Accept url and provider arguments in hdwallet-provider constructor

### DIFF
--- a/packages/hdwallet-provider/package.json
+++ b/packages/hdwallet-provider/package.json
@@ -39,7 +39,8 @@
     "ganache-core": "2.13.0",
     "mocha": "8.1.2",
     "ts-node": "^9.0.0",
-    "typescript": "^4.1.4"
+    "typescript": "^4.1.4",
+    "web3": "1.5.3"
   },
   "keywords": [
     "etheruem",

--- a/packages/hdwallet-provider/src/constructor/Constructor.ts
+++ b/packages/hdwallet-provider/src/constructor/Constructor.ts
@@ -3,6 +3,7 @@ import type {
   MnemonicPhrase,
   PrivateKey,
   Provider,
+  ProviderUrl,
   ProviderOrUrl,
   AddressIndex,
   NumberOfAddresses,
@@ -41,7 +42,7 @@ export type InputSigningAuthority =
 export interface CommonOptions {
   providerOrUrl?: ProviderOrUrl;
   provider?: Provider;
-  url?: string;
+  url?: ProviderUrl;
   addressIndex?: AddressIndex;
   numberOfAddresses?: NumberOfAddresses;
   shareNonce?: ShareNonce;

--- a/packages/hdwallet-provider/src/constructor/Constructor.ts
+++ b/packages/hdwallet-provider/src/constructor/Constructor.ts
@@ -2,6 +2,7 @@ import type {
   Mnemonic,
   MnemonicPhrase,
   PrivateKey,
+  Provider,
   ProviderOrUrl,
   AddressIndex,
   NumberOfAddresses,
@@ -38,7 +39,9 @@ export type InputSigningAuthority =
   | PrivateKeysSigningAuthority;
 
 export interface CommonOptions {
-  providerOrUrl: ProviderOrUrl;
+  providerOrUrl?: ProviderOrUrl;
+  provider?: Provider;
+  url?: string;
   addressIndex?: AddressIndex;
   numberOfAddresses?: NumberOfAddresses;
   shareNonce?: ShareNonce;

--- a/packages/hdwallet-provider/src/constructor/getOptions.ts
+++ b/packages/hdwallet-provider/src/constructor/getOptions.ts
@@ -111,7 +111,7 @@ const matchesNewInputOptions = (
 
   // beyond that, determine based on property inclusion check for required keys
   return (
-    "providerOrUrl" in options &&
+    ("providerOrUrl" in options || "provider" in options || "url" in options) &&
     ("privateKeys" in options || "mnemonic" in options)
   );
 };

--- a/packages/hdwallet-provider/src/constructor/types.ts
+++ b/packages/hdwallet-provider/src/constructor/types.ts
@@ -7,8 +7,15 @@ export interface Mnemonic {
   phrase: MnemonicPhrase;
   password?: MnemonicPassword;
 }
+import type { Provider as LegacyProvider } from "web3/providers";
+type Eip1193Provider = {
+  request: (options: {
+    method: string;
+    params?: unknown[] | object;
+  }) => Promise<any>;
+};
 export type PrivateKey = string;
-export type Provider = any;
+export type Provider = LegacyProvider | Eip1193Provider;
 export type ProviderUrl = string;
 export type ProviderOrUrl = Provider | ProviderUrl;
 export type AddressIndex = number;

--- a/packages/hdwallet-provider/test/provider.test.ts
+++ b/packages/hdwallet-provider/test/provider.test.ts
@@ -208,20 +208,6 @@ describe("HD Wallet Provider", function () {
       assert(number === 0);
     });
 
-    it("throws on invalid mnemonic", () => {
-      try {
-        provider = new HDWalletProvider({
-          mnemonic: {
-            phrase: "I am not a crook"
-          },
-          providerOrUrl: "http://localhost:8545"
-        });
-        assert.fail("Should throw on invalid mnemonic");
-      } catch (e) {
-        assert(e.message.includes("Mnemonic invalid or undefined"));
-      }
-    });
-
     it("provides for a default polling interval", () => {
       const mnemonicPhrase =
         "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat";
@@ -303,6 +289,51 @@ describe("HD Wallet Provider", function () {
 
       const number = await web3.eth.getBlockNumber();
       assert(number === 0);
+    });
+
+    describe("instantiation errors", () => {
+      it("throws on invalid providers", () => {
+        try {
+          provider = new HDWalletProvider({
+            mnemonic: {
+              phrase: "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat"
+            },
+            // @ts-ignore we gotta do the bad thing here to get the test right
+            provider: { junk: "in", an: "object" }
+          });
+          assert.fail("Should throw on invalid provider");
+        } catch (e) {
+          assert(e.message.includes("invalid provider was specified"));
+        }
+      });
+
+      it("throws on invalid urls", () => {
+        try {
+          provider = new HDWalletProvider({
+            mnemonic: {
+              phrase: "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat"
+            },
+            url: "justABunchOfJunk"
+          });
+          assert.fail("Should throw on invalid url");
+        } catch (e) {
+          assert(e.message.includes("invalid provider was specified"));
+        }
+      });
+
+      it("throws on invalid mnemonic", () => {
+        try {
+          provider = new HDWalletProvider({
+            mnemonic: {
+              phrase: "I am not a crook"
+            },
+            providerOrUrl: "http://localhost:8545"
+          });
+          assert.fail("Should throw on invalid mnemonic");
+        } catch (e) {
+          assert(e.message.includes("Mnemonic invalid or undefined"));
+        }
+      });
     });
   });
 });

--- a/packages/hdwallet-provider/test/provider.test.ts
+++ b/packages/hdwallet-provider/test/provider.test.ts
@@ -140,7 +140,7 @@ describe("HD Wallet Provider", function () {
         mnemonic: {
           phrase: mnemonicPhrase
         },
-        providerOrUrl: `http://localhost:${port}`
+        url: `http://localhost:${port}`
       });
 
       assert.deepEqual(provider.getAddresses(), truffleDevAccounts);
@@ -168,7 +168,7 @@ describe("HD Wallet Provider", function () {
         "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat";
       provider = new HDWalletProvider({
         mnemonic: mnemonicPhrase,
-        providerOrUrl: `http://localhost:${port}`
+        url: `http://localhost:${port}`
       });
 
       assert.deepEqual(provider.getAddresses(), truffleDevAccounts);
@@ -198,7 +198,7 @@ describe("HD Wallet Provider", function () {
           phrase: mnemonicPhrase,
           password: "yummy"
         },
-        providerOrUrl: `http://localhost:${port}`
+        url: `http://localhost:${port}`
       });
 
       assert.deepEqual(provider.getAddresses(), accounts);
@@ -215,7 +215,7 @@ describe("HD Wallet Provider", function () {
         mnemonic: {
           phrase: mnemonicPhrase
         },
-        providerOrUrl: `http://localhost:${port}`,
+        url: `http://localhost:${port}`,
         // polling interval is unspecified
       });
       assert.ok(provider.engine,
@@ -235,7 +235,7 @@ describe("HD Wallet Provider", function () {
         mnemonic: {
           phrase: mnemonicPhrase
         },
-        providerOrUrl: `http://localhost:${port}`,
+        url: `http://localhost:${port}`,
         // double the default value, for less chatty JSON-RPC
         pollingInterval: 8000,
       });
@@ -264,7 +264,7 @@ describe("HD Wallet Provider", function () {
 
       provider = new HDWalletProvider({
         privateKeys,
-        providerOrUrl: `http://localhost:${port}`
+        url: `http://localhost:${port}`
       });
       web3.setProvider(provider);
 
@@ -327,7 +327,7 @@ describe("HD Wallet Provider", function () {
             mnemonic: {
               phrase: "I am not a crook"
             },
-            providerOrUrl: "http://localhost:8545"
+            url: "http://localhost:8545"
           });
           assert.fail("Should throw on invalid mnemonic");
         } catch (e) {

--- a/packages/hdwallet-provider/test/urlValidation.test.ts
+++ b/packages/hdwallet-provider/test/urlValidation.test.ts
@@ -1,5 +1,6 @@
 import assert from "assert";
 import WalletProvider from "../dist";
+import Ganache from "ganache-core";
 import { describe, it } from "mocha";
 
 const { isValidProvider } = WalletProvider;
@@ -20,8 +21,8 @@ describe("HD Wallet Provider Validator", () => {
       assert.fail("did not throw!");
     } catch (e) {
       const expectedMessage = [
-        `Malformed provider URL: '${badUrl}'`,
-        "Please specify a correct URL, using the http, https, ws, or wss protocol.",
+        `No provider or an invalid provider was specified: '${badUrl}'`,
+        "Please specify a valid provider or URL, using the http, https, ws, or wss protocol.",
         ""
       ].join("\n");
       assert.equal(e.message, expectedMessage);
@@ -35,8 +36,8 @@ describe("HD Wallet Provider Validator", () => {
       assert.fail("did not throw!");
     } catch (e) {
       const expectedMessage = [
-        `Malformed provider URL: '${badUrl}'`,
-        "Please specify a correct URL, using the http, https, ws, or wss protocol.",
+        `No provider or an invalid provider was specified: '${badUrl}'`,
+        "Please specify a valid provider or URL, using the http, https, ws, or wss protocol.",
         ""
       ].join("\n");
       assert.equal(e.message, expectedMessage);
@@ -78,6 +79,14 @@ describe("HD Wallet Provider Validator", () => {
       assert.ok(
         isValidProvider(goodUrl),
         "Good WSS Url should pass validation"
+      );
+    });
+
+    it("a provider", () => {
+      const provider = Ganache.provider();
+      assert.ok(
+        isValidProvider(provider),
+        "Good provider should pass validation."
       );
     });
   });


### PR DESCRIPTION
In order to make hdwallet-provider a bit more slick, accept the arguments `provider` and `url` in the constructor.