### PR TITLE
Update Truffle Init Solidity version to 0.8.11

### DIFF
--- a/packages/core/lib/commands/init/initSource/truffle-config.js
+++ b/packages/core/lib/commands/init/initSource/truffle-config.js
@@ -81,7 +81,7 @@ module.exports = {
   // Configure your compilers
   compilers: {
     solc: {
-      version: "0.8.10",    // Fetch exact version from solc-bin (default: truffle's version)
+      version: "0.8.11",    // Fetch exact version from solc-bin (default: truffle's version)
       // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
       // settings: {          // See the solidity docs for advice about optimization and evmVersion
       //  optimizer: {


### PR DESCRIPTION
Since we're still updating this manually, here's the version bump for 0.8.11.

Note: I made this commit with `--no-verify` because I don't think we want `prettier` running on this file (originally I didn't do that and the result was... not what we want, I think).  I may go see about turning it off for this file...