### PR TITLE
Revert "Run CI for PRs targeting `feature/dashboard`"

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -7,7 +7,6 @@ on:
     - master
     - develop
     - next
-    - feature/dashboard
 
   pull_request:
     branches:


### PR DESCRIPTION
Reverts trufflesuite/truffle#4919 

Apparently it wasn't even doing anything for us