### PR TITLE
Remove function that copies ast value to legacyAST value in contract-schema

### DIFF
--- a/packages/contract-schema/index.js
+++ b/packages/contract-schema/index.js
@@ -141,15 +141,7 @@ var properties = {
   source: {},
   sourcePath: {},
   ast: {},
-  legacyAST: {
-    transform: function (value, obj) {
-      if (value) {
-        return value;
-      } else {
-        return obj.ast;
-      }
-    }
-  },
+  legacyAST: {},
   compiler: {},
   networks: {
     /**


### PR DESCRIPTION
### ISSUE
The `normalize` function in the `contract-schema` package has a behavior that was copying `ast` value to the `legacyAST` value field when legacyAST value is absent.

### SOLUTION
This PR removes that behavior from the schema properties because **legacy AST** has been removed from `solc 0.8.0` onwards. However, it is advised not to remove the `legacyAST` property entirely from the schema.