### PR TITLE
Downgrade remaining TS packages to `target: es2016`

### DIFF
--- a/packages/compile-solidity/tsconfig.json
+++ b/packages/compile-solidity/tsconfig.json
@@ -6,7 +6,7 @@
     "esModuleInterop": true,
     "lib": ["esnext", "dom"],
     "skipLibCheck": true,
-    "target": "es2018",
+    "target": "es2016",
     "moduleResolution": "node",
     "downlevelIteration": true,
     "allowSyntheticDefaultImports": true,

--- a/packages/db-kit/tsconfig.json
+++ b/packages/db-kit/tsconfig.json
@@ -6,7 +6,7 @@
     "esModuleInterop": true,
     "lib": ["esnext", "dom"],
     "skipLibCheck": true,
-    "target": "es2018",
+    "target": "es2016",
     "moduleResolution": "node",
     "downlevelIteration": true,
     "allowSyntheticDefaultImports": true,

--- a/packages/error/tsconfig.json
+++ b/packages/error/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "es2016",
     "module": "commonjs",
     "declaration": true,
     "sourceMap": true,

--- a/packages/expect/tsconfig.json
+++ b/packages/expect/tsconfig.json
@@ -5,7 +5,7 @@
     "esModuleInterop": true,
     "lib": ["esnext"],
     "skipLibCheck": true,
-    "target": "es2018",
+    "target": "es2016",
     "moduleResolution": "node",
     "downlevelIteration": true,
     "allowSyntheticDefaultImports": true,

--- a/packages/provisioner/tsconfig.json
+++ b/packages/provisioner/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-      "target": "es2018",
+      "target": "es2016",
       "module": "commonjs",
       "declaration": true,
       "sourceMap": true,


### PR DESCRIPTION
Just a quick follow-on to #4688, I noticed a few packages weren't downgraded, so I put in this PR to get the remaining ones for consistency.