### PR TITLE
Allow users to specify transaction type explicitly, and allow use of access lists, including ENS support

### DIFF
--- a/packages/config/src/configDefaults.ts
+++ b/packages/config/src/configDefaults.ts
@@ -25,6 +25,7 @@ export const getInitialConfig = ({
     gasPrice: null,
     maxFeePerGas: null,
     maxPriorityFeePerGas: null,
+    type: undefined, //don't use null here!
     from: null,
     confirmations: 0,
     timeoutBlocks: 0,
@@ -229,6 +230,20 @@ export const configProps = ({
       set() {
         throw new Error(
           "Don't set config.maxPriorityFeePerGas directly. Instead, set config.networks and then config.networks[<network name>].maxPriorityFeePerGas"
+        );
+      }
+    },
+    type: {
+      get() {
+        try {
+          return configObject.network_config.type;
+        } catch (e) {
+          return null;
+        }
+      },
+      set() {
+        throw new Error(
+          "Don't set config.type directly. Instead, set config.networks and then config.networks[<network name>].type"
         );
       }
     },

--- a/packages/contract/lib/utils/ens.js
+++ b/packages/contract/lib/utils/ens.js
@@ -117,11 +117,6 @@ module.exports = {
       const newAccessList = await Promise.all(
         inputParams.accessList.map(async (entry) => {
           if (entry && entry.address && !isAddress(entry.address)) {
-            //note: this code won't run if the entry is given in the form
-            //[address, storageKeys] rather than { address, storageKeys }.
-            //however I think that's fine, as the former form requires things
-            //to be given as Uint8Arrays rather than as strings, so I think
-            //it's safe to ignore that
             const newAddress = await this.resolveNameToAddress({
               name: entry.address,
               provider: web3.currentProvider,

--- a/packages/contract/lib/utils/index.js
+++ b/packages/contract/lib/utils/index.js
@@ -16,6 +16,7 @@ const allowedTxParams = new Set([
   "value",
   "data",
   "nonce",
+  "accessList",
   "type",
   "privateFor",
   "overwrite"

--- a/packages/contract/lib/utils/index.js
+++ b/packages/contract/lib/utils/index.js
@@ -16,6 +16,7 @@ const allowedTxParams = new Set([
   "value",
   "data",
   "nonce",
+  "type",
   "privateFor",
   "overwrite"
 ]);

--- a/packages/provisioner/src/index.ts
+++ b/packages/provisioner/src/index.ts
@@ -23,7 +23,14 @@ const provision = (contractAbstraction: any, truffleConfig: TruffleConfig) => {
 
   contractAbstraction.ens = truffleConfig.ens;
 
-  ["from", "gas", "gasPrice", "maxFeePerGas", "maxPriorityFeePerGas"].forEach(key => {
+  [
+    "from",
+    "gas",
+    "gasPrice",
+    "maxFeePerGas",
+    "maxPriorityFeePerGas",
+    "type"
+  ].forEach(key => {
     if (truffleConfig[key]) {
       const obj: any = {};
       obj[key] = truffleConfig[key];


### PR DESCRIPTION
Addresses #4156.

Both web3 and ethers allow setting the transaction type expicitly with the `type` option, but we weren't allowing this.  This PR whitelists the `type` option in Truffle Contract, and then in addition I added it to the list of options that users can explicitly set in their config, because it seems like something that users might want a default for.  Note that the default default is set to `undefined`, not `null`; web3 will error if you specify `type: null` (no Pokemon jokes please :P ).

Note that web3 doesn't *fully* respect the type you specify -- if you specify type 1, but don't specify an access list (and with Truffle currently, you still *can't* specify an access list!), it'll use type 0 instead -- but I don't think that's any big reason not to do this.

**Edit**: I've also now updated this PR to finally also add support for access lists into Truffle Contract.  We were holding off on this until Ganache 7 is out, but now that the beta is out, @gnidan said that's good enough. :)

**Edit again**: I also now added ENS support for those access lists. :)

~~I didn't include any tests in this PR, be aware.~~  No longer true!  I added a test of ENS support for access lists. :)