### PR TITLE
Add custom inspect alias to codec inspectors, to support browser-util-inspect

### DIFF
--- a/packages/codec/lib/export.ts
+++ b/packages/codec/lib/export.ts
@@ -290,8 +290,16 @@ function ethersCompatibleNativizeEventArgs(
  */
 export class CalldataDecodingInspector {
   decoding: CalldataDecoding;
+
   constructor(decoding: CalldataDecoding) {
     this.decoding = decoding;
+  }
+  /**
+   * @dev non-standard alternative interface name used by browser-util-inspect
+   *      package
+   */
+  inspect(depth: number | null, options: InspectOptions): string {
+    return this[util.inspect.custom].bind(this)(depth, options);
   }
   [util.inspect.custom](depth: number | null, options: InspectOptions): string {
     switch (this.decoding.kind) {
@@ -346,6 +354,13 @@ export class LogDecodingInspector {
   constructor(decoding: LogDecoding) {
     this.decoding = decoding;
   }
+  /**
+   * @dev non-standard alternative interface name used by browser-util-inspect
+   *      package
+   */
+  inspect(depth: number | null, options: InspectOptions): string {
+    return this[util.inspect.custom].bind(this)(depth, options);
+  }
   [util.inspect.custom](depth: number | null, options: InspectOptions): string {
     const className = this.decoding.definedIn
       ? this.decoding.definedIn.typeName
@@ -373,6 +388,13 @@ export class ReturndataDecodingInspector {
   decoding: ReturndataDecoding;
   constructor(decoding: ReturndataDecoding) {
     this.decoding = decoding;
+  }
+  /**
+   * @dev non-standard alternative interface name used by browser-util-inspect
+   *      package
+   */
+  inspect(depth: number | null, options: InspectOptions): string {
+    return this[util.inspect.custom].bind(this)(depth, options);
   }
   [util.inspect.custom](depth: number | null, options: InspectOptions): string {
     switch (this.decoding.kind) {

--- a/packages/codec/lib/format/utils/inspect.ts
+++ b/packages/codec/lib/format/utils/inspect.ts
@@ -57,6 +57,13 @@ export class ResultInspector {
   constructor(result: Format.Values.Result) {
     this.result = result;
   }
+  /**
+   * @dev non-standard alternative interface name used by browser-util-inspect
+   *      package
+   */
+  inspect(depth: number | null, options: InspectOptions): string {
+    return this[util.inspect.custom].bind(this)(depth, options);
+  }
   [util.inspect.custom](depth: number | null, options: InspectOptions): string {
     switch (this.result.kind) {
       case "value":
@@ -665,11 +672,17 @@ export function nativizeAccessList(
   return wrappedAccessList.value.map(wrappedAccessListForAddress => {
     //HACK: we're just going to coerce all over the place here
     const addressStorageKeysPair = <Format.Values.OptionallyNamedValue[]>(
-      <Format.Values.TupleValue>wrappedAccessListForAddress
-    ).value;
-    const wrappedAddress = <Format.Values.AddressValue>addressStorageKeysPair[0].value;
-    const wrappedStorageKeys = <Format.Values.ArrayValue>addressStorageKeysPair[1].value;
-    const wrappedStorageKeysArray = <Format.Values.UintValue[]>wrappedStorageKeys.value;
+      (<Format.Values.TupleValue>wrappedAccessListForAddress).value
+    );
+    const wrappedAddress = <Format.Values.AddressValue>(
+      addressStorageKeysPair[0].value
+    );
+    const wrappedStorageKeys = <Format.Values.ArrayValue>(
+      addressStorageKeysPair[1].value
+    );
+    const wrappedStorageKeysArray = <Format.Values.UintValue[]>(
+      wrappedStorageKeys.value
+    );
     return {
       address: wrappedAddress.value.asAddress,
       storageKeys: wrappedStorageKeysArray.map(wrappedStorageKey =>


### PR DESCRIPTION
[browser-util-inspect](https://www.npmjs.com/package/browser-util-inspect) is pretty cool because it provides the Node.js `util.inspect` functionality in the browser! It even supports custom inspect functions...

... except instead of looking for the symbol `util.inspect.custom`, it looks for a method called `inspect`.

This PR aliases the existing symbol-defined method with an additional `inspect` interface for use by this package in the browser.