### PR TITLE
Dependency update: Update highlightjs-solidity to ^2.0.4

### DIFF
--- a/packages/debug-utils/package.json
+++ b/packages/debug-utils/package.json
@@ -23,7 +23,7 @@
     "bn.js": "^5.1.3",
     "chalk": "^2.4.2",
     "debug": "^4.3.1",
-    "highlightjs-solidity": "^2.0.3"
+    "highlightjs-solidity": "^2.0.4"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18125,10 +18125,10 @@ highlight.js@^10.4.1:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.4.1.tgz#d48fbcf4a9971c4361b3f95f302747afe19dbad0"
   integrity sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg==
 
-highlightjs-solidity@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/highlightjs-solidity/-/highlightjs-solidity-2.0.3.tgz#c89b6eca7d462f849acfb3a94c18f7db2b6d0c69"
-  integrity sha512-tjFm5dtIE61VQBzjlZmkCtY5fLs3CaEABbVuUNyXeW+UuOCsxMg3MsPFy0kCelHP74hPpkoqDejLrbnV1axAIw==
+highlightjs-solidity@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/highlightjs-solidity/-/highlightjs-solidity-2.0.4.tgz#b7bceecaae6a509be832caae4b040c96a194f1b5"
+  integrity sha512-jsmfDXrjjxt4LxWfzp27j4CX6qYk6B8uK8sxzEDyGts8Ut1IuVlFCysAu6n5RrgHnuEKA+SCIcGPweO7qlPhCg==
 
 hkts@^0.3.1:
   version "0.3.1"


### PR DESCRIPTION
I just put out a new release of highlightjs-solidity to update its highlighting for Solidity 0.8.12.  (Specifically, I added highlighting for the new `string.concat` builtin.)  This PR updates Truffle to use it.