### PR TITLE
Bug fix: Don't autogenerate accounts when forking for a dry run

### DIFF
--- a/packages/core/lib/commands/migrate/index.js
+++ b/packages/core/lib/commands/migrate/index.js
@@ -1,6 +1,8 @@
 module.exports = {
   run: require("./run"),
   meta: require("./meta"),
+  runMigrations: require("./runMigrations"),
+  setUpDryRunEnvironmentThenRunMigrations: require("./setUpDryRunEnvironmentThenRunMigrations"),
   determineDryRunSettings: require("./determineDryRunSettings"),
   prepareConfigForRealMigrations: require("./prepareConfigForRealMigrations")
 };

--- a/packages/core/lib/commands/migrate/prepareConfigForRealMigrations.js
+++ b/packages/core/lib/commands/migrate/prepareConfigForRealMigrations.js
@@ -25,7 +25,10 @@ module.exports = async function (buildDir, options) {
     }
 
     config.dryRun = false;
-    return { config, proceed: true };
+    return {
+      preparedConfig: config,
+      proceed: true
+    };
   } else {
     return { proceed: false };
   }

--- a/packages/core/lib/commands/migrate/run.js
+++ b/packages/core/lib/commands/migrate/run.js
@@ -48,6 +48,11 @@ module.exports = async function (options) {
     await Environment.fork(config, {
       logging: {
         quiet: true
+      },
+      // we need to tell Ganache to not unlock any accounts so that only
+      // user's accounts are unlocked since this will be a dry run
+      wallet: {
+        totalAccounts: 0
       }
     });
     // Copy artifacts to a temporary directory

--- a/packages/core/lib/commands/migrate/runMigrations.js
+++ b/packages/core/lib/commands/migrate/runMigrations.js
@@ -1,0 +1,16 @@
+const Migrate = require("@truffle/migrate");
+
+module.exports = async function (config) {
+  if (config.f) {
+    return await Migrate.runFrom(config.f, config);
+  } else {
+    const needsMigrating = await Migrate.needsMigrating(config);
+
+    if (needsMigrating) {
+      return await Migrate.run(config);
+    } else {
+      config.logger.log("Network up to date.");
+      return;
+    }
+  }
+}

--- a/packages/core/lib/commands/migrate/runMigrations.js
+++ b/packages/core/lib/commands/migrate/runMigrations.js
@@ -10,7 +10,6 @@ module.exports = async function (config) {
       return await Migrate.run(config);
     } else {
       config.logger.log("Network up to date.");
-      return;
     }
   }
-}
+};

--- a/packages/core/lib/commands/migrate/setUpDryRunEnvironmentThenRunMigrations.js
+++ b/packages/core/lib/commands/migrate/setUpDryRunEnvironmentThenRunMigrations.js
@@ -1,0 +1,37 @@
+const { Environment } = require("@truffle/environment");
+const { promisify } = require("util");
+const Artifactor = require("@truffle/artifactor");
+const Resolver = require("@truffle/resolver");
+const copy = require("../../copy");
+const tmp = require("tmp");
+tmp.setGracefulCleanup();
+const runMigrations = require("./runMigrations");
+
+module.exports = async function (config) {
+  await Environment.fork(config, {
+    logging: {
+      quiet: true
+    },
+    // we need to tell Ganache to not unlock any accounts so that only
+    // user's accounts are unlocked since this will be a dry run
+    wallet: {
+      totalAccounts: 0
+    }
+  });
+  // Copy artifacts to a temporary directory
+  const temporaryDirectory = tmp.dirSync({
+    unsafeCleanup: true,
+    prefix: "migrate-dry-run-"
+  }).name;
+
+  await promisify(copy)(config.contracts_build_directory, temporaryDirectory);
+
+  config.contracts_build_directory = temporaryDirectory;
+  // Note: Create a new artifactor and resolver with the updated config.
+  // This is because the contracts_build_directory changed.
+  // Ideally we could architect them to be reactive of the config changes.
+  config.artifactor = new Artifactor(temporaryDirectory);
+  config.resolver = new Resolver(config);
+
+  return await runMigrations(config);
+};

--- a/packages/core/test/config.js
+++ b/packages/core/test/config.js
@@ -31,6 +31,9 @@ describe("config", function () {
         provider: Ganache.provider({
           miner: {
             instamine: "strict"
+          },
+          logging: {
+            quiet: true
           }
         })
       }

--- a/packages/core/test/ethpm.js
+++ b/packages/core/test/ethpm.js
@@ -35,6 +35,9 @@ describe.skip("EthPM integration", function () {
     provider = Ganache.provider({
       miner: {
         instamine: "strict"
+      },
+      logging: {
+        quiet: true
       }
     });
 

--- a/packages/core/test/migrate.js
+++ b/packages/core/test/migrate.js
@@ -26,6 +26,9 @@ describe("migrate", function () {
       seed: network,
       miner: {
         instamine: "strict"
+      },
+      logging: {
+        quiet: true
       }
     });
     const web3 = new Web3(provider);

--- a/packages/truffle/test/scenarios/commands/obtain.js
+++ b/packages/truffle/test/scenarios/commands/obtain.js
@@ -41,7 +41,7 @@ describe("truffle obtain", function () {
   });
 
   it("respects the `quiet` option", async function () {
-    this.timeout(70000);
+    this.timeout(80000);
     // ensure the compiler does not yet exist
     try {
       fse.unlinkSync(expectedPath);

--- a/packages/truffle/test/scenarios/commands/obtain.js
+++ b/packages/truffle/test/scenarios/commands/obtain.js
@@ -54,8 +54,18 @@ describe("truffle obtain", function () {
     await CommandRunner.run("obtain --solc=0.7.2 --quiet", config);
     // logger.contents() returns false as long as nothing is written to the
     // stream that is used for logging in MemoryLogger
+
+    // in Node12, Ganache prints a warning and it cannot be suppressed
+    // I guess we have to allow it until we stop supporting Node12
+    const ganacheNode12WarningRegex =
+      /This\sversion\sof\sµWS.*?may\sbe\sdegraded\.\n\n\n/s;
+    const removeGanacheWarning = text => {
+      return text ? text.replace(ganacheNode12WarningRegex, "") : text;
+    };
+
+    const loggedStuff = removeGanacheWarning(logger.contents());
     assert(
-      !logger.contents(),
+      !loggedStuff,
       "The command logged to the console when it shouldn't have."
     );
     fse.unlinkSync(expectedPath);


### PR DESCRIPTION
addresses https://github.com/trufflesuite/truffle/issues/2928

When Truffle forks for a dry run, it initializes a Ganache instance. That Ganache instance is passed a provider, presumably with the user's unlocked accounts. On initialization, however, Ganache generates another set of 10 accounts that are unlocked which pushes any accounts the user has unlocked to the second half of the array of unlocked accounts. This behavior is probably not what we want, as the user should probably expect that his unlocked accounts will start at index 0.

To remedy this, this PR adds `wallet: { totalAccounts: 0 }` to the list of options passed to Ganache. This causes Ganache to refrain from unlocking additional accounts.

To test this, you can simply create a network configuration that has a provider with unlocked accounts (@truffle/hdwallet-provider). In your migrations, use the `accounts` variable (`module.exports = (deployer, network, accounts) => {...` to print out the list of accounts while using the currently published Truffle. You should receive an array with 20 accounts, the accounts you unlocked being at the end of the array. Use this branch to run the same migration and you should get an array of 10 accounts: only the ones unlocked in your provider in the network configuration.