### PR TITLE
Enhancement: Have `fetchAndCompile` return name of fetcher used

### DIFF
--- a/packages/fetch-and-compile/lib/debug.ts
+++ b/packages/fetch-and-compile/lib/debug.ts
@@ -79,14 +79,13 @@ export class DebugRecognizer implements Recognizer {
 
   async addCompiledInfo(
     info: FetchAndCompileResult,
-    address: string,
-    fetcherName: string
+    address: string
   ): Promise<void> {
     debug("compileResult: %O", info.compileResult);
     const compilations = info.compileResult.compilations;
     const shimmedCompilations = Codec.Compilations.Utils.shimCompilations(
       compilations,
-      `externalFor(${address})Via(${fetcherName})`
+      `externalFor(${address})Via(${info.fetchedVia})`
     );
     await this.bugger.addExternalCompilations(shimmedCompilations);
   }

--- a/packages/fetch-and-compile/lib/fetch.ts
+++ b/packages/fetch-and-compile/lib/fetch.ts
@@ -136,9 +136,9 @@ async function tryFetchAndCompileAddress(
       {
         compileResult,
         sourceInfo: result,
+        fetchedVia: fetcher.fetcherName
       },
-      address,
-      fetcher.fetcherName
+      address
     );
     failureReason = undefined; //mark as *not* failed in case a previous fetcher failed
     //check: did this actually help?

--- a/packages/fetch-and-compile/lib/recognizer.ts
+++ b/packages/fetch-and-compile/lib/recognizer.ts
@@ -11,6 +11,7 @@ import type { SourceInfo } from "@truffle/source-fetcher";
 export class SingleRecognizer implements Recognizer {
   private address: string;
   private recognized: boolean = false;
+  private fetchedVia: string;
   private compileResult: WorkflowCompileResult;
   private sourceInfo: SourceInfo;
 
@@ -21,7 +22,8 @@ export class SingleRecognizer implements Recognizer {
   getResult(): FetchAndCompileResult {
     return {
       compileResult: this.compileResult,
-      sourceInfo: this.sourceInfo
+      sourceInfo: this.sourceInfo,
+      fetchedVia: this.fetchedVia
     };
   }
 
@@ -59,13 +61,13 @@ export class SingleRecognizer implements Recognizer {
 
   addCompiledInfo(
     info: FetchAndCompileResult,
-    address: string,
-    _fetcherName: string
+    address: string
   ): void {
     this.compileResult = info.compileResult;
     this.sourceInfo = info.sourceInfo;
     if (address === this.address) { //I guess? this should never be false
       this.recognized = true;
+      this.fetchedVia = info.fetchedVia;
     }
   }
 }

--- a/packages/fetch-and-compile/lib/types.ts
+++ b/packages/fetch-and-compile/lib/types.ts
@@ -6,6 +6,7 @@ export type FailureType = "fetch" | "compile" | "language";
 export interface FetchAndCompileResult {
   compileResult: WorkflowCompileResult;
   sourceInfo: SourceInfo;
+  fetchedVia: string;
 }
 
 export interface FetchExternalErrors {
@@ -19,8 +20,7 @@ export interface Recognizer {
   getAnUnrecognizedAddress(): string | undefined;
   addCompiledInfo(
     info: FetchAndCompileResult,
-    address: string,
-    fetcherName: string
+    address: string
   ): void | Promise<void>;
   markUnrecognizable(address: string, reason?: FailureType): void;
   markBadFetcher(fetcherName: string): void;


### PR DESCRIPTION
Addresses #4446.

The `SingleRecognizer` now records and returns the name of the fetcher used, in addition to the other information.  Note that to do this I put `fetchedVia` into the `FetchAndCompileResult` type; so I removed the third argument from `addCompiledInfo` as it was now redundant.  I think we can reasonably say that's not really a breaking change, as it doesn't break either `fetchAndCompile` or `fetchAndCompileForDebugger`; it only breaks `fetchAndCompileForRecognizer`, which... c'mon, that's pretty internal (it's not even used elsewhere in Truffle although I did export it).

The functionality of `fetchAndCompileForDebugger` remains unchanged.

If we really are worried about that sort of thing, I can redo it in a truly non-breaking way, but this was the most straightforward way.

Note this PR has no tests, because fetch-and-compile has no tests; but once #4424 is merged I can go back and add tests of this.  (Or if @leeftk merges this in then he can add the tests on his PR, but I don't know that he wants that extra work. XD )