### PR TITLE
spinners: fix spinner color issues

### DIFF
--- a/packages/compile-solidity/package.json
+++ b/packages/compile-solidity/package.json
@@ -25,7 +25,7 @@
     "@truffle/contract-sources": "^0.1.12",
     "@truffle/expect": "^0.1.1",
     "@truffle/profiler": "^0.1.18",
-    "@truffle/spinners": "^0.1.2",
+    "@truffle/spinners": "^0.2.0-0",
     "axios": "0.26.1",
     "axios-retry": "^3.1.9",
     "debug": "^4.3.1",

--- a/packages/compile-solidity/src/compilerSupplier/loadingStrategies/Docker.ts
+++ b/packages/compile-solidity/src/compilerSupplier/loadingStrategies/Docker.ts
@@ -108,7 +108,7 @@ export class Docker {
     }
     const spinner = new Spinner("compile-solidity:docker-download", {
       text: "Downloading Docker image",
-      color: "red"
+      prefixColor: "red"
     });
     try {
       execSync(`docker pull ethereum/solc:${image}`);

--- a/packages/core/lib/debug/cli.js
+++ b/packages/core/lib/debug/cli.js
@@ -81,11 +81,7 @@ class CLIDebugger {
         );
       }
       // simulate ora's "warn" feature
-      fetchSpinner.stop({
-        text: `⚠ ${warningStrings.join("  ")}`,
-        color: "yellow",
-        status: "stopped"
-      });
+      fetchSpinner.warn(warningStrings.join("  "));
     }
   }
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,7 +50,7 @@
     "@truffle/require": "^2.0.95",
     "@truffle/resolver": "^8.0.17",
     "@truffle/source-fetcher": "^1.0.2",
-    "@truffle/spinners": "^0.1.2",
+    "@truffle/spinners": "^0.2.0-0",
     "@truffle/workflow-compile": "^4.0.13",
     "address": "^1.1.2",
     "chai": "^4.2.0",

--- a/packages/events/defaultSubscribers/migrate/Reporter.js
+++ b/packages/events/defaultSubscribers/migrate/Reporter.js
@@ -289,7 +289,7 @@ class Reporter {
       {
         text: message,
         indent: 3,
-        color: "red"
+        prefixColor: "red"
       }
     );
   }
@@ -338,7 +338,7 @@ class Reporter {
     this.blockSpinner = new Spinner("events:subscribers:migrate:reporter", {
       text: this.currentBlockWait,
       indent: 3,
-      color: "red"
+      prefixColor: "red"
     });
   }
 

--- a/packages/events/defaultSubscribers/obtain.js
+++ b/packages/events/defaultSubscribers/obtain.js
@@ -43,10 +43,13 @@ module.exports = {
         if (this.quiet) {
           return;
         }
-        this.downloadSpinner = new Spinner("events:subscribers:obtain:download", {
-          text: `Downloading compiler. Attempt #${attemptNumber}.`,
-          color: "red"
-        });
+        this.downloadSpinner = new Spinner(
+          "events:subscribers:obtain:download",
+          {
+            text: `Downloading compiler. Attempt #${attemptNumber}.`,
+            prefixColor: "red"
+          }
+        );
       }
     ],
     "downloadCompiler:succeed": [
@@ -72,7 +75,7 @@ module.exports = {
         }
         this.fetchSpinner = new Spinner("events:subscribers:obtain:fetch", {
           text: `Fetching solc version list from solc-bin. Attempt #${attemptNumber}`,
-          color: "yellow"
+          prefixColor: "yellow"
         });
       }
     ],

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@truffle/spinners": "^0.1.2",
+    "@truffle/spinners": "^0.2.0-0",
     "emittery": "^0.4.1",
     "web3-utils": "1.5.3"
   }

--- a/packages/spinners/lib/spinner.ts
+++ b/packages/spinners/lib/spinner.ts
@@ -1,4 +1,8 @@
-import Spinnies, { SpinnerOptions, StopAllStatus } from "spinnies";
+import Spinnies, {
+  SpinnerOptions,
+  StopAllStatus,
+  Color
+} from "@trufflesuite/spinnies";
 
 const spinnies = new Spinnies();
 
@@ -45,55 +49,54 @@ export class Spinner {
       return;
     }
     spinnies.remove(this.name);
-    spinnies.checkIfActiveSpinners();
   }
 
   /**
    * Stops the spinner without a failed or succeeded status
    */
-  stop(options?: Partial<SpinnerOptions>) {
-    const currentOptions = spinnies.pick(this.name);
-    if (!currentOptions) {
+  stop(text?: string): void;
+  stop(options?: Partial<SpinnerOptions>): void;
+  stop(textOrOptions?: string | Partial<SpinnerOptions>): void {
+    if (!spinnies.pick(this.name)) {
       return;
     }
-
-    spinnies.update(this.name, {
-      ...currentOptions,
-      ...options,
-      status: "stopped"
-    });
+    spinnies.stop(this.name, textOrOptions);
   }
 
   /**
    * Stops the spinner and sets its status to succeeded.
    */
-  succeed(text?: string) {
-    const options = spinnies.pick(this.name);
-
-    if (!options) {
+  succeed(text?: string): void;
+  succeed(options?: Partial<SpinnerOptions>): void;
+  succeed(textOrOptions?: string | Partial<SpinnerOptions>): void {
+    if (!spinnies.pick(this.name)) {
       return;
     }
-
-    spinnies.succeed(this.name, {
-      ...options,
-      text
-    });
+    spinnies.succeed(this.name, textOrOptions);
   }
 
   /**
    * Stops the spinner and sets its status to fail.
    */
-  fail(text?: string) {
-    const options = spinnies.pick(this.name);
-
-    if (!options) {
+  fail(text?: string): void;
+  fail(options?: Partial<SpinnerOptions>): void;
+  fail(textOrOptions?: string | Partial<SpinnerOptions>): void {
+    if (!spinnies.pick(this.name)) {
       return;
     }
+    spinnies.fail(this.name, textOrOptions);
+  }
 
-    spinnies.fail(this.name, {
-      ...options,
-      text
-    });
+  /**
+   * Stops the spinner and sets its status to warn.
+   */
+  warn(text?: string): void;
+  warn(options?: Partial<SpinnerOptions>): void;
+  warn(textOrOptions?: string | Partial<SpinnerOptions>): void {
+    if (!spinnies.pick(this.name)) {
+      return;
+    }
+    spinnies.warn(this.name, textOrOptions);
   }
 
   /**
@@ -144,59 +147,85 @@ export class Spinner {
   /**
    * @returns string the `chalk` color of this spinner's text
    */
-  public get color(): string | undefined {
-    return spinnies.pick(this.name)?.color;
+  public get textColor(): Color | undefined {
+    return spinnies.pick(this.name)?.textColor;
   }
 
   /**
    * updates the `chalk` color of this spinner's text
    */
-  public set color(value: string | undefined) {
-    this._mutateOptions("color", value);
+  public set textColor(value: Color | undefined) {
+    this._mutateOptions("textColor", value);
   }
 
   /**
    * @returns string the `chalk` color of this spinner decoration
    */
-  public get spinnerColor(): string | undefined {
-    return spinnies.pick(this.name)?.spinnerColor;
+  public get prefixColor(): Color | undefined {
+    return spinnies.pick(this.name)?.prefixColor;
   }
 
   /**
    * updates the `chalk` color of this spinner's decoration
    */
-  public set spinnerColor(value: string | undefined) {
-    this._mutateOptions("spinnerColor", value);
+  public set prefixColor(value: Color | undefined) {
+    this._mutateOptions("prefixColor", value);
   }
 
   /**
-   * @returns string the `chalk` color of this spinner text on success (note: on
-   * success, the spinner decoration is always green)
+   * @returns string the prefix used when this spinner is stopped
    */
-  public get succeedColor(): string | undefined {
-    return spinnies.pick(this.name)?.succeedColor;
+  public get stoppedPrefix(): Color | undefined {
+    return spinnies.pick(this.name)?.stoppedPrefix;
   }
 
   /**
-   * Updates the `chalk` color of this spinner's text on success
+   * updates the prefix used when this spinner is stopped
    */
-  public set succeedColor(value: string | undefined) {
-    this._mutateOptions("succeedColor", value);
+  public set stoppedPrefix(value: Color | undefined) {
+    this._mutateOptions("stoppedPrefix", value);
   }
 
   /**
-   * @returns string the `chalk` color of this spinner text on failure (note: on
-   * failure, the spinner decoration is always red)
+   * @returns string the prefix used on success
    */
-  public get failColor(): string | undefined {
-    return spinnies.pick(this.name)?.failColor;
+  public get succeedPrefix(): Color | undefined {
+    return spinnies.pick(this.name)?.succeedPrefix;
   }
 
   /**
-   * Updates the `chalk` color of this spinner's text on failure
+   * updates the prefix used on success
    */
-  public set failColor(value: string | undefined) {
-    this._mutateOptions("failColor", value);
+  public set succeedPrefix(value: Color | undefined) {
+    this._mutateOptions("succeedPrefix", value);
+  }
+
+  /**
+   * @returns string the prefix used on failure
+   */
+  public get failPrefix(): Color | undefined {
+    return spinnies.pick(this.name)?.failPrefix;
+  }
+
+  /**
+   * updates the prefix used on failure
+   */
+  public set failPrefix(value: Color | undefined) {
+    this._mutateOptions("failPrefix", value);
+  }
+
+  /**
+   * @returns string the prefix used on warn
+   */
+  public get warnPrefix(): Color | undefined {
+    return spinnies.pick(this.name)?.warnPrefix;
+  }
+
+  /**
+   * updates the prefix used on warn
+   */
+  public set warnPrefix(value: Color | undefined) {
+    this._mutateOptions("warnPrefix", value);
   }
 
   /**
@@ -213,7 +242,9 @@ export class Spinner {
   }
 
   private _mutateOptions<T>(key: string, value: T) {
-    const options = spinnies.pick(this.name) as { [index: string]: T };
+    const options = spinnies.pick(this.name) as unknown as {
+      [index: string]: T;
+    };
 
     if (!options) {
       return;

--- a/packages/spinners/package.json
+++ b/packages/spinners/package.json
@@ -12,7 +12,7 @@
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"
   },
-  "version": "0.1.2",
+  "version": "0.2.0-0",
   "main": "dist/index.js",
   "files": [
     "dist"
@@ -26,7 +26,7 @@
   },
   "types": "dist/index.d.ts",
   "dependencies": {
-    "spinnies": "^0.5.1"
+    "@trufflesuite/spinnies": "^0.1.0"
   },
   "devDependencies": {
     "@types/mocha": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5687,6 +5687,15 @@
     websocket "^1.0.31"
     ws "^7.3.1"
 
+"@trufflesuite/spinnies@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@trufflesuite/spinnies/-/spinnies-0.1.0.tgz#da09ff7c526b563ff6e4d4d86b7884ec00a77be2"
+  integrity sha512-22rVi7rECyAg9vsopa9jR84xQ9kSbjRxCYI9SPbHx4jjfRQODDzmVZtXLobUuXEQZYLgP1pXBtgY5kReb72E2g==
+  dependencies:
+    chalk "^4.1.2"
+    cli-cursor "^3.1.0"
+    strip-ansi "^6.0.0"
+
 "@trufflesuite/typedoc-default-themes@^0.6.1":
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/@trufflesuite/typedoc-default-themes/-/typedoc-default-themes-0.6.1.tgz#6b733ee896519476f6721d0db3effa2ca3bff7ce"


### PR DESCRIPTION
- [x] replace the `spinnies` dependency with a truffle-maintained fork (`@trufflesuite/spinnies`)
- [x] removes workaround for jcarpanelli/spinnies#34 (fixed by trufflesuite/spinnies#1) 
- [x] implements `warn` feature on `@truffle/spinners`
- [x] changes spinner text color back to terminal default