### PR TITLE
Internal improvement: Fix confusing comment on `toHexString` function

### DIFF
--- a/packages/codec/lib/conversion.ts
+++ b/packages/codec/lib/conversion.ts
@@ -63,12 +63,13 @@ export function toBig(value: BN | number): Big {
 /**
  * @param bytes - Uint8Array | BN
  * @param padLength - number - minimum desired byte length (left-pad with zeroes)
+ * @param padRight - boolean - causes padding to occur on right instead of left
  * @return {string}
  */
 export function toHexString(
   bytes: Uint8Array | BN,
   padLength: number = 0,
-  padRight: boolean = false //pad on right instead of length
+  padRight: boolean = false
 ): string {
   if (BN.isBN(bytes)) {
     bytes = toBytes(bytes);


### PR DESCRIPTION
Was working on codec when I noticed this comment made no sense.  It was clearly supposed to say "left" instead of "length".  So I fixed it, and also changed it to be an `@param` comment, FWIW.