### PR TITLE
default valueUnit to ETH for reporter on empty migration

### DIFF
--- a/packages/reporters/reporters/migrations-V5/messages.js
+++ b/packages/reporters/reporters/migrations-V5/messages.js
@@ -67,9 +67,7 @@ class MigrationsMessages {
       noLibName: () => `${prefix}Cannot link a library with no name.\n`,
 
       noLibAddress: () =>
-        `${prefix}"${
-          data.contract.contractName
-        }" has no address. Has it been deployed?\n`,
+        `${prefix}"${data.contract.contractName}" has no address. Has it been deployed?\n`,
 
       noBytecode: () =>
         `${prefix}"${data.contract.contractName}" ` +
@@ -102,9 +100,7 @@ class MigrationsMessages {
         `        private network or test client (like ganache).\n`,
 
       oogNoGas: () =>
-        `${prefix}"${
-          data.contract.contractName
-        }" ran out of gas. Something in the constructor ` +
+        `${prefix}"${data.contract.contractName}" ran out of gas. Something in the constructor ` +
         `(ex: infinite loop) caused gas estimation to fail. Try:\n` +
         `   * Making your contract constructor more efficient\n` +
         `   * Setting the gas manually in your config or as a deployment parameter\n` +
@@ -113,32 +109,24 @@ class MigrationsMessages {
         `     private network or test client (like ganache).\n`,
 
       rvtReason: () =>
-        `${prefix}"${
-          data.contract.contractName
-        }" hit a require or revert statement ` +
+        `${prefix}"${data.contract.contractName}" hit a require or revert statement ` +
         `with the following reason given:\n` +
         `   * ${data.reason}\n`,
 
       rvtNoReason: () =>
-        `${prefix}"${
-          data.contract.contractName
-        }" hit a require or revert statement ` +
+        `${prefix}"${data.contract.contractName}" hit a require or revert statement ` +
         `somewhere in its constructor. Try:\n` +
         `   * Verifying that your constructor params satisfy all require conditions.\n` +
         `   * Adding reason strings to your require statements.\n`,
 
       asrtNoReason: () =>
-        `${prefix}"${
-          data.contract.contractName
-        }" hit an invalid opcode while deploying. Try:\n` +
+        `${prefix}"${data.contract.contractName}" hit an invalid opcode while deploying. Try:\n` +
         `   * Verifying that your constructor params satisfy all assert conditions.\n` +
         `   * Verifying your constructor code doesn't access an array out of bounds.\n` +
         `   * Adding reason strings to your assert statements.\n`,
 
       noMoney: () =>
-        `${prefix}"${
-          data.contract.contractName
-        }" could not deploy due to insufficient funds\n` +
+        `${prefix}"${data.contract.contractName}" could not deploy due to insufficient funds\n` +
         `   * Account:  ${data.from}\n` +
         `   * Balance:  ${data.balance} wei\n` +
         `   * Message:  ${data.error.message}\n` +
@@ -164,17 +152,13 @@ class MigrationsMessages {
         `   * Try: setting gas manually in 'truffle-config.js' or as parameter to 'deployer.deploy'\n`,
 
       nonce: () =>
-        `${prefix}"${data.contract.contractName}" received: ${
-          data.error.message
-        }.\n` +
+        `${prefix}"${data.contract.contractName}" received: ${data.error.message}.\n` +
         `   * This error is common when Infura is under heavy network load.\n` +
         `   * Try: setting the 'confirmations' key in your network config\n` +
         `          to wait for several block confirmations between each deployment.\n`,
 
       geth: () =>
-        `${prefix}"${
-          data.contract.contractName
-        }" received a generic error from Geth that\n` +
+        `${prefix}"${data.contract.contractName}" received a generic error from Geth that\n` +
         `can be caused by hitting revert in a contract constructor or running out of gas.\n` +
         `   * ${data.estimateError.message}.\n` +
         `   * Try: + using the '--dry-run' option to reproduce this failure with clearer errors.\n` +
@@ -318,9 +302,7 @@ class MigrationsMessages {
       linking: () => {
         let output =
           self.underline(`Linking`) +
-          `\n   * Contract: ${data.contractName} <--> Library: ${
-            data.libraryName
-          } `;
+          `\n   * Contract: ${data.contractName} <--> Library: ${data.libraryName} `;
 
         if (!reporter.migration.dryRun)
           output += `(at address: ${data.libraryAddress})`;
@@ -412,10 +394,16 @@ class MigrationsMessages {
         if (!reporter.migration.dryRun && deployments.length)
           output += `   > Saving artifacts\n`;
 
+        if (data.valueUnit == undefined) {
+          data.valueUnit = "ETH";
+        }
+
         output +=
           self.underline(37) +
           "\n" +
-          `   > ${"Total cost:".padEnd(15)} ${data.cost.padStart(15)} ${data.valueUnit}\n`;
+          `   > ${"Total cost:".padEnd(15)} ${data.cost.padStart(15)} ${
+            data.valueUnit
+          }\n`;
 
         if (self.describeJson) {
           output +=

--- a/packages/reporters/reporters/migrations-V5/messages.js
+++ b/packages/reporters/reporters/migrations-V5/messages.js
@@ -394,15 +394,11 @@ class MigrationsMessages {
         if (!reporter.migration.dryRun && deployments.length)
           output += `   > Saving artifacts\n`;
 
-        if (data.valueUnit == undefined) {
-          data.valueUnit = "ETH";
-        }
-
         output +=
           self.underline(37) +
           "\n" +
           `   > ${"Total cost:".padEnd(15)} ${data.cost.padStart(15)} ${
-            data.valueUnit
+            data.valueUnit || "ETH"
           }\n`;
 
         if (self.describeJson) {


### PR DESCRIPTION
When there's an empty migration, the reporter prints total cost as '0 undefined'. This PR defaults the valueUnit to 'ETH' in the reporter for when this happens. 