### PR TITLE
Bug fix: Remove incorrect warnings from `truffle test --show-events` (and prevent Solidity tests from incorrectly passing?)

### DIFF
--- a/packages/codec/lib/types.ts
+++ b/packages/codec/lib/types.ts
@@ -605,4 +605,9 @@ export interface LogOptions {
    * with this option.
    */
   id?: string;
+  /**
+   * Allows decodings that don't pass the re-encoding test.  Don't turn
+   * this on unless you know what you're doing!
+   */
+  disableChecks?: boolean;
 }

--- a/packages/core/lib/testing/SolidityTest.js
+++ b/packages/core/lib/testing/SolidityTest.js
@@ -18,7 +18,7 @@ const SolidityTest = {
       // contracts) which need to be compiled before initializing the runner
       await self.compileNewAbstractInterface.bind(this)(runner);
       await runner.initialize.bind(runner)();
-      runner.disableChecks(); //for handling of test events on Solidity <0.7.6 due to empty string problem
+      runner.disableChecksOnEventDecoding(); //for handling of test events on Solidity <0.7.6 due to empty string problem
       await self.deployTestDependencies.bind(this)(
         abstraction,
         dependencyPaths,
@@ -27,7 +27,7 @@ const SolidityTest = {
     });
 
     suite.afterAll("clean up", function () {
-      runner.reEnableChecks();
+      runner.reEnableChecksOnEventDecoding();
     });
 
     suite.beforeEach("before test", async function () {

--- a/packages/core/lib/testing/TestRunner.js
+++ b/packages/core/lib/testing/TestRunner.js
@@ -39,11 +39,11 @@ class TestRunner {
     this.TEST_TIMEOUT = (options.mocha && options.mocha.timeout) || 300000;
   }
 
-  disableChecks() {
+  disableChecksOnEventDecoding() {
     this.disableChecks = true; //used by Solidity testing due to empty string problem on Solidity <0.7.6
   }
 
-  reEnableChecks() {
+  reEnableChecksOnEventDecoding() {
     this.disableChecks = false;
   }
 

--- a/packages/core/lib/testing/TestRunner.js
+++ b/packages/core/lib/testing/TestRunner.js
@@ -39,6 +39,14 @@ class TestRunner {
     this.TEST_TIMEOUT = (options.mocha && options.mocha.timeout) || 300000;
   }
 
+  disableChecks() {
+    this.disableChecks = true; //used by Solidity testing due to empty string problem on Solidity <0.7.6
+  }
+
+  reEnableChecks() {
+    this.disableChecks = false;
+  }
+
   async initialize() {
     debug("initializing");
     this.config.resolver = new Resolver(this.config, {
@@ -169,7 +177,8 @@ class TestRunner {
       //should be fine, but should change this once decoder
       //accepts more general types for blocks
       fromBlock: this.currentTestStartBlock.toNumber(),
-      extras: "necessary" //include weird decodings if usual ones fail :P
+      extras: "necessary", //include weird decodings if usual ones fail :P
+      disableChecks: this.disableChecks //for Solidity testing
     });
 
     const userDefinedEventLogs = logs.filter(log => {

--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -287,6 +287,9 @@ export class ProjectDecoder {
    * Changing `options.extras = "on"` or `options.extras = "necessary"` will change the
    * above behavior; see the documentation on [[ExtrasAllowed]] for more.
    *
+   * If absolutely necessary, you can also set `options.disableChecks = true` to allow
+   * looser decoding.  Only use this option if you know what you are doing.
+   *
    * @param log The log to be decoded.
    * @param options Options for controlling decoding.
    */

--- a/packages/decoder/lib/types.ts
+++ b/packages/decoder/lib/types.ts
@@ -190,6 +190,11 @@ export interface DecodeLogOptions {
    * the event -- should be returned.  Defaults to `"off"`.
    */
   extras?: ExtrasAllowed;
+  /**
+   * Allows decodings that don't pass the re-encoding test.  Don't turn
+   * this on unless you know what you're doing!
+   */
+  disableChecks?: boolean;
 }
 
 /**

--- a/packages/truffle/test/scenarios/solidity_testing/testEventsAndMixedTests.js
+++ b/packages/truffle/test/scenarios/solidity_testing/testEventsAndMixedTests.js
@@ -25,7 +25,7 @@ describe("TestEvents and mixed sol/js testing", function () {
   });
 
   it("will correctly decode events as appropriate", async function () {
-    this.timeout(70000);
+    this.timeout(120000);
 
     try {
       //will fail, since we included a failing test

--- a/packages/truffle/test/scenarios/solidity_testing/testEventsAndMixedTests.js
+++ b/packages/truffle/test/scenarios/solidity_testing/testEventsAndMixedTests.js
@@ -1,0 +1,50 @@
+const MemoryLogger = require("../MemoryLogger");
+const CommandRunner = require("../commandRunner");
+const path = require("path");
+const assert = require("assert");
+const Server = require("../server");
+const Reporter = require("../reporter");
+const sandbox = require("../sandbox");
+
+describe("TestEvents and mixed sol/js testing", function () {
+  let config;
+  const project = path.join(__dirname, "../../sources/mixed_testing");
+  const logger = new MemoryLogger();
+
+  before(done => Server.start(done));
+  after(done => Server.stop(done));
+
+  before(async function () {
+    this.timeout(10000);
+    config = await sandbox.create(project);
+    config.network = "development";
+    config.logger = logger;
+    config.mocha = {
+      reporter: new Reporter(logger)
+    };
+  });
+
+  it("will correctly decode events as appropriate", async function () {
+    this.timeout(70000);
+
+    try {
+      //will fail, since we included a failing test
+      await CommandRunner.run("test --show-events", config);
+    } catch {
+      //ignore the error
+    }
+    const output = logger.contents();
+    //check number 1: did we avoid any warnings about undecodeable events?
+    //(these will occur if we fail to filter out test events)
+    assert(!output.includes("Warning"), "failed to filter out test event");
+    //check number 2: did the second test fail?
+    assert(
+      output.includes("1) testShouldFail"),
+      "failing Solidity test succeeded instead"
+    );
+    //check number 3: did we avoid ambiguous decodings in the JS test?
+    //(here we are checking that the loosened decoding mode used in the Solidity tests
+    //was properly turned off before proceeding to JS tests)
+    assert(!output.includes("Ambiguous"), "disableChecks was not turned off");
+  });
+});

--- a/packages/truffle/test/sources/mixed_testing/.eslintrc.json
+++ b/packages/truffle/test/sources/mixed_testing/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../../../.eslintrc.truffle.json"]
+}

--- a/packages/truffle/test/sources/mixed_testing/contracts/StrangeEventTest.sol
+++ b/packages/truffle/test/sources/mixed_testing/contracts/StrangeEventTest.sol
@@ -4,10 +4,46 @@ pragma solidity ^0.7.0;
 contract StrangeEventTest {
   event StrangeEvent(uint indexed, string, string, uint);
   function run() public {
-    emit StrangeEvent(96, "ABC", "123", 96);
+    emit StrangeEvent(0x60, "ABC", "123", 0x60);
+  }
+
+  function dontRunThis() public {
+    //the presence of this function is just to make it so that
+    //StrangeEventTest could notionally emit StrangeEventLibrary.StrangeEvent
+    //as part of its own code (the decoder doesn't actually care about that,
+    //but it makes the intention clearer :P )
+    StrangeEventLibrary.doStuff();
   }
 }
 
 library StrangeEventLibrary {
   event StrangeEvent(uint, string, string, uint indexed);
+
+  function doStuff() internal {
+    emit StrangeEvent(1, "a", "b", 2); //arbitrary, we're not using this
+  }
 }
+
+/*
+ * Explanation:
+ * StrangeEventTest.StrangeEvent(0x60, "ABC", "123", 0x60)
+ * encodes as
+ * topics:
+ * 80500dceb2defa8d2b7262e3575ef96df4f1532158b5e96eae652f3be1ceeb06
+ * 0000000000000000000000000000000000000000000000000000000000000060
+ * data:
+ * 0000000000000000000000000000000000000000000000000000000000000020
+ * 0000000000000000000000000000000000000000000000000000000000000060
+ * 00000000000000000000000000000000000000000000000000000000000000a0
+ * 0000000000000000000000000000000000000000000000000000000000000060
+ * 0000000000000000000000000000000000000000000000000000000000000003
+ * 4142430000000000000000000000000000000000000000000000000000000000
+ * 0000000000000000000000000000000000000000000000000000000000000003
+ * 3132330000000000000000000000000000000000000000000000000000000000
+ * 
+ * If this is decoded with disableChecks set, then it will *also*
+ * (incorrectly) decode as
+ * StrangeEventLibrary.StrangeEvent(0x60, "123", "ABC", 0x60)
+ * (note how the order of the strings is swapped)
+ * (the "ABC" and "123" are arbitrary, but the use of 0x60 is not arbitrary!)
+ */

--- a/packages/truffle/test/sources/mixed_testing/contracts/StrangeEventTest.sol
+++ b/packages/truffle/test/sources/mixed_testing/contracts/StrangeEventTest.sol
@@ -1,0 +1,13 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.7.0;
+
+contract StrangeEventTest {
+  event StrangeEvent(uint indexed, string, string, uint);
+  function run() public {
+    emit StrangeEvent(96, "ABC", "123", 96);
+  }
+}
+
+library StrangeEventLibrary {
+  event StrangeEvent(uint, string, string, uint indexed);
+}

--- a/packages/truffle/test/sources/mixed_testing/migrations/2_deploy_contracts.js
+++ b/packages/truffle/test/sources/mixed_testing/migrations/2_deploy_contracts.js
@@ -1,0 +1,5 @@
+const StrangeEventTest = artifacts.require("StrangeEventTest");
+
+module.exports = async function (deployer) {
+  await deployer.deploy(StrangeEventTest);
+};

--- a/packages/truffle/test/sources/mixed_testing/test/SolTest.sol
+++ b/packages/truffle/test/sources/mixed_testing/test/SolTest.sol
@@ -1,0 +1,15 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.7.0;
+
+import "truffle/Assert.sol";
+
+contract Tester {
+
+  function testShouldSucceed() public {
+    Assert.isTrue(true, "");
+  }
+
+  function testShouldFail() public {
+    Assert.fail("");
+  }
+}

--- a/packages/truffle/test/sources/mixed_testing/test/js-test.js
+++ b/packages/truffle/test/sources/mixed_testing/test/js-test.js
@@ -1,0 +1,8 @@
+const StrangeEventTest = artifacts.require("StrangeEventTest");
+
+contract("StrangeEventTest", function () {
+  it("should emit a strange event", async function () {
+    const instance = await StrangeEventTest.deployed();
+    await instance.run();
+  });
+});

--- a/packages/truffle/test/sources/mixed_testing/truffle-config.js
+++ b/packages/truffle/test/sources/mixed_testing/truffle-config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  compilers: {
+    solc: {
+      version: "0.7.5" //do not upgrade! testing behavior specific to <=0.7.5
+    }
+  }
+};


### PR DESCRIPTION
Addresses #4722.  This PR adds the `disableChecks` option codec and decoder when decoding events.  If this option is passed, codec will be a bit looser about checking that its event decodings are strictly accurate.  This can, in some cases, lead to events being incorrectly decoded as ambiguous (where, without the option set, they would correctly be decoded as unambiguous).

So why add such an option?  Well, it turns out that Solidity versions older than 0.7.6, when using ABI encoder V1, sometimes incorrectly encodes the empty string (using an encoding for it that has more padding than it should).  And this is particularly a problem for us because the `TestEvent`s that we use for Solidity testing often include empty strings in their arguments!  In the case of a passing test, this would cause a bunch of incorrect warnings to show up when using `--show-events`.  In the case of a failing test, this notionally could cause it to incorrectly be treated as passing, although oddly I haven't been able to get this case to actually occur (more on this in a bit).

As for the problem of what to do about this generally (#4696), I don't really know.  But @gnidan and I came up with this stopgap to address #4722, the problems this causes for Solidity testing.

The stopgap is this: First, we create the `disableChecks` flag, described above.  Then, we have Solidity testing use that flag.  As such, it will be able to correctly `TestEvent`s even if they were decoded wrong.  That's it!  This does mean that other events emitted during Solidity testing could be incorrectly decoded as ambiguous, but @gnidan and I figured this was the lesser of two evils, as extra encodings appearing from `disableChecks` being set ought to be pretty rare.

What the `disableChecks` flag actually does, see, is that codec, when decoding events, checks its work afterward by *re-encoding* the event to make sure it matches what was passed in.  If the `disableChecks` flag turned off that check entirely, it would be pretty easy to construct nasty examples.  However, I made it so that the `disableChecks` flag turns off that check as applied to the event *data*, but leaves it on for the event *topics*.  (Since the empty string issue can't come up in the event topics!)  The result is that examples that will fool codec with `disableChecks` set have to be fairly contrived.  (If you want to see one, though, take a look at the `StrangeEventTest` I added.  The particular strings used are arbitrary... but those `96`s are not! :)  I've engineered this event so that `StrangeEventTest.StrangeEvent(96, "ABC", "123", 96)` will, if `disableChecks` is on, get an incorrect alternate decoding of `StrangeEventLibrary.StrangeEvent(96, "123", "ABC", 96)`... note how the order of the strings is swapped.  If people *really* want, I can explain how that happens, but I think I'll skip going into the binary for now!)

I do have to make a note here... as mentioned above, I was not actually able to observe any cases where a *failing* `TestEvent` got encoded wrong, even when its message was empty.  I have no idea why.  I had the same contract emitting both -- not in the same transaction admittedly but that shouldn't matter -- and could see in the binary that the failing ones got encoded right and the passing ones got encoded wrong.  I have no idea what's up with this, and I'm not sure if this suggests that a different solution would be better.  Well, I've put up this PR 

In addition to adding this functionality, I of course also added tests of it.  (Well, one test that makes three checks... sorry, it was just easier than splitting things up.)  Rather than add new tests to `decoder`, I decided to add these as tests in `truffle`, testing the `truffle test --show-events` command.  The test checks that:
1. We don't get any warnings due to undecodeable events as a result of `TestEvent`s;
2. The failing test fails as it should;
3. That after the Solidity tests run, the `disableChecks` flag is properly reset, so that the Javascript test doesn't get fooled by my tricksy event and correctly realizes it's unambiguous (despite running after Solidity tests).

And that's it!  Well, and `prettier` also made some changes... the real changes to `codec/lib/core.js` are the ones from lines 420 to 441, the rest are just due to prettier and can be ignored.