### PR TITLE
Dependency update: Update coveralls to 3.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.6.0",
     "@typescript-eslint/parser": "^5.6.0",
-    "coveralls": "^3.0.2",
+    "coveralls": "^3.1.1",
     "eslint": "^8.4.1",
     "husky": "^7.0.4",
     "lerna": "^3.16.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10083,16 +10083,16 @@ cosmiconfig@^5.1.0:
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
 
-coveralls@^3.0.2:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-3.0.9.tgz#8cfc5a5525f84884e2948a0bf0f1c0e90aac0420"
-  integrity sha512-nNBg3B1+4iDox5A5zqHKzUTiwl2ey4k2o0NEcVZYvl+GOSJdKBj4AJGKLv6h3SvWch7tABHePAQOSZWM9E2hMg==
+coveralls@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-3.1.1.tgz#f5d4431d8b5ae69c5079c8f8ca00d64ac77cf081"
+  integrity sha512-+dxnG2NHncSD1NrqbSM3dn/lE57O6Qf/koe9+I7c+wzkqRmEvcp0kgJdxKInzYzkICKkFMZsX3Vct3++tsF9ww==
   dependencies:
     js-yaml "^3.13.1"
     lcov-parse "^1.0.0"
     log-driver "^1.2.7"
-    minimist "^1.2.0"
-    request "^2.88.0"
+    minimist "^1.2.5"
+    request "^2.88.2"
 
 cpr@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
Just updating this.  We're not really using this at the moment, but per discussion with @gnidan we're not removing it (it would, after all, be quite nice to get code coverage working again!).

...I was kind of hoping this would help resolve some dependabot alerts, but now that I look more closely, it probably actually won't.  Oh well.  Still, seems good on net, right? :)