### PR TITLE
Bug fix: Fix incorrect action name and account for null location

### DIFF
--- a/packages/debugger/lib/stacktrace/reducers.js
+++ b/packages/debugger/lib/stacktrace/reducers.js
@@ -81,14 +81,14 @@ function lastPosition(state = null, action) {
   switch (action.type) {
     case actions.JUMP_IN:
     case actions.JUMP_OUT:
-    // FIXME: WHEN THIS IS ADDED IN CORRECTLY THE TESTS FAIL.
-    // case actions.EXTERNAL_CALL:
+    case actions.EXTERNAL_CALL:
     case actions.EXTERNAL_RETURN:
     case actions.UPDATE_POSITION:
     case actions.EXECUTE_RETURN:
       const { location } = action;
-      if (location.source.id === undefined || location.source.internal) {
+      if (location === null || location.source.id === undefined || location.source.internal) {
         //don't update for unmapped or internal!
+        //also don't update for null location
         return state;
       }
       return location;


### PR DESCRIPTION
This is an odd one.  The `EXTERNAL_CALL` case in the `lastPosition` reducer in `stacktrace` was typo'd to `ETERNAL_CALL`.  So external calls were getting ignored!

Why didn't this cause test failures?  Well, presumably because this would only affect the source positions given in the stacktrace, which we weren't testing.  (Notionally I could add tests for those, but due to this PR's status as an add-on to another PR, that would be impractical here; we can go back and do that later if we think it's necessary.)

Note that fixing the typo caused failures though... because I didn't account for the fact that the initial `EXTERNAL_CALL` has `location` equal to `null`.  So, I just checked for that case and ignored it.