### PR TITLE
Enhancement: Support panic codes in Truffle Contract

### DIFF
--- a/packages/contract-tests/test/deploy.js
+++ b/packages/contract-tests/test/deploy.js
@@ -211,18 +211,26 @@ describe("Deployments", function () {
     // Constructor in this test consumes ~6388773 (ganache) vs blockLimit of 6721975.
     it("doesn't multiply past the blockLimit", async function () {
       this.timeout(50000);
-      let iterations = 6000; // # of times to set a uint in a loop, consuming gas.
+      let iterations = 5000; // # of times to set a uint in a loop, consuming gas.
 
       const estimate = await Example.new.estimateGas(iterations);
       const block = await web3.eth.getBlock("latest");
       const multiplier = Example.gasMultiplier;
 
-      assert(multiplier === 1.25, "Multiplier should be initialized to 1.25");
+      assert.equal(
+        multiplier,
+        1.25,
+        "Multiplier should be initialized to 1.25"
+      );
       assert(
         multiplier * estimate > block.gasLimit,
         "Multiplied estimate should be too high"
       );
-      assert(estimate < block.gasLimit, "Estimate on it's own should be ok");
+      assert.isAtMost(
+        estimate,
+        block.gasLimit,
+        "Estimate on its own should be ok"
+      );
 
       await Example.new(iterations);
     });

--- a/packages/contract-tests/test/errors.js
+++ b/packages/contract-tests/test/errors.js
@@ -181,9 +181,17 @@ describe("Client appends errors (vmErrorsOnRPCResponse)", function () {
         await example.triggerRequireWithReasonError();
         assert.fail();
       } catch (e) {
-        assert(e.reason === "reasonstring", "Should include reason property");
-        assert(e.message.includes("reasonstring"), "Should reason in message");
-        assert(e.message.includes("revert"), "Should include revert message");
+        assert.equal(
+          e.reason,
+          "reasonstring",
+          "Should include reason property"
+        );
+        assert.include(
+          e.message,
+          "reasonstring",
+          "Should include reason in message"
+        );
+        assert.include(e.message, "revert", "Should include revert");
       }
     });
 
@@ -193,9 +201,57 @@ describe("Client appends errors (vmErrorsOnRPCResponse)", function () {
         await example.triggerRequireWithReasonError({ gas: 200000 });
         assert.fail();
       } catch (e) {
-        assert(e.reason === "reasonstring", "Should include reason property");
-        assert(e.message.includes("reasonstring"), "Should reason in message");
-        assert(e.message.includes("revert"), "Should include revert");
+        assert.equal(
+          e.reason,
+          "reasonstring",
+          "Should include reason property"
+        );
+        assert.include(
+          e.message,
+          "reasonstring",
+          "Should include reason in message"
+        );
+        assert.include(e.message, "revert", "Should include revert");
+      }
+    });
+
+    it("errors with panic code on panic", async function () {
+      const example = await Example.new(1);
+      try {
+        await example.triggerAssertError();
+        assert.fail();
+      } catch (e) {
+        assert.equal(
+          e.reason,
+          "Panic: Failed assertion",
+          "Should include reason property"
+        );
+        assert.include(
+          e.message,
+          "Failed assertion",
+          "Should include panic reason in message"
+        );
+        assert.include(e.message, "Panic", "Should include 'Panic'");
+      }
+    });
+
+    it("errors with panic code on panic (gas specified)", async function () {
+      const example = await Example.new(1);
+      try {
+        await example.triggerAssertError({ gas: 200000 });
+        assert.fail();
+      } catch (e) {
+        assert.equal(
+          e.reason,
+          "Panic: Failed assertion",
+          "Should include reason property"
+        );
+        assert.include(
+          e.message,
+          "Failed assertion",
+          "Should include panic reason in message"
+        );
+        assert.include(e.message, "Panic", "Should include 'Panic'");
       }
     });
 

--- a/packages/contract-tests/test/errors.js
+++ b/packages/contract-tests/test/errors.js
@@ -202,7 +202,7 @@ describe("Client appends errors (vmErrorsOnRPCResponse)", function () {
     it("errors with invalid opcode when gas specified", async function () {
       const example = await Example.new(1);
       try {
-        await example.triggerAssertError({ gas: 200000 });
+        await example.triggerInvalidOpcode({ gas: 200000 });
         assert.fail();
       } catch (e) {
         assert(!e.reason, "Should not include reason string");
@@ -220,7 +220,7 @@ describe("Client appends errors (vmErrorsOnRPCResponse)", function () {
     it("errors with invalid opcode when gas not specified", async function () {
       const example = await Example.new(1);
       try {
-        await example.triggerAssertError();
+        await example.triggerInvalidOpcode();
         assert.fail();
       } catch (e) {
         assert(e.message.includes("invalid opcode"));

--- a/packages/contract-tests/test/sources/ABIV2UserDirectory.sol
+++ b/packages/contract-tests/test/sources/ABIV2UserDirectory.sol
@@ -1,5 +1,4 @@
-pragma solidity ^0.5.0;
-pragma experimental ABIEncoderV2;
+pragma solidity ^0.8.0;
 
 // credit where it's due - this contract was lifted from this gist:
 // https://gist.github.com/ricmoo/e38d4d71dff7156033922d2e5de88d37
@@ -22,7 +21,7 @@ contract ABIV2UserDirectory {
 
   // User struct in the event
   event UserAdded(address indexed addr, User user);
-  constructor() public {
+  constructor() {
     _admin = msg.sender;
   }
 

--- a/packages/contract-tests/test/sources/Example.sol
+++ b/packages/contract-tests/test/sources/Example.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.8.0;
 
 contract Example {
 
@@ -15,7 +15,7 @@ contract Example {
 
   enum ExampleEnum { ExampleZero, ExampleOne, ExampleTwo }
 
-  constructor(uint val) public {
+  constructor(uint val) {
     // Constructor revert
     require(val != 13);
     require(val != 2001, 'reasonstring');
@@ -110,6 +110,12 @@ contract Example {
     assert(false);
   }
 
+  function triggerInvalidOpcode() public {
+    assembly {
+      invalid()
+    }
+  }
+
   function triggerRequireWithReasonError() public {
     require(false, 'reasonstring');
   }
@@ -201,7 +207,7 @@ contract Example {
     return arr;
   }
 
-  function() external payable {
+  fallback() external payable {
     fallbackTriggered = true;
   }
 }

--- a/packages/contract-tests/test/util.js
+++ b/packages/contract-tests/test/util.js
@@ -43,7 +43,7 @@ const util = {
       quiet: true,
       compilers: {
         solc: {
-          version: "0.5.0",
+          version: "0.8.12",
           settings: {
             optimizer: {
               enabled: false,

--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -34,59 +34,59 @@ const verbosePanicTable = {
 };
 
 const commandReference = {
-  "o": "step over",
-  "i": "step into",
-  "u": "step out",
-  "n": "step next",
+  o: "step over",
+  i: "step into",
+  u: "step out",
+  n: "step next",
   ";": "step instruction (include number to step multiple)",
-  "p": "print instruction & state (`p [mem|cal|sto]*`; see docs for more)",
-  "l": "print additional source context (`l [+<lines-ahead>] [-<lines-back>]`)",
-  "h": "print this help",
-  "v": "print variables and values (`v [bui|glo|con|loc]*`)",
+  p: "print instruction & state (`p [mem|cal|sto]*`; see docs for more)",
+  l: "print additional source context (`l [+<lines-ahead>] [-<lines-back>]`)",
+  h: "print this help",
+  v: "print variables and values (`v [bui|glo|con|loc]*`)",
   ":": "evaluate expression - see `v`",
   "+": "add watch expression (`+:<expr>`)",
   "-": "remove watch expression (-:<expr>)",
   "?": "list existing watch expressions and breakpoints",
-  "b": "add breakpoint (`b [[<source-file>:]<line-number>]`; see docs for more)",
-  "B": "remove breakpoint (similar to adding, or `B all` to remove all)",
-  "c": "continue until breakpoint",
-  "q": "quit",
-  "r": "reset",
-  "t": "load new transaction",
-  "T": "unload transaction",
-  "s": "print stacktrace",
-  "g": "turn on generated sources",
-  "G": "turn off generated sources except via `;`",
-  "y": "(if at end) reset & continue to final error",
-  "Y": "reset & continue to previous error"
+  b: "add breakpoint (`b [[<source-file>:]<line-number>]`; see docs for more)",
+  B: "remove breakpoint (similar to adding, or `B all` to remove all)",
+  c: "continue until breakpoint",
+  q: "quit",
+  r: "reset",
+  t: "load new transaction",
+  T: "unload transaction",
+  s: "print stacktrace",
+  g: "turn on generated sources",
+  G: "turn off generated sources except via `;`",
+  y: "(if at end) reset & continue to final error",
+  Y: "reset & continue to previous error"
 };
 
 const shortCommandReference = {
-  "o": "step over",
-  "i": "step into",
-  "u": "step out",
-  "n": "step next",
+  o: "step over",
+  i: "step into",
+  u: "step out",
+  n: "step next",
   ";": "step instruction",
-  "p": "print state",
-  "l": "print context",
-  "h": "print help",
-  "v": "print variables",
+  p: "print state",
+  l: "print context",
+  h: "print help",
+  v: "print variables",
   ":": "evaluate",
   "+": "add watch",
   "-": "remove watch",
   "?": "list watches & breakpoints",
-  "b": "add breakpoint",
-  "B": "remove breakpoint",
-  "c": "continue",
-  "q": "quit",
-  "r": "reset",
-  "t": "load",
-  "T": "unload",
-  "s": "stacktrace",
-  "g": "turn on generated sources",
-  "G": "turn off generated sources",
-  "y": "reset & go to final error",
-  "Y": "reset & go to previous error"
+  b: "add breakpoint",
+  B: "remove breakpoint",
+  c: "continue",
+  q: "quit",
+  r: "reset",
+  t: "load",
+  T: "unload",
+  s: "stacktrace",
+  g: "turn on generated sources",
+  G: "turn off generated sources",
+  y: "reset & go to final error",
+  Y: "reset & go to previous error"
 };
 
 const truffleColors = {
@@ -107,75 +107,75 @@ const DEFAULT_TAB_WIDTH = 8;
 
 const trufflePalette = {
   /* base (chromafi special, not hljs) */
-  "base": chalk,
-  "lineNumbers": chalk,
-  "trailingSpace": chalk,
+  base: chalk,
+  lineNumbers: chalk,
+  trailingSpace: chalk,
   /* classes hljs-solidity actually uses */
-  "keyword": truffleColors.mint,
-  "number": truffleColors.red,
-  "string": truffleColors.green,
-  "params": truffleColors.pink,
-  "builtIn": truffleColors.watermelon,
-  "built_in": truffleColors.watermelon, //just to be sure
-  "literal": truffleColors.watermelon,
-  "function": truffleColors.orange,
-  "title": truffleColors.orange,
-  "class": truffleColors.orange,
-  "comment": truffleColors.comment,
-  "doctag": truffleColors.comment,
-  "operator": truffleColors.blue,
-  "punctuation": truffleColors.purple,
+  keyword: truffleColors.mint,
+  number: truffleColors.red,
+  string: truffleColors.green,
+  params: truffleColors.pink,
+  builtIn: truffleColors.watermelon,
+  built_in: truffleColors.watermelon, //just to be sure
+  literal: truffleColors.watermelon,
+  function: truffleColors.orange,
+  title: truffleColors.orange,
+  class: truffleColors.orange,
+  comment: truffleColors.comment,
+  doctag: truffleColors.comment,
+  operator: truffleColors.blue,
+  punctuation: truffleColors.purple,
   /* classes it might soon use! */
-  "meta": truffleColors.pink,
-  "metaString": truffleColors.green,
+  meta: truffleColors.pink,
+  metaString: truffleColors.green,
   "meta-string": truffleColors.green, //similar
   /* classes it doesn't currently use but notionally could */
-  "type": truffleColors.orange,
-  "symbol": truffleColors.orange,
-  "metaKeyword": truffleColors.mint,
+  type: truffleColors.orange,
+  symbol: truffleColors.orange,
+  metaKeyword: truffleColors.mint,
   "meta-keyword": truffleColors.mint, //again, to be sure
-  "property": chalk, //not putting any highlighting here for now
+  property: chalk, //not putting any highlighting here for now
   /* classes that don't make sense for Solidity */
-  "regexp": chalk, //solidity does not have regexps
-  "subst": chalk, //or string interpolation
-  "name": chalk, //or s-expressions
-  "builtInName": chalk, //or s-expressions, again
+  regexp: chalk, //solidity does not have regexps
+  subst: chalk, //or string interpolation
+  name: chalk, //or s-expressions
+  builtInName: chalk, //or s-expressions, again
   "builtin-name": chalk, //just to be sure
   /* classes for config, markup, CSS, templates, diffs (not programming) */
-  "section": chalk,
-  "tag": chalk,
-  "attr": chalk,
-  "attribute": chalk,
-  "variable": chalk,
-  "bullet": chalk,
-  "code": chalk,
-  "emphasis": chalk,
-  "strong": chalk,
-  "formula": chalk,
-  "link": chalk,
-  "quote": chalk,
-  "selectorAttr": chalk, //lotta redundancy follows
+  section: chalk,
+  tag: chalk,
+  attr: chalk,
+  attribute: chalk,
+  variable: chalk,
+  bullet: chalk,
+  code: chalk,
+  emphasis: chalk,
+  strong: chalk,
+  formula: chalk,
+  link: chalk,
+  quote: chalk,
+  selectorAttr: chalk, //lotta redundancy follows
   "selector-attr": chalk,
-  "selectorClass": chalk,
+  selectorClass: chalk,
   "selector-class": chalk,
-  "selectorId": chalk,
+  selectorId: chalk,
   "selector-id": chalk,
-  "selectorPseudo": chalk,
+  selectorPseudo: chalk,
   "selector-pseudo": chalk,
-  "selectorTag": chalk,
+  selectorTag: chalk,
   "selector-tag": chalk,
-  "templateTag": chalk,
+  templateTag: chalk,
   "template-tag": chalk,
-  "templateVariable": chalk,
+  templateVariable: chalk,
   "template-variable": chalk,
-  "addition": chalk,
-  "deletion": chalk
+  addition: chalk,
+  deletion: chalk
 };
 
 var DebugUtils = {
   truffleColors, //make these externally available
 
-  //panicCode may be either a number or a BN
+  //panicCode may be either a number, BN, or decimal string
   panicString: function (panicCode, verbose = false) {
     const unknownString = "Unknown panic";
     const verboseUnknownString = "A panic occurred of unrecognized type.";


### PR DESCRIPTION
Addresses #3873.  This PR adds support for panic codes in Truffle Contract.  More specifically, `reason.js` will now return a reason not only for revert strings, but also for panic codes.  Of course there's still no support for custom errors, which wouldn't be reasonable to support in Truffle Contract right now, but I did add a case for these with the generic message `"Custom error (could not decode)"`.

Anyway, as for the actual decoding, it's pretty straightforward.  Of course I could have used Truffle Codec here, but I think probably we shouldn't introduce that dependency yet?  So instead it's just done manually in line with the current way.  While I was doing this I took the time to try to make some of the variables a bit clearer.

Note that getting the string for the panic code is done with `debug-utils`, but we already use `debug-utils` in contract, so, that's not a new dependency!

Note, importantly, that this PR kind of just overloads the existing revert reason interface!  It does *not* attempt to draw a hard distinction between panics and revert strings in what it returns; it just has the panics start with `"Panic: "`.  If someone has a revert string start with `"Panic: "`, it may look like a panic!  This is kind of unfortunate, but I'm not sure if there's a good alternative for now?  That said, if this is unacceptable, we can try to find a different way of doing this.  (@gnidan, any opinion on this?)

Also, I didn't include the numerical panic code in the message.  Not sure if that's OK.  Please let me know if that should be changed.  (Again, @gnidan, any opinion?)

I also added tests of this; in order to do this, I also updated the tests in `contract-tests` from Solidity 0.5.0 to 0.8.12.  This did increase gas costs for some tests, so I had to turn down the number of iterations in that one deliberately-expensive test to keep it still deliberate-expensive but not more-than-the-block-limit expensive.  Note that the new panic tests used the existing `triggerAssertError()` function (since those now panic), while I changed the invalid opcode tests to use a new `triggerInvalidOpcode()` function that uses assembly.  I also improved the style a little in the tests I touched.