### PR TITLE
Bug fix: Use Unicode matching in Sourcify replacement

### DIFF
--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -139,7 +139,7 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     //note: sourcify replaces special characters in paths with underscores
     //(special characters here being anything other than ASCII alphanumerics,
     //hyphens, periods, and forward slashes)
-    const transformedSourcePath = sourcePath.replace(/[^\w.\/-]/g, "_");
+    const transformedSourcePath = sourcePath.replace(/[^\w.\/-]/gu, "_");
     return await this.requestWithRetries<string>({
       url: `https://${this.domain}/contracts/${matchType}_match/${this.networkId}/${address}/sources/${transformedSourcePath}`,
       responseType: "text",


### PR DESCRIPTION
Sorry, just a quick follow-on to #4610... the regex I used didn't use the `u` flag, so if any astral-plane characters were used, it would get things wrong (replacing them with two underscores instead of one... yes I tested and Sourcify will just put the one).  This PR just adds the `u` flag that should have been there.

I guess most of the time we don't worry too much about astral-plane stuff, and I don't intend to make accounting for that like some sort of general effort (outside of codec of course which is certainly aware of that stuff :P ), but I thought I should account for it here.