### PR TITLE
Bug fix: Make hdwallet-provider's `initialize` method always resolve

### DIFF
--- a/packages/hdwallet-provider/src/index.ts
+++ b/packages/hdwallet-provider/src/index.ts
@@ -279,30 +279,28 @@ class HDWalletProvider {
           // always resolve the Promise - if an error occurs, throw it when
           // this.initialized is checked so errors can be handled by the user
           if (error) {
-            resolve({
+            return resolve({
               success: false,
               error
             });
-            return;
           } else if (response.error) {
-            resolve({
+            return resolve({
               success: false,
               error: response.error
             });
-            return;
           }
           if (isNaN(parseInt(response.result, 16))) {
             const message =
               "When requesting the chain id from the node, it" +
               `returned the malformed result ${response.result}.`;
             const error = new Error(message);
-            resolve({
+            return resolve({
               success: false,
               error
             });
           }
           this.chainId = parseInt(response.result, 16);
-          resolve({
+          return resolve({
             success: true,
             error: null
           });


### PR DESCRIPTION
There is an interesting behavior that hdwallet-provider has when, for example, a bad url is passed. In the constructor, the package goes to fetch the chain id asynchronously. If the connection or url is bad, then the package will throw an error asynchronously which can cause peoples' apps problems. We want to allow them to handle the errors in their code. So now when this call for the chain id fails, we resolve the Promise (instead of previously rejecting) with a `success` field and an `error` field. This way we can wait until the user goes to interact with hdwallet-provider before throwing an error. This will allow them to handle the error without crashing their process.