### PR TITLE
Enhancement: Create decoding inspectors (and use them in some places)

### DIFF
--- a/packages/codec/lib/format/utils/inspect.ts
+++ b/packages/codec/lib/format/utils/inspect.ts
@@ -13,14 +13,11 @@ interface InspectOptions {
   breakLength: number;
 }
 
-//HACK -- inspect options are ridiculous, I swear >_>
-function cleanStylize(options: InspectOptions) {
-  return Object.assign(
-    {},
-    ...Object.entries(options).map(([key, value]) =>
-      key === "stylize" ? {} : { [key]: value }
-    )
-  );
+//HACK?
+function cleanStylize(options: InspectOptions): InspectOptions {
+  const clonedOptions: InspectOptions = { ...options };
+  delete clonedOptions.stylize;
+  return clonedOptions;
 }
 
 /**
@@ -126,12 +123,12 @@ export class ResultInspector {
           case "mapping":
             return util.inspect(
               new Map(
-                (<Format.Values.MappingValue>(
-                  this.result
-                )).value.map(({ key, value }) => [
-                  new ResultInspector(key),
-                  new ResultInspector(value)
-                ])
+                (<Format.Values.MappingValue>this.result).value.map(
+                  ({ key, value }) => [
+                    new ResultInspector(key),
+                    new ResultInspector(value)
+                  ]
+                )
               ),
               options
             );
@@ -151,8 +148,12 @@ export class ResultInspector {
             );
           }
           case "userDefinedValueType": {
-            const typeName = Format.Types.typeStringWithoutLocation(this.result.type);
-            const coercedResult = <Format.Values.UserDefinedValueTypeValue>this.result;
+            const typeName = Format.Types.typeStringWithoutLocation(
+              this.result.type
+            );
+            const coercedResult = <Format.Values.UserDefinedValueTypeValue>(
+              this.result
+            );
             const inspectOfUnderlying = util.inspect(
               new ResultInspector(coercedResult.value),
               options
@@ -544,7 +545,9 @@ function unsafeNativizeWithTable(
       }
     }
     case "userDefinedValueType": {
-      return unsafeNativize((<Format.Values.UserDefinedValueTypeValue>result).value);
+      return unsafeNativize(
+        (<Format.Values.UserDefinedValueTypeValue>result).value
+      );
     }
     case "mapping":
       return Object.assign(
@@ -605,9 +608,9 @@ function unsafeNativizeWithTable(
     case "magic":
       return Object.assign(
         {},
-        ...Object.entries(
-          (<Format.Values.MagicValue>result).value
-        ).map(([key, value]) => ({ [key]: unsafeNativize(value) }))
+        ...Object.entries((<Format.Values.MagicValue>result).value).map(
+          ([key, value]) => ({ [key]: unsafeNativize(value) })
+        )
       );
     case "enum":
       return enumFullName(<Format.Values.EnumValue>result);

--- a/packages/codec/lib/format/utils/inspect.ts
+++ b/packages/codec/lib/format/utils/inspect.ts
@@ -7,7 +7,7 @@ import * as Exception from "./exception";
 
 //we'll need to write a typing for the options type ourself, it seems; just
 //going to include the relevant properties here
-interface InspectOptions {
+export interface InspectOptions {
   stylize?: (toMaybeColor: string, style?: string) => string;
   colors: boolean;
   breakLength: number;

--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -468,7 +468,7 @@ class DebugPrinter {
       //case 8: known bytecode
       this.config.logger.log("");
       const decoding = decodings[0];
-      const contractKind = decoding.contractKind || "contract";
+      const contractKind = decoding.class.contractKind || "contract";
       if (decoding.address !== undefined) {
         this.config.logger.log(
           `Returned bytecode for a ${contractKind} ${decoding.class.typeName} at ${decoding.address}.`

--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -710,6 +710,7 @@ var DebugUtils = {
   },
 
   //note: only intended to be used for *custom* errors :)
+  //note: this is now pretty duplicative of the ReturndataDecodingInspector...
   formatCustomError: function (decoding, indent = 0) {
     const name = decoding.definedIn
       ? `${decoding.definedIn.typeName}.${decoding.abi.name}`

--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -34,59 +34,59 @@ const verbosePanicTable = {
 };
 
 const commandReference = {
-  o: "step over",
-  i: "step into",
-  u: "step out",
-  n: "step next",
+  "o": "step over",
+  "i": "step into",
+  "u": "step out",
+  "n": "step next",
   ";": "step instruction (include number to step multiple)",
-  p: "print instruction & state (`p [mem|cal|sto]*`; see docs for more)",
-  l: "print additional source context (`l [+<lines-ahead>] [-<lines-back>]`)",
-  h: "print this help",
-  v: "print variables and values (`v [bui|glo|con|loc]*`)",
+  "p": "print instruction & state (`p [mem|cal|sto]*`; see docs for more)",
+  "l": "print additional source context (`l [+<lines-ahead>] [-<lines-back>]`)",
+  "h": "print this help",
+  "v": "print variables and values (`v [bui|glo|con|loc]*`)",
   ":": "evaluate expression - see `v`",
   "+": "add watch expression (`+:<expr>`)",
   "-": "remove watch expression (-:<expr>)",
   "?": "list existing watch expressions and breakpoints",
-  b: "add breakpoint (`b [[<source-file>:]<line-number>]`; see docs for more)",
-  B: "remove breakpoint (similar to adding, or `B all` to remove all)",
-  c: "continue until breakpoint",
-  q: "quit",
-  r: "reset",
-  t: "load new transaction",
-  T: "unload transaction",
-  s: "print stacktrace",
-  g: "turn on generated sources",
-  G: "turn off generated sources except via `;`",
-  y: "(if at end) reset & continue to final error",
-  Y: "reset & continue to previous error"
+  "b": "add breakpoint (`b [[<source-file>:]<line-number>]`; see docs for more)",
+  "B": "remove breakpoint (similar to adding, or `B all` to remove all)",
+  "c": "continue until breakpoint",
+  "q": "quit",
+  "r": "reset",
+  "t": "load new transaction",
+  "T": "unload transaction",
+  "s": "print stacktrace",
+  "g": "turn on generated sources",
+  "G": "turn off generated sources except via `;`",
+  "y": "(if at end) reset & continue to final error",
+  "Y": "reset & continue to previous error"
 };
 
 const shortCommandReference = {
-  o: "step over",
-  i: "step into",
-  u: "step out",
-  n: "step next",
+  "o": "step over",
+  "i": "step into",
+  "u": "step out",
+  "n": "step next",
   ";": "step instruction",
-  p: "print state",
-  l: "print context",
-  h: "print help",
-  v: "print variables",
+  "p": "print state",
+  "l": "print context",
+  "h": "print help",
+  "v": "print variables",
   ":": "evaluate",
   "+": "add watch",
   "-": "remove watch",
   "?": "list watches & breakpoints",
-  b: "add breakpoint",
-  B: "remove breakpoint",
-  c: "continue",
-  q: "quit",
-  r: "reset",
-  t: "load",
-  T: "unload",
-  s: "stacktrace",
-  g: "turn on generated sources",
-  G: "turn off generated sources",
-  y: "reset & go to final error",
-  Y: "reset & go to previous error"
+  "b": "add breakpoint",
+  "B": "remove breakpoint",
+  "c": "continue",
+  "q": "quit",
+  "r": "reset",
+  "t": "load",
+  "T": "unload",
+  "s": "stacktrace",
+  "g": "turn on generated sources",
+  "G": "turn off generated sources",
+  "y": "reset & go to final error",
+  "Y": "reset & go to previous error"
 };
 
 const truffleColors = {
@@ -107,69 +107,69 @@ const DEFAULT_TAB_WIDTH = 8;
 
 const trufflePalette = {
   /* base (chromafi special, not hljs) */
-  base: chalk,
-  lineNumbers: chalk,
-  trailingSpace: chalk,
+  "base": chalk,
+  "lineNumbers": chalk,
+  "trailingSpace": chalk,
   /* classes hljs-solidity actually uses */
-  keyword: truffleColors.mint,
-  number: truffleColors.red,
-  string: truffleColors.green,
-  params: truffleColors.pink,
-  builtIn: truffleColors.watermelon,
-  built_in: truffleColors.watermelon, //just to be sure
-  literal: truffleColors.watermelon,
-  function: truffleColors.orange,
-  title: truffleColors.orange,
-  class: truffleColors.orange,
-  comment: truffleColors.comment,
-  doctag: truffleColors.comment,
-  operator: truffleColors.blue,
-  punctuation: truffleColors.purple,
+  "keyword": truffleColors.mint,
+  "number": truffleColors.red,
+  "string": truffleColors.green,
+  "params": truffleColors.pink,
+  "builtIn": truffleColors.watermelon,
+  "built_in": truffleColors.watermelon, //just to be sure
+  "literal": truffleColors.watermelon,
+  "function": truffleColors.orange,
+  "title": truffleColors.orange,
+  "class": truffleColors.orange,
+  "comment": truffleColors.comment,
+  "doctag": truffleColors.comment,
+  "operator": truffleColors.blue,
+  "punctuation": truffleColors.purple,
   /* classes it might soon use! */
-  meta: truffleColors.pink,
-  metaString: truffleColors.green,
+  "meta": truffleColors.pink,
+  "metaString": truffleColors.green,
   "meta-string": truffleColors.green, //similar
   /* classes it doesn't currently use but notionally could */
-  type: truffleColors.orange,
-  symbol: truffleColors.orange,
-  metaKeyword: truffleColors.mint,
+  "type": truffleColors.orange,
+  "symbol": truffleColors.orange,
+  "metaKeyword": truffleColors.mint,
   "meta-keyword": truffleColors.mint, //again, to be sure
-  property: chalk, //not putting any highlighting here for now
+  "property": chalk, //not putting any highlighting here for now
   /* classes that don't make sense for Solidity */
-  regexp: chalk, //solidity does not have regexps
-  subst: chalk, //or string interpolation
-  name: chalk, //or s-expressions
-  builtInName: chalk, //or s-expressions, again
+  "regexp": chalk, //solidity does not have regexps
+  "subst": chalk, //or string interpolation
+  "name": chalk, //or s-expressions
+  "builtInName": chalk, //or s-expressions, again
   "builtin-name": chalk, //just to be sure
   /* classes for config, markup, CSS, templates, diffs (not programming) */
-  section: chalk,
-  tag: chalk,
-  attr: chalk,
-  attribute: chalk,
-  variable: chalk,
-  bullet: chalk,
-  code: chalk,
-  emphasis: chalk,
-  strong: chalk,
-  formula: chalk,
-  link: chalk,
-  quote: chalk,
-  selectorAttr: chalk, //lotta redundancy follows
+  "section": chalk,
+  "tag": chalk,
+  "attr": chalk,
+  "attribute": chalk,
+  "variable": chalk,
+  "bullet": chalk,
+  "code": chalk,
+  "emphasis": chalk,
+  "strong": chalk,
+  "formula": chalk,
+  "link": chalk,
+  "quote": chalk,
+  "selectorAttr": chalk, //lotta redundancy follows
   "selector-attr": chalk,
-  selectorClass: chalk,
+  "selectorClass": chalk,
   "selector-class": chalk,
-  selectorId: chalk,
+  "selectorId": chalk,
   "selector-id": chalk,
-  selectorPseudo: chalk,
+  "selectorPseudo": chalk,
   "selector-pseudo": chalk,
-  selectorTag: chalk,
+  "selectorTag": chalk,
   "selector-tag": chalk,
-  templateTag: chalk,
+  "templateTag": chalk,
   "template-tag": chalk,
-  templateVariable: chalk,
+  "templateVariable": chalk,
   "template-variable": chalk,
-  addition: chalk,
-  deletion: chalk
+  "addition": chalk,
+  "deletion": chalk
 };
 
 var DebugUtils = {
@@ -718,7 +718,7 @@ var DebugUtils = {
       return `${name}()`;
     }
     const prefix = `${name}(`;
-    const formattedValues = decoding.arguments.map(({ name, value }) => {
+    let formattedValues = decoding.arguments.map(({ name, value }) => {
       const argumentPrefix = name ? `${name}: ` : "";
       const typeString = ` (type: ${Codec.Format.Types.typeStringWithoutLocation(
         value.type
@@ -732,6 +732,11 @@ var DebugUtils = {
         .map(line => " ".repeat(indent) + line)
         .join(OS.EOL);
     });
+    const len = formattedValues.length;
+    if (len > 0) {
+      //remove final comma!
+      formattedValues[len - 1] = formattedValues[len - 1].slice(0, -1);
+    }
     return [prefix, ...formattedValues, ")"].join(OS.EOL);
   },
 

--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -34,59 +34,59 @@ const verbosePanicTable = {
 };
 
 const commandReference = {
-  "o": "step over",
-  "i": "step into",
-  "u": "step out",
-  "n": "step next",
+  o: "step over",
+  i: "step into",
+  u: "step out",
+  n: "step next",
   ";": "step instruction (include number to step multiple)",
-  "p": "print instruction & state (`p [mem|cal|sto]*`; see docs for more)",
-  "l": "print additional source context (`l [+<lines-ahead>] [-<lines-back>]`)",
-  "h": "print this help",
-  "v": "print variables and values (`v [bui|glo|con|loc]*`)",
+  p: "print instruction & state (`p [mem|cal|sto]*`; see docs for more)",
+  l: "print additional source context (`l [+<lines-ahead>] [-<lines-back>]`)",
+  h: "print this help",
+  v: "print variables and values (`v [bui|glo|con|loc]*`)",
   ":": "evaluate expression - see `v`",
   "+": "add watch expression (`+:<expr>`)",
   "-": "remove watch expression (-:<expr>)",
   "?": "list existing watch expressions and breakpoints",
-  "b": "add breakpoint (`b [[<source-file>:]<line-number>]`; see docs for more)",
-  "B": "remove breakpoint (similar to adding, or `B all` to remove all)",
-  "c": "continue until breakpoint",
-  "q": "quit",
-  "r": "reset",
-  "t": "load new transaction",
-  "T": "unload transaction",
-  "s": "print stacktrace",
-  "g": "turn on generated sources",
-  "G": "turn off generated sources except via `;`",
-  "y": "(if at end) reset & continue to final error",
-  "Y": "reset & continue to previous error"
+  b: "add breakpoint (`b [[<source-file>:]<line-number>]`; see docs for more)",
+  B: "remove breakpoint (similar to adding, or `B all` to remove all)",
+  c: "continue until breakpoint",
+  q: "quit",
+  r: "reset",
+  t: "load new transaction",
+  T: "unload transaction",
+  s: "print stacktrace",
+  g: "turn on generated sources",
+  G: "turn off generated sources except via `;`",
+  y: "(if at end) reset & continue to final error",
+  Y: "reset & continue to previous error"
 };
 
 const shortCommandReference = {
-  "o": "step over",
-  "i": "step into",
-  "u": "step out",
-  "n": "step next",
+  o: "step over",
+  i: "step into",
+  u: "step out",
+  n: "step next",
   ";": "step instruction",
-  "p": "print state",
-  "l": "print context",
-  "h": "print help",
-  "v": "print variables",
+  p: "print state",
+  l: "print context",
+  h: "print help",
+  v: "print variables",
   ":": "evaluate",
   "+": "add watch",
   "-": "remove watch",
   "?": "list watches & breakpoints",
-  "b": "add breakpoint",
-  "B": "remove breakpoint",
-  "c": "continue",
-  "q": "quit",
-  "r": "reset",
-  "t": "load",
-  "T": "unload",
-  "s": "stacktrace",
-  "g": "turn on generated sources",
-  "G": "turn off generated sources",
-  "y": "reset & go to final error",
-  "Y": "reset & go to previous error"
+  b: "add breakpoint",
+  B: "remove breakpoint",
+  c: "continue",
+  q: "quit",
+  r: "reset",
+  t: "load",
+  T: "unload",
+  s: "stacktrace",
+  g: "turn on generated sources",
+  G: "turn off generated sources",
+  y: "reset & go to final error",
+  Y: "reset & go to previous error"
 };
 
 const truffleColors = {
@@ -107,69 +107,69 @@ const DEFAULT_TAB_WIDTH = 8;
 
 const trufflePalette = {
   /* base (chromafi special, not hljs) */
-  "base": chalk,
-  "lineNumbers": chalk,
-  "trailingSpace": chalk,
+  base: chalk,
+  lineNumbers: chalk,
+  trailingSpace: chalk,
   /* classes hljs-solidity actually uses */
-  "keyword": truffleColors.mint,
-  "number": truffleColors.red,
-  "string": truffleColors.green,
-  "params": truffleColors.pink,
-  "builtIn": truffleColors.watermelon,
-  "built_in": truffleColors.watermelon, //just to be sure
-  "literal": truffleColors.watermelon,
-  "function": truffleColors.orange,
-  "title": truffleColors.orange,
-  "class": truffleColors.orange,
-  "comment": truffleColors.comment,
-  "doctag": truffleColors.comment,
-  "operator": truffleColors.blue,
-  "punctuation": truffleColors.purple,
+  keyword: truffleColors.mint,
+  number: truffleColors.red,
+  string: truffleColors.green,
+  params: truffleColors.pink,
+  builtIn: truffleColors.watermelon,
+  built_in: truffleColors.watermelon, //just to be sure
+  literal: truffleColors.watermelon,
+  function: truffleColors.orange,
+  title: truffleColors.orange,
+  class: truffleColors.orange,
+  comment: truffleColors.comment,
+  doctag: truffleColors.comment,
+  operator: truffleColors.blue,
+  punctuation: truffleColors.purple,
   /* classes it might soon use! */
-  "meta": truffleColors.pink,
-  "metaString": truffleColors.green,
+  meta: truffleColors.pink,
+  metaString: truffleColors.green,
   "meta-string": truffleColors.green, //similar
   /* classes it doesn't currently use but notionally could */
-  "type": truffleColors.orange,
-  "symbol": truffleColors.orange,
-  "metaKeyword": truffleColors.mint,
+  type: truffleColors.orange,
+  symbol: truffleColors.orange,
+  metaKeyword: truffleColors.mint,
   "meta-keyword": truffleColors.mint, //again, to be sure
-  "property": chalk, //not putting any highlighting here for now
+  property: chalk, //not putting any highlighting here for now
   /* classes that don't make sense for Solidity */
-  "regexp": chalk, //solidity does not have regexps
-  "subst": chalk, //or string interpolation
-  "name": chalk, //or s-expressions
-  "builtInName": chalk, //or s-expressions, again
+  regexp: chalk, //solidity does not have regexps
+  subst: chalk, //or string interpolation
+  name: chalk, //or s-expressions
+  builtInName: chalk, //or s-expressions, again
   "builtin-name": chalk, //just to be sure
   /* classes for config, markup, CSS, templates, diffs (not programming) */
-  "section": chalk,
-  "tag": chalk,
-  "attr": chalk,
-  "attribute": chalk,
-  "variable": chalk,
-  "bullet": chalk,
-  "code": chalk,
-  "emphasis": chalk,
-  "strong": chalk,
-  "formula": chalk,
-  "link": chalk,
-  "quote": chalk,
-  "selectorAttr": chalk, //lotta redundancy follows
+  section: chalk,
+  tag: chalk,
+  attr: chalk,
+  attribute: chalk,
+  variable: chalk,
+  bullet: chalk,
+  code: chalk,
+  emphasis: chalk,
+  strong: chalk,
+  formula: chalk,
+  link: chalk,
+  quote: chalk,
+  selectorAttr: chalk, //lotta redundancy follows
   "selector-attr": chalk,
-  "selectorClass": chalk,
+  selectorClass: chalk,
   "selector-class": chalk,
-  "selectorId": chalk,
+  selectorId: chalk,
   "selector-id": chalk,
-  "selectorPseudo": chalk,
+  selectorPseudo: chalk,
   "selector-pseudo": chalk,
-  "selectorTag": chalk,
+  selectorTag: chalk,
   "selector-tag": chalk,
-  "templateTag": chalk,
+  templateTag: chalk,
   "template-tag": chalk,
-  "templateVariable": chalk,
+  templateVariable: chalk,
   "template-variable": chalk,
-  "addition": chalk,
-  "deletion": chalk
+  addition: chalk,
+  deletion: chalk
 };
 
 var DebugUtils = {
@@ -697,7 +697,7 @@ var DebugUtils = {
     };
     let valueToInspect = nativized
       ? value
-      : new Codec.Format.Utils.Inspect.ResultInspector(value);
+      : new Codec.Export.ResultInspector(value);
     return util
       .inspect(valueToInspect, inspectOptions)
       .split(/\r?\n/g)


### PR DESCRIPTION
Addresses #4368, or mostly does, anyway.

This PR creates three decoding inspector classes, `CalldataDecodingInspector`, `LogDecodingInspector`, and `ReturndataDecodingInspector`, analogous to `ResultInspector`.  I put these in `export.ts` rather than `format/utils/inspect.ts` as I think `export.ts` is basically the new location for this stuff.

In addition, I updated various code to use these inspectors rather than their own result-inspecting logic.  However I didn't update *all* code this way.  I'll discuss this more in a bit.

First off, I updated Truffle Test to use the `LogDecodingInspector` for event printing.  The logic for the `LogDecodingInspector` is basically copied from how Truffle Test already prints events.

Second, I updated the debugger CLI to use the `ReturndataDecodingInspector` for *some* things; specifically, custom errors and returned bytecode.  I left it alone for other things, as in many cases the debugger wants to do something a bit more specialized than what a generic `ReturndataDecodingInspector` can reasonably expected to do.  I mostly don't think this is a problem, but there's one case that bugs me; I'll get back to this in a moment.

I did *not* update db-kit to use the `CalldataDecodingInspector`.  That's because the relevant part of db-kit is a bunch of tsx that I don't know how to deal with, and maybe it's just fine for it to do it's own thing, I don't know.

So, let me tell you about the part of this PR that bothers me, and that I'm hoping to get some advice on.

The debugger actually has two separate functions for printing the return from a transaction; there's `printReturnValue` and there's `printRevertMessage`.  The former prints any return value, including unsuccesful ones such as revert messages; the latter is more specialized and only deals with unsuccessful returns.  They're invoked in different situations, to be clear, and in those cases that they both handle (unsuccessful returns) they print slightly different things.

So, let's talk about the `ReturndataDecodingInspector` and custom errors.

Because data returned could be any of a number of things, I decided that the `ReturndataDecodingInspector` would generally preface its result with an appropriate descriptor, such as `Returned values:` or `Error thrown:` or whatever.  For custom errors, I picked it to match up with what the debugger was already doing, so I could just use it in the debugger.  Except really I picked it to match up with what `printReturnValue` was already doing... leaving `printRevertMessage` in the lurch, because it printed that sort of header a bit differently.

The result is that `printRevertMessage` still uses `formatCustomError` from debug-utils, which is now basically duplicated code.  I don't really like this, but I'm a little unsure what to do about it.  Possibilities:

1. Just leave the duplicated code in.  I don't like this for obvious reasons.
2. Just use `ReturndataDecodingInspector` anyway; sure, the printouts don't agree at the moment, but who says they can't?  I don't really like this because I wrote them differently for a reason.
3. Use `ReturndataDecodingInspector`, and then do a search/replace.  This is hella hacky; it means that altering one message will break the other.
4. Alter `ReturndataDecodingInspector` to not put those headers.  Seems kind of unsatisfactory for anyone using `ReturndataDecoingInspector` on its own.
5. The `ReturndataDecodingInspector` relies on a function called `formatFunctionLike` for formatting custom errors (the other inspectors use this too for formatting things that look like functions).  Right now that function isn't exported because I meant it to be an internal thing.  I could export it, though, and then `printRevertMessage` could invoke it directly, and we could get rid of the duplicated code in `formatCustomError` (or we could alter `formatCustomError` to use it).  I'm not sure I like exposing that function, but, this is what I'm currently leaning towards as the cleanest solution.

Thoughts?