### PR TITLE
Enhancement: Indicate which storage variables have unknown values in debugger

### DIFF
--- a/packages/codec/lib/export.ts
+++ b/packages/codec/lib/export.ts
@@ -370,7 +370,7 @@ export function containsDeliberateReadError(
       }
     case "error":
       switch (result.error.kind) {
-        case "ReadErrorStorageDeliberate":
+        case "StorageNotSuppliedError":
           return true;
         default:
           return false;

--- a/packages/codec/lib/export.ts
+++ b/packages/codec/lib/export.ts
@@ -345,6 +345,39 @@ export class CalldataDecodingInspector {
   }
 }
 
+export function containsDeliberateReadError(
+  result: Format.Values.Result
+): boolean {
+  switch (result.kind) {
+    case "value":
+      switch (result.type.typeClass) {
+        case "struct":
+          //this is currently only intended for use with storage variables, so I
+          //won't bother with handling tuple, magic, options
+          return (result as Format.Values.StructValue).value.some(({ value }) =>
+            containsDeliberateReadError(value)
+          );
+        case "array":
+          return (result as Format.Values.ArrayValue).value.some(
+            containsDeliberateReadError
+          );
+        case "mapping":
+          return (result as Format.Values.MappingValue).value.some(
+            ({ value }) => containsDeliberateReadError(value)
+          );
+        default:
+          return false;
+      }
+    case "error":
+      switch (result.error.kind) {
+        case "ReadErrorStorageDeliberate":
+          return true;
+        default:
+          return false;
+      }
+  }
+}
+
 /**
  * Similar to [[ResultInspector]], but for a [[LogDecoding]].
  * See [[ResultInspector]] for more information.

--- a/packages/codec/lib/format/errors.ts
+++ b/packages/codec/lib/format/errors.ts
@@ -814,6 +814,7 @@ export type ReadError =
   | ReadErrorStack
   | ReadErrorBytes
   | ReadErrorStorage
+  | ReadErrorStorageDeliberate
   | UnusedImmutableError;
 
 /**
@@ -908,6 +909,18 @@ export interface ReadErrorBytes {
  */
 export interface ReadErrorStorage {
   kind: "ReadErrorStorage";
+  range: Storage.Range;
+}
+
+/**
+ * A read error in storage, but one triggered deliberately to indicate
+ * that that particular area of storage is unknown, rather than due to
+ * an unexpected error condition.
+ *
+ * @Category Generic errors
+ */
+export interface ReadErrorStorageDeliberate {
+  kind: "ReadErrorStorageDeliberate";
   range: Storage.Range;
 }
 

--- a/packages/codec/lib/format/errors.ts
+++ b/packages/codec/lib/format/errors.ts
@@ -814,7 +814,7 @@ export type ReadError =
   | ReadErrorStack
   | ReadErrorBytes
   | ReadErrorStorage
-  | ReadErrorStorageDeliberate
+  | StorageNotSuppliedError
   | UnusedImmutableError;
 
 /**
@@ -915,12 +915,13 @@ export interface ReadErrorStorage {
 /**
  * A read error in storage, but one triggered deliberately to indicate
  * that that particular area of storage is unknown, rather than due to
- * an unexpected error condition.
+ * an unexpected error condition.  This error is triggered by passing
+ * null in response to a storage request.
  *
  * @Category Generic errors
  */
-export interface ReadErrorStorageDeliberate {
-  kind: "ReadErrorStorageDeliberate";
+export interface StorageNotSuppliedError {
+  kind: "StorageNotSuppliedError";
   range: Storage.Range;
 }
 

--- a/packages/codec/lib/format/utils/exception.ts
+++ b/packages/codec/lib/format/utils/exception.ts
@@ -44,7 +44,7 @@ export function message(error: Format.Errors.ErrorForThrowing): string {
           error.range.to.index
         } in ${slotAddressPrintout(error.range.to.slot)}`;
       }
-    case "ReadErrorStorageDeliberate":
+    case "StorageNotSuppliedError":
       if (error.range.length) {
         return `Unknown storage for ${
           error.range.length

--- a/packages/codec/lib/format/utils/exception.ts
+++ b/packages/codec/lib/format/utils/exception.ts
@@ -19,9 +19,7 @@ export function message(error: Format.Errors.ErrorForThrowing): string {
       let typeName = Format.Types.isContractDefinedType(error.type)
         ? error.type.definingContractName + "." + error.type.typeName
         : error.type.typeName;
-      return `Unknown ${error.type.typeClass} type ${typeName} of id ${
-        error.type.id
-      }`;
+      return `Unknown ${error.type.typeClass} type ${typeName} of id ${error.type.id}`;
     case "UnsupportedConstantError":
       return `Unsupported constant type ${AstUtils.typeClass(
         error.definition
@@ -31,9 +29,7 @@ export function message(error: Format.Errors.ErrorForThrowing): string {
     case "ReadErrorStack":
       return `Can't read stack from position ${error.from} to ${error.to}`;
     case "ReadErrorBytes":
-      return `Can't read ${error.length} bytes from ${
-        error.location
-      } starting at ${error.start}`;
+      return `Can't read ${error.length} bytes from ${error.location} starting at ${error.start}`;
     case "ReadErrorStorage":
       if (error.range.length) {
         return `Can't read ${
@@ -43,6 +39,20 @@ export function message(error: Format.Errors.ErrorForThrowing): string {
         } in ${slotAddressPrintout(error.range.from.slot)}`;
       } else {
         return `Can't read storage from index ${
+          error.range.from.index
+        } in ${slotAddressPrintout(error.range.from.slot)} to index ${
+          error.range.to.index
+        } in ${slotAddressPrintout(error.range.to.slot)}`;
+      }
+    case "ReadErrorStorageDeliberate":
+      if (error.range.length) {
+        return `Unknown storage for ${
+          error.range.length
+        } bytes starting at index ${
+          error.range.from.index
+        } in ${slotAddressPrintout(error.range.from.slot)}`;
+      } else {
+        return `Unknown storage from index ${
           error.range.from.index
         } in ${slotAddressPrintout(error.range.from.slot)} to index ${
           error.range.to.index
@@ -78,9 +88,10 @@ function slotAddressPrintout(slot: Storage.Slot): string {
 //this is like the old toSoliditySha3Input, but for debugging purposes ONLY
 //it will NOT produce correct input to soliditySha3
 //please use mappingKeyAsHex instead if you wish to encode a mapping key.
-function keyInfoForPrinting(
-  input: Format.Values.ElementaryValue
-): { type: string; value: string } {
+function keyInfoForPrinting(input: Format.Values.ElementaryValue): {
+  type: string;
+  value: string;
+} {
   switch (input.type.typeClass) {
     case "uint":
       return {

--- a/packages/codec/lib/format/utils/inspect.ts
+++ b/packages/codec/lib/format/utils/inspect.ts
@@ -381,7 +381,7 @@ export class ResultInspector {
           case "ReadErrorStorage":
           case "ReadErrorBytes":
             return Exception.message(errorResult.error); //yay, these five are already defined!
-          case "ReadErrorStorageDeliberate":
+          case "StorageNotSuppliedError":
             //this one has a message, but we're going to special-case it
             return options.stylize("?", "undefined");
         }

--- a/packages/codec/lib/format/utils/inspect.ts
+++ b/packages/codec/lib/format/utils/inspect.ts
@@ -381,6 +381,9 @@ export class ResultInspector {
           case "ReadErrorStorage":
           case "ReadErrorBytes":
             return Exception.message(errorResult.error); //yay, these five are already defined!
+          case "ReadErrorStorageDeliberate":
+            //this one has a message, but we're going to special-case it
+            return options.stylize("?", "undefined");
         }
       }
     }

--- a/packages/codec/lib/storage/read/index.ts
+++ b/packages/codec/lib/storage/read/index.ts
@@ -88,7 +88,7 @@ export function* readStorage(
     if (word === null) {
       //check for null as a way to deliberately indicate an error
       throw new DecodingError({
-        kind: "ReadErrorStorageDeliberate" as const,
+        kind: "StorageNotSuppliedError" as const,
         range
       });
     }

--- a/packages/codec/lib/storage/read/index.ts
+++ b/packages/codec/lib/storage/read/index.ts
@@ -85,9 +85,14 @@ export function* readStorage(
   for (let i = 0; i < totalWords; i++) {
     let offset = from.slot.offset.addn(i);
     const word = yield* readSlot(storage, { ...from.slot, offset });
-    if (typeof word !== "undefined") {
-      data.set(word, i * Evm.Utils.WORD_SIZE);
+    if (word === null) {
+      //check for null as a way to deliberately indicate an error
+      throw new DecodingError({
+        kind: "ReadErrorStorageDeliberate" as const,
+        range
+      });
     }
+    data.set(word, i * Evm.Utils.WORD_SIZE);
   }
   debug("words %o", data);
 

--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -693,6 +693,8 @@ class DebugPrinter {
 
     this.config.logger.log();
 
+    let printLegend = false;
+
     // printout the sections that are included in the inputs and have positive contents length
     for (const [section, variables] of Object.entries(sections)) {
       // only check the first 3 characters of each name given in the input sectionPrintouts
@@ -712,9 +714,18 @@ class DebugPrinter {
             longestNameLength + 5
           );
           this.config.logger.log("  " + paddedName, formatted);
+          if (Codec.Export.containsDeliberateReadError(value)) {
+            printLegend = true;
+          }
         }
         this.config.logger.log();
       }
+    }
+
+    if (printLegend) {
+      this.config.logger.log(
+        "Note: Some storage variables could not be fully decoded; the debugger can only see storage it has seen touched during the transaction."
+      );
     }
   }
 
@@ -741,6 +752,11 @@ class DebugPrinter {
       let formatted = DebugUtils.formatValue(variables[variable], indent);
       this.config.logger.log(formatted);
       this.config.logger.log();
+      if (Codec.Export.containsDeliberateReadError(variables[variable])) {
+        this.config.logger.log(
+          "Note: Variable could not be fully decoded as the debugger can only see storage it has seen touched during the transaction."
+        );
+      }
       return;
     }
     debug("expression case");

--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -681,7 +681,7 @@ class DebugPrinter {
   }
 
   async printVariables(sectionOuts = this.sectionPrintouts) {
-    const values = await this.session.variables();
+    const values = await this.session.variables({ indicateUnknown: true });
     const sections = this.session.view(data.current.identifiers.sections);
 
     const sectionNames = {
@@ -731,7 +731,7 @@ class DebugPrinter {
    *        :!<trace.step.stack>[1]
    */
   async evalAndPrintExpression(raw, indent, suppress) {
-    let variables = await this.session.variables();
+    let variables = await this.session.variables({ indicateUnknown: true });
 
     //if we're just dealing with a single variable, handle that case
     //separately (so that we can do things in a better way for that

--- a/packages/debugger/lib/data/sagas/index.js
+++ b/packages/debugger/lib/data/sagas/index.js
@@ -69,7 +69,12 @@ function* tickSaga() {
   yield* trace.signalTickSagaCompletion();
 }
 
-export function* decode(definition, ref, compilationId) {
+export function* decode(
+  definition,
+  ref,
+  compilationId,
+  indicateUnknown = false
+) {
   const userDefinedTypes = yield select(data.views.userDefinedTypes);
   const state = yield select(data.current.state);
   const mappingKeys = yield select(data.views.mappingKeys);
@@ -111,7 +116,9 @@ export function* decode(definition, ref, compilationId) {
       case "storage":
         //the debugger supplies all storage it knows at the beginning.
         //any storage it does not know is presumed to be zero.
-        response = ZERO_WORD;
+        //(unlesss indicateUnknown is passed, in which case we use
+        //null as a deliberately invalid response)
+        response = indicateUnknown ? null : ZERO_WORD;
         break;
       case "code":
         response = yield* requestCode(request.address);

--- a/packages/debugger/lib/session/index.js
+++ b/packages/debugger/lib/session/index.js
@@ -466,7 +466,10 @@ export default class Session {
     return true;
   }
 
-  async variable(name) {
+  /**
+   * see variables() for supported options
+   */
+  async variable(name, options) {
     const definitions = this.view(data.current.identifiers.definitions);
     const refs = this.view(data.current.identifiers.refs);
     const compilationId = this.view(data.current.compilationId);
@@ -478,11 +481,16 @@ export default class Session {
       dataSagas.decode,
       definitions[name],
       refs[name],
-      compilationId
+      compilationId,
+      (options || {}).indicateUnknown
     );
   }
 
-  async variables() {
+  /**
+   * only current option is indicateUnknown, which causes unknown storage
+   * to yield a ReadErrorStorageDeliberate instead of zero
+   */
+  async variables(options) {
     if (!this.view(session.status.loaded)) {
       return {};
     }
@@ -496,7 +504,8 @@ export default class Session {
           dataSagas.decode,
           definitions[identifier],
           ref,
-          compilationId
+          compilationId,
+          (options || {}).indicateUnknown
         );
       }
     }

--- a/packages/debugger/lib/session/index.js
+++ b/packages/debugger/lib/session/index.js
@@ -488,7 +488,7 @@ export default class Session {
 
   /**
    * only current option is indicateUnknown, which causes unknown storage
-   * to yield a ReadErrorStorageDeliberate instead of zero
+   * to yield a StorageNotSuppliedError instead of zero
    */
   async variables(options) {
     if (!this.view(session.status.loaded)) {

--- a/packages/debugger/test/data/more-decoding.js
+++ b/packages/debugger/test/data/more-decoding.js
@@ -457,7 +457,7 @@ describe("Further Decoding", function () {
       bytesMap: { "0x01": "0x01" },
       uintMap: { 1: 1, 2: 2 },
       intMap: { "-1": -1 },
-      stringMap: { "0xdeadbeef": "0xdeadbeef", "12345": "12345", "hello": "hello" },
+      stringMap: { "0xdeadbeef": "0xdeadbeef", 12345: "12345", hello: "hello" },
       addressMap: { [address]: address },
       contractMap: { [address]: address },
       enumMap: { "ElementaryTest.Ternary.Blue": "ElementaryTest.Ternary.Blue" },
@@ -665,7 +665,7 @@ describe("Further Decoding", function () {
 
     const assertIsUnknown = variable => {
       assert.equal(variable.kind, "error");
-      assert.equal(variable.error.kind, "ReadErrorStorageDeliberate");
+      assert.equal(variable.error.kind, "StorageNotSuppliedError");
     };
 
     await bugger.continueUntilBreakpoint();
@@ -677,13 +677,19 @@ describe("Further Decoding", function () {
     assert.equal(variables.partialPair.kind, "value"); //it's known but individual entries are not
     assertIsUnknown(variables.partialPair.value[0].value);
     assertIsUnknown(variables.partialPair.value[1].value);
-    assert.isTrue(Codec.Export.containsDeliberateReadError(variables.partialPair));
+    assert.isTrue(
+      Codec.Export.containsDeliberateReadError(variables.partialPair)
+    );
     assert.equal(variables.partialArray.kind, "value"); //again, it's known but individual entries are not
     assertIsUnknown(variables.partialArray.value[0]);
     assertIsUnknown(variables.partialArray.value[1]);
-    assert.isTrue(Codec.Export.containsDeliberateReadError(variables.partialArray));
+    assert.isTrue(
+      Codec.Export.containsDeliberateReadError(variables.partialArray)
+    );
     assertIsUnknown(variables.partialDynamic); //this OTOH is wholly unknown since we don't know its length
-    assert.isTrue(Codec.Export.containsDeliberateReadError(variables.partialDynamic));
+    assert.isTrue(
+      Codec.Export.containsDeliberateReadError(variables.partialDynamic)
+    );
     assert.equal(variables.theMap.kind, "value"); //maps should never turn up unknown
     assert.lengthOf(variables.theMap.value, 0); //no keys recorded
     assert.isFalse(Codec.Export.containsDeliberateReadError(variables.theMap));
@@ -697,15 +703,21 @@ describe("Further Decoding", function () {
     assert.equal(variables.partialPair.kind, "value"); //first entry now known, second still unknown
     assert.equal(variables.partialPair.value[0].value.kind, "value");
     assertIsUnknown(variables.partialPair.value[1].value);
-    assert.isTrue(Codec.Export.containsDeliberateReadError(variables.partialPair));
+    assert.isTrue(
+      Codec.Export.containsDeliberateReadError(variables.partialPair)
+    );
     assert.equal(variables.partialArray.kind, "value"); //similar
     assert.equal(variables.partialArray.value[0].kind, "value");
     assertIsUnknown(variables.partialArray.value[1]);
-    assert.isTrue(Codec.Export.containsDeliberateReadError(variables.partialArray));
+    assert.isTrue(
+      Codec.Export.containsDeliberateReadError(variables.partialArray)
+    );
     assert.equal(variables.partialDynamic.kind, "value"); //length & first entry now known
     assert.equal(variables.partialDynamic.value[0].kind, "value");
     assertIsUnknown(variables.partialDynamic.value[1]);
-    assert.isTrue(Codec.Export.containsDeliberateReadError(variables.partialDynamic));
+    assert.isTrue(
+      Codec.Export.containsDeliberateReadError(variables.partialDynamic)
+    );
     assert.equal(variables.theMap.kind, "value"); //maps should never turn up unknown
     assert.lengthOf(variables.theMap.value, 1); //1 key recorded
     assert.isFalse(Codec.Export.containsDeliberateReadError(variables.theMap));

--- a/packages/debugger/test/data/more-decoding.js
+++ b/packages/debugger/test/data/more-decoding.js
@@ -457,7 +457,7 @@ describe("Further Decoding", function () {
       bytesMap: { "0x01": "0x01" },
       uintMap: { 1: 1, 2: 2 },
       intMap: { "-1": -1 },
-      stringMap: { "0xdeadbeef": "0xdeadbeef", 12345: "12345", hello: "hello" },
+      stringMap: { "0xdeadbeef": "0xdeadbeef", "12345": "12345", "hello": "hello" },
       addressMap: { [address]: address },
       contractMap: { [address]: address },
       enumMap: { "ElementaryTest.Ternary.Blue": "ElementaryTest.Ternary.Blue" },
@@ -671,32 +671,44 @@ describe("Further Decoding", function () {
     await bugger.continueUntilBreakpoint();
     let variables = await bugger.variables({ indicateUnknown: true });
     assertIsUnknown(variables.known); //it's not known yet
+    assert.isTrue(Codec.Export.containsDeliberateReadError(variables.known));
     assertIsUnknown(variables.unknown);
+    assert.isTrue(Codec.Export.containsDeliberateReadError(variables.unknown));
     assert.equal(variables.partialPair.kind, "value"); //it's known but individual entries are not
     assertIsUnknown(variables.partialPair.value[0].value);
     assertIsUnknown(variables.partialPair.value[1].value);
+    assert.isTrue(Codec.Export.containsDeliberateReadError(variables.partialPair));
     assert.equal(variables.partialArray.kind, "value"); //again, it's known but individual entries are not
     assertIsUnknown(variables.partialArray.value[0]);
     assertIsUnknown(variables.partialArray.value[1]);
+    assert.isTrue(Codec.Export.containsDeliberateReadError(variables.partialArray));
     assertIsUnknown(variables.partialDynamic); //this OTOH is wholly unknown since we don't know its length
+    assert.isTrue(Codec.Export.containsDeliberateReadError(variables.partialDynamic));
     assert.equal(variables.theMap.kind, "value"); //maps should never turn up unknown
     assert.lengthOf(variables.theMap.value, 0); //no keys recorded
+    assert.isFalse(Codec.Export.containsDeliberateReadError(variables.theMap));
 
     await bugger.runToEnd();
     variables = await bugger.variables({ indicateUnknown: true });
     assert.equal(variables.known.kind, "value"); //known now
+    assert.isFalse(Codec.Export.containsDeliberateReadError(variables.known));
     assertIsUnknown(variables.unknown); //still unknown
+    assert.isTrue(Codec.Export.containsDeliberateReadError(variables.unknown));
     assert.equal(variables.partialPair.kind, "value"); //first entry now known, second still unknown
     assert.equal(variables.partialPair.value[0].value.kind, "value");
     assertIsUnknown(variables.partialPair.value[1].value);
+    assert.isTrue(Codec.Export.containsDeliberateReadError(variables.partialPair));
     assert.equal(variables.partialArray.kind, "value"); //similar
     assert.equal(variables.partialArray.value[0].kind, "value");
     assertIsUnknown(variables.partialArray.value[1]);
+    assert.isTrue(Codec.Export.containsDeliberateReadError(variables.partialArray));
     assert.equal(variables.partialDynamic.kind, "value"); //length & first entry now known
     assert.equal(variables.partialDynamic.value[0].kind, "value");
     assertIsUnknown(variables.partialDynamic.value[1]);
+    assert.isTrue(Codec.Export.containsDeliberateReadError(variables.partialDynamic));
     assert.equal(variables.theMap.kind, "value"); //maps should never turn up unknown
     assert.lengthOf(variables.theMap.value, 1); //1 key recorded
+    assert.isFalse(Codec.Export.containsDeliberateReadError(variables.theMap));
   });
 
   describe("Overflow", function () {


### PR DESCRIPTION
Note: This PR is not quite up to my usual standards, but I'm PRing it anyway because we're trying to get this out fast!  I'm intending to address the problems in a later PR.  (Possibly I'll just handle this when I implement reverse ENS resolution, or possibly I'll do it separately first.)

This PR adds an option to the debugger's `variables` and `variable` methods so that it will indicate which storage variables are unknown, as opposed to just filling in the missing values with zero.  It then also sets the CLI debugger to use that option, and display such missing values with gray question marks.  (Note that when dealing with complex values, parts can be known and parts unknown!)  It also makes it so that the debugger will print an explanatory note when there is at least one such gray question mark.

Naturally, this involves some changes to codec.  First, there's a new type of error, `ReadErrorStorageDeliberate`.  (Alternative name suggestions are appreciated -- `NoStorageSuppliedError`, perhaps?)  This error is used for values that are unknown because the storage is unknown.  This error is thrown if the storage returned in response to a request is `null` instead of a `Uint8Array`.  Meanwhile, the debugger's `decode` saga gets an option to pass `null` instead of zero when it doesn't know the storage, and the `variables` and `variable` methods get options that are forwarded to the `decode` option.

Also, `ResultInpsector` has been updated for the new error type, and displays it as a gray question mark, as mentioned.

There's also a function added to detect when a variable contains any of these errors (however deep), so we can add the note to the debugger printout when necessary.  Note that due to practical limitations, we only apply this note to `v` and to `:variable`, but not to more general expressions, as we don't have a good way of determining what variables are used in more general expressions.

Also I added a test.

OK, so what's the thing that's wrong with this PR that I'll need to go back and change later?

Well, it's that whole `null` thing -- the response type for decoding is supposed to be `Uint8Array`, not `Uint8Array | null`.  Of course, since codec doesn't currently have `strictNullChecks` on, this doesn't actually matter.  Still, I should avoid relying on that!  So I should update the types to have `| null`.  But by the same logic that also means I should account for the possibility of a `null` in response to a code request, and add a similar error there (`ReadErrorCodeDeliberate`? `NoCodeSuppliedError`?).  So yeah.  But in the interest of speed that's been dropped from this PR... so this will come later, I guess!

Btw this is going to cause merge conflicts with #4882 because this edits code that that moved. :-/