### PR TITLE
Update the README.md

### DIFF
--- a/packages/contract/README.md
+++ b/packages/contract/README.md
@@ -318,7 +318,7 @@ instance.getValue().then(function(val) {
 
 #### Processing transaction results
 
-When you make a transaction, you're given a `result` object that gives you a wealth of information about the transaction. You're given the transaction has (`result.tx`), the decoded events (also known as logs; `result.logs`), and a transaction receipt (`result.receipt`). In the below example, you'll recieve the `ValueSet()` event because you triggered the event using the `setValue()` function:
+When you make a transaction, you're given a `result` object that gives you a wealth of information about the transaction. You're given the transaction hash (`result.tx`), the decoded events (also known as logs; `result.logs`), and a transaction receipt (`result.receipt`). In the below example, you'll recieve the `ValueSet()` event because you triggered the event using the `setValue()` function:
 
 ```javascript
 instance.setValue(5).then(function(result) {


### PR DESCRIPTION
The sentence wasn't making much sense " You're given the transaction has (`result.tx`)". replace 'has' with 'hash'.