### PR TITLE
Bug fix: Avoid using url in CLI debugger when no url specified

### DIFF
--- a/packages/core/lib/commands/debug/mergeConfigNetwork.js
+++ b/packages/core/lib/commands/debug/mergeConfigNetwork.js
@@ -1,10 +1,12 @@
 module.exports = function (config, options) {
-  const inlineConfigNetwork = "inline_config";
-  config.networks[inlineConfigNetwork] = {
-    url: options.url,
-    network_id: "*"
-  };
-  config.network = inlineConfigNetwork;
+  if (options.url) {
+    const inlineConfigNetwork = "inline_config";
+    config.networks[inlineConfigNetwork] = {
+      url: options.url,
+      network_id: "*"
+    };
+    config.network = inlineConfigNetwork;
+  }
   config.merge(options);
   return config;
 };

--- a/packages/core/test/lib/commands/debug.js
+++ b/packages/core/test/lib/commands/debug.js
@@ -52,5 +52,10 @@ describe("debug", () => {
       result = mergeConfigNetwork(config, options);
       assert.equal(result.network, "different_network");
     });
+
+    it("should not use url when url not passed", () => {
+      result = mergeConfigNetwork(config, {});
+      assert.notEqual(result.netwok, "inline_config");
+    });
   });
 });

--- a/packages/core/test/lib/commands/debug.js
+++ b/packages/core/test/lib/commands/debug.js
@@ -6,17 +6,17 @@ const {
 const Config = require("@truffle/config");
 let config, result, options;
 
-describe("debug", () => {
-  describe("loadConfig(options)", () => {
-    it("throws error when file not found", () => {
+describe("debug", function () {
+  describe("loadConfig(options)", function () {
+    it("throws error when file not found", function () {
       options = {};
-      assert.throws(() => {
+      assert.throws(function () {
         loadConfig(options);
       }, "Could not find suitable configuration file.");
     });
 
-    describe("url option is specified", () => {
-      it("loads default config with compileNone", () => {
+    describe("url option is specified", function () {
+      it("loads default config with compileNone", function () {
         options = { url: "https://someUrl:8888" };
         result = loadConfig(options);
         assert.equal(result.compileNone, true);
@@ -25,15 +25,15 @@ describe("debug", () => {
     });
   });
 
-  describe("mergeConfigNetwork(config, options)", () => {
-    beforeEach(() => {
+  describe("mergeConfigNetwork(config, options)", function () {
+    beforeEach(function () {
       config = Config.default();
       options = {
         url: "http://urlhost:1234"
       };
     });
 
-    it("should create networks item in config", () => {
+    it("should create networks item in config", function () {
       result = mergeConfigNetwork(config, options);
 
       assert.notEqual(result.networks.inline_config, undefined);
@@ -41,19 +41,19 @@ describe("debug", () => {
       assert.equal(result.networks.inline_config.network_id, "*");
     });
 
-    it("should set inline_network by default", () => {
+    it("should set inline_network by default", function () {
       result = mergeConfigNetwork(result, options);
       assert.equal(result.network, "inline_config");
     });
 
-    it("should override network field when specified in options", () => {
+    it("should override network field when specified in options", function () {
       options.network = "different_network";
 
       result = mergeConfigNetwork(config, options);
       assert.equal(result.network, "different_network");
     });
 
-    it("should not use url when url not passed", () => {
+    it("should not use url when url not passed", function () {
       result = mergeConfigNetwork(config, {});
       assert.notEqual(result.netwok, "inline_config");
     });


### PR DESCRIPTION
Oops, it seems that #4552 broke the debugger when `--url` is *not* specified; looks like nobody checked that.  Basically it tries to use `url` no matter what; the check for that got lost somewhere along the way.  This is a quick fix for that; it adds in a check so that `url` isn't used unless it was actually specified.