### PR TITLE
Show program counter instead of instruction index in `truffle opcode`

### DIFF
--- a/packages/core/lib/commands/opcode/run.js
+++ b/packages/core/lib/commands/opcode/run.js
@@ -31,7 +31,10 @@ module.exports = async function (options) {
   const opcodes = CodeUtils.parseCode(bytecode, numInstructions);
 
   if (opcodes.length === 0) {
-    throw new TruffleError("List of instructions is empty!");
+    console.log(
+      "Contract has no bytecode. Please check to make sure it's not an `abstract contract` or an `interface`."
+    );
+    return;
   }
 
   const lastPCByteLength = Conversion.toBytes(

--- a/packages/core/lib/commands/opcode/run.js
+++ b/packages/core/lib/commands/opcode/run.js
@@ -30,15 +30,15 @@ module.exports = async function (options) {
   }
   const opcodes = CodeUtils.parseCode(bytecode, numInstructions);
 
-  const indexLength = (opcodes.length + "").length;
+  const lastPCByteLength = Conversion.toBytes(
+    opcodes[opcodes.length - 1].pc
+  ).byteLength;
 
   opcodes.forEach(opcode => {
-    let strIndex = Conversion.toHexString(opcode.pc) + ":";
-
-    while (strIndex.length < indexLength + 1) {
-      strIndex += " ";
-    }
-
-    console.log(strIndex + " " + opcode.name + " " + (opcode.pushData || ""));
+    console.log(
+      Conversion.toHexString(opcode.pc, lastPCByteLength) + ":",
+      opcode.name,
+      opcode.pushData || ""
+    );
   });
 };

--- a/packages/core/lib/commands/opcode/run.js
+++ b/packages/core/lib/commands/opcode/run.js
@@ -30,6 +30,10 @@ module.exports = async function (options) {
   }
   const opcodes = CodeUtils.parseCode(bytecode, numInstructions);
 
+  if (opcodes.length === 0) {
+    throw new TruffleError("List of instructions is empty!");
+  }
+
   const lastPCByteLength = Conversion.toBytes(
     opcodes[opcodes.length - 1].pc
   ).byteLength;

--- a/packages/core/lib/commands/opcode/run.js
+++ b/packages/core/lib/commands/opcode/run.js
@@ -3,6 +3,8 @@ module.exports = async function (options) {
   const TruffleError = require("@truffle/error");
   const WorkflowCompile = require("@truffle/workflow-compile");
   const CodeUtils = require("@truffle/code-utils");
+  const Codec = require("@truffle/codec");
+  const Conversion = Codec.Conversion;
 
   if (options._.length === 0) {
     throw new TruffleError("Please specify a contract name.");
@@ -31,8 +33,8 @@ module.exports = async function (options) {
 
   const indexLength = (opcodes.length + "").length;
 
-  opcodes.forEach((opcode, index) => {
-    let strIndex = index + ":";
+  opcodes.forEach(opcode => {
+    let strIndex = Conversion.toHexString(opcode.pc) + ":";
 
     while (strIndex.length < indexLength + 1) {
       strIndex += " ";

--- a/packages/core/lib/commands/opcode/run.js
+++ b/packages/core/lib/commands/opcode/run.js
@@ -3,8 +3,7 @@ module.exports = async function (options) {
   const TruffleError = require("@truffle/error");
   const WorkflowCompile = require("@truffle/workflow-compile");
   const CodeUtils = require("@truffle/code-utils");
-  const Codec = require("@truffle/codec");
-  const Conversion = Codec.Conversion;
+  const { Conversion } = require("@truffle/codec");
 
   if (options._.length === 0) {
     throw new TruffleError("Please specify a contract name.");


### PR DESCRIPTION
## Task
The problem was that the `truffle opcode` gave instruction indexes instead of PC values. Issue: #4835.

Works done:
- [x] Corrected output for `truffle opcode`.

## Environment
- Truffle version (`truffle version`): 5.5.6