### PR TITLE
Bug fix: Use bind with provider.send in debugger's adapter

### DIFF
--- a/packages/debugger/lib/web3/adapter.js
+++ b/packages/debugger/lib/web3/adapter.js
@@ -10,7 +10,8 @@ export default class Web3Adapter {
   }
 
   async getTrace(txHash) {
-    let result = await promisify(this.web3.currentProvider.send)(
+    const provider = this.web3.currentProvider;
+    const result = await promisify(provider.send.bind(provider))(
       //send *only* uses callbacks, so we use promsifiy to make things more
       //readable
       {

--- a/packages/debugger/lib/web3/adapter.js
+++ b/packages/debugger/lib/web3/adapter.js
@@ -11,22 +11,22 @@ export default class Web3Adapter {
 
   async getTrace(txHash) {
     const provider = this.web3.currentProvider;
-    const result = await promisify(provider.send.bind(provider))(
-      //send *only* uses callbacks, so we use promsifiy to make things more
-      //readable
-      {
-        jsonrpc: "2.0",
-        method: "debug_traceTransaction",
-        params: [
-          txHash,
-          {
-            enableMemory: true, //recent geth versions require this option
-            disableStorage: true //we no longer use storage
-          }
-        ],
-        id: new Date().getTime()
-      }
-    );
+    //send *only* uses callbacks, so we use promsifiy to make things more readable
+    //we also use bind here to prevent a problem that sometimes occurs where
+    //provider.send ends up unable to call its own methods because `this` gets
+    //set incorrectly
+    const result = await promisify(provider.send.bind(provider))({
+      jsonrpc: "2.0",
+      method: "debug_traceTransaction",
+      params: [
+        txHash,
+        {
+          enableMemory: true, //recent geth versions require this option
+          disableStorage: true //we no longer use storage
+        }
+      ],
+      id: new Date().getTime()
+    });
     if (!result.result) {
       //we assume if there's no result then there is an error.
       //note: some nodes may return an error even if there is a


### PR DESCRIPTION
Addresses #4635.

I'll be honest, I don't fully understand this one.  For some reason, the way that `provider.send` was being invoked, somehow `this` was getting set to the wrong value (i.e., not the provider).  As such, when `provider.send()` attempted to call `this._prepareRequest()`, intending to call its own method `provider._prepareRequest()`, it instead called `somethingElse._prepareRequest()`, causing a crash.  (I didn't bother determining the value of `somethingElse`.)

I have no idea why this happened in this case, and, for that matter, why it *doesn't* happen normally... this doesn't happen when the debugger is used via the CLI, for instance!

Regardless, it was happening, so I just used `bind` to enforce that `this` was set correctly.  This is kind of the lazy approach -- ideally I should figure out exactly why this was happening and perhaps root out the problem earlier -- but I don't think I have a reasonable chance of actually figuring that out, and it seems unlikely to me that the solution would be different in that case, so I just don't think it's worth it to try to figure that out; I think the lazy solution is appropriate here.