### PR TITLE
Bug fix: Set exit code instead of calling process.exit

### DIFF
--- a/packages/core/cli.js
+++ b/packages/core/cli.js
@@ -56,7 +56,9 @@ if (userWantsGeneralHelp) {
 
 command
   .run(inputArguments, options)
-  .then(returnStatus => process.exit(returnStatus))
+  .then(returnStatus => {
+    returnStatus ? (process.exitCode = returnStatus) : (process.exitCode = 0);
+  })
   .catch(error => {
     if (error instanceof TaskError) {
       analytics.send({

--- a/packages/core/cli.js
+++ b/packages/core/cli.js
@@ -57,7 +57,9 @@ if (userWantsGeneralHelp) {
 command
   .run(inputArguments, options)
   .then(returnStatus => {
-    returnStatus ? (process.exitCode = returnStatus) : (process.exitCode = 0);
+    typeof returnStatus !== undefined
+      ? (process.exitCode = returnStatus)
+      : (process.exitCode = 0);
   })
   .catch(error => {
     if (error instanceof TaskError) {

--- a/packages/core/cli.js
+++ b/packages/core/cli.js
@@ -57,9 +57,7 @@ if (userWantsGeneralHelp) {
 command
   .run(inputArguments, options)
   .then(returnStatus => {
-    returnStatus !== undefined
-      ? (process.exitCode = returnStatus)
-      : (process.exitCode = 0);
+    returnStatus !== undefined ? process.exit(returnStatus) : process.exit();
   })
   .catch(error => {
     if (error instanceof TaskError) {
@@ -87,7 +85,7 @@ command
           : "(unbundled) " + versionInfo.core
       });
       // If a number is returned, exit with that number.
-      process.exitCode = error;
+      process.exit(error);
     } else {
       let errorData = error.stack || error.message || error.toString();
       //remove identifying information if error stack is passed to analytics
@@ -110,5 +108,5 @@ command
       console.log(error.stack || error.message || error.toString());
       version.logTruffleAndNode(options.logger);
     }
-    process.exitCode = 1;
+    process.exit(1);
   });

--- a/packages/core/cli.js
+++ b/packages/core/cli.js
@@ -87,7 +87,7 @@ command
           : "(unbundled) " + versionInfo.core
       });
       // If a number is returned, exit with that number.
-      process.exit(error);
+      process.exitCode = error;
     } else {
       let errorData = error.stack || error.message || error.toString();
       //remove identifying information if error stack is passed to analytics
@@ -110,5 +110,5 @@ command
       console.log(error.stack || error.message || error.toString());
       version.logTruffleAndNode(options.logger);
     }
-    process.exit(1);
+    process.exitCode = 1;
   });

--- a/packages/core/cli.js
+++ b/packages/core/cli.js
@@ -57,7 +57,7 @@ if (userWantsGeneralHelp) {
 command
   .run(inputArguments, options)
   .then(returnStatus => {
-    typeof returnStatus !== undefined
+    returnStatus !== undefined
       ? (process.exitCode = returnStatus)
       : (process.exitCode = 0);
   })

--- a/packages/core/lib/commands/compile/run.js
+++ b/packages/core/lib/commands/compile/run.js
@@ -39,7 +39,6 @@ module.exports = async function (options) {
   if (config.db && config.db.enabled) {
     await WorkflowCompile.assignNames(config, result);
   }
-  return result;
 };
 
 const listVersions = async function (options) {


### PR DESCRIPTION
According to Node, it is perhaps preferable to set the exit code and "exit gracefully" rather than calling `process.exit`. See [this article](https://nodejs.dev/learn/how-to-exit-from-a-nodejs-program).

Also, command `run` functions probably should not return anything unless they explicitly want to return an exit code.

**Update:** For whatever reason setting `process.exitCode` causes a lot of tests to fail. I subtracted that change from this PR and left it calling `process.exit`.