### PR TITLE
Bug: view function can cause insufficient funds error

### DIFF
--- a/packages/contract/lib/execute.js
+++ b/packages/contract/lib/execute.js
@@ -99,7 +99,7 @@ const execute = {
       // view function fail with "insufficient funds for gas" errors"
       // For calls intending to skip network check, it should also skip this check to.
       // A workaround would be simply having the gasPrice field delted
-      params.gasPrice;
+      delete params.gasPrice;
       return { args, params };
     }
     const network = await constructor.detectNetwork();

--- a/packages/contract/lib/execute.js
+++ b/packages/contract/lib/execute.js
@@ -95,6 +95,11 @@ const execute = {
     }
     //skipNetworkCheck flag used to skip network call for read data (calls type) methods invocation
     if (skipNetworkCheck) {
+      // Having gasPrice set (often as default gas price in truffle-config) can also cause
+      // view function fail with "insufficient funds for gas" errors"
+      // For calls intending to skip network check, it should also skip this check to.
+      // A workaround would be simply having the gasPrice field delted
+      params.gasPrice;
       return { args, params };
     }
     const network = await constructor.detectNetwork();


### PR DESCRIPTION
In addition to #4397

We also noticed that sometimes view function can cause the following errors (on polygon, could be specific to their node?):

```
err: insufficient funds for gas * price + value: address 0xd66E40b0c30595bEc72153B502aC1E0c4785991B have 13763260682756217913 want 50000000000000000000000 (supplied gas 500000)
```

This occurs when using truffle, and set a default gas price in the network config, for example:

```
        matic: {
            gasPrice: +process.env.MATIC_GAS_PRICE || 30e9,
        },
```

The proposed solution is to remove "gasPrice" parameters for view calls.

## How to reproduce

https://github.com/hellwolf/truffle_contract_staticcall_gasprice_issue

        // This will trigger the bug, by using high default gasPrice
        // `GAS_PRICE=1e12 npx truffle --network matic exec scripts/test.js`
        // but without GAS_PRICE setting, it works
        // `npx truffle --network matic exec scripts/test.js`

```
$ npx truffle --network matic exec scripts/test.js 
Using network 'matic'.

usdcx name:  Super USDC (PoS)
```

```
$ GAS_PRICE=1e12 npx truffle --network matic exec scripts/test.js 
Using network 'matic'.

err: insufficient funds for gas * price + value: address 0x627306090abaB3A6e1400e9345bC60c78a8BEf57 have 62406659 want 600000000000000000000000000 (supplied gas 50000000)
Truffle v5.4.21 (core: 5.4.21)
Node v14.18.1
```