### PR TITLE
chore: use `@achrinza/node-ipc`

### DIFF
--- a/packages/environment/chain.js
+++ b/packages/environment/chain.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 require("source-map-support/register");
 
-const IPC = require("node-ipc").IPC;
+const IPC = require("@achrinza/node-ipc").IPC;
 const Ganache = require("ganache");
 const path = require("path");
 const debug = require("debug");

--- a/packages/environment/develop.js
+++ b/packages/environment/develop.js
@@ -1,4 +1,4 @@
-const { IPC } = require("node-ipc");
+const { IPC } = require("@achrinza/node-ipc");
 const path = require("path");
 const { spawn } = require("child_process");
 const debug = require("debug");

--- a/packages/environment/package.json
+++ b/packages/environment/package.json
@@ -20,13 +20,13 @@
     "test": "mocha ./test/** ./test/**/*"
   },
   "dependencies": {
-    "@truffle/artifactor": "^4.0.146",
+    "@achrinza/node-ipc": "9.2.2",
+    "@truffle/artifactor": "^4.0.145",
     "@truffle/error": "^0.1.0",
     "@truffle/expect": "^0.1.0",
     "@truffle/interface-adapter": "^0.5.12",
     "@truffle/resolver": "^8.0.13",
     "ganache": "^7.0.3",
-    "node-ipc": "9.2.1",
     "source-map-support": "^0.5.19",
     "web3": "1.5.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,6 +40,15 @@
     js-sha3 "^0.7.0"
     lodash "^4.17.5"
 
+"@achrinza/node-ipc@9.2.2":
+  version "9.2.2"
+  resolved "https://registry.yarnpkg.com/@achrinza/node-ipc/-/node-ipc-9.2.2.tgz#ae1b5d3d6a9362034eea60c8d946b93893c2e4ec"
+  integrity sha512-b90U39dx0cU6emsOvy5hxU4ApNXnE3+Tuo8XQZfiKTGelDwpMwBVgBP7QX6dGTcJgu/miyJuNJ/2naFBliNWEw==
+  dependencies:
+    "@node-ipc/js-queue" "2.0.3"
+    event-pubsub "4.3.0"
+    js-message "1.0.7"
+
 "@ampproject/remapping@^2.0.0":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.1.1.tgz#7922fb0817bf3166d8d9e258c57477e3fd1c3610"
@@ -4731,6 +4740,13 @@
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@multiformats/base-x/-/base-x-4.0.1.tgz#95ff0fa58711789d53aefb2590a8b7a4e715d121"
   integrity sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw==
+
+"@node-ipc/js-queue@2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@node-ipc/js-queue/-/js-queue-2.0.3.tgz#ac7fe33d766fa53e233ef8fedaf3443a01c5a4cd"
+  integrity sha512-fL1wpr8hhD5gT2dA1qifeVaoDFlQR5es8tFuKqjHX+kdOtdNHnxkVZbtIrR2rxnMFvehkjaZRNV2H/gPXlb0hw==
+  dependencies:
+    easy-stack "1.0.1"
 
 "@nodefactory/filsnap-adapter@^0.2.1":
   version "0.2.2"
@@ -13125,7 +13141,7 @@ dynamic-dedupe@^0.3.0:
   dependencies:
     xtend "^4.0.0"
 
-easy-stack@^1.0.1:
+easy-stack@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/easy-stack/-/easy-stack-1.0.1.tgz#8afe4264626988cabb11f3c704ccd0c835411066"
   integrity sha512-wK2sCs4feiiJeFXn3zvY0p41mdU5VUgbgs1rNsc/y5ngFUijdWd+iIN8eoyuZHKB8xN6BL4PdWmzqFmxNg6V2w==
@@ -19908,13 +19924,6 @@ js-message@1.0.7:
   resolved "https://registry.yarnpkg.com/js-message/-/js-message-1.0.7.tgz#fbddd053c7a47021871bb8b2c95397cc17c20e47"
   integrity sha512-efJLHhLjIyKRewNS9EGZ4UpI8NguuL6fKkhRxVuMmrGV2xN/0APGdQYwLFky5w9naebSZ0OwAGp0G6/2Cg90rA==
 
-js-queue@2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/js-queue/-/js-queue-2.0.2.tgz#0be590338f903b36c73d33c31883a821412cd482"
-  integrity sha512-pbKLsbCfi7kriM3s1J4DDCo7jQkI58zPLHi0heXPzPlj0hjUsm+FesPUbE0DSbIVIK503A36aUBoCN7eMFedkA==
-  dependencies:
-    easy-stack "^1.0.1"
-
 js-scrypt@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/js-scrypt/-/js-scrypt-0.2.0.tgz#7a62b701b4616e70ad0cde544627aabb99d7fe39"
@@ -22993,15 +23002,6 @@ node-interval-tree@^1.3.3:
   integrity sha512-K9vk96HdTK5fEipJwxSvIIqwTqr4e3HRJeJrNxBSeVMNSC/JWARRaX7etOLOuTmrRMeOI/K5TCJu3aWIwZiNTw==
   dependencies:
     shallowequal "^1.0.2"
-
-node-ipc@9.2.1:
-  version "9.2.1"
-  resolved "https://registry.yarnpkg.com/node-ipc/-/node-ipc-9.2.1.tgz#b32f66115f9d6ce841dc4ec2009d6a733f98bb6b"
-  integrity sha512-mJzaM6O3xHf9VT8BULvJSbdVbmHUKRNOH7zDDkCrA1/T+CVjq2WVIDfLt0azZRXpgArJtl3rtmEozrbXPZ9GaQ==
-  dependencies:
-    event-pubsub "4.3.0"
-    js-message "1.0.7"
-    js-queue "2.0.2"
 
 node-libs-browser@^2.0.0, node-libs-browser@^2.2.1:
   version "2.2.1"


### PR DESCRIPTION
`node-ipc` contains nested transient dependencies that is managed by the same author (e.g. `easy-stack`). This change ensures that all packages maintained by @/riaevangelist in the dependency tree are pinned.

More info about the fork: https://github.com/achrinza/node-ipc/issues/1

Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>