### PR TITLE
Bug fix: Remove compilationTarget field from metadata from Sourcify

### DIFF
--- a/packages/source-fetcher/lib/common.ts
+++ b/packages/source-fetcher/lib/common.ts
@@ -24,15 +24,18 @@ export function makeFilename(name: string, extension: string = ".sol"): string {
   }
 }
 
-export const makeTimer: (
-  milliseconds: number
-) => Promise<void> = util.promisify(setTimeout);
+export const makeTimer: (milliseconds: number) => Promise<void> =
+  util.promisify(setTimeout);
 
 export function removeLibraries(
-  settings: Types.SolcSettings
+  settings: Types.SolcSettings,
+  alsoRemoveCompilationTarget: boolean = false
 ): Types.SolcSettings {
   let copySettings: Types.SolcSettings = { ...settings };
   delete copySettings.libraries;
+  if (alsoRemoveCompilationTarget) {
+    delete copySettings.compilationTarget;
+  }
   return copySettings;
 }
 

--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -94,13 +94,16 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
       address,
       matchType
     );
+    debug("compilationTarget: %O", metadata.settings.compilationTarget);
     return {
       contractName: Object.values(metadata.settings.compilationTarget)[0],
       sources,
       options: {
         language: metadata.language,
         version: metadata.compiler.version,
-        settings: removeLibraries(metadata.settings),
+        //we also pass the flag to remove compilationTarget, as its
+        //presence can cause compile errors
+        settings: removeLibraries(metadata.settings, true),
         specializations: {
           constructorArguments,
           libraries: metadata.settings.libraries


### PR DESCRIPTION
This PR fixes some compile errors that could occur when using `fetch-and-compile` to fetch sources off of Sourcify.  See, Sourcify gives us the *metadata*, which is not *quite* the same thing as actual compiler input.  For the most part we account for this, but in this case we hadn't.  The metadata settings include a setting called `compilationTarget`.  Actual compiler input doesn't include that setting, but we weren't removing it, and so sometimes the compiler would error out becasue of the presence of this setting.  So, now we delete it to prevent errors.

Ideally I would disunify the `SolcSettings` type into `SolcSettings` and `SolcMetadata`, but I didn't bother as that just seemed like needless complication (for instance, then I'd have to write a type predicate to distinguish them if I wanted functions to be able to operate on both without type errors).

I didn't add a test for the usual reasons but I tested it manually, and, if nothing else, it causes us to get more meaningful compile errors. :P