### PR TITLE
Internal improvement: Increase timeout on debugger test

### DIFF
--- a/packages/debugger/test/load.js
+++ b/packages/debugger/test/load.js
@@ -53,6 +53,7 @@ describe("Loading and unloading transactions", function () {
   });
 
   it("Starts in transactionless mode and loads a transaction", async function () {
+    this.timeout(4000);
     let instance = await abstractions.Contract1.deployed();
     let receipt = await instance.run();
     let txHash = receipt.tx;


### PR DESCRIPTION
This test has been timing out occasionally recently; increasing its timeout to 4 seconds.