### PR TITLE
Disable EthPM zeppelin installation test

### DIFF
--- a/packages/truffle/test/scenarios/commands/install.js
+++ b/packages/truffle/test/scenarios/commands/install.js
@@ -5,7 +5,8 @@ const fse = require("fs-extra");
 const path = require("path");
 let config;
 
-describe("truffle install [ @standalone ]", () => {
+//This test is currently broken
+describe.skip("truffle install [ @standalone ]", () => {
   before(async () => {
     config = await sandbox.create(
       path.join(__dirname, "../../sources/install/init")


### PR DESCRIPTION
This test is causing all other PRs to fail CI. Disable to allow PRs and Releases to proceed.

```console
$ truffle install zeppelin
Error: Unknown server response 405 when downloading hash QmaCaDgbXgTJXdt8JRU46R59sH4UwnDHiAopdbndEDGqxV
    at Request._callback (/Users/amal/.nvm/versions/node/v16.14.0/lib/node_modules/truffle/build/webpack:/node_modules/ethpm/lib/hosts/ipfshostwithlocalreader.js:27:1)
    at Request.self.callback (/Users/amal/.nvm/versions/node/v16.14.0/lib/node_modules/truffle/build/webpack:/node_modules/ethpm/node_modules/request/request.js:185:1)
    at Request.emit (node:events:520:28)
    at Request.<anonymous> (/Users/amal/.nvm/versions/node/v16.14.0/lib/node_modules/truffle/build/webpack:/node_modules/ethpm/node_modules/request/request.js:1154:1)
    at Request.emit (node:events:520:28)
    at IncomingMessage.<anonymous> (/Users/amal/.nvm/versions/node/v16.14.0/lib/node_modules/truffle/build/webpack:/node_modules/ethpm/node_modules/request/request.js:1076:1)
    at Object.onceWrapper (node:events:639:28)
    at IncomingMessage.emit (node:events:532:35)
    at endReadableNT (node:internal/streams/readable:1346:12)
    at processTicksAndRejections (node:internal/process/task_queues:83:21)
Truffle v5.5.2 (core: 5.5.2)
Node v16.14.0
```