### PR TITLE
Internal improvement: Swap in mvdir for cpr package

### DIFF
--- a/packages/core/lib/commands/create/helpers.js
+++ b/packages/core/lib/commands/create/helpers.js
@@ -1,7 +1,6 @@
 const copy = require("../../copy");
 const path = require("path");
 const fs = require("fs");
-const { promisify } = require("util");
 
 const templates = {
   test: {
@@ -65,7 +64,7 @@ const Create = {
       throw new Error("Can not create " + name + ".sol: file exists");
     }
 
-    await promisify(copy.file.bind(copy))(from, to);
+    await copy(from, to);
 
     replaceContents(to, templates.contract.name, name);
     if ((license = getLicense(options))) {
@@ -83,7 +82,7 @@ const Create = {
       throw new Error("Can not create " + underscored + ".js: file exists");
     }
 
-    await promisify(copy.file.bind(copy))(from, to);
+    await copy(from, to);
     replaceContents(to, templates.contract.name, name);
     replaceContents(to, templates.contract.variable, underscored);
   },
@@ -104,7 +103,7 @@ const Create = {
     if (!options.force && fs.existsSync(to)) {
       throw new Error("Can not create " + filename + ": file exists");
     }
-    return await promisify(copy.file.bind(copy))(from, to);
+    await copy(from, to);
   }
 };
 

--- a/packages/core/lib/commands/migrate/setUpDryRunEnvironmentThenRunMigrations.js
+++ b/packages/core/lib/commands/migrate/setUpDryRunEnvironmentThenRunMigrations.js
@@ -1,5 +1,4 @@
 const { Environment } = require("@truffle/environment");
-const { promisify } = require("util");
 const Artifactor = require("@truffle/artifactor");
 const Resolver = require("@truffle/resolver");
 const copy = require("../../copy");
@@ -24,7 +23,7 @@ module.exports = async function (config) {
     prefix: "migrate-dry-run-"
   }).name;
 
-  await promisify(copy)(config.contracts_build_directory, temporaryDirectory);
+  await copy(config.contracts_build_directory, temporaryDirectory);
 
   config.contracts_build_directory = temporaryDirectory;
   // Note: Create a new artifactor and resolver with the updated config.

--- a/packages/core/lib/commands/migrate/setUpDryRunEnvironmentThenRunMigrations.js
+++ b/packages/core/lib/commands/migrate/setUpDryRunEnvironmentThenRunMigrations.js
@@ -23,9 +23,7 @@ module.exports = async function (config) {
     prefix: "migrate-dry-run-"
   }).name;
 
-  await copy(config.contracts_build_directory, temporaryDirectory, {
-    overwrite: true
-  });
+  await copy(config.contracts_build_directory, temporaryDirectory);
 
   config.contracts_build_directory = temporaryDirectory;
   // Note: Create a new artifactor and resolver with the updated config.

--- a/packages/core/lib/commands/migrate/setUpDryRunEnvironmentThenRunMigrations.js
+++ b/packages/core/lib/commands/migrate/setUpDryRunEnvironmentThenRunMigrations.js
@@ -23,7 +23,15 @@ module.exports = async function (config) {
     prefix: "migrate-dry-run-"
   }).name;
 
-  await copy(config.contracts_build_directory, temporaryDirectory);
+  // copy returns an error if there is an error, undefined if successful
+  const error = await copy(
+    config.contracts_build_directory,
+    temporaryDirectory,
+    { overwrite: true }
+  );
+  if (error) {
+    throw error;
+  }
 
   config.contracts_build_directory = temporaryDirectory;
   // Note: Create a new artifactor and resolver with the updated config.

--- a/packages/core/lib/commands/migrate/setUpDryRunEnvironmentThenRunMigrations.js
+++ b/packages/core/lib/commands/migrate/setUpDryRunEnvironmentThenRunMigrations.js
@@ -23,15 +23,9 @@ module.exports = async function (config) {
     prefix: "migrate-dry-run-"
   }).name;
 
-  // copy returns an error if there is an error, undefined if successful
-  const error = await copy(
-    config.contracts_build_directory,
-    temporaryDirectory,
-    { overwrite: true }
-  );
-  if (error) {
-    throw error;
-  }
+  await copy(config.contracts_build_directory, temporaryDirectory, {
+    overwrite: true
+  });
 
   config.contracts_build_directory = temporaryDirectory;
   // Note: Create a new artifactor and resolver with the updated config.

--- a/packages/core/lib/commands/test/copyArtifactsToTempDir.js
+++ b/packages/core/lib/commands/test/copyArtifactsToTempDir.js
@@ -1,5 +1,4 @@
 const copyArtifactsToTempDir = async config => {
-  const {promisify} = require("util");
   const copy = require("../../copy");
   const fs = require("fs");
   const OS = require("os");
@@ -19,11 +18,11 @@ const copyArtifactsToTempDir = async config => {
     return {temporaryDirectory};
   }
 
-  await promisify(copy)(config.contracts_build_directory, temporaryDirectory);
+  await copy(config.contracts_build_directory, temporaryDirectory);
   if (config.runnerOutputOnly !== true) {
     config.logger.log("Using network '" + config.network + "'." + OS.EOL);
   }
-  return {temporaryDirectory};
+  return { temporaryDirectory };
 };
 
 module.exports = {

--- a/packages/core/lib/commands/test/copyArtifactsToTempDir.js
+++ b/packages/core/lib/commands/test/copyArtifactsToTempDir.js
@@ -15,10 +15,13 @@ const copyArtifactsToTempDir = async config => {
   try {
     fs.statSync(config.contracts_build_directory);
   } catch (_error) {
-    return {temporaryDirectory};
+    return { temporaryDirectory };
   }
 
-  await copy(config.contracts_build_directory, temporaryDirectory);
+  await copy(config.contracts_build_directory, temporaryDirectory, {
+    overwrite: true
+  });
+
   if (config.runnerOutputOnly !== true) {
     config.logger.log("Using network '" + config.network + "'." + OS.EOL);
   }

--- a/packages/core/lib/commands/test/copyArtifactsToTempDir.js
+++ b/packages/core/lib/commands/test/copyArtifactsToTempDir.js
@@ -18,9 +18,7 @@ const copyArtifactsToTempDir = async config => {
     return { temporaryDirectory };
   }
 
-  await copy(config.contracts_build_directory, temporaryDirectory, {
-    overwrite: true
-  });
+  await copy(config.contracts_build_directory, temporaryDirectory);
 
   if (config.runnerOutputOnly !== true) {
     config.logger.log("Using network '" + config.network + "'." + OS.EOL);

--- a/packages/core/lib/copy.js
+++ b/packages/core/lib/copy.js
@@ -1,62 +1,13 @@
-var cpr = require("cpr");
-var fs = require("fs");
-var _ = require("lodash");
+const mvdir = require("mvdir");
 
-var cpr_options = {
-  deleteFirst: false,
+const mvdirOptions = {
+  log: false,
   overwrite: false,
-  confirm: true
+  copy: true
 };
 
-// This module will copy a file or directory, and by default
-// won't override individual files. If a file exists, it will
-// simply move onto the next file.
-
-var copy = function(from, to, extra_options, callback) {
-  if (typeof extra_options === "function") {
-    callback = extra_options;
-    extra_options = {};
-  }
-
-  var options = _.merge(_.clone(cpr_options), extra_options);
-
-  cpr(from, to, options, function(err, files) {
-    var new_files = [];
-
-    // Remove placeholders. Placeholders allow us to copy "empty" directories,
-    // but lets NPM and git not ignore them.
-    files = files || [];
-    for (var file of files) {
-      if (file.match(/.*PLACEHOLDER.*/) != null) {
-        fs.unlinkSync(file);
-        continue;
-      }
-      new_files.push(file);
-    }
-
-    callback(err, new_files);
-  });
-};
-
-copy.file = function(from, to, callback) {
-  var readStream = fs.createReadStream(from, "utf8");
-  var writeStream = fs.createWriteStream(to, "utf8");
-
-  readStream.on("error", function(err) {
-    callback(err);
-    callback = function() {};
-  });
-
-  writeStream.on("error", function(err) {
-    callback(err);
-    callback = function() {};
-  });
-
-  writeStream.on("finish", function() {
-    callback();
-  });
-
-  readStream.pipe(writeStream);
+const copy = async function (from, to) {
+  await mvdir(from, to, mvdirOptions);
 };
 
 module.exports = copy;

--- a/packages/core/lib/copy.js
+++ b/packages/core/lib/copy.js
@@ -7,10 +7,14 @@ const mvdirOptions = {
 };
 
 const copy = async function (from, to, options) {
-  return await mvdir(from, to, {
+  // mvdir returns undefined if successful, an error if not
+  const error = await mvdir(from, to, {
     ...mvdirOptions,
     ...options
   });
+  if (error) {
+    throw error;
+  }
 };
 
 module.exports = copy;

--- a/packages/core/lib/copy.js
+++ b/packages/core/lib/copy.js
@@ -6,8 +6,11 @@ const mvdirOptions = {
   copy: true
 };
 
-const copy = async function (from, to) {
-  await mvdir(from, to, mvdirOptions);
+const copy = async function (from, to, options) {
+  return await mvdir(from, to, {
+    ...mvdirOptions,
+    ...options
+  });
 };
 
 module.exports = copy;

--- a/packages/core/lib/copy.js
+++ b/packages/core/lib/copy.js
@@ -2,7 +2,7 @@ const mvdir = require("mvdir");
 
 const mvdirOptions = {
   log: false,
-  overwrite: false,
+  overwrite: true,
   copy: true
 };
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,7 +57,7 @@
     "colors": "1.4.0",
     "command-exists": "^1.2.8",
     "conf": "^10.0.2",
-    "cpr": "^3.0.1",
+    "mvdir": "1.0.21",
     "debug": "^4.3.1",
     "del": "^2.2.0",
     "ethereum-cryptography": "^0.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11634,16 +11634,6 @@ cp-file@^7.0.0:
     nested-error-stacks "^2.0.0"
     p-event "^4.1.0"
 
-cpr@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/cpr/-/cpr-3.0.1.tgz#b9a55038b7cd81a35c17b9761895bd8496aef1e5"
-  integrity sha1-uaVQOLfNgaNcF7l2GJW9hJau8eU=
-  dependencies:
-    graceful-fs "^4.1.5"
-    minimist "^1.2.0"
-    mkdirp "~0.5.1"
-    rimraf "^2.5.4"
-
 cpy-cli@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/cpy-cli/-/cpy-cli-3.1.1.tgz#2adb06544102c948ce098e522d5b8ddcf4f7c0b4"
@@ -16708,7 +16698,7 @@ got@^8.3.1:
     url-parse-lax "^3.0.0"
     url-to-options "^1.0.1"
 
-graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.5, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.3, graceful-fs@^4.2.4:
+graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.3, graceful-fs@^4.2.4:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
@@ -17655,7 +17645,7 @@ inquirer-autocomplete-prompt@^1.4.0:
     run-async "^2.4.0"
     rxjs "^6.6.2"
 
-inquirer@8.2.2:
+inquirer@8.2.2, inquirer@^8.2.0:
   version "8.2.2"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.2.tgz#1310517a87a0814d25336c78a20b44c3d9b7629d"
   integrity sha512-pG7I/si6K/0X7p1qU+rfWnpTE1UIkTONN1wxtzh0d+dHXtT/JG6qBgLxoyHVsQa8cFABxAPh0pD6uUUHiAoaow==
@@ -17695,25 +17685,6 @@ inquirer@^3.2.2:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
-inquirer@^7.0.0:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.0.1.tgz#13f7980eedc73c689feff3994b109c4e799c6ebb"
-  integrity sha512-V1FFQ3TIO15det8PijPLFR9M9baSlnRs9nL7zWu1MNVA2T9YVl9ZbrHJhYs7e9X8jeMZ3lr2JH/rdHFgNCBdYw==
-  dependencies:
-    ansi-escapes "^4.2.1"
-    chalk "^2.4.2"
-    cli-cursor "^3.1.0"
-    cli-width "^2.0.0"
-    external-editor "^3.0.3"
-    figures "^3.0.0"
-    lodash "^4.17.15"
-    mute-stream "0.0.8"
-    run-async "^2.2.0"
-    rxjs "^6.5.3"
-    string-width "^4.1.0"
-    strip-ansi "^5.1.0"
-    through "^2.3.6"
-
 inquirer@^7.3.3:
   version "7.3.3"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.3.3.tgz#04d176b2af04afc157a83fd7c100e98ee0aad003"
@@ -17729,26 +17700,6 @@ inquirer@^7.3.3:
     mute-stream "0.0.8"
     run-async "^2.4.0"
     rxjs "^6.6.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-    through "^2.3.6"
-
-inquirer@^8.2.0:
-  version "8.2.2"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.2.tgz#1310517a87a0814d25336c78a20b44c3d9b7629d"
-  integrity sha512-pG7I/si6K/0X7p1qU+rfWnpTE1UIkTONN1wxtzh0d+dHXtT/JG6qBgLxoyHVsQa8cFABxAPh0pD6uUUHiAoaow==
-  dependencies:
-    ansi-escapes "^4.2.1"
-    chalk "^4.1.1"
-    cli-cursor "^3.1.0"
-    cli-width "^3.0.0"
-    external-editor "^3.0.3"
-    figures "^3.0.0"
-    lodash "^4.17.21"
-    mute-stream "0.0.8"
-    ora "^5.4.1"
-    run-async "^2.4.0"
-    rxjs "^7.5.5"
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
     through "^2.3.6"
@@ -22585,6 +22536,11 @@ mute-stream@0.0.8, mute-stream@~0.0.4:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
+
+mvdir@1.0.21:
+  version "1.0.21"
+  resolved "https://registry.yarnpkg.com/mvdir/-/mvdir-1.0.21.tgz#d8de39037c3198a4ab8478c7afa64e99f0e77483"
+  integrity sha512-au1XRgt8EOlAzDxDSAkH7T+lpHsguZZi6mNYMZzwy5PO1xT6jw2Lu2ZUe4GN0PFb5xVoyAEnTcDu1eV4wbxC+Q==
 
 mz@^2.4.0, mz@^2.7.0:
   version "2.7.0"
@@ -27429,7 +27385,7 @@ rx-lite@*, rx-lite@^4.0.8:
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
   integrity sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=
 
-rxjs@^6.4.0, rxjs@^6.5.3:
+rxjs@^6.4.0:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.3.tgz#510e26317f4db91a7eb1de77d9dd9ba0a4899a3a"
   integrity sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==


### PR DESCRIPTION
Truffle has a `copy` utility responsible for copying files or directories. It uses a very old package called `cpr` which this PR swaps out for a package with very few dependencies called `mvdir`. A lot of the code in the `copy` utility was also updated to be more modern and simple.