### PR TITLE
Internal improvement: Allow ES2021 globals in ESLint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,6 @@
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint"],
   "parserOptions": {
-    "ecmaVersion": 2021,
     "sourceType": "module"
   },
   "ignorePatterns": ["dist"],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "root": true,
   "env": {
-    "es6": true,
+    "es2021": true,
     "node": true
   },
   "extends": [
@@ -10,7 +10,7 @@
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint"],
   "parserOptions": {
-    "ecmaVersion": 9,
+    "ecmaVersion": 2021,
     "sourceType": "module"
   },
   "ignorePatterns": ["dist"],


### PR DESCRIPTION
We need this so it doesn't complain about `BigInt` and such!