### PR TITLE
Internal improvement: Remove compatibility selectors from debugger (breaking change)

### DIFF
--- a/packages/debugger/lib/debugger.js
+++ b/packages/debugger/lib/debugger.js
@@ -79,7 +79,6 @@ const Debugger = {
       trace: traceSelector,
       evm: evmSelector,
       sourcemapping: sourcemappingSelector,
-      solidity: sourcemappingSelector, //for compatibility
       stacktrace: stacktraceSelector,
       session: sessionSelector,
       controller: controllerSelector

--- a/packages/debugger/lib/session/index.js
+++ b/packages/debugger/lib/session/index.js
@@ -548,7 +548,6 @@ export default class Session {
       trace,
       evm,
       sourcemapping,
-      solidity: sourcemapping, //for compatibility
       stacktrace,
       session,
       controller: controllerSelector


### PR DESCRIPTION
These were added in #4808, but after seeing some tests time out on my local machine, I'm potentially worried that there might be a performance impact.  @gnidan said to just go ahead and break things rather than risk that, so, here we are.