### PR TITLE
Run tests against Node.js v16 (LTS) in CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        node-version: [12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
         env: [GETH=true, PACKAGES=true, INTEGRATION=true]
     runs-on: ${{ matrix.platform }}
 


### PR DESCRIPTION
👋  Since nodejs 16 just became the latest LTS version, let's also add it into the CI checks. Thanks!