### PR TITLE
Remove clobbered `paths` key from tsconfig

### DIFF
--- a/packages/decoder/tsconfig.json
+++ b/packages/decoder/tsconfig.json
@@ -11,11 +11,6 @@
     "outDir": "dist",
     "baseUrl": ".",
     "lib": ["es2019"],
-    "paths": {
-      "web3": ["../../node_modules/@types/web3/index", "node_modules/web3/index"],
-      "web3/types": ["../../node_modules/@types/web3/types", "node_modules/web3/types"],
-      "web3/eth/types": ["../../node_modules/@types/web3/eth/types", "node_modules/web3/eth/types"]
-    },
     "rootDir": "lib",
     "paths": {
       "web3": [

--- a/packages/encoder/tsconfig.json
+++ b/packages/encoder/tsconfig.json
@@ -13,11 +13,6 @@
     "outDir": "dist",
     "baseUrl": ".",
     "lib": ["es2019"],
-    "paths": {
-      "web3": ["../../node_modules/@types/web3/index", "node_modules/web3/index"],
-      "web3/types": ["../../node_modules/@types/web3/types", "node_modules/web3/types"],
-      "web3/eth/types": ["../../node_modules/@types/web3/eth/types", "node_modules/web3/eth/types"]
-    },
     "rootDir": "lib",
     "paths": {
       "web3": [


### PR DESCRIPTION
The encoder and decoder packages had a duplicate `paths` key in their `tsconrfig.json`. This PR removes the first occurrence, leaving the one that JavaScript would use in this case. 