### PR TITLE
Prepare @truffle/dashboard* packages for release

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,7 @@
     "@truffle/compile-solidity": "^6.0.12",
     "@truffle/config": "^1.3.18",
     "@truffle/contract": "^4.4.8",
-    "@truffle/dashboard": "^0.1.0",
+    "@truffle/dashboard": "^0.1.0-0",
     "@truffle/debug-utils": "^6.0.8",
     "@truffle/debugger": "^9.2.15",
     "@truffle/decoder": "^5.1.11",

--- a/packages/dashboard-message-bus/package.json
+++ b/packages/dashboard-message-bus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truffle/dashboard-message-bus",
-  "version": "0.1.0",
+  "version": "0.1.0-0",
   "description": "Message bus that handles communication between the Dashboard and its components",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/packages/dashboard-provider/package.json
+++ b/packages/dashboard-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truffle/dashboard-provider",
-  "version": "0.1.0",
+  "version": "0.1.0-0",
   "description": "Web3 provider that uses a browser-based web3 wallet through the Truffle Dasboard",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",
@@ -46,8 +46,8 @@
     "web3": "^1.6.1"
   },
   "dependencies": {
-    "@truffle/dashboard": "^0.1.0",
-    "@truffle/dashboard-message-bus": "^0.1.0",
+    "@truffle/dashboard": "^0.1.0-0",
+    "@truffle/dashboard-message-bus": "^0.1.0-0",
     "debug": "^4.3.3",
     "delay": "^5.0.0",
     "isomorphic-ws": "^4.0.1",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -10,7 +10,7 @@
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"
   },
-  "version": "0.1.0",
+  "version": "0.1.0-0",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",
   "files": [
@@ -18,7 +18,7 @@
     "dist/bin"
   ],
   "dependencies": {
-    "@truffle/dashboard-message-bus": "^0.1.0",
+    "@truffle/dashboard-message-bus": "^0.1.0-0",
     "cors": "^2.8.5",
     "debug": "^4.3.2",
     "express": "^4.17.1",


### PR DESCRIPTION
This PR "downgrades" the package.json versions for the three new packages, so as to facilitate `lerna version` setting these to v0.1.0 in the next release.

This is just playing it safe; from what I recall, `lerna version` doesn't like it when you try to bump a package's version to itself.