### PR TITLE
Fix: official repo to list Solidity's releases

### DIFF
--- a/packages/compile-solidity/src/compilerSupplier/loadingStrategies/VersionRange.ts
+++ b/packages/compile-solidity/src/compilerSupplier/loadingStrategies/VersionRange.ts
@@ -29,14 +29,14 @@ export class VersionRange {
   constructor(options: StrategyOptions) {
     const defaultConfig = {
       compilerRoots: [
-        // Best performance binaries, via Truffle relay node
+        // this order of url root preference was recommended by Cameel from the
+        // Solidity team here -- https://github.com/trufflesuite/truffle/pull/5008
         "https://relay.trufflesuite.com/solc/emscripten-wasm32/",
-        // Fallback binaries, via Truffle relay node
-        "https://relay.trufflesuite.com/solc/emscripten-asmjs/",
-        // The last two addresses exist so that we have a backup option
-        // in case relay node fails
         "https://binaries.soliditylang.org/emscripten-wasm32/",
-        "https://binaries.soliditylang.org/emscripten-asmjs/"
+        "https://relay.trufflesuite.com/solc/emscripten-asmjs/",
+        "https://binaries.soliditylang.org/emscripten-asmjs/",
+        "https://solc-bin.ethereum.org/bin/",
+        "https://ethereum.github.io/solc-bin/bin/"
       ]
     };
     this.config = Object.assign({}, defaultConfig, options);

--- a/packages/compile-solidity/src/compilerSupplier/loadingStrategies/VersionRange.ts
+++ b/packages/compile-solidity/src/compilerSupplier/loadingStrategies/VersionRange.ts
@@ -29,15 +29,14 @@ export class VersionRange {
   constructor(options: StrategyOptions) {
     const defaultConfig = {
       compilerRoots: [
-        // Official repo of Solidity's releases
-        "https://binaries.soliditylang.org/bin/",
-        // Backup repo. Please note sometime this URL just redirects (302 Found) or returns error (i.e. 522 Connection Timed Out)
-        "https://relay.trufflesuite.com/solc/bin/",
-        // The last two relay addresses exist so that we have a backup option in
-        // case more official distribution mechanisms fail.
-        // Note both are DEPRECATED because they are not updated anymore after 0.7.2
-        "https://solc-bin.ethereum.org/bin/",
-        "https://ethereum.github.io/solc-bin/bin/"
+        // Best performance binaries, via Truffle relay node
+        "https://relay.trufflesuite.com/solc/emscripten-wasm32/",
+        // Fallback binaries, via Truffle relay node
+        "https://relay.trufflesuite.com/solc/emscripten-asmjs/",
+        // The last two addresses exist so that we have a backup option
+        // in case relay node fails
+        "https://binaries.soliditylang.org/emscripten-wasm32/",
+        "https://binaries.soliditylang.org/emscripten-asmjs/"
       ]
     };
     this.config = Object.assign({}, defaultConfig, options);

--- a/packages/compile-solidity/src/compilerSupplier/loadingStrategies/VersionRange.ts
+++ b/packages/compile-solidity/src/compilerSupplier/loadingStrategies/VersionRange.ts
@@ -29,12 +29,13 @@ export class VersionRange {
   constructor(options: StrategyOptions) {
     const defaultConfig = {
       compilerRoots: [
-        // NOTE this relay address exists so that we have a backup option in
-        // case more official distribution mechanisms fail.
-        //
-        // currently this URL just redirects (302 Found); we may alter this to
-        // host for real in the future.
+        // Official repo of Solidity's releases
+        "https://binaries.soliditylang.org/bin/",
+        // Backup repo. Please note sometime this URL just redirects (302 Found) or returns error (i.e. 522 Connection Timed Out)
         "https://relay.trufflesuite.com/solc/bin/",
+        // The last two relay addresses exist so that we have a backup option in
+        // case more official distribution mechanisms fail.
+        // Note both are DEPRECATED because they are not updated anymore after 0.7.2
         "https://solc-bin.ethereum.org/bin/",
         "https://ethereum.github.io/solc-bin/bin/"
       ]

--- a/packages/compile-solidity/test/test_supplier.js
+++ b/packages/compile-solidity/test/test_supplier.js
@@ -152,8 +152,9 @@ describe("CompilerSupplier", function () {
       );
 
       // Delete if it's already there.
-      if (await fse.exists(compilerCacheDirectory))
-        await fse.removeSync(compilerCacheDirectory);
+      if (fse.existsSync(compilerCacheDirectory)) {
+        fse.removeSync(compilerCacheDirectory);
+      }
 
       options.compilers = {
         solc: { version: "0.4.21" }
@@ -172,8 +173,9 @@ describe("CompilerSupplier", function () {
         return filename.includes("v0.4.21+commit.dfe3193c");
       });
 
-      assert(
-        compilerFilename !== undefined,
+      assert.equal(
+        compilerFilename,
+        undefined,
         "The compiler should have been cached but wasn't"
       );
 

--- a/packages/compile-solidity/test/test_supplier.js
+++ b/packages/compile-solidity/test/test_supplier.js
@@ -1,7 +1,7 @@
 const debug = require("debug")("compile:test:test_supplier");
 const fse = require("fs-extra");
 const path = require("path");
-const assert = require("assert");
+const { assert } = require("chai");
 const { Resolver } = require("@truffle/resolver");
 const { Compile } = require("@truffle/compile-solidity");
 const Config = require("@truffle/config");
@@ -173,9 +173,8 @@ describe("CompilerSupplier", function () {
         return filename.includes("v0.4.21+commit.dfe3193c");
       });
 
-      assert.equal(
+      assert.isDefined(
         compilerFilename,
-        undefined,
         "The compiler should have been cached but wasn't"
       );
 

--- a/packages/compile-solidity/test/test_supplier.js
+++ b/packages/compile-solidity/test/test_supplier.js
@@ -150,13 +150,10 @@ describe("CompilerSupplier", function () {
         Config.getTruffleDataDirectory(),
         "compilers/node_modules"
       );
-      const expectedCache = path.resolve(
-        compilerCacheDirectory,
-        "soljson-v0.4.21+commit.dfe3193c.js"
-      );
 
       // Delete if it's already there.
-      if (await fse.exists(expectedCache)) await fse.unlink(expectedCache);
+      if (await fse.exists(compilerCacheDirectory))
+        await fse.removeSync(compilerCacheDirectory);
 
       options.compilers = {
         solc: { version: "0.4.21" }
@@ -170,10 +167,23 @@ describe("CompilerSupplier", function () {
         options: cachedOptions
       });
 
-      assert(await fse.exists(expectedCache), "Should have cached compiler");
+      const cachedCompilerFilenames = fse.readdirSync(compilerCacheDirectory);
+      const compilerFilename = cachedCompilerFilenames.find(filename => {
+        return filename.includes("v0.4.21+commit.dfe3193c");
+      });
+
+      assert(
+        compilerFilename !== undefined,
+        "The compiler should have been cached but wasn't"
+      );
+
+      const cachedCompilerPath = path.join(
+        compilerCacheDirectory,
+        compilerFilename
+      );
 
       // Get cached solc access time
-      initialAccessTime = (await fse.stat(expectedCache)).atime.getTime();
+      initialAccessTime = (await fse.stat(cachedCompilerPath)).atime.getTime();
 
       // Wait a second and recompile, verifying that the cached solc
       // got accessed / ran ok.
@@ -184,7 +194,7 @@ describe("CompilerSupplier", function () {
         options: cachedOptions
       });
 
-      finalAccessTime = (await fse.stat(expectedCache)).atime.getTime();
+      finalAccessTime = (await fse.stat(cachedCompilerPath)).atime.getTime();
       const NewPragma = findOne("NewPragma", compilations[0].contracts);
 
       assert(NewPragma.contractName === "NewPragma", "Should have compiled");

--- a/packages/truffle/test/scenarios/commands/obtain.js
+++ b/packages/truffle/test/scenarios/commands/obtain.js
@@ -6,55 +6,52 @@ const path = require("path");
 const assert = require("assert");
 const sandbox = require("../sandbox");
 
-let logger, config, project, expectedPath;
+let logger, config, project, compilersCacheDirectory;
 
 describe("truffle obtain", function () {
   project = path.join(__dirname, "../../sources/obtain");
 
   beforeEach(async function () {
-    expectedPath = path.join(
+    compilersCacheDirectory = path.join(
       Config.getTruffleDataDirectory(),
       "compilers",
-      "node_modules",
-      "soljson-v0.7.2+commit.51b20bc0.js"
+      "node_modules"
     );
     this.timeout(10000);
     config = await sandbox.create(project);
     logger = new MemoryLogger();
     config.logger = logger;
+
+    // ensure the compiler is not cached beforehand
+    if (fse.existsSync(compilersCacheDirectory)) {
+      fse.removeSync(compilersCacheDirectory);
+    }
+  });
+
+  afterEach(() => {
+    if (fse.existsSync(compilersCacheDirectory)) {
+      fse.removeSync(compilersCacheDirectory);
+    }
   });
 
   it("fetches the solc version specified", async function () {
     this.timeout(70000);
-    // ensure the compiler does not yet exist
-    try {
-      fse.unlinkSync(expectedPath);
-    } catch (error) {
-      // unlink throws when file doesn't exist
-      if (error.code !== "ENOENT") {
-        throw error;
-      }
-    }
     await CommandRunner.run("obtain --solc=0.7.2", config);
-    assert(fse.statSync(expectedPath), "The compiler was not obtained!");
-    fse.unlinkSync(expectedPath);
+    const cachedCompilersFilenames = fse.readdirSync(compilersCacheDirectory);
+
+    assert(
+      cachedCompilersFilenames.some(filename => {
+        return filename.includes("v0.7.2+commit.51b20bc0");
+      }),
+      "The compiler was not obtained!"
+    );
   });
 
   it("respects the `quiet` option", async function () {
     this.timeout(80000);
-    // ensure the compiler does not yet exist
-    try {
-      fse.unlinkSync(expectedPath);
-    } catch (error) {
-      // unlink throws when file doesn't exist
-      if (error.code !== "ENOENT") {
-        throw error;
-      }
-    }
     await CommandRunner.run("obtain --solc=0.7.2 --quiet", config);
     // logger.contents() returns false as long as nothing is written to the
     // stream that is used for logging in MemoryLogger
-
     // in Node12, Ganache prints a warning and it cannot be suppressed
     // I guess we have to allow it until we stop supporting Node12
     const ganacheNode12WarningRegex =
@@ -68,6 +65,5 @@ describe("truffle obtain", function () {
       !loggedStuff,
       "The command logged to the console when it shouldn't have."
     );
-    fse.unlinkSync(expectedPath);
   });
 });


### PR DESCRIPTION
Added the official repo for Solidity's Compiler releases, before the Truffle custom one.
Added a note for the last two deprecated repo.