### PR TITLE
Add items to .gitignore specific to Windows based dev envs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,11 +5,13 @@ node_modules
 yarn-error.log
 .vscode
 .DS_Store
+Thumbs.db
 
 # truffle
 packages/truffle/build
 packages/truffle/stats.json
 packages/truffle/.DS_Store
+packages/truffle/Thumbs.db
 packages/truffle/.tern-port
 packages/truffle/dependencies
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ yarn-error.log
 .vscode
 .DS_Store
 Thumbs.db
+$RECYCLE.BIN/
 
 # truffle
 packages/truffle/build
@@ -14,6 +15,7 @@ packages/truffle/.DS_Store
 packages/truffle/Thumbs.db
 packages/truffle/.tern-port
 packages/truffle/dependencies
+packages/truffle/$RECYCLE.BIN/
 
 # @truffle/debugger
 packages/debugger/.tmp


### PR DESCRIPTION
Add the following items to .gitignore relevant to Windows based development environments: Thumbs.db and $RECYCLE.BIN/