### PR TITLE
Allow the truffle dashboard to disable the process button after click

### DIFF
--- a/packages/dashboard/src/components/DashboardProvider/IncomingRequest.tsx
+++ b/packages/dashboard/src/components/DashboardProvider/IncomingRequest.tsx
@@ -4,6 +4,7 @@ import { handleDashboardProviderRequest, respond } from "../../utils/utils";
 import Button from "../common/Button";
 import Card from "../common/Card";
 import { DashboardProviderMessage } from "@truffle/dashboard-message-bus";
+import React from "react";
 
 interface Props {
   request: DashboardProviderMessage;
@@ -17,6 +18,8 @@ interface Props {
 }
 
 function IncomingRequest({ provider, socket, request, setRequests }: Props) {
+  const [disable, setDisable]=React.useState(false);
+
   const removeFromRequests = () => {
     setRequests(previousRequests =>
       previousRequests.filter(other => other.id !== request.id)
@@ -104,12 +107,26 @@ function IncomingRequest({ provider, socket, request, setRequests }: Props) {
 
   const body = <div>{formatDashboardProviderRequestParameters(request)}</div>;
 
-  const footer = (
-    <div className="flex justify-start items-center gap-2">
-      <Button onClick={process} text="Process" />
-      <Button onClick={reject} text="Reject" />
-    </div>
-  );
+  var footer;
+  if (disable) {
+    footer = (
+      <div className="flex justify-start items-center gap-2">
+        <button
+          className="rounded p-2 text-truffle-brown uppercase hover:bg-white"
+          disabled={disable}
+        >
+          Processing...
+        </button>
+      </div>
+    );
+  } else {
+    footer = (
+      <div className="flex justify-start items-center gap-2">
+        <Button onClick={() => {process(); setDisable(true);}} text="Process" />
+        <Button onClick={reject} text="Reject" />
+      </div>
+    );
+  }
 
   return (
     <div key={request.id} className="flex justify-center items-center">


### PR DESCRIPTION
This PR allows the truffle dashboard to disables the "PROCESS" button and to display
"PROCESSING..." after click the "PROCESS" button as reuqested in issue #4758.

The truffle dashboard displays two buttons: PROCESS and REJECT in the
"INCOMING REQUESTS" page. The user can click one of the buttons to process or reject
the request.  But, after click the "PROCESS" button, it may take some time for the
transaction to complete. In particular, when involving HD wallets, the delay could be
significant.  During the delay period, the truffle dashboard shall disable the buttons
and change the text to "PROCESSING...".