### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/packages/dashboard/src/utils/utils.ts
+++ b/packages/dashboard/src/utils/utils.ts
@@ -125,5 +125,5 @@ export const reverseLookup = async (
 };
 
 export const shortenAddress = (address: string) => {
-  return `${address.substr(0, 6)}...${address.substr(address.length - 4, 4)}`;
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
 };

--- a/packages/events/Subscriber/helpers.js
+++ b/packages/events/Subscriber/helpers.js
@@ -54,8 +54,8 @@ const convertHandlerNameToRegex = name => {
     start += match.index + matchLength;
     str += cleanString + starRegex;
   }
-  str += name.substr(start).replace(reRegExpChar, "\\$&");
-  return new RegExp(`^${str.substr(1)}$`, "i");
+  str += name.slice(start).replace(reRegExpChar, "\\$&");
+  return new RegExp(`^${str.slice(1)}$`, "i");
 };
 
 const createLookupTable = handlerNames => {


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.