### PR TITLE
Allow recognition of deployed Vyper bytecode with immutables

### DIFF
--- a/packages/codec/lib/contexts/utils.ts
+++ b/packages/codec/lib/contexts/utils.ts
@@ -42,13 +42,17 @@ export function findContext(
 }
 
 export function matchContext(context: Context, givenBinary: string): boolean {
-  let { binary, isConstructor } = context;
-  let lengthDifference = givenBinary.length - binary.length;
-  //first: if it's not a constructor, they'd better be equal in length.
-  //if it is a constructor, the given binary must be at least as long,
-  //and the difference must be a multiple of 64
+  const { binary, compiler, isConstructor } = context;
+  const lengthDifference = givenBinary.length - binary.length;
+  //first: if it's not a constructor, and it's not Vyper,
+  //they'd better be equal in length.
+  //if it is a constructor, or is Vyper,
+  //the given binary must be at least as long,
+  //and the difference must be a multiple of 32 bytes (64 hex digits)
+  const additionalAllowed = isConstructor ||
+    (compiler != undefined && compiler.name === "vyper");
   if (
-    (!isConstructor && lengthDifference !== 0) ||
+    (!additionalAllowed && lengthDifference !== 0) ||
     lengthDifference < 0 ||
     lengthDifference % (2 * Evm.Utils.WORD_SIZE) !== 0
   ) {

--- a/packages/debugger/test/context-vyper.js
+++ b/packages/debugger/test/context-vyper.js
@@ -1,0 +1,84 @@
+import debugModule from "debug";
+const debug = debugModule("debugger:test:context");
+
+import { assert } from "chai";
+
+import Ganache from "ganache-core";
+
+import { prepareContracts } from "./helpers";
+import Debugger from "lib/debugger";
+
+import sessionSelector from "lib/session/selectors";
+
+const __IMMUTABLE = `
+event Num:
+    num: uint256
+
+imm: immutable(uint256)
+
+@external
+def __init__(x: uint256):
+    imm = x
+
+@external
+def report():
+    log Num(imm)
+`;
+
+const __MIGRATION = `
+const ImmutableTest = artifacts.require("ImmutableTest");
+
+module.exports = function(deployer) {
+  deployer.deploy(ImmutableTest, 107);
+};
+`;
+
+const migrations = {
+  "2_deploy_contracts.js": __MIGRATION
+};
+
+const sources = {
+  "ImmutableTest.vy": __IMMUTABLE
+};
+
+describe("Contexts (Vyper)", function () {
+  var provider;
+
+  var abstractions;
+  var compilations;
+
+  before("Create Provider", async function () {
+    provider = Ganache.provider({ seed: "debugger", gasLimit: 7000000 });
+  });
+
+  before("Prepare contracts and artifacts", async function () {
+    this.timeout(30000);
+
+    let prepared = await prepareContracts(provider, sources, migrations);
+    abstractions = prepared.abstractions;
+    compilations = prepared.compilations;
+  });
+
+  it("correctly identifies context in presence of immutables", async function () {
+    let ImmutableTest = await abstractions.ImmutableTest.deployed();
+    let address = ImmutableTest.address;
+
+    // run outer contract method
+    let result = await ImmutableTest.report();
+
+    let txHash = result.tx;
+
+    let bugger = await Debugger.forTx(txHash, {
+      provider,
+      compilations,
+      lightMode: true
+    });
+    debug("debugger ready");
+
+    let affectedInstances = bugger.view(sessionSelector.info.affectedInstances);
+    debug("affectedInstances: %o", affectedInstances);
+
+    assert.property(affectedInstances, address);
+    assert.equal(affectedInstances[address].contractName, "ImmutableTest");
+  });
+});

--- a/packages/debugger/test/context-vyper.js
+++ b/packages/debugger/test/context-vyper.js
@@ -12,12 +12,12 @@ import sessionSelector from "lib/session/selectors";
 
 const __IMMUTABLE = `
 event Num:
-    num: uint256
+    num: int128
 
-imm: immutable(uint256)
+imm: immutable(int128)
 
 @external
-def __init__(x: uint256):
+def __init__(x: int128):
     imm = x
 
 @external

--- a/packages/debugger/test/helpers.js
+++ b/packages/debugger/test/helpers.js
@@ -31,6 +31,11 @@ export async function prepareContracts(provider, sources = {}, migrations) {
         optimizer: { enabled: false, runs: 200 },
         evmVersion: "london"
       }
+    },
+    vyper: {
+      settings: {
+        evmVersion: "berlin"
+      }
     }
   };
 

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -30,9 +30,9 @@ if [ "$INTEGRATION" = true ]; then
 
 	sudo add-apt-repository -y ppa:deadsnakes/ppa
 	sudo add-apt-repository -y ppa:ethereum/ethereum
-	sudo apt install -y jq python3.6 python3.6-dev python3.6-venv solc
+	sudo apt install -y jq python3.8 python3.8-dev python3.8-venv solc
 	wget https://bootstrap.pypa.io/get-pip.py
-	sudo python3.6 get-pip.py
+	sudo python3.8 get-pip.py
 	sudo pip3 install vyper
 	lerna run --scope truffle test --stream
 
@@ -81,9 +81,9 @@ elif [ "$PACKAGES" = true ]; then
 	sudo add-apt-repository -y ppa:deadsnakes/ppa
 	sudo add-apt-repository -y ppa:ethereum/ethereum
 	sudo apt update
-	sudo apt install -y python3.6 python3.6-dev python3.6-venv solc
+	sudo apt install -y python3.8 python3.8-dev python3.8-venv solc
 	wget https://bootstrap.pypa.io/get-pip.py
-	sudo python3.6 get-pip.py
+	sudo python3.8 get-pip.py
 	sudo pip3 install vyper
 	lerna run --ignore truffle test --stream --concurrency=1
 
@@ -93,9 +93,9 @@ elif [ "$COVERAGE" = true ]; then
 	sudo add-apt-repository -y ppa:deadsnakes/ppa
 	sudo add-apt-repository -y ppa:ethereum/ethereum
 	sudo apt update
-	sudo apt install -y jq python3.6 python3.6-dev python3.6-venv solc
+	sudo apt install -y jq python3.8 python3.8-dev python3.8-venv solc
 	wget https://bootstrap.pypa.io/get-pip.py
-	sudo python3.6 get-pip.py
+	sudo python3.8 get-pip.py
 	sudo pip3 install vyper
 	cd packages/debugger && yarn test:coverage \
 		&& cd ../../ && nyc lerna run --ignore debugger test \


### PR DESCRIPTION
This PR allows the debugger and decoder to recognize bytecode from a deployed Vyper contract that uses immutables.

Now, unlike Solidity, the Vyper compiler doesn't given us any `immutableReferences` output.  But fortunately, unlike Solidity, Vyper puts its immutables at the end of the bytecode -- like constructor arguments -- rather than inline.  This means that we can simply allow "constructor arguments" at the end of deployed bytecode, so long as the context we're trying to match is a Vyper one.

(I thought about not restricting it to Vyper, but decided to leave that restriction in for now.)

So, with this change, it is now possible to debug (i.e. step through) a transaction made against a Vyper contract that uses immutables.  (It also affects things like `decodeTransaction` and `decodeEvent` in the decoder.)

I also added a test of this functionality.  Because this test requires having Vyper installed, I put it in a separate file from the other context tests, with separate setup, so that not having Vyper installed doesn't cause the others to fail.  (This is the first actual automated test to be added of Vyper in the debugger!)

I also updated relevant comments, and some minor style matters.