### PR TITLE
Remove sources from workflow-compile return to match TS type

### DIFF
--- a/packages/workflow-compile/index.js
+++ b/packages/workflow-compile/index.js
@@ -10,7 +10,6 @@ const SUPPORTED_COMPILERS = {
   external: require("@truffle/external-compile").Compile
 };
 
-
 async function compile(config) {
   // determine compiler(s) to use
   //
@@ -51,12 +50,8 @@ async function compile(config) {
     return a.concat(compilation.contracts);
   }, []);
 
-  const sources = compilations.reduce((a, compilation) => {
-    return a.concat(compilation.sources);
-  }, []);
-
   // return WorkflowCompileResult
-  return { contracts, sources, compilations };
+  return { contracts, compilations };
 }
 
 const WorkflowCompile = {
@@ -65,7 +60,7 @@ const WorkflowCompile = {
 
     if (config.events) config.events.emit("compile:start");
 
-    const { contracts, sources, compilations } = await compile(config);
+    const { contracts, compilations } = await compile(config);
 
     const compilers = compilations
       .reduce((a, compilation) => {
@@ -90,27 +85,22 @@ const WorkflowCompile = {
 
     return {
       contracts,
-      sources,
       compilations
     };
   },
 
   async compileAndSave(options) {
-    const { contracts, sources, compilations } = await this.compile(options);
+    const { contracts, compilations } = await this.compile(options);
 
-    return await this.save(options, { contracts, sources, compilations });
+    return await this.save(options, { contracts, compilations });
   },
 
-  async save(options, { contracts, sources, compilations }) {
+  async save(options, { contracts, compilations }) {
     const config = prepareConfig(options);
 
     await fse.ensureDir(config.contracts_build_directory);
 
-    if (
-      options.db &&
-      options.db.enabled === true &&
-      contracts.length > 0
-    ) {
+    if (options.db && options.db.enabled === true && contracts.length > 0) {
       // currently if Truffle Db fails to load, getTruffleDb returns `null`
       const Db = getTruffleDb();
 
@@ -124,7 +114,7 @@ const WorkflowCompile = {
           }
         });
         ({ contracts, compilations } = await project.loadCompile({
-          result: { contracts, sources, compilations }
+          result: { contracts, compilations }
         }));
       }
     }
@@ -132,7 +122,7 @@ const WorkflowCompile = {
     const artifacts = contracts.map(Shims.NewToLegacy.forContract);
     await config.artifactor.saveAll(artifacts);
 
-    return { contracts, sources, compilations };
+    return { contracts, compilations };
   },
 
   async assignNames(options, { contracts }) {

--- a/packages/workflow-compile/test/index.js
+++ b/packages/workflow-compile/test/index.js
@@ -1,7 +1,7 @@
 const Contracts = require("../");
 const assert = require("assert");
-const {existsSync, removeSync} = require("fs-extra");
-const {join} = require("path");
+const { existsSync, removeSync } = require("fs-extra");
+const { join } = require("path");
 
 let config;
 
@@ -37,7 +37,7 @@ describe("Contracts.compile", () => {
   describe("when config.all is true", () => {
     it("recompiles all contracts in contracts_directory", async () => {
       // initial compile
-      const {contracts} = await Contracts.compileAndSave(config);
+      const { contracts } = await Contracts.compileAndSave(config);
 
       let contractName = contracts[0].contractName;
       assert(
@@ -46,7 +46,7 @@ describe("Contracts.compile", () => {
 
       // compile again
       config.all = true;
-      const {compilations} = await Contracts.compileAndSave(config);
+      const { compilations } = await Contracts.compileAndSave(config);
 
       assert(
         compilations[0].sourceIndexes[0] ===
@@ -55,13 +55,5 @@ describe("Contracts.compile", () => {
           )
       );
     }).timeout(4000);
-
-    it("provides an array of sources in compilation result", async () => {
-      config.all = true;
-      const {sources} = await Contracts.compileAndSave(config);
-
-      assert(sources.length === 1);
-      assert(existsSync(sources[0].sourcePath));
-    });
   });
 });


### PR DESCRIPTION
**Breaking change to `@truffle/workflow-compile`.**  Per discussion with @gnidan.  The workflow-compile package was returning this, but it's not actually on the type, and nothing uses it (lots of stuff uses the sources info attached to the individual compilations, but not to the reduced form that was being attached to the whole thing).

Doing this as step one of fixing a more pervasive typing issue where `CompilerResult` and `WorkflowCompileResult` are being conflated in various places; before we deal with the rest of that, Nick thought it made sense to correct the actual output of workflow-compile first.