### PR TITLE
Replace lodash.assignIn with native JS implementation

### DIFF
--- a/packages/config/.eslintrc.json
+++ b/packages/config/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+    "extends": ["../../.eslintrc.package.json"]
+}

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -26,7 +26,6 @@
     "@truffle/provider": "^0.2.45",
     "conf": "^10.0.2",
     "find-up": "^2.1.0",
-    "lodash.assignin": "^4.2.0",
     "lodash.merge": "^4.6.2",
     "module": "^1.2.5",
     "original-require": "^1.0.1"
@@ -34,7 +33,6 @@
   "devDependencies": {
     "@types/configstore": "^4.0.0",
     "@types/find-up": "^2.1.0",
-    "@types/lodash.assignin": "^4.2.6",
     "@types/lodash.merge": "^4.6.6",
     "@types/node": "12.12.21",
     "@types/sinon": "^9.0.10",

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,5 +1,4 @@
 import path from "path";
-import assignIn from "lodash.assignin";
 import merge from "lodash.merge";
 import Module from "module";
 import findUp from "find-up";
@@ -11,8 +10,8 @@ import { EventManager } from "@truffle/events";
 
 const DEFAULT_CONFIG_FILENAME = "truffle-config.js";
 const BACKUP_CONFIG_FILENAME = "truffle.js"; // old config filename
-
 class TruffleConfig {
+  // eslint-disable-next-line no-undef
   [key: string]: any;
 
   private _deepCopy: string[];
@@ -51,7 +50,7 @@ class TruffleConfig {
     Object.defineProperty(this, propertyName, {
       get:
         descriptor.get ||
-        function() {
+        function () {
           // value is specified
           if (propertyName in self._values) {
             return self._values[propertyName];
@@ -67,7 +66,7 @@ class TruffleConfig {
         },
       set:
         descriptor.set ||
-        function(value) {
+        function (value) {
           self._values[propertyName] = descriptor.transform
             ? descriptor.transform(value)
             : value;
@@ -92,10 +91,12 @@ class TruffleConfig {
   }
 
   public with(obj: any): TruffleConfig {
+    //Normalized, or shallow clowning only copies an object's own enumerable
+    //properties ignoring properties up the prototype chain
     const current = this.normalize(this);
     const normalized = this.normalize(obj);
 
-    const newConfig = assignIn(
+    const newConfig = Object.assign(
       Object.create(TruffleConfig.prototype),
       current,
       normalized

--- a/packages/config/test/unit.test.ts
+++ b/packages/config/test/unit.test.ts
@@ -1,0 +1,54 @@
+import assert from "assert";
+import TruffleConfig from "../dist";
+import { describe, it } from "mocha";
+
+describe("TruffleConfig unit tests", async () => {
+  describe("with", async () => {
+    let truffleConfig: TruffleConfig;
+
+    beforeEach(() => {
+      truffleConfig = TruffleConfig.default();
+    });
+
+    it("a simple object", async () => {
+      const expectedRandom = 42;
+      const expectedFoo = "bar";
+      const obj = {
+        random: expectedRandom,
+        foo: expectedFoo
+      };
+      const newConfig = truffleConfig.with(obj);
+      assert.equal(expectedRandom, newConfig.random);
+      assert.equal(expectedFoo, newConfig.foo);
+    });
+
+    it("overwrites a known property", () => {
+      const expectedProvider = { a: "propertyA", b: "propertyB" };
+      const newConfig = truffleConfig.with({ provider: expectedProvider });
+      assert.deepEqual(expectedProvider, newConfig.provider);
+    });
+
+    it("ignores properties that throw", () => {
+      const expectedSurvivor = "BatMan";
+      const minefield = { who: expectedSurvivor };
+
+      const hits = ["boom", "pow", "crash", "zonk"];
+      hits.forEach(hit => {
+        Object.defineProperty(minefield, hit, {
+          get() {
+            throw new Error("BOOM!");
+          },
+          enumerable: true //must be enumerable
+        });
+      });
+
+      const newConfig = truffleConfig.with(minefield);
+
+      //one survivor
+      assert.equal(expectedSurvivor, newConfig.who);
+
+      //these jokers shouldn't be included
+      hits.forEach(hit => assert.equal(undefined, newConfig[hit]));
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4592,13 +4592,6 @@
   dependencies:
     "@types/lodash" "*"
 
-"@types/lodash.assignin@^4.2.6":
-  version "4.2.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.assignin/-/lodash.assignin-4.2.6.tgz#fe94b7bbad78f97897a028e8f4e8945c03d84a6f"
-  integrity sha512-kO9C2Oq0X8yehLu0o689SwR+wy+m4IQZg2TxRBXNkmpd0WY/GYEV+tTqrWRu2jt69eDOaVMJxna6QnDQ/g1TSg==
-  dependencies:
-    "@types/lodash" "*"
-
 "@types/lodash.clonedeep@^4.5.4":
   version "4.5.6"
   resolved "https://registry.yarnpkg.com/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz#3b6c40a0affe0799a2ce823b440a6cf33571d32b"
@@ -18752,7 +18745,7 @@ lodash.assign@^4.0.3, lodash.assign@^4.0.6, lodash.assign@^4.2.0:
   resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
   integrity sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=
 
-lodash.assignin@^4.0.9, lodash.assignin@^4.2.0:
+lodash.assignin@^4.0.9:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assignin/-/lodash.assignin-4.2.0.tgz#ba8df5fb841eb0a3e8044232b0e263a8dc6a28a2"
   integrity sha1-uo31+4QesKPoBEIysOJjqNxqKKI=


### PR DESCRIPTION
This PR removes the [lodash.assignIn](https://lodash.com/docs/4.17.15#assignIn) dependency with a native JavaScript implementation. `TruffleConfig.with` is the only place that uses `lodash.assignIn`, *however,* it normalizes all inputs and, in the process, removes their prototype references making `lodash.assignIn` overkill. We can instead use `Object.assign` for this `assignIn` business.
