### PR TITLE
Pass compiler info to resolver sources

### DIFF
--- a/packages/compile-solidity/src/compileWithPragmaAnalysis.js
+++ b/packages/compile-solidity/src/compileWithPragmaAnalysis.js
@@ -101,6 +101,10 @@ const compileWithPragmaAnalysis = async ({ paths, options }) => {
         path,
         base_path: options.contracts_directory,
         resolver: options.resolver,
+        compiler: {
+          name: "solc",
+          version: parserVersion
+        },
         compilers: {
           solc: {
             version: parserVersion

--- a/packages/compile-solidity/src/compilerSupplier/index.ts
+++ b/packages/compile-solidity/src/compilerSupplier/index.ts
@@ -1,6 +1,3 @@
-import debugModule from "debug";
-const debug = debugModule("compile-solidity:compilerSupplier");
-
 import path from "path";
 import fs from "fs";
 import semver from "semver";
@@ -70,11 +67,6 @@ export class CompilerSupplier {
 
     if (strategy) {
       const solc = await strategy.load(userSpecification);
-      debug(
-        "Loaded solc v%s using %s strategy",
-        solc.version(),
-        strategy.constructor.name
-      );
       return { solc };
     } else {
       throw new BadInputError(userSpecification);

--- a/packages/compile-solidity/src/compilerSupplier/index.ts
+++ b/packages/compile-solidity/src/compilerSupplier/index.ts
@@ -1,3 +1,6 @@
+import debugModule from "debug";
+const debug = debugModule("compile-solidity:compilerSupplier");
+
 import path from "path";
 import fs from "fs";
 import semver from "semver";
@@ -67,6 +70,11 @@ export class CompilerSupplier {
 
     if (strategy) {
       const solc = await strategy.load(userSpecification);
+      debug(
+        "Loaded solc v%s using %s strategy",
+        solc.version(),
+        strategy.constructor.name
+      );
       return { solc };
     } else {
       throw new BadInputError(userSpecification);

--- a/packages/compile-solidity/src/index.js
+++ b/packages/compile-solidity/src/index.js
@@ -146,7 +146,11 @@ const Compile = {
       options.with({
         paths: solidityPaths,
         base_path: options.contracts_directory,
-        resolver: options.resolver
+        resolver: options.resolver,
+        compiler: {
+          name: "solc",
+          version: solc.version()
+        }
       })
     );
     debug("compilationTargets: %O", compilationTargets);

--- a/packages/compile-solidity/src/index.js
+++ b/packages/compile-solidity/src/index.js
@@ -129,6 +129,12 @@ const Compile = {
     options = Config.default().merge(options);
     options = normalizeOptions(options);
 
+    const supplier = new CompilerSupplier({
+      events: options.events,
+      solcConfig: options.compilers.solc
+    });
+    const { solc } = await supplier.load();
+
     //note: solidityPaths here still includes JSON as well!
     const [yulPaths, solidityPaths] = partition(paths, path =>
       path.endsWith(".yul")
@@ -161,7 +167,7 @@ const Compile = {
     if (Object.keys(allSources).length > 0) {
       const solidityOptions = options.with({ compilationTargets });
       debug("Compiling Solidity");
-      const compilation = await run(allSources, solidityOptions);
+      const compilation = await run(allSources, solidityOptions, { solc });
       debug("Solidity compiled successfully");
 
       // returns CompilerResult - see @truffle/compile-common

--- a/packages/profiler/src/index.ts
+++ b/packages/profiler/src/index.ts
@@ -51,7 +51,8 @@ export class Profiler {
       resolver,
       paths,
       base_path: basePath,
-      contracts_directory: contractsDirectory
+      contracts_directory: contractsDirectory,
+      compiler // { name, version }
     } = options;
 
     debug("paths: %O", paths);
@@ -61,7 +62,7 @@ export class Profiler {
       //be resolved, it will show up as a compile error rather than a Truffle
       //error.
       try {
-        return await resolver.resolve(filePath, importedFrom);
+        return await resolver.resolve(filePath, importedFrom, { compiler });
       } catch (error) {
         //resolver doesn't throw structured errors at the moment,
         //so we'll check the messag to see whether this is an expected error

--- a/packages/profiler/src/index.ts
+++ b/packages/profiler/src/index.ts
@@ -95,10 +95,15 @@ export class Profiler {
   async requiredSourcesForSingleFile(options: TruffleConfig) {
     expect.options(options, ["path", "base_path", "resolver"]);
 
-    const { resolver, path, base_path: basePath } = options;
+    const {
+      resolver,
+      path,
+      base_path: basePath,
+      compiler // { name, version }
+    } = options;
 
     const resolve = ({ filePath, importedFrom }: UnresolvedSource) =>
-      resolver.resolve(filePath, importedFrom);
+      resolver.resolve(filePath, importedFrom, { compiler });
 
     const allPaths = convertToAbsolutePaths([path], basePath);
     const updatedPaths = allPaths;

--- a/packages/profiler/src/index.ts
+++ b/packages/profiler/src/index.ts
@@ -70,6 +70,11 @@ export class Profiler {
         if(error.message.startsWith("Could not find ")) {
           return undefined;
         } else {
+          debug(
+            "Error resolving filePath: %o via importedFrom: %s",
+            filePath,
+            importedFrom
+          );
           //rethrow unexpected errors
           throw error;
         }

--- a/packages/profiler/src/index.ts
+++ b/packages/profiler/src/index.ts
@@ -70,11 +70,6 @@ export class Profiler {
         if(error.message.startsWith("Could not find ")) {
           return undefined;
         } else {
-          debug(
-            "Error resolving filePath: %o via importedFrom: %s",
-            filePath,
-            importedFrom
-          );
           //rethrow unexpected errors
           throw error;
         }

--- a/packages/resolver/lib/resolver.ts
+++ b/packages/resolver/lib/resolver.ts
@@ -81,14 +81,23 @@ export class Resolver {
 
   async resolve(
     importPath: string,
-    importedFrom: string
+    importedFrom: string,
+    options: {
+      compiler?: {
+        name: string;
+        version: string;
+      }
+    } = {}
   ): Promise<ResolvedSource> {
     let body: string | null = null;
     let filePath: string | null = null;
     let source: ResolverSource | null = null;
 
     for (source of this.sources) {
-      ({ body, filePath } = await source.resolve(importPath, importedFrom));
+      ({
+        body,
+        filePath
+      } = await source.resolve(importPath, importedFrom, options));
 
       if (body !== undefined) {
         break;

--- a/packages/resolver/lib/source.ts
+++ b/packages/resolver/lib/source.ts
@@ -2,7 +2,16 @@ import type { ContractObject } from "@truffle/contract-schema/spec";
 
 export interface ResolverSource {
   require(importPath: string, searchPath?: string): ContractObject | null;
-  resolve(importPath: string, importedFrom: string): Promise<SourceResolution>;
+  resolve(
+    importPath: string,
+    importedFrom: string,
+    options?: {
+      compiler?: {
+        name: string;
+        version: string;
+      }
+    }
+  ): Promise<SourceResolution>;
   resolveDependencyPath(importPath: string, dependencyPath: string): string | null | Promise<string | null>;
 }
 


### PR DESCRIPTION
Seeks to address #4384 

This PR roughly does two things:
1. Ensure we pass the compiler info from compile-solidity all the way through the Profiler and ultimately to the ResolverSources, which may choose to handle this information.
2. Invoke the CompilerSupplier before we run the Profiler, since otherwise we won't have the information yet (currently, compile-solidity invokes the CompilerSupplier _after_ invoking the Profiler, so this PR changes that behavior)

I've tried to be very safe about this (i.e., by making all new arguments optional), but maybe this is overly cautious and we can afford to be looser about it. 