### PR TITLE
Internal improvement: Up timeout on debugger tests

### DIFF
--- a/packages/debugger/test/endstate.js
+++ b/packages/debugger/test/endstate.js
@@ -78,6 +78,7 @@ describe("End State", function () {
   });
 
   it("Gets vars at end of successful contract (and marks it successful)", async function () {
+    this.timeout(4000);
     let instance = await abstractions.SuccessTest.deployed();
     let receipt = await instance.run();
     let txHash = receipt.tx;

--- a/packages/debugger/test/load.js
+++ b/packages/debugger/test/load.js
@@ -74,6 +74,7 @@ describe("Loading and unloading transactions", function () {
   });
 
   it("Unloads a transaction and loads a new one", async function () {
+    this.timeout(4000);
     let instance1 = await abstractions.Contract1.deployed();
     let receipt1 = await instance1.run();
     let txHash1 = receipt1.tx;


### PR DESCRIPTION
Some debugger tests have been timing out a bunch lately.  Getting these when I see them.