### PR TITLE
Internal improvement: Simplify Truffle's crypto.getRandomValues shim

### DIFF
--- a/packages/core/cli.js
+++ b/packages/core/cli.js
@@ -2,19 +2,19 @@
 require("source-map-support/register");
 
 const semver = require("semver"); // to validate Node version
-
-const crypto = require("crypto");
-global.crypto = crypto;
-// we need to make sure this function exists so ensjs doesn't complain
-// it requires getRandomValues for some functionalities
-global.crypto.getRandomValues = require("get-random-values");
-
 const TruffleError = require("@truffle/error");
 const TaskError = require("./lib/errors/taskerror");
 const analytics = require("./lib/services/analytics");
 const version = require("./lib/version");
 const versionInfo = version.info();
 const XRegExp = require("xregexp");
+
+// we need to make sure this function exists so ensjs doesn't complain as it requires
+// getRandomValues for some functionalities - webpack strips out the crypto lib
+// so we shim it here
+global.crypto = {
+  getRandomValues: require("get-random-values")
+};
 
 // pre-flight check: Node version compatibility
 const minimumNodeVersion = "10.9.0";

--- a/packages/core/lib/console-child.js
+++ b/packages/core/lib/console-child.js
@@ -4,14 +4,15 @@ const Config = require("@truffle/config");
 const Web3 = require("web3");
 const yargs = require("yargs");
 
-const crypto = require("crypto");
-global.crypto = crypto;
-// we need to make sure this function exists so ensjs doesn't complain
-// it requires getRandomValues for some functionalities
-global.crypto.getRandomValues = require("get-random-values");
-
 const input = process.argv[2].split(" -- ");
 const inputStrings = input[1];
+
+// we need to make sure this function exists so ensjs doesn't complain as it requires
+// getRandomValues for some functionalities - webpack strips out the crypto lib
+// so we shim it here
+global.crypto = {
+  getRandomValues: require("get-random-values")
+};
 
 //detect config so we can get the provider and resolver without having to serialize
 //and deserialize them


### PR DESCRIPTION
In https://github.com/trufflesuite/truffle/pull/4128 we shimmed the crypto library as webpack strips it out and ensjs requires the `getRandomValues` function. If it is not present it will print warnings to the console. This PR attempts to simplify the `crypto` shim as we don't need the entire `crypto` package.