### PR TITLE
Add --quiet option in allowedGlobalOptions array in truffle migrate command

### DIFF
--- a/packages/core/lib/commands/migrate/meta.js
+++ b/packages/core/lib/commands/migrate/meta.js
@@ -104,6 +104,6 @@ module.exports = {
           "Adds extra verbosity to the status of an ongoing migration"
       }
     ],
-    allowedGlobalOptions: ["network", "config"]
+    allowedGlobalOptions: ["network", "config", "quiet"]
   }
 };


### PR DESCRIPTION
### ISSUE
When using the --quiet option with the migrate command, Truffle displays the "possible unsupported option" message.
See issue #4464 .

### SOLUTION
--quiet option is added in the allowedGlobalOptions array to avoid displaying the "Possible unsupported option" message.