### PR TITLE
Core: add managed ganache version info to the output of truffle version

### DIFF
--- a/packages/core/.eslintrc.json
+++ b/packages/core/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": ["../../.eslintrc.package.json"]
+  "extends": ["../../.eslintrc.package.json"],
+  "globals": {
+    "BUNDLE_VERSION":"readonly"
+  }
 }

--- a/packages/core/.eslintrc.json
+++ b/packages/core/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": ["../../.eslintrc.package.json"],
   "globals": {
-    "BUNDLE_VERSION":"readonly"
+    "BUNDLE_VERSION": "readonly"
   }
 }

--- a/packages/core/lib/version.js
+++ b/packages/core/lib/version.js
@@ -60,9 +60,15 @@ const logWeb3 = (logger = console) => {
   logger.log(`Web3.js v${web3Version}`);
 };
 
+const logGanache = (logger = console) => {
+  const ganacheVersion = pkg.dependencies.ganache;
+  logger.log(`Ganache V${ganacheVersion}`);
+};
+
 const logAll = (logger = console, config) => {
   const versionInformation = info(config);
   logTruffle(logger, versionInformation);
+  logGanache(logger);
   logSolidity(logger, versionInformation, config);
   logNode(logger);
   logWeb3(logger);

--- a/packages/core/lib/version.js
+++ b/packages/core/lib/version.js
@@ -62,7 +62,7 @@ const logWeb3 = (logger = console) => {
 
 const logGanache = (logger = console) => {
   const ganacheVersion = pkg.dependencies.ganache;
-  logger.log(`Ganache V${ganacheVersion}`);
+  logger.log(`Ganache v${ganacheVersion}`);
 };
 
 const logAll = (logger = console, config) => {


### PR DESCRIPTION
Resolved issue #4678 by reading from Truffle's package.json for Ganache's version number.
Once Ganache adds .version, we can make a change to use that instead. 

Also, BUNDLE_VERSION is causing an eslint no-undef rule complaint, this variable is now on the package level eslintrc.json, should this be moved to global eslintrc.json?