### PR TITLE
Internal improvement: Ensure consistent naming of build scripts

### DIFF
--- a/packages/abi-utils/package.json
+++ b/packages/abi-utils/package.json
@@ -24,7 +24,8 @@
     "directory": "packages/abi-utils"
   },
   "scripts": {
-    "prepare": "tsc",
+    "build": "tsc",
+    "prepare": "yarn build",
     "test": "jest lib/**"
   },
   "bugs": {

--- a/packages/compile-solidity/package.json
+++ b/packages/compile-solidity/package.json
@@ -15,7 +15,8 @@
   "version": "6.0.6",
   "main": "dist/index.js",
   "scripts": {
-    "prepare": "ttsc",
+    "build": "ttsc",
+    "prepare": "yarn build",
     "test": "./scripts/test.sh"
   },
   "dependencies": {

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -15,6 +15,7 @@
   "version": "4.4.2",
   "main": "index.js",
   "scripts": {
+    "build": "yarn compile",
     "compile": "sh -c \"mkdir -p ./dist\" && browserify --debug ./index.js | exorcist ./dist/truffle-contract.js.map > ./dist/truffle-contract.js && uglifyjs ./dist/truffle-contract.js -o ./dist/truffle-contract.min.js",
     "prepare": "yarn compile",
     "publish:next": "node ../truffle/scripts/prereleaseVersion.js next next"

--- a/packages/db-loader/package.json
+++ b/packages/db-loader/package.json
@@ -27,7 +27,8 @@
     "access": "public"
   },
   "scripts": {
-    "prepare": "tsc"
+    "build": "tsc",
+    "prepare": "yarn build"
   },
   "optionalDependencies": {
     "@truffle/db": "^0.5.45"


### PR DESCRIPTION
Addresses #4567.  They're all called `build` now.  (I left in `compile` as an alias in `contract`.)  People making new packages, take note, please name things accordingly!  (...assuming people agree that this is good and merge it, anyway.)