### PR TITLE
Rename event more appropriately after its respective command

### DIFF
--- a/packages/core/lib/testing/Test.js
+++ b/packages/core/lib/testing/Test.js
@@ -108,7 +108,7 @@ const Test = {
 
     if (config.migrateNone || config['migrate-none']) {
       if (config.events) {
-        config.events.emit("migrate:skipped");
+        config.events.emit("test:migration:skipped");
       }
     } else {
       await this.performInitialDeploy(config, testResolver);

--- a/packages/events/defaultSubscribers/index.js
+++ b/packages/events/defaultSubscribers/index.js
@@ -1,6 +1,6 @@
 module.exports = {
   compile: require("./compile"),
-  migrate: require("./migrate"),
+  test: require("./test"),
   init: require("./init"),
   obtain: require("./obtain"),
   unbox: require("./unbox"),

--- a/packages/events/defaultSubscribers/test.js
+++ b/packages/events/defaultSubscribers/test.js
@@ -3,7 +3,7 @@ module.exports = {
     this.logger = console;
   },
   handlers: {
-    "migrate:skipped": [
+    "test:migration:skipped": [
       function () {
         if (this.quiet) return;
         this.logger.log(


### PR DESCRIPTION
This event was accidentally named after the incorrect command flow. While it was named "migrate:skipped", it really should have been named "test:**" as it is part of the flow for `truffle test` and not `truffle migrate`.