### PR TITLE
Bug fix: Improve hdwallet-provider argument validation

### DIFF
--- a/packages/hdwallet-provider/src/constructor/getOptions.ts
+++ b/packages/hdwallet-provider/src/constructor/getOptions.ts
@@ -135,9 +135,9 @@ export const getOptions = (
     return fromArguments(args);
   } else {
     const message =
-      "Unknown arguments format passed to new HDWalletProvider." +
-      " Please ensure you passed both provider information and a menmonic or " +
-      "private keys.";
+      "Unknown arguments format passed to new HDWalletProvider. " +
+      "Please ensure you passed provider information along with either a " +
+      "mnemonic or private keys.";
     throw new Error(message);
   }
 };

--- a/packages/hdwallet-provider/src/constructor/getOptions.ts
+++ b/packages/hdwallet-provider/src/constructor/getOptions.ts
@@ -9,21 +9,18 @@ import { wordlist } from "ethereum-cryptography/bip39/wordlists/english";
 const isMnemonicPhrase = (
   credentials: LegacyConstructor.Credentials
 ): credentials is MnemonicPhrase =>
-  typeof credentials === "string" &&
-  validateMnemonic(credentials, wordlist);
+  typeof credentials === "string" && validateMnemonic(credentials, wordlist);
 
 // check that the first argument is a list of private keys
 const isPrivateKeys = (
   credentials: LegacyConstructor.Credentials
-): credentials is PrivateKey[] =>
-  credentials instanceof Array;
+): credentials is PrivateKey[] => credentials instanceof Array;
 
 // check that the first argument is a single private key (default case for invalid mnemonics)
 const isPrivateKey = (
   credentials: LegacyConstructor.Credentials
 ): credentials is PrivateKey =>
-  !isPrivateKeys(credentials) &&
-  !isMnemonicPhrase(credentials);
+  !isPrivateKeys(credentials) && !isMnemonicPhrase(credentials);
 
 // turn polymorphic first argument into { mnemonic } or { privateKeys }
 const getSigningAuthorityOptions = (
@@ -39,14 +36,16 @@ const getSigningAuthorityOptions = (
     return {
       privateKeys: credentials
     };
-  } else if (isPrivateKey(credentials)) { // if(...) included for explicitness
+  } else if (isPrivateKey(credentials)) {
+    // if(...) included for explicitness
     return {
       privateKeys: [credentials]
     };
-  } else { // this won't be reached until/unless we validate private key(s)
+  } else {
+    // this won't be reached until/unless we validate private key(s)
     throw new Error(
       `First argument to new HDWalletProvider() must be a mnemonic phrase, a ` +
-      `single private key, or a list of private keys. ` +
+        `single private key, or a list of private keys. ` +
         `Received: ${JSON.stringify(credentials)}`
     );
   }
@@ -65,7 +64,7 @@ const fromInputOptions = (
   } else {
     return options as Constructor.Options;
   }
-}
+};
 
 // convert legacy style positional arguments to new, single-arg options format
 const fromArguments = (
@@ -102,12 +101,9 @@ const fromArguments = (
 const matchesNewInputOptions = (
   args: ConstructorArguments
 ): args is [Constructor.InputOptions] => {
-  // new-style means exactly one argument
-  if (args.length !== 1) {
-    return false;
-  }
-
   const [options] = args;
+  // new-style means exactly one argument and an object
+  if (args.length !== 1 || typeof options !== "object") return false;
 
   // beyond that, determine based on property inclusion check for required keys
   return (
@@ -115,8 +111,6 @@ const matchesNewInputOptions = (
     ("privateKeys" in options || "mnemonic" in options)
   );
 };
-
-
 
 // type predicate guard to determine at runtime if arguments conform to
 // old-style constructor args.
@@ -140,8 +134,10 @@ export const getOptions = (
   } else if (matchesLegacyArguments(args)) {
     return fromArguments(args);
   } else {
-    throw new Error(
-      "Unknown arguments format passed to new HDWalletProvider. Please check your configuration and try again"
-    );
+    const message =
+      "Unknown arguments format passed to new HDWalletProvider." +
+      " Please ensure you passed both provider information and a menmonic or " +
+      "private keys.";
+    throw new Error(message);
   }
 };


### PR DESCRIPTION
Currently hdwallet-provider's checks for input arguments is a bit primitive. It just checks to see if you passed one argument as the check for "new-style input arguments". If you were trying to use old-style arguments (positional) and provided just one argument (let's say a string for the provider url), it will then fail with an unhelpful "cannot use in with string"-type error. This PR adds one more check to make sure that that argument is an object.

This PR also adds some information to the message for the error that is thrown when the input arguments do not validate successfully, telling the user to make sure they provide both provider info as well as private keys/mnemonic which are required.