### PR TITLE
Bug fix: Shim output from compileWithPragmaAnalysis

### DIFF
--- a/packages/compile-solidity/src/index.js
+++ b/packages/compile-solidity/src/index.js
@@ -186,9 +186,7 @@ const Compile = {
       paths,
       options
     });
-    return Compilations.promoteCompileResult({
-      compilations: compilationResult.compilations
-    });
+    return Compilations.promoteCompileResult(compilationResult);
   }
 };
 

--- a/packages/compile-solidity/src/index.js
+++ b/packages/compile-solidity/src/index.js
@@ -182,7 +182,13 @@ const Compile = {
   },
 
   async sourcesWithPragmaAnalysis({ paths, options }) {
-    return compileWithPragmaAnalysis({ paths, options });
+    const compilationResult = await compileWithPragmaAnalysis({
+      paths,
+      options
+    });
+    return Compilations.promoteCompileResult({
+      compilations: compilationResult.compilations
+    });
   }
 };
 


### PR DESCRIPTION
In [this commit](https://github.com/trufflesuite/truffle/commit/34e716be929f3a53e6e3b7bd83d245887e59f5a4) the compilation results were shimmed and converted to `WorkflowCompileResult`s. The output from `compileWithPragmaAnalysis` was accidentally left out. This PR shims that method as well.