### PR TITLE
Internal improvement: Remove listener from debugger trace submodule

### DIFF
--- a/packages/debugger/lib/session/sagas/index.js
+++ b/packages/debugger/lib/session/sagas/index.js
@@ -150,7 +150,7 @@ function* forkListeners(moduleOptions) {
     mainApps.push(data);
     mainApps.push(txlog);
   }
-  let otherApps = [trace, controller, web3];
+  let otherApps = [controller, web3];
   const submoduleCount = mainApps.length;
   const apps = mainApps.concat(otherApps);
   yield* trace.setSubmoduleCount(submoduleCount);

--- a/packages/debugger/lib/trace/actions/index.js
+++ b/packages/debugger/lib/trace/actions/index.js
@@ -16,6 +16,11 @@ export function tock() {
   return { type: TOCK };
 }
 
+export const ADVANCE = "TRACE_ADVANCE";
+export function advance() {
+  return { type: ADVANCE };
+}
+
 export const END_OF_TRACE = "TRACE_EOT";
 export function endTrace() {
   return { type: END_OF_TRACE };
@@ -29,11 +34,6 @@ export function reset() {
 export const UNLOAD_TRANSACTION = "TRACE_UNLOAD_TRANSACTION";
 export function unloadTransaction() {
   return { type: UNLOAD_TRANSACTION };
-}
-
-export const BACKTICK = "TRACE_BACKTICK";
-export function backtick() {
-  return { type: BACKTICK };
 }
 
 export const SET_SUBMODULE_COUNT = "TRACE_SET_SUBMODULE_COUNT";

--- a/packages/debugger/lib/trace/actions/index.js
+++ b/packages/debugger/lib/trace/actions/index.js
@@ -6,11 +6,6 @@ export function saveSteps(steps) {
   };
 }
 
-export const NEXT = "TRACE_NEXT";
-export function next() {
-  return { type: NEXT };
-}
-
 export const TICK = "TRACE_TICK";
 export function tick() {
   return { type: TICK };

--- a/packages/debugger/lib/trace/reducers.js
+++ b/packages/debugger/lib/trace/reducers.js
@@ -7,7 +7,7 @@ import * as actions from "./actions";
 
 function index(state = 0, action) {
   switch (action.type) {
-    case actions.TOCK:
+    case actions.ADVANCE:
       return state + 1;
 
     case actions.RESET:

--- a/packages/debugger/lib/trace/sagas/index.js
+++ b/packages/debugger/lib/trace/sagas/index.js
@@ -31,16 +31,13 @@ export function* advance() {
   let waitingForSubmodules = 0;
 
   if (remaining > 0) {
-    debug("putting TICK");
     // updates state for current step
     waitingForSubmodules = yield select(trace.application.submoduleCount);
     yield put(actions.tick());
-    debug("put TICK");
 
     //wait for all backticks before continuing
     while (waitingForSubmodules > 0) {
-      yield take(actions.BACKTICK);
-      debug("got BACKTICK");
+      yield take(actions.TOCK);
       waitingForSubmodules--;
     }
 
@@ -48,19 +45,15 @@ export function* advance() {
   }
 
   if (remaining) {
-    debug("putting TOCK");
     // updates step to next step in trace
-    yield put(actions.tock());
-    debug("put TOCK");
+    yield put(actions.advance());
   } else {
-    debug("putting END_OF_TRACE");
     yield put(actions.endTrace());
-    debug("put END_OF_TRACE");
   }
 }
 
 export function* signalTickSagaCompletion() {
-  yield put(actions.backtick());
+  yield put(actions.tock());
 }
 
 export function* processTrace(steps) {

--- a/packages/debugger/lib/trace/sagas/index.js
+++ b/packages/debugger/lib/trace/sagas/index.js
@@ -1,9 +1,8 @@
 import debugModule from "debug";
 const debug = debugModule("debugger:trace:sagas");
 
-import {take, takeEvery, put, select} from "redux-saga/effects";
+import { take, put, select } from "redux-saga/effects";
 import {
-  prefixName,
   isCallMnemonic,
   isCreateMnemonic,
   isSelfDestructMnemonic
@@ -25,14 +24,6 @@ export function* addSubmoduleToCount(increment = 1) {
 }
 
 export function* advance() {
-  yield put(actions.next());
-
-  debug("TOCK to take");
-  yield take([actions.TOCK, actions.END_OF_TRACE]);
-  debug("TOCK taken");
-}
-
-function* next() {
   let remaining = yield select(trace.stepsRemaining);
   debug("remaining: %o", remaining);
   let steps = yield select(trace.steps);
@@ -80,7 +71,7 @@ export function* processTrace(steps) {
   let createdBinaries = {};
 
   for (let index = 0; index < steps.length; index++) {
-    const {op, depth, stack, memory} = steps[index];
+    const { op, depth, stack, memory } = steps[index];
     if (isCallMnemonic(op)) {
       callAddresses.add(Codec.Evm.Utils.toAddress(stack[stack.length - 2]));
     } else if (isCreateMnemonic(op)) {
@@ -130,9 +121,3 @@ export function* reset() {
 export function* unload() {
   yield put(actions.unloadTransaction());
 }
-
-export function* saga() {
-  yield takeEvery(actions.NEXT, next);
-}
-
-export default prefixName("trace", saga);


### PR DESCRIPTION
This PR removes the indirect system of communication between `next` and `advance` in the debugger's `trace` submodule.  I noticed that this was overly complicated while going through the code with @dongmingh.  So, now, `next` is gone; the whole thing is replaced by `advance`.  The listener is of course gone too, which means that `session` no longer has to start the listener.  And, that's it.  I don't know if this will meaningfully improve debugger performance, but it's definitely simpler to read, at least.

(Also, `prettier` made some changes as well.)

Edit: Oops, I forgot to remove the definition of the `NEXT` action itself!  Went back and did that now.

Edit again: One more thing -- I figured while I was at it, I would rename `BACKTICK` to `TOCK` and `TOCK` to `ADVANCE`.  I think that makes things clearer! :)