### PR TITLE
Bug fix: Remove remaining debugger reliance on traced storage

### DIFF
--- a/packages/debugger/lib/evm/reducers.js
+++ b/packages/debugger/lib/evm/reducers.js
@@ -277,9 +277,11 @@ function codex(state = DEFAULT_CODEX, action) {
   const safePop = array => (array.length > 2 ? array.slice(0, -1) : array);
 
   //later: may add "force" parameter
+  //note: we don't need to wipe zero account when saving, because we'll never
+  //attempt to save the zero account in the first place
   const safeSave = array =>
     array.length > 2
-      ? array.slice(0, -2).concat([wipeZeroAccount(array[array.length - 1])])
+      ? array.slice(0, -2).concat([array[array.length - 1]])
       : array;
 
   switch (action.type) {

--- a/packages/debugger/lib/evm/reducers.js
+++ b/packages/debugger/lib/evm/reducers.js
@@ -149,13 +149,8 @@ const DEFAULT_AFFECTED_INSTANCES = { byAddress: {} };
 function affectedInstances(state = DEFAULT_AFFECTED_INSTANCES, action) {
   switch (action.type) {
     case actions.ADD_AFFECTED_INSTANCE:
-      const {
-        address,
-        binary,
-        context,
-        creationBinary,
-        creationContext
-      } = action;
+      const { address, binary, context, creationBinary, creationContext } =
+        action;
       return {
         byAddress: {
           ...state.byAddress,
@@ -213,15 +208,31 @@ function callstack(state = [], action) {
   }
 }
 
+const EMPTY_ACCOUNT = {
+  code: "0x",
+  context: null,
+  storage: {}
+};
+
 const DEFAULT_CODEX = [
   {
-    accounts: {}
-    //will be more here in the future!
+    accounts: {
+      //we always include an account for the zero address;
+      //this is not actually used for the zero address, but
+      //rather is used to represent failed contract creations
+      //in cases where we can't determine what the address
+      //would have been.  So keep in mind that this does not
+      //actually represent the zero address.
+      [Codec.Evm.Utils.ZERO_ADDRESS]: EMPTY_ACCOUNT
+    }
+    //if we ever start keeping track of the self-destruct set,
+    //the log series, or various gas-related stuff, there may
+    //be more here in the future
   }
 ];
 
 function codex(state = DEFAULT_CODEX, action) {
-  let newState, topCodex;
+  let newState, topCodex, topCodexNoZero;
 
   const updateFrameStorage = (frame, address, slot, value) => ({
     ...frame,
@@ -255,13 +266,20 @@ function codex(state = DEFAULT_CODEX, action) {
     };
   };
 
-  //later: will add "force" parameter
+  const wipeZeroAccount = frame => ({
+    accounts: {
+      ...frame.accounts,
+      [Codec.Evm.Utils.ZERO_ADDRESS]: EMPTY_ACCOUNT
+    }
+  });
+
+  //later: may add "force" parameter
   const safePop = array => (array.length > 2 ? array.slice(0, -1) : array);
 
-  //later: will add "force" parameter
+  //later: may add "force" parameter
   const safeSave = array =>
     array.length > 2
-      ? array.slice(0, -2).concat([array[array.length - 1]])
+      ? array.slice(0, -2).concat([wipeZeroAccount(array[array.length - 1])])
       : array;
 
   switch (action.type) {
@@ -269,24 +287,26 @@ function codex(state = DEFAULT_CODEX, action) {
       debug("call action");
       debug("codex: %O", state);
       //on a call, we can just make a new stackframe by cloning the top
-      //stackframe; there should already be an account for the address we're
+      //stackframe; except we wipe the zero account, since the information
+      //it represents is stackframe-specific
+      topCodex = state[state.length - 1];
+      topCodexNoZero = wipeZeroAccount(topCodex);
+      //note there should already be an account for the address we're
       //calling into, so we don't need to make one
-      return [...state, state[state.length - 1]];
+      return [...state, topCodexNoZero];
 
     case actions.CREATE:
       debug("create action");
-      //on a create, make a new stackframe, then add a new pages to the
-      //codex if necessary; don't add a zero page though (or pages that already
-      //exist)
+      //on a create, make a new stackframe, then add a new page to the
+      //codex if necessary
 
       //first, add a new stackframe by cloning the top one
-      newState = [...state, state[state.length - 1]];
-      topCodex = newState[newState.length - 1];
+      //(and wiping the zero page)
+      topCodex = state[state.length - 1];
+      topCodexNoZero = wipeZeroAccount(topCodex);
+      newState = [...state, topCodexNoZero];
       //now, do we need to add a new address to this stackframe?
-      if (
-        topCodex.accounts[action.storageAddress] !== undefined ||
-        action.storageAddress === Codec.Evm.Utils.ZERO_ADDRESS
-      ) {
+      if (topCodex.accounts[action.storageAddress] !== undefined) {
         //if we don't
         return newState;
       }
@@ -295,12 +315,7 @@ function codex(state = DEFAULT_CODEX, action) {
         ...topCodex,
         accounts: {
           ...topCodex.accounts,
-          [action.storageAddress]: {
-            storage: {},
-            code: "0x",
-            context: null
-            //there will be more here in the future!
-          }
+          [action.storageAddress]: EMPTY_ACCOUNT
         }
       };
       return newState;
@@ -310,10 +325,6 @@ function codex(state = DEFAULT_CODEX, action) {
       //on a store, the relevant page should already exist, so we can just
       //add or update the needed slot
       const { address, slot, value } = action;
-      if (address === Codec.Evm.Utils.ZERO_ADDRESS) {
-        //as always, we do not maintain a zero page
-        return state;
-      }
       newState = state.slice(); //clone the state
       topCodex = newState[newState.length - 1];
       newState[newState.length - 1] = updateFrameStorage(
@@ -332,7 +343,13 @@ function codex(state = DEFAULT_CODEX, action) {
       //to update *every* stackframe
       const { address, slot, value } = action;
       if (address === Codec.Evm.Utils.ZERO_ADDRESS) {
-        //as always, we do not maintain a zero page
+        //even though we now have a zero page, we still don't allow SLOADs to
+        //affect it.  firstly, because there will never be preexsting data on
+        //the zero page (it's only used for contract creations), so any SLOAD
+        //should only ever be of data that we already know (or that is zero).
+        //secondly, because the zero page represents something that is specific
+        //to a single stackframe, we definitely do *not* want to update every
+        //stackframe with its storage!
         return state;
       }
       topCodex = state[state.length - 1];

--- a/packages/debugger/lib/evm/selectors/index.js
+++ b/packages/debugger/lib/evm/selectors/index.js
@@ -395,10 +395,16 @@ const evm = createSelectorTree({
        * returns function (binary) => context (returns the *ID* of the context)
        * (returns null on no match)
        */
-      search: createLeaf(["/info/contexts"], contexts => binary =>
-        //HACK: the type of contexts doesn't actually match!! fortunately
-        //it's good enough to work
-        (Codec.Contexts.Utils.findContext(contexts, binary) || { context: null }).context
+      search: createLeaf(
+        ["/info/contexts"],
+        contexts => binary =>
+          //HACK: the type of contexts doesn't actually match!! fortunately
+          //it's good enough to work
+          (
+            Codec.Contexts.Utils.findContext(contexts, binary) || {
+              context: null
+            }
+          ).context
       )
     }
   },
@@ -495,7 +501,7 @@ const evm = createSelectorTree({
      */
     state: Object.assign(
       {},
-      ...["depth", "error", "gas", "memory", "stack", "storage"].map(param => ({
+      ...["depth", "error", "gas", "memory", "stack"].map(param => ({
         [param]: createLeaf([trace.step], step => step[param])
       }))
     ),
@@ -733,17 +739,12 @@ const evm = createSelectorTree({
 
       /**
        * evm.current.codex.storage
-       * the current storage, as fetched from the codex... unless we're in a
-       * failed creation call, then we just fall back on the state (which will
-       * work, since nothing else can interfere with the storage of a failed
-       * creation call!)
+       * the current storage, as fetched from the codex
        */
       storage: createLeaf(
-        ["./_", "../state/storage", "../call"],
-        (codex, rawStorage, { storageAddress }) =>
-          storageAddress === Codec.Evm.Utils.ZERO_ADDRESS
-            ? rawStorage //HACK -- if zero address ignore the codex
-            : codex[codex.length - 1].accounts[storageAddress].storage
+        ["./_", "../call"],
+        (codex, { storageAddress }) =>
+          codex[codex.length - 1].accounts[storageAddress].storage
       ),
 
       /*

--- a/packages/debugger/lib/web3/adapter.js
+++ b/packages/debugger/lib/web3/adapter.js
@@ -16,7 +16,13 @@ export default class Web3Adapter {
       {
         jsonrpc: "2.0",
         method: "debug_traceTransaction",
-        params: [txHash, { enableMemory: true }], //recent geth versions require this option
+        params: [
+          txHash,
+          {
+            enableMemory: true, //recent geth versions require this option
+            disableStorage: true //we no longer use storage
+          }
+        ],
         id: new Date().getTime()
       }
     );


### PR DESCRIPTION
Addresses #4583.

This PR eliminates the debugger's remaining uses of `storage` taken from the trace.  I had already mostly eliminated the use of `storage` in #3102; this gets rid of the remaining uses.

The debugger mostly doesn't use the `storage` field, because it uses the codex to determine storage, and the codex is built from the stack.  However, there's one case where the debugger bypasses the codex when determining storage: When inside a failed contract creation that was initiated with the `CREATE` opcode, the debugger would bypass the codex and read the `storage` field directly.

The reason for this is that, in order to meaningfully use the codex, we need to know the current address.  However, currently, the debugger has no way to determine the current address when inside a failed contract creation that was initiated with the `CREATE` opcode.  This will be remedied eventually (see issue #2894), but for now we're stuck with that limitation.  So, currently, in such cases, the debugger treats the address as zero.

As such, the debugger would bypass the codex when the current storage address was equal to zero; and it would not update the codex with a zero account.  But now, we can't bypass the codex anymore.  So how do we handle this?

Well, firstly, we now allow the codex to contain a zero account; in fact, we start it off with a zero account.  But the zero account isn't like other accounts; it gets special treatment.  It's treated as transient, basically; the zero account is always specific to the stackframe it's in.  That is to say, unlike with other accounts, the zero account of each stackframe is prevented from affecting the zero accounts of other stackframes.  Thus, each failed contract creation gets its own storage; if there are multiple on the stack at once, then they're in different stackframes, and their storages don't affect one another.

To accomplish this, whenever a new stackframe is added to the codex, its zero account is wiped.  Note that we don't make any changes to the code handling what happens when a stackframe returns; when a stackframe using the zero account returns, it necessarily does so by *failing*, so its changes already don't get saved, without further intervention needed.  So the wipe on stackframe creation is sufficient to achieve the desired effect that each zero account is isolated to the specific stackframe it's in.

Also, while I've removed the guard preventing `SSTORE`s from affecting the zero account, I've left in place the guard preventing `SLOAD`s from affecting the zero account.  This is for two reasons.  Firstly, the behavior of an `SLOAD` on the codex when a value was not already present is to update *all* stackframes, not just the top one (because if a value was not already present, then the read value is preexisting and thus exists in all current stackframes); obviously, for the zero account, which is supposed to be isolated to a specific stackframe, we don't want that.  But also, there's simply no *need* to account for such `SLOAD`s, because if we're inside a contract creation, an `SLOAD` that's loading a value not already present *must* be loading zero!  So why bother, given that we treat unknown storage as zero anyway?

(I mean, notionally I could have such `SLOAD`s affect the zero account, just I'd do it specially and have it only affect the current stack frame instead of all of them... but I figured this was simpler, if arguably slightly less correct.)

Note that this PR does *not* do anything to address #4595... I tried to do something about that and then I realized it was harder than I thought, so I left it alone; I don't think there's any particular urgency on that one.

As a side benefit, eliminating the reliance on storage means we can now pass the `disableStorage` flag when requesting traces; this ought to reduce the size of the traces we get back, at least with some clients (I don't know if they all respect it).

This PR also adds a test of decoding storage variables while inside a failed contract creation.  However, I must warn you that this PR was mostly tested manually.  A proper test of it requires multiple nested contract creations... we've historically avoided such tests in the debugger due to how slow they can be, so I've similarly avoided it here.  Also, obviously a key part of this PR is that it makes the debugger work with recent versions of Geth, but the debugger tests use Ganache, and I left that as-is; again, I tested that manually.  Possibly we should add some Geth debugger tests, but I'd prefer to save that for a different PR.

Anyway, with this, the debugger no longer relies on the `storage` field at all, and its Geth-compatibility problems should now be solved!