### PR TITLE
Fix unbox event output

### DIFF
--- a/packages/box/lib/utils/index.ts
+++ b/packages/box/lib/utils/index.ts
@@ -2,8 +2,6 @@ import unbox from "./unbox";
 import fs from "fs";
 import config from "../config";
 import tmp from "tmp";
-import process from "process";
-const cwd = require("process").cwd();
 import path from "path";
 import type { boxConfig, unboxOptions } from "typings";
 
@@ -11,14 +9,9 @@ export = {
   downloadBox: async (source: string, destination: string, events: any) => {
     events.emit("unbox:downloadingBox:start");
 
-    try {
-      await unbox.verifySourcePath(source);
-      await unbox.fetchRepository(source, destination);
-      events.emit("unbox:downloadingBox:succeed");
-    } catch (error) {
-      events.emit("unbox:fail");
-      throw error;
-    }
+    await unbox.verifySourcePath(source);
+    await unbox.fetchRepository(source, destination);
+    events.emit("unbox:downloadingBox:succeed");
   },
 
   readBoxConfig: async (destination: string) => {
@@ -40,17 +33,12 @@ export = {
     const options = {
       unsafeCleanup: true
     };
-    try {
-      const tmpDir = tmp.dirSync(options);
-      events.emit("unbox:preparingToDownload:succeed");
-      return {
-        path: path.join(tmpDir.name, "box"),
-        cleanupCallback: tmpDir.removeCallback
-      };
-    } catch (error) {
-      events.emit("unbox:fail");
-      throw error;
-    }
+    const tmpDir = tmp.dirSync(options);
+    events.emit("unbox:preparingToDownload:succeed");
+    return {
+      path: path.join(tmpDir.name, "box"),
+      cleanupCallback: tmpDir.removeCallback
+    };
   },
 
   unpackBox: async (
@@ -65,12 +53,7 @@ export = {
 
   setUpBox: (boxConfig: boxConfig, destination: string, events: any) => {
     events.emit("unbox:settingUpBox:start");
-    try {
-      unbox.installBoxDependencies(boxConfig, destination);
-      events.emit("unbox:settingUpBox:succeed");
-    } catch (error) {
-      events.emit("unbox:fail");
-      throw error;
-    }
+    unbox.installBoxDependencies(boxConfig, destination);
+    events.emit("unbox:settingUpBox:succeed");
   }
 };

--- a/packages/events/defaultSubscribers/unbox.js
+++ b/packages/events/defaultSubscribers/unbox.js
@@ -34,7 +34,10 @@ module.exports = {
         if (this.quiet) {
           return;
         }
-        this.spinners.prepareDownloadSpinner = new Spinner("events:subscribers:unbox:download-prepare", "Preparing to download box");
+        this.spinners.prepareDownloadSpinner = new Spinner(
+          "events:subscribers:unbox:download-prepare",
+          "Preparing to download box"
+        );
       }
     ],
     "unbox:preparingToDownload:succeed": [
@@ -50,7 +53,10 @@ module.exports = {
         if (this.quiet) {
           return;
         }
-        this.spinners.downloadSpinner = new Spinner("events:subscribers:unbox:download", "Downloading");
+        this.spinners.downloadSpinner = new Spinner(
+          "events:subscribers:unbox:download",
+          "Downloading"
+        );
       }
     ],
     "unbox:downloadingBox:succeed": [
@@ -58,7 +64,7 @@ module.exports = {
         if (this.quiet) {
           return;
         }
-        this.spinners.downloadSpinner.succeed("unbox-handler");
+        this.spinners.downloadSpinner.succeed();
       }
     ],
     "unbox:cleaningTempFiles:start": [
@@ -66,7 +72,10 @@ module.exports = {
         if (this.quiet) {
           return;
         }
-        this.spinners.cleanUpSpinner = new Spinner("events:subscribers:unbox:cleanup", "Cleaning up temporary files");
+        this.spinners.cleanUpSpinner = new Spinner(
+          "events:subscribers:unbox:cleanup",
+          "Cleaning up temporary files"
+        );
       }
     ],
     "unbox:cleaningTempFiles:succeed": [
@@ -82,7 +91,10 @@ module.exports = {
         if (this.quiet) {
           return;
         }
-        this.spinners.unboxHandlerSpinner = new Spinner("events:subscribers:unbox:handler", "Setting up box");
+        this.spinners.unboxHandlerSpinner = new Spinner(
+          "events:subscribers:unbox:handler",
+          "Setting up box"
+        );
       }
     ],
     "unbox:settingUpBox:succeed": [
@@ -118,7 +130,7 @@ module.exports = {
         if (this.quiet) {
           return;
         }
-        Object.values(this.spinners).map((spinner) => {
+        Object.values(this.spinners).map(spinner => {
           if (spinner.isSpinning) {
             spinner.fail();
           }


### PR DESCRIPTION
Fixes some minor errors in the output of the `unbox` command. Namely duplicate messages on failure due to the `unbox:fail` event firing twice, and a bad spinner success message due to a missed string when migrating from `spinnes` to `@truffle/spinners`. 