### PR TITLE
[WIP] Integrate BSAN into truffle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,21 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "@jbrower95/bsan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@jbrower95/bsan/-/bsan-1.0.1.tgz",
+      "integrity": "sha512-U0bb1WnFGEe6PekKQsgsg53FPB5UlYLpsgo9g6qyaT039TGPDbr16H3ALmHVyb44r4TFZXwd10ynNqUdHZd5dg==",
+      "dev": true,
+      "requires": {
+        "ganache-time-traveler": "^1.0.16"
+      }
+    },
+    "ganache-time-traveler": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/ganache-time-traveler/-/ganache-time-traveler-1.0.16.tgz",
+      "integrity": "sha512-oUaQge9tiT/zzcGqehqJcoH10claKi9QFhq7zI1Wa3KtdPobjgLVMYvqXCJuHCAZoS7sHvLB/N/rSnhmivxaKw==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "update": "lernaupdate"
   },
   "devDependencies": {
+    "@jbrower95/bsan": "^1.0.1",
     "@typescript-eslint/eslint-plugin": "^5.6.0",
     "@typescript-eslint/parser": "^5.6.0",
     "coveralls": "^3.1.1",


### PR DESCRIPTION
1. Introduce a `contract.stateful` in truffle to replace the manual `describeDapp` from bsan.
2. Automatically set up + validate state in additional beforeEach / afterEach calls from the test.
3. In this API, users should provide a `@jbrower95/bsan` "DappState" object. Truffle should probably re-export the DappState object.

This remains WIP because
- this needs a sample test 
- bsan needs to use truffle's logging scheme for debug output.