### PR TITLE
Bug fix: Allow functions as input for functions and contracts in `@truffle/encoder`

### DIFF
--- a/packages/codec/lib/wrap/utils.ts
+++ b/packages/codec/lib/wrap/utils.ts
@@ -72,7 +72,7 @@ export function isEncodingTextInput(input: any): input is EncodingTextInput {
 
 export function isContractInput(input: any): input is ContractInput {
   return (
-    typeof input === "object" &&
+    (typeof input === "object" || typeof input === "function") &&
     input !== null &&
     typeof input.address === "string" &&
     //we *don't* check anything more for addresses, we'll let the
@@ -85,7 +85,7 @@ export function isFunctionExternalInput(
   input: any
 ): input is FunctionExternalInput {
   return (
-    typeof input === "object" &&
+    (typeof input === "object" || typeof input === "function") &&
     input !== null &&
     "address" in input &&
     "selector" in input

--- a/packages/encoder/test/address.test.ts
+++ b/packages/encoder/test/address.test.ts
@@ -173,6 +173,18 @@ describe("Encoding", () => {
       );
     });
 
+    it("Encodes callable objects with an address field", async () => {
+      let input: any = () => undefined;
+      input.address = "0x10ca7e901d10CA7E901D10Ca7e901D10CA7e901D";
+      input.garbate = "garbage";
+      const { data } = await encoder.encodeTxNoResolution(abi, [input]);
+      assert.strictEqual(
+        data,
+        selector +
+          "00000000000000000000000010ca7e901d10ca7e901d10ca7e901d10ca7e901d"
+      );
+    });
+
     it("Encodes ENS names", async () => {
       const { data } = await encoder.encodeTxNoResolution(abi, ["locate.gold"]);
       assert.strictEqual(

--- a/packages/encoder/test/function.test.ts
+++ b/packages/encoder/test/function.test.ts
@@ -90,6 +90,19 @@ describe("Encoding", () => {
       );
     });
 
+    it("Encodes callable objects w/ address & selector", async () => {
+      let input: any = () => undefined;
+      input.address = "0x10ca7e901d10CA7E901D10Ca7e901D10CA7e901D";
+      input.selector = "0xdeadbeef";
+      input.garbate = "garbage";
+      const { data } = await encoder.encodeTxNoResolution(abi, [input]);
+      assert.strictEqual(
+        data,
+        selector +
+          "10ca7e901d10ca7e901d10ca7e901d10ca7e901ddeadbeef0000000000000000"
+      );
+    });
+
     it("Encodes objects w/ address & selector (unusual forms for these)", async () => {
       const { data } = await encoder.encodeTxNoResolution(abi, [
         {


### PR DESCRIPTION
A thing I forgot while writing encoder: If `x` is callable, then `typeof x` will return `"function"`, not `"object"`!  This means that callable objects wouldn't be accepted as input for external functions.  It was always my intention that those would work (because of the intended use case with Truffle Contract, that with a rewritten version of Truffle Contract one could actually pass in the methods), but they didn't.  So, I made that work, and also added a test.

I also did the same for contract input, because, well, why not; figured it makes the most sense for it to act analogously.