### PR TITLE
Set Truffle network config options for Truffle test's internal ganache network

### DIFF
--- a/packages/core/lib/commands/test/run.js
+++ b/packages/core/lib/commands/test/run.js
@@ -82,7 +82,6 @@ module.exports = async function (options) {
     !configuredNetwork["url"];
   const port = await require("get-port")();
   const ipcOptions = { network: "test" };
-  let numberOfFailures;
 
   if (testNetworkDefined && noProviderHostOrUrlConfigured) {
     const ganacheOptions = {
@@ -97,19 +96,21 @@ module.exports = async function (options) {
       },
       ...config.networks[config.network]
     };
-    numberOfFailures = await startGanacheAndRunTests(
+    const numberOfFailures = await startGanacheAndRunTests(
       ipcOptions,
       ganacheOptions,
       config
     );
+    return numberOfFailures;
   } else if (configuredNetwork) {
     await Environment.detect(config);
     const { temporaryDirectory } = await copyArtifactsToTempDir(config);
-    numberOfFailures = await prepareConfigAndRunTests({
+    const numberOfFailures = await prepareConfigAndRunTests({
       config,
       files,
       temporaryDirectory
     });
+    return numberOfFailures;
   } else {
     const ganacheOptions = {
       host: "127.0.0.1",
@@ -122,13 +123,13 @@ module.exports = async function (options) {
         instamine: "strict"
       }
     };
-    numberOfFailures = await startGanacheAndRunTests(
+    const numberOfFailures = await startGanacheAndRunTests(
       ipcOptions,
       ganacheOptions,
       config
     );
+    return numberOfFailures;
   }
-  return numberOfFailures;
 
   // Start internal ganache network
   async function startGanacheAndRunTests(ipcOptions, ganacheOptions, config) {

--- a/packages/core/lib/commands/test/run.js
+++ b/packages/core/lib/commands/test/run.js
@@ -87,17 +87,17 @@ module.exports = async function (options) {
   });
 
   const configuredNetwork = config.networks[config.network];
-  const testNetworkDefined = configuredNetwork && config.network === "test";
+  const testNetworkDefinedAndUsed =
+    configuredNetwork && config.network === "test";
   const noProviderHostOrUrlConfigured =
     configuredNetwork &&
     !configuredNetwork.provider &&
     !configuredNetwork.host &&
     !configuredNetwork.url;
   const ipcOptions = { network: "test" };
-  let numberOfFailures, port;
+  let numberOfFailures;
   let ganacheOptions = {
     host: "127.0.0.1",
-    port,
     network_id: 4447,
     mnemonic:
       "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat",
@@ -108,13 +108,13 @@ module.exports = async function (options) {
   };
 
   if (
-    (testNetworkDefined && noProviderHostOrUrlConfigured) ||
+    (testNetworkDefinedAndUsed && noProviderHostOrUrlConfigured) ||
     !configuredNetwork
   ) {
     // Use managed ganache with overriding user specified config or without any specification in the config
     const port = await require("get-port")();
 
-    //configuredNetwork will spread only when it is defined and ignored when undefined
+    // configuredNetwork will spread only when it is defined and ignored when undefined
     ganacheOptions = { ...ganacheOptions, port, ...configuredNetwork };
     numberOfFailures = await startGanacheAndRunTests(
       ipcOptions,

--- a/packages/core/lib/commands/test/run.js
+++ b/packages/core/lib/commands/test/run.js
@@ -112,7 +112,7 @@ module.exports = async function (options) {
     !configuredNetwork
   ) {
     // Use managed ganache with overriding user specified config or without any specification in the config
-    port = await require("get-port")();
+    const port = await require("get-port")();
 
     //configuredNetwork will spread only when it is defined and ignored when undefined
     ganacheOptions = { ...ganacheOptions, port, ...configuredNetwork };

--- a/packages/core/lib/commands/test/run.js
+++ b/packages/core/lib/commands/test/run.js
@@ -82,6 +82,7 @@ module.exports = async function (options) {
     !configuredNetwork["url"];
   const port = await require("get-port")();
   const ipcOptions = { network: "test" };
+  let numberOfFailures;
 
   if (testNetworkDefined && noProviderHostOrUrlConfigured) {
     const ganacheOptions = {
@@ -96,21 +97,19 @@ module.exports = async function (options) {
       },
       ...config.networks[config.network]
     };
-    const numberOfFailures = await startGanacheAndRunTests(
+    numberOfFailures = await startGanacheAndRunTests(
       ipcOptions,
       ganacheOptions,
       config
     );
-    return numberOfFailures;
   } else if (configuredNetwork) {
     await Environment.detect(config);
     const { temporaryDirectory } = await copyArtifactsToTempDir(config);
-    const numberOfFailures = await prepareConfigAndRunTests({
+    numberOfFailures = await prepareConfigAndRunTests({
       config,
       files,
       temporaryDirectory
     });
-    return numberOfFailures;
   } else {
     const ganacheOptions = {
       host: "127.0.0.1",
@@ -123,13 +122,13 @@ module.exports = async function (options) {
         instamine: "strict"
       }
     };
-    const numberOfFailures = await startGanacheAndRunTests(
+    numberOfFailures = await startGanacheAndRunTests(
       ipcOptions,
       ganacheOptions,
       config
     );
-    return numberOfFailures;
   }
+  return numberOfFailures;
 
   // Start internal ganache network
   async function startGanacheAndRunTests(ipcOptions, ganacheOptions, config) {

--- a/packages/core/lib/commands/test/run.js
+++ b/packages/core/lib/commands/test/run.js
@@ -113,6 +113,8 @@ module.exports = async function (options) {
   ) {
     // Use managed ganache with overriding user specified config or without any specification in the config
     port = await require("get-port")();
+
+    //configuredNetwork will spread only when it is defined and ignored when undefined
     ganacheOptions = { ...ganacheOptions, port, ...configuredNetwork };
     numberOfFailures = await startGanacheAndRunTests(
       ipcOptions,


### PR DESCRIPTION
### ISSUE
No way to set Truffle network config options for Truffle Test's internal Ganache network. See issue #4327 

### SOLUTION
This PR solves the issue of non-configurable Truffle test's managed ganache network from the truffle-config.js.
If the configured network is "test" and provider, host or url doesn't exist, or there is no configured network defined, then managed ganache is started overriding with the user specified configurations or the default configurations.
If there is a configured network in the config, then it connects to that external network.
