### PR TITLE
Internal improvement: Add url to debugger usage line

### DIFF
--- a/packages/core/lib/commands/debug/meta.js
+++ b/packages/core/lib/commands/debug/meta.js
@@ -35,7 +35,7 @@ module.exports = {
   },
   help: {
     usage:
-      "truffle debug [<transaction_hash>] [--fetch-external|-x]" +
+      "truffle debug [<transaction_hash>] [--fetch-external|-x] [--url <provider_url>]" +
       OS.EOL +
       "                             [--compile-tests|--compile-all|--compile-none]",
     options: [

--- a/packages/core/lib/commands/debug/meta.js
+++ b/packages/core/lib/commands/debug/meta.js
@@ -35,7 +35,9 @@ module.exports = {
   },
   help: {
     usage:
-      "truffle debug [<transaction_hash>] [--fetch-external|-x] [--url <provider_url>]" +
+      "truffle debug [<transaction_hash>] [--fetch-external|-x]" +
+      OS.EOL +
+      "                             [--network <network>|--url <provider_url>]" +
       OS.EOL +
       "                             [--compile-tests|--compile-all|--compile-none]",
     options: [
@@ -48,6 +50,11 @@ module.exports = {
         option: "--fetch-external|-x",
         description:
           "Allows debugging of external contracts with verified sources."
+      },
+      {
+        option: "--network",
+        description:
+          "The network to connect to, as specified in the Truffle config."
       },
       {
         option: "--url",
@@ -70,6 +77,6 @@ module.exports = {
           "Forces the debugger to use artifacts even if it detects a problem.  Dangerous; may cause errors."
       }
     ],
-    allowedGlobalOptions: ["network", "config"]
+    allowedGlobalOptions: ["config"] //network is allowed but is handled separately above so usage can be combined w/url
   }
 };

--- a/packages/core/lib/commands/debug/meta.js
+++ b/packages/core/lib/commands/debug/meta.js
@@ -77,6 +77,10 @@ module.exports = {
           "Forces the debugger to use artifacts even if it detects a problem.  Dangerous; may cause errors."
       }
     ],
-    allowedGlobalOptions: ["config"] //network is allowed but is handled separately above so usage can be combined w/url
+    allowedGlobalOptions: ["config"]
+    //although network is an allowed global option, it isn't listed here because listing it here would cause
+    //it to be tacked on to the end of usage, which would prevent us from doing the thing above where we
+    //combine its usage instructions with url to show that they're mutually exclusive.  so as a workaround
+    //we've excluded network from here, and added it manually above.
   }
 };


### PR DESCRIPTION
Just noticed this was missing.  Ideally I'd like to do this as `[--network <network>|--url <provider_url>]` but the way that `network` gets tacked on at the end prevents that.  Oh well?  Let me know if there's a better way to do this.