### PR TITLE
Reduce lodash imports to those necessary

### DIFF
--- a/packages/artifactor/utils.ts
+++ b/packages/artifactor/utils.ts
@@ -1,5 +1,6 @@
 import fse from "fs-extra";
-import { merge, assign } from "lodash";
+import merge from "lodash/merge";
+import assign from "lodash/assign";
 import type { ContractObject } from "@truffle/contract-schema";
 
 export function writeArtifact(

--- a/packages/codec/lib/abi-data/allocate/index.ts
+++ b/packages/codec/lib/abi-data/allocate/index.ts
@@ -45,7 +45,7 @@ import type {
 } from "./types";
 import type { DecodingMode } from "@truffle/codec/types";
 import * as Format from "@truffle/codec/format";
-import { partition } from "lodash";
+import partition from "lodash/partition";
 
 export {
   AbiAllocations,

--- a/packages/codec/lib/abi-data/encode/index.ts
+++ b/packages/codec/lib/abi-data/encode/index.ts
@@ -11,7 +11,7 @@ import {
   AbiSizeInfo,
   abiSizeInfo
 } from "@truffle/codec/abi-data/allocate";
-import { sum } from "lodash";
+import sum from "lodash/sum";
 
 //UGH -- it turns out TypeScript can't handle nested tagged unions
 //see: https://github.com/microsoft/TypeScript/issues/18758

--- a/packages/codec/lib/ast/utils.ts
+++ b/packages/codec/lib/ast/utils.ts
@@ -6,7 +6,7 @@ import * as Common from "@truffle/codec/common";
 
 import type { AstNode, AstNodes, Scopes } from "./types";
 import BN from "bn.js";
-import { cloneDeep } from "lodash";
+import cloneDeep from "lodash/cloneDeep";
 
 /** @category Definition Reading */
 export function typeIdentifier(definition: AstNode): string {

--- a/packages/codec/lib/contexts/utils.ts
+++ b/packages/codec/lib/contexts/utils.ts
@@ -7,7 +7,7 @@ import type * as Ast from "@truffle/codec/ast";
 import * as Conversion from "@truffle/codec/conversion";
 import type { CompilerVersion } from "@truffle/codec/compiler";
 import type { Context, Contexts } from "./types";
-import { escapeRegExp } from "lodash";
+import escapeRegExp from "lodash/escapeRegExp";
 import * as cbor from "cbor";
 import { Shims } from "@truffle/compile-common";
 import * as Abi from "@truffle/abi-utils";

--- a/packages/codec/lib/storage/allocate/index.ts
+++ b/packages/codec/lib/storage/allocate/index.ts
@@ -21,7 +21,7 @@ import type { ImmutableReferences } from "@truffle/contract-schema/spec";
 import * as Evm from "@truffle/codec/evm";
 import * as Format from "@truffle/codec/format";
 import BN from "bn.js";
-import { partition } from "lodash";
+import partition from "lodash/partition";
 
 export {
   StorageAllocation,

--- a/packages/compile-solidity/src/compileWithPragmaAnalysis.js
+++ b/packages/compile-solidity/src/compileWithPragmaAnalysis.js
@@ -5,7 +5,7 @@ const Profiler = require("./profiler");
 const { run } = require("./run");
 const { reportSources } = require("./reportSources");
 const OS = require("os");
-const { cloneDeep } = require("lodash");
+const cloneDeep = require("lodash/cloneDeep");
 
 const getSemverExpression = source => {
   return source.match(/pragma solidity(.*);/)[1]

--- a/packages/compile-solidity/src/index.js
+++ b/packages/compile-solidity/src/index.js
@@ -9,7 +9,7 @@ const { compileWithPragmaAnalysis } = require("./compileWithPragmaAnalysis");
 const { reportSources } = require("./reportSources");
 const { Compilations } = require("@truffle/compile-common");
 const expect = require("@truffle/expect");
-const { partition } = require("lodash");
+const partition = require("lodash/partition");
 const fs = require("fs-extra");
 
 async function compileYulPaths(yulPaths, options) {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,5 +1,5 @@
 import path from "path";
-import { merge } from "lodash";
+import merge from "lodash/merge";
 import Module from "module";
 import findUp from "find-up";
 import Conf from "conf";

--- a/packages/debugger/lib/data/sagas/index.js
+++ b/packages/debugger/lib/data/sagas/index.js
@@ -18,7 +18,7 @@ import * as web3 from "lib/web3/sagas";
 
 import data from "../selectors";
 
-import { sum } from "lodash";
+import sum from "lodash/sum";
 import jsonpointer from "json-pointer";
 
 import * as Codec from "@truffle/codec";

--- a/packages/debugger/lib/data/selectors/index.js
+++ b/packages/debugger/lib/data/selectors/index.js
@@ -3,7 +3,7 @@ const debug = debugModule("debugger:data:selectors");
 
 import { createSelectorTree, createLeaf } from "reselect-tree";
 import jsonpointer from "json-pointer";
-import { merge } from "lodash";
+import merge from "lodash/merge";
 import semver from "semver";
 
 import { stableKeccak256, makePath } from "lib/helpers";

--- a/packages/debugger/lib/stacktrace/selectors/index.js
+++ b/packages/debugger/lib/stacktrace/selectors/index.js
@@ -8,7 +8,7 @@ import evm from "lib/evm/selectors";
 import solidity from "lib/solidity/selectors";
 
 import jsonpointer from "json-pointer";
-import { zipWith } from "lodash";
+import zipWith from "lodash/zipWith";
 import { popNWhere } from "lib/helpers";
 import * as Codec from "@truffle/codec";
 


### PR DESCRIPTION
This PR imports only the `lodash` methods needed in each package, to reduce bundle size and follow `lodash` best practices as described [here](https://lodash.com/per-method-packages). 