### PR TITLE
Update Solidity version in Truffle Init to 0.8.12

### DIFF
--- a/packages/core/lib/commands/init/initSource/truffle-config.js
+++ b/packages/core/lib/commands/init/initSource/truffle-config.js
@@ -81,7 +81,7 @@ module.exports = {
   // Configure your compilers
   compilers: {
     solc: {
-      version: "0.8.11",    // Fetch exact version from solc-bin (default: truffle's version)
+      version: "0.8.12",    // Fetch exact version from solc-bin (default: truffle's version)
       // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
       // settings: {          // See the solidity docs for advice about optimization and evmVersion
       //  optimizer: {


### PR DESCRIPTION
Just realize we didn't update this for 0.8.12.  Since we still have no automation for this, here's a manual PR.  Again, I used `--no-verify` to keep prettier from altering the comment indentation on the db stuff.