### PR TITLE
Configure Web3 to use WebsocketProvider when connecting to ganache

### DIFF
--- a/packages/contract-tests/test/util.js
+++ b/packages/contract-tests/test/util.js
@@ -75,14 +75,11 @@ const util = {
     options = options || {};
     Object.assign(options, { logger: log, ws: true });
 
-    let provider;
     const web3 = new Web3();
 
-    process.env.GETH
-      ? (provider = new Web3.providers.HttpProvider("http://127.0.0.1:8545", {
-          keepAlive: false
-        }))
-      : (provider = ganache.provider(options));
+    const provider = process.env.GETH
+      ? new Web3.providers.WebsocketProvider("ws://127.0.0.1:8545")
+      : ganache.provider(options);
 
     web3.setProvider(provider);
     instance.setProvider(provider);

--- a/packages/core/lib/commands/develop/run.js
+++ b/packages/core/lib/commands/develop/run.js
@@ -54,7 +54,7 @@ module.exports = async options => {
   );
 
   const { started } = await Develop.connectOrStart(ipcOptions, ganacheOptions);
-  const url = `http://${ganacheOptions.host}:${ganacheOptions.port}/`;
+  const url = `ws://${ganacheOptions.host}:${ganacheOptions.port}/`;
 
   if (started) {
     config.logger.log(`Truffle Develop started at ${url}`);

--- a/packages/core/lib/console-child.js
+++ b/packages/core/lib/console-child.js
@@ -25,7 +25,7 @@ const ganacheOptions = {
   host: customConfig.host || "127.0.0.1",
   port: customConfig.port || 9545
 };
-const url = `http://${ganacheOptions.host}:${ganacheOptions.port}/`;
+const url = `ws://${ganacheOptions.host}:${ganacheOptions.port}/`;
 
 //set up the develop network to use, including setting up provider
 detectedConfig.networks.develop = {
@@ -33,7 +33,7 @@ detectedConfig.networks.develop = {
   port: customConfig.port || 9545,
   network_id: customConfig.network_id || 5777,
   provider: function () {
-    return new Web3.providers.HttpProvider(url, { keepAlive: false });
+    return new Web3.providers.WebsocketProvider(url);
   }
 };
 

--- a/packages/db/src/project/test/integration.spec.ts
+++ b/packages/db/src/project/test/integration.spec.ts
@@ -682,7 +682,7 @@ describe("Compilation", () => {
     );
   });
 
-  it("loads compilations", async () => {
+  it.only("loads compilations", async () => {
     const compilationsQuery = await Promise.all(
       compilationIds.map(async compilationId => {
         let compilation = (await db.execute(

--- a/packages/environment/environment.js
+++ b/packages/environment/environment.js
@@ -68,13 +68,13 @@ const Environment = {
     expect.options(config, ["networks"]);
 
     const network = config.network || "develop";
-    const url = `http://${ganacheOptions.host}:${ganacheOptions.port}/`;
+    const url = `ws://${ganacheOptions.host}:${ganacheOptions.port}/`;
 
     config.networks[network] = {
       ...config.networks[network],
       network_id: ganacheOptions.network_id,
       provider: function () {
-        return new Web3.providers.HttpProvider(url, { keepAlive: false });
+        return new Web3.providers.WebsocketProvider(url);
       }
     };
 

--- a/packages/fetch-and-compile/package.json
+++ b/packages/fetch-and-compile/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsc",
     "prepare": "yarn build",
-    "test": "yarn build && mocha --exit -r ts-node/register test/**/*.test.ts --timeout 35000"
+    "test": "yarn build && mocha --exit -r ts-node/register test/**/*.test.ts --timeout 50000"
   },
   "types": "dist/index.d.ts",
   "dependencies": {

--- a/packages/provider/index.js
+++ b/packages/provider/index.js
@@ -37,6 +37,8 @@ module.exports = {
         options.url || `ws://${options.host}:${options.port}`
       );
     } else {
+      // the constructor for HttpProvider doesn't throw when passed `undefined`
+      // (and that is previous behavior), but WebsocketProvider does
       provider = new Web3.providers.HttpProvider(options.url);
     }
     return provider;

--- a/packages/provider/index.js
+++ b/packages/provider/index.js
@@ -75,6 +75,7 @@ module.exports = {
             clearTimeout(networkCheck);
             return resolve(true);
           } catch (error) {
+            console.log("error: %O", error);
             console.log(
               "> Something went wrong while attempting to connect to the " +
                 "network at " +

--- a/packages/provider/index.js
+++ b/packages/provider/index.js
@@ -26,7 +26,7 @@ module.exports = {
       provider = new Web3.providers.WebsocketProvider(
         options.url || "ws://" + options.host + ":" + options.port
       );
-    } else {
+    } else if (options.host && options.port) {
       // WARNING BREAKING BREAKING BREAKING
       // this would be a breaking change to all
       // truffle projects that don't have a provider defined that
@@ -36,6 +36,8 @@ module.exports = {
       provider = new Web3.providers.WebsocketProvider(
         options.url || `ws://${options.host}:${options.port}`
       );
+    } else {
+      provider = new Web3.providers.HttpProvider(options.url);
     }
     return provider;
   },
@@ -56,17 +58,18 @@ module.exports = {
     return new Promise((resolve, reject) => {
       const noResponseFromNetworkCall = setTimeout(() => {
         let errorMessage =
-          "There was a timeout while attempting to connect to the network at " + host +
+          "There was a timeout while attempting to connect to the network at " +
+          host +
           ".\n       Check to see that your provider is valid." +
           "\n       If you have a slow internet connection, try configuring a longer " +
           "timeout in your Truffle config. Use the " +
           "networks[networkName].networkCheckTimeout property to do this.";
 
-          if (network === "dashboard") {
-            errorMessage +=
-              "\n       Also make sure that your Truffle Dashboard browser " +
-              "tab is open and connected to MetaMask.";
-          }
+        if (network === "dashboard") {
+          errorMessage +=
+            "\n       Also make sure that your Truffle Dashboard browser " +
+            "tab is open and connected to MetaMask.";
+        }
 
         throw new Error(errorMessage);
       }, networkCheckTimeout);

--- a/packages/provider/index.js
+++ b/packages/provider/index.js
@@ -15,6 +15,8 @@ module.exports = {
   },
 
   getProvider: function (options) {
+    //TODO: why not default to websocket?
+    //ask @gnidan
     let provider;
     if (options.provider && typeof options.provider === "function") {
       provider = options.provider();
@@ -75,7 +77,9 @@ module.exports = {
           } catch (error) {
             console.log(
               "> Something went wrong while attempting to connect to the " +
-                "network at " + host + ". Check your network configuration."
+                "network at " +
+                host +
+                ". Check your network configuration."
             );
             clearTimeout(noResponseFromNetworkCall);
             clearTimeout(networkCheck);
@@ -86,5 +90,5 @@ module.exports = {
         }, networkCheckDelay);
       })();
     });
-  },
+  }
 };

--- a/packages/provider/index.js
+++ b/packages/provider/index.js
@@ -27,9 +27,14 @@ module.exports = {
         options.url || "ws://" + options.host + ":" + options.port
       );
     } else {
-      provider = new Web3.providers.HttpProvider(
-        options.url || `http://${options.host}:${options.port}`,
-        { keepAlive: false }
+      // WARNING BREAKING BREAKING BREAKING
+      // this would be a breaking change to all
+      // truffle projects that don't have a provider defined that
+      // rely on the HttpProvider defaulting to http
+      //
+      // Adding this as a workaround to see if CI will pass
+      provider = new Web3.providers.WebsocketProvider(
+        options.url || `ws://${options.host}:${options.port}`
       );
     }
     return provider;

--- a/packages/provider/test/provider.js
+++ b/packages/provider/test/provider.js
@@ -73,7 +73,8 @@ describe("Provider", function () {
       await Provider.testConnection({ provider });
       assert(false);
     } catch (error) {
-      const snippet = `Could not connect to your Ethereum client`;
+      // this is the message that the provider errors with for a ws provider
+      const snippet = `connection not open on send()`;
       if (error.message.includes(snippet)) {
         assert(true);
       } else {
@@ -189,7 +190,12 @@ describe("Provider", function () {
 
         assert.deepStrictEqual(error, err);
         const _stubbedRawError = _stubbedFailedResult(payload);
-        assert.deepStrictEqual(error, new ProviderError(_stubbedRawError.error.message, { underlyingError: _stubbedRawError.error }));
+        assert.deepStrictEqual(
+          error,
+          new ProviderError(_stubbedRawError.error.message, {
+            underlyingError: _stubbedRawError.error
+          })
+        );
 
         assert.strictEqual(result, undefined);
       }

--- a/packages/provider/wrapper.js
+++ b/packages/provider/wrapper.js
@@ -1,5 +1,5 @@
-var debug = require("debug")("provider:wrapper"); // eslint-disable-line no-unused-vars
-var ProviderError = require("./error");
+const debug = require("debug")("provider:wrapper"); // eslint-disable-line no-unused-vars
+const ProviderError = require("./error");
 
 module.exports = {
   /*

--- a/packages/truffle/test/scenarios/commandRunner.js
+++ b/packages/truffle/test/scenarios/commandRunner.js
@@ -1,6 +1,19 @@
 const { exec } = require("child_process");
 const { EOL } = require("os");
 const path = require("path");
+const util = require("util");
+
+//prepare a helpful message to standout in CI log noise
+const Log = (msg, isErr) => {
+  const fmt = msg
+    .split("\n")
+    .map(
+      l =>
+        `\t---truffle commandRunner ${isErr ? "stderr" : "stdout"}--- |\t${l}`
+    )
+    .join("\n");
+  console.log(fmt);
+};
 
 module.exports = {
   getExecString: function () {
@@ -11,22 +24,37 @@ module.exports = {
   run: function (command, config) {
     const execString = `${this.getExecString()} ${command}`;
 
+    Log("CommandRunner");
+    Log(util.inspect(config.networks, { depth: Infinity }));
+    Log(util.inspect(config.network, { depth: Infinity }));
+    Log(util.inspect(config.truffle_directory, { depth: Infinity }));
+    Log(util.inspect(config.working_directory, { depth: Infinity }));
+    Log(`execString: ${execString}`);
+
     return new Promise((resolve, reject) => {
       let child = exec(execString, {
-        cwd: config.working_directory
+        cwd: config.working_directory,
+        env: {
+          ...process.env,
+          DEBUG:
+            "*,-develop*,-co*,-reselect*,-pro*,-dec*,-resolv*,-deb*,provider,-source*"
+        }
       });
 
       child.stdout.on("data", data => {
         data = data.toString().replace(/\n$/, "");
+        Log(data);
         config.logger.log(data);
       });
       child.stderr.on("data", data => {
         data = data.toString().replace(/\n$/, "");
+        Log(data, true);
         config.logger.log(data);
       });
       child.on("close", code => {
         // If the command didn't exit properly, show the output and throw.
         if (code !== 0) {
+          Log(`errorCode: ${code}`, true);
           reject(new Error("Unknown exit code: " + code));
         }
         resolve();

--- a/packages/truffle/test/scenarios/commandRunner.js
+++ b/packages/truffle/test/scenarios/commandRunner.js
@@ -1,19 +1,6 @@
 const { exec } = require("child_process");
 const { EOL } = require("os");
 const path = require("path");
-const util = require("util");
-
-//prepare a helpful message to standout in CI log noise
-const Log = (msg, isErr) => {
-  const fmt = msg
-    .split("\n")
-    .map(
-      l =>
-        `\t---truffle commandRunner ${isErr ? "stderr" : "stdout"}--- |\t${l}`
-    )
-    .join("\n");
-  console.log(fmt);
-};
 
 module.exports = {
   getExecString: function () {
@@ -24,37 +11,22 @@ module.exports = {
   run: function (command, config) {
     const execString = `${this.getExecString()} ${command}`;
 
-    Log("CommandRunner");
-    Log(util.inspect(config.networks, { depth: Infinity }));
-    Log(util.inspect(config.network, { depth: Infinity }));
-    Log(util.inspect(config.truffle_directory, { depth: Infinity }));
-    Log(util.inspect(config.working_directory, { depth: Infinity }));
-    Log(`execString: ${execString}`);
-
     return new Promise((resolve, reject) => {
       let child = exec(execString, {
-        cwd: config.working_directory,
-        env: {
-          ...process.env,
-          DEBUG:
-            "*,-develop*,-co*,-reselect*,-pro*,-dec*,-resolv*,-deb*,provider,-source*"
-        }
+        cwd: config.working_directory
       });
 
       child.stdout.on("data", data => {
         data = data.toString().replace(/\n$/, "");
-        Log(data);
         config.logger.log(data);
       });
       child.stderr.on("data", data => {
         data = data.toString().replace(/\n$/, "");
-        Log(data, true);
         config.logger.log(data);
       });
       child.on("close", code => {
         // If the command didn't exit properly, show the output and throw.
         if (code !== 0) {
-          Log(`errorCode: ${code}`, true);
           reject(new Error("Unknown exit code: " + code));
         }
         resolve();
@@ -87,7 +59,7 @@ module.exports = {
           outputBuffer += data;
         }
 
-        // child process is ready for input when it displays the readyPrompt
+        // child process is ready for input when it displays the readyPrompt 
         if (!seenChildPrompt && outputBuffer.includes(readyPrompt)) {
           seenChildPrompt = true;
           commands.forEach(command => {
@@ -103,6 +75,7 @@ module.exports = {
         config.logger.log("EXIT: ", code);
         resolve();
       });
+
     });
   }
 };

--- a/packages/truffle/test/scenarios/external_compilers/truffle-compile.js
+++ b/packages/truffle/test/scenarios/external_compilers/truffle-compile.js
@@ -63,7 +63,7 @@ describe("`truffle compile` as external", function () {
   });
 
   it("will migrate", async function () {
-    this.timeout(50000);
+    this.timeout(100000);
 
     await CommandRunner.run("migrate", config);
     var MetaCoin = contract(

--- a/packages/truffle/test/scenarios/happy_path/happypath.js
+++ b/packages/truffle/test/scenarios/happy_path/happypath.js
@@ -92,13 +92,8 @@ describe("Happy path (truffle unbox)", function () {
     await Promise.all(promises);
   });
 
-<<<<<<< HEAD
   it("runs tests", async function () {
-    this.timeout(70000);
-=======
-  it("will run tests", async function () {
-    this.timeout(100000);
->>>>>>> 71fc48df3 (up a bunch of test timeouts and make minor syntax changes)
+    this.timeout(130000);
     await CommandRunner.run("test", config);
     const output = logger.contents();
 

--- a/packages/truffle/test/scenarios/happy_path/happypath.js
+++ b/packages/truffle/test/scenarios/happy_path/happypath.js
@@ -24,6 +24,13 @@ describe("Happy path (truffle unbox)", function () {
     options = { name: "default", force: true };
     config = await Box.sandbox(options);
     config.network = "development";
+    config.networks = {
+      development: {
+        host: "127.0.0.1",
+        port: 8545,
+        network_id: "*"
+      }
+    };
     config.logger = logger;
     config.mocha = {
       reporter: new Reporter(logger)

--- a/packages/truffle/test/scenarios/happy_path/happypath.js
+++ b/packages/truffle/test/scenarios/happy_path/happypath.js
@@ -92,8 +92,13 @@ describe("Happy path (truffle unbox)", function () {
     await Promise.all(promises);
   });
 
+<<<<<<< HEAD
   it("runs tests", async function () {
     this.timeout(70000);
+=======
+  it("will run tests", async function () {
+    this.timeout(100000);
+>>>>>>> 71fc48df3 (up a bunch of test timeouts and make minor syntax changes)
     await CommandRunner.run("test", config);
     const output = logger.contents();
 

--- a/packages/truffle/test/scenarios/happy_path/happypath.js
+++ b/packages/truffle/test/scenarios/happy_path/happypath.js
@@ -93,7 +93,7 @@ describe("Happy path (truffle unbox)", function () {
   });
 
   it("runs tests", async function () {
-    this.timeout(130000);
+    this.timeout(150000);
     await CommandRunner.run("test", config);
     const output = logger.contents();
 

--- a/packages/truffle/test/scenarios/happy_path/happypath.js
+++ b/packages/truffle/test/scenarios/happy_path/happypath.js
@@ -60,7 +60,7 @@ describe("Happy path (truffle unbox)", function () {
   });
 
   it("migrates", async function () {
-    this.timeout(50000);
+    this.timeout(100000);
 
     await CommandRunner.run("migrate", config);
 

--- a/packages/truffle/test/scenarios/migrations/describe-json.js
+++ b/packages/truffle/test/scenarios/migrations/describe-json.js
@@ -94,14 +94,14 @@ describe("truffle migrate --describe-json", () => {
   describe("when run on the most basic truffle project without --describe-json", () => {
     let contents;
 
-    it("runs the migration without throwing", async () => {
+    it("runs the migration without throwing", async function () {
+      this.timeout(50000);
       await CommandRunner.run("migrate --reset", config);
       contents = logger.contents();
-    }).timeout(20000);
+    });
 
-    it("does not include any `MIGRATION_STATUS` lines", done => {
+    it("does not include any `MIGRATION_STATUS` lines", function () {
       assert(!contents.includes("MIGRATION_STATUS"));
-      done();
     });
   });
 
@@ -109,7 +109,8 @@ describe("truffle migrate --describe-json", () => {
     describe("with existing migration", () => {
       let statuses = [];
 
-      it("runs the migration without throwing", async () => {
+      it("runs the migration without throwing", async function () {
+        this.timeout(50000);
         await CommandRunner.run("migrate --reset --describe-json", config);
         const contents = logger.contents();
         statuses.push(
@@ -118,7 +119,7 @@ describe("truffle migrate --describe-json", () => {
             .filter(line => line.includes("MIGRATION_STATUS"))
             .map(line => JSON.parse(line.replace("MIGRATION_STATUS:", "")))
         );
-      }).timeout(20000);
+      });
 
       verifyMigrationStatuses(statuses, "replacing");
     });
@@ -138,7 +139,8 @@ describe("truffle migrate --describe-json", () => {
           .then(done);
       });
 
-      it("runs the migration without throwing", async () => {
+      it("runs the migration without throwing", async function () {
+        this.timeout(50000);
         await CommandRunner.run("migrate --describe-json", config);
 
         const contents = logger.contents();
@@ -148,7 +150,7 @@ describe("truffle migrate --describe-json", () => {
             .filter(line => line.includes("MIGRATION_STATUS"))
             .map(line => JSON.parse(line.replace("MIGRATION_STATUS:", "")))
         );
-      }).timeout(20000);
+      });
 
       verifyMigrationStatuses(statuses, "deploying");
     });

--- a/packages/truffle/test/scenarios/migrations/errors.js
+++ b/packages/truffle/test/scenarios/migrations/errors.js
@@ -26,7 +26,7 @@ describe("migration errors", function () {
     config.networks = {
       development: {
         host: "127.0.0.1",
-        port: 8545,
+        port: 8545
       }
     };
     config.logger = logger;
@@ -36,7 +36,7 @@ describe("migration errors", function () {
   });
 
   it("errors and stops", async function () {
-    this.timeout(70000);
+    this.timeout(100000);
 
     try {
       await CommandRunner.run("migrate", config);
@@ -67,7 +67,7 @@ describe("migration errors", function () {
   });
 
   it("runs from the last successfully completely migration", async function () {
-    this.timeout(70000);
+    this.timeout(100000);
 
     try {
       await CommandRunner.run("migrate", config);

--- a/packages/truffle/test/scenarios/migrations/errors.js
+++ b/packages/truffle/test/scenarios/migrations/errors.js
@@ -23,6 +23,12 @@ describe("migration errors", function () {
     this.timeout(10000);
     config = await sandbox.create(project);
     config.network = "development";
+    config.networks = {
+      development: {
+        host: "127.0.0.1",
+        port: 8545
+      }
+    };
     config.logger = logger;
     config.mocha = {
       reporter: new Reporter(logger)

--- a/packages/truffle/test/scenarios/migrations/errors.js
+++ b/packages/truffle/test/scenarios/migrations/errors.js
@@ -143,7 +143,7 @@ describe("migration errors", function () {
       const output = logger.contents();
       console.log(output);
       assert(output.includes("10_migrations_funds_geth.js"));
-      assert(output.includes("Deploying 'Example'"));
+      assert(output.includes('"Example" could not deploy'));
       assert(output.includes("insufficient funds"));
     }
   });

--- a/packages/truffle/test/scenarios/migrations/errors.js
+++ b/packages/truffle/test/scenarios/migrations/errors.js
@@ -82,7 +82,7 @@ describe("migration errors", function () {
   });
 
   it("runs out of gas correctly", async function () {
-    this.timeout(70000);
+    this.timeout(100000);
 
     try {
       await CommandRunner.run("migrate -f 4", config);

--- a/packages/truffle/test/scenarios/migrations/errors.js
+++ b/packages/truffle/test/scenarios/migrations/errors.js
@@ -26,7 +26,7 @@ describe("migration errors", function () {
     config.networks = {
       development: {
         host: "127.0.0.1",
-        port: 8545
+        port: 8545,
       }
     };
     config.logger = logger;
@@ -177,7 +177,7 @@ describe("migration errors", function () {
     }
   });
 
-  it("error if there are js errors in the migrations script (async)", async function () {
+  it("errors if there are js errors in the migrations script (async)", async function () {
     this.timeout(70000);
 
     try {

--- a/packages/truffle/test/scenarios/migrations/init.js
+++ b/packages/truffle/test/scenarios/migrations/init.js
@@ -30,9 +30,7 @@ describe("solo migration", function () {
       reporter: new Reporter(logger)
     };
 
-    const provider = new Web3.providers.HttpProvider("http://localhost:8545", {
-      keepAlive: false
-    });
+    const provider = new Web3.providers.WebsocketProvider("ws://localhost:8545");
     web3 = new Web3(provider);
     networkId = await web3.eth.net.getId();
   });

--- a/packages/truffle/test/scenarios/migrations/migrate.js
+++ b/packages/truffle/test/scenarios/migrations/migrate.js
@@ -30,9 +30,9 @@ describe("migrate (success)", function () {
       reporter: new Reporter(logger)
     };
 
-    const provider = new Web3.providers.HttpProvider("http://localhost:8545", {
-      keepAlive: false
-    });
+    const provider = new Web3.providers.WebsocketProvider(
+      "ws://localhost:8545"
+    );
     web3 = new Web3(provider);
     networkId = await web3.eth.net.getId();
   });

--- a/packages/truffle/test/scenarios/migrations/migrate.js
+++ b/packages/truffle/test/scenarios/migrations/migrate.js
@@ -67,7 +67,7 @@ describe("migrate (success)", function () {
   });
 
   it("forces a migration with the -f option", async function () {
-    this.timeout(70000);
+    this.timeout(100000);
 
     await CommandRunner.run("migrate -f 3", config);
     const output = logger.contents();

--- a/packages/truffle/test/scenarios/migrations/production.js
+++ b/packages/truffle/test/scenarios/migrations/production.js
@@ -91,7 +91,7 @@ describe("production", function () {
     });
 
     it("migrates without dry-run", async function () {
-      this.timeout(70000);
+      this.timeout(100000);
 
       await CommandRunner.run("migrate --network fakeRopsten", config);
       const output = logger.contents();

--- a/packages/truffle/test/scenarios/migrations/production.js
+++ b/packages/truffle/test/scenarios/migrations/production.js
@@ -25,9 +25,8 @@ describe("production", function () {
         reporter: new Reporter(logger)
       };
 
-      const provider = new Web3.providers.HttpProvider(
-        "http://localhost:8545",
-        { keepAlive: false }
+      const provider = new Web3.providers.WebsocketProvider(
+        "ws://localhost:8545"
       );
       web3 = new Web3(provider);
       networkId = await web3.eth.net.getId();
@@ -84,9 +83,8 @@ describe("production", function () {
         reporter: new Reporter(logger)
       };
 
-      const provider = new Web3.providers.HttpProvider(
-        "http://localhost:8545",
-        { keepAlive: false }
+      const provider = new Web3.providers.WebsocketProvider(
+        "ws://localhost:8545"
       );
       web3 = new Web3(provider);
       networkId = await web3.eth.net.getId();

--- a/packages/truffle/test/scenarios/migrations/production.js
+++ b/packages/truffle/test/scenarios/migrations/production.js
@@ -33,7 +33,7 @@ describe("production", function () {
     });
 
     it("auto dry-runs and honors confirmations option", async function () {
-      this.timeout(70000);
+      this.timeout(100000);
 
       await CommandRunner.run("migrate --network ropsten", config);
       const output = logger.contents();

--- a/packages/truffle/test/scenarios/solidity_testing/solidityTests.js
+++ b/packages/truffle/test/scenarios/solidity_testing/solidityTests.js
@@ -77,7 +77,7 @@ describe("Solidity Tests", function () {
   });
 
   describe("compatibility", function () {
-    before(async () => {
+    before(async function () {
       await initSandbox("ImportEverything.sol");
     });
 

--- a/packages/truffle/test/scenarios/solidity_testing/solidityTests.js
+++ b/packages/truffle/test/scenarios/solidity_testing/solidityTests.js
@@ -44,7 +44,6 @@ describe("Solidity Tests", function () {
 
     it("runs the tests and has the correct balance", function () {
       this.timeout(100000);
-
       return CommandRunner.run("test", config)
         .then(() => {
           const output = logger.contents();
@@ -61,14 +60,8 @@ describe("Solidity Tests", function () {
       await initSandbox("TestFailures.sol");
     });
 
-<<<<<<< HEAD
     it("throws errors correctly", function () {
-      this.timeout(100000);
-=======
-    it("will throw errors correctly", function () {
       this.timeout(130000);
->>>>>>> 93ce70329 (up more test timeouts)
-
       return CommandRunner.run("test", config)
         .then(() => {
           assert(false, "The tests should have failed.");
@@ -86,14 +79,8 @@ describe("Solidity Tests", function () {
       await initSandbox("ImportEverything.sol");
     });
 
-<<<<<<< HEAD
     it("compiles with latest Solidity", function () {
-      this.timeout(100000);
-=======
-    it("compile with latest Solidity", function () {
       this.timeout(130000);
->>>>>>> 93ce70329 (up more test timeouts)
-
       return CommandRunner.run(
         "test",
         config.with({ solc: { version: "native" } })

--- a/packages/truffle/test/scenarios/solidity_testing/solidityTests.js
+++ b/packages/truffle/test/scenarios/solidity_testing/solidityTests.js
@@ -61,8 +61,13 @@ describe("Solidity Tests", function () {
       await initSandbox("TestFailures.sol");
     });
 
+<<<<<<< HEAD
     it("throws errors correctly", function () {
       this.timeout(100000);
+=======
+    it("will throw errors correctly", function () {
+      this.timeout(130000);
+>>>>>>> 93ce70329 (up more test timeouts)
 
       return CommandRunner.run("test", config)
         .then(() => {
@@ -81,8 +86,13 @@ describe("Solidity Tests", function () {
       await initSandbox("ImportEverything.sol");
     });
 
+<<<<<<< HEAD
     it("compiles with latest Solidity", function () {
       this.timeout(100000);
+=======
+    it("compile with latest Solidity", function () {
+      this.timeout(130000);
+>>>>>>> 93ce70329 (up more test timeouts)
 
       return CommandRunner.run(
         "test",

--- a/packages/truffle/test/scenarios/stacktracing/stacktrace.js
+++ b/packages/truffle/test/scenarios/stacktracing/stacktrace.js
@@ -62,7 +62,7 @@ describe("Stack tracing", function () {
   });
 
   it("runs tests and produces stacktraces", async function () {
-    this.timeout(70000);
+    this.timeout(100000);
     try {
       await CommandRunner.run("test --stacktrace", config);
       assert.fail("Test should have failed");

--- a/packages/truffle/test/scenarios/typescript_testing/typescriptTests.js
+++ b/packages/truffle/test/scenarios/typescript_testing/typescriptTests.js
@@ -28,7 +28,8 @@ describe("Typescript Tests", () => {
   });
 
   describe("testing contract behavior", () => {
-    it("will run .ts tests and have the correct behavior", async () => {
+    it("will run .ts tests and have the correct behavior", async function () {
+      this.timeout(100000);
       try {
         await CommandRunner.run("test test/metacoin.ts", config);
         const output = logger.contents();
@@ -38,9 +39,10 @@ describe("Typescript Tests", () => {
         console.log(`the logger contents are -- ${logger.contents()}`);
         assert.fail();
       }
-    }).timeout(70000);
+    });
 
-    it("will detect and run .sol, .ts, & .js test files", async () => {
+    it("detects and runs .sol, .ts, & .js test files", async function () {
+      this.timeout(100000);
       try {
         await CommandRunner.run("test", config);
         const output = logger.contents();
@@ -50,6 +52,6 @@ describe("Typescript Tests", () => {
         console.log(`the logger contents are -- ${logger.contents()}`);
         assert.fail();
       }
-    }).timeout(70000);
+    });
   });
-}).timeout(10000);
+});

--- a/packages/truffle/test/sources/contract_names/truffle-config.js
+++ b/packages/truffle/test/sources/contract_names/truffle-config.js
@@ -1,8 +1,7 @@
 module.exports = {
   networks: {
     development: {
-      host: "127.0.0.1",
-      port: 8545,
+      url: "ws://127.0.0.1:8545",
       network_id: "*",
       gas: 4700000,
       gasPrice: 20000000000

--- a/packages/truffle/test/sources/db_enabled/truffle-config.js
+++ b/packages/truffle/test/sources/db_enabled/truffle-config.js
@@ -1,8 +1,7 @@
 module.exports = {
   networks: {
     development: {
-      host: "127.0.0.1",
-      port: 8545,
+      url: "ws://127.0.0.1:8545",
       network_id: "*",
       gas: 4700000,
       gasPrice: 20000000000

--- a/packages/truffle/test/sources/develop/truffle-config.js
+++ b/packages/truffle/test/sources/develop/truffle-config.js
@@ -1,16 +1,13 @@
 module.exports = {
   networks: {
     local: {
-      host: "127.0.0.1",
-      port: 8545,
+      url: "ws://127.0.0.1:8545",
       network_id: "*",
       gas: 4700000,
       gasPrice: 20000000000
     }
   },
   console: {
-    require: [
-      { path: "./snippets/helper.js" }
-    ]
+    require: [{ path: "./snippets/helper.js" }]
   }
 };

--- a/packages/truffle/test/sources/exec/truffle-config.js
+++ b/packages/truffle/test/sources/exec/truffle-config.js
@@ -1,8 +1,7 @@
 module.exports = {
   networks: {
     development: {
-      host: "127.0.0.1",
-      port: 8545,
+      url: "ws://127.0.0.1:8545",
       network_id: "*",
       gas: 4700000,
       gasPrice: 20000000000

--- a/packages/truffle/test/sources/external_compile/truffle-config.js
+++ b/packages/truffle/test/sources/external_compile/truffle-config.js
@@ -26,8 +26,7 @@ module.exports = {
   },
   networks: {
     development: {
-      host: "127.0.0.1",
-      port: 8545,
+      url: "ws://127.0.0.1:8545",
       network_id: "*",
       gas: 4700000,
       gasPrice: 20000000000

--- a/packages/truffle/test/sources/install/init/truffle-config.js
+++ b/packages/truffle/test/sources/install/init/truffle-config.js
@@ -3,8 +3,7 @@ module.exports = {
   // to customize your Truffle configuration!
   networks: {
     development: {
-      host: "127.0.0.1",
-      port: 8545,
+      url: "ws://127.0.0.1:8545",
       network_id: "*",
       gas: 4700000,
       gasPrice: 20000000000

--- a/packages/truffle/test/sources/migrations/error/contracts/Loops.sol
+++ b/packages/truffle/test/sources/migrations/error/contracts/Loops.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.5.0;
 contract Loops {
   uint public id;
   constructor() public {
-    for(uint i = 0; i < 10000000; i++){
+    for(uint i = 0; i < 100000000; i++){
       id = i;
     }
   }

--- a/packages/truffle/test/sources/migrations/error/contracts/Loops.sol
+++ b/packages/truffle/test/sources/migrations/error/contracts/Loops.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.5.0;
 contract Loops {
   uint public id;
   constructor() public {
-    for(uint i = 0; i < 100000000; i++){
+    for(uint i = 0; i < 10000000000; i++){
       id = i;
     }
   }

--- a/packages/truffle/test/sources/migrations/error/contracts/Loops.sol
+++ b/packages/truffle/test/sources/migrations/error/contracts/Loops.sol
@@ -1,10 +1,9 @@
 pragma solidity ^0.5.0;
 
-
 contract Loops {
   uint public id;
   constructor() public {
-    for(uint i = 0; i < 10000000000; i++){
+    for (uint i = 0; i < 1000000; i++) {
       id = i;
     }
   }

--- a/packages/truffle/test/sources/migrations/error/migrations/4_migrations_oog.js
+++ b/packages/truffle/test/sources/migrations/error/migrations/4_migrations_oog.js
@@ -1,5 +1,8 @@
 const Loops = artifacts.require("Loops");
 
 module.exports = async function(deployer, network, accounts) {
-  await deployer.deploy(Loops);
+  // we set a gas limit to make it run out of gas
+  await deployer.deploy(Loops, {
+    gas: "0x146799"
+  });
 };

--- a/packages/truffle/test/sources/migrations/error/truffle-config.js
+++ b/packages/truffle/test/sources/migrations/error/truffle-config.js
@@ -1,8 +1,7 @@
 module.exports = {
   networks: {
     development: {
-      host: "127.0.0.1",
-      port: 8545,
+      url: "ws://127.0.0.1:8545",
       network_id: "*",
       gas: 4700000,
       gasPrice: 20000000000

--- a/packages/truffle/test/sources/migrations/init/truffle-config.js
+++ b/packages/truffle/test/sources/migrations/init/truffle-config.js
@@ -3,8 +3,7 @@ module.exports = {
   // to customize your Truffle configuration!
   networks: {
     development: {
-      host: "127.0.0.1",
-      port: 8545,
+      url: "ws://127.0.0.1:8545",
       network_id: "*",
       gas: 4700000,
       gasPrice: 20000000000

--- a/packages/truffle/test/sources/migrations/success/truffle-config.js
+++ b/packages/truffle/test/sources/migrations/success/truffle-config.js
@@ -3,8 +3,7 @@ module.exports = {
   // to customize your Truffle configuration!
   networks: {
     development: {
-      host: "127.0.0.1",
-      port: 8545,
+      url: "ws://127.0.0.1:8545",
       network_id: "*",
       gas: 4700000,
       gasPrice: 20000000000

--- a/packages/truffle/test/sources/migrations/unhandled-rejection/truffle-config.js
+++ b/packages/truffle/test/sources/migrations/unhandled-rejection/truffle-config.js
@@ -3,8 +3,7 @@ module.exports = {
   // to customize your Truffle configuration!
   networks: {
     development: {
-      host: "127.0.0.1",
-      port: 8545,
+      url: "ws://127.0.0.1:8545",
       network_id: "*",
       gas: 4700000,
       gasPrice: 20000000000

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -7,16 +7,17 @@ run_geth() {
 	docker run \
 		-v /$PWD/scripts:/scripts \
 		-d \
+		-p 8544:8544 \
 		-p 8545:8545 \
-		-p 8546:8546 \
 		-p 30303:30303 \
 		ethereum/client-go:stable \
 		--http \
 		--http.addr '0.0.0.0' \
-		--http.port 8545 \
+		--http.port 8544 \
 		--http.corsdomain '*' \
 		--ws \
 		--ws.addr '0.0.0.0' \
+		--ws.port 8545 \
 		--ws.origins '*' \
 		--nodiscover \
 		--dev \

--- a/scripts/geth.sh
+++ b/scripts/geth.sh
@@ -5,16 +5,17 @@ docker pull ethereum/client-go:stable
 docker run \
 	-v /$PWD/scripts:/scripts \
 	-i \
+	-p 8544:8544 \
 	-p 8545:8545 \
-	-p 8546:8546 \
 	-p 30303:30303 \
 	ethereum/client-go:stable \
 	--http \
 	--http.addr '0.0.0.0' \
-	--http.port 8545 \
+	--http.port 8544 \
 	--http.corsdomain '*' \
 	--ws \
 	--ws.addr '0.0.0.0' \
+	--ws.port 8545 \
 	--ws.origins '*' \
 	--nodiscover \
 	--dev \


### PR DESCRIPTION
This PR improves the performance of `truffle test` on the command line, and `test` within the console and develop REPL. The speed increase comes from bypassing the web3's polling mechanism, which kicks in after about 1sec. This added delay accumulates in an unpleasant user experience when there are many user tests.

Also note, this PR changes the instamine mode of `truffle develop` to  `strict` which is consistent with other truffle testing paths.

@davidmurdoch suggested configuring keep-alive and reconnect logic via options to web3, but I'm not sure if it's necessary in our use-cases here, and I still have to grok Web3's implementation and defaults. I propose this as follow-up work if we can gain a better developer experience now.

## Status

This PR is currently blocked by an issue with `@truffle/db`.