### PR TITLE
Internal improvement: Increase timeout on another debugger test

### DIFF
--- a/packages/debugger/test/reset.js
+++ b/packages/debugger/test/reset.js
@@ -51,6 +51,7 @@ describe("Reset Button", function () {
   });
 
   it("Correctly resets after finishing", async function () {
+    this.timeout(4000);
     let instance = await abstractions.SetsThings.deployed();
     let receipt = await instance.run();
     let txHash = receipt.tx;
@@ -73,22 +74,30 @@ describe("Reset Button", function () {
     });
 
     variables[0].push(
-      Codec.Format.Utils.Inspect.unsafeNativizeVariables(await bugger.variables())
+      Codec.Format.Utils.Inspect.unsafeNativizeVariables(
+        await bugger.variables()
+      )
     );
     await bugger.continueUntilBreakpoint(); //advance to line 10
     variables[0].push(
-      Codec.Format.Utils.Inspect.unsafeNativizeVariables(await bugger.variables())
+      Codec.Format.Utils.Inspect.unsafeNativizeVariables(
+        await bugger.variables()
+      )
     );
     await bugger.runToEnd();
     variables[0].push(
-      Codec.Format.Utils.Inspect.unsafeNativizeVariables(await bugger.variables())
+      Codec.Format.Utils.Inspect.unsafeNativizeVariables(
+        await bugger.variables()
+      )
     );
 
     //now, reset and do it again
     await bugger.reset();
 
     variables[1].push(
-      Codec.Format.Utils.Inspect.unsafeNativizeVariables(await bugger.variables())
+      Codec.Format.Utils.Inspect.unsafeNativizeVariables(
+        await bugger.variables()
+      )
     );
     await bugger.addBreakpoint({
       sourceId,
@@ -96,11 +105,15 @@ describe("Reset Button", function () {
     });
     await bugger.continueUntilBreakpoint(); //advance to line 10
     variables[1].push(
-      Codec.Format.Utils.Inspect.unsafeNativizeVariables(await bugger.variables())
+      Codec.Format.Utils.Inspect.unsafeNativizeVariables(
+        await bugger.variables()
+      )
     );
     await bugger.runToEnd();
     variables[1].push(
-      Codec.Format.Utils.Inspect.unsafeNativizeVariables(await bugger.variables())
+      Codec.Format.Utils.Inspect.unsafeNativizeVariables(
+        await bugger.variables()
+      )
     );
 
     assert.deepEqual(variables[1], variables[0]);


### PR DESCRIPTION
Found another one of these tests that was timing out, upped it.

(Also, `prettier` is working!  Yay!)