### PR TITLE
Add sanitize function for network_id in truffle test

### DIFF
--- a/packages/core/lib/commands/test/run.js
+++ b/packages/core/lib/commands/test/run.js
@@ -122,15 +122,18 @@ module.exports = async function (options) {
     }
   }
 
+  if (configuredNetwork) {
+    configuredNetwork.network_id = sanitizeNetworkID(
+      configuredNetwork.network_id
+    );
+  }
+
   if (
     (testNetworkDefinedAndUsed && noProviderHostOrUrlConfigured) ||
     !configuredNetwork
   ) {
     // Use managed ganache with overriding user specified config or without any specification in the config
     const port = await require("get-port")();
-    configuredNetwork.network_id = sanitizeNetworkID(
-      configuredNetwork.network_id
-    );
 
     // configuredNetwork will spread only when it is defined and ignored when undefined
     ganacheOptions = { ...ganacheOptions, port, ...configuredNetwork };

--- a/packages/core/lib/commands/test/run.js
+++ b/packages/core/lib/commands/test/run.js
@@ -34,7 +34,7 @@ const parseCommandLineFlags = options => {
 
 // Sanitize ganache options specified in the config
 function sanitizeGanacheOptions(ganacheOptions) {
-  let network_id = ganacheOptions.network_id;
+  const network_id = ganacheOptions.network_id;
 
   // Use default network_id if "*" is defined in config
   if (network_id === "*") {
@@ -137,8 +137,6 @@ module.exports = async function (options) {
 
     // configuredNetwork will spread only when it is defined and ignored when undefined
     ganacheOptions = { ...ganacheOptions, port, ...configuredNetwork };
-
-    // Sanitize the ganache options if required
     const sanitizedGanacheOptions = sanitizeGanacheOptions(ganacheOptions);
 
     numberOfFailures = await startGanacheAndRunTests(

--- a/packages/core/lib/commands/test/run.js
+++ b/packages/core/lib/commands/test/run.js
@@ -33,13 +33,11 @@ const parseCommandLineFlags = options => {
 // Sanitize ganache options specified in the config
 function sanitizeGanacheOptions(ganacheOptions) {
   let network_id = ganacheOptions.network_id;
-  let ganacheOptionsChanged;
 
   // Use default network_id if "*" is defined in config
   if (network_id === "*") {
     network_id = 4447;
-    ganacheOptionsChanged = { ...ganacheOptions, network_id };
-    return ganacheOptionsChanged;
+    return { ...ganacheOptions, network_id };
   }
 
   const parsedNetworkId = parseInt(network_id, 10);
@@ -50,8 +48,7 @@ function sanitizeGanacheOptions(ganacheOptions) {
     throw new Error(error);
   }
   network_id = parsedNetworkId;
-  ganacheOptionsChanged = { ...ganacheOptions, network_id };
-  return ganacheOptionsChanged;
+  return { ...ganacheOptions, network_id };
 }
 
 module.exports = async function (options) {

--- a/packages/core/lib/commands/test/run.js
+++ b/packages/core/lib/commands/test/run.js
@@ -1,3 +1,5 @@
+const defaultNetworkIdForTestCommand = 4447;
+
 const parseCommandLineFlags = options => {
   // parse out command line flags to merge in to the config
   const grep = options.grep || options.g;
@@ -36,7 +38,7 @@ function sanitizeGanacheOptions(ganacheOptions) {
 
   // Use default network_id if "*" is defined in config
   if (network_id === "*") {
-    network_id = 4447;
+    network_id = defaultNetworkIdForTestCommand;
     return { ...ganacheOptions, network_id };
   }
 
@@ -119,7 +121,7 @@ module.exports = async function (options) {
   let numberOfFailures;
   let ganacheOptions = {
     host: "127.0.0.1",
-    network_id: 4447,
+    network_id: defaultNetworkIdForTestCommand,
     mnemonic:
       "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat",
     time: config.genesis_time,

--- a/packages/core/lib/commands/test/run.js
+++ b/packages/core/lib/commands/test/run.js
@@ -48,8 +48,7 @@ function sanitizeGanacheOptions(ganacheOptions) {
       `(${network_id}) is not valid. Please properly configure the network id as an integer value.`;
     throw new Error(error);
   }
-  network_id = parsedNetworkId;
-  return { ...ganacheOptions, network_id };
+  return { ...ganacheOptions, network_id: parsedNetworkId };
 }
 
 module.exports = async function (options) {

--- a/packages/core/lib/commands/test/run.js
+++ b/packages/core/lib/commands/test/run.js
@@ -107,12 +107,30 @@ module.exports = async function (options) {
     }
   };
 
+  function sanitizeNetworkID(network_id) {
+    if (network_id !== "*") {
+      if (!parseInt(network_id, 10)) {
+        const error =
+          `The network id specified in the truffle config ` +
+          `(${network_id}) is not valid. Please properly configure the network id as an integer value.`;
+        throw new Error(error);
+      }
+      return network_id;
+    } else {
+      // We have a "*" network. Return the default.
+      return 4447;
+    }
+  }
+
   if (
     (testNetworkDefinedAndUsed && noProviderHostOrUrlConfigured) ||
     !configuredNetwork
   ) {
     // Use managed ganache with overriding user specified config or without any specification in the config
     const port = await require("get-port")();
+    configuredNetwork.network_id = sanitizeNetworkID(
+      configuredNetwork.network_id
+    );
 
     // configuredNetwork will spread only when it is defined and ignored when undefined
     ganacheOptions = { ...ganacheOptions, port, ...configuredNetwork };

--- a/packages/core/lib/commands/test/run.js
+++ b/packages/core/lib/commands/test/run.js
@@ -38,8 +38,7 @@ function sanitizeGanacheOptions(ganacheOptions) {
 
   // Use default network_id if "*" is defined in config
   if (network_id === "*") {
-    network_id = defaultNetworkIdForTestCommand;
-    return { ...ganacheOptions, network_id };
+    return { ...ganacheOptions, network_id: defaultNetworkIdForTestCommand };
   }
 
   const parsedNetworkId = parseInt(network_id, 10);

--- a/packages/core/lib/commands/test/run.js
+++ b/packages/core/lib/commands/test/run.js
@@ -108,19 +108,24 @@ module.exports = async function (options) {
   };
 
   function sanitizeGanacheOptions(ganacheOptions) {
-    if (ganacheOptions.network_id === "*") {
-      ganacheOptions.network_id = 4447;
-      return ganacheOptions;
+    let network_id = ganacheOptions.network_id;
+
+    // Use default network_id if "*" is defined in config
+    if (network_id === "*") {
+      network_id = 4447;
+      let ganacheOptionsChanged = { ...ganacheOptions, network_id };
+      return ganacheOptionsChanged;
     }
-    const parsedNetworkId = parseInt(ganacheOptions.network_id, 10);
-    if (isNaN(parsedNetworkId)) { 
+    const parsedNetworkId = parseInt(network_id, 10);
+    if (isNaN(parsedNetworkId)) {
       const error =
-          `The network id specified in the truffle config ` +
-          `(${ganacheOptions.network_id}) is not valid. Please properly configure the network id as an integer value.`;
+        `The network id specified in the truffle config ` +
+        `(${network_id}) is not valid. Please properly configure the network id as an integer value.`;
       throw new Error(error);
     }
-    ganacheOptions.network_id = parsedNetworkId;
-    return ganacheOptions;
+    network_id = parsedNetworkId;
+    let ganacheOptionsChanged = { ...ganacheOptions, network_id };
+    return ganacheOptionsChanged;
   }
 
   if (


### PR DESCRIPTION
### ISSUE
`truffle test` command was breaking when invalid or "*" is passed as network_id from `truffle-config.js`.

### SOLUTION
Added a sanitize function for the ganache options passed from the `truffle-config.js`.