### PR TITLE
Internal improvement: refactor connectOrStart

### DIFF
--- a/packages/environment/.eslintrc.json
+++ b/packages/environment/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../.eslintrc.package.json"]
+}

--- a/packages/environment/chain.js
+++ b/packages/environment/chain.js
@@ -227,14 +227,13 @@ class GanacheMixin {
 
   // cleanup Ganache process on exit
   exit(_supervisor) {
-    this.ganache.close(err => {
-      if (err) {
+    this.ganache
+      .close()
+      .then(() => process.exit())
+      .catch(err => {
         console.error(err.stack || err);
         process.exit(1);
-      } else {
-        process.exit();
-      }
-    });
+      });
   }
 }
 

--- a/packages/environment/chain.js
+++ b/packages/environment/chain.js
@@ -229,10 +229,10 @@ class GanacheMixin {
   exit(_supervisor) {
     this.ganache
       .close()
-      .then(() => process.exit())
+      .then(() => (process.exitCode = 0))
       .catch(err => {
         console.error(err.stack || err);
-        process.exit(1);
+        process.exitCode = 1;
       });
   }
 }

--- a/packages/environment/develop.js
+++ b/packages/environment/develop.js
@@ -129,7 +129,10 @@ const Develop = {
       disconnect = await this.connect(options);
       started = true;
     } finally {
-      return { disconnect, started };
+      return {
+        disconnect,
+        started
+      };
     }
   }
 };

--- a/packages/environment/develop.js
+++ b/packages/environment/develop.js
@@ -4,7 +4,7 @@ const { spawn } = require("child_process");
 const debug = require("debug");
 
 const Develop = {
-  start: async function(ipcNetwork, options = {}) {
+  start: async function (ipcNetwork, options = {}) {
     let chainPath;
 
     // The path to the dev env process depends on whether or not
@@ -39,7 +39,7 @@ const Develop = {
     });
   },
 
-  connect: function(options) {
+  connect: function (options) {
     const debugServer = debug("develop:ipc:server");
     const debugClient = debug("develop:ipc:client");
     const debugRPC = debug("develop:ganache");
@@ -69,7 +69,7 @@ const Develop = {
     if (options.log) {
       debugRPC.enabled = true;
 
-      loggers.ganache = function() {
+      loggers.ganache = function () {
         // HACK-y: replace `{}` that is getting logged instead of ""
         var args = Array.prototype.slice.call(arguments);
         if (
@@ -88,21 +88,21 @@ const Develop = {
       ipc.config.maxRetries = 0;
     }
 
-    var disconnect = function() {
+    var disconnect = function () {
       ipc.disconnect(ipcNetwork);
     };
 
     return new Promise((resolve, reject) => {
-      ipc.connectTo(ipcNetwork, connectPath, function() {
-        ipc.of[ipcNetwork].on("destroy", function() {
+      ipc.connectTo(ipcNetwork, connectPath, function () {
+        ipc.of[ipcNetwork].on("destroy", function () {
           reject(new Error("IPC connection destroyed"));
         });
 
-        ipc.of[ipcNetwork].on("truffle.ready", function() {
+        ipc.of[ipcNetwork].on("truffle.ready", function () {
           resolve(disconnect);
         });
 
-        Object.keys(loggers).forEach(function(key) {
+        Object.keys(loggers).forEach(function (key) {
           var log = loggers[key];
           if (log) {
             var message = `truffle.${key}.log`;
@@ -113,30 +113,23 @@ const Develop = {
     });
   },
 
-  connectOrStart: async function(options, ganacheOptions) {
+  connectOrStart: async function (options, ganacheOptions) {
     options.retry = false;
 
     const ipcNetwork = options.network || "develop";
 
-    let connectedAlready = false;
+    let started = false;
+    let disconnect;
 
     try {
-      const disconnect = await this.connect(options);
-      connectedAlready = true;
-      return {
-        started: false,
-        disconnect
-      };
+      disconnect = await this.connect(options);
     } catch (_error) {
       await this.start(ipcNetwork, ganacheOptions);
       options.retry = true;
-      const disconnect = await this.connect(options);
-      if (connectedAlready) return;
-      connectedAlready = true;
-      return {
-        started: true,
-        disconnect
-      };
+      disconnect = await this.connect(options);
+      started = true;
+    } finally {
+      return { disconnect, started };
     }
   }
 };

--- a/packages/environment/test/connectOrStartTest.js
+++ b/packages/environment/test/connectOrStartTest.js
@@ -1,0 +1,33 @@
+const assert = require("chai").assert;
+const Develop = require("../develop");
+
+describe("connectOrStart test network", async function () {
+  const ipcOptions = { network: "test" };
+  const ganacheOptions = {
+    host: "127.0.0.1",
+    network_id: 666,
+    port: 6969
+  };
+
+  it("starts Ganache when no Ganache instance is running", async function () {
+    const connection = await Develop.connectOrStart(ipcOptions, ganacheOptions);
+    assert.isTrue(connection.started);
+    assert.isFunction(connection.disconnect);
+    connection.disconnect();
+  });
+
+  it("connects to an established ganache instance", async function () {
+    //establish a connection
+    const { disconnect: connectionOneDisconnect } =
+      await Develop.connectOrStart(ipcOptions, ganacheOptions);
+
+    //invoke the method again
+    const { disconnect: connectionTwoDisconnect, started } =
+      await Develop.connectOrStart(ipcOptions, ganacheOptions);
+    assert.isFalse(started);
+
+    //cleanup
+    await connectionOneDisconnect();
+    await connectionTwoDisconnect();
+  });
+});

--- a/packages/environment/test/connectOrStartTest.js
+++ b/packages/environment/test/connectOrStartTest.js
@@ -13,19 +13,16 @@ describe("connectOrStart test network", async function () {
     let connection;
     try {
       connection = await Develop.connectOrStart(ipcOptions, ganacheOptions);
-      assert.isTrue(connection.started, "A new server did not spin up");
-      assert.isFunction(connection.disconnect, "Disconnect is not a function");
-    } catch (error) {
-      console.log(error);
-      assert.fail("Develop.connectOrStart should not have thrown!");
+      assert.isTrue(connection.started, "A new Ganache server did not spin up");
+      assert.isFunction(connection.disconnect, "disconnect is not a function");
     } finally {
       if (connection) {
-        return connection.disconnect();
+        connection.disconnect();
       }
     }
   });
 
-  it("connects to an established ganache instance", async function () {
+  it("connects to an established Ganache instance", async function () {
     let connectionOneDisconnect, connectionTwoDisconnect;
 
     try {
@@ -37,10 +34,10 @@ describe("connectOrStart test network", async function () {
       //invoke the method again
       const result = await Develop.connectOrStart(ipcOptions, ganacheOptions);
       connectionTwoDisconnect = result.disconnect;
-      assert.isFalse(result.started);
-    } catch (error) {
-      console.log(error);
-      assert.fail("Develop.connectOrStart should not have thrown!");
+      assert.isFalse(
+        result.started,
+        "Should have connected to established Ganache server"
+      );
     } finally {
       //cleanup
       if (connectionOneDisconnect) {

--- a/packages/environment/test/connectOrStartTest.js
+++ b/packages/environment/test/connectOrStartTest.js
@@ -10,24 +10,45 @@ describe("connectOrStart test network", async function () {
   };
 
   it("starts Ganache when no Ganache instance is running", async function () {
-    const connection = await Develop.connectOrStart(ipcOptions, ganacheOptions);
-    assert.isTrue(connection.started);
-    assert.isFunction(connection.disconnect);
-    connection.disconnect();
+    let connection;
+    try {
+      connection = await Develop.connectOrStart(ipcOptions, ganacheOptions);
+      assert.isTrue(connection.started, "A new server did not spin up");
+      assert.isFunction(connection.disconnect, "Disconnect is not a function");
+    } catch (error) {
+      console.log(error);
+      assert.fail("Develop.connectOrStart should not have thrown!");
+    } finally {
+      if (connection) {
+        return connection.disconnect();
+      }
+    }
   });
 
   it("connects to an established ganache instance", async function () {
-    //establish a connection
-    const { disconnect: connectionOneDisconnect } =
-      await Develop.connectOrStart(ipcOptions, ganacheOptions);
+    let connectionOneDisconnect, connectionTwoDisconnect;
 
-    //invoke the method again
-    const { disconnect: connectionTwoDisconnect, started } =
-      await Develop.connectOrStart(ipcOptions, ganacheOptions);
-    assert.isFalse(started);
+    try {
+      //establish a connection
+      connectionOneDisconnect = (
+        await Develop.connectOrStart(ipcOptions, ganacheOptions)
+      ).disconnect;
 
-    //cleanup
-    await connectionOneDisconnect();
-    await connectionTwoDisconnect();
+      //invoke the method again
+      const result = await Develop.connectOrStart(ipcOptions, ganacheOptions);
+      connectionTwoDisconnect = result.disconnect;
+      assert.isFalse(result.started);
+    } catch (error) {
+      console.log(error);
+      assert.fail("Develop.connectOrStart should not have thrown!");
+    } finally {
+      //cleanup
+      if (connectionOneDisconnect) {
+        connectionOneDisconnect();
+      }
+      if (connectionTwoDisconnect) {
+        connectionTwoDisconnect();
+      }
+    }
   });
 });

--- a/packages/environment/test/develop.js
+++ b/packages/environment/test/develop.js
@@ -29,17 +29,15 @@ describe("Environment develop", function () {
         gas: expectedNetwork.gas
       }
     };
+  });
+
+  it("Environment.develop overwrites the network_id of the network", async function () {
+    //Stub detect in order to prevent its executing during this test
+    //which is invoked during `Environment.develop(..)`
     sinon.stub(Environment, "detect");
-  });
-
-  afterEach("Restore Environment detect", async function () {
-    Environment.detect.restore();
-  });
-
-  it("Environment.develop overwrites the network_id of the network", async function() {
     await Environment.develop(config, testOptions);
-    const mutatedNetwork = config.networks[config.network];
 
+    const mutatedNetwork = config.networks[config.network];
     assert.equal(
       mutatedNetwork.port,
       expectedNetwork.port,
@@ -55,6 +53,8 @@ describe("Environment develop", function () {
       expectedNetwork.gas,
       "The gas of the network should be unchanged."
     );
-  });
 
+    //Restore `detect` functionality
+    Environment.detect.restore();
+  });
 }).timeout(10000);


### PR DESCRIPTION
This PR 
  - updates the use of the Ganache's `server.close()` method, which uses a promise instead of node's callback idiom. We should tear down Ganache properly.
  - cleans up the logic for `connectOrStart`
  - adds 2 tests to verify `connectOfStart` try/catch logic path.