### PR TITLE
Enhancement: Have fetchAndCompile rethrow particular errors

### DIFF
--- a/packages/fetch-and-compile/lib/debug.ts
+++ b/packages/fetch-and-compile/lib/debug.ts
@@ -57,6 +57,7 @@ export class DebugRecognizer implements Recognizer {
   }
 
   markUnrecognizable(address: string, reason?: FailureType): void {
+    //debugger does not keep track of detailed errors
     if (reason) {
       switch (reason) {
         case "fetch":

--- a/packages/fetch-and-compile/lib/fetch.ts
+++ b/packages/fetch-and-compile/lib/fetch.ts
@@ -83,6 +83,7 @@ async function tryFetchAndCompileAddress(
 ): Promise<void> {
   let found: boolean = false;
   let failureReason: FailureType | undefined; //undefined if no failure
+  let failureError: Error | undefined;
   //(this includes if no source is found)
   for (const fetcher of fetchers) {
     //now comes all the hard parts!
@@ -94,6 +95,7 @@ async function tryFetchAndCompileAddress(
     } catch (error) {
       debug("error in getting sources! %o", error);
       failureReason = "fetch";
+      failureError = error;
       continue;
     }
     if (result === null) {
@@ -129,6 +131,7 @@ async function tryFetchAndCompileAddress(
     } catch (error) {
       debug("compile error: %O", error);
       failureReason = "compile";
+      failureError = error;
       continue; //try again with a different fetcher, I guess?
     }
     //add it!
@@ -141,6 +144,7 @@ async function tryFetchAndCompileAddress(
       address
     );
     failureReason = undefined; //mark as *not* failed in case a previous fetcher failed
+    failureError = undefined;
     //check: did this actually help?
     debug("checking result");
     if (!recognizer.isAddressUnrecognized(address)) {
@@ -157,7 +161,7 @@ async function tryFetchAndCompileAddress(
   }
   if (found === false) {
     //if we couldn't find it, add it to the list of addresses to skip
-    recognizer.markUnrecognizable(address, failureReason);
+    recognizer.markUnrecognizable(address, failureReason, failureError);
   }
 }
 

--- a/packages/fetch-and-compile/lib/recognizer.ts
+++ b/packages/fetch-and-compile/lib/recognizer.ts
@@ -39,9 +39,11 @@ export class SingleRecognizer implements Recognizer {
     return this.recognized ? undefined : this.address;
   }
 
-  markUnrecognizable(address: string, reason?: FailureType): never {
+  markUnrecognizable(address: string, reason?: FailureType, error?: Error): never {
     //just throw...
-    if (reason) {
+    if (error) {
+      throw error;
+    } else if (reason) {
       switch (reason) {
         case "fetch":
           throw new Error(`Error in fetching sources for ${address}`);

--- a/packages/fetch-and-compile/lib/types.ts
+++ b/packages/fetch-and-compile/lib/types.ts
@@ -22,7 +22,7 @@ export interface Recognizer {
     info: FetchAndCompileResult,
     address: string
   ): void | Promise<void>;
-  markUnrecognizable(address: string, reason?: FailureType): void;
+  markUnrecognizable(address: string, reason?: FailureType, error?: Error): void;
   markBadFetcher(fetcherName: string): void;
 }
 


### PR DESCRIPTION
Addresses #4538.

This PR makes it so that when `fetchAndCompile` hits an error when fetching or compiling, it will actually rethrow that error, rather than throwing a generic unhelpful error.  This required a slight change to the recognizer interface, but not even a breaking one.

(Note that `fetchAndCompileForDebugger` still swallows particular errors.)

This PR has no tests because tests for this package are waiting on #4424, but tests can be added once that PR is merged.