### PR TITLE
Add userLevelSetting to truffle that sets userconfig to save db directory to project level

### DIFF
--- a/packages/core/lib/commands/config/run.js
+++ b/packages/core/lib/commands/config/run.js
@@ -1,8 +1,8 @@
-const userLevelSettings = ["analytics"];
+const userLevelSettings = ["analytics", "saveDbToProjectRoot"];
 /**
  * run config commands to get/set/list Truffle config options
  * @param {Object} options
-**/
+ **/
 module.exports = async function (options) {
   const googleAnalytics = require("../../services/analytics/google.js");
   const Config = require("@truffle/config");
@@ -36,6 +36,15 @@ module.exports = async function (options) {
         } else {
           options.logger.log(googleAnalytics.getAnalytics());
         }
+        break;
+      }
+      case "saveDbToProjectRoot": {
+        const userDbConfig = {
+          ...Config.getUserConfig().get("db"),
+          ...{ saveDbToProjectRoot: !!command.value }
+        };
+
+        Config.getUserConfig().set("db", userDbConfig);
         break;
       }
     }

--- a/packages/core/test/user-config.js
+++ b/packages/core/test/user-config.js
@@ -60,11 +60,10 @@ describe("config", function () {
         expect(config.db.saveDbToProjectRoot).to.equal(true);
       });
       it("respects other config settings", () => {
-        configCommand.run({ _: ["set", "saveDbToProjectRoot", "true"] });
-
         Config.getUserConfig().set("rofl", "copters");
         Config.getUserConfig().set("db.enabled", true);
 
+        configCommand.run({ _: ["set", "saveDbToProjectRoot", "true"] });
         const config = Config.getUserConfig().get();
 
         expect(config.rofl).to.equal("copters");

--- a/packages/core/test/user-config.js
+++ b/packages/core/test/user-config.js
@@ -1,32 +1,92 @@
 const sinon = require("sinon");
+const Config = require("@truffle/config");
+const Conf = require("conf");
+const fs = require("fs");
+const { expect } = require("chai");
 const analytics = require("../lib/services/analytics/google");
 const configCommand = require("../lib/commands/config");
 const inquirer = require("inquirer");
 
-describe("config", function() {
-  describe("#run", function() {
-    beforeEach(() => {
-      sinon.stub(inquirer, "prompt").returns({ then: () => 1 });
-      sinon.stub(analytics, "setAnalytics").resolves();
-      sinon.stub(analytics, "setUserConfigViaPrompt").resolves();
+describe("config", function () {
+  describe("#run", function () {
+    describe("analytics", function () {
+      beforeEach(() => {
+        sinon.stub(inquirer, "prompt").returns({ then: () => 1 });
+        sinon.stub(analytics, "setAnalytics").resolves();
+        sinon.stub(analytics, "setUserConfigViaPrompt").resolves();
+      });
+      afterEach(() => {
+        inquirer.prompt.restore();
+        analytics.setAnalytics.restore();
+        analytics.setUserConfigViaPrompt.restore();
+        sinon.restore();
+      });
+      it("calls analytics.setAnalytics() when provided with enableAnalytics option", function () {
+        configCommand.run({ enableAnalytics: true }, () => {});
+        sinon.assert.calledOnce(analytics.setAnalytics);
+      });
+      it("calls analytics.setAnalytics() when provided with disableAnalytics option", function () {
+        configCommand.run({ disableAnalytics: true }, () => {});
+        sinon.assert.calledOnce(analytics.setAnalytics);
+      });
+      it("calls analytics.setuserConfigViaPrompt() if not provided with options", function () {
+        configCommand.run({ _: [] });
+        sinon.assert.calledOnce(analytics.setUserConfigViaPrompt);
+      });
     });
-    afterEach(() => {
-      inquirer.prompt.restore();
-      analytics.setAnalytics.restore();
-      analytics.setUserConfigViaPrompt.restore();
-      sinon.restore();
-    });
-    it("calls analytics.setAnalytics() when provided with enableAnalytics option", function() {
-      configCommand.run({ enableAnalytics: true }, () => {});
-      sinon.assert.calledOnce(analytics.setAnalytics);
-    });
-    it("calls analytics.setAnalytics() when provided with disableAnalytics option", function() {
-      configCommand.run({ disableAnalytics: true }, () => {});
-      sinon.assert.calledOnce(analytics.setAnalytics);
-    });
-    it("calls analytics.setuserConfigViaPrompt() if not provided with options", function() {
-      configCommand.run({ _: [] });
-      sinon.assert.calledOnce(analytics.setUserConfigViaPrompt);
+    describe("db", function () {
+      const TEST_CONFIG_DIR = "./delme";
+      beforeEach(() => {
+        sinon
+          .stub(Config, "getUserConfig")
+          .returns(new Conf({ cwd: TEST_CONFIG_DIR }));
+      });
+
+      afterEach(() => {
+        Config.getUserConfig.restore();
+        fs.rmdirSync(TEST_CONFIG_DIR, { recursive: true });
+      });
+
+      it("sets saveDbToProjectRoot when no config is set", () => {
+        const noConfig = Config.getUserConfig();
+        expect(typeof noConfig).to.equal("object");
+        expect(noConfig.hasOwnProperty("db")).to.equal(false);
+
+        configCommand.run({ _: ["set", "saveDbToProjectRoot", "true"] });
+
+        const config = Config.getUserConfig().get();
+
+        expect(config.db.hasOwnProperty("saveDbToProjectRoot")).to.equal(true);
+        expect(config.db.saveDbToProjectRoot).to.equal(true);
+      });
+      it("respects other config settings", () => {
+        configCommand.run({ _: ["set", "saveDbToProjectRoot", "true"] });
+
+        Config.getUserConfig().set("rofl", "copters");
+        Config.getUserConfig().set("db.enabled", true);
+
+        const config = Config.getUserConfig().get();
+
+        expect(config.rofl).to.equal("copters");
+        expect(config.db.hasOwnProperty("enabled")).to.equal(true);
+        expect(config.db.enabled).to.equal(true);
+        expect(config.db.hasOwnProperty("saveDbToProjectRoot")).to.equal(true);
+        expect(config.db.saveDbToProjectRoot).to.equal(true);
+      });
+      it('coerces truthy values from user-given string params, correctly interprets "false"', () => {
+        configCommand.run({
+          _: ["set", "saveDbToProjectRoot", "truthy"]
+        });
+        let config = Config.getUserConfig().get();
+
+        expect(config.db.saveDbToProjectRoot).to.equal(true);
+
+        configCommand.run({
+          _: ["set", "saveDbToProjectRoot", "false"]
+        });
+        config = Config.getUserConfig().get();
+        expect(config.db.saveDbToProjectRoot).to.equal(false);
+      });
     });
   });
 });


### PR DESCRIPTION
### Description
Adds a command to set saving the db directory to the project level:

``` bash
$ truffle config set saveDbToProjectRoot true
$ truffle config set saveDbToProjectRoot false
```

This will add a flag to the the user config (~/.conf/truffle-nodejs/conf.json on linux) that adds

``` javascript
"db": {
        "saveDbToProjectRoot": true
},
```

This is needed per the conversation on https://github.com/trufflesuite/truffle/pull/4503 

### To Test
**1.** Backup your existing user config (~/.conf/truffle-nodejs/config.json; dunno about MS/Mac user locations).
**2.** Set use-truffle-core / use-truffle-debug
**3.** Run:
``` bash
$ truffle config set saveDbToProjectRoot true
```

Expected: `config.json` updates to:
```javascript
{
        "version": 1,
        "db": {
                "saveDbToProjectRoot": true
        }
}
```
**4.** Run:
``` bash
$ truffle config set saveDbToProjectRoot false
```

Expected: 
```javascript
{
        "version": 1,
        "db": {
                "saveDbToProjectRoot": false
        }
}
```

**5.** Run

``` bash
$ truffle config
```

Select: "Yes, enable analytics"

Expected: Additional user-level config settings 

``` javascript
{
        "version": 1,
        "db": {
                "saveDbToProjectRoot": false
        },
        "uniqueId": "acb5b96c-c9d1-4b0f-b09a-52c951221910",
        "enableAnalytics": true,
        "analyticsSet": true,
        "analyticsMessageDateTime": 1640211518584
}
```
**6.** Run: 

``` bash
$ truffle config set saveDbToProjectRoot true
```

Expected: `saveDbToProjectRoot: true`, analytics config properties are unchanged (abridged to save space)

**7.** Bonus: Delete your temporary user-level config and run steps 5 -> 3 in reverse order to verify collisions with other user-level params. But this should be handled and verified by Step 5. 

### **Merry Christmas and Happy New Year. Catch you all in January**
