### PR TITLE
Allow non-numeric immutable keys in contract-schema and add test of Yul immutable recognition

### DIFF
--- a/packages/contract-schema/spec/contract-object.spec.json
+++ b/packages/contract-schema/spec/contract-object.spec.json
@@ -151,26 +151,23 @@
     },
     "ImmutableReferences": {
       "type": "object",
-      "patternProperties": {
-        "[1-9][0-9]*": {
-         "type": "array",
-         "items": {
-           "type": "object",
-           "properties": {
-             "start": {
-               "type": "integer",
-               "minimum": 0
-             },
-             "length": {
-               "type": "integer",
-               "minimum": 0
-             }
+      "additionalProperties": {
+       "type": "array",
+       "items": {
+         "type": "object",
+         "properties": {
+           "start": {
+             "type": "integer",
+             "minimum": 0
            },
-           "additionalProperties": false
-         }
+           "length": {
+             "type": "integer",
+             "minimum": 0
+           }
+         },
+         "additionalProperties": false
         }
-      },
-      "additionalProperties": false
+      }
     },
     "GeneratedSources": {
       "type": "array",

--- a/packages/debugger/test/helpers.js
+++ b/packages/debugger/test/helpers.js
@@ -25,7 +25,7 @@ export async function prepareContracts(provider, sources = {}, migrations) {
 
   config.compilers = {
     solc: {
-      version: "0.8.9",
+      version: "0.8.12",
       settings: {
         optimizer: { enabled: false, runs: 200 },
         evmVersion: "london"


### PR DESCRIPTION
As of Solidity 0.8.12, we can now get `immutableReferences` from Yul contracts that use immutables.  However, the keys for these are not numeric AST IDs, but rather simply the names of the immutables.  So, I'm taking out the `patternProperties` and replacing it with `additionalProperties`, since the keys can now be anything.

This PR doesn't do the work of allowing us to actually do things with Yul immutables, like decode them.  I figure that can come later (I've put up issue #4747 for that).  This is just updating the contract schema.

Note: I checked our existing immutable-handling code and as best I can tell this shouldn't screw any of it up.

Edit: Actually, you know what, I was a little bit unsatisfied with this, so I went back and added a test -- not a test of the `contract-schema` change of course, that should have no functional effect at the moment; but a test that yes, the debugger can indeed use Yul's immutableReferences to correctly recognize Yul code with immutables in it (without any code changes to codec or the debugger necessary :) ).  Obviously this required updating the debugger tests to Solidity 0.8.12...