### PR TITLE
Bug fix: Fix decoding of bytecode with internal function pointers in immutables

### DIFF
--- a/packages/codec/lib/basic/decode/index.ts
+++ b/packages/codec/lib/basic/decode/index.ts
@@ -43,7 +43,7 @@ export function* decodeBasic(
       if (!fullType.underlyingType) {
         const error = {
           kind: "UserDefinedTypeNotFoundError" as const,
-          type: fullType,
+          type: fullType
         };
         if (strict || options.allowRetry) {
           throw new StopDecodingError(error, true);
@@ -61,10 +61,13 @@ export function* decodeBasic(
         info,
         options
       );
-      switch (underlyingResult.kind) { //yes this switch is a little unnecessary :P
+      switch (
+        underlyingResult.kind //yes this switch is a little unnecessary :P
+      ) {
         case "value":
           //wrap the value and return
-          return <Format.Values.UserDefinedValueTypeValue>{ //no idea why need coercion here
+          return <Format.Values.UserDefinedValueTypeValue>{
+            //no idea why need coercion here
             type: fullType,
             kind: "value" as const,
             value: underlyingResult
@@ -76,7 +79,8 @@ export function* decodeBasic(
           //does not cause an error in the whole thing, but to do that here
           //would cause problems for the type system :-/
           //so we'll just be inconsistent
-          return <Format.Errors.UserDefinedValueTypeErrorResult>{ //TS is being bad again :-/
+          return <Format.Errors.UserDefinedValueTypeErrorResult>{
+            //TS is being bad again :-/
             type: fullType,
             kind: "error" as const,
             error: {
@@ -280,7 +284,7 @@ export function* decodeBasic(
       switch (dataType.visibility) {
         case "external":
           if (!checkPadding(bytes, dataType, paddingMode)) {
-            let error = {
+            const error = {
               kind: "FunctionExternalNonStackPaddingError" as const,
               paddingType: getPaddingType(dataType, paddingMode),
               raw: Conversion.toHexString(bytes)
@@ -306,22 +310,23 @@ export function* decodeBasic(
             value: yield* decodeExternalFunction(address, selector, info)
           };
         case "internal":
-          if (strict) {
-            //internal functions don't go in the ABI!
-            //this should never happen, but just to be sure...
-            throw new StopDecodingError({
-              kind: "InternalFunctionInABIError" as const
-            });
-          }
+          //note: we no longer error here if strict is true, because we
+          //want to be able to use strict mode to decode immutables, and
+          //these can be immutables.  yes, this is a bit of an abuse of
+          //strict mode, which was meant for ABI decoding, but oh well.
           if (!checkPadding(bytes, dataType, paddingMode)) {
+            const error = {
+              kind: "FunctionInternalPaddingError" as const,
+              paddingType: getPaddingType(dataType, paddingMode),
+              raw: Conversion.toHexString(bytes)
+            };
+            if (strict) {
+              throw new StopDecodingError(error);
+            }
             return {
               type: dataType,
               kind: "error" as const,
-              error: {
-                kind: "FunctionInternalPaddingError" as const,
-                paddingType: getPaddingType(dataType, paddingMode),
-                raw: Conversion.toHexString(bytes)
-              }
+              error
             };
           }
           bytes = removePadding(bytes, dataType, paddingMode);
@@ -334,7 +339,8 @@ export function* decodeBasic(
             dataType,
             deployedPc,
             constructorPc,
-            info
+            info,
+            strict
           );
       }
       break; //to satisfy TypeScript
@@ -584,16 +590,16 @@ export function* decodeExternalFunction(
 }
 
 //this one works a bit differently -- in order to handle errors, it *does* return a FunctionInternalResult
-//also note, I haven't put the same sort of error-handling in this one since it's only intended to run with full info (for now, anyway)
-export function decodeInternalFunction(
+function decodeInternalFunction(
   dataType: Format.Types.FunctionInternalType,
   deployedPcBytes: Uint8Array,
   constructorPcBytes: Uint8Array,
-  info: Evm.EvmInfo
+  info: Evm.EvmInfo,
+  strict: boolean
 ): Format.Values.FunctionInternalResult {
-  let deployedPc: number = Conversion.toBN(deployedPcBytes).toNumber();
-  let constructorPc: number = Conversion.toBN(constructorPcBytes).toNumber();
-  let context: Format.Types.ContractType = Contexts.Import.contextToType(
+  const deployedPc: number = Conversion.toBN(deployedPcBytes).toNumber();
+  const constructorPc: number = Conversion.toBN(constructorPcBytes).toNumber();
+  const context: Format.Types.ContractType = Contexts.Import.contextToType(
     info.currentContext
   );
   //before anything else: do we even have an internal functions table?
@@ -625,44 +631,56 @@ export function decodeInternalFunction(
   }
   //another check: is only the deployed PC zero?
   if (deployedPc === 0 && constructorPc !== 0) {
+    const error = {
+      kind: "MalformedInternalFunctionError" as const,
+      context,
+      deployedProgramCounter: 0,
+      constructorProgramCounter: constructorPc
+    };
+    if (strict) {
+      throw new StopDecodingError(error);
+    }
     return {
       type: dataType,
       kind: "error" as const,
-      error: {
-        kind: "MalformedInternalFunctionError" as const,
-        context,
-        deployedProgramCounter: 0,
-        constructorProgramCounter: constructorPc
-      }
+      error
     };
   }
   //one last pre-check: is this a deployed-format pointer in a constructor?
   if (info.currentContext.isConstructor && constructorPc === 0) {
+    const error = {
+      kind: "DeployedFunctionInConstructorError" as const,
+      context,
+      deployedProgramCounter: deployedPc,
+      constructorProgramCounter: 0
+    };
+    if (strict) {
+      throw new StopDecodingError(error);
+    }
     return {
       type: dataType,
       kind: "error" as const,
-      error: {
-        kind: "DeployedFunctionInConstructorError" as const,
-        context,
-        deployedProgramCounter: deployedPc,
-        constructorProgramCounter: 0
-      }
+      error
     };
   }
   //otherwise, we get our function
-  let pc = info.currentContext.isConstructor ? constructorPc : deployedPc;
-  let functionEntry = info.internalFunctionsTable[pc];
+  const pc = info.currentContext.isConstructor ? constructorPc : deployedPc;
+  const functionEntry = info.internalFunctionsTable[pc];
   if (!functionEntry) {
     //if it's not zero and there's no entry... error!
+    const error = {
+      kind: "NoSuchInternalFunctionError" as const,
+      context,
+      deployedProgramCounter: deployedPc,
+      constructorProgramCounter: constructorPc
+    };
+    if (strict) {
+      throw new StopDecodingError(error);
+    }
     return {
       type: dataType,
       kind: "error" as const,
-      error: {
-        kind: "NoSuchInternalFunctionError" as const,
-        context,
-        deployedProgramCounter: deployedPc,
-        constructorProgramCounter: constructorPc
-      }
+      error
     };
   }
   if (functionEntry.isDesignatedInvalid) {
@@ -677,10 +695,10 @@ export function decodeInternalFunction(
       }
     };
   }
-  let name = functionEntry.name;
-  let mutability = functionEntry.mutability;
-  let definedIn = Evm.Import.functionTableEntryToType(functionEntry); //may be null
-  let id = Evm.Import.makeInternalFunctionId(functionEntry);
+  const name = functionEntry.name;
+  const mutability = functionEntry.mutability;
+  const definedIn = Evm.Import.functionTableEntryToType(functionEntry); //may be null
+  const id = Evm.Import.makeInternalFunctionId(functionEntry);
   return {
     type: dataType,
     kind: "value" as const,
@@ -757,7 +775,9 @@ function checkPaddingDirect(
     case "signed":
       return checkPaddingSigned(bytes, length);
     case "signedOrLeft":
-      return checkPaddingSigned(bytes, length) || checkPaddingLeft(bytes, length);
+      return (
+        checkPaddingSigned(bytes, length) || checkPaddingLeft(bytes, length)
+      );
   }
 }
 

--- a/packages/codec/lib/basic/decode/index.ts
+++ b/packages/codec/lib/basic/decode/index.ts
@@ -310,10 +310,13 @@ export function* decodeBasic(
             value: yield* decodeExternalFunction(address, selector, info)
           };
         case "internal":
-          //note: we no longer error here if strict is true, because we
-          //want to be able to use strict mode to decode immutables, and
-          //these can be immutables.  yes, this is a bit of an abuse of
-          //strict mode, which was meant for ABI decoding, but oh well.
+          //note: we used to error if we hit this point with strict === true,
+          //since internal function pointers don't go in the ABI, and strict
+          //mode is intended for ABI decoding.  however, there are times when
+          //we want to use strict mode to decode immutables, and immutables can
+          //include internal function pointers.  so now we allow this.  yes,
+          //this is a bit of an abuse of strict mode, which was after all meant
+          //for ABI decoding, but oh well.
           if (!checkPadding(bytes, dataType, paddingMode)) {
             const error = {
               kind: "FunctionInternalPaddingError" as const,

--- a/packages/debugger/test/data/returnvalue.js
+++ b/packages/debugger/test/data/returnvalue.js
@@ -16,6 +16,7 @@ pragma solidity ^0.8.0;
 contract ReturnValues {
 
   int8 immutable minus = -1;
+  function() internal immutable trap = fail;
 
   constructor(bool fail) {
     if(fail) {
@@ -37,6 +38,10 @@ contract ReturnValues {
 
   function panic() public {
     assert(false);
+  }
+
+  function dummy() public {
+    trap();
   }
 }
 
@@ -218,12 +223,19 @@ describe("Return value decoding", function () {
     assert.strictEqual(decoding.kind, "bytecode");
     assert.strictEqual(decoding.class.typeName, "ReturnValues");
     const immutables = decoding.immutables;
-    assert.lengthOf(immutables, 1);
+    debug("immutables: %O", immutables);
+    assert.lengthOf(immutables, 2);
     assert.strictEqual(immutables[0].name, "minus");
     assert.strictEqual(immutables[0].class.typeName, "ReturnValues");
     assert.strictEqual(
       Codec.Format.Utils.Inspect.unsafeNativize(immutables[0].value),
       -1
+    );
+    assert.strictEqual(immutables[1].name, "trap");
+    assert.strictEqual(immutables[1].class.typeName, "ReturnValues");
+    assert.strictEqual(
+      Codec.Format.Utils.Inspect.unsafeNativize(immutables[1].value),
+      "ReturnValues.fail"
     );
   });
 


### PR DESCRIPTION
Here's a problem I noticed today: Codec will fail to decode bytecode returned from a constructor when it contains immutables of `function internal` type.  I was debugging a transaction that did this (a test transaction I made, obviously, not something on mainnet or something) and I noticed it was failing to decode the bytecode at the end.

Why did this occur?  Well, we use strict mode for decoding immutables; this is convenient for various reasons.  (Like, it allows for us to distinguish retryable errors and fall back into ABI mode if one occurs; this would be much more difficult without strict mode.)  But there's a problem -- strict mode was meant for ABI decoding; it's actually called `strictAbi` mode internally!  So, I made it so that codec will refuse to decode internal function pointers in strict mode, because those don't go in the ABI.

This presents a problem here.  We could turn off strict mode for immutables, but then we have to handle the retry problem a different way, which gets ugly quickly.  We could split strict mode in two, but, uh, that's a fair bit of work.  So, I figured the simplest solution was to just allow strict mode to decode internal function pointers.  It's a bit of an abuse of strict mode, but, I mean, the case my guard was *intended* to catch (unlike the one it actually caught!) is a can't-happen situation, so, I don't see the harm.

I did have to add a bit more boilerplate to internal function pointer as a result, as now it has to account for both strict mode and loose mode.  But that's no big deal.  (Possibly we could factor this boilerplate error-handling, like we factored some of the other boilerplate error-handling in codec, but it didn't seem worth it to me.)

That said, just changing this didn't fully fix the problem, because, oops, the debugger and decoder weren't passing in the internal functions table when decoding return values!  So I had the debugger do that.  I also added a test of this; or rather, expanded our existing test of decoding returned bytecode to include an immutable internal function pointer. :)

What about the decoder?  Well, the decoder doesn't currently support decoding returned bytecode at all, so, I made no changes there; if it did, though, then I'd have to move the setting up of the internal functions table from the instance decoder to the contract decoder.  (By which I mean, I actually *did* that and got it to compile before realizing it was pointless, so, uh, at least now I know that it's possible should it come up in the future.  I could go back and add that change in if you really want some future-proofing, but be aware that that would be adding untested code...)

Also, while I was at it, I changed some `let`s to `const`s.  Annoyingly, `prettier` also made a bunch of changes, so let me highlight the real changes for you:

1. In `basic/decode/index.ts`, the real changes are the ones from lines 312-685 (in the new version); everything prior is either `prettier` or me changing `let` to `const`.
2. `data/sagas/index.js`, the real changes are the ones on line 152 and earlier.
3. In the tests, all the changes are real.