### PR TITLE
Add dependency-graph script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+dependency-graph.pdf
 lerna-debug.log
 packages/**/node_modules
 node_modules

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "lerna run test --stream --concurrency=1 -- --colors",
     "ci": "./scripts/ci.sh",
     "geth": "./scripts/geth.sh",
+    "dependency-graph": "lerna-dependency-graph -f pdf -o dependency-graph.pdf",
     "solc-bump": "node ./scripts/solc-bump.js",
     "update": "lernaupdate"
   },
@@ -20,6 +21,7 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "husky": "^7.0.4",
     "lerna": "^4.0.0",
+    "lerna-dependency-graph": "^1.1.0",
     "lerna-update-wizard": "^1.1.0",
     "lint-staged": "^12.1.2",
     "nyc": "^13.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4515,7 +4515,7 @@
     npmlog "^4.1.2"
     upath "^2.0.1"
 
-"@lerna/project@4.0.0":
+"@lerna/project@4.0.0", "@lerna/project@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@lerna/project/-/project-4.0.0.tgz#ff84893935833533a74deff30c0e64ddb7f0ba6b"
   integrity sha512-o0MlVbDkD5qRPkFKlBZsXZjoNTWPyuL58564nSfZJ6JYNmgAptnWPB2dQlAc7HWRZkmnC2fCkEdoU+jioPavbg==
@@ -20542,6 +20542,15 @@ left-pad@^1.1.3:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
   integrity sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==
+
+lerna-dependency-graph@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/lerna-dependency-graph/-/lerna-dependency-graph-1.1.0.tgz#ee3f679107c5c49eb7dbe290db2a7200eda4c068"
+  integrity sha512-WddA3FjyTw6vespay42d8vB5NzL09Es/zR7bK/2FbEzaMzUGCGyCPVUp5Kr1kAPuGlXI33T+5UYD/783SyDfOQ==
+  dependencies:
+    "@lerna/project" "^4.0.0"
+    graphviz "0.0.9"
+    yargs "^16.2.0"
 
 lerna-update-wizard@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Generates dependency-graph.pdf in the root of the repo that shows
dependencies between the packages in our workspace. Solid lines reflect
runtime dependencies, dashed lines reflect dev dependencies, and dotted
lines reflect peer dependencies.