### PR TITLE
Internal improvement: Add license field to core package.json

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,7 @@
   "name": "@truffle/core",
   "description": "Core code for Truffle command line tool",
   "author": "consensys.net",
+  "license": "MIT",
   "homepage": "https://github.com/trufflesuite/truffle#readme",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Just noticed this field was missing.  Adding it.