### PR TITLE
Bug fix: Correct error in ProviderAdapter

### DIFF
--- a/packages/decoder/lib/ProviderAdapter.ts
+++ b/packages/decoder/lib/ProviderAdapter.ts
@@ -214,7 +214,7 @@ export class ProviderAdapter {
   ): Promise<string> {
     return await this.sendRequest({
       method: "eth_getStorageAt",
-      params: [address, position, formatBlockSpecifier(block)]
+      params: [address, `0x${position.toString(16)}`, formatBlockSpecifier(block)]
     });
   }
 }


### PR DESCRIPTION
The parameter passed with this rpc method should be a `Quantity` which I believe should be encoded as a string and not a BN. See the section "HEX value encoding" https://eth.wiki/json-rpc/API