### PR TITLE
Internal improvement: Add `optimize` flag to `VyperSettings` type in source-fetcher

### DIFF
--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -360,7 +360,12 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
   ): Types.VyperSettings {
     const evmVersion: string =
       result.EVMVersion === "Default" ? undefined : result.EVMVersion;
-    //the optimize flag is not currently supported by etherscan
+    //the optimize flag is not currently supported by etherscan;
+    //any Vyper contract currently verified on etherscan necessarily has
+    //optimize flag left unspecified (and therefore effectively true).
+    //do NOT look at OptimizationUsed for Vyper contracts; it will always
+    //be "0" even though in fact optimization *was* used.  just leave
+    //the optimize flag unspecified.
     if (evmVersion !== undefined) {
       return { evmVersion };
     } else {

--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -360,6 +360,7 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
   ): Types.VyperSettings {
     const evmVersion: string =
       result.EVMVersion === "Default" ? undefined : result.EVMVersion;
+    //the optimize flag is not currently supported by etherscan
     if (evmVersion !== undefined) {
       return { evmVersion };
     } else {

--- a/packages/source-fetcher/lib/types.ts
+++ b/packages/source-fetcher/lib/types.ts
@@ -78,7 +78,9 @@ export interface SolcSettings {
 
 export interface VyperSettings {
   evmVersion?: string; //not gonna enumerate these
-  optimize?: boolean; //warning: defaults to true if not specified! not currently supported by Etherscan
+  optimize?: boolean; //warning: the Vyper compiler treats this as true if it's not specified!
+  //also Etherscan currently doesn't support this flag; any Vyper contract currently
+  //verified on Etherscan necessarily has this field unspecified (and thus effectively true)
 }
 
 export interface SolcSpecializations {

--- a/packages/source-fetcher/lib/types.ts
+++ b/packages/source-fetcher/lib/types.ts
@@ -78,6 +78,7 @@ export interface SolcSettings {
 
 export interface VyperSettings {
   evmVersion?: string; //not gonna enumerate these
+  optimize?: boolean; //warning: defaults to true if not specified! not currently supported by Etherscan
 }
 
 export interface SolcSpecializations {


### PR DESCRIPTION
I noticed this was missing from the `VyperSettings` type.  There's no functional change here as Etherscan doesn't currently support this flag, so there was no need to make any updates to make the fetcher support it, but I thought I'd at least update the type (and comments).