### PR TITLE
Allow Truffle debugger to display opcodes as a group

### DIFF
--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -184,6 +184,7 @@ class DebugPrinter {
 
   printInstruction(locations = this.locationPrintouts) {
     const instruction = this.session.view(solidity.current.instruction);
+    const instructions = this.session.view(solidity.current.instructions);
     const step = this.session.view(trace.step);
     const traceIndex = this.session.view(trace.index);
     const totalSteps = this.session.view(trace.steps).length;
@@ -209,10 +210,33 @@ class DebugPrinter {
       this.config.logger.log(DebugUtils.formatStack(step.stack));
       this.config.logger.log("");
     }
-    this.config.logger.log(
-      DebugUtils.formatInstruction(traceIndex + 1, totalSteps, instruction)
-    );
-    this.config.logger.log(DebugUtils.formatPC(step.pc));
+
+    // printout instructions
+    const previousInstructions = 3;
+    const upcomingInstructions = 3;
+    const currentIndex = instruction.index;
+    // printout 3 previous instructions
+    if (currentIndex - previousInstructions + 1 > 0) {
+      this.config.logger.log("...");
+    }
+    for (let i = currentIndex - previousInstructions; i < currentIndex; i++) {
+      if (i >= 0) {
+        this.config.logger.log(DebugUtils.formatInstruction(instructions[i]));
+      }
+    }
+
+    // printout current instruction
+    this.config.logger.log(DebugUtils.formatCurrentInstruction(instruction));
+
+    // printout 3 upcoming instructions
+    for (let i = currentIndex + 1; i <= currentIndex + upcomingInstructions; i++) {
+      if (i >= instructions.length) break;
+      this.config.logger.log(DebugUtils.formatInstruction(instructions[i]));
+    }
+    if (currentIndex + upcomingInstructions < instructions.length) {
+      this.config.logger.log("...");
+    }
+
     this.config.logger.log("");
     this.config.logger.log(step.gas + " gas remaining");
   }

--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -212,14 +212,13 @@ class DebugPrinter {
     }
 
     this.config.logger.log("Instructions:");
-    this.config.logger.log("");
 
     // printout instructions
-    // add an ellipse if there exist additional instructions before
     const previousInstructions = 3;
     const upcomingInstructions = 3;
     const currentIndex = instruction.index;
 
+    // add an ellipse if there exist additional instructions before
     if (currentIndex - previousInstructions >= 0) {
       this.config.logger.log("...");
     }
@@ -246,7 +245,12 @@ class DebugPrinter {
     }
 
     this.config.logger.log("");
-    this.config.logger.log("Step ", + traceIndex + "/" + totalSteps);
+    this.config.logger.log(
+      "Step " +
+      (traceIndex + 1).toString() +
+      "/" +
+      totalSteps.toString()
+    );
     this.config.logger.log(step.gas + " gas remaining");
   }
 

--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -215,7 +215,7 @@ class DebugPrinter {
     this.config.logger.log("");
 
     // printout instructions
-    // add an ellipse if the first instruction of the stack will not be included in the printout
+    // add an ellipse if there exist additional instructions before
     const previousInstructions = 3;
     const upcomingInstructions = 3;
     const currentIndex = instruction.index;
@@ -240,7 +240,7 @@ class DebugPrinter {
       this.config.logger.log(DebugUtils.formatInstruction(instructions[i]));
     }
 
-    // add an ellipse if the last instruction of the stack is not included in the printout
+    // add an ellipse if there exist additional instructions after
     if (currentIndex + upcomingInstructions < instructions.length) {
       this.config.logger.log("...");
     }

--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -211,33 +211,42 @@ class DebugPrinter {
       this.config.logger.log("");
     }
 
+    this.config.logger.log("Instructions:");
+    this.config.logger.log("");
+
     // printout instructions
+    // add an ellipse if the first instruction of the stack will not be included in the printout
     const previousInstructions = 3;
     const upcomingInstructions = 3;
     const currentIndex = instruction.index;
-    // printout 3 previous instructions
-    if (currentIndex - previousInstructions + 1 > 0) {
+
+    if (currentIndex - previousInstructions >= 0) {
       this.config.logger.log("...");
     }
-    for (let i = currentIndex - previousInstructions; i < currentIndex; i++) {
-      if (i >= 0) {
-        this.config.logger.log(DebugUtils.formatInstruction(instructions[i]));
-      }
+    // printout 3 previous instructions
+    for (let i = Math.max(currentIndex - previousInstructions, 0);
+      i < currentIndex;
+      i++) {
+      this.config.logger.log(DebugUtils.formatInstruction(instructions[i]));
     }
 
     // printout current instruction
     this.config.logger.log(DebugUtils.formatCurrentInstruction(instruction));
 
     // printout 3 upcoming instructions
-    for (let i = currentIndex + 1; i <= currentIndex + upcomingInstructions; i++) {
-      if (i >= instructions.length) break;
+    for (let i = Math.min(currentIndex + 1, instructions.length);
+      i <= currentIndex + upcomingInstructions;
+      i++) {
       this.config.logger.log(DebugUtils.formatInstruction(instructions[i]));
     }
+
+    // add an ellipse if the last instruction of the stack is not included in the printout
     if (currentIndex + upcomingInstructions < instructions.length) {
       this.config.logger.log("...");
     }
 
     this.config.logger.log("");
+    this.config.logger.log("Step ", + traceIndex + "/" + totalSteps);
     this.config.logger.log(step.gas + " gas remaining");
   }
 

--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -530,13 +530,16 @@ var DebugUtils = {
     }
   },
 
-  formatInstruction: function (traceIndex, traceLength, instruction) {
+  formatCurrentInstruction: function (instruction) {
+    const pc = this.formatPC(instruction.pc);
+    const formattedInstruction = this.formatInstruction(instruction);
     return (
-      "(" +
-      traceIndex +
-      "/" +
-      traceLength +
-      ") " +
+      truffleColors.mint("-> " + formattedInstruction + pc )
+    );
+  },
+
+  formatInstruction: function (instruction) {
+    return (
       truffleColors.mint(instruction.name + " " + (instruction.pushData || ""))
     );
   },
@@ -546,7 +549,7 @@ var DebugUtils = {
     if (hex.length % 2 !== 0) {
       hex = "0" + hex; //ensure even length
     }
-    return "  PC = " + pc.toString() + " = 0x" + hex;
+    return " (PC=" + pc.toString() + ", 0x" + hex+")";
   },
 
   formatStack: function (stack) {

--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -534,7 +534,7 @@ var DebugUtils = {
     const pc = this.formatPC(instruction.pc);
     const formattedInstruction = this.formatInstruction(instruction);
     return (
-      truffleColors.mint("-> " + formattedInstruction + pc )
+      "-> " + truffleColors.mint(formattedInstruction) + pc
     );
   },
 


### PR DESCRIPTION
This PR is to address the request in the issue #4353 to allow
Truffle debugger to display opcodes as a group.  The debugger
will now display 3 previous instructions and 3 upcoming instructions
in addition to current instruction.