### PR TITLE
Removed workingDirectory as it no longer exists

### DIFF
--- a/packages/db/src/system.ts
+++ b/packages/db/src/system.ts
@@ -17,7 +17,6 @@ import {
  *
  * ```typescript
  * type ConnectOptions = {
- *   workingDirectory: string;
  *   adapter?:
  *     | {
  *         name: "couch";


### PR DESCRIPTION
## Problem
The docs for truffle db ConnectOptions include a `workingDirectory: string;` attribute which is no longer valid.

## Solution
Remove it.