### PR TITLE
Bug fix: Fix decoding of UDVT arrays in Solidity 0.8.8

### DIFF
--- a/packages/codec/lib/storage/decode/index.ts
+++ b/packages/codec/lib/storage/decode/index.ts
@@ -52,7 +52,12 @@ export function* decodeStorageReferenceByAddress(
   const startOffset = Conversion.toBN(rawValue);
   let rawSize: Storage.StorageLength;
   try {
-    rawSize = storageSize(dataType, info.userDefinedTypes, allocations);
+    rawSize = storageSize(
+      dataType,
+      info.userDefinedTypes,
+      allocations,
+      info.currentContext.compiler
+    );
   } catch (error) {
     return handleDecodingError(dataType, error);
   }
@@ -133,7 +138,8 @@ export function* decodeStorageReference(
         baseSize = storageSize(
           dataType.baseType,
           info.userDefinedTypes,
-          allocations
+          allocations,
+          info.currentContext.compiler
         );
       } catch (error) {
         return handleDecodingError(dataType, error);
@@ -386,7 +392,12 @@ export function* decodeStorageReference(
       const valueType = dataType.valueType;
       let valueSize: Storage.StorageLength;
       try {
-        valueSize = storageSize(valueType, info.userDefinedTypes, allocations);
+        valueSize = storageSize(
+          valueType,
+          info.userDefinedTypes,
+          allocations,
+          info.currentContext.compiler
+        );
       } catch (error) {
         return handleDecodingError(dataType, error);
       }


### PR DESCRIPTION
Due to the 0.8.8 bug, `storageSize` now takes an optional compiler argument, but these calls to it weren't passing it.  The pointer one doesn't actually matter, but on 0.8.8, the array and mapping ones one would cause incorrect decodings of storage arrays of, or mappings of, UDVTs.  So, I changed these to pass that.  (The pointer one doesn't matter because you can't have a pointer to a UDVT.)

Because this only affects 0.8.8, and our tests aren't on that version, I didn't add any tests.  However I tested it manually to make sure it works.