### PR TITLE
Update slack build integration 

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -56,10 +56,12 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: 8398a7/action-slack@v1.1.1
+      - uses: 8398a7/action-slack@v3
         continue-on-error: true
         with:
-          type: success
+          channel: '#buidl-status'
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,eventName,took,pullRequest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
This PR updates truffle's slack integration. Work not captured in the PR is generating the project `secrets.SLACK_WEBHOOK_URL` from [this website](https://slack.com/apps/A0F7XDUAZ-incoming-webhooks?tab=more_info) as an authenticated user. Note, that when generating the `SLACK_WEBHOOK_URL`, you get to choose the Slack channel to target.