### PR TITLE
Fix incorrect key name in migrate prepareCall

### DIFF
--- a/packages/contract/lib/execute.js
+++ b/packages/contract/lib/execute.js
@@ -84,7 +84,7 @@ const execute = {
       const { web3 } = constructor;
       const processedValues = await utils.ens.convertENSNames({
         networkId: constructor.network_id,
-        ensSettings: constructor.ens,
+        ens: constructor.ens,
         inputArgs: args,
         inputParams: params,
         methodABI,


### PR DESCRIPTION
This PR fixed an error in the key name ens when calling convertENSNames in the migrate prepareCall. The error causes truffle-box v5.1-example-box fails to migrate, see issue #4477.