### PR TITLE
Changed the deploy method to return the contract instance

### DIFF
--- a/packages/deployer/index.js
+++ b/packages/deployer/index.js
@@ -49,11 +49,19 @@ class Deployer extends Deployment {
     return this.queueOrExec(link(library, destinations, this));
   }
 
-  deploy() {
+  deploy1() {
     const args = Array.prototype.slice.call(arguments);
     const contract = args.shift();
 
     return this.queueOrExec(this.executeDeployment(contract, args, this));
+  }
+
+  async deploy() {
+    const args = Array.prototype.slice.call(arguments);
+    const contract = args.shift();
+
+    let instance = await this.executeDeployment(contract, args, this);
+    return instance;
   }
 
   new() {


### PR DESCRIPTION
### ISSUE
The deployer.deploy() method doesn't return the contract instance and needs an additional line of code as Contract.deployed() to get it. See issue #3867 .

### SOLUTION
New async/await methods are added to get the contract instance directly from the deployer.deploy() method.