### PR TITLE
Have individual compile packages return WorkflowCompileResult (instead of CompilerResult)

### DIFF
--- a/packages/abi-utils/tsconfig.json
+++ b/packages/abi-utils/tsconfig.json
@@ -6,7 +6,7 @@
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "es6",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
-    "lib": ["es2017"],                             /* Specify library files to be included in the compilation. */
+    "lib": ["es2019"],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */

--- a/packages/artifactor/tsconfig.json
+++ b/packages/artifactor/tsconfig.json
@@ -9,7 +9,7 @@
     "sourceMap": true,
     "outDir": "dist",
     "baseUrl": ".",
-    "lib": ["es2017"],
+    "lib": ["es2019"],
     "paths": {
       "web3": [
         "../../node_modules/@types/web3/index",

--- a/packages/blockchain-utils/tsconfig.json
+++ b/packages/blockchain-utils/tsconfig.json
@@ -9,7 +9,7 @@
     "sourceMap": true,
     "outDir": "dist",
     "baseUrl": ".",
-    "lib": ["es2017"],
+    "lib": ["es2019"],
     "paths": {
       "web3": [
         "../../node_modules/@types/web3/index",

--- a/packages/box/tsconfig.json
+++ b/packages/box/tsconfig.json
@@ -9,7 +9,7 @@
     "sourceMap": true,
     "outDir": "dist",
     "baseUrl": ".",
-    "lib": ["es2017"],
+    "lib": ["es2019"],
     "paths": {
       "web3": [
         "../../node_modules/@types/web3/index",

--- a/packages/code-utils/tsconfig.json
+++ b/packages/code-utils/tsconfig.json
@@ -9,7 +9,7 @@
     "sourceMap": true,
     "outDir": "dist",
     "baseUrl": ".",
-    "lib": ["es2017"],
+    "lib": ["es2019"],
     "paths": {
       "web3": [
         "../../node_modules/@types/web3/index",

--- a/packages/codec/tsconfig.json
+++ b/packages/codec/tsconfig.json
@@ -10,7 +10,7 @@
     "sourceMap": true,
     "outDir": "dist",
     "baseUrl": ".",
-    "lib": ["es2017"],
+    "lib": ["es2019"],
     "paths": {
       "@truffle/codec": ["./lib"],
       "@truffle/codec/*": ["./lib/*"]

--- a/packages/compile-common/src/compilations.ts
+++ b/packages/compile-common/src/compilations.ts
@@ -1,0 +1,9 @@
+import type { CompilerResult, WorkflowCompileResult } from "./types";
+
+export function promoteCompileResult(
+  result: CompilerResult
+): WorkflowCompileResult {
+  const { compilations } = result;
+  const contracts = compilations.flatMap(compilation => compilation.contracts);
+  return { compilations, contracts };
+}

--- a/packages/compile-common/src/compilations.ts
+++ b/packages/compile-common/src/compilations.ts
@@ -7,3 +7,7 @@ export function promoteCompileResult(
   const contracts = compilations.flatMap(compilation => compilation.contracts);
   return { compilations, contracts };
 }
+
+export function emptyWorkflowCompileResult(): WorkflowCompileResult {
+  return { compilations: [], contracts: [] };
+}

--- a/packages/compile-common/src/index.ts
+++ b/packages/compile-common/src/index.ts
@@ -1,4 +1,5 @@
 export * as Shims from "./shims";
 export * as Sources from "./sources";
 export * as Errors from "./errors";
+export * as Compilations from "./compilations";
 export * from "./types";

--- a/packages/compile-common/tsconfig.json
+++ b/packages/compile-common/tsconfig.json
@@ -9,7 +9,7 @@
     "sourceMap": true,
     "outDir": "dist",
     "baseUrl": ".",
-    "lib": ["es2017"],
+    "lib": ["es2019"],
     "paths": {
     },
     "rootDir": ".",

--- a/packages/compile-solidity/src/index.js
+++ b/packages/compile-solidity/src/index.js
@@ -157,7 +157,7 @@ const Compile = {
       fileName.endsWith(".sol")
     );
     if (solidityTargets.length === 0 && yulPaths.length === 0) {
-      return { compilations: [], contracts: [] };
+      return Compilations.emptyWorkflowCompileResult();
     }
 
     reportSources({ paths: [...compilationTargets, ...yulPaths], options });

--- a/packages/compile-solidity/src/index.js
+++ b/packages/compile-solidity/src/index.js
@@ -7,6 +7,7 @@ const { run } = require("./run");
 const { normalizeOptions } = require("./normalizeOptions");
 const { compileWithPragmaAnalysis } = require("./compileWithPragmaAnalysis");
 const { reportSources } = require("./reportSources");
+const { Compilations } = require("@truffle/compile-common");
 const expect = require("@truffle/expect");
 const partition = require("lodash.partition");
 const fs = require("fs-extra");
@@ -20,14 +21,11 @@ async function compileYulPaths(yulPaths, options) {
     //for simplicity, since there are no imports to worry about)
     const yulSource = fs.readFileSync(path, { encoding: "utf8" });
     debug("Compiling Yul");
-    const compilation = await run(
-      { [path]: yulSource },
-      yulOptions,
-      { language: "Yul" }
-    );
+    const compilation = await run({ [path]: yulSource }, yulOptions, {
+      language: "Yul"
+    });
     debug("Yul compiled successfully");
 
-    // returns CompilerResult - see @truffle/compile-common
     if (compilation.contracts.length > 0) {
       yulCompilations.push(compilation);
     }
@@ -61,11 +59,9 @@ const Compile = {
     let yulCompilations = [];
     if (solidityNames.length > 0) {
       debug("Compiling Solidity (specified sources)");
-      const compilation = await run(
-        soliditySources,
-        options,
-        { noTransform: true }
-      );
+      const compilation = await run(soliditySources, options, {
+        noTransform: true
+      });
       debug("Compiled Solidity");
       if (compilation.contracts.length > 0) {
         solidityCompilations = [compilation];
@@ -73,15 +69,15 @@ const Compile = {
     }
     for (const name of yulNames) {
       debug("Compiling Yul (specified sources)");
-      const compilation = await run(
-        { [name]: sources[name] },
-        options,
-        { language: "Yul", noTransform: true },
-      );
+      const compilation = await run({ [name]: sources[name] }, options, {
+        language: "Yul",
+        noTransform: true
+      });
       debug("Compiled Yul");
       yulCompilations.push(compilation);
     }
-    return { compilations: [...solidityCompilations, ...yulCompilations] };
+    const compilations = [...solidityCompilations, ...yulCompilations];
+    return Compilations.promoteCompileResult({ compilations });
   },
 
   async all(options) {
@@ -161,7 +157,7 @@ const Compile = {
       fileName.endsWith(".sol")
     );
     if (solidityTargets.length === 0 && yulPaths.length === 0) {
-      return { compilations: [] };
+      return { compilations: [], contracts: [] };
     }
 
     reportSources({ paths: [...compilationTargets, ...yulPaths], options });
@@ -174,7 +170,6 @@ const Compile = {
       const compilation = await run(allSources, solidityOptions, { solc });
       debug("Solidity compiled successfully");
 
-      // returns CompilerResult - see @truffle/compile-common
       if (compilation.contracts.length > 0) {
         solidityCompilations = [compilation];
       }
@@ -182,9 +177,8 @@ const Compile = {
 
     const yulCompilations = await compileYulPaths(yulPaths, options);
 
-    return {
-      compilations: [...solidityCompilations, ...yulCompilations]
-    };
+    const compilations = [...solidityCompilations, ...yulCompilations];
+    return Compilations.promoteCompileResult({ compilations });
   },
 
   async sourcesWithPragmaAnalysis({ paths, options }) {

--- a/packages/compile-vyper/index.js
+++ b/packages/compile-vyper/index.js
@@ -10,6 +10,7 @@ const findContracts = require("@truffle/contract-sources");
 const Config = require("@truffle/config");
 const { Profiler } = require("@truffle/profiler");
 const { requiredSources } = require("./profiler");
+const { Compilations } = require("@truffle/compile-common");
 
 const { compileJson } = require("./vyper-json");
 
@@ -201,7 +202,7 @@ async function compileNoJson({ paths: sources, options, version }) {
   });
   const compilations = await Promise.all(promises);
 
-  return { compilations };
+  return Compilations.promoteCompileResult({ compilations });
 }
 
 const Compile = {
@@ -216,7 +217,7 @@ const Compile = {
     // no vyper files found, no need to check vyper
     // (note that JSON-only will not activate vyper)
     if (vyperFiles.length === 0) {
-      return { compilations: [] };
+      return { compilations: [], contracts: [] };
     }
 
     Compile.display(vyperFiles, options);
@@ -242,7 +243,7 @@ const Compile = {
 
     // no vyper targets found, no need to check Vyper
     if (vyperFilesStrict.length === 0) {
-      return { compilations: [] };
+      return { compilations: [], contracts: [] };
     }
 
     const { allSources, compilationTargets } = await requiredSources(
@@ -267,7 +268,7 @@ const Compile = {
 
     // no vyper targets found, no need to activate Vyper
     if (vyperTargets.length === 0) {
-      return { compilations: [] };
+      return { compilations: [], contracts: [] };
     }
 
     //having gotten the sources from the resolver, we invoke compileJson
@@ -308,7 +309,7 @@ const Compile = {
     );
     // no vyper targets found, no need to check Vyper
     if (vyperFilesStrict.length === 0) {
-      return { compilations: [] };
+      return { compilations: [], contracts: [] };
     }
 
     return await Compile.sourcesWithDependencies({
@@ -328,7 +329,7 @@ const Compile = {
     const profiler = await new Profiler({});
     const updated = await profiler.updated(options);
     if (updated.length === 0) {
-      return { compilations: [] };
+      return { compilations: [], contracts: [] };
     }
     return await Compile.sourcesWithDependencies({
       paths: updated,

--- a/packages/compile-vyper/index.js
+++ b/packages/compile-vyper/index.js
@@ -217,7 +217,7 @@ const Compile = {
     // no vyper files found, no need to check vyper
     // (note that JSON-only will not activate vyper)
     if (vyperFiles.length === 0) {
-      return { compilations: [], contracts: [] };
+      return Compilations.emptyWorkflowCompileResult();
     }
 
     Compile.display(vyperFiles, options);
@@ -243,7 +243,7 @@ const Compile = {
 
     // no vyper targets found, no need to check Vyper
     if (vyperFilesStrict.length === 0) {
-      return { compilations: [], contracts: [] };
+      return Compilations.emptyWorkflowCompileResult();
     }
 
     const { allSources, compilationTargets } = await requiredSources(
@@ -268,7 +268,7 @@ const Compile = {
 
     // no vyper targets found, no need to activate Vyper
     if (vyperTargets.length === 0) {
-      return { compilations: [], contracts: [] };
+      return Compilations.emptyWorkflowCompileResult();
     }
 
     //having gotten the sources from the resolver, we invoke compileJson
@@ -309,7 +309,7 @@ const Compile = {
     );
     // no vyper targets found, no need to check Vyper
     if (vyperFilesStrict.length === 0) {
-      return { compilations: [], contracts: [] };
+      return Compilations.emptyWorkflowCompileResult();
     }
 
     return await Compile.sourcesWithDependencies({
@@ -329,7 +329,7 @@ const Compile = {
     const profiler = await new Profiler({});
     const updated = await profiler.updated(options);
     if (updated.length === 0) {
-      return { compilations: [], contracts: [] };
+      return Compilations.emptyWorkflowCompileResult();
     }
     return await Compile.sourcesWithDependencies({
       paths: updated,

--- a/packages/compile-vyper/vyper-json.js
+++ b/packages/compile-vyper/vyper-json.js
@@ -16,15 +16,12 @@ function compileJson({ sources: rawSources, options, version, command }) {
   //the contracts directory is the root directory.  note this means that
   //if an imported source from somewhere other than FS uses an absolute
   //import to refer to its own project root, it won't work.  But, oh well.
-  const {
-    sources,
-    targets,
-    originalSourcePaths
-  } = Common.Sources.collectSources(
-    rawSources,
-    options.compilationTargets,
-    options.contracts_directory
-  );
+  const { sources, targets, originalSourcePaths } =
+    Common.Sources.collectSources(
+      rawSources,
+      options.compilationTargets,
+      options.contracts_directory
+    );
 
   //Vyper complains if we give it a source that is not also a target,
   //*unless* we give it as an interface.  So we have to split that out.
@@ -32,8 +29,8 @@ function compileJson({ sources: rawSources, options, version, command }) {
   const [properSourcePaths, interfacePaths] = partition(
     Object.keys(sources),
     targets.length > 0
-      ? sourcePath => !sourcePath.endsWith(".json") &&
-        targets.includes(sourcePath)
+      ? sourcePath =>
+          !sourcePath.endsWith(".json") && targets.includes(sourcePath)
       : sourcePath => !sourcePath.endsWith(".json")
   );
 
@@ -104,7 +101,9 @@ function compileJson({ sources: rawSources, options, version, command }) {
     compiler
   };
 
-  return { compilations: [compilation] };
+  return Common.Compilations.promoteCompileResult({
+    compilations: [compilation]
+  });
 }
 
 function invokeCompiler({ compilerInput, command }) {
@@ -120,12 +119,7 @@ function execVyperJson(inputString, command) {
   });
 }
 
-function prepareCompilerInput({
-  sources,
-  settings,
-  interfaces,
-  version
-}) {
+function prepareCompilerInput({ sources, settings, interfaces, version }) {
   const outputSelection = prepareOutputSelection({ version });
   return {
     language: "Vyper",
@@ -153,7 +147,7 @@ function prepareInterfaces({ interfaces }) {
       sourcePath.endsWith(".json") //for JSON we need the ABI *object*, not JSON!
         ? { [sourcePath]: { abi: JSON.parse(content) } }
         : { [sourcePath]: { content } }
-     )
+    )
     .reduce((a, b) => Object.assign({}, a, b), {});
 }
 

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -10,7 +10,7 @@
     "strict": true,
     "outDir": "dist",
     "baseUrl": ".",
-    "lib": ["es2017", "dom"],
+    "lib": ["es2019", "dom"],
     "rootDir": "./src",
     "typeRoots": [
       "./typings",

--- a/packages/db-loader/tsconfig.json
+++ b/packages/db-loader/tsconfig.json
@@ -8,7 +8,7 @@
     "moduleResolution": "node",
     "sourceMap": true,
     "outDir": "dist",
-    "lib": ["es2017"],
+    "lib": ["es2019"],
     "paths": {},
     "types": ["node"],
   },

--- a/packages/decoder/tsconfig.json
+++ b/packages/decoder/tsconfig.json
@@ -10,7 +10,7 @@
     "sourceMap": true,
     "outDir": "dist",
     "baseUrl": ".",
-    "lib": ["es2017"],
+    "lib": ["es2019"],
     "paths": {
       "web3": ["../../node_modules/@types/web3/index", "node_modules/web3/index"],
       "web3/types": ["../../node_modules/@types/web3/types", "node_modules/web3/types"],

--- a/packages/external-compile/index.js
+++ b/packages/external-compile/index.js
@@ -9,7 +9,7 @@ const fs = require("fs");
 const expect = require("@truffle/expect");
 const Schema = require("@truffle/contract-schema");
 const web3Utils = require("web3-utils");
-const { Shims } = require("@truffle/compile-common");
+const { Shims, Compilations } = require("@truffle/compile-common");
 const Config = require("@truffle/config");
 
 const DEFAULT_ABI = [
@@ -283,23 +283,22 @@ const Compile = {
     await runCommand(command, { cwd, logger });
 
     const contracts = await processTargets(targets, cwd, logger);
-    return {
-      compilations: [
-        {
-          contracts: contracts.map(Shims.LegacyToNew.forContract),
-          // sourceIndexes is empty because we have no way of
-          // knowing for certain the source paths for the contracts
-          sourceIndexes: [],
-          // since we don't know the sourcePaths, we can't really provide
-          // the source info reliably
-          sources: [],
-          compiler: {
-            name: "external",
-            version: undefined
-          }
+    const compilations = [
+      {
+        contracts: contracts.map(Shims.LegacyToNew.forContract),
+        // sourceIndexes is empty because we have no way of
+        // knowing for certain the source paths for the contracts
+        sourceIndexes: [],
+        // since we don't know the sourcePaths, we can't really provide
+        // the source info reliably
+        sources: [],
+        compiler: {
+          name: "external",
+          version: undefined
         }
-      ]
-    };
+      }
+    ];
+    return Compilations.promoteCompileResult({ compilations });
   },
 
   async sourcesWithDependencies({ options }) {

--- a/packages/fetch-and-compile/tsconfig.json
+++ b/packages/fetch-and-compile/tsconfig.json
@@ -12,7 +12,7 @@
     "sourceMap": true,
     "outDir": "dist",
     "baseUrl": ".",
-    "lib": ["es2017"],
+    "lib": ["es2019"],
     "paths": {
     },
     "rootDir": "lib",

--- a/packages/hdwallet-provider/tsconfig.json
+++ b/packages/hdwallet-provider/tsconfig.json
@@ -8,7 +8,7 @@
     "esModuleInterop": true,
     "strict": true,
     "lib": [
-      "es2017"
+      "es2019"
     ],
     "outDir": "dist",
     "baseUrl": ".",

--- a/packages/interface-adapter/tsconfig.json
+++ b/packages/interface-adapter/tsconfig.json
@@ -9,7 +9,7 @@
     "sourceMap": true,
     "outDir": "dist",
     "baseUrl": ".",
-    "lib": ["es2017"],
+    "lib": ["es2019"],
     "paths": {
       "web3": [
         "../../node_modules/@types/web3/index",

--- a/packages/plugins/tsconfig.json
+++ b/packages/plugins/tsconfig.json
@@ -9,7 +9,7 @@
     "sourceMap": true,
     "outDir": "dist",
     "baseUrl": ".",
-    "lib": ["es2017"],
+    "lib": ["es2019"],
     "paths": {
     },
     "rootDir": ".",

--- a/packages/preserve-fs/tsconfig.json
+++ b/packages/preserve-fs/tsconfig.json
@@ -9,7 +9,7 @@
     "sourceMap": true,
     "outDir": "dist",
     "baseUrl": ".",
-    "lib": ["es2017", "dom"],
+    "lib": ["es2019", "dom"],
     "paths": {
     },
     "rootDir": ".",

--- a/packages/preserve-to-buckets/tsconfig.json
+++ b/packages/preserve-to-buckets/tsconfig.json
@@ -10,7 +10,7 @@
     "sourceMap": true,
     "outDir": "dist",
     "baseUrl": ".",
-    "lib": ["es2017", "dom"],
+    "lib": ["es2019", "dom"],
     "skipLibCheck": true,
     "paths": {
     },

--- a/packages/preserve-to-filecoin/tsconfig.json
+++ b/packages/preserve-to-filecoin/tsconfig.json
@@ -9,7 +9,7 @@
     "sourceMap": true,
     "outDir": "dist",
     "baseUrl": ".",
-    "lib": ["es2017", "dom"],
+    "lib": ["es2019", "dom"],
     "skipLibCheck": true,
     "paths": {
     },

--- a/packages/preserve-to-ipfs/tsconfig.json
+++ b/packages/preserve-to-ipfs/tsconfig.json
@@ -10,7 +10,7 @@
     "sourceMap": true,
     "outDir": "dist",
     "baseUrl": ".",
-    "lib": ["es2017", "dom"],
+    "lib": ["es2019", "dom"],
     "skipLibCheck": true,
     "paths": {
     },

--- a/packages/preserve/tsconfig.json
+++ b/packages/preserve/tsconfig.json
@@ -10,7 +10,7 @@
     "sourceMap": true,
     "outDir": "dist",
     "baseUrl": ".",
-    "lib": ["es2017"],
+    "lib": ["es2019"],
     "paths": {
     },
     "rootDir": ".",

--- a/packages/profiler/tsconfig.json
+++ b/packages/profiler/tsconfig.json
@@ -9,7 +9,7 @@
     "sourceMap": true,
     "outDir": "dist",
     "baseUrl": ".",
-    "lib": ["es2017"],
+    "lib": ["es2019"],
     "paths": {
     },
     "rootDir": ".",

--- a/packages/resolver/tsconfig.json
+++ b/packages/resolver/tsconfig.json
@@ -9,7 +9,7 @@
     "sourceMap": true,
     "outDir": "dist",
     "baseUrl": ".",
-    "lib": ["es2017"],
+    "lib": ["es2019"],
     "paths": {
     },
     "rootDir": ".",

--- a/packages/source-fetcher/tsconfig.json
+++ b/packages/source-fetcher/tsconfig.json
@@ -10,7 +10,7 @@
     "sourceMap": true,
     "outDir": "dist",
     "baseUrl": ".",
-    "lib": ["es2017"],
+    "lib": ["es2019"],
     "paths": {
     },
     "rootDir": "lib",

--- a/packages/workflow-compile/index.js
+++ b/packages/workflow-compile/index.js
@@ -46,9 +46,10 @@ async function compile(config) {
     return a;
   }, []);
 
-  const contracts = compilations.reduce((a, compilation) => {
-    return a.concat(compilation.contracts);
-  }, []);
+  // collect together contracts as well as compilations
+  const contracts = rawCompilations.flatMap(
+    compilerResult => compilerResult.contracts
+  );
 
   // return WorkflowCompileResult
   return { contracts, compilations };


### PR DESCRIPTION
Follow-on to #4650.  This makes it so that `compile-solidity`, `compile-vyper`, and `external-compile` all return a `WorkflowCompileResult`, instead of just a `CompilerResult`.  To do this, the logic for attaching `contracts` was moved from `workflow-compile` to `compile-common` and put in a new function called `promoteCompileResult`.  (Maybe not the best name, but feel free to suggest a better one.)  Of course, `workflow-compile` as a result got logic for concatenating the `contracts`.

Also, I wanted to use `flatMap`, but TS complained because the lib setting was on es2017.  So I updated it to es2019 (in all packages that were on es2017); we no longer support Node 10 so anything from es2019 is fair game.  (@gnidan, you think I should update `target` as well? :) )