### PR TITLE
Bug fix: Suppress Ganache logging when running the dry run

### DIFF
--- a/packages/core/lib/commands/migrate/run.js
+++ b/packages/core/lib/commands/migrate/run.js
@@ -45,7 +45,11 @@ module.exports = async function (options) {
   }
 
   async function setupDryRunEnvironmentThenRunMigrations(config) {
-    await Environment.fork(config);
+    await Environment.fork(config, {
+      logging: {
+        quiet: true
+      }
+    });
     // Copy artifacts to a temporary directory
     const temporaryDirectory = tmp.dirSync({
       unsafeCleanup: true,

--- a/packages/environment/environment.js
+++ b/packages/environment/environment.js
@@ -26,7 +26,7 @@ const Environment = {
   },
 
   // Ensure you call Environment.detect() first.
-  fork: async function (config) {
+  fork: async function (config, ganacheOptions) {
     expect.options(config, ["from", "provider", "networks", "network"]);
 
     const interfaceAdapter = createInterfaceAdapter({
@@ -47,15 +47,16 @@ const Environment = {
     const upstreamNetwork = config.network;
     const upstreamConfig = config.networks[upstreamNetwork];
     const forkedNetwork = config.network + "-fork";
-    const ganacheOptions = {
+    const options = {
+      ...ganacheOptions,
       fork: config.provider,
       gasLimit: block.gasLimit
     };
-    if (accounts.length > 0) ganacheOptions.unlocked_accounts = accounts;
+    if (accounts.length > 0) options.unlocked_accounts = accounts;
 
     config.networks[forkedNetwork] = {
       network_id: config.network_id,
-      provider: Ganache.provider(ganacheOptions),
+      provider: Ganache.provider(options),
       from: config.from,
       gas: upstreamConfig.gas,
       gasPrice: upstreamConfig.gasPrice

--- a/packages/environment/environment.js
+++ b/packages/environment/environment.js
@@ -47,16 +47,16 @@ const Environment = {
     const upstreamNetwork = config.network;
     const upstreamConfig = config.networks[upstreamNetwork];
     const forkedNetwork = config.network + "-fork";
-    const options = {
+    ganacheOptions = {
       ...ganacheOptions,
       fork: config.provider,
       gasLimit: block.gasLimit
     };
-    if (accounts.length > 0) options.unlocked_accounts = accounts;
+    if (accounts.length > 0) ganacheOptions.unlocked_accounts = accounts;
 
     config.networks[forkedNetwork] = {
       network_id: config.network_id,
-      provider: Ganache.provider(options),
+      provider: Ganache.provider(ganacheOptions),
       from: config.from,
       gas: upstreamConfig.gas,
       gasPrice: upstreamConfig.gasPrice


### PR DESCRIPTION
This addresses https://github.com/trufflesuite/truffle/issues/4665.

Ganache logs by default, this PR suppresses logging by adding an extra argument to `Environment.fork` that allows passing options for starting Ganache. It then passes the appropriate options for suppressing logging when doing the dry run.