### PR TITLE
refactor: improve number matching

### DIFF
--- a/packages/migrate/Migration.js
+++ b/packages/migrate/Migration.js
@@ -14,13 +14,21 @@ class Migration {
   constructor(file, reporter, config) {
     this.file = path.resolve(file);
     this.reporter = reporter;
-    this.number = parseInt(path.basename(file));
+    this.number = Migration.getNumber(path.basename(file));
     this.emitter = new Emittery();
     this.isFirst = false;
     this.isLast = false;
     this.dryRun = config.dryRun;
     this.interactive = config.interactive;
     this.config = config || {};
+  }
+
+  static getNumber(fileName) {
+    const match = fileName.match(/\d+/);
+    if (!match.length) {
+      return null;
+    }
+    return Number(match[0]);
   }
 
   // ------------------------------------- Private -------------------------------------------------
@@ -114,11 +122,7 @@ class Migration {
       let artifacts = resolver
         .contracts()
         .map(abstraction => abstraction._json);
-      if (
-        this.config.db &&
-        this.config.db.enabled &&
-        artifacts.length > 0
-      ) {
+      if (this.config.db && this.config.db.enabled && artifacts.length > 0) {
         // currently if Truffle Db fails to load, getTruffleDb returns `null`
         const Db = getTruffleDb();
 
@@ -185,12 +189,8 @@ class Migration {
    * @param  {Object}   options  config and command-line
    */
   async run(options) {
-    const {
-      interfaceAdapter,
-      resolver,
-      context,
-      deployer
-    } = this.prepareForMigrations(options);
+    const { interfaceAdapter, resolver, context, deployer } =
+      this.prepareForMigrations(options);
 
     // Connect reporter to this migration
     if (this.reporter) {

--- a/packages/migrate/Migration.js
+++ b/packages/migrate/Migration.js
@@ -24,6 +24,9 @@ class Migration {
   }
 
   static getNumber(fileName) {
+    if (!fileName || typeof fileName !== "string") {
+      return null;
+    }
     const match = fileName.match(/^\d+/);
     if (!match) {
       return null;

--- a/packages/migrate/Migration.js
+++ b/packages/migrate/Migration.js
@@ -24,8 +24,8 @@ class Migration {
   }
 
   static getNumber(fileName) {
-    const match = fileName.match(/\d+/);
-    if (!match.length) {
+    const match = fileName.match(/^\d+/);
+    if (!match) {
       return null;
     }
     return Number(match[0]);

--- a/packages/migrate/index.js
+++ b/packages/migrate/index.js
@@ -42,12 +42,12 @@ const Migrate = {
     if (files.length === 0) return [];
 
     let migrations = files
-      .filter(
-        file =>
-          path.extname(file).match(config.migrations_file_extension_regexp) !=
-          null
-      )
       .filter(file => {
+        if (
+          !path.extname(file).match(config.migrations_file_extension_regexp)
+        ) {
+          return false;
+        }
         const hasNumber = Migration.getNumber(path.basename(file)) !== null;
         if (!hasNumber) {
           process.emitWarning(
@@ -222,7 +222,7 @@ const Migrate = {
     } else {
       completedMigration = 0;
     }
-    return Migration.getNumber(completedMigration);
+    return parseInt(completedMigration);
   },
 
   needsMigrating: function (options) {

--- a/packages/migrate/index.js
+++ b/packages/migrate/index.js
@@ -51,7 +51,8 @@ const Migrate = {
         const hasNumber = Migration.getNumber(path.basename(file)) !== null;
         if (!hasNumber) {
           process.emitWarning(
-            `Migration file ${file} does not have a number, add one if you want it to be migrated.`
+            `Migration file ${file} does not have a number at the beggining of the file, \
+            migration file names should match the schema \`\${\\d+}you_migration_file.js\``
           );
         }
         return hasNumber;

--- a/packages/migrate/index.js
+++ b/packages/migrate/index.js
@@ -42,12 +42,20 @@ const Migrate = {
     if (files.length === 0) return [];
 
     let migrations = files
-      .filter(file => isNaN(parseInt(path.basename(file))) === false)
       .filter(
         file =>
           path.extname(file).match(config.migrations_file_extension_regexp) !=
           null
       )
+      .filter(file => {
+        const hasNumber = Migration.getNumber(path.basename(file)) !== null;
+        if (!hasNumber) {
+          process.emitWarning(
+            `Migration file ${file} does not have a number, add one if you want it to be migrated.`
+          );
+        }
+        return hasNumber;
+      })
       .map(file => new Migration(file, Migrate.reporter, config));
 
     // Make sure to sort the prefixes as numbers and not strings.
@@ -72,7 +80,7 @@ const Migrate = {
         "network",
         "network_id",
         "logger",
-        "from", // address doing deployment
+        "from" // address doing deployment
       ]);
 
       if (options.reset === true) {
@@ -140,7 +148,7 @@ const Migrate = {
 
     await this.emitter.emit("preAllMigrations", {
       dryRun: options.dryRun,
-      migrations,
+      migrations
     });
 
     try {
@@ -151,13 +159,13 @@ const Migrate = {
       }
       await this.emitter.emit("postAllMigrations", {
         dryRun: options.dryRun,
-        error: null,
+        error: null
       });
       return;
     } catch (error) {
       await this.emitter.emit("postAllMigrations", {
         dryRun: options.dryRun,
-        error: error.toString(),
+        error: error.toString()
       });
       throw error;
     } finally {
@@ -173,7 +181,7 @@ const Migrate = {
         abstraction.setProvider(provider);
         return abstraction;
       },
-      resolve: resolver.resolve,
+      resolve: resolver.resolve
     };
   },
 
@@ -213,7 +221,7 @@ const Migrate = {
     } else {
       completedMigration = 0;
     }
-    return parseInt(completedMigration);
+    return Migration.getNumber(completedMigration);
   },
 
   needsMigrating: function (options) {
@@ -234,7 +242,7 @@ const Migrate = {
         })
         .catch(error => reject(error));
     });
-  },
+  }
 };
 
 module.exports = Migrate;

--- a/packages/migrate/test/migration.js
+++ b/packages/migrate/test/migration.js
@@ -7,8 +7,8 @@ let options,
   fakeInterfaceAdapter,
   migration,
   context,
-  resolver;
-let deployer;
+  resolver,
+  deployer;
 
 describe("Migration", () => {
   before(() => {
@@ -20,21 +20,21 @@ describe("Migration", () => {
         resolver,
         logger: "crushin it wit a loggerzzz",
         networks: {
-          "fake network": {},
+          "fake network": {}
         },
         network: "fake network",
         network_id: "this is also fake",
-        from: "Russia with love",
+        from: "Russia with love"
       }));
     fakeInterfaceAdapter = {
-      getBlock: sinon.stub().returns({ gasLimit: 2000 }),
+      getBlock: sinon.stub().returns({ gasLimit: 2000 })
     };
     context = { interfaceAdapter: fakeInterfaceAdapter };
     prepareForMigrationsReturn = {
       interfaceAdapter: fakeInterfaceAdapter,
       resolver,
       context,
-      deployer,
+      deployer
     };
     migration = new Migration("fake/file.js", undefined, options);
   });


### PR DESCRIPTION
Reviewing the code to look how could i implement typescript migrations, i saw that the number of the migration was being obtained with the parseInt function that returns the first matching number, even though this works i think is not the "correct"  way to do it as it is not declarative enough, so in this PR i did the following:

- Improve number matching by using regex instead of parseInt
- Change order of filters
- Add warning in case some of the matching files doesn't have a number