### PR TITLE
Internal improvement: Put all BUNDLE globals in main .eslintrc.json

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,13 @@
     "es2021": true,
     "node": true
   },
+  "globals": {
+    "BUNDLE_VERSION": "readonly",
+    "BUNDLE_CHAIN_FILENAME": "readonly",
+    "BUNDLE_ANALYTICS_FILENAME": "readonly",
+    "BUNDLE_LIBRARY_FILENAME": "readonly",
+    "BUNDLE_CONSOLE_CHILD_FILENAME": "readonly"
+  },
   "extends": [
     "plugin:react-hooks/recommended"
   ],

--- a/packages/core/.eslintrc.json
+++ b/packages/core/.eslintrc.json
@@ -1,6 +1,3 @@
 {
-  "extends": ["../../.eslintrc.package.json"],
-  "globals": {
-    "BUNDLE_VERSION": "readonly"
-  }
+  "extends": ["../../.eslintrc.package.json"]
 }


### PR DESCRIPTION
What with @lsqproduction dealing with `BUNDLE_VERSION` in #4686, and @cds-amal dealing with `BUNDLE_CHAIN_FILENAME` in #4671, I thought it was probably best to just take the whole list of these variables and stick them in the main `.eslintrc.json`, so we don't have to keep worrying about this (unless we add new ones of these!).

(Hope you don't mind @cds-amal!)