### PR TITLE
Internal improvement: Increase timeout on docker tags test

### DIFF
--- a/packages/core/test/lib/commands/compile.js
+++ b/packages/core/test/lib/commands/compile.js
@@ -121,6 +121,7 @@ describe("compile", function () {
     });
 
     it("prints a list of docker tags", async function () {
+      this.timeout(4000);
       const options = {
         list: "docker"
       };


### PR DESCRIPTION
We're getting a lot of timeouts recently!  This test in particular has been timing out a lot recently!  So I'm upping it!

If this PR fails CI I may add other timeout increases to it as well.