### PR TITLE
Re-add system to skip uninformative frames in stacktraces

### DIFF
--- a/packages/debugger/lib/stacktrace/actions/index.js
+++ b/packages/debugger/lib/stacktrace/actions/index.js
@@ -4,7 +4,7 @@ export function jumpIn(location, functionNode, contractNode) {
     type: JUMP_IN,
     location,
     functionNode,
-    contractNode,
+    contractNode
   };
 }
 
@@ -12,17 +12,23 @@ export const JUMP_OUT = "STACKTRACE_JUMP_OUT";
 export function jumpOut(location) {
   return {
     type: JUMP_OUT,
-    location,
+    location
   };
 }
 
 export const EXTERNAL_CALL = "STACKTRACE_EXTERNAL_CALL";
-export function externalCall(location, context, address) {
+export function externalCall(
+  location,
+  context,
+  address,
+  combineWithNextInternal
+) {
   return {
     type: EXTERNAL_CALL,
     location,
     context,
     address,
+    combineWithNextInternal
   };
 }
 
@@ -42,7 +48,7 @@ export function executeReturn(counter, location) {
   return {
     type: EXECUTE_RETURN,
     counter,
-    location,
+    location
   };
 }
 
@@ -50,20 +56,20 @@ export const UPDATE_POSITION = "STACKTRACE_UPDATE_POSITION";
 export function updatePosition(location) {
   return {
     type: UPDATE_POSITION,
-    location,
+    location
   };
 }
 
 export const RESET = "STACKTRACE_RESET";
 export function reset() {
   return {
-    type: RESET,
+    type: RESET
   };
 }
 
 export const UNLOAD_TRANSACTION = "STACKTRACE_UNLOAD_TRANSACTION";
 export function unloadTransaction() {
   return {
-    type: UNLOAD_TRANSACTION,
+    type: UNLOAD_TRANSACTION
   };
 }

--- a/packages/debugger/lib/stacktrace/actions/index.js
+++ b/packages/debugger/lib/stacktrace/actions/index.js
@@ -1,10 +1,11 @@
 export const JUMP_IN = "STACKTRACE_JUMP_IN";
-export function jumpIn(location, functionNode, contractNode) {
+export function jumpIn(location, functionNode, contractNode, sourceIsInternal) {
   return {
     type: JUMP_IN,
     location,
     functionNode,
-    contractNode
+    contractNode,
+    sourceIsInternal
   };
 }
 

--- a/packages/debugger/lib/stacktrace/reducers.js
+++ b/packages/debugger/lib/stacktrace/reducers.js
@@ -10,7 +10,7 @@ function callstack(state = [], action) {
   let newFrame;
   switch (action.type) {
     case actions.JUMP_IN:
-      let { location, functionNode, contractNode } = action;
+      const { location, functionNode, contractNode, sourceIsInternal } = action;
       newFrame = {
         type: "internal",
         calledFromLocation: location,
@@ -25,7 +25,8 @@ function callstack(state = [], action) {
           contractNode && contractNode.nodeType === "ContractDefinition"
             ? contractNode.name
             : undefined,
-        combineWithNextInternal: false
+        combineWithNextInternal: false,
+        sourceIsInternal
         //note we don't currently account for getters because currently
         //we can't; fallback, receive, constructors, & modifiers also remain
         //unaccounted for at present
@@ -47,6 +48,7 @@ function callstack(state = [], action) {
         functionName: undefined,
         contractName: action.context.contractName,
         combineWithNextInternal: action.combineWithNextInternal
+        //sourceIsInternal doesn't really apply here, so let's just omit it
       };
       return [...state, newFrame];
     case actions.EXECUTE_RETURN:

--- a/packages/debugger/lib/stacktrace/reducers.js
+++ b/packages/debugger/lib/stacktrace/reducers.js
@@ -24,7 +24,8 @@ function callstack(state = [], action) {
         contractName:
           contractNode && contractNode.nodeType === "ContractDefinition"
             ? contractNode.name
-            : undefined
+            : undefined,
+        combineWithNextInternal: false
         //note we don't currently account for getters because currently
         //we can't; fallback, receive, constructors, & modifiers also remain
         //unaccounted for at present
@@ -44,7 +45,8 @@ function callstack(state = [], action) {
         address: action.address,
         calledFromLocation: action.location,
         functionName: undefined,
-        contractName: action.context.contractName
+        contractName: action.context.contractName,
+        combineWithNextInternal: action.combineWithNextInternal
       };
       return [...state, newFrame];
     case actions.EXECUTE_RETURN:

--- a/packages/debugger/lib/stacktrace/sagas/index.js
+++ b/packages/debugger/lib/stacktrace/sagas/index.js
@@ -32,12 +32,14 @@ function* stacktraceSaga() {
     const index = yield select(stacktrace.current.index);
     const updateIndex = yield select(stacktrace.current.updateIndex);
     debug("returning!");
-    yield put(actions.externalReturn(
-      lastLocation,
-      status,
-      currentLocation,
-      updateIndex ? index : null //we use null to mean don't update
-    ));
+    yield put(
+      actions.externalReturn(
+        lastLocation,
+        status,
+        currentLocation,
+        updateIndex ? index : null //we use null to mean don't update
+      )
+    );
     positionUpdated = true;
   } else if (
     //next: are we *executing* a return?
@@ -80,7 +82,17 @@ function* stacktraceSaga() {
     //doesn't work across call contexts!
     const nextContext = yield select(stacktrace.current.callContext);
     const nextAddress = yield select(stacktrace.current.callAddress);
-    yield put(actions.externalCall(currentLocation, nextContext, nextAddress));
+    const combineWithNextInternal = yield select(
+      stacktrace.current.callCombinesWithNextJumpIn
+    );
+    yield put(
+      actions.externalCall(
+        currentLocation,
+        nextContext,
+        nextAddress,
+        combineWithNextInternal
+      )
+    );
     positionUpdated = true;
   }
   //finally, if no other action updated the position, do so here
@@ -100,7 +112,12 @@ export function* unload() {
 export function* begin() {
   const context = yield select(stacktrace.current.context);
   const address = yield select(stacktrace.current.address);
-  yield put(actions.externalCall(null, context, address));
+  const combineWithNextInternal = yield select(
+    stacktrace.transaction.initialCallCombinesWithNextJumpIn
+  );
+  yield put(
+    actions.externalCall(null, context, address, combineWithNextInternal)
+  );
 }
 
 export function* saga() {

--- a/packages/debugger/lib/stacktrace/sagas/index.js
+++ b/packages/debugger/lib/stacktrace/sagas/index.js
@@ -62,7 +62,15 @@ function* stacktraceSaga() {
     //note: do NOT process jumps while there are returns waiting to execute
     const nextLocation = yield select(stacktrace.next.location);
     const nextParent = yield select(stacktrace.next.contractNode);
-    yield put(actions.jumpIn(currentLocation, nextLocation.node, nextParent));
+    const nextSourceIsInternal = yield select(stacktrace.next.sourceIsInternal);
+    yield put(
+      actions.jumpIn(
+        currentLocation,
+        nextLocation.node,
+        nextParent,
+        nextSourceIsInternal
+      )
+    );
     positionUpdated = true;
   } else if (
     (yield select(stacktrace.current.willJumpOut)) &&

--- a/packages/debugger/lib/stacktrace/selectors/index.js
+++ b/packages/debugger/lib/stacktrace/selectors/index.js
@@ -14,8 +14,34 @@ import * as Codec from "@truffle/codec";
 
 const identity = x => x;
 
-function generateReport(callstack, location, status, message) {
-  //step 1: shift everything over by 1 and recombine :)
+function generateReport(rawStack, location, status, message) {
+  //step 1: process combined frames
+  let callstack = [];
+  //we're doing a C-style loop here!
+  //because we want to skip some items <grin>
+  for (let i = 0; i < rawStack.length; i++) {
+    const frame = rawStack[i];
+    if (
+      frame.combineWithNextInternal &&
+      i < rawStack.length - 1 &&
+      rawStack[i + 1].type === "internal"
+    ) {
+      const combinedFrame = {
+        ...rawStack[i + 1],
+        calledFromLocation: frame.calledFromLocation
+        //note: since the next frame is internal, it will have the
+        //same address as this, so we don't have to specify which
+        //one to take the address from
+      };
+      callstack.push(combinedFrame);
+      i++; //!! SKIP THE NEXT FRAME!
+    } else {
+      //ordinary case: just push the frame
+      callstack.push(frame);
+    }
+  }
+  debug("callstack: %O", callstack);
+  //step 2: shift everything over by 1 and recombine :)
   let locations = callstack.map(frame => frame.calledFromLocation);
   //remove initial null, add final location on end
   locations.shift();
@@ -112,6 +138,19 @@ let stacktrace = createSelectorTree({
    * stacktrace.state
    */
   state: state => state.stacktrace,
+
+  /**
+   * stacktrace.transaction
+   */
+  transaction: {
+    /**
+     * stacktrace.transaction.initialCallCombinesWithNextJumpIn
+     */
+    initialCallCombinesWithNextJumpIn: createLeaf(
+      [solidity.transaction.bottomStackframeRequiresPhantomFrame],
+      identity
+    )
+  },
 
   /**
    * stacktrace.current
@@ -211,6 +250,14 @@ let stacktrace = createSelectorTree({
      * stacktrace.current.callContext
      */
     callContext: createLeaf([evm.current.step.callContext], identity),
+
+    /**
+     * stacktrace.current.callCombinesWithNextJumpIn
+     */
+    callCombinesWithNextJumpIn: createLeaf(
+      [solidity.current.callRequiresPhantomFrame],
+      identity
+    ),
 
     /**
      * stacktrace.current.willReturn

--- a/packages/debugger/lib/stacktrace/selectors/index.js
+++ b/packages/debugger/lib/stacktrace/selectors/index.js
@@ -24,7 +24,8 @@ function generateReport(rawStack, location, status, message) {
     if (
       frame.combineWithNextInternal &&
       i < rawStack.length - 1 &&
-      rawStack[i + 1].type === "internal"
+      rawStack[i + 1].type === "internal" &&
+      !rawStack[i + 1].sourceIsInternal
     ) {
       const combinedFrame = {
         ...rawStack[i + 1],
@@ -100,6 +101,14 @@ function createMultistepSelectors(stepSelector) {
        */
       pointer: createLeaf([stepSelector.pointer], identity)
     },
+
+    /**
+     * .sourceIsInternal
+     */
+    sourceIsInternal: createLeaf(
+      ["./location/source"],
+      source => source.id === undefined || source.internal
+    ),
 
     /**
      * .strippedLocation

--- a/packages/debugger/test/stacktrace.js
+++ b/packages/debugger/test/stacktrace.js
@@ -50,7 +50,7 @@ contract StacktraceTest {
 
   function runRequire(bool succeed) public {
     emit Num(1); //EMIT
-    require(succeed); //REQUIRE
+    require(succeed, "requirement failed"); //REQUIRE
   }
 
   function runPay(bool succeed) public {
@@ -83,8 +83,10 @@ contract StacktraceTest {
     fail(); //CANTFALLBACK
   }
 
+  error CustomFailure();
+
   function fail() public {
-    revert("Nope!"); //FALLBACKFAIL
+    revert CustomFailure(); //FALLBACKFAIL
   }
 
   function runFallback(bool succeed) public {
@@ -220,6 +222,7 @@ describe("Stack tracing", function () {
     let prevLocation = report[report.length - 2].location;
     assert.strictEqual(location.sourceRange.lines.start.line, failLine);
     assert.strictEqual(prevLocation.sourceRange.lines.start.line, callLine);
+    assert.strictEqual(report[0].message, "requirement failed");
   });
 
   it("Generates correct stack trace at an intermediate state", async function () {
@@ -386,6 +389,7 @@ describe("Stack tracing", function () {
     let prevLocation = report[report.length - 4].location; //similar
     assert.strictEqual(location.sourceRange.lines.start.line, failLine);
     assert.strictEqual(prevLocation.sourceRange.lines.start.line, callLine);
+    assert.strictEqual(report[0].panic.toNumber(), 0x51);
   });
 
   it("Generates correct stack trace on unexpected self-destruct", async function () {
@@ -515,6 +519,7 @@ describe("Stack tracing", function () {
       callLine,
       "wrong call line"
     );
+    assert.strictEqual(report[0].message, "Nope!");
   });
 
   it("Generates correct stack trace after an internal call in a fallback function", async function () {
@@ -572,6 +577,7 @@ describe("Stack tracing", function () {
       callLine,
       "wrong call line"
     );
+    assert.isTrue(report[0].custom);
   });
 
   it("Generates correct stack trace after an internal call in a constructor", async function () {
@@ -636,5 +642,6 @@ describe("Stack tracing", function () {
     let prevLocation = report[report.length - 2].location;
     assert.strictEqual(location.sourceRange.lines.start.line, failLine);
     assert.strictEqual(prevLocation.sourceRange.lines.start.line, callLine);
+    assert.strictEqual(report[0].message, "Nope!");
   });
 });

--- a/packages/debugger/test/stacktrace.js
+++ b/packages/debugger/test/stacktrace.js
@@ -153,12 +153,9 @@ describe("Stack tracing", function () {
     let report = bugger.view(stacktrace.current.finalReport);
     let functionNames = report.map(({ functionName }) => functionName);
     assert.deepEqual(functionNames, [
-      undefined,
       "run",
-      undefined,
       "run3",
       "run2",
-      undefined,
       "run1",
       "runRequire"
     ]);
@@ -206,15 +203,7 @@ describe("Stack tracing", function () {
 
     let report = bugger.view(stacktrace.current.report);
     let functionNames = report.map(({ functionName }) => functionName);
-    assert.deepEqual(functionNames, [
-      undefined,
-      "run",
-      undefined,
-      "run2",
-      undefined,
-      "run1",
-      "runRequire"
-    ]);
+    assert.deepEqual(functionNames, ["run", "run2", "run1", "runRequire"]);
     let contractNames = report.map(({ contractName }) => contractName);
     assert(contractNames.every(name => name === "StacktraceTest"));
     let addresses = report.map(({ address }) => address);
@@ -231,12 +220,9 @@ describe("Stack tracing", function () {
     report = bugger.view(stacktrace.current.report);
     functionNames = report.map(({ functionName }) => functionName);
     assert.deepEqual(functionNames, [
-      undefined,
       "run",
-      undefined,
       "run3",
       "run2",
-      undefined,
       "run1",
       "runRequire"
     ]);
@@ -281,12 +267,9 @@ describe("Stack tracing", function () {
     let report = bugger.view(stacktrace.current.finalReport);
     let functionNames = report.map(({ functionName }) => functionName);
     assert.deepEqual(functionNames, [
-      undefined,
       "run",
-      undefined,
       "run3",
       "run2",
-      undefined,
       "run1",
       "runPay",
       undefined
@@ -332,12 +315,9 @@ describe("Stack tracing", function () {
     let report = bugger.view(stacktrace.current.finalReport);
     let functionNames = report.map(({ functionName }) => functionName);
     assert.deepEqual(functionNames, [
-      undefined,
       "run",
-      undefined,
       "run3",
       "run2",
-      undefined,
       "run1",
       "runInternal",
       undefined,
@@ -351,7 +331,7 @@ describe("Stack tracing", function () {
     assert(addresses.every(address => address === instance.address));
     let status = report[report.length - 1].status;
     assert.isFalse(status);
-    let location = report[report.length - 3].location; //note, -2 because of panic & undefined on top
+    let location = report[report.length - 3].location; //note, -3 because of panic & undefined on top
     let prevLocation = report[report.length - 4].location; //similar
     assert.strictEqual(location.sourceRange.lines.start.line, failLine);
     assert.strictEqual(prevLocation.sourceRange.lines.start.line, callLine);
@@ -387,37 +367,30 @@ describe("Stack tracing", function () {
     let report = bugger.view(stacktrace.current.finalReport);
     let functionNames = report.map(({ functionName }) => functionName);
     assert.deepEqual(functionNames, [
-      undefined,
       "run",
-      undefined,
       "run3",
       "run2",
-      undefined,
       "run1",
       "runBoom",
-      undefined,
       "boom"
     ]);
     let contractNames = report.map(({ contractName }) => contractName);
     assert.strictEqual(contractNames[contractNames.length - 1], "Boom");
     contractNames.pop(); //top frame
-    assert.strictEqual(contractNames[contractNames.length - 1], "Boom");
-    contractNames.pop(); //second-top frame
     assert(contractNames.every(name => name === "StacktraceTest"));
     let addresses = report.map(({ address }) => address);
-    assert.strictEqual(
+    assert.notEqual(
+      //check that Boom and StacktraceTest are not same address
       addresses[addresses.length - 1],
       addresses[addresses.length - 2]
     );
-    addresses.pop();
     addresses.pop();
     assert(addresses.every(address => address === instance.address));
     let status = report[report.length - 1].status;
     assert.isTrue(status);
     let location = report[report.length - 1].location;
-    //skip a frame for the junk frame
-    let prevLocation = report[report.length - 3].location;
-    let prev2Location = report[report.length - 4].location;
+    let prevLocation = report[report.length - 2].location;
+    let prev2Location = report[report.length - 3].location;
     assert.strictEqual(location.sourceRange.lines.start.line, failLine);
     assert.strictEqual(prevLocation.sourceRange.lines.start.line, callLine);
     assert.strictEqual(


### PR DESCRIPTION
Addresses #4739.  This PR re-adds the system that I removed in #2976.  As such there's not really much new here, it's mostly just adding the deleted code back in and then adjusting the tests appropriately.  I did rename some of the fields and variables because I feel like the old names could have been clearer.  There is one new thing I had to add -- but I'll get to that.

Anyway, to explain: As of Solidity 0.5.1, when we make an external call, there's a jump-in marking, so without any additional work, `stacktrace` would generate two stackframes; one for the external call, then one for the jump-in.  In the `solidity` submodule, we have the phantom guard system to ensure that these get combined.  It wasn't being applied here.  Now we apply it here.  (The reason it wasn't being applied here before was that due to #4697, the phantom guard was activated inappropriately in some situations, and so applying it here would have caused some stackframes to be skipped.  Now that #4697 is resolved, this is no longer a problem.)

So, when adding a frame to the stack in `stacktrace`, we now add two additional fields: `combineWithNextInternal`, and `sourceIsInternal`.  These are both booleans; the first is set for external calls for which the phantom guard is set, indicating that, when generating the final stacktrace, this frame should be combined with the one after it, so long as the one after it is an internal call (and not to an internal source, i.e., unmapped code or a generated source).  The second, `sourceIsInternal`, we actually only include for internal calls (since it's meaningless for external ones), and records whether the source being jumped to is an internal source (meaning, again, unmapped code or a generated source).

Then, in the `generateReport` function in the selectors, we now add a preprocessing step where we go over the list of stackframes and combine any pair where the lower is marked `combineWithNextInternal` and the upper is of `type: "internal"` (i.e., an internal call) and not marked `sourceIsInternal` (not to an internal source).  (Sorry about the terminological overloading, but, that's what we've been calling these.)  "Combining" them means we take most of the information from the upper one (since that's the actual function call), but we take the `calledFromLocation` information from the lower one (since we want to treat the whole thing as a single call).  You might think we'd take `address` from the lower one as well, but actually we don't need to, since they'll already have the same address.

Actually, I said above that #4697 is now solved, but that's not exactly true; there is one case where the phantom guard will still be set inappropriately, and that's when calling a getter.  However, since getters don't call other functions (other than perhaps generated functions that won't get combined anyway), this ends up not causing any problems.  (Other than that the getter won't have its name displayed... this is making me wonder whether we should do something about #3878.)

Of course I had to adjust the tests.  Note I didn't bother adding a test for stacktraces starting in an internal source, to check that those don't get combined; that would have been difficult to write a test for, so I just tested it manually instead.  I also added three new tests, to test that stackframes that truly shouldn't get combined don't.  While I was at it, I also noticed that the existing tests didn't test the `stacktrace` submodule's reporting of the revert message, so I added that to the tests too.

Also note that I didn't need to make any changes to debug-utils; the `formatStacktrace` function in debug-utils is already prepared to handle the case of a stackframe with both a `functionName` and an `address`, even though that has never existed previously (since the `address` field was only added after I removed this system in #2976).

(Edit: I'm wrong, it did previously exist, I forgot that for a while we printed address on every stackframe!)