### PR TITLE
@truffle/db Option to save .db directory to project directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ packages/debugger/.tmp
 
 # @truffle/contract
 packages/contract/dist
+
+# @truffle/db
+**/*.db

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -22,6 +22,7 @@ system that can keep track of multiple contracts in this situation.
 ## Built With
 
 Truffle DB is built with:
+
 - TypeScript
 - GraphQL
 - Apollo
@@ -36,9 +37,17 @@ db: {
   enabled: true
 }
 ```
+
 Note: Enabling Truffle DB does not affect artifacts, but will produce a new `.db`
 directory when you compile or migrate your project.
 
+Add the following to your user truffle config (`~/.config/truffle-nodejs/config.json`) to enable saving the `.db` directory to your project directory
+
+```
+db: {
+  saveToProjectRoot: true
+}
+```
 
 It will soon be possible to load and access Truffle DB data via `truffle compile` and `truffle migrate`.
 Stay tuned!

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -33,7 +33,8 @@ Add the following to your `truffle-config.js` file in order to enable Truffle DB
 
 ```
 db: {
-  enabled: true
+  enabled: true,
+  saveLocally: true // Optional - save the .db directory to the project directory. Default: false.
 }
 ```
 Note: Enabling Truffle DB does not affect artifacts, but will produce a new `.db`

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -33,8 +33,7 @@ Add the following to your `truffle-config.js` file in order to enable Truffle DB
 
 ```
 db: {
-  enabled: true,
-  saveLocally: true // Optional - save the .db directory to the project directory. Default: false.
+  enabled: true
 }
 ```
 Note: Enabling Truffle DB does not affect artifacts, but will produce a new `.db`

--- a/packages/db/src/meta/pouch/adapters/fs.ts
+++ b/packages/db/src/meta/pouch/adapters/fs.ts
@@ -29,7 +29,7 @@ export const getDefaultSettings: GetDefaultSettings = () => {
   return {
     directory: path.join(
       userConfig.get("db")?.saveLocally 
-        ? new Config().working_directory  
+        ? Config.default().working_directory 
         : Config.getTruffleDataDirectory()
         , ".db", "json")
   };

--- a/packages/db/src/meta/pouch/adapters/fs.ts
+++ b/packages/db/src/meta/pouch/adapters/fs.ts
@@ -17,7 +17,7 @@ export interface DatabasesSettings {
 }
 
 type UserConfigDbSettings = {
-  saveToProjectRoot: boolean | undefined,
+  saveToProjectRoot?: boolean,
 };
 
 type UserConfig = {

--- a/packages/db/src/meta/pouch/adapters/fs.ts
+++ b/packages/db/src/meta/pouch/adapters/fs.ts
@@ -31,7 +31,7 @@ export const getDefaultSettings: GetDefaultSettings = () => {
       userConfig.get("db")?.saveLocally 
         ? new Config().working_directory  
         : Config.getTruffleDataDirectory()
-        , ".db", "sqlite")
+        , ".db", "json")
   };
 };
 

--- a/packages/db/src/meta/pouch/adapters/fs.ts
+++ b/packages/db/src/meta/pouch/adapters/fs.ts
@@ -15,8 +15,9 @@ import Config from "@truffle/config";
 export interface DatabasesSettings {
   directory: string;
 }
+
 type UserConfigDbSettings = {
-  saveLocally: boolean | undefined,
+  saveToProjectRoot: boolean | undefined,
 };
 
 type UserConfig = {
@@ -28,8 +29,8 @@ export const getDefaultSettings: GetDefaultSettings = () => {
   
   return {
     directory: path.join(
-      userConfig.get("db")?.saveLocally 
-        ? Config.default().working_directory 
+      userConfig.get("db")?.saveToProjectRoot 
+        ? Config.detect().workingDirectory
         : Config.getTruffleDataDirectory()
         , ".db", "json")
   };

--- a/packages/db/src/meta/pouch/adapters/fs.ts
+++ b/packages/db/src/meta/pouch/adapters/fs.ts
@@ -17,7 +17,7 @@ export interface DatabasesSettings {
 }
 
 export const getDefaultSettings: GetDefaultSettings = () => ({
-  directory: path.join(Config.getTruffleDataDirectory(), ".db", "json")
+  directory: path.join(Config.detect().db.saveLocally ? Config.detect().working_directory : Config.getTruffleDataDirectory(), ".db", "json")
 });
 
 export class Databases<C extends Collections> extends Base.Databases<C> {

--- a/packages/db/src/meta/pouch/adapters/fs.ts
+++ b/packages/db/src/meta/pouch/adapters/fs.ts
@@ -15,10 +15,25 @@ import Config from "@truffle/config";
 export interface DatabasesSettings {
   directory: string;
 }
+type UserConfigDbSettings = {
+  saveLocally: boolean | undefined,
+};
 
-export const getDefaultSettings: GetDefaultSettings = () => ({
-  directory: path.join(Config.detect().db.saveLocally ? Config.detect().working_directory : Config.getTruffleDataDirectory(), ".db", "json")
-});
+type UserConfig = {
+  get: (key: "db") => UserConfigDbSettings,
+};
+
+export const getDefaultSettings: GetDefaultSettings = () => {
+  const userConfig: UserConfig = Config.getUserConfig();
+  
+  return {
+    directory: path.join(
+      userConfig.get("db")?.saveLocally 
+        ? new Config().working_directory  
+        : Config.getTruffleDataDirectory()
+        , ".db", "sqlite")
+  };
+};
 
 export class Databases<C extends Collections> extends Base.Databases<C> {
   private directory: string;

--- a/packages/db/src/meta/pouch/adapters/sqlite.ts
+++ b/packages/db/src/meta/pouch/adapters/sqlite.ts
@@ -16,7 +16,7 @@ export interface DatabasesSettings {
 }
 
 type UserConfigDbSettings = {
-  saveLocally: boolean | undefined,
+  saveToProjectRoot?: boolean,
 };
 
 type UserConfig = {
@@ -28,8 +28,8 @@ export const getDefaultSettings: GetDefaultSettings = () => {
   
   return {
     directory: path.join(
-      userConfig.get("db")?.saveLocally 
-        ? Config.default().working_directory  
+      userConfig.get("db")?.saveToProjectRoot 
+        ? Config.detect().workingDirectory
         : Config.getTruffleDataDirectory()
         , ".db", "sqlite")
   };

--- a/packages/db/src/meta/pouch/adapters/sqlite.ts
+++ b/packages/db/src/meta/pouch/adapters/sqlite.ts
@@ -16,7 +16,7 @@ export interface DatabasesSettings {
 }
 
 export const getDefaultSettings: GetDefaultSettings = () => ({
-  directory: path.join(Config.getTruffleDataDirectory(), ".db", "sqlite")
+  directory: path.join(Config.detect().db.saveLocally ? Config.detect().working_directory : Config.getTruffleDataDirectory(), ".db", "json")
 });
 
 export class Databases<C extends Collections> extends Base.Databases<C> {

--- a/packages/db/src/meta/pouch/adapters/sqlite.ts
+++ b/packages/db/src/meta/pouch/adapters/sqlite.ts
@@ -29,7 +29,7 @@ export const getDefaultSettings: GetDefaultSettings = () => {
   return {
     directory: path.join(
       userConfig.get("db")?.saveLocally 
-        ? new Config().working_directory  
+        ? Config.default().working_directory  
         : Config.getTruffleDataDirectory()
         , ".db", "sqlite")
   };

--- a/packages/db/src/meta/pouch/adapters/sqlite.ts
+++ b/packages/db/src/meta/pouch/adapters/sqlite.ts
@@ -16,7 +16,7 @@ export interface DatabasesSettings {
 }
 
 export const getDefaultSettings: GetDefaultSettings = () => ({
-  directory: path.join(Config.detect().db.saveLocally ? Config.detect().working_directory : Config.getTruffleDataDirectory(), ".db", "json")
+  directory: path.join(Config.detect().db.saveLocally ? Config.detect().working_directory : Config.getTruffleDataDirectory(), ".db", "sqlite")
 });
 
 export class Databases<C extends Collections> extends Base.Databases<C> {

--- a/packages/db/src/meta/pouch/adapters/sqlite.ts
+++ b/packages/db/src/meta/pouch/adapters/sqlite.ts
@@ -15,9 +15,25 @@ export interface DatabasesSettings {
   directory: string;
 }
 
-export const getDefaultSettings: GetDefaultSettings = () => ({
-  directory: path.join(Config.detect().db.saveLocally ? Config.detect().working_directory : Config.getTruffleDataDirectory(), ".db", "sqlite")
-});
+type UserConfigDbSettings = {
+  saveLocally: boolean | undefined,
+};
+
+type UserConfig = {
+  get: (key: "db") => UserConfigDbSettings,
+};
+
+export const getDefaultSettings: GetDefaultSettings = () => {
+  const userConfig: UserConfig = Config.getUserConfig();
+  
+  return {
+    directory: path.join(
+      userConfig.get("db")?.saveLocally 
+        ? new Config().working_directory  
+        : Config.getTruffleDataDirectory()
+        , ".db", "sqlite")
+  };
+};
 
 export class Databases<C extends Collections> extends Base.Databases<C> {
   private directory: string;


### PR DESCRIPTION
#### Summary 
Adds the `saveLocally` property to the `db` section of the `truffle-config.js`

```
db: {
      enabled: true,
      saveLocally: true,      
    },
```

When enabled, the db adapters will return the working directory as the location to save the `.db` folder. 

#### To Test
1. Enable the db flag above in your `truffle-config.js`. 
2. I tested using db-kit, it's enough to just start the application. 

ER: `.db` directory exists in `~/.config/truffle-nodejs/` (@truffle/config `getTruffleDataDirectory()`)

3. Bomb out of db-kit (ctrl-c)
4. Enable the `saveLocally` config flag above with the already enabled db flag. 
5. Start db-kit

ER: `.db` directory exists in your truffle project directory (@truffle/config `detect().working_directory`)

Closes #4495 