### PR TITLE
core: fix debugger -x crash due to missing spinner

### DIFF
--- a/packages/core/lib/debug/cli.js
+++ b/packages/core/lib/debug/cli.js
@@ -169,7 +169,7 @@ class CLIDebugger {
         lightMode: true
       }); //note: may throw!
       await this.fetchExternalSources(bugger); //note: mutates bugger!
-      const startSpinner = ("core:debug:cli:start", startMessage);
+      const startSpinner = new Spinner("core:debug:cli:start", startMessage);
       await bugger.startFullMode();
       //I'm removing the failure check here because I don't think that can
       //actually happen


### PR DESCRIPTION
Bit of an embarrassing one. Seems I've come to lean too heavily on the TS compiler 😊