### PR TITLE
Bug fix: Prevent generated sources from clearing the phantom guard

### DIFF
--- a/packages/debugger/lib/solidity/sagas/index.js
+++ b/packages/debugger/lib/solidity/sagas/index.js
@@ -32,7 +32,14 @@ function* functionDepthSaga() {
     debug("checking guard");
     let guard = yield select(solidity.current.nextFrameIsPhantom);
     let nextSource = yield select(solidity.next.source);
-    if (jumpDirection === "i" && guard && nextSource.id !== undefined) {
+    if (
+      jumpDirection === "i" &&
+      guard &&
+      nextSource.id !== undefined &&
+      !nextSource.internal
+    ) {
+      //note that we don't want jumps into unmapped code or internal sources to clear
+      //the phantom guard; those will just be counted like normal
       yield put(actions.clearPhantomGuard());
     } else {
       yield put(actions.jump(jumpDirection));


### PR DESCRIPTION
This PR is a continuation of #3149.  That PR made it so that the phantom call guard wouldn't be cleared by jumps into unmapped code.  However, when later versions of Solidity added generated sources, I didn't think to prevent them from clearing the phantom call guard also.  This PR does that.

...OK, I'm going to need to explain that for most of the reviewers.  The phantom call guard system was added back in #2696.  It makes it so that, when you enter an external function call, the function depth only goes up once, rather than twice.  By itself, it'd go up twice -- once on entering the new contract, and again at the start of the actual function.  (Note that the phantom call guard is not used when dealing with Solidity versions older than 0.5.1, as they lacked a jump in at the start of external functions.)

So, we set a flag -- the phantom call guard -- and, when a jump in occurs, if the flag is set, instead of incrementing the function depth, we clear the flag.  Simple, right?

Except, sometimes, at the start of the function, before the jump in, you go into generated sources or unmapped code.  If not accounted for, such a jump in would clear the flag and not increment the depth.  And then later, when we got to the jump in to the actual function, the flag would already be cleared, and the depth would get incremented.

That's not really what we want.  So, as mentioned, #3149 made it so that jumps into unmapped code would increment the function depth, not clear the flag.  Except, as also mentioned, I never changed that code to also apply to generated sources; this PR does that.

I also added a test of this.  Or rather, I fixed up an existing test to test this more properly.  It was checking for `functionDepth` at most 1, but it should have been checking for `functionDepth` at most 0.  I added a parameter to the test being run to ensure that it goes into generated sources before the function starts.  Note how the test uses `stepNext`, so it will never stop inside the generated source; it's testing that the function depth remains at 0 while in the user source.