### PR TITLE
resolve to patched lodash.template

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "prettier": "^2.5.1",
     "prs-merged-since": "^1.1.0"
   },
+  "resolutions": {
+    "lodash.template": "^4.5.0"
+  },
   "workspaces": {
     "packages": [
       "packages/*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -21298,7 +21298,7 @@ lodash-es@^4.2.1:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
   integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
 
-lodash._reinterpolate@^3.0.0, lodash._reinterpolate@~3.0.0:
+lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
@@ -21312,11 +21312,6 @@ lodash.assignin@^4.0.9:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assignin/-/lodash.assignin-4.2.0.tgz#ba8df5fb841eb0a3e8044232b0e263a8dc6a28a2"
   integrity sha1-uo31+4QesKPoBEIysOJjqNxqKKI=
-
-lodash.assigninwith@^4.0.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.assigninwith/-/lodash.assigninwith-4.2.0.tgz#af02c98432ac86d93da695b4be801401971736af"
-  integrity sha1-rwLJhDKshtk9ppW0voAUAZcXNq8=
 
 lodash.bind@^4.1.4:
   version "4.2.1"
@@ -21388,7 +21383,7 @@ lodash.ismatch@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz#756cb5150ca3ba6f11085a78849645f188f85f37"
   integrity sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=
 
-lodash.keys@^4.0.0, lodash.keys@^4.2.0:
+lodash.keys@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-4.2.0.tgz#a08602ac12e4fb83f91fc1fb7a360a4d9ba35205"
   integrity sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU=
@@ -21443,11 +21438,6 @@ lodash.reject@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.reject/-/lodash.reject-4.6.0.tgz#80d6492dc1470864bbf583533b651f42a9f52415"
   integrity sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU=
 
-lodash.rest@^4.0.0:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/lodash.rest/-/lodash.rest-4.0.5.tgz#954ef75049262038c96d1fc98b28fdaf9f0772aa"
-  integrity sha1-lU73UEkmIDjJbR/Jiyj9r58Hcqo=
-
 lodash.some@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
@@ -21463,19 +21453,7 @@ lodash.sum@^4.0.2:
   resolved "https://registry.yarnpkg.com/lodash.sum/-/lodash.sum-4.0.2.tgz#ad90e397965d803d4f1ff7aa5b2d0197f3b4637b"
   integrity sha1-rZDjl5ZdgD1PH/eqWy0Bl/O0Y3s=
 
-lodash.template@4.2.4:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.2.4.tgz#d053c19e8e74e38d965bf4fb495d80f109e7f7a4"
-  integrity sha1-0FPBno50442WW/T7SV2A8Qnn96Q=
-  dependencies:
-    lodash._reinterpolate "~3.0.0"
-    lodash.assigninwith "^4.0.0"
-    lodash.keys "^4.0.0"
-    lodash.rest "^4.0.0"
-    lodash.templatesettings "^4.0.0"
-    lodash.tostring "^4.0.0"
-
-lodash.template@^4.5.0:
+lodash.template@4.2.4, lodash.template@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.5.0.tgz#f976195cf3f347d0d5f52483569fe8031ccce8ab"
   integrity sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==
@@ -21499,11 +21477,6 @@ lodash.topath@^4.5.2:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.topath/-/lodash.topath-4.5.2.tgz#3616351f3bba61994a0931989660bd03254fd009"
   integrity sha1-NhY1Hzu6YZlKCTGYlmC9AyVP0Ak=
-
-lodash.tostring@^4.0.0:
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/lodash.tostring/-/lodash.tostring-4.1.4.tgz#560c27d1f8eadde03c2cce198fef5c031d8298fb"
-  integrity sha1-Vgwn0fjq3eA8LM4Zj+9cAx2CmPs=
 
 lodash.truncate@^4.4.2:
   version "4.4.2"


### PR DESCRIPTION
:warning: This PR is to test if package.resolution is viable :warning:

[Depandabot identified this vulnerability with `lodash.template`](https://github.com/trufflesuite/truffle/security/dependabot/4), recommending upgrading to `v4.17.12`
| module   |      vulnerable versions      |  patched |
|----------|:-------------:|------:|
|lodash.template|  < 4.5.0| 4.5.0|

- Use resolutions in package.json to resolve to patched `lodash.template` version.

## Controversy 

Should we use this yarn's resolution feature? 

### Pro
- part of yarn toolset
- fits in our current `build -> webpack bundle -> npm install` pipeline
- this is no different from dependabot PRs we currently accept which directly modify `yarn.lock`. This is kind of the same mechanic that `resolutions` use

### Con
- caused complications in the past (need to document them)
- is not recognized by npm (even though our current pipeline accounts for that)
- npm dependency black magic
- current tests may not invoke a code path to validate change


## Analysis

Truffle imports two `lodash.template` versions, the innocuous v4.5.0 and the
vulnerable v4.2.4 required by the `module` dependency of `@truffle/config`.

```console
$ yarn why lodash.template  # n.b. abbreviated output
=> Found "module#lodash.template@4.2.4" 
This module exists because "_project_#@truffle#config#module" depends on it.

$ yarn why lodash.template | grep Found
=> Found "lodash.template@4.5.0"
=> Found "module#lodash.template@4.2.4"
```

### Suggested Solution

This transitive dependency can be forced to resolve to the patched version
using yarn's resolutions directive in `package.json`

- the patched version, v4.5.0, is within the same compitable range as v4.2.4.
- the new version will be preserved for npm via our yarn build -> webpack ->
  publish pipeline

## Verification

- 1 version of lodash.template after resolutions applied
  ```console
  $ yarn why lodash.template
  yarn why v1.22.17
  => Found "lodash.template@4.5.0"
  info Reasons this module exists
     - "_project_#@truffle#config#module" depends on it
     - Hoisted from "_project_#@truffle#config#module#lodash.template"
     - Hoisted from "_project_#lerna#@lerna#version#@lerna#conventional-commits#lodash.template"
     - Hoisted from "_project_#@truffle#dashboard#react-scripts#workbox-webpack-plugin#workbox-build#lodash.template"

  $ yarn why lodash.template | grep Found
  => Found "lodash.template@4.5.0"
  ```
- `yarn audit --level critical` identified 7 critical warnings related to
  `lodash.template` and dropped to 1 critical warning after applying this
  solution.

  <details><summary>Original audit report</summary>

  ```console
  ╰─$ yarn audit --level critical
  yarn audit v1.22.17
  ┌───────────────┬──────────────────────────────────────────────────────────────┐
  │ critical      │ Prototype pollution in 101                                   │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ Package       │ 101                                                          │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ Patched in    │ No patch available                                           │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ Dependency of │ @truffle/core                                                │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ Path          │ @truffle/core > @truffle/preserve-to-filecoin > filecoin.js  │
  │               │ > rpc-websockets > assert-args > 101                         │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ More info     │ https://www.npmjs.com/advisories/1005188                     │
  └───────────────┴──────────────────────────────────────────────────────────────┘
  ┌───────────────┬──────────────────────────────────────────────────────────────┐
  │ critical      │ Prototype Pollution in lodash                                │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ Package       │ lodash.template                                              │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ Patched in    │ >=4.5.0                                                      │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ Dependency of │ @truffle/config                                              │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ Path          │ @truffle/config > module > lodash.template                   │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ More info     │ https://www.npmjs.com/advisories/1006307                     │
  └───────────────┴──────────────────────────────────────────────────────────────┘
  ┌───────────────┬──────────────────────────────────────────────────────────────┐
  │ critical      │ Prototype Pollution in lodash                                │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ Package       │ lodash.template                                              │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ Patched in    │ >=4.5.0                                                      │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ Dependency of │ @truffle/box                                                 │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ Path          │ @truffle/box > @truffle/config > module > lodash.template    │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ More info     │ https://www.npmjs.com/advisories/1006307                     │
  └───────────────┴──────────────────────────────────────────────────────────────┘
  ┌───────────────┬──────────────────────────────────────────────────────────────┐
  │ critical      │ Prototype Pollution in lodash                                │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ Package       │ lodash.template                                              │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ Patched in    │ >=4.5.0                                                      │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ Dependency of │ @truffle/core                                                │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ Path          │ @truffle/core > @truffle/box > @truffle/config > module >    │
  │               │ lodash.template                                              │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ More info     │ https://www.npmjs.com/advisories/1006307                     │
  └───────────────┴──────────────────────────────────────────────────────────────┘
  ┌───────────────┬──────────────────────────────────────────────────────────────┐
  │ critical      │ Prototype Pollution in lodash                                │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ Package       │ lodash.template                                              │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ Patched in    │ >=4.5.0                                                      │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ Dependency of │ @truffle/core                                                │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ Path          │ @truffle/core > @truffle/fetch-and-compile >                 │
  │               │ @truffle/compile-solidity > @truffle/config > module >       │
  │               │ lodash.template                                              │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ More info     │ https://www.npmjs.com/advisories/1006307                     │
  └───────────────┴──────────────────────────────────────────────────────────────┘
  ┌───────────────┬──────────────────────────────────────────────────────────────┐
  │ critical      │ Prototype Pollution in lodash                                │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ Package       │ lodash.template                                              │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ Patched in    │ >=4.5.0                                                      │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ Dependency of │ @truffle/workflow-compile                                    │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ Path          │ @truffle/workflow-compile > @truffle/compile-vyper >         │
  │               │ @truffle/resolver > @truffle/provisioner > @truffle/config > │
  │               │ module > lodash.template                                     │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ More info     │ https://www.npmjs.com/advisories/1006307                     │
  └───────────────┴──────────────────────────────────────────────────────────────┘
  ┌───────────────┬──────────────────────────────────────────────────────────────┐
  │ critical      │ Prototype Pollution in lodash                                │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ Package       │ lodash.template                                              │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ Patched in    │ >=4.5.0                                                      │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ Dependency of │ @truffle/core                                                │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ Path          │ @truffle/core > @truffle/workflow-compile >                  │
  │               │ @truffle/compile-vyper > @truffle/resolver >                 │
  │               │ @truffle/provisioner > @truffle/config > module >            │
  │               │ lodash.template                                              │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ More info     │ https://www.npmjs.com/advisories/1006307                     │
  └───────────────┴──────────────────────────────────────────────────────────────┘
  475 vulnerabilities found - Packages audited: 3427
  Severity: 30 Low | 245 Moderate | 193 High | 7 Critical
  ```

    </details>

    <details><summary>Audit report after applying solution</summary>

  ```console
  ╰─$ yarn audit --level critical
  yarn audit v1.22.17
  ┌───────────────┬──────────────────────────────────────────────────────────────┐
  │ critical      │ Prototype pollution in 101                                   │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ Package       │ 101                                                          │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ Patched in    │ No patch available                                           │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ Dependency of │ @truffle/core                                                │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ Path          │ @truffle/core > @truffle/preserve-to-filecoin > filecoin.js  │
  │               │ > rpc-websockets > assert-args > 101                         │
  ├───────────────┼──────────────────────────────────────────────────────────────┤
  │ More info     │ https://www.npmjs.com/advisories/1005188                     │
  └───────────────┴──────────────────────────────────────────────────────────────┘
  469 vulnerabilities found - Packages audited: 3423
  Severity: 30 Low | 245 Moderate | 193 High | 1 Critical
  Done in 3.88s.
  ```
    </details>


