### PR TITLE
Enhancement: Add getSupportedNetworks() to source-fetcher and fetch-and-compile

### DIFF
--- a/packages/fetch-and-compile/lib/fetch.ts
+++ b/packages/fetch-and-compile/lib/fetch.ts
@@ -28,8 +28,12 @@ export async function fetchAndCompileForRecognizer(
 }
 
 //sort/filter fetchers by user's order, if given; otherwise use default order
-function getSortedFetcherConstructors(config: Config): FetcherConstructor[] {
-  const userFetcherNames: string[] | undefined = config.sourceFetchers;
+export function getSortedFetcherConstructors(
+  config?: Config
+): FetcherConstructor[] {
+  const userFetcherNames: string[] | undefined = (
+    config || { sourceFetchers: undefined }
+  ).sourceFetchers;
   let sortedFetchers: FetcherConstructor[] = [];
   if (userFetcherNames) {
     for (let name of userFetcherNames) {

--- a/packages/fetch-and-compile/lib/index.ts
+++ b/packages/fetch-and-compile/lib/index.ts
@@ -47,12 +47,12 @@ export async function fetchAndCompileForDebugger(
   return recognizer.getErrors();
 }
 
-export function getSupportedNetworks(config?: Config): Types.NetworkInfos {
+export function getSupportedNetworks(config?: Config): Types.SupportedNetworks {
   const fetchers = getSortedFetcherConstructors(config);
   //strictly speaking these are fetcher constructors, but since we
   //won't be using fetcher instances in this function, I'm not going
   //to worry about the difference
-  let supportedNetworks: Types.NetworkInfos = {};
+  let supportedNetworks: Types.SupportedNetworks = {};
   for (const fetcher of fetchers) {
     const fetcherNetworks = fetcher.getSupportedNetworks();
     for (const name in fetcherNetworks) {

--- a/packages/fetch-and-compile/lib/types.ts
+++ b/packages/fetch-and-compile/lib/types.ts
@@ -1,5 +1,16 @@
 import type { WorkflowCompileResult } from "@truffle/compile-common";
-import type { SourceInfo } from "@truffle/source-fetcher";
+import type {
+  SourceInfo,
+  NetworkInfo as FetcherNetworkInfo
+} from "@truffle/source-fetcher";
+
+export interface NetworkInfo extends FetcherNetworkInfo {
+  fetchers: string[];
+}
+
+export interface NetworkInfos {
+  [name: string]: NetworkInfo;
+}
 
 export type FailureType = "fetch" | "compile" | "language";
 

--- a/packages/fetch-and-compile/lib/types.ts
+++ b/packages/fetch-and-compile/lib/types.ts
@@ -8,7 +8,7 @@ export interface NetworkInfo extends FetcherNetworkInfo {
   fetchers: string[];
 }
 
-export interface NetworkInfos {
+export interface SupportedNetworks {
   [name: string]: NetworkInfo;
 }
 

--- a/packages/fetch-and-compile/package.json
+++ b/packages/fetch-and-compile/package.json
@@ -49,10 +49,12 @@
   "devDependencies": {
     "@truffle/compile-common": "^0.7.26",
     "@truffle/config": "^1.3.17",
+    "@types/chai": "^4.2.22",
     "@types/debug": "^4.1.7",
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.11.6",
     "@types/semver": "^7.3.9",
+    "chai": "^4.2.0",
     "mocha": "^9.1.3",
     "ts-node": "^10.4.0",
     "typescript": "^4.1.4"

--- a/packages/fetch-and-compile/test/fetch.test.ts
+++ b/packages/fetch-and-compile/test/fetch.test.ts
@@ -395,7 +395,7 @@ describe("fetchAndCompileMultiple", function () {
       addresses,
       config
     );
-    assert.equal(Object.keys(failures).length, 0); //there should be no failures
+    assert.isEmpty(failures); //there should be no failures
     const expectedNames = ["UniswapV2Router02", "ENSRegistryWithFallback"];
     for (let i = 0; i < addresses.length; i++) {
       const result = results[addresses[i]];

--- a/packages/fetch-and-compile/test/fetch.test.ts
+++ b/packages/fetch-and-compile/test/fetch.test.ts
@@ -1,10 +1,14 @@
 import debugModule from "debug";
 const debug = debugModule("fetch-and-compile:test");
 
-import assert from "assert";
+import { assert } from "chai";
 import "mocha";
 import Config from "@truffle/config";
-import { fetchAndCompile, fetchAndCompileMultiple } from "../lib/index";
+import {
+  fetchAndCompile,
+  fetchAndCompileMultiple,
+  getSupportedNetworks
+} from "../lib/index";
 import axios from "axios";
 import sinon from "sinon";
 import path from "path";
@@ -80,6 +84,20 @@ afterEach(function () {
   axios.get.restore();
   //@ts-ignore
   axios.request.restore();
+});
+
+describe("Supported networks", function () {
+  it("Lists supported networks", function () {
+    const networks = getSupportedNetworks();
+    assert.property(networks, "mainnet");
+    assert.notProperty(networks, "completelymadeupnetworkthatwillneverexist");
+    assert.deepEqual(networks.mainnet, {
+      name: "mainnet",
+      networkId: 1,
+      chainId: 1,
+      fetchers: ["etherscan", "sourcify"]
+    });
+  });
 });
 
 describe("Etherscan single-source Solidity case", function () {

--- a/packages/source-fetcher/lib/common.ts
+++ b/packages/source-fetcher/lib/common.ts
@@ -3,18 +3,6 @@ import util from "util";
 import { setTimeout } from "timers";
 import type * as Types from "./types";
 
-export const networksById: { [id: number]: string } = {
-  1: "mainnet",
-  3: "ropsten",
-  4: "rinkeby",
-  5: "goerli",
-  42: "kovan",
-  10: "optimistic",
-  69: "kovan-optimistic",
-  42161: "arbitrum",
-  137: "polygon"
-};
-
 export function makeFilename(name: string, extension: string = ".sol"): string {
   if (!name) {
     return "Contract" + extension;

--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -25,11 +25,11 @@ const etherscanCommentHeader = `/**
 const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
   implements Fetcher
 {
-  get fetcherName(): string {
-    return "etherscan";
-  }
   static get fetcherName(): string {
     return "etherscan";
+  }
+  get fetcherName(): string {
+    return EtherscanFetcher.fetcherName;
   }
 
   static async forNetworkId(

--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -6,12 +6,12 @@ const Web3Utils = require("web3-utils");
 import type { Fetcher, FetcherConstructor } from "./types";
 import type * as Types from "./types";
 import {
-  networksById,
   makeFilename,
   makeTimer,
   removeLibraries,
   InvalidNetworkError
 } from "./common";
+import { networkNamesById, networksByName } from "./networks";
 import axios from "axios";
 import retry from "async-retry";
 
@@ -41,26 +41,32 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
     return new EtherscanFetcher(id, options ? options.apiKey : "");
   }
 
+  private readonly networkName: string;
+
   private readonly apiKey: string;
   private readonly delay: number; //minimum # of ms to wait between requests
 
   private ready: Promise<void>; //always await this timer before making a request.
   //then, afterwards, start a new timer.
 
+  private static readonly supportedNetworks = new Set([
+    "mainnet",
+    "ropsten",
+    "kovan",
+    "rinkeby",
+    "goerli",
+    "optimistic",
+    "kovan-optimistic",
+    "arbitrum",
+    "polygon"
+  ]);
+
   constructor(networkId: number, apiKey: string = "") {
-    const networkName = networksById[networkId];
-    const supportedNetworks = [
-      "mainnet",
-      "ropsten",
-      "kovan",
-      "rinkeby",
-      "goerli",
-      "optimistic",
-      "kovan-optimistic",
-      "arbitrum",
-      "polygon"
-    ];
-    if (networkName === undefined || !supportedNetworks.includes(networkName)) {
+    const networkName = networkNamesById[networkId];
+    if (
+      networkName === undefined ||
+      !EtherscanFetcher.supportedNetworks.has(networkName)
+    ) {
       throw new InvalidNetworkError(networkId, "etherscan");
     }
     this.networkName = networkName;
@@ -72,7 +78,13 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
     this.ready = makeTimer(0); //at start, it's ready to go immediately
   }
 
-  private readonly networkName: string;
+  static getSupportedNetworks(): Types.NetworkInfos {
+    return Object.fromEntries(
+      Object.entries(networksByName).filter(([name, _]) =>
+        EtherscanFetcher.supportedNetworks.has(name)
+      )
+    );
+  }
 
   async fetchSourcesForAddress(
     address: string

--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -78,7 +78,7 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
     this.ready = makeTimer(0); //at start, it's ready to go immediately
   }
 
-  static getSupportedNetworks(): Types.NetworkInfos {
+  static getSupportedNetworks(): Types.SupportedNetworks {
     return Object.fromEntries(
       Object.entries(networksByName).filter(([name, _]) =>
         EtherscanFetcher.supportedNetworks.has(name)

--- a/packages/source-fetcher/lib/index.ts
+++ b/packages/source-fetcher/lib/index.ts
@@ -1,6 +1,17 @@
-import type { Fetcher, FetcherConstructor, SourceInfo } from "./types";
+import type {
+  Fetcher,
+  FetcherConstructor,
+  SourceInfo,
+  NetworkInfo
+} from "./types";
 import { InvalidNetworkError } from "./common";
-export { Fetcher, FetcherConstructor, InvalidNetworkError, SourceInfo };
+export {
+  Fetcher,
+  FetcherConstructor,
+  InvalidNetworkError,
+  SourceInfo,
+  NetworkInfo
+};
 
 import EtherscanFetcher from "./etherscan";
 import SourcifyFetcher from "./sourcify";

--- a/packages/source-fetcher/lib/networks.ts
+++ b/packages/source-fetcher/lib/networks.ts
@@ -1,0 +1,19 @@
+import type * as Types from "./types";
+
+export const networkNamesById: { [id: number]: string } = {
+  1: "mainnet",
+  3: "ropsten",
+  4: "rinkeby",
+  5: "goerli",
+  42: "kovan",
+  10: "optimistic",
+  69: "kovan-optimistic",
+  42161: "arbitrum",
+  137: "polygon"
+};
+
+export const networksByName: Types.NetworkInfos = Object.fromEntries(
+  Object.entries(networkNamesById).map(
+    ([id, name]) => [name, { name, networkId: Number(id), chainId: Number(id) }] //id is a string since it's a key so must use Number()
+  )
+);

--- a/packages/source-fetcher/lib/networks.ts
+++ b/packages/source-fetcher/lib/networks.ts
@@ -12,7 +12,7 @@ export const networkNamesById: { [id: number]: string } = {
   137: "polygon"
 };
 
-export const networksByName: Types.NetworkInfos = Object.fromEntries(
+export const networksByName: Types.SupportedNetworks = Object.fromEntries(
   Object.entries(networkNamesById).map(
     ([id, name]) => [name, { name, networkId: Number(id), chainId: Number(id) }] //id is a string since it's a key so must use Number()
   )

--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -53,7 +53,7 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     }
   }
 
-  static getSupportedNetworks(): Types.NetworkInfos {
+  static getSupportedNetworks(): Types.SupportedNetworks {
     return Object.fromEntries(
       Object.entries(networksByName).filter(([name, _]) =>
         SourcifyFetcher.supportedNetworks.has(name)

--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -12,11 +12,11 @@ import retry from "async-retry";
 const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
   implements Fetcher
 {
-  get fetcherName(): string {
-    return "sourcify";
-  }
   static get fetcherName(): string {
     return "sourcify";
+  }
+  get fetcherName(): string {
+    return SourcifyFetcher.fetcherName;
   }
 
   static async forNetworkId(

--- a/packages/source-fetcher/lib/types.ts
+++ b/packages/source-fetcher/lib/types.ts
@@ -1,7 +1,7 @@
 export interface FetcherConstructor {
   readonly fetcherName: string;
   forNetworkId(networkId: number, options?: FetcherOptions): Promise<Fetcher>;
-  getSupportedNetworks(): NetworkInfos;
+  getSupportedNetworks(): SupportedNetworks;
 }
 
 export interface Fetcher {
@@ -23,7 +23,7 @@ export interface NetworkInfo {
   chainId: number;
 }
 
-export interface NetworkInfos {
+export interface SupportedNetworks {
   [name: string]: NetworkInfo;
 }
 

--- a/packages/source-fetcher/lib/types.ts
+++ b/packages/source-fetcher/lib/types.ts
@@ -1,6 +1,7 @@
 export interface FetcherConstructor {
   readonly fetcherName: string;
   forNetworkId(networkId: number, options?: FetcherOptions): Promise<Fetcher>;
+  getSupportedNetworks(): NetworkInfos;
 }
 
 export interface Fetcher {
@@ -14,6 +15,16 @@ export interface Fetcher {
    * case, although currently there are no such cases)
    */
   fetchSourcesForAddress(address: string): Promise<SourceInfo | null>;
+}
+
+export interface NetworkInfo {
+  name: string;
+  networkId: number;
+  chainId: number;
+}
+
+export interface NetworkInfos {
+  [name: string]: NetworkInfo;
 }
 
 export interface FetcherOptions {
@@ -57,7 +68,8 @@ export interface SolcSettings {
   metadata?: MetadataSettings;
   viaIR?: boolean;
   libraries?: LibrarySettings; //note: we don't actually want to return this!
-  compilationTarget?: { //not actually a valid compiler setting, but rather where the
+  compilationTarget?: {
+    //not actually a valid compiler setting, but rather where the
     //contract name is stored! (as the lone value, the lone key being the source
     //where it's defined)
     [sourcePath: string]: string;


### PR DESCRIPTION
Addresses #4643.  This PR adds a `getSupportedNetworks()` function to `@truffle/fetch-and-compile`, and a static `getSupportedNetworks()` method to each source fetcher in `@truffle/source-fetcher`.  It also adds a quick test of this functionality.

This PR is mostly pretty straightforward.  For the source-fetcher part, each source fetcher now has a static `getSupportedNetworks()` function.  I could have added an instance version too (like we have for `fetcherName`) but I didn't see a need so I didn't.  I moved the networks information out of `common.ts` and into a new file `networks.ts`.  For now it's pretty bare-bones and continues to make the assumption that network ID equals chain ID.

The networks are returned indexed by name, and each is given as an object with fields `name`, `networkId`, and `chainId`.  Right now those latter two will always be equal, but we may need to allow them to be unequal at some point in the future.

As for the fetch-and-compile part, its `getSupportedNetworks()` function is mostly similar.  Note that this function is not for a specific fetcher, but draws from all of them and combines the results together.  Well, usually it will draw from all of them -- it takes an optional config; if a config is passed in, its `sourceFetchers` field will control which fetchers are pulled from.  In addition, the networks returned by this function all have a `fetchers` field, which gives the names of the fetchers that support that network.

I also added a test, and also did some minor cleanup of various things while I was at it.  And that's it!

I'm intending to follow this up by adding support for more networks to both fetchers, but @gnidan thought this ought to be done first. :)