### PR TITLE
Internal improvement: Add some missing fields to @truffle/dashboard package.json

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,5 +1,16 @@
 {
   "name": "@truffle/dashboard",
+  "license": "MIT",
+  "author": "Rosco Kalis <roscokalis@gmail.com>",
+  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/dashboard#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/dashboard"
+  },
+  "bugs": {
+    "url": "https://github.com/trufflesuite/truffle/issues"
+  },
   "version": "0.1.0",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",


### PR DESCRIPTION
Just added some fields I noticed were missing.  I left out `description` and `keywords` because I wasn't sure what to put for those, but, uh, @rkalis, feel free to update this PR to add those in?