### PR TITLE
Bug fix: Account for Geth format in reason.js

### DIFF
--- a/packages/contract/lib/reason.js
+++ b/packages/contract/lib/reason.js
@@ -38,9 +38,7 @@ const reason = {
         // NOTE this only works for a single failed transaction at a time.
         const hash = Object.keys(data)[0];
         const errorDetails = data[hash];
-        resData =
-          errorDetails.result /* ganache 3.0 */ ||
-          errorDetails.return /* ganache 2.0 */;
+        resData = errorDetails.return /* ganache 2.0 */;
       }
 
       if (resData && resData.includes(errorStringHash)) {

--- a/packages/contract/lib/reason.js
+++ b/packages/contract/lib/reason.js
@@ -10,7 +10,7 @@ const reason = {
    * @param  {InterfaceAdapter}      interfaceAdapter a new helpful friend
    * @return {String|Undefined}      decoded reason string
    */
-  _extract: function(res, web3, _interfaceAdapter) {
+  _extract: function (res, web3, _interfaceAdapter) {
     //I'm not sure why interfaceAdapter is here if it's not used,
     //so I just put an underscore in front of its name for now...
     if (!res || (!res.error && !res.result)) return;
@@ -28,8 +28,10 @@ const reason = {
       // be updated to respect (instead of computing here)
       const data = res.error.data;
       let resData;
-      if ("result" in data) {
-        // there is a single result (only in ganache 3.0+)
+      if (typeof data === "string") {
+        resData = data; // geth, Ganache >7.0.0
+      } else if ("result" in data) {
+        // there is a single result (Ganache 7.0.0)
         resData = data.result;
       } else {
         // handle `evm_mine`, `miner_start`, batch payloads, and ganache 2.0
@@ -37,16 +39,13 @@ const reason = {
         const hash = Object.keys(data)[0];
         const errorDetails = data[hash];
         resData =
-          errorDetails.result /* ganache 3.0 */
-          || errorDetails.return /* ganache 2.0 */;
+          errorDetails.result /* ganache 3.0 */ ||
+          errorDetails.return /* ganache 2.0 */;
       }
 
       if (resData && resData.includes(errorStringHash)) {
         try {
-          return web3.eth.abi.decodeParameter(
-            "string",
-            resData.slice(10)
-          );
+          return web3.eth.abi.decodeParameter("string", resData.slice(10));
         } catch (_) {
           return undefined;
         }
@@ -66,7 +65,7 @@ const reason = {
    * @param  {Object} interfaceAdapter
    * @return {String|Undefined}
    */
-  get: function(params, web3, interfaceAdapter) {
+  get: function (params, web3, interfaceAdapter) {
     const packet = {
       jsonrpc: "2.0",
       method: "eth_call",


### PR DESCRIPTION
Added a case for `data` being a string directly, which @davidmurdoch says is how Geth does it, and how Ganache will do it starting in 7.0.1.

@davidmurdoch, can you confirm that I've got this correct?

~~(Also, is the current way `return` or `result`?  You said `return`, but our current code is `result` and it seems to pass tests...)~~

Edit: @davidmurdoch confirms it is indeed `result`.