### PR TITLE
Internal improvement: Remove lodash.flatten dependency

### DIFF
--- a/packages/debugger/lib/solidity/reducers.js
+++ b/packages/debugger/lib/solidity/reducers.js
@@ -4,7 +4,6 @@ const debug = debugModule("debugger:solidity:reducers");
 import { combineReducers } from "redux";
 
 import * as actions from "./actions";
-import flatten from "lodash.flatten";
 
 const DEFAULT_SOURCES = {
   byCompilationId: {}, //user sources
@@ -57,11 +56,10 @@ function sources(state = DEFAULT_SOURCES, action) {
           ...state.byId,
           ...Object.assign(
             {},
-            ...flatten(
-              Object.values(action.sources.user).concat(
-                Object.values(action.sources.internal)
-              )
-            ).map(source => (source ? { [source.id]: source } : {}))
+            ...Object.values(action.sources.user)
+              .concat(Object.values(action.sources.internal))
+              .flat()
+              .map(source => (source ? { [source.id]: source } : {}))
           )
         }
       };

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -30,7 +30,6 @@
     "debug": "^4.3.1",
     "json-pointer": "^0.6.1",
     "json-stable-stringify": "^1.0.1",
-    "lodash.flatten": "^4.4.0",
     "lodash.merge": "^4.6.2",
     "lodash.sum": "^4.0.2",
     "lodash.zipwith": "^4.2.0",

--- a/packages/debugger/test/helpers.js
+++ b/packages/debugger/test/helpers.js
@@ -10,7 +10,6 @@ import Migrate from "@truffle/migrate";
 import Box from "@truffle/box";
 import Resolver from "@truffle/resolver";
 import * as Codec from "@truffle/codec";
-import flatten from "lodash.flatten";
 
 export async function prepareContracts(provider, sources = {}, migrations) {
   let config = await createSandbox();
@@ -129,10 +128,8 @@ export async function compile(config) {
       quiet: true
     })
   );
-  const contractNames = flatten(
-    compilations.map(compilation =>
-      compilation.contracts.map(contract => contract.contractName)
-    )
+  const contractNames = compilations.flatMap(compilation =>
+    compilation.contracts.map(contract => contract.contractName)
   );
   return { compilations, contractNames };
 }

--- a/packages/decoder/package.json
+++ b/packages/decoder/package.json
@@ -46,7 +46,6 @@
     "chai": "^4.2.0",
     "ganache": "7.0.0",
     "lodash.clonedeep": "^4.5.0",
-    "lodash.flatten": "^4.4.0",
     "mocha": "8.1.2",
     "tmp": "^0.2.1",
     "typescript": "^4.1.4",

--- a/packages/decoder/test/helpers.js
+++ b/packages/decoder/test/helpers.js
@@ -6,7 +6,6 @@ const Migrate = require("@truffle/migrate");
 const Codec = require("@truffle/codec");
 const Config = require("@truffle/config");
 const { Environment } = require("@truffle/environment");
-const flatten = require("lodash.flatten");
 const tmp = require("tmp");
 tmp.setGracefulCleanup();
 
@@ -51,9 +50,8 @@ async function prepareContracts(provider, projectDir) {
     abstractions[name] = config.resolver.require(name);
   }
 
-  const compilations = Codec.Compilations.Utils.shimCompilations(
-    rawCompilations
-  );
+  const compilations =
+    Codec.Compilations.Utils.shimCompilations(rawCompilations);
 
   return {
     abstractions,
@@ -69,10 +67,8 @@ async function compile(config) {
       quiet: true
     })
   );
-  const contractNames = flatten(
-    compilations.map(compilation =>
-      compilation.contracts.map(contract => contract.contractName)
-    )
+  const contractNames = compilations.flatMap(compilation =>
+    compilation.contracts.map(contract => contract.contractName)
   );
   return { compilations, contractNames };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -18804,7 +18804,7 @@ lodash.find@4.6.0:
   resolved "https://registry.yarnpkg.com/lodash.find/-/lodash.find-4.6.0.tgz#cb0704d47ab71789ffa0de8b97dd926fb88b13b1"
   integrity sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E=
 
-lodash.flatten@^4.2.0, lodash.flatten@^4.4.0:
+lodash.flatten@^4.2.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
   integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=


### PR DESCRIPTION
We're on Node 12 now, no need to be using `lodash.flatten` anymore, that's what `array.flat` and `array.flatMap` are for. :)  I've taken out `lodash.flatten` and replaced it with uses of those functions. :)

(Note there are still plenty of places in our code that are doing other ad-hoc things instead of using `flat` and `flatMap`, but, uh, I don't think there's any hurry to go replacing those all immediately...)