### PR TITLE
events: better encapsulation of --quiet flag logic

### DIFF
--- a/packages/events/defaultSubscribers/compile.js
+++ b/packages/events/defaultSubscribers/compile.js
@@ -1,20 +1,16 @@
 const OS = require("os");
 
 module.exports = {
-  initialization: function () {
-    this.logger = console;
-  },
+  initialization: function () {},
   handlers: {
     "compile:start": [
       function () {
-        if (this.quiet) return;
         this.logger.log(OS.EOL + `Compiling your contracts...`);
         this.logger.log(`===========================`);
       }
     ],
     "compile:succeed": [
       function ({ contractsBuildDirectory, compilers }) {
-        if (this.quiet) return;
         if (compilers.length > 0) {
           this.logger.log(`> Artifacts written to ${contractsBuildDirectory}`);
           this.logger.log(`> Compiled successfully using:`);
@@ -39,8 +35,9 @@ module.exports = {
     ],
     "compile:sourcesToCompile": [
       function ({ sourceFileNames }) {
-        if (this.quiet) return;
-        if (!sourceFileNames) return;
+        if (!sourceFileNames) {
+          return;
+        }
         sourceFileNames.forEach(sourceFileName =>
           this.logger.log("> Compiling " + sourceFileName)
         );
@@ -48,21 +45,18 @@ module.exports = {
     ],
     "compile:warnings": [
       function ({ warnings }) {
-        if (this.quiet) return;
         this.logger.log("> Compilation warnings encountered:");
         this.logger.log(`${OS.EOL}    ${warnings.join()}`);
       }
     ],
     "compile:infos": [
       function ({ infos }) {
-        if (this.quiet) return;
         this.logger.log("> Compilation notices encountered:");
         this.logger.log(`${OS.EOL}    ${infos.join()}`);
       }
     ],
     "compile:nothingToCompile": [
       function () {
-        if (this.quiet) return;
         this.logger.log(
           `> Everything is up to date, there is nothing to compile.`
         );
@@ -70,7 +64,6 @@ module.exports = {
     ],
     "compile:skipped": [
       function () {
-        if (this.quiet) return;
         this.logger.log(
           `> Compilation skipped because --compile-none option was passed.`
         );

--- a/packages/events/defaultSubscribers/init.js
+++ b/packages/events/defaultSubscribers/init.js
@@ -1,9 +1,7 @@
 const OS = require("os");
 
 module.exports = {
-  initialization: function () {
-    this.logger = console;
-  },
+  initialization: function () {},
   handlers: {
     "init:start": [
       function () {

--- a/packages/events/defaultSubscribers/migrate/Messages.js
+++ b/packages/events/defaultSubscribers/migrate/Messages.js
@@ -226,10 +226,11 @@ class Messages {
 
         let output = "";
 
-        if (!reporter.subscriber.config.dryRun)
+        if (!reporter.subscriber.config.dryRun) {
           output += `   > ${"contract address:".padEnd(20)} ${
             data.receipt.contractAddress
           }\n`;
+        }
 
         output += `   > ${"block number:".padEnd(20)} ${
           data.receipt.blockNumber
@@ -248,10 +249,11 @@ class Messages {
         if (
           reporter.subscriber.config.confirmations !== undefined &&
           reporter.subscriber.config.confirmations !== 0
-        )
+        ) {
           output += self.underline(
             `Pausing for ${reporter.subscriber.config.confirmations} confirmations...\n`
           );
+        }
 
         if (reporter.subscriber.config.describeJson) {
           output += self.migrationStatus({
@@ -275,7 +277,9 @@ class Messages {
 
       // Transactions
       endTransaction: () => {
-        if (reporter.blockSpinner) reporter.blockSpinner.stop();
+        if (reporter.blockSpinner) {
+          reporter.blockSpinner.stop();
+        }
         return `   > ${data.message}`;
       },
 
@@ -285,8 +289,9 @@ class Messages {
           self.underline(`Linking`) +
           `\n   * Contract: ${data.contractName} <--> Library: ${data.libraryName} `;
 
-        if (!reporter.subscriber.config.dryRun)
+        if (!reporter.subscriber.config.dryRun) {
           output += `(at address: ${data.libraryAddress})`;
+        }
 
         return output;
       },
@@ -369,8 +374,9 @@ class Messages {
         let deployments =
           self.reporter.summary[self.reporter.currentFileIndex].deployments;
 
-        if (!self.reporter.subscriber.config.dryRun && deployments.length)
+        if (!self.reporter.subscriber.config.dryRun && deployments.length) {
           output += `   > Saving artifacts\n`;
+        }
 
         output +=
           self.underline(37) +

--- a/packages/events/defaultSubscribers/migrate/Reporter.js
+++ b/packages/events/defaultSubscribers/migrate/Reporter.js
@@ -231,7 +231,9 @@ class Reporter {
         );
 
       // if it returns null, try again!
-      if (!txCostReport) return this.postDeploy(data);
+      if (!txCostReport) {
+        return this.postDeploy(data);
+      }
 
       data = {
         ...data,
@@ -318,7 +320,9 @@ class Reporter {
    * @param  {Object} data
    */
   async txHash(data) {
-    if (this.subscriber.config.dryRun) return;
+    if (this.subscriber.config.dryRun) {
+      return;
+    }
 
     let message = this.messages.steps("hash", data);
     this.subscriber.logger.log(message);

--- a/packages/events/defaultSubscribers/migrate/index.js
+++ b/packages/events/defaultSubscribers/migrate/index.js
@@ -1,9 +1,7 @@
 const Reporter = require("./Reporter");
 
 module.exports = {
-  initialization: function (config) {
-    this.logger = config.logger || console;
-    this.config = config;
+  initialization: function () {
     this.reporter = new Reporter({
       subscriber: this
     });
@@ -11,13 +9,17 @@ module.exports = {
   handlers: {
     "migrate:dryRun:notAccepted": [
       async function () {
-        if (this.config.quiet) return;
+        if (this.quiet) {
+          return;
+        }
         this.logger.log("\n> Exiting without migrating...\n\n");
       }
     ],
     "migrate:runMigrations:start": [
       async function ({ dryRun, migrations }) {
-        if (this.config.quiet) return;
+        if (this.quiet) {
+          return;
+        }
         const message = this.reporter.messages.steps("preAllMigrations", {
           migrations,
           dryRun
@@ -27,7 +29,9 @@ module.exports = {
     ],
     "migrate:runMigrations:finish": [
       async function ({ dryRun, error }) {
-        if (this.config.quiet) return;
+        if (this.quiet) {
+          return;
+        }
         const message = this.reporter.messages.steps("postAllMigrations", {
           dryRun,
           error
@@ -38,14 +42,18 @@ module.exports = {
 
     "migrate:settingCompletedMigrations:start": [
       async function (data) {
-        if (this.config.quiet) return;
+        if (this.quiet) {
+          return;
+        }
 
         await this.reporter.startTransaction(data);
       }
     ],
     "migrate:settingCompletedMigrations:succeed": [
       async function (data) {
-        if (this.config.quiet) return;
+        if (this.quiet) {
+          return;
+        }
         const message = await this.reporter.endTransaction(data);
         this.logger.log(message);
       }
@@ -53,21 +61,27 @@ module.exports = {
 
     "migrate:migration:start": [
       async function (data) {
-        if (this.config.quiet) return;
+        if (this.quiet) {
+          return;
+        }
         const message = await this.reporter.preMigrate(data);
         this.logger.log(message);
       }
     ],
     "migrate:migration:succeed": [
       async function (eventArgs) {
-        if (this.config.quiet) return;
+        if (this.quiet) {
+          return;
+        }
         const message = await this.reporter.postMigrate(eventArgs);
         this.logger.log(message);
       }
     ],
     "migrate:migration:error": [
       async function (errorData) {
-        if (this.config.quiet) return;
+        if (this.quiet) {
+          return;
+        }
         const message = await this.reporter.error(errorData);
         this.logger.log(message);
       }
@@ -75,7 +89,9 @@ module.exports = {
 
     "deployment:error": [
       async function (data) {
-        if (this.config.quiet) return;
+        if (this.quiet) {
+          return;
+        }
         const message = await this.reporter.error(data);
         this.logger.error(message);
         return message;
@@ -83,7 +99,9 @@ module.exports = {
     ],
     "deployment:failed": [
       async function (data) {
-        if (this.config.quiet) return;
+        if (this.quiet) {
+          return;
+        }
         const message = await this.reporter.deployFailed(data);
         this.logger.log(message);
         return message;
@@ -91,14 +109,18 @@ module.exports = {
     ],
     "deployment:start": [
       async function (data) {
-        if (this.config.quiet) return;
+        if (this.quiet) {
+          return;
+        }
         const message = await this.reporter.preDeploy(data);
         this.logger.log(message);
       }
     ],
     "deployment:succeed": [
       async function (data) {
-        if (this.config.quiet) return;
+        if (this.quiet) {
+          return;
+        }
         const message = await this.reporter.postDeploy(data);
         this.logger.log(message);
       }
@@ -106,33 +128,43 @@ module.exports = {
 
     "deployment:block": [
       async function (data) {
-        if (this.config.quiet) return;
+        if (this.quiet) {
+          return;
+        }
         await this.reporter.block(data);
       }
     ],
     "deployment:confirmation": [
       async function (data) {
-        if (this.config.quiet) return;
+        if (this.quiet) {
+          return;
+        }
         const message = await this.reporter.confirmation(data);
         this.logger.log(message);
       }
     ],
     "deployment:txHash": [
       async function (data) {
-        if (this.config.quiet) return;
+        if (this.quiet) {
+          return;
+        }
         await this.reporter.txHash(data);
       }
     ],
     "deployment:linking": [
       async function (data) {
-        if (this.config.quiet) return;
+        if (this.quiet) {
+          return;
+        }
         const message = await this.reporter.linking(data);
         this.logger.log(message);
       }
     ],
     "deployment:newContract": [
       function ({ contract }) {
-        if (this.config.quiet) return;
+        if (this.quiet) {
+          return;
+        }
         this.logger.log("Creating new instance of " + contract.contractName);
       }
     ]

--- a/packages/events/defaultSubscribers/obtain.js
+++ b/packages/events/defaultSubscribers/obtain.js
@@ -1,22 +1,16 @@
-const ora = require("ora");
 const OS = require("os");
 
 module.exports = {
-  initialization: function() {
-    this.logger = console;
-    this.ora = ora;
-  },
+  initialization: function () {},
   handlers: {
     "obtain:start": [
-      function() {
-        if (this.quiet) return;
+      function () {
         this.logger.log(`${OS.EOL}Starting obtain...`);
         this.logger.log(`==================${OS.EOL}`);
       }
     ],
     "obtain:succeed": [
-      function({ compiler }) {
-        if (this.quiet) return;
+      function ({ compiler }) {
         const { name, version } = compiler;
         this.logger.log(
           `    > successfully downloaded and cached version ${version} ` +
@@ -25,47 +19,47 @@ module.exports = {
       }
     ],
     "obtain:fail": [
-      function() {
-        if (this.quiet) return;
-        if (this.spinner.isSpinning) this.spinner.fail();
+      function () {
+        if (this.spinner.isSpinning) {
+          this.spinner.fail();
+        }
         this.logger.log("Unbox failed!");
       }
     ],
 
     "downloadCompiler:start": [
-      function({ attemptNumber }) {
-        if (this.quiet) return;
-        this.spinner = this.ora({
+      function ({ attemptNumber }) {
+        this.spinner = this.getSpinner({
           text: `Downloading compiler. Attempt #${attemptNumber}.`,
           color: "red"
         });
       }
     ],
     "downloadCompiler:succeed": [
-      function() {
-        if (this.quiet) return;
+      function () {
         this.spinner.succeed();
       }
     ],
     "fetchSolcList:start": [
-      function({ attemptNumber }) {
-        if (this.quiet) return;
-        this.spinner = this.ora({
+      function ({ attemptNumber }) {
+        this.spinner = this.getSpinner({
           text: `Fetching solc version list from solc-bin. Attempt #${attemptNumber}`,
           color: "yellow"
         }).start();
       }
     ],
     "fetchSolcList:succeed": [
-      function() {
-        if (this.quiet) return;
-        if (this.spinner.isSpinning) this.spinner.succeed();
+      function () {
+        if (this.spinner.isSpinning) {
+          this.spinner.succeed();
+        }
       }
     ],
     "fetchSolcList:fail": [
-      function() {
-        if (this.quiet) return;
-        if (this.spinner.isSpinning) this.spinner.fail();
+      function () {
+        if (this.spinner.isSpinning) {
+          this.spinner.fail();
+        }
       }
     ]
   }

--- a/packages/events/defaultSubscribers/test.js
+++ b/packages/events/defaultSubscribers/test.js
@@ -1,11 +1,8 @@
 module.exports = {
-  initialization: function () {
-    this.logger = console;
-  },
+  initialization: function () {},
   handlers: {
     "test:migration:skipped": [
       function () {
-        if (this.quiet) return;
         this.logger.log(
           `> Migration skipped because --migrate-none option was passed.`
         );

--- a/packages/events/defaultSubscribers/unbox.js
+++ b/packages/events/defaultSubscribers/unbox.js
@@ -1,102 +1,91 @@
-const ora = require("ora");
 const OS = require("os");
 
-const formatCommands = (commands) => {
+const formatCommands = commands => {
   const names = Object.keys(commands);
   const maxLength = Math.max.apply(
     null,
-    names.map((name) => name.length)
+    names.map(name => name.length)
   );
 
-  return names.map((name) => {
+  return names.map(name => {
     const spacing = Array(maxLength - name.length + 1).join(" ");
     return `  ${name}: ${spacing}${commands[name]}`;
   });
 };
 
 module.exports = {
-  initialization: function () {
-    this.logger = console;
-    this.ora = ora;
-  },
+  initialization: function () {},
   handlers: {
     "unbox:start": [
       function () {
-        if (this.quiet) return;
         this.logger.log(`${OS.EOL}Starting unbox...`);
         this.logger.log(`=================${OS.EOL}`);
-      },
+      }
     ],
     "unbox:preparingToDownload:start": [
       function () {
-        if (this.quiet) return;
-        this.spinner = this.ora("Preparing to download box").start();
-      },
+        this.spinner = this.getSpinner("Preparing to download box").start();
+      }
     ],
     "unbox:preparingToDownload:succeed": [
       function () {
-        if (this.quiet) return;
         this.spinner.succeed();
-      },
+      }
     ],
     "unbox:downloadingBox:start": [
       function () {
-        if (this.quiet) return;
-        this.spinner = this.ora("Downloading").start();
-      },
+        this.spinner = this.getSpinner("Downloading").start();
+      }
     ],
     "unbox:downloadingBox:succeed": [
       function () {
-        if (this.quiet) return;
         this.spinner.succeed();
-      },
+      }
     ],
     "unbox:cleaningTempFiles:start": [
       function () {
-        if (this.quiet) return;
-        this.spinner = this.ora("Cleaning up temporary files").start();
-      },
+        this.spinner = this.getSpinner("Cleaning up temporary files").start();
+      }
     ],
     "unbox:cleaningTempFiles:succeed": [
       function () {
-        if (this.quiet) return;
         this.spinner.succeed();
-      },
+      }
     ],
     "unbox:settingUpBox:start": [
       function () {
-        if (this.quiet) return;
-        this.spinner = this.ora("Setting up box").start();
-      },
+        this.spinner = this.getSpinner("Setting up box").start();
+      }
     ],
     "unbox:settingUpBox:succeed": [
       function () {
-        if (this.quiet) return;
         this.spinner.succeed();
-      },
+      }
     ],
     "unbox:succeed": [
       function ({ boxConfig }) {
-        if (this.quiet) return;
         this.logger.log(`${OS.EOL}Unbox successful, sweet!${OS.EOL}`);
 
         const commandMessages = formatCommands(boxConfig.commands);
-        if (commandMessages.length > 0) this.logger.log("Commands:" + OS.EOL);
+        if (commandMessages.length > 0) {
+          this.logger.log("Commands:" + OS.EOL);
+        }
 
-        commandMessages.forEach((message) => this.logger.log(message));
+        commandMessages.forEach(message => this.logger.log(message));
         this.logger.log("");
 
         if (boxConfig.epilogue) {
           this.logger.log(boxConfig.epilogue.replace("\n", OS.EOL));
         }
-      },
+      }
     ],
     "unbox:fail": [
       function () {
-        if (this.quiet) return;
-        if (this.spinner) this.spinner.fail();
+        if (this.spinner) {
+          this.spinner.fail();
+        }
         this.logger.log("Unbox failed!");
-      },
-    ],
-  },
+      }
+    ]
+  }
 };


### PR DESCRIPTION
This was prompted by feedback in #4875 regarding `if` statements w/o curly braces.

However, the bulk of the `if` statements in question appear to have been added due to the concern of silencing console output not being encapsulated well in the default event handlers. As a result, I did a bit of refactoring and pushed that concern down into the `Subscriber` type.

This does introduce a bit of a cohesion issue now, as ideally the `Subscriber` type wouldn't need to know about these things, however I think the ultimate solution for this would be to introduce a proper presentation layer for Truffle.