### PR TITLE
Allow more permissive format in reason determination (make `reason.js` work with Ganache 7)

### DIFF
--- a/packages/contract/lib/reason.js
+++ b/packages/contract/lib/reason.js
@@ -24,13 +24,16 @@ const reason = {
 
     if (isObject) {
       const data = res.error.data;
-      const hash = Object.keys(data)[0];
+      //new format: encoded message is in data.result
+      //old format: there is no data.result, but the encoded message can
+      //be found in data[hash].return, where hash is the first key
+      const encodedMessage = data.result || Object.values(data)[0].return;
 
-      if (data[hash].return && data[hash].return.includes(errorStringHash)) {
+      if (encodedMessage && encodedMessage.includes(errorStringHash)) {
         try {
           return web3.eth.abi.decodeParameter(
             "string",
-            data[hash].return.slice(10)
+            encodedMessage.slice(10)
           );
         } catch (_) {
           return undefined;


### PR DESCRIPTION
I just noticed that `reason.js` causes crashes when used with Ganache 7, due to it returning its errors in a new format.  So on a revert, you get a useless error message, instead of the revert message.

I've fixed this up to work with Ganache 7 while still working the old way.

Um, I only realized just now that this might be duplicative of work already going on on #4483.  @eggplantzzz, let me know if so and I can close this. :P