### PR TITLE
Bug fix: Pass `enableMemory: true` when requesting traces

### DIFF
--- a/packages/debugger/lib/web3/adapter.js
+++ b/packages/debugger/lib/web3/adapter.js
@@ -16,7 +16,7 @@ export default class Web3Adapter {
       {
         jsonrpc: "2.0",
         method: "debug_traceTransaction",
-        params: [txHash, {}],
+        params: [txHash, { enableMemory: true }], //recent geth versions require this option
         id: new Date().getTime()
       }
     );


### PR DESCRIPTION
Addresses #4565.  It turns out you can pass `enableMemory: true` to get the memory in recent geth versions, so this PR does that.

I didn't do a comprehensive test of other clients (didn't check besu or erigon), but Ganache (both 6 and 7 at least) have no problem with this option being passed.

Note this still leaves the problem of us not getting storage.  I thought the debugger doesn't use that; I forgot that actually it still does in certain cases (namely: when debugging failed contract creations, unless they were performed with `CREATE2`).  So we'll want to get that too, but I figure that can be left for later; first let's fix the big obvious crash.