### PR TITLE
Support for "BigInt" as a numberFormat (for output)

### DIFF
--- a/packages/contract-tests/test/methods.js
+++ b/packages/contract-tests/test/methods.js
@@ -291,6 +291,16 @@ describe("Methods", function () {
       Example.numberFormat = "BigNumber";
     });
 
+    it("should output int values as BigInt when set to 'BigInt' (call)", async function () {
+      let value;
+      Example.numberFormat = "BigInt";
+      const example = await Example.new(1);
+
+      value = await example.returnsInt();
+      assert(typeof value === "bigint");
+      Example.numberFormat = "BigNumber";
+    });
+
     it("should emit a transaction hash", function (done) {
       Example.new(5).then(function (instance) {
         instance.setValue(25).on("transactionHash", function (hash) {

--- a/packages/contract/README.md
+++ b/packages/contract/README.md
@@ -209,7 +209,7 @@ var MyOtherContract = MyContract.clone(1337);
 #### `MyContract.numberFormat = number_type`
 You can set this property to choose the number format that abstraction methods return.  The default behavior is to return BN.
 ```javascript
-// Choices are:  `["BigNumber", "BN", "String"].
+// Choices are:  `["BigNumber", "BN", "String", "BigInt"].
 var Example = artifacts.require('Example');
 Example.numberFormat = 'BigNumber';
 ```

--- a/packages/contract/lib/contract/properties.js
+++ b/packages/contract/lib/contract/properties.js
@@ -57,7 +57,7 @@ module.exports = {
       return this._json.numberFormat;
     },
     set: function (val) {
-      const allowedFormats = ["BigNumber", "BN", "String"];
+      const allowedFormats = ["BigNumber", "BN", "String", "BigInt"];
 
       const msg =
         `Invalid number format setting: "${val}": ` +

--- a/packages/contract/lib/reformat.js
+++ b/packages/contract/lib/reformat.js
@@ -20,6 +20,8 @@ const _convertNumber = function(val, format) {
       return web3Utils.toBN(val);
     case "String":
       return val;
+    case "BigInt":
+      return BigInt(val);
     default:
       throw new Error(badFormatMsg);
   }


### PR DESCRIPTION
## Task
This PR adds support for `BigInt` as a `numberFormat`. Issue with a description of the task #4777.

Works done:
- [x] Added `BigInt` support.
- [x] Updated `README.md`, added `BigInt` support.
- [x] Added new test case to check `BigInt`.

## Environment
- Truffle version (`truffle version`): 5.5.2