### PR TITLE
Internal improvement: Have debugger test always cleanup afterward, including on failure

### DIFF
--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -19,7 +19,7 @@
     "docs": "esdoc",
     "prepare": "yarn build",
     "start": "node ./webpack/dev-server.js",
-    "test": "mocha-webpack --webpack-config webpack/webpack.config-test.js --recursive && rm -r dist && yarn build",
+    "test": "mocha-webpack --webpack-config webpack/webpack.config-test.js --recursive; STATUS=$?; rm -r dist; yarn build; (exit $STATUS)",
     "test:coverage": "nyc mocha-webpack --webpack-config webpack/webpack.config-test.js --recursive",
     "test:debug": "NODE_ENV=testing node --inspect ./node_modules/.bin/mocha-webpack --webpack-config webpack/webpack.config-test.js --recursive"
   },


### PR DESCRIPTION
The way that it's necessary to clean up the after the debugger tests run is definitely something of a tripping hazard... sure, the cleanup happens automatically now, but only if the tests *succeed*!  If the tests fail, no cleanup occurs.

So, this PR alters the debugger test script so that the cleanup occurs no matter what (without accidentally making it so that failing tests are ignored).  We run the tests, save the exit status, run the cleanup, and then finally return the saved exit status (so that we get a failure if the tests failed).  It's perhaps a bit awkward, but it works.  (I did a manual test to make sure that yes, we really do get a failure if one of the tests fails.)

It's not perfect, obviously -- if you interrupt the tests, you're still going to need to run the cleanup yourself, and I'm sure some poor newbie is going to encounter that at some point and be pretty confused as to what's wrong -- but it's an improvement, at least.