### PR TITLE
Update url in the comments in config and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $ truffle init
 
 From there, you can run `truffle compile`, `truffle migrate` and `truffle test` to compile your contracts, deploy those contracts to the network, and run their associated unit tests.
 
-Truffle comes bundled with a local development blockchain server that launches automatically when you invoke the commands  above. If you'd like to [configure a more advanced development environment](https://trufflesuite.com/docs/advanced/configuration) we recommend you install the blockchain server separately by running `npm install -g ganache-cli` at the command line.
+Truffle comes bundled with a local development blockchain server that launches automatically when you invoke the commands  above. If you'd like to [configure a more advanced development environment](https://trufflesuite.com/docs/truffle/reference/configuration) we recommend you install the blockchain server separately by running `npm install -g ganache-cli` at the command line.
 
 +  [ganache](https://github.com/trufflesuite/ganache): a command-line version of Truffle's blockchain server.
 +  [ganache-ui](https://github.com/trufflesuite/ganache-ui): A GUI for the server that displays your transaction history and chain state.

--- a/packages/core/lib/commands/init/initSource/truffle-config.js
+++ b/packages/core/lib/commands/init/initSource/truffle-config.js
@@ -5,8 +5,8 @@
  * them to suit your project as necessary.
  *
  * More information about configuration can be found at:
- *
- * trufflesuite.com/docs/advanced/configuration
+ * 
+ * https://trufflesuite.com/docs/truffle/reference/configuration
  *
  * To deploy via Infura you'll need a wallet provider (like @truffle/hdwallet-provider)
  * to sign your transactions before they're sent to a remote public node. Infura accounts

--- a/packages/truffle/README.md
+++ b/packages/truffle/README.md
@@ -34,7 +34,7 @@ $ truffle init
 
 From there, you can run `truffle compile`, `truffle migrate` and `truffle test` to compile your contracts, deploy those contracts to the network, and run their associated unit tests.
 
-Truffle comes bundled with a local development blockchain server that launches automatically when you invoke the commands  above. If you'd like to [configure a more advanced development environment](http://trufflesuite.com/docs/advanced/configuration) we recommend you install the blockchain server separately by running `npm install -g ganache-cli` at the command line.
+Truffle comes bundled with a local development blockchain server that launches automatically when you invoke the commands  above. If you'd like to [configure a more advanced development environment](https://trufflesuite.com/docs/truffle/reference/configuration) we recommend you install the blockchain server separately by running `npm install -g ganache-cli` at the command line.
 
 +  [ganache-cli](https://github.com/trufflesuite/ganache-cli): a command-line version of Truffle's blockchain server.
 +  [ganache](http://trufflesuite.com/ganache/): A GUI for the server that displays your transaction history and chain state.


### PR DESCRIPTION
### ISSUE
`truffle-config.js` and README files have an outdated url mentioned. See #4912 .

### SOLUTION
The outdated url is replaced with the new url pointing to the required documentation (in `truffle-config.js` and `README.md`).