### PR TITLE
Update truffle/contract README examples

### DIFF
--- a/packages/contract/README.md
+++ b/packages/contract/README.md
@@ -17,17 +17,28 @@ $ npm install @truffle/contract
 
 ### Usage
 
-First, set up a new web3 provider instance and initialize your contract, then `require("@truffle/contract")`. The input to the `contract` function is a JSON blob defined by [@truffle/contract-schema](https://github.com/trufflesuite/truffle/tree/master/packages/contract-schema). This JSON blob is structured in a way that can be passed to all truffle-related projects.
+First, set up a new web3 provider instance and initialize your contract, then `require("@truffle/contract")`.
+The input to the `contract` function is a JSON blob defined by [@truffle/contract-schema](https://github.com/trufflesuite/truffle/tree/master/packages/contract-schema). This JSON blob is structured in a way that can be passed to all truffle-related projects.
 
 ```javascript
 const provider = new Web3.providers.HttpProvider("http://localhost:8545");
 const contract = require("@truffle/contract");
 
-// Artifact json previosly saved by @truffle/artifactor
+const MyContract = contract({
+  abi: [...], // minimum required
+  address: "0x...", // optional
+  // many more
+});
+MyContract.setProvider(provider);
+```
+
+Instead of providing these values manually though, the contract-scheme matches the output of the @truffle/artifactor
+
+```javascript
+// json output provided by @truffle/artifactor
 const contractArtifact = require("./path/to/contractArtifact.json");
 
 const MyContract = contract(contractArtifact);
-MyContract.setProvider(provider);
 ```
 
 You now have access to the following functions on `MyContract`, as well as many others:

--- a/packages/contract/README.md
+++ b/packages/contract/README.md
@@ -22,14 +22,14 @@ The contract-schema matches the output of the [@truffle/artifactor](https://gith
 
 ```javascript
 const provider = new Web3.providers.HttpProvider("http://localhost:8545");
-const MyContract = require("./path/to/contractArtifact.json"); //produced by truffle compile
+const MyContract = require("./path/to/contractArtifact.json"); //produced by Truffle compile
 const contract = require("@truffle/contract");
 
 const instance = contract(MyContract);
 ```
 
-If you aren't using truffle artifacts, the input to the `contract` function is a JSON blob defined by [@truffle/contract-schema](https://github.com/trufflesuite/truffle/tree/master/packages/contract-schema). This JSON blob is structured in a way that can be passed to all Truffle-related projects.
-Minimally, it requires the contract ABI, but passing this alone may cause issues using certain features of truffle contract.
+If you aren't using Truffle artifacts, the input to the `contract` function is a JSON blob defined by [@truffle/contract-schema](https://github.com/trufflesuite/truffle/tree/master/packages/contract-schema). This JSON blob is structured in a way that can be passed to all Truffle-related projects.
+Minimally, it requires the contract ABI, but passing this alone may cause issues using certain features of Truffle contract.
 
 ```javascript
 const instance = contract({

--- a/packages/contract/README.md
+++ b/packages/contract/README.md
@@ -40,14 +40,10 @@ Each instance is tied to a specific address on the Ethereum network, and each in
 
 ```javascript
 let deployed;
-MyContract.deployed()
-  .then(function (instance) {
-    deployed = instance;
-    return instance.someFunction(5);
-  })
-  .then(function (result) {
-    // Do something with the result or continue with more transactions.
-  });
+const instance = await MyContract.deployed();
+deployed = instance;
+const result = await instance.someFunction(5);
+// Do something with the result or continue with more transactions.
 ```
 
 or equivalently in ES6 <sup>(node.js 8 or newer)</sup>:
@@ -250,10 +246,8 @@ From Javascript's point of view, this contract has three functions: `setValue`, 
 When we call `setValue()`, this creates a transaction. From Javascript:
 
 ```javascript
-instance.setValue(5).then(function (result) {
-  // result object contains import information about the transaction
-  console.log("Value was set to", result.logs[0].args.val);
-});
+const result = instance.setValue(5);
+console.log("Value was set to", result.logs[0].args.val);
 ```
 
 The result object that gets returned looks like this:
@@ -292,7 +286,7 @@ in the `logs` array.
 We can call `setValue()` without creating a transaction by explicitly using `.call`:
 
 ```javascript
-instance.setValue.call(5).then(...);
+const result = await instance.setValue.call(5);
 ```
 
 This isn't very useful in this case, since `setValue()` sets things, and the value we pass won't be saved since we're not creating a transaction.
@@ -302,19 +296,17 @@ This isn't very useful in this case, since `setValue()` sets things, and the val
 However, we can _get_ the value using `getValue()`, using `.call()`. Calls are always free and don't cost any Ether, so they're good for calling functions that read data off the blockchain:
 
 ```javascript
-instance.getValue.call().then(function (val) {
-  // val represents the `value` storage object in the solidity contract
-  // since the contract returns that value.
-});
+const val = instance.getValue.call();
+// val represents the `value` storage object in the solidity contract
+// since the contract returns that value.
 ```
 
 Even more helpful, however is we _don't even need_ to use `.call` when a function is marked as `view` or `pure`, because `@truffle/contract` will automatically know that that function can only be interacted with via a call:
 
 ```javascript
-instance.getValue().then(function (val) {
-  // val reprsents the `value` storage object in the solidity contract
-  // since the contract returns that value.
-});
+const val = instance.getValue();
+// val reprsents the `value` storage object in the solidity contract
+// since the contract returns that value.
 ```
 
 #### Processing transaction results
@@ -322,11 +314,10 @@ instance.getValue().then(function (val) {
 When you make a transaction, you're given a `result` object that gives you a wealth of information about the transaction. You're given the transaction hash (`result.tx`), the decoded events (also known as logs; `result.logs`), and a transaction receipt (`result.receipt`). In the below example, you'll recieve the `ValueSet()` event because you triggered the event using the `setValue()` function:
 
 ```javascript
-instance.setValue(5).then(function (result) {
-  // result.tx => transaction hash, string
-  // result.logs => array of trigger events (1 item in this case)
-  // result.receipt => receipt object
-});
+const result = await instance.setValue(5);
+// result.tx => transaction hash, string
+// result.logs => array of trigger events (1 item in this case)
+// result.receipt => receipt object
 ```
 
 #### Sending Ether / Triggering the fallback function
@@ -334,9 +325,8 @@ instance.setValue(5).then(function (result) {
 You can trigger the fallback function by sending a transaction to this function:
 
 ```javascript
-instance.sendTransaction({...}).then(function(result) {
-  // Same result object as above.
-});
+// Same result object as above.
+const result = await instance.sendTransaction({...})
 ```
 
 This is promisified like all available contract instance functions, and has the same API as `web3.eth.sendTransaction` without the callback. The `to` value will be automatically filled in for you.
@@ -344,9 +334,8 @@ This is promisified like all available contract instance functions, and has the 
 If you only want to send Ether to the contract a shorthand is available:
 
 ```javascript
-instance.send(web3.toWei(1, "ether")).then(function (result) {
-  // Same result object as above.
-});
+// Same result object as above.
+const result = await instance.send(web3.toWei(1, "ether"));
 ```
 
 #### Estimating gas usage
@@ -354,9 +343,8 @@ instance.send(web3.toWei(1, "ether")).then(function (result) {
 Run this function to estimate the gas usage:
 
 ```javascript
-instance.setValue.estimateGas(5).then(function (result) {
-  // result => estimated gas for this transaction
-});
+//estimated gas for this transaction
+const result = await instance.setValue.estimateGas(5);
 ```
 
 # Testing

--- a/packages/contract/README.md
+++ b/packages/contract/README.md
@@ -22,25 +22,25 @@ The contract-schema matches the output of the [@truffle/artifactor](https://gith
 
 ```javascript
 const provider = new Web3.providers.HttpProvider("http://localhost:8545");
-const MyContract = require("./path/to/contractArtifact.json"); //produced by Truffle compile
+const contractArtifact = require("./path/to/contractArtifact.json"); //produced by Truffle compile
 const contract = require("@truffle/contract");
 
-const instance = contract(MyContract);
+const MyContract = contract(contractArtifact);
 ```
 
 If you aren't using Truffle artifacts, the input to the `contract` function is a JSON blob defined by [@truffle/contract-schema](https://github.com/trufflesuite/truffle/tree/master/packages/contract-schema). This JSON blob is structured in a way that can be passed to all Truffle-related projects.
 Minimally, it requires the contract ABI, but passing this alone may cause issues using certain features of Truffle contract.
 
 ```javascript
-const instance = contract({
+const MyContract = contract({
   abi: [...], // minimum required
   address: "0x...", // optional
   // many more
 });
-instance.setProvider(provider);
+MyContract.setProvider(provider);
 ```
 
-You now have access to the following functions on `instance`, as well as many others:
+You now have access to the following functions on `MyContract`, as well as many others:
 
 - `at()`: Create an instance of `MyContract` that represents your contract at a specific address.
 - `deployed()`: Create an instance of `MyContract` that represents the default address managed by `MyContract`.
@@ -49,9 +49,7 @@ You now have access to the following functions on `instance`, as well as many ot
 Each instance is tied to a specific address on the Ethereum network, and each instance has a 1-to-1 mapping from Javascript functions to contract functions. For instance, if your Solidity contract had a function defined `someFunction(uint value) {}` (solidity), then you could execute that function on the network like so:
 
 ```javascript
-const deployed;
 const instance = await MyContract.deployed();
-deployed = instance;
 const result = await instance.someFunction(5);
 // Do something with the result or continue with more transactions.
 ```
@@ -82,11 +80,11 @@ Let's use `@truffle/contract` with an example contract from [Dapps For Beginners
 ```javascript
 const contract = require("@truffle/contract");
 // Require the package that was previosly saved by @truffle/artifactor
-const MetacoinArtifact = require("./path/to/MetaCoin.json");
-const instance = contract(MetacoinArtifact);
+const metacoinArtifact = require("./path/to/MetaCoin.json");
+const MetaCoin = contract(metacoinArtifact);
 
 // Remember to set the Web3 provider (see above).
-instance.setProvider(provider);
+MetaCoin.setProvider(provider);
 
 // In this scenario, two users will send MetaCoin back and forth, showing
 // how @truffle/contract allows for easy control flow.
@@ -96,26 +94,26 @@ const accountTwo = "e1fd0d4a52...";
 // Note our MetaCoin contract exists at a specific address.
 const contractAddress = "8e2e2cf785...";
 
-const coin = await instance.at(contractAddress);
+const instance = await MetaCoin.at(contractAddress);
 
 try {
   // Make a transaction that calls the function `sendCoin`, sending 3 MetaCoin
   // to the account listed as accountTwo.
-  let result = await coin.sendCoin(accountTwo, 3, { from: accountOne });
+  let result = await instance.sendCoin(accountTwo, 3, { from: accountOne });
   // This code block will not be executed until @truffle/contract has verified
   // the transaction has been processed and it is included in a mined block.
   // @truffle/contract will error if the transaction hasn't been processed in 120 seconds.
 
   // Since we're using promises, we can return a promise for a call that will
   // check account two's balance.
-  let balancerOfAccountTwo = await coin.balances.call(accountTwo);
+  let balancerOfAccountTwo = await instance.balances.call(accountTwo);
   console.log("Balance of account two is " + balancerOfAccountTwo + "!"); // => 3
 
   // But maybe too much was sent. Let's send some back.
   // Like before, will create a transaction that returns a promise, where
   // the callback won't be executed until the transaction has been processed.
-  result = await coin.sendCoin(accountOne, 1.5, { from: accountTwo });
-  balancerOfAccountTwo = await coin.balances.call(accountTwo);
+  result = await instance.sendCoin(accountOne, 1.5, { from: accountTwo });
+  balancerOfAccountTwo = await instance.balances.call(accountTwo);
   console.log("Balance of account two is " + balancerOfAccountTwo + "!"); // => 1.5
 } catch (err) {
   // Easily catch all errors along the whole execution.

--- a/packages/contract/README.md
+++ b/packages/contract/README.md
@@ -18,27 +18,26 @@ $ npm install @truffle/contract
 ### Usage
 
 First, set up a new web3 provider instance and initialize your contract, then `require("@truffle/contract")`.
-The input to the `contract` function is a JSON blob defined by [@truffle/contract-schema](https://github.com/trufflesuite/truffle/tree/master/packages/contract-schema). This JSON blob is structured in a way that can be passed to all truffle-related projects.
+The contract-schema matches the output of the [@truffle/artifactor](https://github.com/trufflesuite/truffle/tree/master/packages/artifactor), so you can pass in the artifact file truffle produces when you run `truffle compile`.
 
 ```javascript
 const provider = new Web3.providers.HttpProvider("http://localhost:8545");
+const ContractArtifact = require("./path/to/contractArtifact.json"); //produced by truffle compile
 const contract = require("@truffle/contract");
 
+const instance = contract(ContractArtifact);
+```
+
+If you aren't using truffle artifacts, the input to the `contract` function is a JSON blob defined by [@truffle/contract-schema](https://github.com/trufflesuite/truffle/tree/master/packages/contract-schema). This JSON blob is structured in a way that can be passed to all truffle-related projects.
+Minimally, it requires the contract ABI, but passing this alone may cause issues using certain features of truffle contract.
+
+```javascript
 const instance = contract({
   abi: [...], // minimum required
   address: "0x...", // optional
   // many more
 });
 instance.setProvider(provider);
-```
-
-Instead of providing these values individually though, the contract-scheme matches the output of the [@truffle/artifactor](https://github.com/trufflesuite/truffle/tree/master/packages/artifactor) so you might initialize it like so:
-
-```javascript
-// json output provided by @truffle/artifactor
-const ContractArtifact = require("./path/to/contractArtifact.json");
-
-const instance = contract(ContractArtifact);
 ```
 
 You now have access to the following functions on `MyContract`, as well as many others:

--- a/packages/contract/README.md
+++ b/packages/contract/README.md
@@ -39,13 +39,15 @@ You now have access to the following functions on `MyContract`, as well as many 
 Each instance is tied to a specific address on the Ethereum network, and each instance has a 1-to-1 mapping from Javascript functions to contract functions. For instance, if your Solidity contract had a function defined `someFunction(uint value) {}` (solidity), then you could execute that function on the network like so:
 
 ```javascript
-const deployed;
-MyContract.deployed().then(function(instance) {
-  deployed = instance;
-  return instance.someFunction(5);
-}).then(function(result) {
-  // Do something with the result or continue with more transactions.
-});
+let deployed;
+MyContract.deployed()
+  .then(function (instance) {
+    deployed = instance;
+    return instance.someFunction(5);
+  })
+  .then(function (result) {
+    // Do something with the result or continue with more transactions.
+  });
 ```
 
 or equivalently in ES6 <sup>(node.js 8 or newer)</sup>:

--- a/packages/contract/README.md
+++ b/packages/contract/README.md
@@ -18,17 +18,17 @@ $ npm install @truffle/contract
 ### Usage
 
 First, set up a new web3 provider instance and initialize your contract, then `require("@truffle/contract")`.
-The contract-schema matches the output of the [@truffle/artifactor](https://github.com/trufflesuite/truffle/tree/master/packages/artifactor), so you can pass in the artifact file truffle produces when you run `truffle compile`.
+The contract-schema matches the output of the [@truffle/artifactor](https://github.com/trufflesuite/truffle/tree/master/packages/artifactor), so you can pass in the artifact file Truffle produces and stores in the artifact file when you run `truffle compile`.
 
 ```javascript
 const provider = new Web3.providers.HttpProvider("http://localhost:8545");
-const ContractArtifact = require("./path/to/contractArtifact.json"); //produced by truffle compile
+const MyContract = require("./path/to/contractArtifact.json"); //produced by truffle compile
 const contract = require("@truffle/contract");
 
-const instance = contract(ContractArtifact);
+const instance = contract(MyContract);
 ```
 
-If you aren't using truffle artifacts, the input to the `contract` function is a JSON blob defined by [@truffle/contract-schema](https://github.com/trufflesuite/truffle/tree/master/packages/contract-schema). This JSON blob is structured in a way that can be passed to all truffle-related projects.
+If you aren't using truffle artifacts, the input to the `contract` function is a JSON blob defined by [@truffle/contract-schema](https://github.com/trufflesuite/truffle/tree/master/packages/contract-schema). This JSON blob is structured in a way that can be passed to all Truffle-related projects.
 Minimally, it requires the contract ABI, but passing this alone may cause issues using certain features of truffle contract.
 
 ```javascript
@@ -40,7 +40,7 @@ const instance = contract({
 instance.setProvider(provider);
 ```
 
-You now have access to the following functions on `MyContract`, as well as many others:
+You now have access to the following functions on `instance`, as well as many others:
 
 - `at()`: Create an instance of `MyContract` that represents your contract at a specific address.
 - `deployed()`: Create an instance of `MyContract` that represents the default address managed by `MyContract`.
@@ -49,18 +49,11 @@ You now have access to the following functions on `MyContract`, as well as many 
 Each instance is tied to a specific address on the Ethereum network, and each instance has a 1-to-1 mapping from Javascript functions to contract functions. For instance, if your Solidity contract had a function defined `someFunction(uint value) {}` (solidity), then you could execute that function on the network like so:
 
 ```javascript
-let deployed;
+const deployed;
 const instance = await MyContract.deployed();
 deployed = instance;
 const result = await instance.someFunction(5);
 // Do something with the result or continue with more transactions.
-```
-
-or equivalently in ES6 <sup>(node.js 8 or newer)</sup>:
-
-```javascript
-const instance = await MyContract.deployed();
-const result = await instance.someFunction(5);
 ```
 
 ### Browser Usage
@@ -97,33 +90,33 @@ instance.setProvider(provider);
 
 // In this scenario, two users will send MetaCoin back and forth, showing
 // how @truffle/contract allows for easy control flow.
-const account_one = "5b42bd01ff...";
-const account_two = "e1fd0d4a52...";
+const accountOne = "5b42bd01ff...";
+const accountTwo = "e1fd0d4a52...";
 
 // Note our MetaCoin contract exists at a specific address.
-const contract_address = "8e2e2cf785...";
+const contractAddress = "8e2e2cf785...";
 
-const coin = await instance.at(contract_address);
+const coin = await instance.at(contractAddress);
 
 try {
   // Make a transaction that calls the function `sendCoin`, sending 3 MetaCoin
-  // to the account listed as account_two.
-  let result = await coin.sendCoin(account_two, 3, { from: account_one });
+  // to the account listed as accountTwo.
+  let result = await coin.sendCoin(accountTwo, 3, { from: accountOne });
   // This code block will not be executed until @truffle/contract has verified
   // the transaction has been processed and it is included in a mined block.
   // @truffle/contract will error if the transaction hasn't been processed in 120 seconds.
 
   // Since we're using promises, we can return a promise for a call that will
   // check account two's balance.
-  let balance_of_account_two = await coin.balances.call(account_two);
-  console.log("Balance of account two is " + balance_of_account_two + "!"); // => 3
+  let balancerOfAccountTwo = await coin.balances.call(accountTwo);
+  console.log("Balance of account two is " + balancerOfAccountTwo + "!"); // => 3
 
   // But maybe too much was sent. Let's send some back.
   // Like before, will create a transaction that returns a promise, where
   // the callback won't be executed until the transaction has been processed.
-  result = await coin.sendCoin(account_one, 1.5, { from: account_two });
-  balance_of_account_two = await coin.balances.call(account_two);
-  console.log("Balance of account two is " + balance_of_account_two + "!"); // => 1.5
+  result = await coin.sendCoin(accountOne, 1.5, { from: accountTwo });
+  balancerOfAccountTwo = await coin.balances.call(accountTwo);
+  console.log("Balance of account two is " + balancerOfAccountTwo + "!"); // => 1.5
 } catch (err) {
   // Easily catch all errors along the whole execution.
   console.log("ERROR! " + err.message);

--- a/packages/contract/README.md
+++ b/packages/contract/README.md
@@ -24,21 +24,21 @@ The input to the `contract` function is a JSON blob defined by [@truffle/contrac
 const provider = new Web3.providers.HttpProvider("http://localhost:8545");
 const contract = require("@truffle/contract");
 
-const MyContract = contract({
+const instance = contract({
   abi: [...], // minimum required
   address: "0x...", // optional
   // many more
 });
-MyContract.setProvider(provider);
+instance.setProvider(provider);
 ```
 
-Instead of providing these values manually though, the contract-scheme matches the output of the @truffle/artifactor
+Instead of providing these values individually though, the contract-scheme matches the output of the [@truffle/artifactor](https://github.com/trufflesuite/truffle/tree/master/packages/artifactor) so you might initialize it like so:
 
 ```javascript
 // json output provided by @truffle/artifactor
-const contractArtifact = require("./path/to/contractArtifact.json");
+const ContractArtifact = require("./path/to/contractArtifact.json");
 
-const MyContract = contract(contractArtifact);
+const instance = contract(ContractArtifact);
 ```
 
 You now have access to the following functions on `MyContract`, as well as many others:
@@ -90,11 +90,11 @@ Let's use `@truffle/contract` with an example contract from [Dapps For Beginners
 ```javascript
 const contract = require("@truffle/contract");
 // Require the package that was previosly saved by @truffle/artifactor
-const metacoinArtifact = require("./path/to/MetaCoin.json");
-const metacoin = contract(metacoinArtifact)
+const MetacoinArtifact = require("./path/to/MetaCoin.json");
+const instance = contract(MetacoinArtifact);
 
 // Remember to set the Web3 provider (see above).
-metacoin.setProvider(provider);
+instance.setProvider(provider);
 
 // In this scenario, two users will send MetaCoin back and forth, showing
 // how @truffle/contract allows for easy control flow.
@@ -104,7 +104,7 @@ const account_two = "e1fd0d4a52...";
 // Note our MetaCoin contract exists at a specific address.
 const contract_address = "8e2e2cf785...";
 
-const coin = await metacoin.at(contract_address)
+const coin = await instance.at(contract_address);
 
 try {
   // Make a transaction that calls the function `sendCoin`, sending 3 MetaCoin
@@ -125,10 +125,10 @@ try {
   result = await coin.sendCoin(account_one, 1.5, { from: account_two });
   balance_of_account_two = await coin.balances.call(account_two);
   console.log("Balance of account two is " + balance_of_account_two + "!"); // => 1.5
-} catch(function (err) {
+} catch (err) {
   // Easily catch all errors along the whole execution.
   console.log("ERROR! " + err.message);
-};
+}
 ```
 
 # API

--- a/packages/contract/README.md
+++ b/packages/contract/README.md
@@ -120,7 +120,7 @@ try {
   console.log("Balance of account two is " + balance_of_account_two + "!"); // => 1.5
 } catch(function (err) {
   // Easily catch all errors along the whole execution.
-  alert("ERROR! " + err.message);
+  console.log("ERROR! " + err.message);
 };
 ```
 


### PR DESCRIPTION
The truffle contract README includes some misleading examples.  I updated these and linted the file.  Happy to remove the linting if it's offensive.

I also updated a lot of instances of ```MyContract.deployed().then(function(instance) {...})``` to ```const instance = await MyContract.deployed();``` since that syntax is more common these days.