### PR TITLE
Enhancement: Allow `ContractInstanceDecoder` to decode transactions sent to that instance even if no bytecode was supplied

### DIFF
--- a/packages/decoder/test/current/contracts/DowngradeTest.sol
+++ b/packages/decoder/test/current/contracts/DowngradeTest.sol
@@ -82,6 +82,10 @@ contract DowngradeTest is DowngradeTestParent {
   function throwCustom() public pure {
     revert CustomError(Pair(1, MyInt.wrap(2)));
   }
+
+  function simple(uint) public {
+    emit Done();
+  }
 }
 
 library DecoyLibrary {


### PR DESCRIPTION
Oddly, it looks like we forgot to ever open an issue for this.  Oops.  Oh well.  (Also, sorry about all the changes caused by `prettier` and ESLint.)

(**Edit**: To make this more reviewable, let me point out here where the real changes are:
1. `allocate/index.ts` -- only the added export on line 61 is real, everything else is `prettier`... sorry (OK, and lines 1259-1267 were deleted due to ESLint noticing they were never used)
2. `decoders.ts` -- nearly all the changes are real, only a tiny bit is `prettier`
3. `downgrade-test.js` -- the added test is real, the rest is `prettier`
)

Anyway, this PR allows the `ContractInstanceDecoder` to decode transactions sent to that particular contract instance, even if no bytecode was supplied for that contract in the project information.  It also adds a test of this functionality.

Most of the pieces of this PR were actually already in place, they just needed to be hooked up.  Specifically:

1. The `additionalContexts` system in the `ContractInstanceDecoder` already allowed said decoder to recognize the address of its instance as belonging to its instance, and
2. The `noBytecodeAllocations` system in the `ContractDecoder` already set up backup allocations to use if there's no bytecode available.

The problem, then, is to connect these things together.  Suppose that `instanceDecoder.decodeTransaction()` is called, and no bytecode was ever supplied for the instance.  The `additionalContexts` mechanism, which was already in place, allows the decoder to correctly get a context for this instance anyway.  The problem is that this context has no calldata allocations associated to it.

But, we know what calldata allocations to use for it: `noBytecodeAllocations`!  So... what if we just patched the `noBytecodeAllocations`, into the calldata allocations, in a place where `@truffle/codec` can see it and make use of it?  That's basically all we do here.

There are some guards on this to prevent it from activating inappropriately and potentially messing things up.  First off, we only patch the allocations like this if the context we found is coming from the `additionalContexts`, and not the main contexts.  The main contexts have their allocations already; they don't need this.  Only the `additionalContexts` never had their allocations set up.  Secondly, we only patch in these additional allocations if there aren't already allocations for that context hash; we allow the pre-existing ones to override the new ones.  (These two guards are possibly redundant, but, oh well... that doesn't seem like a bad thing, really.)

But, um, that's mostly it; it was basically just hooking up components that already existed.  Hopefully the many changes due to `prettier` don't obscure the core of it too much...