### PR TITLE
Bug fix: Fix function depth for Yul contracts

### DIFF
--- a/packages/codec/lib/contexts/types.ts
+++ b/packages/codec/lib/contexts/types.ts
@@ -46,6 +46,7 @@ export interface DebuggerContext {
   abi?: Abi.Abi;
   sourceMap?: string;
   primarySource?: number;
+  primaryLanguage?: string;
   compiler?: Compiler.CompilerVersion;
   compilationId?: string;
   payable?: boolean;

--- a/packages/debugger/lib/evm/actions/index.js
+++ b/packages/debugger/lib/evm/actions/index.js
@@ -1,34 +1,8 @@
 export const ADD_CONTEXT = "EVM_ADD_CONTEXT";
-export function addContext({
-  context,
-  contractName,
-  binary,
-  sourceMap,
-  primarySource,
-  immutableReferences,
-  compiler,
-  compilationId,
-  abi,
-  contractId,
-  contractKind,
-  isConstructor,
-  linearizedBaseContracts
-}) {
+export function addContext(context) {
   return {
-    type: ADD_CONTEXT,
-    context,
-    contractName,
-    binary,
-    sourceMap,
-    primarySource,
-    immutableReferences,
-    compiler,
-    compilationId,
-    abi,
-    contractId,
-    contractKind,
-    isConstructor,
-    linearizedBaseContracts
+    ...context,
+    type: ADD_CONTEXT
   };
 }
 

--- a/packages/debugger/lib/evm/reducers.js
+++ b/packages/debugger/lib/evm/reducers.js
@@ -18,44 +18,17 @@ function contexts(state = DEFAULT_CONTEXTS, action) {
      * Adding a new context
      */
     case actions.ADD_CONTEXT:
-      const {
-        context,
-        contractName,
-        binary,
-        sourceMap,
-        primarySource,
-        immutableReferences,
-        compiler,
-        compilationId,
-        abi,
-        contractId,
-        contractKind,
-        isConstructor,
-        linearizedBaseContracts
-      } = action;
-      debug("action %O", action);
+      let contextObject = { ...action };
+      delete contextObject.type; //this doesn't go in a context!
+      contextObject.payable = Codec.AbiData.Utils.abiHasPayableFallback(
+        contextObject.abi
+      );
 
       return {
         ...state,
         byContext: {
           ...state.byContext,
-          [context]: {
-            context,
-            contractName,
-            context,
-            binary,
-            sourceMap,
-            primarySource,
-            immutableReferences,
-            compiler,
-            compilationId,
-            abi,
-            contractId,
-            contractKind,
-            isConstructor,
-            linearizedBaseContracts,
-            payable: Codec.AbiData.Utils.abiHasPayableFallback(abi)
-          }
+          [contextObject.context]: contextObject
         }
       };
 

--- a/packages/debugger/lib/session/index.js
+++ b/packages/debugger/lib/session/index.js
@@ -194,6 +194,11 @@ export default class Session {
           );
         }
         //otherwise leave it undefined
+        let primaryLanguage;
+        if (primarySourceIndex !== undefined) {
+          primaryLanguage = compilation.sources[primarySourceIndex].language;
+        }
+        //leave undefined if can't locate primary source
 
         //now: we need to find the contract node.
         //note: ideally we'd hold this off till later, but that would break the
@@ -242,6 +247,7 @@ export default class Session {
             contractId,
             contractKind,
             linearizedBaseContracts,
+            primaryLanguage,
             isConstructor: true
           });
           if (generatedSources) {
@@ -285,6 +291,7 @@ export default class Session {
             contractId,
             contractKind,
             linearizedBaseContracts,
+            primaryLanguage,
             isConstructor: false
           });
           if (deployedGeneratedSources) {

--- a/packages/debugger/lib/solidity/selectors/index.js
+++ b/packages/debugger/lib/solidity/selectors/index.js
@@ -20,9 +20,10 @@ function contextRequiresPhantomStackframes(context, data) {
     abiEntry => abiEntry.type === "fallback" || abiEntry.type === "receive"
   );
   return (
+    context.primaryLanguage === "Solidity" && //do not use phantom frames for Yul or Vyper!
     context.compiler !== undefined && //(do NOT just put context.compiler here,
     //we need this to be a boolean, not undefined, because it gets put in the state)
-    context.compiler.name === "solc" &&
+    context.compiler.name === "solc" && //this check is possibly redundant now but I'll keep it in
     semver.satisfies(context.compiler.version, ">=0.5.1", {
       includePrerelease: true
     }) &&


### PR DESCRIPTION
Addresses #4756.  It turns out I wasn't *quite* done with fixing the function depth -- I still hadn't fixed it for Yul contracts!  Yul contracts shouldn't have the phantom call guard set, as when you call them, you are legitimately running outside a function at first.  So, we want to restrict the phantom call guard to when the language is Solidity.  This PR does that.

(What about Vyper, you may ask?  Vyper also shouldn't have the guard set, because like Solidity <0.5.1 the initial function call lacks a jump marking; but this was already handled by the check that the guard only applies to things compiled with `solc`.)

To do this, we have to check the language of the context's primary source; we only set the guard if the language is `"Solidity"`.  Problem: How can we check this?  Once we're *in* the context, we can look up the context's primary source and check its language... but the call guard has to be determined *before* we enter the context.  And until we enter the context, we don't have its sources available.  (OK, now that I look at it more, actually we *could* make those sources available if I had taken an alternate approach, but I didn't think of that possibility until just now, so, uh, I didn't do that.)

Instead, the way I decided to handle it was to attach a new `primaryLanguage` field to each context, determined at startup.  So we can just check `context.primaryLanguage`.

While I was doing this, I decided to simplify the code for adding contexts, because having to maintain that each time I add something new is annoying.  Not that I add new things often, but!

I also added a test to ensure that function depth hits 1 when inside a Yul function call.  Anyway, now function depth should *finally* be correct.  (Until Vyper decides to change things or we add a new language or something.)