### PR TITLE
Bug fix: Fix phantom call guard and function depth interaction with fallback functions (and some other things)

### DIFF
--- a/packages/debugger/lib/evm/selectors/index.js
+++ b/packages/debugger/lib/evm/selectors/index.js
@@ -252,10 +252,13 @@ function createStepSelectors(step, state = null) {
        * data passed to EVM call
        */
       callData: createLeaf(
-        ["./isCall", "./isShortCall", state],
-        (isCall, short, { stack, memory }) => {
+        ["./isCall", "./isShortCall", "./isCreate", state],
+        (isCall, short, isCreate, { stack, memory }) => {
           if (!isCall) {
-            return null;
+            //if it's not a call or create, this is invalid and we return null.
+            //for creations, we return 0x (if you want the binary, use createBinary
+            //instead)
+            return isCreate ? "0x" : null;
           }
 
           //if it's 6-argument call, the data start and offset will be one spot

--- a/packages/debugger/lib/evm/selectors/index.js
+++ b/packages/debugger/lib/evm/selectors/index.js
@@ -1,5 +1,5 @@
 import debugModule from "debug";
-const debug = debugModule("debugger:evm:selectors"); // eslint-disable-line no-unused-vars
+const debug = debugModule("debugger:evm:selectors");
 
 import { createSelectorTree, createLeaf } from "reselect-tree";
 import BN from "bn.js";

--- a/packages/debugger/lib/solidity/selectors/index.js
+++ b/packages/debugger/lib/solidity/selectors/index.js
@@ -32,7 +32,11 @@ function contextRequiresPhantomStackframes(context, data) {
       //because libraries don't always have a reliable ABI we can use for our purposes here.
       //fortunately, since libraries don't have fallbacks or receives, the condition isn't
       //relevant to them anyway!
-      selector in Codec.AbiData.Utils.computeSelectors(context.abi || [])) //fallbacks & receive should not get phantom
+      (context.abi || []).some(
+        abiEntry =>
+          abiEntry.type === "function" &&
+          Codec.AbiData.Utils.abiSelector(abiEntry) === selector //fallback & receive should not get phantom
+      ))
   );
 }
 


### PR DESCRIPTION
Addresses #4697.  This PR attempts to finally get the function depth and the phantom call guard right once and for all.  Previous versions of these had focused solely on getting function depth working well enough to distinguish variables; however, I forgot that function depth has a second function, namely, stepping.  With this PR, function depth should be reliable enough that it can also be used for stepping without too much worry.

This PR was intended to fix one specific bug (#4697), but on the way I found a second, so I fixed that too.  I also added three more tests that will hopefully catch this sort of problem if we need to alter this code in the future.

The problem is this.  Suppose you enter an external function call, on Solidity 0.5.1 or greater.  Without the phantom call guard, the function depth would be incremented *twice* -- once for the EVM-level call, once for the jump-in.  So, when we make the call, we set the phantom call guard, so that the next jump-in (excluding jump-ins to unmapped or generated code) doesn't increment the function depth.  Simple, right?

Well, no, because constructors and fallbacks/receives don't *have* a jump-in, meaning that the phantom call guard will be inappropriately applied to the *next* jump-in, which we don't want (or, are no longer content to tolerate).  Now, we already checked when setting the guard if we were calling a constructor, and didn't set it in that case; but we had no check for fallbacks and receives.

Thus, I've added one.  If the selector extracted from the calldata is not in the ABI of the contract being called, *and* said contract has a fallback or receive function in its ABI, then we do not set the phantom call guard.

You may be wondering what on earth is up with that second condition -- why do we need to check if the contract has a fallback or receive function?  Surely just checking if the selector is in the ABI is sufficient?

Well, there's a problem with that approach, and that problem is libraries.  Library functions don't always appear in the ABI; and when they do, their selectors aren't always computed the normal way.  So, if we just took the naive approach, calls to library functions might appear to be calls to fallback functions, and thus not have the guard set.

So we need some way to know if we're calling a library.  The straightforward way would be to check `context.contractKind === "library"`.  However, I decided to take a more indirect approach.  While the direct approach here should *probably* be fine, it relies on having the AST, and I thought it would be nice to take an approach that will work even if the AST is missing.  Therefore, instead of checking `contractKind`, I checked for the presence of a fallback or receive function.  Libraries can't have these, so if we see one, we know we're not dealing with a library, and can take seriously the absence of a matching function.  Meanwhile, if we *don't* see one, then we may or may not be dealing with a library, but it doesn't really matter, because our call won't be doing much except reverting!  So while this is making use of a proxy, in this case, I think the proxy is actually better than the direct check.

So that's that, right?  Well, I also turned up one other bug: Turns out, when determining whether to apply the phantom call guard, we were checking the *current* context, instead of the one being called!  Yikes!  This often doesn't matter and it's a little difficult to test, so it had slipped by unnoticed.  So I fixed that too.  Note that the combination of this fix and the change above meant I had to change `evm.current.step.callData` to return `"0x"` when on a `CREATE` or `CREATE2`, rather than `null`... well, OK, that, or rearrange my code, but I found the former to be easier. :P

So hopefully with this the function depth will finally stop giving us headaches!  It'll just be the modifier depth that's such a pain. :P