### PR TITLE
Ensure consistent use of debug package across @truffle/profiler

### DIFF
--- a/packages/profiler/src/convertToAbsolutePaths.ts
+++ b/packages/profiler/src/convertToAbsolutePaths.ts
@@ -1,3 +1,6 @@
+import debugModule from "debug";
+const debug = debugModule("profiler:convertToAbsolutePaths");
+
 import path from "path";
 
 import { isExplicitlyRelative } from "./isExplicitlyRelative";

--- a/packages/profiler/src/getImports.ts
+++ b/packages/profiler/src/getImports.ts
@@ -1,6 +1,6 @@
 import debugModule from "debug";
 import path from "path";
-const debug = debugModule("compile-common:profiler:getImports");
+const debug = debugModule("profiler:getImports");
 
 //HACK: do *not* import ResolvedSource from @truffle/resolver because
 //that would create a circular dependency!

--- a/packages/profiler/src/getImports.ts
+++ b/packages/profiler/src/getImports.ts
@@ -1,6 +1,7 @@
 import debugModule from "debug";
-import path from "path";
 const debug = debugModule("profiler:getImports");
+
+import path from "path";
 
 //HACK: do *not* import ResolvedSource from @truffle/resolver because
 //that would create a circular dependency!

--- a/packages/profiler/src/index.ts
+++ b/packages/profiler/src/index.ts
@@ -1,5 +1,5 @@
 import debugModule from "debug";
-const debug = debugModule("compile-common:profiler");
+const debug = debugModule("profiler");
 const findContracts = require("@truffle/contract-sources");
 const expect = require("@truffle/expect");
 

--- a/packages/profiler/src/index.ts
+++ b/packages/profiler/src/index.ts
@@ -1,5 +1,6 @@
 import debugModule from "debug";
 const debug = debugModule("profiler");
+
 const findContracts = require("@truffle/contract-sources");
 const expect = require("@truffle/expect");
 

--- a/packages/profiler/src/isExplicitlyRelative.ts
+++ b/packages/profiler/src/isExplicitlyRelative.ts
@@ -1,3 +1,6 @@
+import debugModule from "debug";
+const debug = debugModule("profiler:isExplicitlyRelative");
+
 export function isExplicitlyRelative(importPath: string): boolean {
   return importPath.startsWith("./") || importPath.startsWith("../");
 }

--- a/packages/profiler/src/requiredSources.ts
+++ b/packages/profiler/src/requiredSources.ts
@@ -1,6 +1,6 @@
 import debugModule from "debug";
 import path from "path";
-const debug = debugModule("compile-common:profiler:requiredSources");
+const debug = debugModule("profiler:requiredSources");
 
 import {
   resolveAllSources,

--- a/packages/profiler/src/requiredSources.ts
+++ b/packages/profiler/src/requiredSources.ts
@@ -1,6 +1,7 @@
 import debugModule from "debug";
-import path from "path";
 const debug = debugModule("profiler:requiredSources");
+
+import path from "path";
 
 import {
   resolveAllSources,

--- a/packages/profiler/src/resolveAllSources.ts
+++ b/packages/profiler/src/resolveAllSources.ts
@@ -1,5 +1,5 @@
 import debugModule from "debug";
-const debug = debugModule("compile-common:profiler:resolveAllSources");
+const debug = debugModule("profiler:resolveAllSources");
 import { getImports, ResolvedSource } from "./getImports";
 //note: see getImports.ts for why we don't import from @truffle/resolver
 

--- a/packages/profiler/src/resolveAllSources.ts
+++ b/packages/profiler/src/resolveAllSources.ts
@@ -1,5 +1,6 @@
 import debugModule from "debug";
 const debug = debugModule("profiler:resolveAllSources");
+
 import { getImports, ResolvedSource } from "./getImports";
 //note: see getImports.ts for why we don't import from @truffle/resolver
 

--- a/packages/profiler/src/updated.ts
+++ b/packages/profiler/src/updated.ts
@@ -1,3 +1,6 @@
+import debugModule from "debug";
+const debug = debugModule("profiler:updated");
+
 import * as path from "path";
 import * as fs from "fs";
 


### PR DESCRIPTION
I noticed a couple of the `debugModule` names here were still referencing `compile-common:profiler`, so this PR updates those and also ensures all other modules in this package have the requisite imports ready to go.