### PR TITLE
Update Solidity version in Truffle Init

### DIFF
--- a/packages/core/lib/commands/init/initSource/truffle-config.js
+++ b/packages/core/lib/commands/init/initSource/truffle-config.js
@@ -81,7 +81,7 @@ module.exports = {
   // Configure your compilers
   compilers: {
     solc: {
-      version: "0.8.9",    // Fetch exact version from solc-bin (default: truffle's version)
+      version: "0.8.10",    // Fetch exact version from solc-bin (default: truffle's version)
       // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
       // settings: {          // See the solidity docs for advice about optimization and evmVersion
       //  optimizer: {


### PR DESCRIPTION
Doing this now that Solidity 0.8.10 is out.  As @sukanyaparashar has pointed out, we should really find some way to automate this in the future, but for now, here's me doing it manually.