### PR TITLE
Allow debugger to handle an instruction with invalid source range

### DIFF
--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -172,22 +172,39 @@ class DebugPrinter {
     const colorizedLines = splitLines(colorizedSource);
 
     this.config.logger.log("");
-    // We clone range though only "lines" is used here.
-    let rangePrintout = JSON.parse(JSON.stringify(range));
+    // We create printoutRange with range.lines as initial value for printing.
+    let printoutRange = {
+      start: {
+        line: range.lines.start.line,
+        column: range.lines.start.column
+      },
+      end: {
+        line: range.lines.end.line,
+        column: range.lines.end.column
+      }
+    };
+
     // We print a warning message and display the end of source code when the
     // instruction's byte-offset to the start of the range in the source code
-    // is past the end of source code
-    const instruction = this.session.view(solidity.current.instruction);
-    if (instruction.start >= source.length) {
+    // is past the end of source code.
+    if (range.start >= source.length) {
       this.config.logger.log(
-        `${colors.bold("Warning:")} Past end of source, displaying end.`
+        `${colors.bold(
+          "Warning:"
+        )} Location is past end of source, displaying end.`
       );
       this.config.logger.log("");
-      // We set the lines of the cloned range with the end of source code.
+      // We set the printoutRange with the end of source code.
       // Note that "lines" is the split lines of source code as defined above.
-      rangePrintout.lines = {
-        start: { line: lines.length - 1, column: 0 },
-        end: { line: lines.length - 1, column: 0 }
+      printoutRange = {
+        start: {
+          line: lines.length - 1,
+          column: 0
+        },
+        end: {
+          line: lines.length - 1,
+          column: 0
+        }
       };
     }
 
@@ -196,7 +213,7 @@ class DebugPrinter {
     this.config.logger.log(
       DebugUtils.formatRangeLines(
         colorizedLines,
-        rangePrintout.lines,
+        printoutRange,
         lines,
         contextBefore,
         contextAfter

--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -172,16 +172,21 @@ class DebugPrinter {
     const colorizedLines = splitLines(colorizedSource);
 
     this.config.logger.log("");
-    // printout a warning message and display the end of source code when the instruction's
-    // byte-offset to the start of the range in the source code is past the end of source code
+    // We print a warning message and display the end of source code when the
+    // instruction's byte-offset to the start of the range in the source code
+    // is past the end of source code
     const instruction = this.session.view(solidity.current.instruction);
-    if (instruction.start > source.length - 1) {
+    if (instruction.start >= source.length) {
       this.config.logger.log(
-        `${colors.bold(
-          "Warning:"
-        )} The end of source code is displayed since the instruction's source range is past the end of source code.`
+        `${colors.bold("Warning:")} Past end of source, displaying end.`
       );
       this.config.logger.log("");
+      // We set the source range to the end of source code for printing purpose only
+      // Note that the object "lines" is the split lines of source code as defined above
+      range.lines = {
+        start: { line: Object.keys(lines).length - 1, column: 0 },
+        end: { line: Object.keys(lines).length - 1, column: 0 }
+      };
     }
 
     //HACK -- the line-pointer formatter doesn't work right with colorized

--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -172,6 +172,8 @@ class DebugPrinter {
     const colorizedLines = splitLines(colorizedSource);
 
     this.config.logger.log("");
+    // We clone range though only "lines" is used here.
+    let rangePrintout = JSON.parse(JSON.stringify(range));
     // We print a warning message and display the end of source code when the
     // instruction's byte-offset to the start of the range in the source code
     // is past the end of source code
@@ -181,11 +183,11 @@ class DebugPrinter {
         `${colors.bold("Warning:")} Past end of source, displaying end.`
       );
       this.config.logger.log("");
-      // We set the source range to the end of source code for printing purpose only
-      // Note that the object "lines" is the split lines of source code as defined above
-      range.lines = {
-        start: { line: Object.keys(lines).length - 1, column: 0 },
-        end: { line: Object.keys(lines).length - 1, column: 0 }
+      // We set the lines of the cloned range with the end of source code.
+      // Note that "lines" is the split lines of source code as defined above.
+      rangePrintout.lines = {
+        start: { line: lines.length - 1, column: 0 },
+        end: { line: lines.length - 1, column: 0 }
       };
     }
 
@@ -194,7 +196,7 @@ class DebugPrinter {
     this.config.logger.log(
       DebugUtils.formatRangeLines(
         colorizedLines,
-        range.lines,
+        rangePrintout.lines,
         lines,
         contextBefore,
         contextAfter

--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -172,6 +172,17 @@ class DebugPrinter {
     const colorizedLines = splitLines(colorizedSource);
 
     this.config.logger.log("");
+    // printout a warning message and display the end of source code when the instruction's
+    // byte-offset to the start of the range in the source code is past the end of source code
+    const instruction = this.session.view(solidity.current.instruction);
+    if (instruction.start > source.length - 1) {
+      this.config.logger.log(
+        `${colors.bold(
+          "Warning:"
+        )} The end of source code is displayed since the instruction's source range is past the end of source code.`
+      );
+      this.config.logger.log("");
+    }
 
     //HACK -- the line-pointer formatter doesn't work right with colorized
     //lines, so we pass in the uncolored version too

--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -173,16 +173,7 @@ class DebugPrinter {
 
     this.config.logger.log("");
     // We create printoutRange with range.lines as initial value for printing.
-    let printoutRange = {
-      start: {
-        line: range.lines.start.line,
-        column: range.lines.start.column
-      },
-      end: {
-        line: range.lines.end.line,
-        column: range.lines.end.column
-      }
-    };
+    let printoutRange = range.lines;
 
     // We print a warning message and display the end of source code when the
     // instruction's byte-offset to the start of the range in the source code

--- a/packages/source-map-utils/index.js
+++ b/packages/source-map-utils/index.js
@@ -170,31 +170,16 @@ var SourceMapUtils = {
         }
         const lineAndColumnMapping =
           lineAndColumnMappings[instruction.file] || {};
-        // we set the source range of an instruction to the end of source code for display
-        // purpose when its byte-offset to the start of the range in the source code is past
-        // the end of source code
-        if (
-          instruction.file !== -1 &&
-          instruction.start > lineAndColumnMapping.length - 1
-        ) {
-          instruction.range = {
-            start: lineAndColumnMapping[lineAndColumnMapping.length - 1],
-            end: lineAndColumnMapping[lineAndColumnMapping.length - 1]
-          };
-        } else {
-          instruction.range = {
-            start: lineAndColumnMapping[instruction.start] || {
-              line: null,
-              column: null
-            },
-            end: lineAndColumnMapping[
-              instruction.start + instruction.length
-            ] || {
-              line: null,
-              column: null
-            }
-          };
-        }
+        instruction.range = {
+          start: lineAndColumnMapping[instruction.start] || {
+            line: null,
+            column: null
+          },
+          end: lineAndColumnMapping[instruction.start + instruction.length] || {
+            line: null,
+            column: null
+          }
+        };
 
         return instruction;
       });

--- a/packages/source-map-utils/index.js
+++ b/packages/source-map-utils/index.js
@@ -170,16 +170,31 @@ var SourceMapUtils = {
         }
         const lineAndColumnMapping =
           lineAndColumnMappings[instruction.file] || {};
-        instruction.range = {
-          start: lineAndColumnMapping[instruction.start] || {
-            line: null,
-            column: null
-          },
-          end: lineAndColumnMapping[instruction.start + instruction.length] || {
-            line: null,
-            column: null
-          }
-        };
+        // we set the source range of an instruction to the end of source code for display
+        // purpose when its byte-offset to the start of the range in the source code is past
+        // the end of source code
+        if (
+          instruction.file !== -1 &&
+          instruction.start > lineAndColumnMapping.length - 1
+        ) {
+          instruction.range = {
+            start: lineAndColumnMapping[lineAndColumnMapping.length - 1],
+            end: lineAndColumnMapping[lineAndColumnMapping.length - 1]
+          };
+        } else {
+          instruction.range = {
+            start: lineAndColumnMapping[instruction.start] || {
+              line: null,
+              column: null
+            },
+            end: lineAndColumnMapping[
+              instruction.start + instruction.length
+            ] || {
+              line: null,
+              column: null
+            }
+          };
+        }
 
         return instruction;
       });


### PR DESCRIPTION
This PR is to address the crash reported in issue #4616.

The root cause of the issue is that an instruction's byte-offset to the start of the range in the source code is past the end of source code. This is impossible since the byte-offset should always be within the range of the source code. Then the debugger sets the source range to null for such an instruction since it does not exist in the source code. And the null source range causes crash when printing the source code.  However, all instructions along with their attributes including the byte-offset are given by the source map which is provided by the compiler. Hence, this issue is caused by the invalid input from the compiler.

However, the debugger needs to be protected from crash with such an invalid input or even does something more than just not crash. Two options are considered when such an instruction is detected. The first option is to issue a warning message and not print any source code. Hence, there will be no crash. But this option is simply to protect debugger from crash. The second option is to print part of the source code, such as the end of source code, in addition to the warning message. The reason to choose the end of source code because the byte-offset is past the end of source code. The second option is selected because it protects the debugger from crash, issues a warning message, and provides some information of the source code.

A note about implementation:
When an invalid byte-offset of an instruction is detected, we only set its source range to the end of source code for the purpose of displaying source code. Other attributes of the instruction including the invalid byte-offset are remained intact. The warning message is issued when printing the source code.