### PR TITLE
Dependency update: Update @trufflesuite/chromafi to 3.0.0

### DIFF
--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -34,59 +34,59 @@ const verbosePanicTable = {
 };
 
 const commandReference = {
-  o: "step over",
-  i: "step into",
-  u: "step out",
-  n: "step next",
+  "o": "step over",
+  "i": "step into",
+  "u": "step out",
+  "n": "step next",
   ";": "step instruction (include number to step multiple)",
-  p: "print instruction & state (`p [mem|cal|sto]*`; see docs for more)",
-  l: "print additional source context (`l [+<lines-ahead>] [-<lines-back>]`)",
-  h: "print this help",
-  v: "print variables and values (`v [bui|glo|con|loc]*`)",
+  "p": "print instruction & state (`p [mem|cal|sto]*`; see docs for more)",
+  "l": "print additional source context (`l [+<lines-ahead>] [-<lines-back>]`)",
+  "h": "print this help",
+  "v": "print variables and values (`v [bui|glo|con|loc]*`)",
   ":": "evaluate expression - see `v`",
   "+": "add watch expression (`+:<expr>`)",
   "-": "remove watch expression (-:<expr>)",
   "?": "list existing watch expressions and breakpoints",
-  b: "add breakpoint (`b [[<source-file>:]<line-number>]`; see docs for more)",
-  B: "remove breakpoint (similar to adding, or `B all` to remove all)",
-  c: "continue until breakpoint",
-  q: "quit",
-  r: "reset",
-  t: "load new transaction",
-  T: "unload transaction",
-  s: "print stacktrace",
-  g: "turn on generated sources",
-  G: "turn off generated sources except via `;`",
-  y: "(if at end) reset & continue to final error",
-  Y: "reset & continue to previous error"
+  "b": "add breakpoint (`b [[<source-file>:]<line-number>]`; see docs for more)",
+  "B": "remove breakpoint (similar to adding, or `B all` to remove all)",
+  "c": "continue until breakpoint",
+  "q": "quit",
+  "r": "reset",
+  "t": "load new transaction",
+  "T": "unload transaction",
+  "s": "print stacktrace",
+  "g": "turn on generated sources",
+  "G": "turn off generated sources except via `;`",
+  "y": "(if at end) reset & continue to final error",
+  "Y": "reset & continue to previous error"
 };
 
 const shortCommandReference = {
-  o: "step over",
-  i: "step into",
-  u: "step out",
-  n: "step next",
+  "o": "step over",
+  "i": "step into",
+  "u": "step out",
+  "n": "step next",
   ";": "step instruction",
-  p: "print state",
-  l: "print context",
-  h: "print help",
-  v: "print variables",
+  "p": "print state",
+  "l": "print context",
+  "h": "print help",
+  "v": "print variables",
   ":": "evaluate",
   "+": "add watch",
   "-": "remove watch",
   "?": "list watches & breakpoints",
-  b: "add breakpoint",
-  B: "remove breakpoint",
-  c: "continue",
-  q: "quit",
-  r: "reset",
-  t: "load",
-  T: "unload",
-  s: "stacktrace",
-  g: "turn on generated sources",
-  G: "turn off generated sources",
-  y: "reset & go to final error",
-  Y: "reset & go to previous error"
+  "b": "add breakpoint",
+  "B": "remove breakpoint",
+  "c": "continue",
+  "q": "quit",
+  "r": "reset",
+  "t": "load",
+  "T": "unload",
+  "s": "stacktrace",
+  "g": "turn on generated sources",
+  "G": "turn off generated sources",
+  "y": "reset & go to final error",
+  "Y": "reset & go to previous error"
 };
 
 const truffleColors = {
@@ -107,69 +107,69 @@ const DEFAULT_TAB_WIDTH = 8;
 
 const trufflePalette = {
   /* base (chromafi special, not hljs) */
-  base: chalk,
-  lineNumbers: chalk,
-  trailingSpace: chalk,
+  "base": chalk,
+  "lineNumbers": chalk,
+  "trailingSpace": chalk,
   /* classes hljs-solidity actually uses */
-  keyword: truffleColors.mint,
-  number: truffleColors.red,
-  string: truffleColors.green,
-  params: truffleColors.pink,
-  builtIn: truffleColors.watermelon,
-  built_in: truffleColors.watermelon, //just to be sure
-  literal: truffleColors.watermelon,
-  function: truffleColors.orange,
-  title: truffleColors.orange,
-  class: truffleColors.orange,
-  comment: truffleColors.comment,
-  doctag: truffleColors.comment,
-  operator: truffleColors.blue,
-  punctuation: truffleColors.purple,
+  "keyword": truffleColors.mint,
+  "number": truffleColors.red,
+  "string": truffleColors.green,
+  "params": truffleColors.pink,
+  "builtIn": truffleColors.watermelon,
+  "built_in": truffleColors.watermelon, //just to be sure
+  "literal": truffleColors.watermelon,
+  "function": truffleColors.orange,
+  "title": truffleColors.orange,
+  "class": truffleColors.orange,
+  "comment": truffleColors.comment,
+  "doctag": truffleColors.comment,
+  "operator": truffleColors.blue,
+  "punctuation": truffleColors.purple,
   /* classes it might soon use! */
-  meta: truffleColors.pink,
-  metaString: truffleColors.green,
+  "meta": truffleColors.pink,
+  "metaString": truffleColors.green,
   "meta-string": truffleColors.green, //similar
   /* classes it doesn't currently use but notionally could */
-  type: truffleColors.orange,
-  symbol: truffleColors.orange,
-  metaKeyword: truffleColors.mint,
+  "type": truffleColors.orange,
+  "symbol": truffleColors.orange,
+  "metaKeyword": truffleColors.mint,
   "meta-keyword": truffleColors.mint, //again, to be sure
-  property: chalk, //not putting any highlighting here for now
+  "property": chalk, //not putting any highlighting here for now
   /* classes that don't make sense for Solidity */
-  regexp: chalk, //solidity does not have regexps
-  subst: chalk, //or string interpolation
-  name: chalk, //or s-expressions
-  builtInName: chalk, //or s-expressions, again
+  "regexp": chalk, //solidity does not have regexps
+  "subst": chalk, //or string interpolation
+  "name": chalk, //or s-expressions
+  "builtInName": chalk, //or s-expressions, again
   "builtin-name": chalk, //just to be sure
   /* classes for config, markup, CSS, templates, diffs (not programming) */
-  section: chalk,
-  tag: chalk,
-  attr: chalk,
-  attribute: chalk,
-  variable: chalk,
-  bullet: chalk,
-  code: chalk,
-  emphasis: chalk,
-  strong: chalk,
-  formula: chalk,
-  link: chalk,
-  quote: chalk,
-  selectorAttr: chalk, //lotta redundancy follows
+  "section": chalk,
+  "tag": chalk,
+  "attr": chalk,
+  "attribute": chalk,
+  "variable": chalk,
+  "bullet": chalk,
+  "code": chalk,
+  "emphasis": chalk,
+  "strong": chalk,
+  "formula": chalk,
+  "link": chalk,
+  "quote": chalk,
+  "selectorAttr": chalk, //lotta redundancy follows
   "selector-attr": chalk,
-  selectorClass: chalk,
+  "selectorClass": chalk,
   "selector-class": chalk,
-  selectorId: chalk,
+  "selectorId": chalk,
   "selector-id": chalk,
-  selectorPseudo: chalk,
+  "selectorPseudo": chalk,
   "selector-pseudo": chalk,
-  selectorTag: chalk,
+  "selectorTag": chalk,
   "selector-tag": chalk,
-  templateTag: chalk,
+  "templateTag": chalk,
   "template-tag": chalk,
-  templateVariable: chalk,
+  "templateVariable": chalk,
   "template-variable": chalk,
-  addition: chalk,
-  deletion: chalk
+  "addition": chalk,
+  "deletion": chalk
 };
 
 var DebugUtils = {
@@ -822,8 +822,6 @@ var DebugUtils = {
       tabsToSpaces: false, //we handle this ourself and don't
       //want chromafi's padding
       lineEndPad: false
-      //NOTE: you might think you should pass highlight: true,
-      //but you'd be wrong!  I don't understand this either
     };
     switch (language) {
       case "Solidity":

--- a/packages/debug-utils/package.json
+++ b/packages/debug-utils/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@truffle/codec": "^0.11.26",
-    "@trufflesuite/chromafi": "^2.2.2",
+    "@trufflesuite/chromafi": "^3.0.0",
     "bn.js": "^5.1.3",
     "chalk": "^2.4.2",
     "debug": "^4.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5833,25 +5833,19 @@
   dependencies:
     node-gyp-build "4.3.0"
 
-"@trufflesuite/chromafi@^2.2.2":
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/@trufflesuite/chromafi/-/chromafi-2.2.2.tgz#d3fc507aa8504faffc50fb892cedcfe98ff57f77"
-  integrity sha512-mItQwVBsb8qP/vaYHQ1kDt2vJLhjoEXJptT6y6fJGvFophMFhOI/NsTVUa0nJL1nyMeFiS6hSYuNVdpQZzB1gA==
+"@trufflesuite/chromafi@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@trufflesuite/chromafi/-/chromafi-3.0.0.tgz#f6956408c1af6a38a6ed1657783ce59504a1eb8b"
+  integrity sha512-oqWcOqn8nT1bwlPPfidfzS55vqcIDdpfzo3HbU9EnUmcSTX+I8z0UyUFI3tZQjByVJulbzxHxUGS3ZJPwK/GPQ==
   dependencies:
-    ansi-mark "^1.0.0"
-    ansi-regex "^3.0.0"
-    array-uniq "^1.0.3"
     camelcase "^4.1.0"
     chalk "^2.3.2"
     cheerio "^1.0.0-rc.2"
     detect-indent "^5.0.0"
-    he "^1.1.1"
     highlight.js "^10.4.1"
     lodash.merge "^4.6.2"
-    min-indent "^1.0.0"
     strip-ansi "^4.0.0"
     strip-indent "^2.0.0"
-    super-split "^1.1.0"
 
 "@trufflesuite/typedoc-default-themes@^0.6.1":
   version "0.6.1"
@@ -8183,17 +8177,6 @@ ansi-html@0.0.7, ansi-html@^0.0.7:
   resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
   integrity sha1-gTWEAhliqenm/QOflA0S9WynhZ4=
 
-ansi-mark@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/ansi-mark/-/ansi-mark-1.0.4.tgz#1cd4ba8d57f15f109d6aaf6ec9ca9786c8a4ee6c"
-  integrity sha1-HNS6jVfxXxCdaq9uycqXhsik7mw=
-  dependencies:
-    ansi-regex "^3.0.0"
-    array-uniq "^1.0.3"
-    chalk "^2.3.2"
-    strip-ansi "^4.0.0"
-    super-split "^1.1.0"
-
 ansi-regex@^2.0.0, ansi-regex@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -8649,7 +8632,7 @@ array-union@^2.1.0:
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
-array-uniq@^1.0.1, array-uniq@^1.0.3:
+array-uniq@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
   integrity sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=
@@ -18101,7 +18084,7 @@ hdkey@^1.1.0:
     safe-buffer "^5.1.1"
     secp256k1 "^3.0.1"
 
-he@1.2.0, he@^1.1.1, he@^1.2.0:
+he@1.2.0, he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
@@ -32534,11 +32517,6 @@ subscriptions-transport-ws@^0.9.19:
     iterall "^1.2.1"
     symbol-observable "^1.0.4"
     ws "^5.2.0 || ^6.0.0 || ^7.0.0"
-
-super-split@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/super-split/-/super-split-1.1.0.tgz#43b3ba719155f4d43891a32729d59b213d9155fc"
-  integrity sha512-I4bA5mgcb6Fw5UJ+EkpzqXfiuvVGS/7MuND+oBxNFmxu3ugLNrdIatzBLfhFRMVMLxgSsRy+TjIktgkF9RFSNQ==
 
 supports-color@7.1.0:
   version "7.1.0"


### PR DESCRIPTION
Addresses #4726.  Updates our chromafi fork to the one I just published that gets rid of a bunch of dependencies.  It's 3.0.0 because one of those dependencies I removed was providing actual functionality, so it was a breaking change... but it doesn't break anything for us, as the removed functionality (the `highlight` option) wasn't anything we were using.  (No, that option did *not* control whether syntax highlighting is on or not; it's confusingly named and frankly I don't really understand *what* it did.)  I also removed the comment in debug-utils about that option since it's gone now.