### PR TITLE
Update solc to the latest version in contract-schema dependencies

### DIFF
--- a/packages/contract-schema/package.json
+++ b/packages/contract-schema/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "json-schema-to-typescript": "^5.5.0",
     "mocha": "8.1.2",
-    "solc": "0.6.0"
+    "solc": "0.8.13"
   },
   "keywords": [
     "artifacts",


### PR DESCRIPTION
### ISSUE
`solc` in `contract-schema` dependencies has an outdated version.

### SOLUTION
This PR updates the `solc` to the latest version in **contract-schema** `package.json` file.