### PR TITLE
Bug fix: Check matching result for null values with pragma setting

### DIFF
--- a/packages/compile-solidity/src/compileWithPragmaAnalysis.js
+++ b/packages/compile-solidity/src/compileWithPragmaAnalysis.js
@@ -8,9 +8,8 @@ const OS = require("os");
 const cloneDeep = require("lodash/cloneDeep");
 
 const getSemverExpression = source => {
-  return source.match(/pragma solidity(.*);/)[1]
-    ? source.match(/pragma solidity(.*);/)[1].trim()
-    : undefined;
+  const result = source.match(/pragma solidity(.*);/);
+  return result && result[1] ? result[1].trim() : undefined;
 };
 
 const getSemverExpressions = sources => {
@@ -89,7 +88,7 @@ const compileWithPragmaAnalysis = async ({ paths, options }) => {
     });
     if (!parserVersion) {
       const m =
-        `Could not find a pragma expression in ${path}. To use the ` +
+        `Could not find a valid pragma expression in ${path}. To use the ` +
         `"pragma" compiler setting your contracts must contain a pragma ` +
         `expression.`;
       throw new Error(m);

--- a/packages/compile-solidity/src/compileWithPragmaAnalysis.js
+++ b/packages/compile-solidity/src/compileWithPragmaAnalysis.js
@@ -22,7 +22,7 @@ const validateSemverExpressions = semverExpressions => {
   for (const expression of semverExpressions) {
     if (semver.validRange(expression) === null) {
       const message =
-        `Invalid semver expression (${expression}) found in` +
+        `Invalid semver expression (${expression}) found in ` +
         `one of your contract's imports.`;
       throw new Error(message);
     }

--- a/packages/compile-solidity/test/compileWithPragmaAnalysis.js
+++ b/packages/compile-solidity/test/compileWithPragmaAnalysis.js
@@ -116,6 +116,16 @@ describe("compileWithPragmaAnalysis", function () {
       assert.equal(compilations.length, 3);
     });
 
+    it.only("compiles files with imports without pragma expressions", async function () {
+      const { compilations } = await compileWithPragmaAnalysis({
+        options: config,
+        paths: paths.concat([
+          path.join(sourceDirectory, "withImports", "D.sol")
+        ])
+      });
+      assert.equal(compilations.length, 1);
+    });
+
     it("finds a version that satisfies all pragmas if it exists", async function () {
       const { compilations } = await compileWithPragmaAnalysis({
         options: config,

--- a/packages/compile-solidity/test/compileWithPragmaAnalysis.js
+++ b/packages/compile-solidity/test/compileWithPragmaAnalysis.js
@@ -86,7 +86,7 @@ describe("compileWithPragmaAnalysis", function () {
 
     // note that it will find the newest version of Solidity that satisifes
     // each pragma expression and then do one compilation per version
-    it("will make one compilation per compiler version", async function () {
+    it("makes one compilation per compiler version", async function () {
       const { compilations } = await compileWithPragmaAnalysis({
         options: config,
         paths
@@ -94,7 +94,7 @@ describe("compileWithPragmaAnalysis", function () {
       assert.equal(compilations.length, 3);
     });
 
-    it("will compile files with the same version together", async function () {
+    it("compiles files with the same version together", async function () {
       const { compilations } = await compileWithPragmaAnalysis({
         options: config,
         paths: paths.concat(
@@ -116,12 +116,10 @@ describe("compileWithPragmaAnalysis", function () {
       assert.equal(compilations.length, 3);
     });
 
-    it.only("compiles files with imports without pragma expressions", async function () {
+    it("compiles files with imports without pragma expressions", async function () {
       const { compilations } = await compileWithPragmaAnalysis({
         options: config,
-        paths: paths.concat([
-          path.join(sourceDirectory, "withImports", "D.sol")
-        ])
+        paths: [path.join(sourceDirectory, "withImports", "D.sol")]
       });
       assert.equal(compilations.length, 1);
     });
@@ -146,9 +144,10 @@ describe("compileWithPragmaAnalysis", function () {
         assert.fail("compiling that source should have failed");
       } catch (error) {
         const expectedSnippet = "Could not find a single version of the";
-        if (!error.message.includes(expectedSnippet)) {
-          throw error;
-        }
+        assert(
+          error.message.includes(expectedSnippet),
+          `The function call threw in an unexpected way. The error: ${error}.`
+        );
       }
     });
   });
@@ -163,12 +162,9 @@ describe("compileWithPragmaAnalysis", function () {
         assert.fail("The function should have thrown.");
       } catch (error) {
         const expectedMessage = "Could not find a valid pragma expression";
-        if (error.message.includes(expectedMessage)) {
-          return "all good";
-        }
-        assert.fail(
-          "The function call threw in an unexpected way. The " +
-            `error is ${error.message}.`
+        assert(
+          error.message.includes(expectedMessage),
+          `The function call threw in an unexpected way. The error: ${error}.`
         );
       }
     });
@@ -182,12 +178,9 @@ describe("compileWithPragmaAnalysis", function () {
         assert.fail("The function should have thrown.");
       } catch (error) {
         const expectedMessage = "Could not find a valid pragma expression";
-        if (error.message.includes(expectedMessage)) {
-          return "all good";
-        }
-        assert.fail(
-          "The function call threw in an unexpected way. The " +
-            `error is ${error.message}.`
+        assert(
+          error.message.includes(expectedMessage),
+          `The function call threw in an unexpected way. The error: ${error}.`
         );
       }
     });
@@ -203,12 +196,9 @@ describe("compileWithPragmaAnalysis", function () {
         assert.fail("The function should have thrown.");
       } catch (error) {
         const expectedMessage = "Invalid semver expression ($0.5.3)";
-        if (error.message.includes(expectedMessage)) {
-          return "all good";
-        }
-        assert.fail(
-          "The function call threw in an unexpected way. The " +
-            `error is ${error.message}.`
+        assert(
+          error.message.includes(expectedMessage),
+          `The function call threw in an unexpected way. The error: ${error}.`
         );
       }
     });

--- a/packages/compile-solidity/test/compileWithPragmaAnalysis.js
+++ b/packages/compile-solidity/test/compileWithPragmaAnalysis.js
@@ -1,9 +1,11 @@
 const assert = require("assert");
 const Config = require("@truffle/config");
-const {CompilerSupplier} = require("../dist/index");
+const { CompilerSupplier } = require("../dist/index");
 const Resolver = require("@truffle/resolver");
 const sinon = require("sinon");
-const {compileWithPragmaAnalysis} = require("../dist/compileWithPragmaAnalysis");
+const {
+  compileWithPragmaAnalysis
+} = require("../dist/compileWithPragmaAnalysis");
 const path = require("path");
 let paths = [];
 
@@ -13,14 +15,7 @@ const sourceDirectory = path.resolve(
   "multipleSolcVersions"
 );
 
-const config = new Config().with({
-  compilers: {
-    solc: {
-      settings: {},
-      version: "analyzePragmas"
-    }
-  }
-});
+const config = new Config();
 
 const releases = {
   prereleases: [],
@@ -149,6 +144,25 @@ describe("compileWithPragmaAnalysis", function () {
   });
 
   describe("when there is a semver expression error", function () {
+    it("throws an error when a 'direct source' lacks a pragma expression", async function () {
+      try {
+        await compileWithPragmaAnalysis({
+          options: config,
+          paths: [path.join(__dirname, "sources", "badSources", "NoPragma.sol")]
+        });
+        assert.fail("The function should have thrown.");
+      } catch (error) {
+        const expectedMessage = "Could not find a valid pragma expression";
+        if (error.message.includes(expectedMessage)) {
+          return "all good";
+        }
+        assert.fail(
+          "The function call threw in an unexpected way. The " +
+            `error is ${error.message}.`
+        );
+      }
+    });
+
     it("throws an error when it can't determine parser version", async function () {
       try {
         await compileWithPragmaAnalysis({
@@ -157,11 +171,14 @@ describe("compileWithPragmaAnalysis", function () {
         });
         assert.fail("The function should have thrown.");
       } catch (error) {
-        const expectedMessage = "Could not find a pragma expression";
+        const expectedMessage = "Could not find a valid pragma expression";
         if (error.message.includes(expectedMessage)) {
           return "all good";
         }
-        throw error;
+        assert.fail(
+          "The function call threw in an unexpected way. The " +
+            `error is ${error.message}.`
+        );
       }
     });
 
@@ -179,7 +196,10 @@ describe("compileWithPragmaAnalysis", function () {
         if (error.message.includes(expectedMessage)) {
           return "all good";
         }
-        throw error;
+        assert.fail(
+          "The function call threw in an unexpected way. The " +
+            `error is ${error.message}.`
+        );
       }
     });
   });

--- a/packages/compile-solidity/test/compileWithPragmaAnalysis.js
+++ b/packages/compile-solidity/test/compileWithPragmaAnalysis.js
@@ -144,10 +144,9 @@ describe("compileWithPragmaAnalysis", function () {
         assert.fail("compiling that source should have failed");
       } catch (error) {
         const expectedSnippet = "Could not find a single version of the";
-        assert(
-          error.message.includes(expectedSnippet),
-          `The function call threw in an unexpected way. The error: ${error}.`
-        );
+        if (!error.message.includes(expectedSnippet)) {
+          throw error;
+        }
       }
     });
   });
@@ -162,10 +161,9 @@ describe("compileWithPragmaAnalysis", function () {
         assert.fail("The function should have thrown.");
       } catch (error) {
         const expectedMessage = "Could not find a valid pragma expression";
-        assert(
-          error.message.includes(expectedMessage),
-          `The function call threw in an unexpected way. The error: ${error}.`
-        );
+        if (!error.message.includes(expectedMessage)) {
+          throw error;
+        }
       }
     });
 
@@ -178,10 +176,9 @@ describe("compileWithPragmaAnalysis", function () {
         assert.fail("The function should have thrown.");
       } catch (error) {
         const expectedMessage = "Could not find a valid pragma expression";
-        assert(
-          error.message.includes(expectedMessage),
-          `The function call threw in an unexpected way. The error: ${error}.`
-        );
+        if (!error.message.includes(expectedMessage)) {
+          throw error;
+        }
       }
     });
 
@@ -196,10 +193,9 @@ describe("compileWithPragmaAnalysis", function () {
         assert.fail("The function should have thrown.");
       } catch (error) {
         const expectedMessage = "Invalid semver expression ($0.5.3)";
-        assert(
-          error.message.includes(expectedMessage),
-          `The function call threw in an unexpected way. The error: ${error}.`
-        );
+        if (!error.message.includes(expectedMessage)) {
+          throw error;
+        }
       }
     });
   });

--- a/packages/compile-solidity/test/sources/badSources/Imported.sol
+++ b/packages/compile-solidity/test/sources/badSources/Imported.sol
@@ -1,5 +1,4 @@
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-contract Imported {
-}
+contract Imported {}

--- a/packages/compile-solidity/test/sources/badSources/NoPragma.sol
+++ b/packages/compile-solidity/test/sources/badSources/NoPragma.sol
@@ -1,4 +1,2 @@
 //SPDX-License-Identifier: MIT
-paragma solidity >0.4.0;
-
 contract Error {}

--- a/packages/compile-solidity/test/sources/multipleSolcVersions/withImports/D.sol
+++ b/packages/compile-solidity/test/sources/multipleSolcVersions/withImports/D.sol
@@ -1,0 +1,6 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.6.12;
+
+import "./NoPragma.sol";
+
+contract D {}

--- a/packages/compile-solidity/test/sources/multipleSolcVersions/withImports/NoPragma.sol
+++ b/packages/compile-solidity/test/sources/multipleSolcVersions/withImports/NoPragma.sol
@@ -1,0 +1,3 @@
+//SPDX-License-Identifier: MIT
+
+contract NoPragma {}


### PR DESCRIPTION
addresses https://github.com/trufflesuite/truffle/issues/4928

There is currently a bug where Truffle throws an unhelpful error when a user utilizes the "pragma" compiler setting and doesn't include a pragma expression in one of their sources. Though this is legal Solidity, Truffle requires the user to have a pragma expression in the sources the user creates because Truffle needs to load a version of the Solidity parser to find imports for the source.

There is code meant to handle this case but it turns out that it fails before running this code as it tries to index into a regex match when that result could possibly be `null`. This PR adds a check that determines whether a result is present before attempting to index into the result.

I'm going to try and write (a) test(s) for this bug fix.