### PR TITLE
Don't resolve args

### DIFF
--- a/packages/deployer/src/actions/new.js
+++ b/packages/deployer/src/actions/new.js
@@ -5,8 +5,6 @@ module.exports = function (contract, args, deployer) {
         contract
       });
     }
-    // Evaluate any arguments if they're promises
-    await Promise.all(args);
     return contract.new.apply(contract, args);
   };
 };


### PR DESCRIPTION
This PR is to remove the *unnecessary* await in the deployer code to deploy. The function takes a TruffleContract abstraction and the arguments (`args`) it needs to deploy the associated Solidity contract. For some reason, the code considers the `args` to be promises and awaits them in a Promise.all. 

I tried two mutually exclusive paths forward, #4674 using the resolved promises in `contract.new` invocation, and this PR, which doesn't await the promise. Both PRs passed CI, and after consulting with the team to go with this PR's approach.  Arguments to Contracts should not be promises.

``` 
module.exports = function(contract, args, deployer) {
  return async function() {
    deployer.logger.log("Creating new instance of " + contract.contract_name);
    // Evaluate any arguments if they're promises          
    await Promise.all(args);                             <-- The awaited values are 
    return contract.new.apply(contract, args);           <-- ignored! huh?
  };
};
```


