### PR TITLE
Fix mocha reporter issue to work with both command line and truffle-config.js

### DIFF
--- a/packages/core/lib/commands/test/meta.js
+++ b/packages/core/lib/commands/test/meta.js
@@ -14,7 +14,7 @@ module.exports = {
       type: "boolean",
       default: false
     },
-    debug: {
+    "debug": {
       describe: "Enable in-test debugging",
       type: "boolean",
       default: false
@@ -28,13 +28,13 @@ module.exports = {
       type: "boolean",
       default: false
     },
-    bail: {
+    "bail": {
       alias: "b",
       describe: "Bail after first test failure",
       type: "boolean",
       default: false
     },
-    stacktrace: {
+    "stacktrace": {
       alias: "t",
       describe: "Produce Solidity stacktraces",
       type: "boolean",
@@ -45,10 +45,10 @@ module.exports = {
       type: "boolean",
       default: false
     },
-    reporter: {
+    "reporter": {
       alias: "r",
       describe: "Specify the type of mocha reporter",
-      default: "spec"
+      default: undefined
     }
   },
   help: {

--- a/packages/core/lib/commands/test/run.js
+++ b/packages/core/lib/commands/test/run.js
@@ -5,10 +5,14 @@ const parseCommandLineFlags = options => {
   const reporter = options.reporter || options.r;
 
   /**
-   * If the reporter is returned as undefined, it will overlap the reporter specified in the
-   * config and will display the default mocha reporter "spec".
-   * This if-else condition is explicitly written to avoid this overlapping when user specifies a mocha reporter type
+   * This if-else condition is explicitly written to avoid the overlapping of
+   * the config by the default mocha reporter type when user specifies a mocha reporter type
    * in the config and doesn't specify it as the command line argument.
+   * If condition - The reporter is not returned when it is undefined by the user in the command line which in
+   * turn will check the reporter value specified in the config.
+   * This is required because if the reporter is returned as undefined, it will overlap the reporter specified in the
+   * config and will display the default mocha reporter "spec".
+   * Else condition - The reporter is returned only when the user specifies a reporter type from the command line
    */
   if (reporter === undefined) {
     return {

--- a/packages/core/lib/commands/test/run.js
+++ b/packages/core/lib/commands/test/run.js
@@ -5,8 +5,10 @@ const parseCommandLineFlags = options => {
   const reporter = options.reporter || options.r;
 
   /**
-   * This if-else condition is explicitly defined so that when the reporter is not specified by the user
-   * as the command line argument, it returns the reporter specified in the config.
+   * If the reporter is returned as undefined, it will overlap the reporter specified in the
+   * config and will display the default mocha reporter "spec".
+   * This if-else condition is explicitly written to avoid this overlapping when user specifies a mocha reporter type
+   * in the config and doesn't specify it as the command line argument.
    */
   if (reporter === undefined) {
     return {

--- a/packages/core/lib/commands/test/run.js
+++ b/packages/core/lib/commands/test/run.js
@@ -3,13 +3,22 @@ const parseCommandLineFlags = options => {
   const grep = options.grep || options.g;
   const bail = options.bail || options.b;
   const reporter = options.reporter || options.r;
-  return {
-    mocha: {
-      grep,
-      bail,
-      reporter
-    }
-  };
+  if (reporter === undefined) {
+    return {
+      mocha: {
+        grep,
+        bail
+      }
+    };
+  } else {
+    return {
+      mocha: {
+        grep,
+        bail,
+        reporter
+      }
+    };
+  }
 };
 
 module.exports = async function (options) {

--- a/packages/core/lib/commands/test/run.js
+++ b/packages/core/lib/commands/test/run.js
@@ -3,6 +3,11 @@ const parseCommandLineFlags = options => {
   const grep = options.grep || options.g;
   const bail = options.bail || options.b;
   const reporter = options.reporter || options.r;
+
+  /**
+   * This if-else condition is explicitly defined so that when the reporter is not specified by the user
+   * as the command line argument, it returns the reporter specified in the config.
+   */
   if (reporter === undefined) {
     return {
       mocha: {

--- a/packages/core/lib/commands/test/run.js
+++ b/packages/core/lib/commands/test/run.js
@@ -8,11 +8,9 @@ const parseCommandLineFlags = options => {
    * This if-else condition is explicitly written to avoid the overlapping of
    * the config by the default mocha reporter type when user specifies a mocha reporter type
    * in the config and doesn't specify it as the command line argument.
-   * If condition - The reporter is not returned when it is undefined by the user in the command line which in
-   * turn will check the reporter value specified in the config.
-   * This is required because if the reporter is returned as undefined, it will overlap the reporter specified in the
-   * config and will display the default mocha reporter "spec".
-   * Else condition - The reporter is returned only when the user specifies a reporter type from the command line
+   * If the reporter is returned as undefined, it ignores the specification of any reporter type in the
+   * config and displays the default mocha reporter "spec", as opposed to reporter completely being absent
+   * which results in checking for the reporter type specified in the config.
    */
   if (reporter === undefined) {
     return {


### PR DESCRIPTION
### ISSUE
Setting the mocha reporter in the truffle-config.js file was not working after the --reporter flag was added as the command line argument. See #4627 .

### SOLUTION
The mocha reporter can now be set in the truffle-config.js and it can be run using the truffle test command. And if it is not set in the truffle-config.js file, it can be specified as an command line argument like -
truffle test --reporter <reporter_name>
And if nothing is specified when running the truffle test command or in the truffle-config.js file, the default mocha reporter is displayed which is "spec".