### PR TITLE
Bug fix: Fix incorrect typing on fetchAndCompile return value

### DIFF
--- a/packages/fetch-and-compile/lib/fetch.ts
+++ b/packages/fetch-and-compile/lib/fetch.ts
@@ -11,7 +11,7 @@ import {
 import type Config from "@truffle/config";
 const { Compile } = require("@truffle/compile-solidity"); //sorry for untyped import!
 import type { Recognizer, FailureType } from "./types";
-import type { WorkflowCompileResult } from "@truffle/compile-common";
+import type { CompilerResult } from "@truffle/compile-common";
 
 export async function fetchAndCompileForRecognizer(
   recognizer: Recognizer,
@@ -122,7 +122,7 @@ async function tryFetchAndCompileAddress(
     //if using docker, transform it (this does nothing if not using docker)
     externalConfig = transformIfUsingDocker(externalConfig, config);
     //compile the sources
-    let compileResult: WorkflowCompileResult;
+    let compileResult: CompilerResult;
     try {
       compileResult = await Compile.sources({
         options: externalConfig.with({ quiet: true }),

--- a/packages/fetch-and-compile/lib/recognizer.ts
+++ b/packages/fetch-and-compile/lib/recognizer.ts
@@ -1,14 +1,14 @@
 import debugModule from "debug";
 const debug = debugModule("fetch-and-compile:recognizer");
 import type { Recognizer, FailureType, FetchAndCompileResult } from "./types";
-import type { WorkflowCompileResult } from "@truffle/compile-common";
+import type { CompilerResult } from "@truffle/compile-common";
 import type { SourceInfo } from "@truffle/source-fetcher";
 
 export class SingleRecognizer implements Recognizer {
   private address: string;
   private recognized: boolean = false;
   private fetchedVia: string;
-  private compileResult: WorkflowCompileResult;
+  private compileResult: CompilerResult;
   private sourceInfo: SourceInfo;
 
   constructor(address: string) {

--- a/packages/fetch-and-compile/lib/types.ts
+++ b/packages/fetch-and-compile/lib/types.ts
@@ -1,10 +1,10 @@
-import type { WorkflowCompileResult } from "@truffle/compile-common";
+import type { CompilerResult } from "@truffle/compile-common";
 import type { SourceInfo } from "@truffle/source-fetcher";
 
 export type FailureType = "fetch" | "compile" | "language";
 
 export interface FetchAndCompileResult {
-  compileResult: WorkflowCompileResult;
+  compileResult: CompilerResult;
   sourceInfo: SourceInfo;
   fetchedVia: string;
 }


### PR DESCRIPTION
It seems I was using the incorrect type here; `compile-solidity` (and `compile-vyper`, etc) return a `CompilerResult`, not a `WorkflowCompileResult` (only `workflow-compile` returns the latter).  This PR corrects that.