### PR TITLE
Internal improvement: Use typed imports for web3-utils in codec

### DIFF
--- a/packages/codec/lib/abi-data/allocate/index.ts
+++ b/packages/codec/lib/abi-data/allocate/index.ts
@@ -7,7 +7,7 @@ import type * as Abi from "@truffle/abi-utils";
 
 import * as Import from "@truffle/codec/abi-data/import";
 import * as AbiDataUtils from "@truffle/codec/abi-data/utils";
-const Web3Utils = require("web3-utils"); //sorry for untyped import
+import Web3Utils from "web3-utils";
 import * as Evm from "@truffle/codec/evm";
 import * as Common from "@truffle/codec/common";
 import type * as Compiler from "@truffle/codec/compiler";

--- a/packages/codec/lib/abi-data/utils.ts
+++ b/packages/codec/lib/abi-data/utils.ts
@@ -1,8 +1,7 @@
 import debugModule from "debug";
 const debug = debugModule("codec:abi-data:utils");
 
-// untyped import since no @types/web3-utils exists
-const Web3Utils = require("web3-utils");
+import Web3Utils from "web3-utils";
 import * as Evm from "@truffle/codec/evm";
 import * as Ast from "@truffle/codec/ast";
 import type * as Abi from "@truffle/abi-utils";
@@ -171,9 +170,8 @@ function abiParameterIsObviouslyIllTyped(abiParameter: Abi.Parameter): boolean {
     "tuple"
   ];
   const baseTypeClass = abiParameter.type.match(/^([a-z]*)/)[1];
-  const baseTypeClassIsObviouslyWrong = !legalBaseTypeClasses.includes(
-    baseTypeClass
-  );
+  const baseTypeClassIsObviouslyWrong =
+    !legalBaseTypeClasses.includes(baseTypeClass);
   if (abiParameter.components) {
     return (
       abiParameter.components.some(abiParameterIsObviouslyIllTyped) ||

--- a/packages/codec/lib/core.ts
+++ b/packages/codec/lib/core.ts
@@ -26,8 +26,7 @@ import type * as Format from "@truffle/codec/format";
 import { StopDecodingError } from "@truffle/codec/errors";
 import read from "@truffle/codec/read";
 import decode from "@truffle/codec/decode";
-// untyped import since no @types/web3-utils exists
-const Web3Utils = require("web3-utils");
+import Web3Utils from "web3-utils";
 
 /**
  * @Category Decoding

--- a/packages/codec/lib/evm/utils.ts
+++ b/packages/codec/lib/evm/utils.ts
@@ -2,8 +2,7 @@ import debugModule from "debug";
 const debug = debugModule("codec:evm:utils");
 
 import BN from "bn.js";
-// untyped import since no @types/web3-utils exists
-const Web3Utils = require("web3-utils");
+import Web3Utils from "web3-utils";
 import * as Conversion from "@truffle/codec/conversion";
 
 export const WORD_SIZE = 0x20;

--- a/packages/codec/lib/wrap/address.ts
+++ b/packages/codec/lib/wrap/address.ts
@@ -9,13 +9,12 @@ import type {
   Case,
   AddressLikeType,
   AddressLikeValue,
-  WrapOptions,
+  WrapOptions
 } from "./types";
-import * as Conversion from "@truffle/codec/conversion";
 import * as Utils from "./utils";
 import * as EvmUtils from "@truffle/codec/evm/utils";
 import * as Messages from "./messages";
-const Web3Utils = require("web3-utils"); //importing untyped, sorry!
+import Web3Utils from "web3-utils";
 
 //no separate cases for contracts; even with loose turned off,
 //we consider these interchangeable
@@ -27,7 +26,7 @@ const addressFromStringCases: Case<
 >[] = [
   addressFromHexString,
   addressFromPrefixlessHexString,
-  addressFromOtherString, //Please put after other string cases! Also, can yield
+  addressFromOtherString //Please put after other string cases! Also, can yield
 ];
 
 const addressCasesBasic: Case<
@@ -47,10 +46,7 @@ export const addressCases: Case<
   AddressLikeType,
   AddressLikeValue,
   AddressWrapRequest
->[] = [
-  addressFromTypeValueInput,
-  ...addressCasesBasic
-];
+>[] = [addressFromTypeValueInput, ...addressCasesBasic];
 
 function* addressFromHexString(
   dataType: AddressLikeType,
@@ -101,7 +97,12 @@ function* addressFromPrefixlessHexString(
       "Input was not an unprefixed hex string"
     );
   }
-  return validateNormalizeAndWrap(dataType, "0x" + input, input, wrapOptions.name);
+  return validateNormalizeAndWrap(
+    dataType,
+    "0x" + input,
+    input,
+    wrapOptions.name
+  );
 }
 
 function* addressFromOtherString(
@@ -151,7 +152,12 @@ function* addressFromBoxedString(
     );
   }
   //unbox and try again
-  return yield* wrapWithCases(dataType, input.valueOf(), wrapOptions, addressFromStringCases);
+  return yield* wrapWithCases(
+    dataType,
+    input.valueOf(),
+    wrapOptions,
+    addressFromStringCases
+  );
 }
 
 function* addressFromContractInput(
@@ -168,7 +174,12 @@ function* addressFromContractInput(
       "Input was not a contract-like object"
     );
   }
-  return validateNormalizeAndWrap(dataType, input.address, input, wrapOptions.name);
+  return validateNormalizeAndWrap(
+    dataType,
+    input.address,
+    input,
+    wrapOptions.name
+  );
 }
 
 function* addressFromCodecAddressLikeValue(
@@ -234,9 +245,7 @@ function* addressFromCodecUdvtValue(
       "Input was not a wrapped result"
     );
   }
-  if (
-    input.type.typeClass !== "userDefinedValueType"
-  ) {
+  if (input.type.typeClass !== "userDefinedValueType") {
     throw new TypeMismatchError(
       dataType,
       input,
@@ -254,7 +263,11 @@ function* addressFromCodecUdvtValue(
       Messages.errorResultMessage
     );
   }
-  return yield* addressFromCodecAddressLikeValue(dataType, input.value, wrapOptions);
+  return yield* addressFromCodecAddressLikeValue(
+    dataType,
+    input.value,
+    wrapOptions
+  );
 }
 
 function* addressFromTypeValueInput(
@@ -299,7 +312,7 @@ function* addressFailureCase(
     input,
     wrapOptions.name,
     2,
-   "Input was not recognizable as an address"
+    "Input was not recognizable as an address"
   );
 }
 
@@ -376,5 +389,8 @@ function validateNormalizeAndWrap(
   input: unknown, //for errors
   name: string //for errors
 ): AddressLikeValue {
-  return wrapAsAppropriateType(dataType, validateAndNormalize(asAddress, dataType, input, name));
+  return wrapAsAppropriateType(
+    dataType,
+    validateAndNormalize(asAddress, dataType, input, name)
+  );
 }

--- a/packages/codec/lib/wrap/function.ts
+++ b/packages/codec/lib/wrap/function.ts
@@ -4,17 +4,12 @@ const debug = debugModule("codec:wrap:function");
 import * as Format from "@truffle/codec/format";
 import { wrapWithCases } from "./dispatch";
 import { TypeMismatchError } from "./errors";
-import type {
-  WrapRequest,
-  WrapResponse
-} from "../types";
+import type { WrapRequest, WrapResponse } from "../types";
 import type { Case, WrapOptions } from "./types";
 import * as Messages from "./messages";
-import * as Conversion from "@truffle/codec/conversion";
 import * as Utils from "./utils";
 import * as EvmUtils from "@truffle/codec/evm/utils";
-import type { Options } from "@truffle/codec/common";
-const Web3Utils = require("web3-utils"); //importing untyped, sorry!
+import Web3Utils from "web3-utils";
 
 import { addressCases } from "./address";
 import { bytesCases } from "./bytes";
@@ -34,17 +29,14 @@ export const functionExternalCases: Case<
   Format.Types.FunctionExternalType,
   Format.Values.FunctionExternalValue,
   WrapRequest
->[] = [
-  functionFromTypeValueInput,
-  ...functionExternalCasesBasic
-];
+>[] = [functionFromTypeValueInput, ...functionExternalCasesBasic];
 
 function* functionFromFunctionExternalInput(
   dataType: Format.Types.FunctionExternalType,
   input: unknown,
   wrapOptions: WrapOptions
 ): Generator<WrapRequest, Format.Values.FunctionExternalValue, WrapResponse> {
-  if(!Utils.isFunctionExternalInput(input)) {
+  if (!Utils.isFunctionExternalInput(input)) {
     throw new TypeMismatchError(
       dataType,
       input,
@@ -53,18 +45,16 @@ function* functionFromFunctionExternalInput(
       "Input was not an object with address & selector"
     );
   }
-  const wrappedAddress = <Format.Values.AddressValue>(
-    yield* wrapWithCases(
-      { typeClass: "address", kind: "general" },
-      input.address,
-      {
-        ...wrapOptions,
-        name: `${wrapOptions.name}.address`,
-        specificityFloor: 5
-      },
-      addressCases
-    )
-  );
+  const wrappedAddress = (yield* wrapWithCases(
+    { typeClass: "address", kind: "general" },
+    input.address,
+    {
+      ...wrapOptions,
+      name: `${wrapOptions.name}.address`,
+      specificityFloor: 5
+    },
+    addressCases
+  )) as Format.Values.AddressValue;
   const address = wrappedAddress.value.asAddress;
   const wrappedSelector = yield* wrapWithCases(
     { typeClass: "bytes", kind: "static", length: 4 },
@@ -184,8 +174,11 @@ function* functionFromHexString(
       )
     );
   }
-  let address: string = input.slice(0, EvmUtils.ADDRESS_SIZE * 2 + 2).toLowerCase();
-  const selector = "0x" + input.slice(EvmUtils.ADDRESS_SIZE * 2 + 2).toLowerCase();
+  let address: string = input
+    .slice(0, EvmUtils.ADDRESS_SIZE * 2 + 2)
+    .toLowerCase();
+  const selector =
+    "0x" + input.slice(EvmUtils.ADDRESS_SIZE * 2 + 2).toLowerCase();
   //address & selector must now have the correct length, and we are deliberately *not*
   //checking the checksum on address in this case.  So, the only thing remaining
   //to do is to normalize address.


### PR DESCRIPTION
The `codec` package has a bunch of places where it imports `web3-utils` untyped.  I think this was necessary at one point?  Well, it definitely isn't any longer.  This PR cleans that up and replaces them with typed imports.  It also eliminates a few unused imports in the process.

Also, `prettier` made some changes too, which actually ends up being the bulk of the PR.  Sorry!

...and then also, `prettier` introduced a syntax error at one point, and I had to change a coercion from `<>` to `as` to get it to something `prettier` would handle properly...