### PR TITLE
Internal improvement: Turn up docker tag list timeout even further

### DIFF
--- a/packages/core/test/lib/commands/compile.js
+++ b/packages/core/test/lib/commands/compile.js
@@ -121,7 +121,7 @@ describe("compile", function () {
     });
 
     it("prints a list of docker tags", async function () {
-      this.timeout(4000);
+      this.timeout(8000);
       const options = {
         list: "docker"
       };


### PR DESCRIPTION
4 seconds is working better than 2 seconds, but still timing out occasionally.  Let's try 8!