### PR TITLE
Enhancement: Add decoding of multicalls to `@truffle/decoder`

### DIFF
--- a/packages/codec/lib/core.ts
+++ b/packages/codec/lib/core.ts
@@ -60,13 +60,15 @@ export function* decodeCalldata(
       return {
         kind: "create" as const,
         decodingMode: "full" as const,
-        bytecode: Conversion.toHexString(info.state.calldata)
+        bytecode: Conversion.toHexString(info.state.calldata),
+        interpretations: {}
       };
     } else {
       return {
         kind: "unknown" as const,
         decodingMode: "full" as const,
-        data: Conversion.toHexString(info.state.calldata)
+        data: Conversion.toHexString(info.state.calldata),
+        interpretations: {}
       };
     }
   }
@@ -111,7 +113,8 @@ export function* decodeCalldata(
       class: contractType,
       abi: abiEntry,
       data: Conversion.toHexString(info.state.calldata),
-      decodingMode: "full" as const
+      decodingMode: "full" as const,
+      interpretations: {}
     };
   }
   let decodingMode: DecodingMode = allocation.allocationMode; //starts out this way, degrades to ABI if necessary
@@ -180,7 +183,8 @@ export function* decodeCalldata(
       bytecode: Conversion.toHexString(
         info.state.calldata.slice(0, allocation.offset)
       ),
-      decodingMode
+      decodingMode,
+      interpretations: {}
     };
   } else {
     return {
@@ -189,7 +193,8 @@ export function* decodeCalldata(
       abi: <Abi.FunctionEntry>allocation.abi, //we know it's a function, but typescript doesn't
       arguments: decodedArguments,
       selector,
-      decodingMode
+      decodingMode,
+      interpretations: {}
     };
   }
 }
@@ -466,7 +471,8 @@ export function* decodeEvent(
         class: emittingContractType,
         abi: allocation.abi,
         arguments: decodedArguments,
-        decodingMode
+        decodingMode,
+        interpretations: {}
       };
     } else {
       decoding = {
@@ -476,7 +482,8 @@ export function* decodeEvent(
         abi: allocation.abi,
         arguments: decodedArguments,
         selector,
-        decodingMode
+        decodingMode,
+        interpretations: {}
       };
     }
     decodings.push(decoding);
@@ -682,7 +689,8 @@ export function* decodeReturndata(
         kind: "returnmessage" as const,
         status: true as const,
         data: Conversion.toHexString(info.state.returndata),
-        decodingMode: allocation.allocationMode
+        decodingMode: allocation.allocationMode,
+        interpretations: {}
       };
       decodings.push(decoding);
       continue;
@@ -779,7 +787,8 @@ export function* decodeReturndata(
           kind: "return" as const,
           status: true as const,
           arguments: decodedArguments,
-          decodingMode
+          decodingMode,
+          interpretations: {}
         };
         break;
       case "revert":
@@ -789,21 +798,24 @@ export function* decodeReturndata(
           definedIn: allocation.definedIn,
           status: false as const,
           arguments: decodedArguments,
-          decodingMode
+          decodingMode,
+          interpretations: {}
         };
         break;
       case "selfdestruct":
         decoding = {
           kind: "selfdestruct" as const,
           status: true as const,
-          decodingMode
+          decodingMode,
+          interpretations: {}
         };
         break;
       case "failure":
         decoding = {
           kind: "failure" as const,
           status: false as const,
-          decodingMode
+          decodingMode,
+          interpretations: {}
         };
         break;
     }
@@ -833,7 +845,8 @@ function* decodeBytecode(
       kind: "unknownbytecode" as const,
       status: true as const,
       decodingMode: "full" as const,
-      bytecode
+      bytecode,
+      interpretations: {}
     };
   }
   const contractType = Contexts.Import.contextToType(context);
@@ -881,7 +894,8 @@ function* decodeBytecode(
     decodingMode,
     bytecode,
     immutables,
-    class: contractType
+    class: contractType,
+    interpretations: {}
   };
   //finally: add address if applicable
   if (allocation.delegatecallGuard) {

--- a/packages/codec/lib/export.ts
+++ b/packages/codec/lib/export.ts
@@ -305,10 +305,7 @@ export class CalldataDecodingInspector {
     switch (this.decoding.kind) {
       case "function":
         const fullName = `${this.decoding.class.typeName}.${this.decoding.abi.name}`;
-        if (
-          this.decoding.interpretations &&
-          this.decoding.interpretations.multicall
-        ) {
+        if (this.decoding.interpretations.multicall) {
           return formatMulticall(
             fullName,
             this.decoding.interpretations.multicall,

--- a/packages/codec/lib/export.ts
+++ b/packages/codec/lib/export.ts
@@ -8,7 +8,8 @@ import type {
   CalldataDecoding,
   LogDecoding,
   ReturndataDecoding,
-  AbiArgument
+  AbiArgument,
+  CallInterpretationInfo
 } from "@truffle/codec/types";
 import * as Conversion from "@truffle/codec/conversion";
 
@@ -311,6 +312,42 @@ export class CalldataDecodingInspector {
             this.decoding.interpretations.multicall,
             options
           );
+        } else if (this.decoding.interpretations.aggregate) {
+          return formatAggregate(
+            fullName,
+            this.decoding.interpretations.aggregate,
+            options
+          );
+        } else if (this.decoding.interpretations.tryAggregate) {
+          const { requireSuccess, calls } =
+            this.decoding.interpretations.tryAggregate;
+          return formatAggregate(
+            fullName,
+            calls,
+            options,
+            "requireSuccess",
+            options.stylize(requireSuccess.toString(), "number")
+          );
+        } else if (this.decoding.interpretations.deadlinedMulticall) {
+          const { deadline, calls: decodings } =
+            this.decoding.interpretations.deadlinedMulticall;
+          return formatMulticall(
+            fullName,
+            decodings,
+            options,
+            "deadline",
+            options.stylize(deadline.toString(), "number")
+          );
+        } else if (this.decoding.interpretations.specifiedBlockhashMulticall) {
+          const { specifiedBlockhash, calls: decodings } =
+            this.decoding.interpretations.specifiedBlockhashMulticall;
+          return formatMulticall(
+            fullName,
+            decodings,
+            options,
+            "previousBlockhash",
+            options.stylize(specifiedBlockhash, "number")
+          );
         }
         return formatFunctionLike(fullName, this.decoding.arguments, options);
       case "constructor":
@@ -541,21 +578,59 @@ export function formatFunctionLike(
 function formatMulticall(
   fullName: string,
   decodings: (CalldataDecoding | null)[],
-  options: InspectOptions
+  options: InspectOptions,
+  additionalParameterName?: string,
+  additionalParameterValue?: string
 ): string {
   if (decodings.length === 0) {
     return `${fullName}()`;
   }
   const indent = 2;
-  const formattedDecodings = decodings.map((decoding, index) => {
+  let formattedDecodings = decodings.map((decoding, index) => {
     const formattedDecoding =
       decoding === null
         ? "<decoding error>"
         : util.inspect(new CalldataDecodingInspector(decoding), options);
     return formattedDecoding + (index < decodings.length - 1 ? "," : "");
   });
+  if (additionalParameterName) {
+    formattedDecodings.unshift(
+      `${additionalParameterName}: ${additionalParameterValue},`
+    );
+  }
   return indentMiddleLines(
     `${fullName}(${OS.EOL}${formattedDecodings.join(OS.EOL)}${OS.EOL})`,
+    indent
+  );
+}
+
+function formatAggregate(
+  fullName: string,
+  calls: CallInterpretationInfo[],
+  options: InspectOptions,
+  additionalParameterName?: string,
+  additionalParameterValue?: string
+): string {
+  if (calls.length === 0) {
+    return `${fullName}()`;
+  }
+  const indent = 2;
+  let formattedCalls = calls.map(({ address, decoding }, index) => {
+    const formattedCall =
+      decoding === null
+        ? "<decoding error>"
+        : util
+            .inspect(new CalldataDecodingInspector(decoding), options)
+            .replace(".", `(${options.stylize(address, "number")}).`); //HACK: splice in the address
+    return formattedCall + (index < calls.length - 1 ? "," : "");
+  });
+  if (additionalParameterName) {
+    formattedCalls.unshift(
+      `${additionalParameterName}: ${additionalParameterValue},`
+    );
+  }
+  return indentMiddleLines(
+    `${fullName}(${OS.EOL}${formattedCalls.join(OS.EOL)}${OS.EOL})`,
     indent
   );
 }

--- a/packages/codec/lib/index.ts
+++ b/packages/codec/lib/index.ts
@@ -77,11 +77,7 @@ export {
   decodeReturndata,
   decodeRevert
 } from "./core";
-export {
-  DecodingError,
-  StopDecodingError,
-  NoProjectInfoError
-} from "./errors";
+export { DecodingError, StopDecodingError, NoProjectInfoError } from "./errors";
 
 //now: what types should we export? (other than the ones from ./format)
 //public-facing types for the interface
@@ -120,7 +116,11 @@ export type {
   DecimalWrapResponse,
   AddressWrapResponse,
   BlockSpecifier,
-  RegularizedBlockSpecifier
+  RegularizedBlockSpecifier,
+  CallInterpretationInfo,
+  TryAggregateInfo,
+  DeadlinedMulticallInfo,
+  BlockhashedMulticallInfo
 } from "./types";
 export * from "./common";
 
@@ -148,14 +148,7 @@ import * as Stack from "./stack";
 import * as Storage from "./storage";
 import * as AstConstant from "./ast-constant";
 
-export {
-  MappingKey,
-  Memory,
-  Special,
-  Stack,
-  Storage,
-  AstConstant
-};
+export { MappingKey, Memory, Special, Stack, Storage, AstConstant };
 
 import * as Ast from "./ast";
 export { Ast };

--- a/packages/codec/lib/types.ts
+++ b/packages/codec/lib/types.ts
@@ -103,6 +103,20 @@ export interface FunctionDecoding {
    * more on these.
    */
   decodingMode: DecodingMode;
+  /**
+   * Further information about how the decoding may be interpreted.  Note that interpretations
+   * may be added by things that use @truffle/codec, such as @truffle/decoder, rather than by
+   * @truffle/codec itself.  See individual interpretations for details.
+   */
+  interpretations?: {
+    /**
+     * If this interpretation is present, indicates that the transaction can be
+     * understood as a multicall.  The field contains decodings for the individual
+     * calls that the multicall can be broken into.  Note that in case of an error,
+     * individual decodings will be returned as null, so be sure to check for this.
+     */
+    multicall?: (CalldataDecoding | null)[];
+  };
 }
 
 /**
@@ -144,6 +158,13 @@ export interface ConstructorDecoding {
    * more on these.
    */
   decodingMode: DecodingMode;
+  /**
+   * Further information about how the decoding may be interpreted.  Note that interpretations
+   * may be added by things that use @truffle/codec, such as @truffle/decoder, rather than by
+   * @truffle/codec itself.  See individual interpretations for details.
+   * (Currently there are none for this type.)
+   */
+  interpretations?: {};
 }
 
 /**
@@ -176,6 +197,13 @@ export interface MessageDecoding {
    * more on these.
    */
   decodingMode: DecodingMode;
+  /**
+   * Further information about how the decoding may be interpreted.  Note that interpretations
+   * may be added by things that use @truffle/codec, such as @truffle/decoder, rather than by
+   * @truffle/codec itself.  See individual interpretations for details.
+   * (Currently there are none for this type.)
+   */
+  interpretations?: {};
 }
 
 /**
@@ -198,6 +226,13 @@ export interface UnknownCallDecoding {
    * The data that was sent to the contract.
    */
   data: string;
+  /**
+   * Further information about how the decoding may be interpreted.  Note that interpretations
+   * may be added by things that use @truffle/codec, such as @truffle/decoder, rather than by
+   * @truffle/codec itself.  See individual interpretations for details.
+   * (Currently there are none for this type.)
+   */
+  interpretations?: {};
 }
 
 /**
@@ -220,6 +255,13 @@ export interface UnknownCreationDecoding {
    * The bytecode of the contract creation.
    */
   bytecode: string;
+  /**
+   * Further information about how the decoding may be interpreted.  Note that interpretations
+   * may be added by things that use @truffle/codec, such as @truffle/decoder, rather than by
+   * @truffle/codec itself.  See individual interpretations for details.
+   * (Currently there are none for this type.)
+   */
+  interpretations?: {};
 }
 
 /**
@@ -262,6 +304,13 @@ export interface EventDecoding {
    * more on these.
    */
   decodingMode: DecodingMode;
+  /**
+   * Further information about how the decoding may be interpreted.  Note that interpretations
+   * may be added by things that use @truffle/codec, such as @truffle/decoder, rather than by
+   * @truffle/codec itself.  See individual interpretations for details.
+   * (Currently there are none for this type.)
+   */
+  interpretations?: {};
 }
 
 /**
@@ -300,6 +349,13 @@ export interface AnonymousDecoding {
    * more on these.
    */
   decodingMode: DecodingMode;
+  /**
+   * Further information about how the decoding may be interpreted.  Note that interpretations
+   * may be added by things that use @truffle/codec, such as @truffle/decoder, rather than by
+   * @truffle/codec itself.  See individual interpretations for details.
+   * (Currently there are none for this type.)
+   */
+  interpretations?: {};
 }
 
 /**
@@ -325,6 +381,13 @@ export interface ReturnDecoding {
    * more on these.
    */
   decodingMode: DecodingMode;
+  /**
+   * Further information about how the decoding may be interpreted.  Note that interpretations
+   * may be added by things that use @truffle/codec, such as @truffle/decoder, rather than by
+   * @truffle/codec itself.  See individual interpretations for details.
+   * (Currently there are none for this type.)
+   */
+  interpretations?: {};
 }
 
 /**
@@ -350,6 +413,13 @@ export interface RawReturnDecoding {
    * more on these.
    */
   decodingMode: DecodingMode;
+  /**
+   * Further information about how the decoding may be interpreted.  Note that interpretations
+   * may be added by things that use @truffle/codec, such as @truffle/decoder, rather than by
+   * @truffle/codec itself.  See individual interpretations for details.
+   * (Currently there are none for this type.)
+   */
+  interpretations?: {};
 }
 
 /**
@@ -371,6 +441,13 @@ export interface SelfDestructDecoding {
    * more on these.
    */
   decodingMode: DecodingMode;
+  /**
+   * Further information about how the decoding may be interpreted.  Note that interpretations
+   * may be added by things that use @truffle/codec, such as @truffle/decoder, rather than by
+   * @truffle/codec itself.  See individual interpretations for details.
+   * (Currently there are none for this type.)
+   */
+  interpretations?: {};
 }
 
 /**
@@ -392,6 +469,13 @@ export interface EmptyFailureDecoding {
    * more on these.
    */
   decodingMode: DecodingMode;
+  /**
+   * Further information about how the decoding may be interpreted.  Note that interpretations
+   * may be added by things that use @truffle/codec, such as @truffle/decoder, rather than by
+   * @truffle/codec itself.  See individual interpretations for details.
+   * (Currently there are none for this type.)
+   */
+  interpretations?: {};
 }
 
 /**
@@ -433,6 +517,13 @@ export interface RevertMessageDecoding {
    * more on these.
    */
   decodingMode: DecodingMode;
+  /**
+   * Further information about how the decoding may be interpreted.  Note that interpretations
+   * may be added by things that use @truffle/codec, such as @truffle/decoder, rather than by
+   * @truffle/codec itself.  See individual interpretations for details.
+   * (Currently there are none for this type.)
+   */
+  interpretations?: {};
 }
 
 /**
@@ -479,6 +570,13 @@ export interface BytecodeDecoding {
    * otherwise!
    */
   address?: string;
+  /**
+   * Further information about how the decoding may be interpreted.  Note that interpretations
+   * may be added by things that use @truffle/codec, such as @truffle/decoder, rather than by
+   * @truffle/codec itself.  See individual interpretations for details.
+   * (Currently there are none for this type.)
+   */
+  interpretations?: {};
 }
 
 /**
@@ -509,6 +607,13 @@ export interface UnknownBytecodeDecoding {
    * The bytecode of the contract that was created.
    */
   bytecode: string;
+  /**
+   * Further information about how the decoding may be interpreted.  Note that interpretations
+   * may be added by things that use @truffle/codec, such as @truffle/decoder, rather than by
+   * @truffle/codec itself.  See individual interpretations for details.
+   * (Currently there are none for this type.)
+   */
+  interpretations?: {};
 }
 
 /**
@@ -620,7 +725,10 @@ export interface LogOptions {
  *
  * @Category Requests
  */
-export type WrapRequest = IntegerWrapRequest | DecimalWrapRequest | AddressWrapRequest;
+export type WrapRequest =
+  | IntegerWrapRequest
+  | DecimalWrapRequest
+  | AddressWrapRequest;
 
 /**
  * A request to understand an integer value.
@@ -676,7 +784,10 @@ export interface AddressWrapRequest {
  *
  * @Category Requests
  */
-export type WrapResponse = IntegerWrapResponse | DecimalWrapResponse | AddressWrapResponse;
+export type WrapResponse =
+  | IntegerWrapResponse
+  | DecimalWrapResponse
+  | AddressWrapResponse;
 
 /**
  * A response with an integral numeric value, as BigInt.

--- a/packages/codec/lib/types.ts
+++ b/packages/codec/lib/types.ts
@@ -111,11 +111,32 @@ export interface FunctionDecoding {
   interpretations: {
     /**
      * If this interpretation is present, indicates that the transaction can be
-     * understood as a multicall.  The field contains decodings for the individual
-     * calls that the multicall can be broken into.  Note that in case of an error,
-     * individual decodings will be returned as null, so be sure to check for this.
+     * understood as a multicall (v1).  The field contains decodings for the
+     * individual calls that the multicall can be broken into.  Note that in
+     * case of an error, individual decodings will be returned as null, so be
+     * sure to check for this.
      */
     multicall?: (CalldataDecoding | null)[];
+    /**
+     * If this interpretation is present, indicates that the transaction can be
+     * understood as an `aggregate` (from multicallv2).  This also includes
+     * `blockAndAggregate`.  See [[CallInterpretationInfo]] for more
+     * information.
+     */
+    aggregate?: CallInterpretationInfo[];
+    /**
+     * Similar to the `aggregate` interpretation, but for `tryAggregate`.  Also
+     * includes `tryBlockAndAggregate`.
+     */
+    tryAggregate?: TryAggregateInfo;
+    /**
+     * Similar to `multicall`, but for Uniswap's deadlined multicall.
+     */
+    deadlinedMulticall?: DeadlinedMulticallInfo;
+    /**
+     * Similar to `multicall`, but for Uniswap's multicall with previous block hash.
+     */
+    specifiedBlockhashMulticall?: BlockhashedMulticallInfo;
   };
 }
 
@@ -884,3 +905,66 @@ export type BlockSpecifier = number | "genesis" | "latest" | "pending";
  * @hidden
  */
 export type RegularizedBlockSpecifier = number | "pending";
+
+/**
+ * Used by some multicall-like interpretations.
+ * @category Output
+ */
+export interface CallInterpretationInfo {
+  /**
+   * The address the call was sent to; may be null in case of
+   * an error.
+   */
+  address: string | null;
+  /**
+   * The decoding of the call; may be null in case of error.
+   */
+  decoding: CalldataDecoding | null;
+}
+
+/**
+ * Used by the `tryAggregate` interpretation.
+ * @category Output
+ */
+export interface TryAggregateInfo {
+  /**
+   * Whether success was required.
+   */
+  requireSuccess: boolean;
+  /**
+   * The decodings of the individual calls.
+   */
+  calls: CallInterpretationInfo[];
+}
+
+/**
+ * Used by the `deadlinedMulticall` interpretation.
+ * @category Output
+ */
+export interface DeadlinedMulticallInfo {
+  /**
+   * The deadline.
+   */
+  deadline: BN;
+  /**
+   * The decodings of the individual calls; these may each be null in
+   * case of an error.
+   */
+  calls: (CalldataDecoding | null)[];
+}
+
+/**
+ * Used by the `specifiedBlockhashMulticall` interpretation.
+ * @category Output
+ */
+export interface BlockhashedMulticallInfo {
+  /**
+   * The specified parent blockhash.
+   */
+  specifiedBlockhash: string;
+  /**
+   * The decodings of the individual calls; these may each be null in
+   * case of an error.
+   */
+  calls: (CalldataDecoding | null)[];
+}

--- a/packages/codec/lib/types.ts
+++ b/packages/codec/lib/types.ts
@@ -108,7 +108,7 @@ export interface FunctionDecoding {
    * may be added by things that use @truffle/codec, such as @truffle/decoder, rather than by
    * @truffle/codec itself.  See individual interpretations for details.
    */
-  interpretations?: {
+  interpretations: {
     /**
      * If this interpretation is present, indicates that the transaction can be
      * understood as a multicall.  The field contains decodings for the individual
@@ -164,7 +164,7 @@ export interface ConstructorDecoding {
    * @truffle/codec itself.  See individual interpretations for details.
    * (Currently there are none for this type.)
    */
-  interpretations?: {};
+  interpretations: {};
 }
 
 /**
@@ -203,7 +203,7 @@ export interface MessageDecoding {
    * @truffle/codec itself.  See individual interpretations for details.
    * (Currently there are none for this type.)
    */
-  interpretations?: {};
+  interpretations: {};
 }
 
 /**
@@ -232,7 +232,7 @@ export interface UnknownCallDecoding {
    * @truffle/codec itself.  See individual interpretations for details.
    * (Currently there are none for this type.)
    */
-  interpretations?: {};
+  interpretations: {};
 }
 
 /**
@@ -261,7 +261,7 @@ export interface UnknownCreationDecoding {
    * @truffle/codec itself.  See individual interpretations for details.
    * (Currently there are none for this type.)
    */
-  interpretations?: {};
+  interpretations: {};
 }
 
 /**
@@ -310,7 +310,7 @@ export interface EventDecoding {
    * @truffle/codec itself.  See individual interpretations for details.
    * (Currently there are none for this type.)
    */
-  interpretations?: {};
+  interpretations: {};
 }
 
 /**
@@ -355,7 +355,7 @@ export interface AnonymousDecoding {
    * @truffle/codec itself.  See individual interpretations for details.
    * (Currently there are none for this type.)
    */
-  interpretations?: {};
+  interpretations: {};
 }
 
 /**
@@ -387,7 +387,7 @@ export interface ReturnDecoding {
    * @truffle/codec itself.  See individual interpretations for details.
    * (Currently there are none for this type.)
    */
-  interpretations?: {};
+  interpretations: {};
 }
 
 /**
@@ -419,7 +419,7 @@ export interface RawReturnDecoding {
    * @truffle/codec itself.  See individual interpretations for details.
    * (Currently there are none for this type.)
    */
-  interpretations?: {};
+  interpretations: {};
 }
 
 /**
@@ -447,7 +447,7 @@ export interface SelfDestructDecoding {
    * @truffle/codec itself.  See individual interpretations for details.
    * (Currently there are none for this type.)
    */
-  interpretations?: {};
+  interpretations: {};
 }
 
 /**
@@ -475,7 +475,7 @@ export interface EmptyFailureDecoding {
    * @truffle/codec itself.  See individual interpretations for details.
    * (Currently there are none for this type.)
    */
-  interpretations?: {};
+  interpretations: {};
 }
 
 /**
@@ -523,7 +523,7 @@ export interface RevertMessageDecoding {
    * @truffle/codec itself.  See individual interpretations for details.
    * (Currently there are none for this type.)
    */
-  interpretations?: {};
+  interpretations: {};
 }
 
 /**
@@ -576,7 +576,7 @@ export interface BytecodeDecoding {
    * @truffle/codec itself.  See individual interpretations for details.
    * (Currently there are none for this type.)
    */
-  interpretations?: {};
+  interpretations: {};
 }
 
 /**
@@ -613,7 +613,7 @@ export interface UnknownBytecodeDecoding {
    * @truffle/codec itself.  See individual interpretations for details.
    * (Currently there are none for this type.)
    */
-  interpretations?: {};
+  interpretations: {};
 }
 
 /**

--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -14,10 +14,15 @@ import {
   Compilations,
   Compiler,
   CalldataDecoding,
+  FunctionDecoding,
   LogDecoding,
   ReturndataDecoding,
   BlockSpecifier,
   RegularizedBlockSpecifier,
+  CallInterpretationInfo,
+  TryAggregateInfo,
+  DeadlinedMulticallInfo,
+  BlockhashedMulticallInfo,
   decodeCalldata,
   decodeEvent,
   decodeReturndata
@@ -260,36 +265,13 @@ export class ProjectDecoder {
     let decoding = result.value;
 
     //...except wait!  we're not done yet! we need to do multicall processing!
-    if (
-      decoding.kind === "function" &&
-      decoding.abi.name === "multicall" &&
-      decoding.arguments.length === 1 &&
-      decoding.arguments[0].value.type.typeClass === "array" &&
-      decoding.arguments[0].value.type.baseType.typeClass === "bytes" &&
-      decoding.arguments[0].value.type.baseType.kind === "dynamic" &&
-      decoding.arguments[0].value.kind === "value"
-    ) {
-      const decodedArray = decoding.arguments[0]
-        .value as Format.Values.ArrayValue;
-      const multicallArray = await Promise.all(
-        decodedArray.value.map(async callResult => {
-          const coercedResult = callResult as Format.Values.BytesResult;
-          switch (coercedResult.kind) {
-            case "value":
-              return await this.decodeTransactionWithAdditionalContexts(
-                { ...transaction, input: coercedResult.value.asHex },
-                additionalContexts,
-                additionalAllocations
-              );
-            case "error":
-              return null;
-          }
-        })
+    if (decoding.kind === "function") {
+      decoding = await this.withMulticallInterpretations(
+        decoding,
+        transaction,
+        additionalContexts,
+        additionalAllocations
       );
-      //it's safe to modify decoding -- we've gotten it straight out of codec,
-      //it's not shared with anything else, so for convenience I'm just going to
-      //mutate rather than cloning
-      decoding.interpretations.multicall = multicallArray;
     }
 
     return decoding;
@@ -655,6 +637,342 @@ export class ProjectDecoder {
    */
   public getDeployedContexts(): Contexts.Contexts {
     return this.deployedContexts;
+  }
+
+  //now, the interpretation stuff.  ideally this would be a separate file
+  //(I mean, as would each decoder!) but that would cause circular imports, so... :-/
+  private async withMulticallInterpretations(
+    decoding: FunctionDecoding,
+    transaction: DecoderTypes.Transaction,
+    additionalContexts: Contexts.Contexts = {},
+    additionalAllocations?: {
+      [
+        selector: string
+      ]: AbiData.Allocate.FunctionCalldataAndReturndataAllocation;
+    }
+  ): Promise<CalldataDecoding> {
+    //first, let's clone our decoding and its interpretations
+    decoding = {
+      ...decoding,
+      interpretations: {
+        ...decoding.interpretations
+      }
+    };
+
+    //now we can freely modify decoding.interpretations
+    //(note: these may return undefined)
+    decoding.interpretations.multicall = await this.interpretMulticall(
+      decoding,
+      transaction,
+      additionalContexts,
+      additionalAllocations
+    );
+    decoding.interpretations.aggregate = await this.interpretAggregate(
+      decoding,
+      transaction,
+      additionalContexts,
+      additionalAllocations
+    );
+    decoding.interpretations.tryAggregate = await this.interpretTryAggregate(
+      decoding,
+      transaction,
+      additionalContexts,
+      additionalAllocations
+    );
+    decoding.interpretations.deadlinedMulticall =
+      await this.interpretDeadlinedMulticall(
+        decoding,
+        transaction,
+        additionalContexts,
+        additionalAllocations
+      );
+    decoding.interpretations.specifiedBlockhashMulticall =
+      await this.interpretBlockhashedMulticall(
+        decoding,
+        transaction,
+        additionalContexts,
+        additionalAllocations
+      );
+
+    return decoding;
+  }
+
+  private async interpretMulticall(
+    decoding: Codec.CalldataDecoding,
+    transaction: DecoderTypes.Transaction,
+    additionalContexts: Contexts.Contexts = {},
+    additionalAllocations?: {
+      [
+        selector: string
+      ]: AbiData.Allocate.FunctionCalldataAndReturndataAllocation;
+    }
+  ): Promise<(Codec.CalldataDecoding | null)[] | undefined> {
+    if (
+      decoding.kind === "function" &&
+      decoding.abi.name === "multicall" &&
+      decoding.abi.inputs.length === 1 &&
+      decoding.abi.inputs[0].type === "bytes[]" &&
+      decoding.arguments[0].value.kind === "value"
+    ) {
+      //sorry, this is going to involve some coercion...
+      const decodedArray = decoding.arguments[0]
+        .value as Format.Values.ArrayValue;
+      return await Promise.all(
+        decodedArray.value.map(
+          async callResult =>
+            await this.interpretCallInMulti(
+              callResult as Format.Values.BytesResult,
+              transaction,
+              additionalContexts,
+              additionalAllocations
+            )
+        )
+      );
+    } else {
+      return undefined;
+    }
+  }
+
+  private async interpretCallInMulti(
+    callResult: Format.Values.BytesResult,
+    transaction: DecoderTypes.Transaction,
+    additionalContexts: Contexts.Contexts = {},
+    additionalAllocations?: {
+      [
+        selector: string
+      ]: AbiData.Allocate.FunctionCalldataAndReturndataAllocation;
+    }
+  ): Promise<Codec.CalldataDecoding | null> {
+    switch (callResult.kind) {
+      case "value":
+        return await this.decodeTransactionWithAdditionalContexts(
+          { ...transaction, input: callResult.value.asHex },
+          additionalContexts,
+          additionalAllocations
+        );
+      case "error":
+        return null;
+    }
+  }
+
+  private async interpretAggregate(
+    decoding: Codec.CalldataDecoding,
+    transaction: DecoderTypes.Transaction,
+    additionalContexts: Contexts.Contexts = {},
+    additionalAllocations?: {
+      [
+        selector: string
+      ]: AbiData.Allocate.FunctionCalldataAndReturndataAllocation;
+    }
+  ): Promise<CallInterpretationInfo[] | undefined> {
+    if (
+      decoding.kind === "function" &&
+      (decoding.abi.name === "aggregate" ||
+        decoding.abi.name === "blockAndAggregate") &&
+      decoding.abi.inputs.length === 1 &&
+      decoding.abi.inputs[0].type === "tuple[]" &&
+      decoding.abi.inputs[0].components.length === 2 &&
+      decoding.abi.inputs[0].components[0].type === "address" &&
+      decoding.abi.inputs[0].components[1].type === "bytes" &&
+      decoding.arguments[0].value.kind === "value"
+    ) {
+      //sorry, this is going to involve some coercion...
+      const decodedArray = decoding.arguments[0]
+        .value as Format.Values.ArrayValue;
+      return await Promise.all(
+        decodedArray.value.map(
+          async callResult =>
+            await this.interpretCallInAggregate(
+              callResult as
+                | Format.Values.StructResult
+                | Format.Values.TupleResult,
+              transaction,
+              additionalContexts,
+              additionalAllocations
+            )
+        )
+      );
+    } else {
+      return undefined;
+    }
+  }
+
+  private async interpretCallInAggregate(
+    callResult: Format.Values.StructResult | Format.Values.TupleResult,
+    transaction: DecoderTypes.Transaction,
+    additionalContexts: Contexts.Contexts = {},
+    additionalAllocations?: {
+      [
+        selector: string
+      ]: AbiData.Allocate.FunctionCalldataAndReturndataAllocation;
+    }
+  ): Promise<CallInterpretationInfo> {
+    switch (callResult.kind) {
+      case "value":
+        const addressResult = callResult.value[0]
+          .value as Codec.Format.Values.AddressResult;
+        const bytesResult = callResult.value[1]
+          .value as Codec.Format.Values.BytesResult;
+        let address: string;
+        switch (addressResult.kind) {
+          case "value":
+            address = addressResult.value.asAddress;
+            break;
+          case "error":
+            //can't decode in this case
+            return { address: null, decoding: null };
+        }
+        switch (bytesResult.kind) {
+          case "value":
+            const subDecoding =
+              await this.decodeTransactionWithAdditionalContexts(
+                {
+                  ...transaction,
+                  input: bytesResult.value.asHex,
+                  to: address
+                },
+                additionalContexts,
+                additionalAllocations
+              );
+            return { address, decoding: subDecoding };
+          case "error":
+            return { address, decoding: null };
+        }
+      case "error":
+        return { address: null, decoding: null };
+    }
+  }
+
+  private async interpretTryAggregate(
+    decoding: Codec.CalldataDecoding,
+    transaction: DecoderTypes.Transaction,
+    additionalContexts: Contexts.Contexts = {},
+    additionalAllocations?: {
+      [
+        selector: string
+      ]: AbiData.Allocate.FunctionCalldataAndReturndataAllocation;
+    }
+  ): Promise<TryAggregateInfo | undefined> {
+    if (
+      decoding.kind === "function" &&
+      (decoding.abi.name === "tryAggregate" ||
+        decoding.abi.name === "tryBlockAndAggregate") &&
+      decoding.abi.inputs.length === 2 &&
+      decoding.abi.inputs[0].type === "bool" &&
+      decoding.abi.inputs[1].type === "tuple[]" &&
+      decoding.abi.inputs[1].components.length === 2 &&
+      decoding.abi.inputs[1].components[0].type === "address" &&
+      decoding.abi.inputs[1].components[1].type === "bytes" &&
+      decoding.arguments[0].value.kind === "value" &&
+      decoding.arguments[1].value.kind === "value"
+    ) {
+      //sorry, this is going to involve some coercion...
+      const decodedBool = decoding.arguments[0]
+        .value as Format.Values.BoolValue;
+      const decodedArray = decoding.arguments[1]
+        .value as Format.Values.ArrayValue;
+      const requireSuccess: boolean = decodedBool.value.asBoolean;
+      const calls = await Promise.all(
+        decodedArray.value.map(
+          async callResult =>
+            await this.interpretCallInAggregate(
+              callResult as
+                | Format.Values.StructResult
+                | Format.Values.TupleResult,
+              transaction,
+              additionalContexts,
+              additionalAllocations
+            )
+        )
+      );
+      return { requireSuccess, calls };
+    } else {
+      return undefined;
+    }
+  }
+
+  private async interpretDeadlinedMulticall(
+    decoding: Codec.CalldataDecoding,
+    transaction: DecoderTypes.Transaction,
+    additionalContexts: Contexts.Contexts = {},
+    additionalAllocations?: {
+      [
+        selector: string
+      ]: AbiData.Allocate.FunctionCalldataAndReturndataAllocation;
+    }
+  ): Promise<DeadlinedMulticallInfo | undefined> {
+    if (
+      decoding.kind === "function" &&
+      decoding.abi.name === "multicall" &&
+      decoding.abi.inputs.length === 2 &&
+      decoding.abi.inputs[0].type === "uint256" &&
+      decoding.abi.inputs[1].type === "bytes[]" &&
+      decoding.arguments[0].value.kind === "value" &&
+      decoding.arguments[1].value.kind === "value"
+    ) {
+      //sorry, this is going to involve some coercion...
+      const decodedUint = decoding.arguments[0]
+        .value as Format.Values.UintValue;
+      const decodedArray = decoding.arguments[1]
+        .value as Format.Values.ArrayValue;
+      const deadline: BN = decodedUint.value.asBN;
+      const calls = await Promise.all(
+        decodedArray.value.map(
+          async callResult =>
+            await this.interpretCallInMulti(
+              callResult as Format.Values.BytesResult,
+              transaction,
+              additionalContexts,
+              additionalAllocations
+            )
+        )
+      );
+      return { deadline, calls };
+    } else {
+      return undefined;
+    }
+  }
+
+  private async interpretBlockhashedMulticall(
+    decoding: Codec.CalldataDecoding,
+    transaction: DecoderTypes.Transaction,
+    additionalContexts: Contexts.Contexts = {},
+    additionalAllocations?: {
+      [
+        selector: string
+      ]: AbiData.Allocate.FunctionCalldataAndReturndataAllocation;
+    }
+  ): Promise<BlockhashedMulticallInfo | undefined> {
+    if (
+      decoding.kind === "function" &&
+      decoding.abi.name === "multicall" &&
+      decoding.abi.inputs.length === 2 &&
+      decoding.abi.inputs[0].type === "bytes32" &&
+      decoding.abi.inputs[1].type === "bytes[]" &&
+      decoding.arguments[0].value.kind === "value" &&
+      decoding.arguments[1].value.kind === "value"
+    ) {
+      //sorry, this is going to involve some coercion...
+      const decodedHash = decoding.arguments[0]
+        .value as Format.Values.BytesValue;
+      const decodedArray = decoding.arguments[1]
+        .value as Format.Values.ArrayValue;
+      const specifiedBlockhash: string = decodedHash.value.asHex;
+      const calls = await Promise.all(
+        decodedArray.value.map(
+          async callResult =>
+            await this.interpretCallInMulti(
+              callResult as Format.Values.BytesResult,
+              transaction,
+              additionalContexts,
+              additionalAllocations
+            )
+        )
+      );
+      return { specifiedBlockhash, calls };
+    } else {
+      return undefined;
+    }
   }
 }
 

--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -289,10 +289,7 @@ export class ProjectDecoder {
       //it's safe to modify decoding -- we've gotten it straight out of codec,
       //it's not shared with anything else, so for convenience I'm just going to
       //mutate rather than cloning
-      decoding.interpretations = {
-        ...decoding.interpretations,
-        multicall: multicallArray
-      };
+      decoding.interpretations.multicall = multicallArray;
     }
 
     return decoding;

--- a/packages/decoder/test/current/contracts/WireTest.sol
+++ b/packages/decoder/test/current/contracts/WireTest.sol
@@ -229,6 +229,33 @@ contract WireTest is WireTestParent, WireTestAbstract {
       address(this).call(datas[i]);
     }
   }
+
+  struct Call {
+    address target;
+    bytes data;
+  }
+
+  function aggregate(Call[] calldata calls) external {
+    for (uint i = 0; i < calls.length; i++) {
+      calls[i].target.call(calls[i].data);
+    }
+  }
+
+  event Result(bytes);
+
+  function tryAggregate(bool requireSuccess, Call[] calldata calls) external {
+    for (uint i = 0; i < calls.length; i++) {
+      (bool success, bytes memory result) = calls[i].target.call(calls[i].data);
+      if (requireSuccess) require(success);
+    }
+  }
+
+  function multicall(uint deadline, bytes[] calldata datas) external {
+    require(block.timestamp <= deadline);
+    for (uint i = 0; i < datas.length; i++) {
+      address(this).call(datas[i]);
+    }
+  }
 }
 
 library WireTestLibrary {
@@ -268,5 +295,9 @@ contract WireTestRedHerring {
 
   function run() public {
     emit NonAmbiguousEvent();
+  }
+
+  function otherMethod(uint k) public {
+    emit SemiAmbiguousEvent(k, 0);
   }
 }

--- a/packages/decoder/test/current/contracts/WireTest.sol
+++ b/packages/decoder/test/current/contracts/WireTest.sol
@@ -224,6 +224,11 @@ contract WireTest is WireTestParent, WireTestAbstract {
     WireTestLibrary.throwAmbiguous();
   }
 
+  function multicall(bytes[] calldata datas) external {
+    for (uint i = 0; i < datas.length; i++) {
+      address(this).call(datas[i]);
+    }
+  }
 }
 
 library WireTestLibrary {


### PR DESCRIPTION
Addresses #4133.  This PR adds `interpretations` to decodings returned by `@truffle/decoder`, with one interpretation currently existing: multicall.

This is mostly pretty straightforward -- the decoder, after decoding a transaction, will check whether it's a multicall (as in: name `multicall`, arguments a single `bytes[]`), and, if it is, will then recurse over the subcalls and decode them, sticking the result in `interpretations.multicall`.  There's not much to say about the logic here!  I also added a test of this functionality.

I also updated `CalldataDecodingInspector` so that it will check for `interpretations.multicall`, and, if it finds it present, print out the the calls made rather than the raw bytestrings for each entry.  In the process I found that the existing logic for `formatFunctionLike` wasn't really working like I wanted so I fixed that up a bit too.

Really, the thing on this PR that really needs looking over is the types.  Here are the questions I have for @gnidan:
1. I made `interpretations` optional, and only included it when there's something to put in there.  Is this right?  Should it be required?  (Note that if we make it required, and then later also make it required on individual values when we do reverse ENS resolution, I'm going to have to go updating all the wrap functions... not that that'd actually be hard, just annoying, but...)
2. You'll notice that `multicall` is not `CalldataDecoding[]`, but rather `(CalldataDecoding | null)[]`.  This is because, what if one of the individual `bytes` decodes to an error?  Yeah, that shouldn't normally happen, but, like, we should be prepared for the possibility.  I realize this isn't ideal but I couldn't think of a better way of handling this.  Like, if you want the actual error, you can always look in `arguments`!  In the inspector, I just had these `null`s turn into a "could not decode" message... should I perhaps have it actually look in `arguments` so I can have it display the actual error message in case of an error?

But yeah, mostly nothing complicated here!