### PR TITLE
Bug fix: Prevent source-map-utils from splitting surrogate pairs

### DIFF
--- a/packages/source-map-utils/index.js
+++ b/packages/source-map-utils/index.js
@@ -9,7 +9,7 @@ var SourceMapUtils = {
   getCharacterOffsetToLineAndColumnMapping: function (source) {
     var mapping = [];
 
-    source = source.split("");
+    source = Array.from(source);
 
     var line = 0;
     var column = 0;
@@ -422,9 +422,7 @@ var SourceMapUtils = {
       for (let offset = 0; offset < template.length; offset++) {
         const instruction = instructions[index + offset];
         const comparison = template[offset];
-        if (
-          !instruction || instruction.name !== comparison.name
-        ) {
+        if (!instruction || instruction.name !== comparison.name) {
           return false;
         }
         if (

--- a/packages/source-map-utils/index.js
+++ b/packages/source-map-utils/index.js
@@ -9,7 +9,9 @@ var SourceMapUtils = {
   getCharacterOffsetToLineAndColumnMapping: function (source) {
     var mapping = [];
 
-    source = Array.from(source);
+    source = Array.from(source); //note: this will correctly handle
+    //surrogate pairs, but there's still the problem of grapheme
+    //clusters!  We should do something about that later.
 
     var line = 0;
     var column = 0;


### PR DESCRIPTION
This function in `source-map-utils` used `source.split("")` to split `source` into characters.  This splits surrogate pairs.  So I changed it to `Array.from(source)`, which doesn't.

...of course, doing this still doesn't *really* solve the problem, as what we really want here is something more like grapheme clusters, not code points.  But solving that problem is harder and would presumably require introducing a dependency, so I thought I'd just throw up this PR quickly to start.  I could open an issue for that though?