### PR TITLE
Set default solc to version range

### DIFF
--- a/packages/core/lib/commands/init/initSource/truffle-config.js
+++ b/packages/core/lib/commands/init/initSource/truffle-config.js
@@ -81,7 +81,7 @@ module.exports = {
   // Configure your compilers
   compilers: {
     solc: {
-      version: "0.8.10",    // Fetch exact version from solc-bin (default: truffle's version)
+      version: "^0.8.10",    // Fetch exact version from solc-bin (default: truffle's version)
       // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
       // settings: {          // See the solidity docs for advice about optimization and evmVersion
       //  optimizer: {


### PR DESCRIPTION
## Problem
When a user runs `truffle init`, we set the default solc version to a specific version.  This is generally fine, though we could be more flexible.

## Solution
As per [the point](https://github.com/trufflesuite/truffle/pull/4371#discussion_r734055821) raised by @haltman-at, Truffle accepts version ranges and will use the latest matching version.  Let's add the `^` to account for supported versions in the range.