### PR TITLE
Remove usage of promisify in decoder

### DIFF
--- a/packages/decoder/lib/ProviderAdapter.ts
+++ b/packages/decoder/lib/ProviderAdapter.ts
@@ -104,6 +104,8 @@ export class ProviderAdapter {
     if (isEip1193Provider(this.provider)) {
       return await this.provider.request({ method, params });
     } else {
+      // HACK this uses a manual `new Promise` instead of promisify because
+      // users reported difficulty running this package in a browser extension
       return await new Promise(
         (accept, reject) =>
           (this.provider as LegacyProvider).send(


### PR DESCRIPTION
Since this was causing problems for tx-insight when trying to run decoder inside a browser extension