### PR TITLE
Internal improvement: Remove unnecessary resolver options, check compiler instead

### DIFF
--- a/packages/compile-vyper/index.js
+++ b/packages/compile-vyper/index.js
@@ -243,15 +243,16 @@ const Compile = {
       return { compilations: [] };
     }
 
-    const { version, json: useJson, jsonCommand } = await checkVyper();
-
     const { allSources, compilationTargets } = await requiredSources(
       options.with({
         paths: vyperFilesStrict,
         base_path: options.contracts_directory,
         compiler: {
-          name: "vyper",
-          version
+          name: "vyper"
+          //HACK: we leave version empty because we haven't determined
+          //it at this point and we don't want to pay the cost of doing
+          //so, and nothing in the resolver sources currently uses
+          //precise vyper version
         }
       })
     );
@@ -270,6 +271,8 @@ const Compile = {
     //having gotten the sources from the resolver, we invoke compileJson
     //ourselves, rather than going through Compile.sources()
     Compile.display(compilationTargets, options);
+
+    const { version, json: useJson, jsonCommand } = await checkVyper();
 
     if (useJson) {
       return compileJson({

--- a/packages/compile-vyper/index.js
+++ b/packages/compile-vyper/index.js
@@ -243,10 +243,16 @@ const Compile = {
       return { compilations: [] };
     }
 
+    const { version, json: useJson, jsonCommand } = await checkVyper();
+
     const { allSources, compilationTargets } = await requiredSources(
       options.with({
         paths: vyperFilesStrict,
-        base_path: options.contracts_directory
+        base_path: options.contracts_directory,
+        compiler: {
+          name: "vyper",
+          version
+        }
       })
     );
 
@@ -264,8 +270,6 @@ const Compile = {
     //having gotten the sources from the resolver, we invoke compileJson
     //ourselves, rather than going through Compile.sources()
     Compile.display(compilationTargets, options);
-
-    const { version, json: useJson, jsonCommand } = await checkVyper();
 
     if (useJson) {
       return compileJson({

--- a/packages/compile-vyper/profiler.js
+++ b/packages/compile-vyper/profiler.js
@@ -6,10 +6,7 @@ const { parseImports } = require("./parser");
 // Returns the minimal set of sources to pass to vyper-json as compilations targets,
 // as well as the complete set of sources so vyper-json can resolve the comp targets' imports.
 async function requiredSources(options) {
-  const resolver = new Resolver(options, {
-    translateJsonToSolidity: false,
-    resolveVyperModules: true
-  });
+  const resolver = new Resolver(options);
 
   debug("resolver.sources.length: %d", resolver.sources.length);
 

--- a/packages/resolver/lib/resolver.ts
+++ b/packages/resolver/lib/resolver.ts
@@ -25,26 +25,27 @@ export class Resolver {
     const { includeTruffleSources } = resolverOptions;
 
     this.options = options;
-    this.sources = [
+
+    let basicSources: ResolverSource[] = [
       new EthPMv1(options.working_directory),
       new NPM(options.working_directory),
       new GlobalNPM(),
       new FS(options.working_directory, options.contracts_build_directory)
     ];
-
     if (includeTruffleSources) {
-      this.sources.unshift(new Truffle(options));
+      basicSources.unshift(new Truffle(options));
     }
 
-    if (options.compiler && options.compiler.name === "solc") {
-      this.sources = [].concat(
-        ...this.sources.map(source => [new ABI(source), source])
-      );
-    }
+    //set up abi-to-sol resolution
+    this.sources = [].concat(
+      ...basicSources.map(source => [new ABI(source), source])
+    );
 
-    if (options.compiler && options.compiler.name === "vyper") {
-      this.sources = [new Vyper(this.sources, options.contracts_directory)];
-    }
+    //set up vyper resolution rules
+    this.sources = [
+      new Vyper(basicSources, options.contracts_directory),
+      ...this.sources //for Vyper this is redundant
+    ];
   }
 
   // This function might be doing too much. If so, too bad (for now).

--- a/packages/resolver/lib/resolver.ts
+++ b/packages/resolver/lib/resolver.ts
@@ -10,15 +10,7 @@ import { EthPMv1, NPM, GlobalNPM, FS, Truffle, ABI, Vyper } from "./sources";
 
 export interface ResolverOptions {
   includeTruffleSources?: boolean;
-  translateJsonToSolidity?: boolean;
-  resolveVyperModules?: boolean;
 }
-
-const defaultResolverOptions = {
-  includeTruffleSources: false,
-  translateJsonToSolidity: true,
-  resolveVyperMoudles: false,
-};
 
 export class Resolver {
   options: any;
@@ -30,15 +22,7 @@ export class Resolver {
       ["working_directory", "contracts_build_directory", "contracts_directory"]
     );
 
-    resolverOptions = {
-      ...defaultResolverOptions,
-      ...resolverOptions
-    };
-    const {
-      includeTruffleSources,
-      translateJsonToSolidity,
-      resolveVyperModules
-    } = resolverOptions;
+    const { includeTruffleSources } = resolverOptions;
 
     this.options = options;
     this.sources = [
@@ -52,13 +36,13 @@ export class Resolver {
       this.sources.unshift(new Truffle(options));
     }
 
-    if (translateJsonToSolidity) {
+    if (options.compiler && options.compiler.name === "solc") {
       this.sources = [].concat(
         ...this.sources.map(source => [new ABI(source), source])
       );
     }
 
-    if (resolveVyperModules) {
+    if (options.compiler && options.compiler.name === "vyper") {
       this.sources = [new Vyper(this.sources, options.contracts_directory)];
     }
   }

--- a/packages/resolver/lib/sources/abi.ts
+++ b/packages/resolver/lib/sources/abi.ts
@@ -30,6 +30,12 @@ export class ABI implements ResolverSource {
     importedFrom: string = "",
     options: { compiler?: { name: string; version: string } } = {}
   ) {
+    const { compiler } = options;
+    if (!compiler || compiler.name !== "solc") {
+      //this resolver source for use by solc only!
+      //vyper doesn't need it and would be quite thrown off by it
+      return { filePath: undefined, body: undefined };
+    }
     let filePath: string | undefined;
     let body: string | undefined;
 
@@ -46,7 +52,6 @@ export class ABI implements ResolverSource {
       return { filePath, body };
     }
 
-    const { compiler } = options;
     const solidityVersion = determineSolidityVersion(compiler);
 
     ({ filePath, body } = resolution);
@@ -90,11 +95,8 @@ export class ABI implements ResolverSource {
 }
 
 function determineSolidityVersion(
-  compiler?: { name: string; version: string }
+  compiler: { name: string; version: string }
 ): string | undefined {
-  if (!compiler) {
-    return;
-  }
 
   const { version } = compiler;
 

--- a/packages/resolver/lib/sources/vyper.ts
+++ b/packages/resolver/lib/sources/vyper.ts
@@ -25,13 +25,27 @@ export class Vyper implements ResolverSource {
     return null;
   }
 
-  async resolve(importModule: string, importedFrom: string) {
+  async resolve(
+    importModule: string,
+    importedFrom: string,
+    options: { compiler?: { name: string; } } = {}
+  ) {
+    const { compiler } = options;
+    if (!compiler || compiler.name !== "vyper") {
+      //this resolver source for use by Vyper only!
+      debug("not Vyper, go away!");
+      return { body: undefined, filePath: undefined };
+    }
+
     importedFrom = importedFrom || "";
 
     debug("importModule: %s", importModule);
     debug("importedFrom: %s", importedFrom);
 
     //attempt to just resolve as if it's a file path rather than Vyper module
+    //(we have to do this rather than just leaving it to the other, unwrapped,
+    //resolver sources, because of resolveDependencyPath... yes, that results
+    //in checking those sources twice on failure :-/ )
     for (const source of this.wrappedSources) {
       const directlyResolvedSource = await source.resolve(
         importModule,
@@ -42,7 +56,8 @@ export class Vyper implements ResolverSource {
         return directlyResolvedSource;
       }
     }
-    //otherwise, it's time for some Vyper module processing...
+    //so if we've made it here, it's time for some Vyper module processing...
+    debug("running Vyper import processing!");
 
     //only attempt this if what we have looks like a Vyper module
     if (!importModule.match(/^[\w.]+$/)) {
@@ -114,7 +129,11 @@ export class Vyper implements ResolverSource {
     //unfortunately, for this sort of source to resolve a dependency path,
     //it's going to need to do a resolve :-/
     debug("importPath: %s", importPath);
-    const resolved = await this.resolve(dependencyPath, importPath);
+    const resolved = await this.resolve(
+      dependencyPath,
+      importPath,
+      { compiler: { name: "vyper" }} //HACK
+    );
     if (resolved) {
       return resolved.filePath;
     } else {


### PR DESCRIPTION
Addresses #4521.  **Is a breaking change to `@truffle/resolver`**.

Most of what there is to say about this one is already discussed in #4521.  The awkward option that defaulted to `true` is now gone; I imagine Nick will be happy about that.

Only one resolver invocation needed to be altered, and that was the one in `compile-vyper`, because that's the one all these auxiliary options were created for!  Now that `includeTruffleSources` is once again the only resolver option, I could notionally change the signature back to the old way, where instead of passing `{ includeTruffleSources: true }` you just passed `true`, but, um, I think it's fairly obvious why we don't want to do that.

(Getting rid of those extra options is also quite helpful if we ever want to implement #3855. :)  The way the options worked previously wouldn't have worked very well with that.)

Note that passing the full version to the profiler meant that I had to move the call to `checkVyper` a bit earlier than it previously was.  Previously it would only be called if there were actual Vyper files to compile; now it can be called as long as there is Vyper in your project, even if no Vyper needs to be compiled at the moment.  This is relevant because the call to `checkVyper` can be a bit slow.  I'm guessing this is probably OK?  But figured it's worth asking.

~~I considered moving all the compiler-checking logic into the individual resolver sources, so that we could just always have all resolver sources active, rather than the current logic where the language controls which ones are active; however, that seemed like unnecessary work, and is a bit awkward with the wrapper thing, so I didn't do that.~~  Edit: I went back and redid it this way!  See later comments.