### PR TITLE
Temp patch for node-ipc malware (CVE-2022-23812)

### DIFF
--- a/packages/environment/package.json
+++ b/packages/environment/package.json
@@ -33,6 +33,10 @@
   "devDependencies": {
     "debug": "^4.3.1"
   },
+   "overrides": {
+    "node-ipc@>9.2.1 <10": "9.2.1",
+    "node-ipc@>10.1.0": "10.1.0"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
node-ipc 9.2.x added the peacenotwar module, which performs an unauthorized file write on users' filesystem. Overriding temporarily for hotfix. Could cause breaking changes. 

Details: https://github.com/RIAEvangelist/node-ipc/issues/233