### PR TITLE
Rename debugger `solidity` submodule to `sourcemapping`

### DIFF
--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -10,7 +10,7 @@ const colors = require("colors");
 const Interpreter = require("js-interpreter");
 
 const selectors = require("@truffle/debugger").selectors;
-const { session, solidity, trace, controller, data, evm, stacktrace } =
+const { session, sourcemapping, trace, controller, data, evm, stacktrace } =
   selectors;
 
 class DebugPrinter {
@@ -44,7 +44,7 @@ class DebugPrinter {
 
     this.colorizedSources = Object.assign(
       {},
-      ...Object.entries(this.session.view(solidity.views.sources)).map(
+      ...Object.entries(this.session.view(sourcemapping.views.sources)).map(
         ([id, source]) => ({
           [id]: colorizeSourceObject(source)
         })
@@ -159,7 +159,8 @@ class DebugPrinter {
 
     //we don't just get extract the source text from the location because passed-in location may be
     //missing the source text
-    const source = this.session.view(solidity.views.sources)[sourceId].source;
+    const source = this.session.view(sourcemapping.views.sources)[sourceId]
+      .source;
     const colorizedSource = this.colorizedSources[sourceId];
 
     debug("range: %o", range);
@@ -215,8 +216,8 @@ class DebugPrinter {
   }
 
   printInstruction(locations = this.locationPrintouts) {
-    const instruction = this.session.view(solidity.current.instruction);
-    const instructions = this.session.view(solidity.current.instructions);
+    const instruction = this.session.view(sourcemapping.current.instruction);
+    const instructions = this.session.view(sourcemapping.current.instructions);
     const step = this.session.view(trace.step);
     const traceIndex = this.session.view(trace.index);
     const totalSteps = this.session.view(trace.steps).length;
@@ -319,7 +320,7 @@ class DebugPrinter {
   }
 
   printBreakpoints() {
-    const sources = this.session.view(solidity.views.sources);
+    const sources = this.session.view(sourcemapping.views.sources);
     const sourceNames = Object.assign(
       //note: only include user sources
       {},

--- a/packages/debugger/lib/ast/selectors/index.js
+++ b/packages/debugger/lib/ast/selectors/index.js
@@ -3,7 +3,7 @@ const debug = debugModule("debugger:ast:selectors");
 
 import { createSelectorTree, createLeaf } from "reselect-tree";
 
-import solidity from "lib/solidity/selectors";
+import sourcemapping from "lib/sourcemapping/selectors";
 
 /**
  * ast
@@ -17,7 +17,7 @@ const ast = createSelectorTree({
      * ast.views.sources
      * let's just flatten this into an array
      */
-    sources: createLeaf([solidity.views.sources], sources =>
+    sources: createLeaf([sourcemapping.views.sources], sources =>
       Object.values(sources)
     )
   }

--- a/packages/debugger/lib/controller/sagas/index.js
+++ b/packages/debugger/lib/controller/sagas/index.js
@@ -9,7 +9,7 @@ import * as trace from "lib/trace/sagas";
 import * as data from "lib/data/sagas";
 import * as txlog from "lib/txlog/sagas";
 import * as evm from "lib/evm/sagas";
-import * as solidity from "lib/solidity/sagas";
+import * as sourcemapping from "lib/sourcemapping/sagas";
 import * as stacktrace from "lib/stacktrace/sagas";
 
 import * as actions from "../actions";
@@ -297,15 +297,13 @@ function* continueUntilBreakpoint(action) {
             length === currentLength &&
             (currentSourceId !== previousSourceId ||
               currentStart !== previousStart ||
-              currentLength !== previousLength
-            ) &&
+              currentLength !== previousLength) &&
             //if we started in a user source (& allow internal is off),
             //we need to make sure we've moved from a user-source POV
             (!startedInUserSource ||
               currentSourceId !== lastUserSourceId ||
-              currentStart !== lastUserStart || 
-              currentLength !== lastUserLength
-            )
+              currentStart !== lastUserStart ||
+              currentLength !== lastUserLength)
           );
         }
         //otherwise, we have a line-style breakpoint; we want to stop at the
@@ -332,7 +330,7 @@ function* continueUntilBreakpoint(action) {
 export function* reset() {
   yield* data.reset();
   yield* evm.reset();
-  yield* solidity.reset();
+  yield* sourcemapping.reset();
   yield* trace.reset();
   yield* stacktrace.reset();
   yield* txlog.reset();

--- a/packages/debugger/lib/controller/selectors/index.js
+++ b/packages/debugger/lib/controller/selectors/index.js
@@ -5,7 +5,7 @@ import { createSelectorTree, createLeaf } from "reselect-tree";
 import { isSkippedNodeType } from "lib/helpers";
 
 import evm from "lib/evm/selectors";
-import solidity from "lib/solidity/selectors";
+import sourcemapping from "lib/sourcemapping/selectors";
 import data from "lib/data/selectors";
 import trace from "lib/trace/selectors";
 
@@ -54,7 +54,7 @@ const controller = createSelectorTree({
     /**
      * controller.current.functionDepth
      */
-    functionDepth: createLeaf([solidity.current.functionDepth], identity),
+    functionDepth: createLeaf([sourcemapping.current.functionDepth], identity),
 
     /**
      * controller.current.executionContext
@@ -74,7 +74,7 @@ const controller = createSelectorTree({
        * controller.current.location.sourceRange
        */
       sourceRange: createLeaf(
-        [solidity.current.sourceRange, "/current/trace/loaded"],
+        [sourcemapping.current.sourceRange, "/current/trace/loaded"],
         (range, loaded) => (loaded ? range : null)
       ),
 
@@ -82,7 +82,7 @@ const controller = createSelectorTree({
        * controller.current.location.source
        */
       source: createLeaf(
-        [solidity.current.source, "/current/trace/loaded"],
+        [sourcemapping.current.source, "/current/trace/loaded"],
         (source, loaded) => (loaded ? source : null)
       ),
 
@@ -90,7 +90,7 @@ const controller = createSelectorTree({
        * controller.current.location.node
        */
       node: createLeaf(
-        [solidity.current.node, "/current/trace/loaded"],
+        [sourcemapping.current.node, "/current/trace/loaded"],
         (node, loaded) => (loaded ? node : null)
       ),
 
@@ -103,7 +103,7 @@ const controller = createSelectorTree({
        * controller.current.location.isMultiline
        */
       isMultiline: createLeaf(
-        [solidity.current.isMultiline, "/current/trace/loaded"],
+        [sourcemapping.current.isMultiline, "/current/trace/loaded"],
         (raw, loaded) => (loaded ? raw : false)
       )
     },
@@ -142,7 +142,7 @@ const controller = createSelectorTree({
      * returns null instead.
      */
     resolver: createLeaf(
-      [solidity.views.sources, solidity.views.overlapFunctions],
+      [sourcemapping.views.sources, sourcemapping.views.overlapFunctions],
       (sources, functions) => breakpoint => {
         let adjustedBreakpoint;
         if (breakpoint.node === undefined) {
@@ -211,7 +211,10 @@ const controller = createSelectorTree({
   /**
    * controller.stepIntoInternalSources
    */
-  stepIntoInternalSources: createLeaf(["./state"], state => state.stepIntoInternalSources)
+  stepIntoInternalSources: createLeaf(
+    ["./state"],
+    state => state.stepIntoInternalSources
+  )
 });
 
 export default controller;

--- a/packages/debugger/lib/data/selectors/index.js
+++ b/packages/debugger/lib/data/selectors/index.js
@@ -10,7 +10,7 @@ import { stableKeccak256, makePath } from "lib/helpers";
 
 import trace from "lib/trace/selectors";
 import evm from "lib/evm/selectors";
-import solidity from "lib/solidity/selectors";
+import sourcemapping from "lib/sourcemapping/selectors";
 import stacktrace from "lib/stacktrace/selectors";
 
 import * as Codec from "@truffle/codec";
@@ -194,7 +194,7 @@ const data = createSelectorTree({
      * data.views.atLastInstructionForSourceRange
      */
     atLastInstructionForSourceRange: createLeaf(
-      [solidity.current.isSourceRangeFinal],
+      [sourcemapping.current.isSourceRangeFinal],
       final => final
     ),
 
@@ -222,7 +222,7 @@ const data = createSelectorTree({
        * inlines, but still no inheritance data
        */
       inlined: createLeaf(
-        ["./_", solidity.views.sources],
+        ["./_", sourcemapping.views.sources],
 
         (scopes, sources) =>
           Object.assign(
@@ -253,7 +253,7 @@ const data = createSelectorTree({
         "/info/userDefinedTypes",
         "./referenceDeclarations",
         "./scopes/inlined",
-        solidity.views.sources
+        sourcemapping.views.sources
       ],
       (userDefinedTypes, referenceDeclarations, scopes, sources) => {
         let typesByCompilation = {};
@@ -298,7 +298,7 @@ const data = createSelectorTree({
       [
         "/info/userDefinedTypes",
         "/views/scopes/inlined",
-        solidity.views.sources,
+        sourcemapping.views.sources,
         evm.info.contexts
       ],
       (userDefinedTypes, scopes, sources, contexts) =>
@@ -351,7 +351,7 @@ const data = createSelectorTree({
         "./scopes/inlined",
         "/info/userDefinedTypes",
         "/info/taggedOutputs",
-        solidity.views.sources
+        sourcemapping.views.sources
       ],
       (scopes, userDefinedTypes, taggedOutputs, sources) =>
         merge(
@@ -615,26 +615,32 @@ const data = createSelectorTree({
     /**
      * data.current.sourceIndex
      */
-    sourceIndex: createLeaf([solidity.current.source], ({ index }) => index),
+    sourceIndex: createLeaf(
+      [sourcemapping.current.source],
+      ({ index }) => index
+    ),
 
     /**
      * data.current.language
      */
-    language: createLeaf([solidity.current.source], ({ language }) => language),
+    language: createLeaf(
+      [sourcemapping.current.source],
+      ({ language }) => language
+    ),
 
     /**
      * data.current.internalSourceFor
      * returns null if in a user source
      */
     internalSourceFor: createLeaf(
-      [solidity.current.source],
+      [sourcemapping.current.source],
       ({ internalFor }) => internalFor || null
     ),
 
     /**
      * data.current.root
      */
-    root: createLeaf([solidity.current.source], ({ ast }) => ast),
+    root: createLeaf([sourcemapping.current.source], ({ ast }) => ast),
 
     /**
      * data.current.scopes (namespace)
@@ -735,7 +741,7 @@ const data = createSelectorTree({
        * Current scopes, with inheritance not handled and no inlining
        */
       raw: createLeaf(
-        ["/views/scopes", solidity.current.sourceIds],
+        ["/views/scopes", sourcemapping.current.sourceIds],
         (scopes, sourceIds) =>
           Object.assign({}, ...sourceIds.map(sourceId => scopes[sourceId]))
       ),
@@ -767,7 +773,7 @@ const data = createSelectorTree({
          * inlines definitions but does not account for inheritance
          */
         raw: createLeaf(
-          ["/views/scopes/inlined", solidity.current.sourceIds],
+          ["/views/scopes/inlined", sourcemapping.current.sourceIds],
           (scopes, sourceIds) =>
             Object.assign({}, ...sourceIds.map(sourceId => scopes[sourceId]))
         )
@@ -880,19 +886,23 @@ const data = createSelectorTree({
     /**
      * data.current.node
      */
-    node: createLeaf([solidity.current.node], identity),
+    node: createLeaf([sourcemapping.current.node], identity),
 
     /**
      * data.current.pointer
      */
-    pointer: createLeaf([solidity.current.pointer], identity),
+    pointer: createLeaf([sourcemapping.current.pointer], identity),
 
     /**
      * data.current.astRef
      * returns null when not in a mapped source
      */
     astRef: createLeaf(
-      [solidity.current.node, solidity.current.pointer, "./sourceIndex"],
+      [
+        sourcemapping.current.node,
+        sourcemapping.current.pointer,
+        "./sourceIndex"
+      ],
       (node, pointer, sourceIndex) =>
         node
           ? node.id !== undefined
@@ -995,13 +1005,13 @@ const data = createSelectorTree({
      * data.current.functionDepth
      */
 
-    functionDepth: createLeaf([solidity.current.functionDepth], identity),
+    functionDepth: createLeaf([sourcemapping.current.functionDepth], identity),
 
     /**
      * data.current.modifierDepth
      */
 
-    modifierDepth: createLeaf([solidity.current.modifierDepth], identity),
+    modifierDepth: createLeaf([sourcemapping.current.modifierDepth], identity),
 
     /**
      * data.current.address
@@ -1015,7 +1025,7 @@ const data = createSelectorTree({
      * data.current.functionsByProgramCounter
      */
     functionsByProgramCounter: createLeaf(
-      [solidity.current.functionsByProgramCounter],
+      [sourcemapping.current.functionsByProgramCounter],
       functions => functions
     ),
 
@@ -1662,18 +1672,18 @@ const data = createSelectorTree({
     },
 
     //HACK WARNING
-    //the following selectors depend on solidity.next
+    //the following selectors depend on sourcemapping.next
     //do not use them when the current instruction is a context change!
 
     /**
      * data.next.node
      */
-    node: createLeaf([solidity.next.node], identity),
+    node: createLeaf([sourcemapping.next.node], identity),
 
     /**
      * data.next.pointer
      */
-    pointer: createLeaf([solidity.next.pointer], identity),
+    pointer: createLeaf([sourcemapping.next.pointer], identity),
 
     /**
      * data.next.modifierInvocation
@@ -1735,7 +1745,7 @@ const data = createSelectorTree({
        * data.nextUserStep.state.stack
        */
       stack: createLeaf(
-        [solidity.current.nextUserStep],
+        [sourcemapping.current.nextUserStep],
 
         step =>
           ((step || {}).stack || []).map(word => Codec.Conversion.toBytes(word))

--- a/packages/debugger/lib/debugger.js
+++ b/packages/debugger/lib/debugger.js
@@ -10,7 +10,7 @@ import txlogSelector from "./txlog/selectors";
 import astSelector from "./ast/selectors";
 import traceSelector from "./trace/selectors";
 import evmSelector from "./evm/selectors";
-import soliditySelector from "./solidity/selectors";
+import sourcemappingSelector from "./sourcemapping/selectors";
 import sessionSelector from "./session/selectors";
 import stacktraceSelector from "./stacktrace/selectors";
 import controllerSelector from "./controller/selectors";
@@ -66,7 +66,7 @@ const Debugger = {
    * Debugger.selectors.ast.current.tree
    *
    * @example
-   * Debugger.selectors.solidity.current.instruction
+   * Debugger.selectors.sourcemapping.current.instruction
    *
    * @example
    * Debugger.selectors.trace.steps
@@ -78,7 +78,8 @@ const Debugger = {
       txlog: txlogSelector,
       trace: traceSelector,
       evm: evmSelector,
-      solidity: soliditySelector,
+      sourcemapping: sourcemappingSelector,
+      solidity: sourcemappingSelector, //for compatibility
       stacktrace: stacktraceSelector,
       session: sessionSelector,
       controller: controllerSelector

--- a/packages/debugger/lib/session/index.js
+++ b/packages/debugger/lib/session/index.js
@@ -23,7 +23,7 @@ import { createNestedSelector } from "reselect-tree";
 import ast from "lib/ast/selectors";
 import trace from "lib/trace/selectors";
 import evm from "lib/evm/selectors";
-import solidity from "lib/solidity/selectors";
+import sourcemapping from "lib/sourcemapping/selectors";
 
 import rootSaga from "./sagas";
 import reducer from "./reducers";
@@ -202,7 +202,7 @@ export default class Session {
 
         //now: we need to find the contract node.
         //note: ideally we'd hold this off till later, but that would break the
-        //direction of the evm/solidity dependence, so we do it now
+        //direction of the evm/sourcemapping dependence, so we do it now
         const contractNode = Codec.Compilations.Utils.getContractNode(
           contract,
           compilation
@@ -547,7 +547,8 @@ export default class Session {
       txlog,
       trace,
       evm,
-      solidity,
+      sourcemapping,
+      solidity: sourcemapping, //for compatibility
       stacktrace,
       session,
       controller: controllerSelector

--- a/packages/debugger/lib/session/reducers.js
+++ b/packages/debugger/lib/session/reducers.js
@@ -5,7 +5,7 @@ import { combineReducers } from "redux";
 
 import data from "lib/data/reducers";
 import evm from "lib/evm/reducers";
-import solidity from "lib/solidity/reducers";
+import sourcemapping from "lib/sourcemapping/reducers";
 import trace from "lib/trace/reducers";
 import controller from "lib/controller/reducers";
 import stacktrace from "lib/stacktrace/reducers";
@@ -99,7 +99,7 @@ const reduceState = combineReducers({
   data,
   txlog,
   evm,
-  solidity,
+  sourcemapping,
   stacktrace,
   trace,
   controller

--- a/packages/debugger/lib/session/sagas/index.js
+++ b/packages/debugger/lib/session/sagas/index.js
@@ -7,7 +7,7 @@ import { prefixName } from "lib/helpers";
 
 import * as ast from "lib/ast/sagas";
 import * as controller from "lib/controller/sagas";
-import * as solidity from "lib/solidity/sagas";
+import * as sourcemapping from "lib/sourcemapping/sagas";
 import * as stacktrace from "lib/stacktrace/sagas";
 import * as evm from "lib/evm/sagas";
 import * as trace from "lib/trace/sagas";
@@ -145,7 +145,7 @@ export default prefixName("session", saga);
 function* forkListeners(moduleOptions) {
   yield fork(listenerSaga); //session listener; this one is separate, sorry
   //(I didn't want to mess w/ the existing structure of defaults)
-  let mainApps = [evm, solidity, stacktrace];
+  let mainApps = [evm, sourcemapping, stacktrace];
   if (!moduleOptions.lightMode) {
     mainApps.push(data);
     mainApps.push(txlog);
@@ -201,7 +201,7 @@ function* fetchTx(txHash) {
 
   debug("sending initial call");
   yield* evm.begin(result); //note: this must occur *before* the other ones!
-  yield* solidity.begin();
+  yield* sourcemapping.begin();
   yield* stacktrace.begin();
   if (!(yield select(session.status.lightMode))) {
     //full-mode-only modules
@@ -216,7 +216,7 @@ function* recordContexts(contexts) {
 }
 
 function* recordSources(sources) {
-  yield* solidity.addSources(sources);
+  yield* sourcemapping.addSources(sources);
 }
 
 //creationBinary can be omitted; should only be used for creations
@@ -245,7 +245,7 @@ function* error(err) {
 export function* unload() {
   debug("unloading");
   yield* data.reset();
-  yield* solidity.unload();
+  yield* sourcemapping.unload();
   yield* evm.unload();
   yield* trace.unload();
   yield* stacktrace.unload();

--- a/packages/debugger/lib/session/selectors/index.js
+++ b/packages/debugger/lib/session/selectors/index.js
@@ -5,7 +5,7 @@ import { createSelectorTree, createLeaf } from "reselect-tree";
 
 import evm from "lib/evm/selectors";
 import trace from "lib/trace/selectors";
-import solidity from "lib/solidity/selectors";
+import sourcemapping from "lib/sourcemapping/selectors";
 
 const session = createSelectorTree({
   /*
@@ -26,7 +26,7 @@ const session = createSelectorTree({
       [
         evm.transaction.affectedInstances,
         evm.info.contexts,
-        solidity.info.sources
+        sourcemapping.info.sources
       ],
 
       (instances, contexts, sources) =>

--- a/packages/debugger/lib/sourcemapping/actions/index.js
+++ b/packages/debugger/lib/sourcemapping/actions/index.js
@@ -1,4 +1,4 @@
-export const ADD_SOURCES = "SOLIDITY_ADD_SOURCES";
+export const ADD_SOURCES = "SOURCEMAPPING_ADD_SOURCES";
 export function addSources(sources) {
   return {
     type: ADD_SOURCES,
@@ -6,7 +6,7 @@ export function addSources(sources) {
   };
 }
 
-export const JUMP = "SOLIDITY_JUMP";
+export const JUMP = "SOURCEMAPPING_JUMP";
 export function jump(jumpDirection) {
   return {
     type: JUMP,
@@ -14,27 +14,27 @@ export function jump(jumpDirection) {
   };
 }
 
-export const EXTERNAL_CALL = "SOLIDITY_EXTERNAL_CALL";
+export const EXTERNAL_CALL = "SOURCEMAPPING_EXTERNAL_CALL";
 export function externalCall(guard) {
   return { type: EXTERNAL_CALL, guard };
 }
 
-export const EXTERNAL_RETURN = "SOLIDITY_EXTERNAL_RETURN";
+export const EXTERNAL_RETURN = "SOURCEMAPPING_EXTERNAL_RETURN";
 export function externalReturn() {
   return { type: EXTERNAL_RETURN };
 }
 
-export const CLEAR_PHANTOM_GUARD = "SOLIDITY_CLEAR_PHANTOM_GUARD";
+export const CLEAR_PHANTOM_GUARD = "SOURCEMAPPING_CLEAR_PHANTOM_GUARD";
 export function clearPhantomGuard() {
   return { type: CLEAR_PHANTOM_GUARD };
 }
 
-export const RESET = "SOLIDITY_RESET";
+export const RESET = "SOURCEMAPPING_RESET";
 export function reset(guard) {
   return { type: RESET, guard };
 }
 
-export const UNLOAD_TRANSACTION = "SOLIDITY_UNLOAD_TRANSACTION";
+export const UNLOAD_TRANSACTION = "SOURCEMAPPING_UNLOAD_TRANSACTION";
 export function unloadTransaction() {
   return { type: UNLOAD_TRANSACTION };
 }

--- a/packages/debugger/lib/sourcemapping/reducers.js
+++ b/packages/debugger/lib/sourcemapping/reducers.js
@@ -1,5 +1,5 @@
 import debugModule from "debug";
-const debug = debugModule("debugger:solidity:reducers");
+const debug = debugModule("debugger:sourcemapping:reducers");
 
 import { combineReducers } from "redux";
 

--- a/packages/debugger/lib/sourcemapping/sagas/index.js
+++ b/packages/debugger/lib/sourcemapping/sagas/index.js
@@ -1,5 +1,5 @@
 import debugModule from "debug";
-const debug = debugModule("debugger:solidity:sagas");
+const debug = debugModule("debugger:sourcemapping:sagas");
 
 import { put, takeEvery, select } from "redux-saga/effects";
 import { prefixName } from "lib/helpers";
@@ -8,7 +8,7 @@ import * as actions from "../actions";
 import { TICK } from "lib/trace/actions";
 import * as trace from "lib/trace/sagas";
 
-import solidity from "../selectors";
+import sourcemapping from "../selectors";
 
 export function* addSources(sources) {
   yield put(actions.addSources(sources));
@@ -18,20 +18,20 @@ function* tickSaga() {
   debug("got TICK");
 
   yield* functionDepthSaga();
-  debug("instruction: %O", yield select(solidity.current.instruction));
+  debug("instruction: %O", yield select(sourcemapping.current.instruction));
   yield* trace.signalTickSagaCompletion();
 }
 
 function* functionDepthSaga() {
-  if (yield select(solidity.current.willReturn)) {
+  if (yield select(sourcemapping.current.willReturn)) {
     //we do this case first so we can be sure we're not failing in any of the
     //other cases below!
     yield put(actions.externalReturn());
-  } else if (yield select(solidity.current.willJump)) {
-    let jumpDirection = yield select(solidity.current.jumpDirection);
+  } else if (yield select(sourcemapping.current.willJump)) {
+    let jumpDirection = yield select(sourcemapping.current.jumpDirection);
     debug("checking guard");
-    let guard = yield select(solidity.current.nextFrameIsPhantom);
-    let nextSource = yield select(solidity.next.source);
+    let guard = yield select(sourcemapping.current.nextFrameIsPhantom);
+    let nextSource = yield select(sourcemapping.next.source);
     if (
       jumpDirection === "i" &&
       guard &&
@@ -44,17 +44,17 @@ function* functionDepthSaga() {
     } else {
       yield put(actions.jump(jumpDirection));
     }
-  } else if (yield select(solidity.current.willCall)) {
+  } else if (yield select(sourcemapping.current.willCall)) {
     //note: includes creations; does not include insta-returns
     debug("checking if guard needed");
-    let guard = yield select(solidity.current.callRequiresPhantomFrame);
+    let guard = yield select(sourcemapping.current.callRequiresPhantomFrame);
     yield put(actions.externalCall(guard));
   }
 }
 
 export function* reset() {
   let guard = yield select(
-    solidity.transaction.bottomStackframeRequiresPhantomFrame
+    sourcemapping.transaction.bottomStackframeRequiresPhantomFrame
   );
   yield put(actions.reset(guard));
 }
@@ -65,7 +65,7 @@ export function* unload() {
 
 export function* begin() {
   let guard = yield select(
-    solidity.transaction.bottomStackframeRequiresPhantomFrame
+    sourcemapping.transaction.bottomStackframeRequiresPhantomFrame
   );
   yield put(actions.externalCall(guard));
 }
@@ -74,4 +74,4 @@ export function* saga() {
   yield takeEvery(TICK, tickSaga);
 }
 
-export default prefixName("solidity", saga);
+export default prefixName("sourcemapping", saga);

--- a/packages/debugger/lib/sourcemapping/selectors/index.js
+++ b/packages/debugger/lib/sourcemapping/selectors/index.js
@@ -1,5 +1,5 @@
 import debugModule from "debug";
-const debug = debugModule("debugger:solidity:selectors");
+const debug = debugModule("debugger:sourcemapping:selectors");
 
 import { createSelectorTree, createLeaf } from "reselect-tree";
 import SourceMapUtils from "@truffle/source-map-utils";
@@ -49,10 +49,10 @@ function createMultistepSelectors(stepSelector) {
      */
     instruction: createLeaf(
       ["/current/instructionAtProgramCounter", stepSelector.programCounter],
-      //HACK: we use solidity.current.instructionAtProgramCounter
-      //even if we're looking at solidity.next.
+      //HACK: we use sourcemapping.current.instructionAtProgramCounter
+      //even if we're looking at sourcemapping.next.
       //This is harmless... so long as the current instruction isn't a context
-      //change.  So, don't use solidity.next when it is.
+      //change.  So, don't use sourcemapping.next when it is.
 
       (map, pc) => map[pc] || {}
     ),
@@ -125,28 +125,28 @@ function createMultistepSelectors(stepSelector) {
   };
 }
 
-let solidity = createSelectorTree({
+let sourcemapping = createSelectorTree({
   /**
-   * solidity.state
+   * sourcemapping.state
    */
-  state: state => state.solidity,
+  state: state => state.sourcemapping,
 
   /**
-   * solidity.info
+   * sourcemapping.info
    */
   info: {
     /**
-     * solidity.info.sources
+     * sourcemapping.info.sources
      */
     sources: createLeaf(["/state"], state => state.info.sources)
   },
 
   /**
-   * solidity.transaction
+   * sourcemapping.transaction
    */
   transaction: {
     /**
-     * solidity.transaction.bottomStackframeRequiresPhantomFrame
+     * sourcemapping.transaction.bottomStackframeRequiresPhantomFrame
      */
     bottomStackframeRequiresPhantomFrame: createLeaf(
       [
@@ -159,12 +159,12 @@ let solidity = createSelectorTree({
   },
 
   /**
-   * solidity.current
+   * sourcemapping.current
    */
   current: {
     /**
-     * solidity.current.sourceIds
-     * like solidity.current.sources, but just has the IDs, not the sources
+     * sourcemapping.current.sourceIds
+     * like sourcemapping.current.sources, but just has the IDs, not the sources
      */
     sourceIds: createLeaf(
       ["/info/sources", evm.current.context],
@@ -194,8 +194,8 @@ let solidity = createSelectorTree({
     ),
 
     /**
-     * solidity.current.sources
-     * This takes the place of the old solidity.info.sources,
+     * sourcemapping.current.sources
+     * This takes the place of the old sourcemapping.info.sources,
      * returning only the sources for the current compilation and context.
      */
     sources: createLeaf(
@@ -204,7 +204,7 @@ let solidity = createSelectorTree({
     ),
 
     /**
-     * solidity.current.sourceMap
+     * sourcemapping.current.sourceMap
      */
     sourceMap: createLeaf(
       [evm.current.context],
@@ -213,24 +213,24 @@ let solidity = createSelectorTree({
     ),
 
     /**
-     * solidity.current.humanReadableSourceMap
+     * sourcemapping.current.humanReadableSourceMap
      */
     humanReadableSourceMap: createLeaf(["./sourceMap"], sourceMap =>
       sourceMap ? SourceMapUtils.getHumanReadableSourceMap(sourceMap) : null
     ),
 
     /**
-     * solidity.current.functionDepthStack
+     * sourcemapping.current.functionDepthStack
      */
-    functionDepthStack: state => state.solidity.proc.functionDepthStack,
+    functionDepthStack: state => state.sourcemapping.proc.functionDepthStack,
 
     /**
-     * solidity.current.nextFrameIsPhantom
+     * sourcemapping.current.nextFrameIsPhantom
      */
-    nextFrameIsPhantom: state => state.solidity.proc.nextFrameIsPhantom,
+    nextFrameIsPhantom: state => state.sourcemapping.proc.nextFrameIsPhantom,
 
     /**
-     * solidity.current.functionDepth
+     * sourcemapping.current.functionDepth
      */
     functionDepth: createLeaf(
       ["./functionDepthStack"],
@@ -238,7 +238,7 @@ let solidity = createSelectorTree({
     ),
 
     /**
-     * solidity.current.callRequiresPhantomFrame
+     * sourcemapping.current.callRequiresPhantomFrame
      */
     callRequiresPhantomFrame: createLeaf(
       [evm.current.step.callContext, evm.current.step.callData],
@@ -246,7 +246,7 @@ let solidity = createSelectorTree({
     ),
 
     /**
-     * solidity.current.instructions
+     * sourcemapping.current.instructions
      */
     instructions: createLeaf(
       ["./sources", evm.current.context, "./humanReadableSourceMap"],
@@ -266,7 +266,7 @@ let solidity = createSelectorTree({
     ),
 
     /**
-     * solidity.current.instructionAtProgramCounter
+     * sourcemapping.current.instructionAtProgramCounter
      */
     instructionAtProgramCounter: createLeaf(
       ["./instructions"],
@@ -283,7 +283,7 @@ let solidity = createSelectorTree({
     ...createMultistepSelectors(evm.current.step),
 
     /**
-     * solidity.current.isSourceRangeFinalRaw
+     * sourcemapping.current.isSourceRangeFinalRaw
      * the old version; doesn't account for internal-source problems
      */
     isSourceRangeFinalRaw: createLeaf(
@@ -311,7 +311,7 @@ let solidity = createSelectorTree({
     ),
 
     /**
-     * solidity.current.isSourceRangeFinal
+     * sourcemapping.current.isSourceRangeFinal
      * if there's no context change, then don't return final
      * on jumping from a user source to an internal source
      */
@@ -332,7 +332,7 @@ let solidity = createSelectorTree({
     ),
 
     /*
-     * solidity.current.functionsByProgramCounter
+     * sourcemapping.current.functionsByProgramCounter
      */
     functionsByProgramCounter: createLeaf(
       [
@@ -354,7 +354,7 @@ let solidity = createSelectorTree({
     ),
 
     /**
-     * solidity.current.isMultiline
+     * sourcemapping.current.isMultiline
      */
     isMultiline: createLeaf(
       ["./sourceRange"],
@@ -363,17 +363,17 @@ let solidity = createSelectorTree({
     ),
 
     /**
-     * solidity.current.willJump
+     * sourcemapping.current.willJump
      */
     willJump: createLeaf([evm.current.step.isJump], isJump => isJump),
 
     /**
-     * solidity.current.jumpDirection
+     * sourcemapping.current.jumpDirection
      */
     jumpDirection: createLeaf(["./instruction"], (i = {}) => i.jump || "-"),
 
     /**
-     * solidity.current.willCall
+     * sourcemapping.current.willCall
      * note: includes creations, does *not* include instareturns
      */
     willCall: createLeaf(
@@ -386,7 +386,7 @@ let solidity = createSelectorTree({
     ),
 
     /**
-     * solidity.current.willReturn
+     * sourcemapping.current.willReturn
      *
      * covers both normal returns & failures
      */
@@ -396,7 +396,7 @@ let solidity = createSelectorTree({
     ),
 
     /**
-     * solidity.current.nextUserStep
+     * sourcemapping.current.nextUserStep
      * returns the next trace step after this one which is sourcemapped to
      * a user source (not -1 or an internal source)
      * HACK: this assumes we're not about to change context! don't use this if
@@ -422,9 +422,9 @@ let solidity = createSelectorTree({
     ),
 
     /**
-     * solidity.current.overlapFunctions
-     * like solidity.views.overlapFunctions, but just returns
-     * an array appropriate to the current context (like solidity.current.sources)
+     * sourcemapping.current.overlapFunctions
+     * like sourcemapping.views.overlapFunctions, but just returns
+     * an array appropriate to the current context (like sourcemapping.current.sources)
      */
     overlapFunctions: createLeaf(
       ["/views/overlapFunctions", "/current/sourceIds"],
@@ -433,25 +433,25 @@ let solidity = createSelectorTree({
   },
 
   /**
-   * solidity.next
+   * sourcemapping.next
    * HACK WARNING: do not use these selectors when the current instruction is a
    * context change! (evm call or evm return)
    */
   next: createMultistepSelectors(evm.next.step),
 
   /**
-   * solidity.views
+   * sourcemapping.views
    */
   views: {
     /**
-     * solidity.views.sources
-     * just the byId part of solidity.info.sources
+     * sourcemapping.views.sources
+     * just the byId part of sourcemapping.info.sources
      * (effectively flattening them)
      */
     sources: createLeaf(["/info/sources"], sources => sources.byId),
 
     /**
-     * solidity.views.overlapFunctions
+     * sourcemapping.views.overlapFunctions
      * organized by source ID
      */
     overlapFunctions: createLeaf(["/views/sources"], sources =>
@@ -465,4 +465,4 @@ let solidity = createSelectorTree({
   }
 });
 
-export default solidity;
+export default sourcemapping;

--- a/packages/debugger/lib/stacktrace/selectors/index.js
+++ b/packages/debugger/lib/stacktrace/selectors/index.js
@@ -5,7 +5,7 @@ import { createSelectorTree, createLeaf } from "reselect-tree";
 
 import trace from "lib/trace/selectors";
 import evm from "lib/evm/selectors";
-import solidity from "lib/solidity/selectors";
+import sourcemapping from "lib/sourcemapping/selectors";
 
 import jsonpointer from "json-pointer";
 import zipWith from "lodash/zipWith";
@@ -156,7 +156,7 @@ let stacktrace = createSelectorTree({
      * stacktrace.transaction.initialCallCombinesWithNextJumpIn
      */
     initialCallCombinesWithNextJumpIn: createLeaf(
-      [solidity.transaction.bottomStackframeRequiresPhantomFrame],
+      [sourcemapping.transaction.bottomStackframeRequiresPhantomFrame],
       identity
     )
   },
@@ -205,7 +205,7 @@ let stacktrace = createSelectorTree({
       state => state.proc.innerErrorIndex
     ),
 
-    ...createMultistepSelectors(solidity.current),
+    ...createMultistepSelectors(sourcemapping.current),
 
     /**
      * stacktrace.current.index
@@ -232,7 +232,7 @@ let stacktrace = createSelectorTree({
      * stacktrace.current.willJumpIn
      */
     willJumpIn: createLeaf(
-      [solidity.current.willJump, solidity.current.jumpDirection],
+      [sourcemapping.current.willJump, sourcemapping.current.jumpDirection],
       (willJump, jumpDirection) => willJump && jumpDirection === "i"
     ),
 
@@ -240,7 +240,7 @@ let stacktrace = createSelectorTree({
      * stacktrace.current.willJumpOut
      */
     willJumpOut: createLeaf(
-      [solidity.current.willJump, solidity.current.jumpDirection],
+      [sourcemapping.current.willJump, sourcemapping.current.jumpDirection],
       (willJump, jumpDirection) => willJump && jumpDirection === "o"
     ),
 
@@ -248,7 +248,7 @@ let stacktrace = createSelectorTree({
      * stacktrace.current.willCall
      * note: includes creations!
      */
-    willCall: createLeaf([solidity.current.willCall], identity),
+    willCall: createLeaf([sourcemapping.current.willCall], identity),
 
     /**
      * stacktrace.current.context
@@ -264,14 +264,14 @@ let stacktrace = createSelectorTree({
      * stacktrace.current.callCombinesWithNextJumpIn
      */
     callCombinesWithNextJumpIn: createLeaf(
-      [solidity.current.callRequiresPhantomFrame],
+      [sourcemapping.current.callRequiresPhantomFrame],
       identity
     ),
 
     /**
      * stacktrace.current.willReturn
      */
-    willReturn: createLeaf([solidity.current.willReturn], identity),
+    willReturn: createLeaf([sourcemapping.current.willReturn], identity),
 
     /**
      * stacktrace.current.returnStatus
@@ -440,7 +440,7 @@ let stacktrace = createSelectorTree({
    * stacktrace.next
    */
   next: {
-    ...createMultistepSelectors(solidity.next)
+    ...createMultistepSelectors(sourcemapping.next)
   }
 });
 

--- a/packages/debugger/test/ast.js
+++ b/packages/debugger/test/ast.js
@@ -8,7 +8,7 @@ import Ganache from "ganache";
 import { prepareContracts } from "./helpers";
 import Debugger from "lib/debugger";
 
-import solidity from "lib/solidity/selectors";
+import sourcemapping from "lib/sourcemapping/selectors";
 import trace from "lib/trace/selectors";
 
 import SourceMapUtils from "@truffle/source-map-utils";
@@ -86,15 +86,15 @@ describe("AST", function () {
       });
 
       do {
-        let { start, length } = bugger.view(solidity.current.sourceRange);
+        let { start, length } = bugger.view(sourcemapping.current.sourceRange);
         let end = start + length;
 
-        let node = bugger.view(solidity.current.node);
+        let node = bugger.view(sourcemapping.current.node);
 
         let [nodeStart, nodeLength] = SourceMapUtils.getRange(node);
         let nodeEnd = nodeStart + nodeLength;
 
-        let pointer = bugger.view(solidity.current.pointer);
+        let pointer = bugger.view(sourcemapping.current.pointer);
 
         assert.isAtMost(
           nodeStart,

--- a/packages/debugger/test/data/calldata.js
+++ b/packages/debugger/test/data/calldata.js
@@ -10,7 +10,7 @@ import Debugger from "lib/debugger";
 
 import * as Codec from "@truffle/codec";
 
-import solidity from "lib/solidity/selectors";
+import sourcemapping from "lib/sourcemapping/selectors";
 
 const __CALLDATA = `
 pragma solidity ^0.8.0;
@@ -143,8 +143,8 @@ describe("Calldata Decoding", function () {
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-    let sourceId = bugger.view(solidity.current.source).id;
-    let source = bugger.view(solidity.current.source).source;
+    let sourceId = bugger.view(sourcemapping.current.source).id;
+    let source = bugger.view(sourcemapping.current.source).source;
     await bugger.addBreakpoint({
       sourceId,
       line: lineOf("break multi", source)
@@ -173,8 +173,8 @@ describe("Calldata Decoding", function () {
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-    let sourceId = bugger.view(solidity.current.source).id;
-    let source = bugger.view(solidity.current.source).source;
+    let sourceId = bugger.view(sourcemapping.current.source).id;
+    let source = bugger.view(sourcemapping.current.source).source;
     await bugger.addBreakpoint({
       sourceId,
       line: lineOf("break simple", source)
@@ -201,8 +201,8 @@ describe("Calldata Decoding", function () {
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-    let sourceId = bugger.view(solidity.current.source).id;
-    let source = bugger.view(solidity.current.source).source;
+    let sourceId = bugger.view(sourcemapping.current.source).id;
+    let source = bugger.view(sourcemapping.current.source).source;
     await bugger.addBreakpoint({
       sourceId,
       line: lineOf("break stringBox", source)
@@ -234,8 +234,8 @@ describe("Calldata Decoding", function () {
       compilations
     });
 
-    let sourceId = bugger.view(solidity.current.source).id;
-    let source = bugger.view(solidity.current.source).source;
+    let sourceId = bugger.view(sourcemapping.current.source).id;
+    let source = bugger.view(sourcemapping.current.source).source;
     await bugger.addBreakpoint({
       sourceId,
       line: lineOf("break static", source)
@@ -265,8 +265,8 @@ describe("Calldata Decoding", function () {
       compilations
     });
 
-    let sourceId = bugger.view(solidity.current.source).id;
-    let source = bugger.view(solidity.current.source).source;
+    let sourceId = bugger.view(sourcemapping.current.source).id;
+    let source = bugger.view(sourcemapping.current.source).source;
     await bugger.addBreakpoint({
       sourceId,
       line: lineOf("break delegate", source)
@@ -296,8 +296,8 @@ describe("Calldata Decoding", function () {
       compilations
     });
 
-    let sourceId = bugger.view(solidity.current.source).id;
-    let source = bugger.view(solidity.current.source).source;
+    let sourceId = bugger.view(sourcemapping.current.source).id;
+    let source = bugger.view(sourcemapping.current.source).source;
     await bugger.addBreakpoint({
       sourceId,
       line: lineOf("break slice", source)
@@ -327,8 +327,8 @@ describe("Calldata Decoding", function () {
       compilations
     });
 
-    let sourceId = bugger.view(solidity.current.source).id;
-    let source = bugger.view(solidity.current.source).source;
+    let sourceId = bugger.view(sourcemapping.current.source).id;
+    let source = bugger.view(sourcemapping.current.source).source;
     await bugger.addBreakpoint({
       sourceId,
       line: lineOf("break fallback", source)

--- a/packages/debugger/test/data/codex.js
+++ b/packages/debugger/test/data/codex.js
@@ -9,7 +9,7 @@ import Ganache from "ganache";
 import { prepareContracts, lineOf } from "../helpers";
 import Debugger from "lib/debugger";
 
-import solidity from "lib/solidity/selectors";
+import sourcemapping from "lib/sourcemapping/selectors";
 
 const __LIBTEST = `
 pragma solidity ^0.8.0;
@@ -203,8 +203,8 @@ describe("Codex", function () {
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-    let sourceId = bugger.view(solidity.current.source).id;
-    let source = bugger.view(solidity.current.source).source;
+    let sourceId = bugger.view(sourcemapping.current.source).id;
+    let source = bugger.view(sourcemapping.current.source).source;
     await bugger.addBreakpoint({
       sourceId,
       line: lineOf("BREAK", source)

--- a/packages/debugger/test/data/function-decoding.js
+++ b/packages/debugger/test/data/function-decoding.js
@@ -9,7 +9,7 @@ import { prepareContracts, lineOf } from "../helpers";
 import Debugger from "lib/debugger";
 import * as Codec from "@truffle/codec";
 
-import solidity from "lib/solidity/selectors";
+import sourcemapping from "lib/sourcemapping/selectors";
 
 const __EXTERNALS = `
 pragma solidity ^0.8.0;
@@ -167,8 +167,8 @@ describe("Function Pointer Decoding", function () {
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-    let sourceId = bugger.view(solidity.current.source).id;
-    let source = bugger.view(solidity.current.source).source;
+    let sourceId = bugger.view(sourcemapping.current.source).id;
+    let source = bugger.view(sourcemapping.current.source).source;
     await bugger.addBreakpoint({
       sourceId,
       line: lineOf("BREAK HERE", source)
@@ -205,8 +205,8 @@ describe("Function Pointer Decoding", function () {
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-    let sourceId = bugger.view(solidity.current.source).id;
-    let source = bugger.view(solidity.current.source).source;
+    let sourceId = bugger.view(sourcemapping.current.source).id;
+    let source = bugger.view(sourcemapping.current.source).source;
     await bugger.addBreakpoint({
       sourceId,
       line: lineOf("BREAK HERE (DEPLOYED)", source)
@@ -240,8 +240,8 @@ describe("Function Pointer Decoding", function () {
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-    let sourceId = bugger.view(solidity.current.source).id;
-    let source = bugger.view(solidity.current.source).source;
+    let sourceId = bugger.view(sourcemapping.current.source).id;
+    let source = bugger.view(sourcemapping.current.source).source;
     await bugger.addBreakpoint({
       sourceId,
       line: lineOf("BREAK HERE (CONSTRUCTOR)", source)

--- a/packages/debugger/test/data/global.js
+++ b/packages/debugger/test/data/global.js
@@ -10,7 +10,7 @@ import Debugger from "lib/debugger";
 
 import * as Codec from "@truffle/codec";
 
-import solidity from "lib/solidity/selectors";
+import sourcemapping from "lib/sourcemapping/selectors";
 
 const __GLOBAL = `
 pragma solidity ^0.8.0;
@@ -209,8 +209,8 @@ describe("Globally-available variables", function () {
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-    let sourceId = bugger.view(solidity.current.source).id;
-    let source = bugger.view(solidity.current.source).source;
+    let sourceId = bugger.view(sourcemapping.current.source).id;
+    let source = bugger.view(sourcemapping.current.source).source;
     await bugger.addBreakpoint({
       sourceId,
       line: lineOf("BREAK SIMPLE", source)
@@ -235,8 +235,8 @@ describe("Globally-available variables", function () {
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-    let sourceId = bugger.view(solidity.current.source).id;
-    let source = bugger.view(solidity.current.source).source;
+    let sourceId = bugger.view(sourcemapping.current.source).id;
+    let source = bugger.view(sourcemapping.current.source).source;
     await bugger.addBreakpoint({
       sourceId,
       line: lineOf("BREAK STATIC", source)
@@ -261,8 +261,8 @@ describe("Globally-available variables", function () {
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-    let sourceId = bugger.view(solidity.current.source).id;
-    let source = bugger.view(solidity.current.source).source;
+    let sourceId = bugger.view(sourcemapping.current.source).id;
+    let source = bugger.view(sourcemapping.current.source).source;
     await bugger.addBreakpoint({
       sourceId,
       line: lineOf("BREAK LIBRARY", source)
@@ -307,8 +307,8 @@ describe("Globally-available variables", function () {
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-    let sourceId = bugger.view(solidity.current.source).id;
-    let source = bugger.view(solidity.current.source).source;
+    let sourceId = bugger.view(sourcemapping.current.source).id;
+    let source = bugger.view(sourcemapping.current.source).source;
     await bugger.addBreakpoint({
       sourceId,
       line: lineOf("BREAK CREATE", source)
@@ -333,8 +333,8 @@ describe("Globally-available variables", function () {
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-    let sourceId = bugger.view(solidity.current.source).id;
-    let source = bugger.view(solidity.current.source).source;
+    let sourceId = bugger.view(sourcemapping.current.source).id;
+    let source = bugger.view(sourcemapping.current.source).source;
     await bugger.addBreakpoint({
       sourceId,
       line: lineOf("BREAK CREATE", source)

--- a/packages/debugger/test/data/helpers.js
+++ b/packages/debugger/test/data/helpers.js
@@ -10,7 +10,7 @@ import { prepareContracts } from "test/helpers";
 
 import Debugger from "lib/debugger";
 
-import solidity from "lib/solidity/selectors";
+import sourcemapping from "lib/sourcemapping/selectors";
 
 export function* generateUints() {
   let x = 0;
@@ -73,7 +73,7 @@ async function prepareDebugger(testName, sources) {
   let source = sources[fileName(testName)];
 
   //we'll need the debugger-internal ID of this source
-  let debuggerSources = Object.values(bugger.view(solidity.views.sources));
+  let debuggerSources = Object.values(bugger.view(sourcemapping.views.sources));
   let matchingSources = debuggerSources.filter(sourceObject =>
     sourceObject.sourcePath.includes(contractName(testName))
   );

--- a/packages/debugger/test/data/ids.js
+++ b/packages/debugger/test/data/ids.js
@@ -9,7 +9,7 @@ import { prepareContracts, lineOf } from "../helpers";
 import Debugger from "lib/debugger";
 
 import trace from "lib/trace/selectors";
-import solidity from "lib/solidity/selectors";
+import sourcemapping from "lib/sourcemapping/selectors";
 import * as Codec from "@truffle/codec";
 
 const __FACTORIAL = `
@@ -234,10 +234,10 @@ describe("Variable IDs", function () {
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-    debug("sourceId %d", bugger.view(solidity.current.source).id);
+    debug("sourceId %d", bugger.view(sourcemapping.current.source).id);
 
-    let sourceId = bugger.view(solidity.current.source).id;
-    let source = bugger.view(solidity.current.source).source;
+    let sourceId = bugger.view(sourcemapping.current.source).id;
+    let source = bugger.view(sourcemapping.current.source).source;
     await bugger.addBreakpoint({
       sourceId,
       line: lineOf("break here #1", source)
@@ -270,10 +270,10 @@ describe("Variable IDs", function () {
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-    debug("sourceId %d", bugger.view(solidity.current.source).id);
+    debug("sourceId %d", bugger.view(sourcemapping.current.source).id);
 
-    let sourceId = bugger.view(solidity.current.source).id;
-    let source = bugger.view(solidity.current.source).source;
+    let sourceId = bugger.view(sourcemapping.current.source).id;
+    let source = bugger.view(sourcemapping.current.source).source;
     await bugger.addBreakpoint({
       sourceId,
       line: lineOf("BREAK HERE #1", source)
@@ -309,10 +309,10 @@ describe("Variable IDs", function () {
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-    debug("sourceId %d", bugger.view(solidity.current.source).id);
+    debug("sourceId %d", bugger.view(sourcemapping.current.source).id);
 
-    let sourceId = bugger.view(solidity.current.source).id;
-    let source = bugger.view(solidity.current.source).source;
+    let sourceId = bugger.view(sourcemapping.current.source).id;
+    let source = bugger.view(sourcemapping.current.source).source;
     await bugger.addBreakpoint({
       sourceId,
       line: lineOf("break here #1", source)
@@ -329,10 +329,10 @@ describe("Variable IDs", function () {
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-    debug("sourceId %d", bugger.view(solidity.current.source).id);
+    debug("sourceId %d", bugger.view(sourcemapping.current.source).id);
 
-    let sourceId = bugger.view(solidity.current.source).id;
-    let source = bugger.view(solidity.current.source).source;
+    let sourceId = bugger.view(sourcemapping.current.source).id;
+    let source = bugger.view(sourcemapping.current.source).source;
     await bugger.addBreakpoint({
       sourceId,
       line: lineOf("break here #2", source)
@@ -349,10 +349,10 @@ describe("Variable IDs", function () {
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-    debug("sourceId %d", bugger.view(solidity.current.source).id);
+    debug("sourceId %d", bugger.view(sourcemapping.current.source).id);
 
-    let sourceId = bugger.view(solidity.current.source).id;
-    let source = bugger.view(solidity.current.source).source;
+    let sourceId = bugger.view(sourcemapping.current.source).id;
+    let source = bugger.view(sourcemapping.current.source).source;
     await bugger.addBreakpoint({
       sourceId,
       line: lineOf("BREAK", source)

--- a/packages/debugger/test/data/immutable.js
+++ b/packages/debugger/test/data/immutable.js
@@ -10,7 +10,7 @@ import Debugger from "lib/debugger";
 
 import * as Codec from "@truffle/codec";
 
-import solidity from "lib/solidity/selectors";
+import sourcemapping from "lib/sourcemapping/selectors";
 
 const __IMMUTABLE = `
 pragma solidity ^0.8.8;
@@ -102,8 +102,8 @@ describe("Immutable state variables", function () {
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-    let sourceId = bugger.view(solidity.current.source).id;
-    let source = bugger.view(solidity.current.source).source;
+    let sourceId = bugger.view(sourcemapping.current.source).id;
+    let source = bugger.view(sourcemapping.current.source).source;
     await bugger.addBreakpoint({
       sourceId,
       line: lineOf("BREAK DEPLOYED", source)
@@ -139,8 +139,8 @@ describe("Immutable state variables", function () {
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-    let sourceId = bugger.view(solidity.current.source).id;
-    let source = bugger.view(solidity.current.source).source;
+    let sourceId = bugger.view(sourcemapping.current.source).id;
+    let source = bugger.view(sourcemapping.current.source).source;
     await bugger.addBreakpoint({
       sourceId,
       line: lineOf("BREAK CONSTRUCTOR", source)

--- a/packages/debugger/test/data/more-decoding.js
+++ b/packages/debugger/test/data/more-decoding.js
@@ -9,7 +9,7 @@ import Ganache from "ganache";
 import { prepareContracts, lineOf } from "../helpers";
 import Debugger from "lib/debugger";
 
-import solidity from "lib/solidity/selectors";
+import sourcemapping from "lib/sourcemapping/selectors";
 import data from "lib/data/selectors";
 import evm from "lib/evm/selectors";
 
@@ -356,8 +356,8 @@ describe("Further Decoding", function () {
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-    let sourceId = bugger.view(solidity.current.source).id;
-    let source = bugger.view(solidity.current.source).source;
+    let sourceId = bugger.view(sourcemapping.current.source).id;
+    let source = bugger.view(sourcemapping.current.source).source;
     await bugger.addBreakpoint({
       sourceId,
       line: lineOf("break here", source)
@@ -393,8 +393,8 @@ describe("Further Decoding", function () {
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-    let sourceId = bugger.view(solidity.current.source).id;
-    let source = bugger.view(solidity.current.source).source;
+    let sourceId = bugger.view(sourcemapping.current.source).id;
+    let source = bugger.view(sourcemapping.current.source).source;
     await bugger.addBreakpoint({
       sourceId,
       line: lineOf("break here", source)
@@ -413,7 +413,7 @@ describe("Further Decoding", function () {
       bytesMap: { "0x01": "0x01" },
       uintMap: { 1: 1, 2: 2 },
       intMap: { "-1": -1 },
-      stringMap: { "0xdeadbeef": "0xdeadbeef", 12345: "12345", hello: "hello" },
+      stringMap: { "0xdeadbeef": "0xdeadbeef", "12345": "12345", "hello": "hello" },
       addressMap: { [address]: address },
       contractMap: { [address]: address },
       enumMap: { "ElementaryTest.Ternary.Blue": "ElementaryTest.Ternary.Blue" },
@@ -443,8 +443,8 @@ describe("Further Decoding", function () {
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-    let sourceId = bugger.view(solidity.current.source).id;
-    let source = bugger.view(solidity.current.source).source;
+    let sourceId = bugger.view(sourcemapping.current.source).id;
+    let source = bugger.view(sourcemapping.current.source).source;
     await bugger.addBreakpoint({
       sourceId,
       line: lineOf("break here", source)
@@ -584,8 +584,8 @@ describe("Further Decoding", function () {
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-    let sourceId = bugger.view(solidity.current.source).id;
-    let source = bugger.view(solidity.current.source).source;
+    let sourceId = bugger.view(sourcemapping.current.source).id;
+    let source = bugger.view(sourcemapping.current.source).source;
     await bugger.addBreakpoint({
       sourceId,
       line: lineOf("BREAK HERE", source)
@@ -611,8 +611,8 @@ describe("Further Decoding", function () {
 
       let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-      let sourceId = bugger.view(solidity.current.source).id;
-      let source = bugger.view(solidity.current.source).source;
+      let sourceId = bugger.view(sourcemapping.current.source).id;
+      let source = bugger.view(sourcemapping.current.source).source;
       await bugger.addBreakpoint({
         sourceId,
         line: lineOf("BREAK UNSIGNED", source)
@@ -641,8 +641,8 @@ describe("Further Decoding", function () {
 
       let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-      let sourceId = bugger.view(solidity.current.source).id;
-      let source = bugger.view(solidity.current.source).source;
+      let sourceId = bugger.view(sourcemapping.current.source).id;
+      let source = bugger.view(sourcemapping.current.source).source;
       await bugger.addBreakpoint({
         sourceId,
         line: lineOf("BREAK SIGNED", source)
@@ -671,8 +671,8 @@ describe("Further Decoding", function () {
 
       let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-      let sourceId = bugger.view(solidity.current.source).id;
-      let source = bugger.view(solidity.current.source).source;
+      let sourceId = bugger.view(sourcemapping.current.source).id;
+      let source = bugger.view(sourcemapping.current.source).source;
       await bugger.addBreakpoint({
         sourceId,
         line: lineOf("BREAK RAW", source)

--- a/packages/debugger/test/data/yul.js
+++ b/packages/debugger/test/data/yul.js
@@ -8,7 +8,7 @@ import Ganache from "ganache";
 import { prepareContracts, lineOf } from "../helpers";
 import Debugger from "lib/debugger";
 
-import solidity from "lib/solidity/selectors";
+import sourcemapping from "lib/sourcemapping/selectors";
 
 import * as Codec from "@truffle/codec";
 
@@ -85,8 +85,8 @@ describe("Assembly decoding", function () {
 
     let bugger = await Debugger.forTx(txHash, { provider, compilations });
 
-    let sourceId = bugger.view(solidity.current.source).id;
-    let source = bugger.view(solidity.current.source).source;
+    let sourceId = bugger.view(sourcemapping.current.source).id;
+    let source = bugger.view(sourcemapping.current.source).source;
     await bugger.addBreakpoint({
       sourceId,
       line: lineOf("BREAK #1", source)

--- a/packages/debugger/test/precompiles.js
+++ b/packages/debugger/test/precompiles.js
@@ -10,7 +10,7 @@ import Debugger from "lib/debugger";
 
 import evm from "lib/evm/selectors";
 import trace from "lib/trace/selectors";
-import solidity from "lib/solidity/selectors";
+import sourcemapping from "lib/sourcemapping/selectors";
 
 const __PRECOMPILE = `
 pragma solidity ^0.8.0;
@@ -40,8 +40,8 @@ const TEST_CASES = [
     selector: evm.current.context
   },
   {
-    name: "solidity.current.sourceRange",
-    selector: solidity.current.sourceRange
+    name: "sourcemapping.current.sourceRange",
+    selector: sourcemapping.current.sourceRange
   }
 ];
 
@@ -146,7 +146,7 @@ describe("Precompiled Contracts", function () {
   });
 
   it("never throws an exception for missing source range", async function () {
-    const result = results["solidity.current.sourceRange"];
+    const result = results["sourcemapping.current.sourceRange"];
 
     for (let step of result) {
       if (step.error) {

--- a/packages/debugger/test/reset.js
+++ b/packages/debugger/test/reset.js
@@ -9,7 +9,7 @@ import { prepareContracts, lineOf } from "./helpers";
 import * as Codec from "@truffle/codec";
 import Debugger from "lib/debugger";
 
-import solidity from "lib/solidity/selectors";
+import sourcemapping from "lib/sourcemapping/selectors";
 
 const __SETSTHINGS = `
 pragma solidity ^0.8.0;
@@ -69,8 +69,8 @@ describe("Reset Button", function () {
       compilations
     });
 
-    let sourceId = bugger.view(solidity.current.source).id;
-    let source = bugger.view(solidity.current.source).source;
+    let sourceId = bugger.view(sourcemapping.current.source).id;
+    let source = bugger.view(sourcemapping.current.source).source;
 
     let variables = [];
     variables[0] = []; //collected during 1st run

--- a/packages/debugger/test/sourcemapping.js
+++ b/packages/debugger/test/sourcemapping.js
@@ -1,5 +1,5 @@
 import debugModule from "debug";
-const debug = debugModule("debugger:test:solidity");
+const debug = debugModule("debugger:test:sourcemapping");
 
 import { assert } from "chai";
 
@@ -8,7 +8,7 @@ import Ganache from "ganache";
 import { prepareContracts, lineOf } from "./helpers";
 import Debugger from "lib/debugger";
 
-import solidity from "lib/solidity/selectors";
+import sourcemapping from "lib/sourcemapping/selectors";
 import controller from "lib/controller/selectors";
 import trace from "lib/trace/selectors";
 
@@ -247,7 +247,7 @@ let sources = {
   "YulFnTest.yul": __CALL_YUL
 };
 
-describe("Solidity Debugging", function () {
+describe("Source mapping (location and jumps))", function () {
   let provider;
   let abstractions;
   let compilations;
@@ -286,7 +286,7 @@ describe("Solidity Debugging", function () {
     });
 
     // at `second();`
-    let source = bugger.view(solidity.current.source);
+    let source = bugger.view(sourcemapping.current.source);
     let breakLine = lineOf("BREAK", source.source);
     let breakpoint = {
       sourceId: source.id,
@@ -299,7 +299,7 @@ describe("Solidity Debugging", function () {
       await bugger.continueUntilBreakpoint();
 
       if (!bugger.view(trace.finished)) {
-        let range = bugger.view(solidity.current.sourceRange);
+        let range = bugger.view(sourcemapping.current.sourceRange);
         assert.equal(range.lines.start.line, breakLine);
       }
     } while (!bugger.view(trace.finished));
@@ -318,7 +318,7 @@ describe("Solidity Debugging", function () {
     });
 
     // at `second();`
-    let source = bugger.view(solidity.current.source);
+    let source = bugger.view(sourcemapping.current.source);
     let breakLine = lineOf("BREAK", source.source);
     let breakpoint = { sourceId: source.id, line: breakLine };
 
@@ -326,7 +326,7 @@ describe("Solidity Debugging", function () {
       await bugger.continueUntilBreakpoint([breakpoint]);
 
       if (!bugger.view(trace.finished)) {
-        let range = bugger.view(solidity.current.sourceRange);
+        let range = bugger.view(sourcemapping.current.sourceRange);
         assert.equal(range.lines.start.line, breakLine);
       }
     } while (!bugger.view(trace.finished));
@@ -345,7 +345,7 @@ describe("Solidity Debugging", function () {
     });
 
     let resolver = bugger.view(controller.breakpoints.resolver);
-    let source = bugger.view(solidity.current.source);
+    let source = bugger.view(sourcemapping.current.source);
 
     let breakpoints = [];
     let expectedResolutions = [];
@@ -390,7 +390,7 @@ describe("Solidity Debugging", function () {
         //note that we use stepNext, which skips internal sources...
         //it may go above 0 while inside an internal source
 
-        const depth = bugger.view(solidity.current.functionDepth);
+        const depth = bugger.view(sourcemapping.current.functionDepth);
 
         assert.equal(depth, 0);
       } while (!bugger.view(trace.finished));
@@ -410,7 +410,7 @@ describe("Solidity Debugging", function () {
       });
 
       while (!bugger.view(trace.finished)) {
-        let depth = bugger.view(solidity.current.functionDepth);
+        let depth = bugger.view(sourcemapping.current.functionDepth);
         assert.equal(depth, numExpected);
 
         await bugger.stepNext();
@@ -441,7 +441,7 @@ describe("Solidity Debugging", function () {
       });
 
       while (!bugger.view(trace.finished)) {
-        let depth = bugger.view(solidity.current.functionDepth);
+        let depth = bugger.view(sourcemapping.current.functionDepth);
         assert.equal(depth, numExpected);
 
         await bugger.stepNext();
@@ -463,7 +463,7 @@ describe("Solidity Debugging", function () {
       // follow functionDepth values in list
       // see source above
       let expectedDepthSequence = [0, 1, 2, 1, 0, 1, 0];
-      let actualSequence = [bugger.view(solidity.current.functionDepth)];
+      let actualSequence = [bugger.view(sourcemapping.current.functionDepth)];
 
       var finished;
 
@@ -471,7 +471,7 @@ describe("Solidity Debugging", function () {
         await bugger.stepNext();
         finished = bugger.view(trace.finished);
 
-        let currentDepth = bugger.view(solidity.current.functionDepth);
+        let currentDepth = bugger.view(sourcemapping.current.functionDepth);
         let lastKnown = actualSequence[actualSequence.length - 1];
 
         if (currentDepth !== lastKnown) {
@@ -494,7 +494,7 @@ describe("Solidity Debugging", function () {
         lightMode: true
       });
 
-      let source = bugger.view(solidity.current.source);
+      let source = bugger.view(sourcemapping.current.source);
       let breakLine1 = lineOf("BREAK #1", source.source);
       let breakpoint1 = {
         sourceId: source.id,
@@ -509,9 +509,9 @@ describe("Solidity Debugging", function () {
       await bugger.addBreakpoint(breakpoint2);
 
       await bugger.continueUntilBreakpoint();
-      let depthBefore = bugger.view(solidity.current.functionDepth);
+      let depthBefore = bugger.view(sourcemapping.current.functionDepth);
       await bugger.continueUntilBreakpoint();
-      let depthAfter = bugger.view(solidity.current.functionDepth);
+      let depthAfter = bugger.view(sourcemapping.current.functionDepth);
 
       assert.equal(depthAfter, depthBefore);
     });
@@ -534,7 +534,7 @@ describe("Solidity Debugging", function () {
         //note that we use stepNext, which skips internal sources...
         //it may go above 2 while inside an internal source
 
-        const depth = bugger.view(solidity.current.functionDepth);
+        const depth = bugger.view(sourcemapping.current.functionDepth);
 
         assert.isAtMost(depth, 2);
         if (depth === 2) {
@@ -562,7 +562,7 @@ describe("Solidity Debugging", function () {
         //note that we use stepNext, which skips internal sources...
         //it may go above 2 while inside an internal source
 
-        const depth = bugger.view(solidity.current.functionDepth);
+        const depth = bugger.view(sourcemapping.current.functionDepth);
 
         assert.isAtMost(depth, 2);
         if (depth === 2) {
@@ -590,7 +590,7 @@ describe("Solidity Debugging", function () {
         //note that we use stepNext, which skips internal sources...
         //it may go above 2 while inside an internal source
 
-        const depth = bugger.view(solidity.current.functionDepth);
+        const depth = bugger.view(sourcemapping.current.functionDepth);
 
         assert.isAtMost(depth, 2);
         if (depth === 2) {
@@ -611,7 +611,7 @@ describe("Solidity Debugging", function () {
         lightMode: true
       });
 
-      const source = bugger.view(solidity.current.source);
+      const source = bugger.view(sourcemapping.current.source);
       const breakLine = lineOf("BREAK", source.source);
       const breakpoint = {
         sourceId: source.id,
@@ -621,7 +621,7 @@ describe("Solidity Debugging", function () {
       await bugger.addBreakpoint(breakpoint);
       await bugger.continueUntilBreakpoint();
 
-      assert.equal(bugger.view(solidity.current.functionDepth), 1);
+      assert.equal(bugger.view(sourcemapping.current.functionDepth), 1);
     });
   });
 });

--- a/packages/debugger/test/stacktrace.js
+++ b/packages/debugger/test/stacktrace.js
@@ -8,7 +8,7 @@ import Ganache from "ganache";
 import { prepareContracts, lineOf } from "./helpers";
 import Debugger from "lib/debugger";
 
-import solidity from "lib/solidity/selectors";
+import sourcemapping from "lib/sourcemapping/selectors";
 import stacktrace from "lib/stacktrace/selectors";
 
 const __STACKTRACE = `
@@ -197,7 +197,7 @@ describe("Stack tracing", function () {
       lightMode: true
     });
 
-    let source = bugger.view(solidity.current.source);
+    let source = bugger.view(sourcemapping.current.source);
     let failLine = lineOf("REQUIRE", source.source);
     let callLine = lineOf("CALL", source.source);
 
@@ -245,7 +245,7 @@ describe("Stack tracing", function () {
       lightMode: true
     });
 
-    let source = bugger.view(solidity.current.source);
+    let source = bugger.view(sourcemapping.current.source);
     let breakLine = lineOf("EMIT", source.source);
     let callLine = lineOf("CALL", source.source);
     let breakpoint = {
@@ -312,7 +312,7 @@ describe("Stack tracing", function () {
       lightMode: true
     });
 
-    let source = bugger.view(solidity.current.source);
+    let source = bugger.view(sourcemapping.current.source);
     let failLine = lineOf("PAY", source.source);
     let callLine = lineOf("CALL", source.source);
 
@@ -360,7 +360,7 @@ describe("Stack tracing", function () {
       lightMode: true
     });
 
-    let source = bugger.view(solidity.current.source);
+    let source = bugger.view(sourcemapping.current.source);
     let failLine = lineOf("GARBAGE", source.source);
     let callLine = lineOf("CALL", source.source);
 
@@ -412,7 +412,7 @@ describe("Stack tracing", function () {
       lightMode: true
     });
 
-    let source = bugger.view(solidity.current.source);
+    let source = bugger.view(sourcemapping.current.source);
     let failLine = lineOf("BOOM", source.source);
     let callLine = lineOf("UHOH", source.source);
     let prevCallLine = lineOf("CALL", source.source);
@@ -474,7 +474,7 @@ describe("Stack tracing", function () {
       lightMode: true
     });
 
-    let source = bugger.view(solidity.current.source);
+    let source = bugger.view(sourcemapping.current.source);
     let failLine = lineOf("CREATEFAIL", source.source);
     let callLine = lineOf("CANTCREATE", source.source);
 
@@ -542,7 +542,7 @@ describe("Stack tracing", function () {
       lightMode: true
     });
 
-    let source = bugger.view(solidity.current.source);
+    let source = bugger.view(sourcemapping.current.source);
     let failLine = lineOf("FALLBACKFAIL", source.source);
     let callLine = lineOf("CANTFALLBACK", source.source);
 
@@ -601,7 +601,7 @@ describe("Stack tracing", function () {
       lightMode: true
     });
 
-    let source = bugger.view(solidity.current.source);
+    let source = bugger.view(sourcemapping.current.source);
     let failLine = lineOf("LIBFAIL", source.source);
     let callLine = lineOf("CANTLIB", source.source);
 


### PR DESCRIPTION
Addresses #3836.  Finally getting this renaming out of the way!

Not much to say about this one, it's mostly a straight renaming.  The `solidity` selectors are left in to keep this from being a breaking change, though.  (Possibly we can remove those later?)  Also due to `eslint` I had to remove an unused variable at one point.

Also `prettier` made some changes.