### PR TITLE
Remove homepage from dashboard package.json because it affects build

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -2,7 +2,6 @@
   "name": "@truffle/dashboard",
   "license": "MIT",
   "author": "Rosco Kalis <roscokalis@gmail.com>",
-  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/dashboard#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/trufflesuite/truffle.git",


### PR DESCRIPTION
Partial undoing of #4733... turns out that `homepage` affects how `dashboard` builds, so, uh, taking it out.

I'd put in a comment saying not to put it back in, but, not clear that comments are allowed in `package.json`, so, not doing that. :-/