### PR TITLE
Internal improvement: Expand pattern for tests in .eslintrc.json

### DIFF
--- a/.eslintrc.package.json
+++ b/.eslintrc.package.json
@@ -1,9 +1,10 @@
 {
   "overrides": [
     {
-      "files": ["./test/**/*.js"],
+      "files": ["./**/test/**/*.[tj]s"],
       "env": {
-        "mocha": true
+        "mocha": true,
+        "jest": true
       }
     }
   ]


### PR DESCRIPTION
I was getting some problems because ESLint didn't recognize some files as test files.  So I expanded the pattern to cover any `ts` or `js` file in a test directory; and I also turned on both `mocha` and `jest` globals.