### PR TITLE
Add artifact verification before instantiation (issue #4422)

### DIFF
--- a/packages/contract-schema/test/schema.js
+++ b/packages/contract-schema/test/schema.js
@@ -22,4 +22,25 @@ describe("Schema", function() {
       assert(abiErrors);
     }
   });
+
+  it("normalizes a correct input", function () {
+    Schema.normalize(MetaCoin);
+  });
+
+  it("throws exception when attempting to normalize an invalid schema", function () {
+    var invalid = {
+      abi: -1
+    };
+
+    try {
+      Schema.normalize(invalid, {
+        validate: true
+      });
+    } catch (err) {
+      var abiErrors = err.errors.filter(function (error) {
+        return error.dataPath === ".abi";
+      });
+      assert(abiErrors);
+    }
+  });
 });

--- a/packages/contract-schema/test/schema.js
+++ b/packages/contract-schema/test/schema.js
@@ -24,7 +24,9 @@ describe("Schema", function() {
   });
 
   it("normalizes a correct input", function () {
-    Schema.normalize(MetaCoin);
+    Schema.normalize(MetaCoin, {
+      validate: true
+    });
   });
 
   it("throws exception when attempting to normalize an invalid schema", function () {

--- a/packages/contract/index.js
+++ b/packages/contract/index.js
@@ -2,10 +2,8 @@ const Schema = require("@truffle/contract-schema");
 const Contract = require("./lib/contract");
 const truffleContractVersion = require("./package.json").version;
 
-const contract = (json = {}) => {
-  const normalizedArtifactObject = Schema.normalize(json, {
-    validate: true
-  });
+const contract = (json = {}, opts = {}) => {
+  const normalizedArtifactObject = Schema.normalize(json, opts);
 
   // Note we don't use `new` here at all. This will cause the class to
   // "mutate" instead of instantiate an instance.

--- a/packages/contract/index.js
+++ b/packages/contract/index.js
@@ -3,7 +3,9 @@ const Contract = require("./lib/contract");
 const truffleContractVersion = require("./package.json").version;
 
 const contract = (json = {}) => {
-  const normalizedArtifactObject = Schema.normalize(json);
+  const normalizedArtifactObject = Schema.normalize(json, {
+    validate: true
+  });
 
   // Note we don't use `new` here at all. This will cause the class to
   // "mutate" instead of instantiate an instance.


### PR DESCRIPTION
Link to issue: https://github.com/trufflesuite/truffle/issues/4422

Given that functionality for checking contract artifacts is present in `@truffle/contract-schema`,
I integrated that functionality in `@truffle/contract`.

Given that no tests for checking that functionality are written in @truffle/contract-schema/test/schema.js
Or, I do not see them,
I wrote 2 tests for checking contract artifacts amid `Schema.normalize(...)`.

----------------

After this commit, an exception should be thrown if contract artifact passed to `@truffle/contract` constructor is invalid. Unfortunately **I did not write tests** for this behaviour because I don't know where. Should they be in `@truffle/core` ? 🤔 