### PR TITLE
Debugger print a warning message if it does not have code of the contract

### DIFF
--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -217,25 +217,6 @@ class DebugPrinter {
     }
 
     this.config.logger.log("Instructions:");
-
-    // printout instructions
-    const previousInstructions = this.instructionLines.beforeLines;
-    const upcomingInstructions = this.instructionLines.afterLines;
-    const currentIndex = instruction.index;
-
-    // add an ellipse if there exist additional instructions before
-    if (currentIndex - previousInstructions > 0) {
-      this.config.logger.log("...");
-    }
-    // printout 3 previous instructions
-    for (
-      let i = Math.max(currentIndex - previousInstructions, 0);
-      i < currentIndex;
-      i++
-    ) {
-      this.config.logger.log(DebugUtils.formatInstruction(instructions[i]));
-    }
-
     if (!instruction || instruction.pc === undefined) {
       // printout warning message if the debugger does not have the code for this contract
       this.config.logger.log(
@@ -244,23 +225,41 @@ class DebugPrinter {
         )} The debugger does not have the code for this contract.`
       );
     } else {
+      // printout instructions
+      const previousInstructions = this.instructionLines.beforeLines;
+      const upcomingInstructions = this.instructionLines.afterLines;
+      const currentIndex = instruction.index;
+
+      // add an ellipse if there exist additional instructions before
+      if (currentIndex - previousInstructions > 0) {
+        this.config.logger.log("...");
+      }
+      // printout 3 previous instructions
+      for (
+        let i = Math.max(currentIndex - previousInstructions, 0);
+        i < currentIndex;
+        i++
+      ) {
+        this.config.logger.log(DebugUtils.formatInstruction(instructions[i]));
+      }
+
       // printout current instruction
       this.config.logger.log(DebugUtils.formatCurrentInstruction(instruction));
-    }
 
-    // printout 3 upcoming instructions
-    for (
-      let i = currentIndex + 1;
-      i <=
-      Math.min(currentIndex + upcomingInstructions, instructions.length - 1);
-      i++
-    ) {
-      this.config.logger.log(DebugUtils.formatInstruction(instructions[i]));
-    }
+      // printout 3 upcoming instructions
+      for (
+        let i = currentIndex + 1;
+        i <=
+        Math.min(currentIndex + upcomingInstructions, instructions.length - 1);
+        i++
+      ) {
+        this.config.logger.log(DebugUtils.formatInstruction(instructions[i]));
+      }
 
-    // add an ellipse if there exist additional instructions after
-    if (currentIndex + upcomingInstructions < instructions.length - 1) {
-      this.config.logger.log("...");
+      // add an ellipse if there exist additional instructions after
+      if (currentIndex + upcomingInstructions < instructions.length - 1) {
+        this.config.logger.log("...");
+      }
     }
 
     this.config.logger.log("");

--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -9,15 +9,8 @@ const colors = require("colors");
 const Interpreter = require("js-interpreter");
 
 const selectors = require("@truffle/debugger").selectors;
-const {
-  session,
-  solidity,
-  trace,
-  controller,
-  data,
-  evm,
-  stacktrace
-} = selectors;
+const { session, solidity, trace, controller, data, evm, stacktrace } =
+  selectors;
 
 class DebugPrinter {
   constructor(config, session) {
@@ -243,13 +236,23 @@ class DebugPrinter {
       this.config.logger.log(DebugUtils.formatInstruction(instructions[i]));
     }
 
-    // printout current instruction
-    this.config.logger.log(DebugUtils.formatCurrentInstruction(instruction));
+    if (!instruction || instruction.pc === undefined) {
+      // printout warning message if the debugger does not have the code for this contract
+      this.config.logger.log(
+        `${colors.bold(
+          "Warning:"
+        )} The debugger does not have the code for this contract.`
+      );
+    } else {
+      // printout current instruction
+      this.config.logger.log(DebugUtils.formatCurrentInstruction(instruction));
+    }
 
     // printout 3 upcoming instructions
     for (
       let i = currentIndex + 1;
-      i <= Math.min(currentIndex + upcomingInstructions, instructions.length - 1);
+      i <=
+      Math.min(currentIndex + upcomingInstructions, instructions.length - 1);
       i++
     ) {
       this.config.logger.log(DebugUtils.formatInstruction(instructions[i]));
@@ -262,10 +265,7 @@ class DebugPrinter {
 
     this.config.logger.log("");
     this.config.logger.log(
-      "Step " +
-      (traceIndex + 1).toString() +
-      "/" +
-      totalSteps.toString()
+      "Step " + (traceIndex + 1).toString() + "/" + totalSteps.toString()
     );
     this.config.logger.log(step.gas + " gas remaining");
   }
@@ -351,8 +351,9 @@ class DebugPrinter {
             );
             break;
           case "revert":
-            const signature =
-              Codec.AbiData.Utils.abiSignature(revertDecoding.abi);
+            const signature = Codec.AbiData.Utils.abiSignature(
+              revertDecoding.abi
+            );
             switch (signature) {
               case "Error(string)":
                 const revertStringInfo =
@@ -390,7 +391,9 @@ class DebugPrinter {
                 break;
               default:
                 this.config.logger.log("The following error was thrown:");
-                this.config.logger.log(DebugUtils.formatCustomError(revertDecoding, 2));
+                this.config.logger.log(
+                  DebugUtils.formatCustomError(revertDecoding, 2)
+                );
             }
             break;
         }
@@ -401,7 +404,7 @@ class DebugPrinter {
         );
         this.config.logger.log("Possible interpretations:");
         for (const decoding of revertDecodings) {
-          this.config.logger.log(DebugUtils.formatCustomError(revertDecoding, 2));
+          this.config.logger.log(DebugUtils.formatCustomError(decoding, 2));
         }
         break;
     }
@@ -530,8 +533,10 @@ class DebugPrinter {
       decodings.filter(decoding => decoding.kind === "revert").length > 1
     ) {
       //case 10: ambiguous revert with message
-      this.config.logger.log("Ambiguous error thrown, possible interpretations:");
-      for (const decoding of revertDecodings) {
+      this.config.logger.log(
+        "Ambiguous error thrown, possible interpretations:"
+      );
+      for (const decoding of decodings) {
         if (decoding.kind !== "revert") {
           break;
         }
@@ -663,8 +668,8 @@ class DebugPrinter {
     for (const [section, variables] of Object.entries(sections)) {
       // only check the first 3 characters of each name given in the input sectionPrintouts
       // since each section name defined in the constructor contains 3 characters
-      const printThisSection = sectionOuts.has(section.slice(0,3));
-      if ( printThisSection && (variables.length > 0) ) {
+      const printThisSection = sectionOuts.has(section.slice(0, 3));
+      if (printThisSection && variables.length > 0) {
         this.config.logger.log(sectionNames[section] + ":");
         // Get the length of the longest name.
         const longestNameLength = variables.reduce((longest, name) => {

--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -34,59 +34,59 @@ const verbosePanicTable = {
 };
 
 const commandReference = {
-  "o": "step over",
-  "i": "step into",
-  "u": "step out",
-  "n": "step next",
+  o: "step over",
+  i: "step into",
+  u: "step out",
+  n: "step next",
   ";": "step instruction (include number to step multiple)",
-  "p": "print instruction & state (`p [mem|cal|sto]*`; see docs for more)",
-  "l": "print additional source context (`l [+<lines-ahead>] [-<lines-back>]`)",
-  "h": "print this help",
-  "v": "print variables and values (`v [bui|glo|con|loc]*`)",
+  p: "print instruction & state (`p [mem|cal|sto]*`; see docs for more)",
+  l: "print additional source context (`l [+<lines-ahead>] [-<lines-back>]`)",
+  h: "print this help",
+  v: "print variables and values (`v [bui|glo|con|loc]*`)",
   ":": "evaluate expression - see `v`",
   "+": "add watch expression (`+:<expr>`)",
   "-": "remove watch expression (-:<expr>)",
   "?": "list existing watch expressions and breakpoints",
-  "b": "add breakpoint (`b [[<source-file>:]<line-number>]`; see docs for more)",
-  "B": "remove breakpoint (similar to adding, or `B all` to remove all)",
-  "c": "continue until breakpoint",
-  "q": "quit",
-  "r": "reset",
-  "t": "load new transaction",
-  "T": "unload transaction",
-  "s": "print stacktrace",
-  "g": "turn on generated sources",
-  "G": "turn off generated sources except via `;`",
-  "y": "(if at end) reset & continue to final error",
-  "Y": "reset & continue to previous error"
+  b: "add breakpoint (`b [[<source-file>:]<line-number>]`; see docs for more)",
+  B: "remove breakpoint (similar to adding, or `B all` to remove all)",
+  c: "continue until breakpoint",
+  q: "quit",
+  r: "reset",
+  t: "load new transaction",
+  T: "unload transaction",
+  s: "print stacktrace",
+  g: "turn on generated sources",
+  G: "turn off generated sources except via `;`",
+  y: "(if at end) reset & continue to final error",
+  Y: "reset & continue to previous error"
 };
 
 const shortCommandReference = {
-  "o": "step over",
-  "i": "step into",
-  "u": "step out",
-  "n": "step next",
+  o: "step over",
+  i: "step into",
+  u: "step out",
+  n: "step next",
   ";": "step instruction",
-  "p": "print state",
-  "l": "print context",
-  "h": "print help",
-  "v": "print variables",
+  p: "print state",
+  l: "print context",
+  h: "print help",
+  v: "print variables",
   ":": "evaluate",
   "+": "add watch",
   "-": "remove watch",
   "?": "list watches & breakpoints",
-  "b": "add breakpoint",
-  "B": "remove breakpoint",
-  "c": "continue",
-  "q": "quit",
-  "r": "reset",
-  "t": "load",
-  "T": "unload",
-  "s": "stacktrace",
-  "g": "turn on generated sources",
-  "G": "turn off generated sources",
-  "y": "reset & go to final error",
-  "Y": "reset & go to previous error"
+  b: "add breakpoint",
+  B: "remove breakpoint",
+  c: "continue",
+  q: "quit",
+  r: "reset",
+  t: "load",
+  T: "unload",
+  s: "stacktrace",
+  g: "turn on generated sources",
+  G: "turn off generated sources",
+  y: "reset & go to final error",
+  Y: "reset & go to previous error"
 };
 
 const truffleColors = {
@@ -107,69 +107,69 @@ const DEFAULT_TAB_WIDTH = 8;
 
 const trufflePalette = {
   /* base (chromafi special, not hljs) */
-  "base": chalk,
-  "lineNumbers": chalk,
-  "trailingSpace": chalk,
+  base: chalk,
+  lineNumbers: chalk,
+  trailingSpace: chalk,
   /* classes hljs-solidity actually uses */
-  "keyword": truffleColors.mint,
-  "number": truffleColors.red,
-  "string": truffleColors.green,
-  "params": truffleColors.pink,
-  "builtIn": truffleColors.watermelon,
-  "built_in": truffleColors.watermelon, //just to be sure
-  "literal": truffleColors.watermelon,
-  "function": truffleColors.orange,
-  "title": truffleColors.orange,
-  "class": truffleColors.orange,
-  "comment": truffleColors.comment,
-  "doctag": truffleColors.comment,
-  "operator": truffleColors.blue,
-  "punctuation": truffleColors.purple,
+  keyword: truffleColors.mint,
+  number: truffleColors.red,
+  string: truffleColors.green,
+  params: truffleColors.pink,
+  builtIn: truffleColors.watermelon,
+  built_in: truffleColors.watermelon, //just to be sure
+  literal: truffleColors.watermelon,
+  function: truffleColors.orange,
+  title: truffleColors.orange,
+  class: truffleColors.orange,
+  comment: truffleColors.comment,
+  doctag: truffleColors.comment,
+  operator: truffleColors.blue,
+  punctuation: truffleColors.purple,
   /* classes it might soon use! */
-  "meta": truffleColors.pink,
-  "metaString": truffleColors.green,
+  meta: truffleColors.pink,
+  metaString: truffleColors.green,
   "meta-string": truffleColors.green, //similar
   /* classes it doesn't currently use but notionally could */
-  "type": truffleColors.orange,
-  "symbol": truffleColors.orange,
-  "metaKeyword": truffleColors.mint,
+  type: truffleColors.orange,
+  symbol: truffleColors.orange,
+  metaKeyword: truffleColors.mint,
   "meta-keyword": truffleColors.mint, //again, to be sure
-  "property": chalk, //not putting any highlighting here for now
+  property: chalk, //not putting any highlighting here for now
   /* classes that don't make sense for Solidity */
-  "regexp": chalk, //solidity does not have regexps
-  "subst": chalk, //or string interpolation
-  "name": chalk, //or s-expressions
-  "builtInName": chalk, //or s-expressions, again
+  regexp: chalk, //solidity does not have regexps
+  subst: chalk, //or string interpolation
+  name: chalk, //or s-expressions
+  builtInName: chalk, //or s-expressions, again
   "builtin-name": chalk, //just to be sure
   /* classes for config, markup, CSS, templates, diffs (not programming) */
-  "section": chalk,
-  "tag": chalk,
-  "attr": chalk,
-  "attribute": chalk,
-  "variable": chalk,
-  "bullet": chalk,
-  "code": chalk,
-  "emphasis": chalk,
-  "strong": chalk,
-  "formula": chalk,
-  "link": chalk,
-  "quote": chalk,
-  "selectorAttr": chalk, //lotta redundancy follows
+  section: chalk,
+  tag: chalk,
+  attr: chalk,
+  attribute: chalk,
+  variable: chalk,
+  bullet: chalk,
+  code: chalk,
+  emphasis: chalk,
+  strong: chalk,
+  formula: chalk,
+  link: chalk,
+  quote: chalk,
+  selectorAttr: chalk, //lotta redundancy follows
   "selector-attr": chalk,
-  "selectorClass": chalk,
+  selectorClass: chalk,
   "selector-class": chalk,
-  "selectorId": chalk,
+  selectorId: chalk,
   "selector-id": chalk,
-  "selectorPseudo": chalk,
+  selectorPseudo: chalk,
   "selector-pseudo": chalk,
-  "selectorTag": chalk,
+  selectorTag: chalk,
   "selector-tag": chalk,
-  "templateTag": chalk,
+  templateTag: chalk,
   "template-tag": chalk,
-  "templateVariable": chalk,
+  templateVariable: chalk,
   "template-variable": chalk,
-  "addition": chalk,
-  "deletion": chalk
+  addition: chalk,
+  deletion: chalk
 };
 
 var DebugUtils = {
@@ -535,11 +535,6 @@ var DebugUtils = {
   },
 
   formatCurrentInstruction: function (instruction) {
-    // return warning message if the debugger does not have the code for this contract
-    if (!instruction || !instruction.pc) {
-      return "WARNING: The debugger does not have the code for this contract.";
-    }
-
     const pc = this.formatPC(instruction.pc);
     const formattedInstruction = this.formatInstruction(instruction);
     return "-> " + truffleColors.mint(formattedInstruction) + pc;

--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -270,8 +270,11 @@ var DebugUtils = {
     //(and don't bother checking generated sources as they're
     //never Solidity)
     debug("checking Solidity ASTs for collisions");
-    return compilation.sources.every(source =>
-      !source || source.language !== "Solidity" || allIDsUnseenSoFar(source.ast)
+    return compilation.sources.every(
+      source =>
+        !source ||
+        source.language !== "Solidity" ||
+        allIDsUnseenSoFar(source.ast)
     );
   },
 
@@ -532,16 +535,19 @@ var DebugUtils = {
   },
 
   formatCurrentInstruction: function (instruction) {
+    // return warning message if the debugger does not have the code for this contract
+    if (!instruction || !instruction.pc) {
+      return "WARNING: The debugger does not have the code for this contract.";
+    }
+
     const pc = this.formatPC(instruction.pc);
     const formattedInstruction = this.formatInstruction(instruction);
-    return (
-      "-> " + truffleColors.mint(formattedInstruction) + pc
-    );
+    return "-> " + truffleColors.mint(formattedInstruction) + pc;
   },
 
   formatInstruction: function (instruction) {
-    return (
-      truffleColors.mint(instruction.name + " " + (instruction.pushData || ""))
+    return truffleColors.mint(
+      instruction.name + " " + (instruction.pushData || "")
     );
   },
 
@@ -550,7 +556,7 @@ var DebugUtils = {
     if (hex.length % 2 !== 0) {
       hex = "0" + hex; //ensure even length
     }
-    return " (PC=" + pc.toString() + ", 0x" + hex+")";
+    return " (PC=" + pc.toString() + ", 0x" + hex + ")";
   },
 
   formatStack: function (stack) {
@@ -717,21 +723,21 @@ var DebugUtils = {
       return `${name}()`;
     }
     const prefix = `${name}(`;
-    const formattedValues = decoding.arguments.map(
-      ({ name, value }) => {
-        const argumentPrefix = name
-          ? `${name}: `
-          : "";
-        const typeString = ` (type: ${Codec.Format.Types.typeStringWithoutLocation(
-          value.type
-        )})`;
-        return (DebugUtils.formatValue(value, argumentPrefix.length) + typeString + ",")
-          .split(/\r?\n/g)
-          .map(line => " ".repeat(indent) + line)
-          .join(OS.EOL);
-      }
-    );
-    return [prefix, ...formattedValues, ')'].join(OS.EOL);
+    const formattedValues = decoding.arguments.map(({ name, value }) => {
+      const argumentPrefix = name ? `${name}: ` : "";
+      const typeString = ` (type: ${Codec.Format.Types.typeStringWithoutLocation(
+        value.type
+      )})`;
+      return (
+        DebugUtils.formatValue(value, argumentPrefix.length) +
+        typeString +
+        ","
+      )
+        .split(/\r?\n/g)
+        .map(line => " ".repeat(indent) + line)
+        .join(OS.EOL);
+    });
+    return [prefix, ...formattedValues, ")"].join(OS.EOL);
   },
 
   formatStacktrace: function (stacktrace, indent = 2) {


### PR DESCRIPTION

The debugger prints error message when it does not have the code of
the contract, see issue #4566. The issue is raised in self-destruc transactions.
This PR prints a warning message instead.