### PR TITLE
Dedupe slack notification channel

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           channel: '#truffle-ci-notifications'
           status: ${{ job.status }}
-          fields: workflow,job,commit,message,ref,author,pullRequest
+          fields: commit,author,pullRequest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -59,9 +59,9 @@ jobs:
       - uses: 8398a7/action-slack@v3
         continue-on-error: true
         with:
-          channel: '#buidl-status'
+          channel: '#truffle-ci-notifications'
           status: ${{ job.status }}
-          fields: repo,message,commit,author,eventName,took,pullRequest
+          fields: workflow,job,commit,message,ref,author,pullRequest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
This PR updates the Slack notification target channel in order to consolidate our GitHub notifications. 

As we evaluate the Slack Integration, we may eventually need to turn this one off. We want to ensure all job runs are captured, but it is unclear if the Slack integration can provide that coverage.

Changes
- change notification channel to #truffle-ci-notifications
- update fields

N.B. secretes.SLACK_WEBHOOK_URL also has to be updated here: https://trufflesuite.slack.com/apps/A0F7XDUAZ-incoming-webhooks\?tab\=more_info

## how to test

Watch the #truffle-ci-integration channel and see if things are integrated.