### PR TITLE
Hook up example events -> dashboard communication

### DIFF
--- a/packages/dashboard-message-bus/lib/message/types.ts
+++ b/packages/dashboard-message-bus/lib/message/types.ts
@@ -32,6 +32,16 @@ export interface LogMessage extends Message {
 }
 
 /**
+ * Message to log in Dashboard browser console
+ */
+export interface DebugMessage extends Message {
+  type: "debug";
+  payload: {
+    message: string;
+  };
+}
+
+/**
  * Message intended to invalidate earlier messages.
  * The payload is the ID of the message that should be invalidated.
  * This is an internal message type that is not intended to be used by publishers or subscribers.
@@ -49,6 +59,10 @@ export const isDashboardProviderMessage = (
 
 export const isLogMessage = (message: Message): message is LogMessage => {
   return message.type === "log";
+};
+
+export const isDebugMessage = (message: Message): message is DebugMessage => {
+  return message.type === "debug";
 };
 
 export const isInvalidateMessage = (

--- a/packages/dashboard-message-bus/lib/utils.ts
+++ b/packages/dashboard-message-bus/lib/utils.ts
@@ -6,6 +6,8 @@ import axios from "axios";
 
 any.shim();
 
+export class MessageBusConnectionError extends Error {}
+
 /**
  * Convert any JS object or value to a base64 representation of it
  */
@@ -152,7 +154,7 @@ export const getMessageBusPorts = async (
     }
   }
 
-  throw new Error(
+  throw new MessageBusConnectionError(
     `Could not connect to dashboard at http://${dashboardHost}:${dashboardPort}/ports`
   );
 };

--- a/packages/dashboard/src/Dashboard.tsx
+++ b/packages/dashboard/src/Dashboard.tsx
@@ -4,12 +4,13 @@ import {
   connectToMessageBusWithRetries,
   isDashboardProviderMessage,
   isInvalidateMessage,
+  isDebugMessage,
   Message,
   base64ToJson
 } from "@truffle/dashboard-message-bus";
 import { useWeb3React } from "@web3-react/core";
 import { useEffect, useState } from "react";
-import { getPorts } from "./utils/utils";
+import { getPorts, respond } from "./utils/utils";
 import Header from "./components/Header/Header";
 import DashboardProvider from "./components/DashboardProvider/DashboardProvider";
 import ConnectNetwork from "./components/ConnectNetwork";
@@ -66,6 +67,10 @@ function Dashboard() {
           setDashboardProviderRequests(previousRequests =>
             previousRequests.filter(request => request.id !== message.payload)
           );
+        } else if (isDebugMessage(message)) {
+          const { payload } = message;
+          console.log(payload.message);
+          respond({ id: message.id }, connectedSocket);
         }
       }
     );

--- a/packages/events/defaultSubscribers/dashboard/client.js
+++ b/packages/events/defaultSubscribers/dashboard/client.js
@@ -1,0 +1,31 @@
+const {
+  connectToMessageBusWithRetries,
+  createMessage,
+  getMessageBusPorts,
+  sendAndAwait
+} = require("@truffle/dashboard-message-bus");
+
+module.exports = class DashboardMessageBusClient {
+  constructor(config) {
+    this.ready = (async () => {
+      const dashboard = config.dashboard || {
+        host: "localhost",
+        port: 24012
+      };
+
+      const { publishPort } = await getMessageBusPorts(
+        dashboard.port,
+        dashboard.host
+      );
+
+      return await connectToMessageBusWithRetries(publishPort, dashboard.host);
+    })();
+  }
+
+  async sendAndAwait({ type, payload }) {
+    const socket = await this.ready;
+    const message = createMessage(type, payload);
+
+    return await sendAndAwait(socket, message);
+  }
+};

--- a/packages/events/defaultSubscribers/dashboard/index.js
+++ b/packages/events/defaultSubscribers/dashboard/index.js
@@ -16,6 +16,16 @@ module.exports = {
     };
   },
   handlers: {
+    "compile:start": [
+      async function () {
+        await this.messageBus.sendAndAwait({
+          type: "debug",
+          payload: {
+            message: "compile:start"
+          }
+        });
+      }
+    ],
     "rpc:request": [
       function (event) {
         const { payload } = event;

--- a/packages/events/defaultSubscribers/dashboard/index.js
+++ b/packages/events/defaultSubscribers/dashboard/index.js
@@ -1,7 +1,10 @@
 const Writable = require("stream").Writable;
+const DashboardMessageBusClient = require("./client");
 
 module.exports = {
   initialization: function (config) {
+    this.messageBus = new DashboardMessageBusClient(config);
+
     this._logger = {
       log: ((...args) => {
         if (config.quiet) {


### PR DESCRIPTION
This PR does a few things:
- Add a new `"debug"` message type, intended for logging in the browser console. This message type behaves like `"provider"` messages, in that it waits for a response from a subscriber.
- Handle this new message type in the frontend by logging and then issuing a blank response to clear it from the message-bus requests queue
- Initialize a quick DashboardMessageBusClient for use in @truffle/events. Define a `sendAndAwait` method to behave similarly to the @truffle/dashboard-message-bus util function
- Use this client to send an example debug message to the browser upon `"compile:start"`