### PR TITLE
Dependency update: Update highlightjs-solidity to 2.0.3

### DIFF
--- a/packages/debug-utils/package.json
+++ b/packages/debug-utils/package.json
@@ -23,7 +23,7 @@
     "bn.js": "^5.1.3",
     "chalk": "^2.4.2",
     "debug": "^4.3.1",
-    "highlightjs-solidity": "^2.0.2"
+    "highlightjs-solidity": "^2.0.3"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15091,10 +15091,10 @@ highlight.js@^10.4.1:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.4.1.tgz#d48fbcf4a9971c4361b3f95f302747afe19dbad0"
   integrity sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg==
 
-highlightjs-solidity@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/highlightjs-solidity/-/highlightjs-solidity-2.0.2.tgz#87ffdec3c51ae8b6def42d50f9a40b4676f57e4e"
-  integrity sha512-q0aYUKiZ9MPQg41qx/KpXKaCpqql50qTvmwGYyLFfcjt9AE/+C9CwjVIdJZc7EYj6NGgJuFJ4im1gfgrzUU1fQ==
+highlightjs-solidity@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/highlightjs-solidity/-/highlightjs-solidity-2.0.3.tgz#c89b6eca7d462f849acfb3a94c18f7db2b6d0c69"
+  integrity sha512-tjFm5dtIE61VQBzjlZmkCtY5fLs3CaEABbVuUNyXeW+UuOCsxMg3MsPFy0kCelHP74hPpkoqDejLrbnV1axAIw==
 
 hkts@^0.3.1:
   version "0.3.1"


### PR DESCRIPTION
I updated highlightjs-solidity for Solidity 0.8.11; this PR just updates us to use the new version I just put out.