### PR TITLE
Enhancement: Put events in txlog (txlog part 2)

### DIFF
--- a/packages/codec/lib/abi-data/allocate/index.ts
+++ b/packages/codec/lib/abi-data/allocate/index.ts
@@ -1306,6 +1306,10 @@ function getEventAllocationsForContract(
   compilationId: string,
   compiler: Compiler.CompilerVersion | undefined
 ): EventAllocationTemporary[] {
+  if (!abi) {
+    //can't do much if no ABI!
+    return [];
+  }
   return abi
     .filter((abiEntry: Abi.Entry) => abiEntry.type === "event")
     .filter(

--- a/packages/codec/lib/export.ts
+++ b/packages/codec/lib/export.ts
@@ -15,10 +15,16 @@ import * as Conversion from "@truffle/codec/conversion";
 import {
   ResultInspector,
   unsafeNativize,
+  unsafeNativizeVariables,
   InspectOptions,
   nativizeAccessList
 } from "@truffle/codec/format/utils/inspect";
-export { ResultInspector, unsafeNativize, nativizeAccessList };
+export {
+  ResultInspector,
+  unsafeNativize,
+  unsafeNativizeVariables,
+  nativizeAccessList
+};
 
 type NumberFormatter = (n: BigInt) => any; //not parameterized since we output any anyway
 

--- a/packages/debugger/lib/data/actions/index.js
+++ b/packages/debugger/lib/data/actions/index.js
@@ -71,7 +71,15 @@ export function defineTaggedOutput(node, sourceId) {
 }
 
 export const ALLOCATE = "DATA_ALLOCATE";
-export function allocate(storage, memory, abi, calldata, returndata, state) {
+export function allocate(
+  storage,
+  memory,
+  abi,
+  calldata,
+  returndata,
+  event,
+  state
+) {
   return {
     type: ALLOCATE,
     storage,
@@ -79,6 +87,7 @@ export function allocate(storage, memory, abi, calldata, returndata, state) {
     abi,
     calldata,
     returndata,
+    event,
     state
   };
 }

--- a/packages/debugger/lib/data/actions/index.js
+++ b/packages/debugger/lib/data/actions/index.js
@@ -70,6 +70,14 @@ export function defineTaggedOutput(node, sourceId) {
   };
 }
 
+export const ADD_CONTRACTS = "DATA_ADD_CONTRACTS";
+export function addContracts(contracts) {
+  return {
+    type: ADD_CONTRACTS,
+    contracts
+  };
+}
+
 export const ALLOCATE = "DATA_ALLOCATE";
 export function allocate(
   storage,

--- a/packages/debugger/lib/data/reducers.js
+++ b/packages/debugger/lib/data/reducers.js
@@ -99,6 +99,7 @@ const DEFAULT_ALLOCATIONS = {
   abi: {},
   calldata: {},
   returndata: {},
+  event: {},
   state: {}
 };
 
@@ -111,6 +112,7 @@ function allocations(state = DEFAULT_ALLOCATIONS, action) {
       abi: action.abi,
       calldata: action.calldata,
       returndata: action.returndata,
+      event: action.event,
       state: action.state
     };
   } else {
@@ -256,10 +258,9 @@ function mappedPaths(state = DEFAULT_PATHS, action) {
           //parent!
           newSlot = {
             ...slot,
-            path:
-              newState.byAddress[address].byType[parentType].bySlotAddress[
-                parentAddress
-              ]
+            path: newState.byAddress[address].byType[parentType].bySlotAddress[
+              parentAddress
+            ]
           };
         } else {
           newSlot = slot;

--- a/packages/debugger/lib/data/reducers.js
+++ b/packages/debugger/lib/data/reducers.js
@@ -120,8 +120,37 @@ function allocations(state = DEFAULT_ALLOCATIONS, action) {
   }
 }
 
+const DEFAULT_CONTRACTS = {
+  byCompilationId: {}
+};
+
+function contracts(state = DEFAULT_CONTRACTS, action) {
+  if (action.type === actions.ADD_CONTRACTS) {
+    //NOTE: this code assumes that we are only ever adding compilations
+    //wholesale, and never adding to existing ones!
+    return {
+      byCompilationId: {
+        ...state.byCompilationId,
+        ...Object.assign(
+          {},
+          ...Object.entries(action.contracts).map(
+            ([compilationId, compilation]) => ({
+              [compilationId]: {
+                byAstId: compilation
+              }
+            })
+          )
+        )
+      }
+    };
+  } else {
+    return state;
+  }
+}
+
 const info = combineReducers({
   scopes,
+  contracts,
   userDefinedTypes,
   taggedOutputs,
   allocations

--- a/packages/debugger/lib/data/sagas/index.js
+++ b/packages/debugger/lib/data/sagas/index.js
@@ -1333,7 +1333,8 @@ export function* recordAllocations() {
     contracts,
     referenceDeclarations,
     userDefinedTypes,
-    abiAllocations
+    abiAllocations,
+    true //signals that we are allowing events from constructors
   );
   const stateAllocations = Codec.Storage.Allocate.getStateAllocations(
     contracts,

--- a/packages/debugger/lib/data/sagas/index.js
+++ b/packages/debugger/lib/data/sagas/index.js
@@ -1355,6 +1355,10 @@ export function* recordAllocations() {
   );
 }
 
+export function* addContracts(contracts) {
+  yield put(actions.addContracts(contracts));
+}
+
 export function* saga() {
   yield takeEvery(TICK, tickSaga);
 }

--- a/packages/debugger/lib/data/selectors/index.js
+++ b/packages/debugger/lib/data/selectors/index.js
@@ -419,7 +419,7 @@ const data = createSelectorTree({
       Object.assign(
         {},
         ...Object.values(contexts).map(context => ({
-          [context.contractId]: debuggerContextToDecoderContext(context)
+          [context.context]: debuggerContextToDecoderContext(context)
         }))
       )
     )

--- a/packages/debugger/lib/data/selectors/index.js
+++ b/packages/debugger/lib/data/selectors/index.js
@@ -409,20 +409,18 @@ const data = createSelectorTree({
     /*
      * data.views.contexts
      * same as evm.info.contexts, but:
-     * 0. we only include non-constructor contexts
-     * 1. we strip out sourceMap and primarySource
-     * 2. we alter abi in two ways:
+     * 1. we strip out fields irrelevant to codec
+     * 2. we alter abi in a few ways ways:
      * 2a. we strip out everything but functions
      * 2b. abi is now an object, not an array, and indexed by these signatures
+     * 2c. fallback/receive stuff instead goes in the fallbackAbi field
      */
     contexts: createLeaf([evm.info.contexts], contexts =>
       Object.assign(
         {},
-        ...Object.values(contexts)
-          .filter(context => !context.isConstructor)
-          .map(context => ({
-            [context.contractId]: debuggerContextToDecoderContext(context)
-          }))
+        ...Object.values(contexts).map(context => ({
+          [context.contractId]: debuggerContextToDecoderContext(context)
+        }))
       )
     )
   },

--- a/packages/debugger/lib/data/selectors/index.js
+++ b/packages/debugger/lib/data/selectors/index.js
@@ -1135,7 +1135,7 @@ const data = createSelectorTree({
     eventId: createLeaf(
       ["./node", "./compilationId"],
       (eventNode, compilationId) => {
-        if (eventNode === null) {
+        if (!eventNode) {
           return undefined;
         }
         switch (eventNode.nodeType) {

--- a/packages/debugger/lib/session/actions/index.js
+++ b/packages/debugger/lib/session/actions/index.js
@@ -50,11 +50,12 @@ export function error(error) {
 }
 
 export const RECORD_CONTRACTS = "SESSION_RECORD_CONTRACTS";
-export function recordContracts(contexts, sources) {
+export function recordContracts(contexts, sources, contracts) {
   return {
     type: RECORD_CONTRACTS,
     contexts,
-    sources
+    sources,
+    contracts
   };
 }
 
@@ -98,10 +99,11 @@ export function startFullMode() {
 }
 
 export const ADD_COMPILATIONS = "SESSION_ADD_COMPILATIONS";
-export function addCompilations(sources, contexts) {
+export function addCompilations(sources, contexts, contracts) {
   return {
     type: ADD_COMPILATIONS,
     sources,
-    contexts
+    contexts,
+    contracts
   };
 }

--- a/packages/debugger/lib/txlog/actions/index.js
+++ b/packages/debugger/lib/txlog/actions/index.js
@@ -180,6 +180,16 @@ export function identifyFunctionCall(
   };
 }
 
+export const LOG_EVENT = "TXLOG_LOG_EVENT";
+export function logEvent(pointer, newPointer, decoding) {
+  return {
+    type: LOG_EVENT,
+    pointer,
+    newPointer, //does not actually affect current pointer!
+    decoding
+  };
+}
+
 export const RECORD_ORIGIN = "TXLOG_RECORD_ORIGIN";
 export function recordOrigin(pointer, address) {
   return {

--- a/packages/debugger/lib/txlog/reducers.js
+++ b/packages/debugger/lib/txlog/reducers.js
@@ -40,6 +40,22 @@ function transactionLog(state = DEFAULT_TX_LOG, action) {
         debug("attempt to set origin of bad node type!");
         return state;
       }
+
+    case actions.LOG_EVENT:
+      return {
+        byPointer: {
+          ...state.byPointer,
+          [pointer]: {
+            ...node,
+            actions: [...node.actions, newPointer]
+          },
+          [newPointer]: {
+            type: "event",
+            decoding: action.decoding
+          }
+        }
+      };
+
     case actions.INTERNAL_CALL:
       return {
         byPointer: {
@@ -353,6 +369,7 @@ function currentNodePointer(state = "", action) {
     case actions.UNLOAD_TRANSACTION:
       return "";
     default:
+      //includes events
       return state;
   }
 }
@@ -373,6 +390,7 @@ function pointerStack(state = [], action) {
     case actions.UNLOAD_TRANSACTION:
       return [];
     default:
+      //includes events
       return state;
   }
 }

--- a/packages/debugger/lib/txlog/selectors/index.js
+++ b/packages/debugger/lib/txlog/selectors/index.js
@@ -141,10 +141,10 @@ let txlog = createSelectorTree({
     ),
 
     /**
-     * txlog.current.nextCallPointer
-     * the pointer where a new call will be added
+     * txlog.current.nextActionPointer
+     * the pointer where a new action will be added
      */
-    nextCallPointer: createLeaf(
+    nextActionPointer: createLeaf(
       ["./pointer", "./node"],
       (pointer, node) => `${pointer}/actions/${node.actions.length}`
     ),
@@ -250,6 +250,11 @@ let txlog = createSelectorTree({
      * txlog.current.jumpDirection
      */
     jumpDirection: createLeaf([sourcemapping.current.jumpDirection], identity),
+
+    /**
+     * txlog.current.isLog
+     */
+    isLog: createLeaf([evm.current.step.isLog], identity),
 
     /**
      * txlog.current.isCall

--- a/packages/debugger/test/txlog.js
+++ b/packages/debugger/test/txlog.js
@@ -508,6 +508,9 @@ describe("Transaction log (visualizer)", function () {
 
       await bugger.runToEnd();
 
+      const untied = bugger.view(txlog.proc.transactionLog);
+      verifyNoIntermediates(untied);
+
       const root = bugger.view(txlog.views.transactionLog);
       assert.equal(root.type, "transaction");
       assert.lengthOf(root.actions, 1);
@@ -565,6 +568,9 @@ describe("Transaction log (visualizer)", function () {
 
       await bugger.runToEnd();
 
+      const untied = bugger.view(txlog.proc.transactionLog);
+      verifyNoIntermediates(untied);
+
       const root = bugger.view(txlog.views.transactionLog);
       assert.equal(root.type, "transaction");
       assert.lengthOf(root.actions, 1);
@@ -608,6 +614,9 @@ describe("Transaction log (visualizer)", function () {
       });
 
       await bugger.runToEnd();
+
+      const untied = bugger.view(txlog.proc.transactionLog);
+      verifyNoIntermediates(untied);
 
       const root = bugger.view(txlog.views.transactionLog);
       assert.equal(root.type, "transaction");
@@ -653,6 +662,9 @@ describe("Transaction log (visualizer)", function () {
       });
 
       await bugger.runToEnd();
+
+      const untied = bugger.view(txlog.proc.transactionLog);
+      verifyNoIntermediates(untied);
 
       const root = bugger.view(txlog.views.transactionLog);
       assert.equal(root.type, "transaction");

--- a/packages/debugger/test/txlog.js
+++ b/packages/debugger/test/txlog.js
@@ -19,6 +19,9 @@ contract VizTest {
 
   event Dummy();
 
+  event TakesArgs(uint indexed x, uint y);
+  event Confusing(uint a, bytes32 indexed b, uint c);
+
   function testCall(uint x) public returns (uint y) {
     return called(x);
   }
@@ -49,6 +52,15 @@ contract VizTest {
     revert("Oops!");
   }
 
+  function testEvent() public {
+    emit TakesArgs(1, 2);
+  }
+
+  function testConfusing() public {
+    emit Confusing(1, hex"deadbeef", 3);
+    VizLibrary.confuse();
+  }
+
   constructor() payable {
   }
 }
@@ -56,12 +68,14 @@ contract VizTest {
 contract Secondary {
 
   event Dummy();
+  event Set(uint);
 
   uint immutable x = another();
   uint immutable w;
 
   constructor(uint y) {
     w = y;
+    emit Set(y);
   }
 
   function another() public returns (uint z) {
@@ -76,10 +90,15 @@ contract Secondary {
 
 library VizLibrary {
   event Noise();
+  event Confusing(uint x, bytes32 y, uint indexed z);
 
   function loudIncrement(uint x) external returns (uint y) {
     emit Noise();
     return x + 1;
+  }
+
+  function confuse() internal {
+    emit Confusing(4, hex"deadf00f", 6);
   }
 }
 `;
@@ -175,14 +194,12 @@ describe("Transaction log (visualizer)", function () {
     assert.equal(call.contractName, "VizTest");
     assert.equal(call.returnKind, "return");
     debug("arguments: %O", call.arguments);
-    let inputs = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
-      byName(call.arguments)
-    );
+    let inputs = Codec.Export.unsafeNativizeVariables(byName(call.arguments));
     debug("nativized: %O", inputs);
     assert.deepEqual(inputs, {
       x: 108
     });
-    let outputs = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
+    let outputs = Codec.Export.unsafeNativizeVariables(
       byName(call.returnValues)
     );
     assert.deepEqual(outputs, {
@@ -194,15 +211,11 @@ describe("Transaction log (visualizer)", function () {
     assert.equal(call.functionName, "called");
     assert.equal(call.contractName, "VizTest");
     assert.equal(call.returnKind, "return");
-    inputs = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
-      byName(call.arguments)
-    );
+    inputs = Codec.Export.unsafeNativizeVariables(byName(call.arguments));
     assert.deepEqual(inputs, {
       x: 108
     });
-    outputs = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
-      byName(call.returnValues)
-    );
+    outputs = Codec.Export.unsafeNativizeVariables(byName(call.returnValues));
     assert.deepEqual(outputs, {
       y: 109
     });
@@ -233,30 +246,26 @@ describe("Transaction log (visualizer)", function () {
     assert.isUndefined(call.functionName);
     assert.equal(call.contractName, "Secondary");
     assert.equal(call.returnKind, "return");
-    let inputs = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
-      byName(call.arguments)
-    );
+    let inputs = Codec.Export.unsafeNativizeVariables(byName(call.arguments));
     assert.deepEqual(inputs, {
       y: 108
     });
     debug("immuts: %O", call.returnImmutables);
-    let outputs = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
+    let outputs = Codec.Export.unsafeNativizeVariables(
       byName(call.returnImmutables)
     );
     assert.deepEqual(outputs, {
       x: 2,
       w: 108
     });
-    assert.lengthOf(call.actions, 1);
+    assert.lengthOf(call.actions, 2); //call to another, then log of Set
     call = call.actions[0];
     assert.equal(call.type, "callinternal");
     assert.equal(call.functionName, "another");
     assert.equal(call.contractName, "Secondary");
     assert.equal(call.returnKind, "return");
     assert.lengthOf(call.arguments, 0);
-    outputs = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
-      byName(call.returnValues)
-    );
+    outputs = Codec.Export.unsafeNativizeVariables(byName(call.returnValues));
     assert.include(outputs, {
       z: 2
     });
@@ -300,13 +309,11 @@ describe("Transaction log (visualizer)", function () {
     assert.equal(call.functionName, "loudIncrement");
     assert.equal(call.contractName, "VizLibrary");
     assert.equal(call.returnKind, "return");
-    let inputs = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
-      byName(call.arguments)
-    );
+    let inputs = Codec.Export.unsafeNativizeVariables(byName(call.arguments));
     assert.deepEqual(inputs, {
       x: 1
     });
-    let outputs = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
+    let outputs = Codec.Export.unsafeNativizeVariables(
       byName(call.returnValues)
     );
     assert.deepEqual(outputs, {
@@ -385,13 +392,11 @@ describe("Transaction log (visualizer)", function () {
     assert.equal(call.functionName, "called");
     assert.equal(call.contractName, "VizTest");
     assert.equal(call.returnKind, "return");
-    let inputs = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
-      byName(call.arguments)
-    );
+    let inputs = Codec.Export.unsafeNativizeVariables(byName(call.arguments));
     assert.deepEqual(inputs, {
       x: 4
     });
-    let outputs = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
+    let outputs = Codec.Export.unsafeNativizeVariables(
       byName(call.returnValues)
     );
     assert.deepEqual(outputs, {
@@ -444,7 +449,7 @@ describe("Transaction log (visualizer)", function () {
     assert.equal(call.error.kind, "revert");
     assert.lengthOf(call.error.arguments, 1);
     assert.equal(
-      Codec.Format.Utils.Inspect.unsafeNativize(call.error.arguments[0].value),
+      Codec.Export.unsafeNativize(call.error.arguments[0].value),
       "Oops!"
     );
   });
@@ -474,9 +479,7 @@ describe("Transaction log (visualizer)", function () {
     assert.equal(call.functionName, "testCall");
     assert.equal(call.contractName, "VizTest");
     assert.notProperty(call, "returnKind");
-    let inputs = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
-      byName(call.arguments)
-    );
+    let inputs = Codec.Export.unsafeNativizeVariables(byName(call.arguments));
     assert.deepEqual(inputs, {
       x: 108
     });
@@ -484,5 +487,211 @@ describe("Transaction log (visualizer)", function () {
     assert.lengthOf(call.actions, 0);
     assert.isTrue(call.waitingForFunctionDefinition);
     assert.isTrue(call.absorbNextInternalCall);
+  });
+
+  describe("Events", function () {
+    it("Correctly logs an event", async function () {
+      this.timeout(12000);
+      const instance = await abstractions.VizTest.deployed();
+      const receipt = await instance.testEvent();
+      const txHash = receipt.tx;
+
+      const bugger = await Debugger.forTx(txHash, {
+        provider,
+        compilations
+      });
+
+      await bugger.runToEnd();
+
+      const root = bugger.view(txlog.views.transactionLog);
+      assert.equal(root.type, "transaction");
+      assert.lengthOf(root.actions, 1);
+      const call = root.actions[0];
+      //basic checks about the call itself
+      assert.equal(call.type, "callexternal");
+      assert.equal(call.kind, "function");
+      assert.equal(call.address, instance.address);
+      assert.equal(call.functionName, "testEvent");
+      assert.equal(call.contractName, "VizTest");
+      assert.lengthOf(call.actions, 1);
+      const event = call.actions[0];
+      assert.equal(event.type, "event");
+      const decoding = event.decoding;
+      assert.equal(decoding.kind, "event");
+      assert.equal(decoding.decodingMode, "full");
+      assert.equal(decoding.class.typeName, "VizTest");
+      assert.equal(decoding.definedIn.typeName, "VizTest");
+      assert.equal(decoding.abi.name, "TakesArgs");
+      assert.lengthOf(decoding.abi.inputs, 2);
+      assert.equal(decoding.abi.inputs[0].type, "uint256");
+      assert.equal(decoding.abi.inputs[1].type, "uint256");
+      assert.lengthOf(decoding.arguments, 2);
+      assert.isTrue(decoding.arguments[0].indexed);
+      assert.equal(decoding.arguments[0].name, "x");
+      assert.isFalse(decoding.arguments[1].indexed);
+      assert.equal(decoding.arguments[1].name, "y");
+      const args = Codec.Export.unsafeNativizeVariables(
+        byName(decoding.arguments)
+      );
+      assert.deepEqual(args, { x: 1, y: 2 });
+    });
+
+    it("Correctly logs an event inside a constructor", async function () {
+      this.timeout(12000);
+      const instance = await abstractions.Secondary.new(683);
+      const txHash = instance.transactionHash;
+
+      const bugger = await Debugger.forTx(txHash, {
+        provider,
+        compilations
+      });
+
+      await bugger.runToEnd();
+
+      const root = bugger.view(txlog.views.transactionLog);
+      assert.equal(root.type, "transaction");
+      assert.lengthOf(root.actions, 1);
+      const call = root.actions[0];
+      //basic checks about the call itself
+      assert.equal(call.type, "callexternal");
+      assert.equal(call.kind, "constructor");
+      assert.equal(call.address, instance.address);
+      assert.isUndefined(call.functionName);
+      assert.equal(call.contractName, "Secondary");
+      assert.lengthOf(call.actions, 2); //call to another, then log of Set
+      const event = call.actions[1];
+      assert.equal(event.type, "event");
+      const decoding = event.decoding;
+      assert.equal(decoding.kind, "event");
+      assert.equal(decoding.decodingMode, "full");
+      assert.equal(decoding.class.typeName, "Secondary");
+      assert.equal(decoding.definedIn.typeName, "Secondary");
+      assert.equal(decoding.abi.name, "Set");
+      assert.lengthOf(decoding.abi.inputs, 1);
+      assert.equal(decoding.abi.inputs[0].type, "uint256");
+      assert.lengthOf(decoding.arguments, 1);
+      assert.isFalse(decoding.arguments[0].indexed);
+      assert.isUndefined(decoding.arguments[0].name);
+      assert.equal(
+        Codec.Export.unsafeNativize(decoding.arguments[0].value),
+        683
+      );
+    });
+
+    it("Correctly logs an event inside a library", async function () {
+      this.timeout(12000);
+      const instance = await abstractions.VizTest.deployed();
+      const library = await abstractions.VizLibrary.deployed();
+      const receipt = await instance.testLibrary();
+      const txHash = receipt.tx;
+
+      const bugger = await Debugger.forTx(txHash, {
+        provider,
+        compilations
+      });
+
+      await bugger.runToEnd();
+
+      const root = bugger.view(txlog.views.transactionLog);
+      assert.equal(root.type, "transaction");
+      assert.lengthOf(root.actions, 1);
+      const call = root.actions[0];
+      //basic checks about the outer call
+      assert.equal(call.type, "callexternal");
+      assert.equal(call.kind, "function");
+      assert.equal(call.address, instance.address);
+      assert.equal(call.functionName, "testLibrary");
+      assert.equal(call.contractName, "VizTest");
+      assert.lengthOf(call.actions, 1);
+      const libCall = call.actions[0];
+      //basic checks about the inner call
+      assert.equal(libCall.type, "callexternal");
+      assert.equal(libCall.kind, "function");
+      assert.equal(libCall.address, library.address);
+      assert.isTrue(libCall.isDelegate);
+      assert.equal(libCall.functionName, "loudIncrement");
+      assert.equal(libCall.contractName, "VizLibrary");
+      assert.lengthOf(libCall.actions, 1);
+      const event = libCall.actions[0];
+      assert.equal(event.type, "event");
+      const decoding = event.decoding;
+      assert.equal(decoding.kind, "event");
+      assert.equal(decoding.decodingMode, "full");
+      assert.equal(decoding.class.typeName, "VizLibrary");
+      assert.equal(decoding.definedIn.typeName, "VizLibrary");
+      assert.equal(decoding.abi.name, "Noise");
+      assert.lengthOf(decoding.abi.inputs, 0);
+      assert.lengthOf(decoding.arguments, 0);
+    });
+
+    it("Correctly disambiguates ambiguous events", async function () {
+      this.timeout(12000);
+      const instance = await abstractions.VizTest.deployed();
+      const receipt = await instance.testConfusing();
+      const txHash = receipt.tx;
+
+      const bugger = await Debugger.forTx(txHash, {
+        provider,
+        compilations
+      });
+
+      await bugger.runToEnd();
+
+      const root = bugger.view(txlog.views.transactionLog);
+      assert.equal(root.type, "transaction");
+      assert.lengthOf(root.actions, 1);
+      const call = root.actions[0];
+      //basic checks about the outer call
+      assert.equal(call.type, "callexternal");
+      assert.equal(call.kind, "function");
+      assert.equal(call.address, instance.address);
+      assert.equal(call.functionName, "testConfusing");
+      assert.equal(call.contractName, "VizTest");
+      assert.lengthOf(call.actions, 2);
+      let event = call.actions[0];
+      //checks about first event
+      assert.equal(event.type, "event");
+      let decoding = event.decoding;
+      assert.equal(decoding.kind, "event");
+      assert.equal(decoding.decodingMode, "full");
+      assert.equal(decoding.class.typeName, "VizTest");
+      assert.equal(decoding.definedIn.typeName, "VizTest");
+      assert.equal(decoding.abi.name, "Confusing");
+      assert.lengthOf(decoding.abi.inputs, 3);
+      assert.isTrue(decoding.abi.inputs[1].indexed);
+      assert.lengthOf(decoding.arguments, 3);
+      let args = Codec.Export.unsafeNativizeVariables(
+        byName(decoding.arguments)
+      );
+      assert.deepEqual(args, {
+        a: 1,
+        b: "0xdeadbeef00000000000000000000000000000000000000000000000000000000",
+        c: 3
+      });
+      const libCall = call.actions[1];
+      //basic checks about the inner call
+      assert.equal(libCall.type, "callinternal");
+      assert.equal(libCall.functionName, "confuse");
+      assert.equal(libCall.contractName, "VizLibrary");
+      assert.lengthOf(libCall.actions, 1);
+      event = libCall.actions[0];
+      //checks about second event
+      assert.equal(event.type, "event");
+      decoding = event.decoding;
+      assert.equal(decoding.kind, "event");
+      assert.equal(decoding.decodingMode, "full");
+      assert.equal(decoding.class.typeName, "VizLibrary");
+      assert.equal(decoding.definedIn.typeName, "VizLibrary");
+      assert.equal(decoding.abi.name, "Confusing");
+      assert.lengthOf(decoding.abi.inputs, 3);
+      assert.isTrue(decoding.abi.inputs[2].indexed);
+      assert.lengthOf(decoding.arguments, 3);
+      args = Codec.Export.unsafeNativizeVariables(byName(decoding.arguments));
+      assert.deepEqual(args, {
+        x: 4,
+        y: "0xdeadf00f00000000000000000000000000000000000000000000000000000000",
+        z: 6
+      });
+    });
   });
 });


### PR DESCRIPTION
Addresses #3824.  (Well, the first part of it -- probably best to close the issue once this is released, and I'll make a second issue for the second part of it, i.e., the flattened log and the CLI command to show it.)

This PR adds events to the txlog.  Specifically, it creates a new type of action, type `"event"`.  This new type of action does not itself have an `actions` subfield, note, because it doesn't represent any sort of call, that might have subactions; it simply represents the logging of an event, something that cannot have subactions.

In fact, this new type of action has only one subfield other than `type`, which is `decoding`, a `LogDecoding` as output by Truffle Codec.  All txlog information about the event is found in here.  (We don't explicitly record the event's address or anything like that, because, well, we have the entire tree structure of the txlog; that just isn't necessary.)

So, how does this work, then?

Well, first off, I added a `decodeLog` saga in the data sagas, similar to `decodeReturnValue` and other similar functions.  This saga invokes Codec's `decodeEvent` functionality to decode an event being emitted on the current step.  There are a few things worth noting here:

1. The actual information to be decoded is passed in as part of `state`; I added new selectors `data.current.state.eventdata` and `data.current.state.eventtopics`.  This is a bit implicit, but it's similar to how the other similar sagas work, and I put comments on it.  These two selectors themselves are based on new selectors in the `evm` submodule.  The one for getting the event data looks at the top two arguments on the stack and then extracts the data from memory; the one for getting the event topics gets the count of topics from the name of the current opcode (`LOG0` has 0 topics, `LOG1` has 1 topic, etc), and then gets them off of the stack.
2. We pass the `id` option.  Because we have the full power of the debugger here, we don't have to decode the event based only on the things the decoder would know (who emitted it and what it contains); instead we can look at where *in the source code* it was emitted.  This gives us an ID (determined in the selector `data.current.eventId`, similar to the already-existing `data.current.errorId`), and we can pass this to Codec to tell it that we're looking for an event with that specific ID.  If it successfully decodes the event as that, great!  Only that decoding will be returned; others will be ignored.  If however we can't determine the ID, or the ID doesn't work, then the ID passed in will be ignored and we'll get back a list of interpretations, of which there may be more than one, as usual.  (Of course, if the event isn't ambiguous in the first place, then none of this is relevant!)
3. We pass `null` for the address.  This is a new capability I just added to Codec's `decodeEvent` function.  See, normally `decodeEvent` will attempt to determine what context emitted the event based on the address passed in.  But in our case, we already know what context emitted the event!  So I made it so that if you pass `null` for the address, the context-determination logic will be bypassed, in favor of using the context passed in for `currentContext`.
4. Speaking of which -- it turns out that `data.views.contexts` contained a nasty bug... it was indexing the contexts by contract ID instead of context hash!  I presume that I did this for a reason, but nothing relies on this behavior, so I changed it.  This never came up before because there's only one place that Codec ever directly indexes into `contexts`, and that's in `decodeEvent`, a function that the debugger never used previously!
5. The other change to `data.views.contexts`, though, is that it now includes both constructor and deployed contexts.  Events can be emitted from constructors, after all, so Codec had better be informed about those!

So, that's the new `decodeLog` saga.  But, obviously, this saga does nothing by itself!  The `txlog` saga has been updated to look for `LOG` instructions (there's an `evm` selector for that, obviously) and invoke `decodeLog` when this occurs, then put an `event` action in the txlog.  This is mostly pretty straightforward and similar to other cases in `txlog`, but there are a few things worth noting:
1. I renamed `txlog.current.nextCallPointer` to `txlog.current.nextActionPointer`, since the next action need not be a call any longer.
2. You'll notice that `newPointer` is used, even though the txlog pointer is not updated; it's used to determine where to create the new event.  This is basically how all new action types, that are not calls or returns and which do not have subactions, will work.  Events are basically the first instance of the "generic case".
3. You'll notice that if there are multiple possible decodings, we just grab the first, similarly to how we handle errors.  I'm pretty sure we decided a while back that it's OK if `txlog` only gives one decoding for each event, similar to how it does errors?  Of course, events aren't often ambiguous anyway, and when they are, the use of the `id` option will often disambiguate (although optimization may cause that to fail).  I think this is probably fine, though?

I also added tests of the new functionality, of course.

But, OK, there's one more thing I need to discuss.  And that's event allocation.  Yes, the already complicated event allocation logic just got even more complicated.  See, previously, events only ever needed to be associated to deployed contexts, but now we need to know about them for constructor contexts as well.  Oh boy!

In order to accomplish this, I made three changes to `getEventAllocations`.  (All changes were to that function, the outermost level; no changes were made to any of the functions it calls, such as `getEventAllocationsForContract`.)  The first is that now, instead of it using deployed context hash as the primary key if it exists and compilation-ID-and-AST-ID otherwise, it now checks deployed context hash, then constructor context hash, and only then falls back on compilation ID and AST ID.  (Also, it now only skips a contract if it lacks all three of those, rather than if it lacks a deployed context and an AST node.)

The second is that there's a new flag (turned off by default), `allowConstructorEvents`.  Only the debugger passes this; the decoder doesn't.

The third change is that, if a contract has both a deployed context and a constructor context, I set up a "swap map" that associates the two.  Then, at the end, when I assign event allocations to contexts, if the `allowConstructorEvents` flag is set, and the contract is not a library, I not only assign it to the context in the allocation, but also its paired one in the swap map.

Why the library restriction, and why the flag?  Well, the thing is that library events are always considered regardless of context, so if we put it in there *twice*, it will appear twice in the decodings.  We don't want that!  There are potentially various ways to fix this, but I figured the simplest was to just turn this mechanism off for libraries.  After all, library constructors don't emit events!

OK, but why the flag?  Because even without libraries, we'd get the same problem if you decoded events with extras turned on!  Again, there are various ways to approach this problem, but a flag seemed the simplest... the debugger can pass this flag, since it has no need for extras, while the decoder, which does need to handle the case of extras, can leave it turned off.  Maybe a bit ugly, but it works.

Sorry, I realize all the event allocation logic is a bit confusing, but I'm hoping this all makes sense!

But with all that, well, we now have events in the txlog!  Not in the CLI yet though, that'll be a separate PR. :)

While I was at it, btw, I made some other internal improvements:
1. I reordered the functions in the data sagas; the current order was a mess and made it difficult to find anything.
2. I had `Codec.Export` import and re-export `unsafeNativizeVariables`; there was no reason to exclude this earlier, I just forgot about it.
3. I added a check to `data.current.errorId`, parallel to the check I put in `data.current.eventId`.