### PR TITLE
Added tests for contract validation amid schema normalization (issue #4487)

### DIFF
--- a/packages/contract-schema/test/schema.js
+++ b/packages/contract-schema/test/schema.js
@@ -19,7 +19,7 @@ describe("Schema", function () {
       const abiErrors = err.errors.filter(function (error) {
         return error.dataPath === ".abi";
       });
-      assert(abiErrors);
+      assert(abiErrors.length > 0);
     }
   });
 
@@ -42,7 +42,7 @@ describe("Schema", function () {
       const abiErrors = err.errors.filter(function (error) {
         return error.dataPath === ".abi";
       });
-      assert(abiErrors);
+      assert(abiErrors.length > 0);
     }
   });
 });

--- a/packages/contract-schema/test/schema.js
+++ b/packages/contract-schema/test/schema.js
@@ -15,10 +15,13 @@ describe("Schema", function () {
 
     try {
       Schema.validate(invalid);
+
+      assert(false);
     } catch (err) {
       const abiErrors = err.errors.filter(function (error) {
         return error.dataPath === ".abi";
       });
+
       assert(abiErrors.length > 0);
     }
   });
@@ -38,10 +41,13 @@ describe("Schema", function () {
       Schema.normalize(invalid, {
         validate: true
       });
+
+      assert(false);
     } catch (err) {
       const abiErrors = err.errors.filter(function (error) {
         return error.dataPath === ".abi";
       });
+
       assert(abiErrors.length > 0);
     }
   });

--- a/packages/contract-schema/test/schema.js
+++ b/packages/contract-schema/test/schema.js
@@ -1,7 +1,7 @@
-var Schema = require("../index.js");
-var assert = require("assert");
+const Schema = require("../index.js");
+const assert = require("assert");
 
-var MetaCoin = require("./MetaCoin.json");
+const MetaCoin = require("./MetaCoin.json");
 
 describe("Schema", function () {
   it("validates correct input", function () {
@@ -9,14 +9,14 @@ describe("Schema", function () {
   });
 
   it("throws exception on invalid input", function () {
-    var invalid = {
+    const invalid = {
       abi: -1
     };
 
     try {
       Schema.validate(invalid);
     } catch (err) {
-      var abiErrors = err.errors.filter(function (error) {
+      const abiErrors = err.errors.filter(function (error) {
         return error.dataPath === ".abi";
       });
       assert(abiErrors);
@@ -30,7 +30,7 @@ describe("Schema", function () {
   });
 
   it("throws exception when attempting to validate invalid input during normalization", function () {
-    var invalid = {
+    const invalid = {
       abi: -1
     };
 
@@ -39,7 +39,7 @@ describe("Schema", function () {
         validate: true
       });
     } catch (err) {
-      var abiErrors = err.errors.filter(function (error) {
+      const abiErrors = err.errors.filter(function (error) {
         return error.dataPath === ".abi";
       });
       assert(abiErrors);

--- a/packages/contract-schema/test/schema.js
+++ b/packages/contract-schema/test/schema.js
@@ -3,12 +3,12 @@ var assert = require("assert");
 
 var MetaCoin = require("./MetaCoin.json");
 
-describe("Schema", function() {
-  it("validates correct input", function() {
+describe("Schema", function () {
+  it("validates correct input", function () {
     Schema.validate(MetaCoin);
   });
 
-  it("throws exception on invalid input", function() {
+  it("throws exception on invalid input", function () {
     var invalid = {
       abi: -1
     };
@@ -16,7 +16,30 @@ describe("Schema", function() {
     try {
       Schema.validate(invalid);
     } catch (err) {
-      var abiErrors = err.errors.filter(function(error) {
+      var abiErrors = err.errors.filter(function (error) {
+        return error.dataPath === ".abi";
+      });
+      assert(abiErrors);
+    }
+  });
+
+  it("normalizes a correct input", function () {
+    Schema.normalize(MetaCoin, {
+      validate: true
+    });
+  });
+
+  it("throws exception when attempting to normalize an invalid schema", function () {
+    var invalid = {
+      abi: -1
+    };
+
+    try {
+      Schema.normalize(invalid, {
+        validate: true
+      });
+    } catch (err) {
+      var abiErrors = err.errors.filter(function (error) {
         return error.dataPath === ".abi";
       });
       assert(abiErrors);

--- a/packages/contract-schema/test/schema.js
+++ b/packages/contract-schema/test/schema.js
@@ -23,13 +23,13 @@ describe("Schema", function () {
     }
   });
 
-  it("normalizes a correct input", function () {
+  it("validates a correct input as part of normalization", function () {
     Schema.normalize(MetaCoin, {
       validate: true
     });
   });
 
-  it("throws exception when attempting to normalize an invalid schema", function () {
+  it("throws exception when attempting to validate invalid input during normalization", function () {
     var invalid = {
       abi: -1
     };


### PR DESCRIPTION
Addresses issue #4487.

I've added the tests for contract validation amid calling `Schema.normalize()`, present inside PR #4432.

Modified only `@truffle/contract-schema/test/schema.js`