### PR TITLE
Use effectiveGasPrice and fall back to gasPrice when missing.

### DIFF
--- a/packages/interface-adapter/lib/adapter/web3/index.ts
+++ b/packages/interface-adapter/lib/adapter/web3/index.ts
@@ -69,7 +69,9 @@ export class Web3InterfaceAdapter implements InterfaceAdapter {
     return this.web3.eth.getBlockNumber();
   }
 
-  public async getTransactionCostReport(receipt: TransactionReceipt): Promise<TransactionCostReport> {
+  public async getTransactionCostReport(
+    receipt: TransactionReceipt
+  ): Promise<TransactionCostReport> {
     const tx = await this.getTransaction(receipt.transactionHash);
     const block = await this.getBlock(receipt.blockNumber);
 
@@ -78,6 +80,8 @@ export class Web3InterfaceAdapter implements InterfaceAdapter {
     const balance = await this.getBalance(tx.from);
     // gasPrice has been deprecated in favor of effectiveGasPrice
     // via https://github.com/ethereum/execution-specs/pull/251
+    // Note: this incidentally conforms to Arbitrum as well
+    // via https://github.com/trufflesuite/truffle/issues/4559
     const gasPrice = new BN(receipt.effectiveGasPrice || tx.gasPrice);
     const gas = new BN(receipt.gasUsed);
     const value = new BN(tx.value);

--- a/packages/interface-adapter/lib/adapter/web3/index.ts
+++ b/packages/interface-adapter/lib/adapter/web3/index.ts
@@ -79,7 +79,17 @@ export class Web3InterfaceAdapter implements InterfaceAdapter {
     const gasPrice = new BN(tx.gasPrice);
     const gas = new BN(receipt.gasUsed);
     const value = new BN(tx.value);
-    const cost = gasPrice.mul(gas).add(value);
+
+    // Arbitrum fees exist in their "feeStats" attribute: https://developer.offchainlabs.com/docs/differences_overview#transaction-receipts
+    var cost = new BN(0);
+    if("feeStats" in receipt && "paid" in receipt["feeStats"]){
+      // If the receipt includes Arbitrum's "feeStats", cost == the sum of its values.
+      cost = new BN(Object.values(receipt["feeStats"]["paid"]).reduce((sum, value) => sum + value));
+    } else {
+      cost = new BN(gasPrice.mul(gas).add(value));
+    }
+    // TODO - ^this new cost calculation complexity seems a bit much for an "InterfaceAdapter".
+    // I'm leaning toward creating a new CostCalculator object for this.
 
     return {
       timestamp: block.timestamp,

--- a/packages/interface-adapter/test/getTransactionReport.test.ts
+++ b/packages/interface-adapter/test/getTransactionReport.test.ts
@@ -1,0 +1,60 @@
+import { describe, it } from "mocha";
+import assert from "assert";
+
+import { Server } from "http";
+import BN from "bn.js";
+
+import Web3 from "web3";
+import Ganache from "ganache-core";
+
+import { createInterfaceAdapter } from "../lib";
+import {
+  InterfaceAdapter,
+  Provider,
+  TransactionReceipt
+} from "../lib/adapter/types";
+
+const port = 12345;
+
+async function prepareGanache(): Promise<{
+  server: Server;
+  interfaceAdapter: InterfaceAdapter;
+}> {
+  return new Promise((resolve, reject) => {
+    const server = Ganache.server();
+    server.listen(port, () => {
+      const interfaceAdapter = createInterfaceAdapter({
+        provider: new Web3.providers.HttpProvider(`http://127.0.0.1:${port}`)
+      });
+      resolve({
+        server,
+        interfaceAdapter
+      });
+    });
+  });
+}
+
+describe("getTransactionReport", function () {
+  let provider: any;
+  let web3: Web3;
+
+  before("Create Provider", async function () {
+    provider = Ganache.provider({ seed: "decoder", gasLimit: 7000000 });
+    web3 = new Web3(provider);
+  });
+
+  it("calculates cost given an effectiveGasPrice", async function () {
+    const preparedGanache = await prepareGanache();
+    const accounts = await web3.eth.getAccounts();
+    const receipt = await web3.eth.sendTransaction({
+      from: accounts[0],
+      to: accounts[1]
+    });
+    const report = await preparedGanache.interfaceAdapter.getTransactionCostReport(
+      receipt
+    );
+    console.log("report", report);
+    assert.strictEqual(report.gasPrice, receipt.effectiveGasPrice);
+    await preparedGanache.server.close();
+  });
+});


### PR DESCRIPTION
## Problem
In, #4559 we noticed that truffle was displaying incorrect transaction fees when using Arbitrum. This has to do with [complexity](https://developer.offchainlabs.com/docs/differences_overview#transaction-receipts) that exists for their L2 that makes `transaction.gasPrice` unreliable compared to `receipt.effectiveGasPrice`. However, this isn't a problem that we need Arbitrum-specific code to support because `gasPrice` has been officially [deprecated](https://github.com/ethereum/execution-specs/pull/251) in favor of `effectiveGasPrice` post-EIP-1559 anyway.

## Solution
When reporting transactions fees, set the gas price to `receipt.effectiveGasFee` if it exists, otherwise `transaction.gasPrice`

## To do
Check that this works on different versions of ganache, EIP-1559 & legacy transactions, Arbitrum & Ethereum.