### PR TITLE
Dependency update: Update reselect-tree to 1.3.5 and json-pointer to 0.6.1

### DIFF
--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -29,7 +29,7 @@
     "@truffle/source-map-utils": "^1.3.63",
     "bn.js": "^5.1.3",
     "debug": "^4.3.1",
-    "json-pointer": "^0.6.0",
+    "json-pointer": "^0.6.1",
     "json-stable-stringify": "^1.0.1",
     "lodash.flatten": "^4.4.0",
     "lodash.merge": "^4.6.2",
@@ -38,7 +38,7 @@
     "redux": "^3.7.2",
     "redux-saga": "1.0.0",
     "remote-redux-devtools": "^0.5.12",
-    "reselect-tree": "^1.3.4",
+    "reselect-tree": "^1.3.5",
     "semver": "^7.3.4",
     "web3": "1.5.3",
     "web3-eth-abi": "1.5.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17935,6 +17935,13 @@ json-pointer@^0.6.0:
   dependencies:
     foreach "^2.0.4"
 
+json-pointer@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/json-pointer/-/json-pointer-0.6.1.tgz#3c6caa6ac139e2599f5a1659d39852154015054d"
+  integrity sha512-3OvjqKdCBvH41DLpV4iSt6v2XhZXV1bPB4OROuknvUXI7ZQNofieCPkmE26stEJ9zdQuvIxDHCuYhfgxFAAs+Q==
+  dependencies:
+    foreach "^2.0.4"
+
 json-rpc-engine@^3.4.0, json-rpc-engine@^3.6.0:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/json-rpc-engine/-/json-rpc-engine-3.8.0.tgz#9d4ff447241792e1d0a232f6ef927302bb0c62a9"
@@ -24667,14 +24674,14 @@ requirejs@^2.3.5:
   resolved "https://registry.yarnpkg.com/requirejs/-/requirejs-2.3.6.tgz#e5093d9601c2829251258c0b9445d4d19fa9e7c9"
   integrity sha512-ipEzlWQe6RK3jkzikgCupiTbTvm4S0/CAU5GlgptkN5SO6F3u0UD0K18wy6ErDqiCyP4J4YYe1HuAShvsxePLg==
 
-reselect-tree@^1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/reselect-tree/-/reselect-tree-1.3.4.tgz#449629728e2dc79bf0602571ec8859ac34737089"
-  integrity sha512-1OgNq1IStyJFqIqOoD3k3Ge4SsYCMP9W88VQOfvgyLniVKLfvbYO1Vrl92SyEK5021MkoBX6tWb381VxTDyPBQ==
+reselect-tree@^1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/reselect-tree/-/reselect-tree-1.3.5.tgz#9ff58ad76f2e64584947f1d1b3285e037a448c23"
+  integrity sha512-h/iXrz7wGBidwMmNFu5L1z0sDvqU6SAdJ2TKr5IIsyGKeyXQchi0gXbfbIJJfGWD8VGcDYjzGAbhy1KaGD4FWQ==
   dependencies:
     debug "^3.1.0"
     esdoc "^1.0.4"
-    json-pointer "^0.6.0"
+    json-pointer "^0.6.1"
     reselect "^4.0.0"
     source-map-support "^0.5.3"
 


### PR DESCRIPTION
Updating these to resolve the dependabot alert regarding json-pointer.