### PR TITLE
Ignore config gas prices when making a call

### DIFF
--- a/packages/contract/lib/execute.js
+++ b/packages/contract/lib/execute.js
@@ -66,17 +66,13 @@ const execute = {
    * @param  {Object} constructor   TruffleContract constructor
    * @param  {Object} methodABI     Function ABI segment w/ inputs & outputs keys.
    * @param  {Array}  _arguments    Arguments passed to method invocation
-   * @param  {Boolean}  skipNetworkCheck    Arguments passed to skip network call for read data (calls type) methods invocation
+   * @param  {Boolean}  isCall      Used when preparing a call as opposed to a tx;
+   *                                  skips network checks and ignores default gas prices
    * @return {Promise}              Resolves object w/ tx params disambiguated from arguments
    */
-  prepareCall: async function (
-    constructor,
-    methodABI,
-    _arguments,
-    skipNetworkCheck
-  ) {
+  prepareCall: async function (constructor, methodABI, _arguments, isCall) {
     let args = Array.prototype.slice.call(_arguments);
-    let params = utils.getTxParams.call(constructor, methodABI, args);
+    let params = utils.getTxParams.call(constructor, methodABI, args, isCall);
 
     args = utils.convertToEthersBN(args);
 
@@ -93,8 +89,8 @@ const execute = {
       args = processedValues.args;
       params = processedValues.params;
     }
-    //skipNetworkCheck flag used to skip network call for read data (calls type) methods invocation
-    if (skipNetworkCheck) {
+    //isCall flag used to skip network call for read data (calls type) methods invocation
+    if (isCall) {
       return { args, params };
     }
     const network = await constructor.detectNetwork();

--- a/packages/contract/lib/utils/index.js
+++ b/packages/contract/lib/utils/index.js
@@ -133,22 +133,27 @@ const Utils = {
   },
 
   // Extracts optional tx params from a list of fn arguments
-  getTxParams(methodABI, args) {
+  getTxParams(methodABI, args, ignoreDefaultGasPriceParams = false) {
     const constructor = this;
 
     const expectedArgCount = methodABI ? methodABI.inputs.length : 0;
 
-    let tx_params = {};
+    let txParams = {};
     const lastArg = args[args.length - 1];
 
-    if (
-      args.length === expectedArgCount + 1 &&
-      Utils.isTxParams(lastArg)
-    ) {
-      tx_params = args.pop();
+    if (args.length === expectedArgCount + 1 && Utils.isTxParams(lastArg)) {
+      txParams = args.pop();
     }
 
-    return Utils.merge(constructor.class_defaults, tx_params);
+    let defaultParams = constructor.class_defaults;
+    if (ignoreDefaultGasPriceParams) {
+      defaultParams = { ...constructor.class_defaults }; //clone
+      delete defaultParams.gasPrice;
+      delete defaultParams.maxFeePerGas;
+      delete defaultParams.maxPriorityFeePerGas;
+    }
+
+    return Utils.merge(defaultParams, txParams);
   },
 
   // Verifies that a contracts libraries have been linked correctly.
@@ -160,9 +165,11 @@ const Utils = {
 
     if (unlinkedLibraries !== null) {
       unlinkedLibraries = unlinkedLibraries
-        .map((
-          name // Remove underscores
-        ) => name.replace(/_/g, ""))
+        .map(
+          (
+            name // Remove underscores
+          ) => name.replace(/_/g, "")
+        )
         .sort()
         .filter((name, index, arr) => {
           // Remove duplicates
@@ -174,11 +181,7 @@ const Utils = {
         })
         .join(", ");
 
-      const error = `${
-        constructor.contractName
-      } contains unresolved libraries. You must deploy and link the following libraries before you can deploy a new version of ${
-        constructor.contractName
-      }: ${unlinkedLibraries}`;
+      const error = `${constructor.contractName} contains unresolved libraries. You must deploy and link the following libraries before you can deploy a new version of ${constructor.contractName}: ${unlinkedLibraries}`;
 
       throw new Error(error);
     }

--- a/packages/contract/lib/utils/index.js
+++ b/packages/contract/lib/utils/index.js
@@ -147,6 +147,10 @@ const Utils = {
 
     let defaultParams = constructor.class_defaults;
     if (ignoreDefaultGasPriceParams) {
+      //this parameter is set when making calls (as opposed to transactions)
+      //gas price params can cause problems with those on some networks, so
+      //we ignore any defaults, and only include them if they were explicitly
+      //specified
       defaultParams = { ...constructor.class_defaults }; //clone
       delete defaultParams.gasPrice;
       delete defaultParams.maxFeePerGas;


### PR DESCRIPTION
Addresses #4457.  Supersedes #4448 because it looks @hellwolf isn't coming back to finish that.

This PR makes it so that, when making a call (not a transaction!) with Truffle Contract, any defaults for `gasPrice`, `maxFeePerGas`, or `maxPriorityFeePerGas` coming from the config are ignored.  The reason for this is that including too-high values for these parameters can cause "insufficient funds" errors on certain networks, even though you're making a call, not a transaction.  This is annoying!

Note that any values for these parameters *explicitly specified when making the call* are still respected, because, I don't know, maybe the user wants to be able to set these.  But any defaults coming from the config will be ignored.

To do this, I added an extra parameter to `getTxParams`, which when passed will exclude those parameters from the defaults.  I renamed the `skipNetworkCheck` flag in `prepare` to `isCall`, since it now both skips network checks, and activates this behavior.

Also, `prettier` has some changes, as always.

I didn't add a test for this PR because, well... the contract tests are confusing and I wasn't sure how to add a test for this, sorry.  But I tested it manually and verified that it worked!