### PR TITLE
Enhancement: Allow deployer to link library instances

### DIFF
--- a/packages/deployer/test/helpers/eventSystem.js
+++ b/packages/deployer/test/helpers/eventSystem.js
@@ -24,12 +24,18 @@ const postDeployOccurredForNames = (options, contractNames) => {
   }, true);
 };
 
-const linkingOccurredForName = (options, contractName, libraryName) => {
+const linkingOccurred = (
+  options,
+  contractName,
+  libraryName,
+  libraryAddress
+) => {
   const allLinks = getAllEventsByName(options, "deployment:linking");
   return allLinks.some(linkEvent => {
     return (
       linkEvent.libraryName === libraryName &&
-      linkEvent.contractName === contractName
+      linkEvent.contractName === contractName &&
+      linkEvent.libraryAddress === libraryAddress
     );
   });
 };
@@ -68,5 +74,5 @@ module.exports = {
   getAllEventsByName,
   preDeployOccurredForNames,
   postDeployOccurredForNames,
-  linkingOccurredForName
+  linkingOccurred
 };


### PR DESCRIPTION
Finally does away with #2838!

This PR allows `deployer.link` to take a library *instance* in the first argument, rather than just a library *constructor*.  This allows for linking to a library at a specified address in deployment:
```
const libraryInstance = await Library.at(address);
await deployer.link(libraryInstance, Contract);
```
thus finally solving issue #2838.

This PR is mostly pretty straightforward; the primary functional change is that now, when looking for the library name, we check `library.constructor.contractName` if `library.contractName` doesn't exist (and `library.constructor` does exist).  You may be wondering how it's possible that I was able to seamlessly replace `library.contract_name` with `library.contractName`; the answer is that these getters are synonyms, so I changed it to the more modern one.

In addition, there was a buggy ternary I had to change -- the condition was simply `typeof library.isDeployed`, which, of course, will always be truthy!  It looks like what was intended was `typeof library.isDeployed === "function"`, which I changed it to.

Now you may notice that I did *not* change the final call to `destination.link(library)`.  What's up with that?  Don't I have to update that call?  The answer is, no!  Unlike `deployer.link()`, `contract.link()` is actually already prepared to handle this case, so I didn't have to do any work there.

Finally, I added a test of this functionality (in addition to giving it a few manual tests).  It seems to work! :)  I also renamed the helper function `linkingOccurredForName` to simply `linkingOccurred`, as it's now checking address as well, so the name no longer seemed appropriate.