### PR TITLE
Bug Fix: Revert ts target to es2016

### DIFF
--- a/packages/abi-utils/tsconfig.json
+++ b/packages/abi-utils/tsconfig.json
@@ -4,7 +4,7 @@
 
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es2018",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "target": "es2016",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     "lib": ["es2019"],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */

--- a/packages/artifactor/tsconfig.json
+++ b/packages/artifactor/tsconfig.json
@@ -3,7 +3,7 @@
     "declaration": true,
     "module": "commonjs",
     "esModuleInterop": true,
-    "target": "es2018",
+    "target": "es2016",
     "noImplicitAny": true,
     "moduleResolution": "node",
     "sourceMap": true,

--- a/packages/blockchain-utils/tsconfig.json
+++ b/packages/blockchain-utils/tsconfig.json
@@ -3,7 +3,7 @@
     "declaration": true,
     "module": "commonjs",
     "esModuleInterop": true,
-    "target": "es2018",
+    "target": "es2016",
     "noImplicitAny": true,
     "moduleResolution": "node",
     "sourceMap": true,

--- a/packages/box/tsconfig.json
+++ b/packages/box/tsconfig.json
@@ -3,7 +3,7 @@
     "declaration": true,
     "module": "commonjs",
     "esModuleInterop": true,
-    "target": "es2018",
+    "target": "es2016",
     "noImplicitAny": true,
     "moduleResolution": "node",
     "sourceMap": true,

--- a/packages/code-utils/tsconfig.json
+++ b/packages/code-utils/tsconfig.json
@@ -3,7 +3,7 @@
     "declaration": true,
     "module": "commonjs",
     "esModuleInterop": true,
-    "target": "es2018",
+    "target": "es2016",
     "noImplicitAny": true,
     "moduleResolution": "node",
     "sourceMap": true,

--- a/packages/codec/tsconfig.json
+++ b/packages/codec/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "esModuleInterop": true,
     "declaration": true,
-    "target": "es2018",
+    "target": "es2016",
     "downlevelIteration": true,
     "noImplicitAny": true,
     "moduleResolution": "node",

--- a/packages/compile-common/tsconfig.json
+++ b/packages/compile-common/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "esModuleInterop": true,
     "declaration": true,
-    "target": "es2018",
+    "target": "es2016",
     "noImplicitAny": true,
     "moduleResolution": "node",
     "sourceMap": true,

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "esModuleInterop": true,
-    "target": "es2018",
+    "target": "es2016",
     "noImplicitAny": true,
     "moduleResolution": "node",
     "sourceMap": true,

--- a/packages/db-loader/tsconfig.json
+++ b/packages/db-loader/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "esModuleInterop": true,
     "declaration": true,
-    "target": "es2018",
+    "target": "es2016",
     "noImplicitAny": true,
     "moduleResolution": "node",
     "sourceMap": true,

--- a/packages/decoder/tsconfig.json
+++ b/packages/decoder/tsconfig.json
@@ -3,7 +3,7 @@
     "declaration": true,
     "module": "commonjs",
     "esModuleInterop": true,
-    "target": "es2018",
+    "target": "es2016",
     "downlevelIteration": true,
     "noImplicitAny": true,
     "moduleResolution": "node",

--- a/packages/fetch-and-compile/tsconfig.json
+++ b/packages/fetch-and-compile/tsconfig.json
@@ -3,7 +3,7 @@
     "declaration": true,
     "module": "commonjs",
     "esModuleInterop": true,
-    "target": "es2018",
+    "target": "es2016",
     "downlevelIteration": true,
     "noImplicitAny": true,
     "strictNullChecks": true,

--- a/packages/hdwallet-provider/tsconfig.json
+++ b/packages/hdwallet-provider/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es2018",
+    "target": "es2016",
     "noImplicitAny": true,
     "declaration": true,
     "sourceMap": true,

--- a/packages/interface-adapter/tsconfig.json
+++ b/packages/interface-adapter/tsconfig.json
@@ -3,7 +3,7 @@
     "declaration": true,
     "module": "commonjs",
     "esModuleInterop": true,
-    "target": "es2018",
+    "target": "es2016",
     "noImplicitAny": true,
     "moduleResolution": "node",
     "sourceMap": true,

--- a/packages/plugins/tsconfig.json
+++ b/packages/plugins/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "esModuleInterop": true,
     "declaration": true,
-    "target": "es2018",
+    "target": "es2016",
     "noImplicitAny": true,
     "moduleResolution": "node",
     "sourceMap": true,

--- a/packages/preserve-fs/tsconfig.json
+++ b/packages/preserve-fs/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "esModuleInterop": true,
     "declaration": true,
-    "target": "es2018",
+    "target": "es2016",
     "noImplicitAny": true,
     "moduleResolution": "node",
     "sourceMap": true,

--- a/packages/preserve-to-buckets/tsconfig.json
+++ b/packages/preserve-to-buckets/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "esModuleInterop": true,
     "declaration": true,
-    "target": "es2018",
+    "target": "es2016",
     // We disable this because of IPFS dependencies that don't adhere
     "noImplicitAny": false,
     "moduleResolution": "node",

--- a/packages/preserve-to-filecoin/tsconfig.json
+++ b/packages/preserve-to-filecoin/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "esModuleInterop": true,
     "declaration": true,
-    "target": "es2018",
+    "target": "es2016",
     "noImplicitAny": true,
     "moduleResolution": "node",
     "sourceMap": true,

--- a/packages/preserve-to-ipfs/tsconfig.json
+++ b/packages/preserve-to-ipfs/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "esModuleInterop": true,
     "declaration": true,
-    "target": "es2018",
+    "target": "es2016",
     // We disable this because of IPFS dependencies that don't adhere
     "noImplicitAny": false,
     "moduleResolution": "node",

--- a/packages/preserve/tsconfig.json
+++ b/packages/preserve/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "esModuleInterop": true,
     "declaration": true,
-    "target": "es2018",
+    "target": "es2016",
     "noImplicitAny": true,
     "moduleResolution": "node",
     "experimentalDecorators": true,

--- a/packages/profiler/tsconfig.json
+++ b/packages/profiler/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "esModuleInterop": true,
     "declaration": true,
-    "target": "es2018",
+    "target": "es2016",
     "noImplicitAny": true,
     "moduleResolution": "node",
     "sourceMap": true,

--- a/packages/resolver/tsconfig.json
+++ b/packages/resolver/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "esModuleInterop": true,
     "declaration": true,
-    "target": "es2018",
+    "target": "es2016",
     "noImplicitAny": true,
     "moduleResolution": "node",
     "sourceMap": true,

--- a/packages/source-fetcher/tsconfig.json
+++ b/packages/source-fetcher/tsconfig.json
@@ -3,7 +3,7 @@
     "declaration": true,
     "module": "commonjs",
     "esModuleInterop": true,
-    "target": "es2018",
+    "target": "es2016",
     "downlevelIteration": true,
     "noImplicitAny": true,
     "moduleResolution": "node",


### PR DESCRIPTION
This PR downgrades the ts target in a few truffle packages as the recent update caused an error when trying to deploy to various test-nets using `@truffle/hdwallet-provider` (`rinkeby` and `ropsten` were the ones tested in this case.) Downgraded the other packages for the sake of consistency. This PR addresses issue #4676.

#### Testing this PR

- `git checkout lee/hdwallet-provider-fix`
- ` cd packages/hdwallet-provider`
- ` yarn link`
-  `cd /path/to/your/new/truffle-test-project`
- `truffle init`
-  Configure `rinkeby` or `ropsten` in your `truffle-config.js`
-  `yarn link @truffle/hdwallet-provider`
-  `truffle migrate --network {your-testnet}`