### PR TITLE
remove extra version fields

### DIFF
--- a/packages/db-kit/package.json
+++ b/packages/db-kit/package.json
@@ -13,7 +13,6 @@
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"
   },
-  "version": "0.1.62",
   "main": "dist/src/index.js",
   "bin": {
     "db-kit": "./dist/bin/cli.js"

--- a/packages/encoder/package.json
+++ b/packages/encoder/package.json
@@ -13,7 +13,6 @@
   "bugs": {
     "url": "https://github.com/trufflesuite/truffle/issues"
   },
-  "version": "0.1.2",
   "main": "dist/index.js",
   "directories": {
     "lib": "lib"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5597,23 +5597,6 @@
     utf8 "^3.0.0"
     web3-utils "1.2.9"
 
-"@truffle/encoder@^0.1.4":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@truffle/encoder/-/encoder-0.1.4.tgz#c70c774d3778851775a7ea1eb3a1564cbe6f8ec3"
-  integrity sha512-+GmNiHo6TQw7szhVJb8cT9dZXorR1c07foTZjZIvxA9vQ34ecfSsaQYFsF+lYKdi6o7vkhIl4vQLKJFfZkpqEw==
-  dependencies:
-    "@ensdomains/ensjs" "^2.0.0"
-    "@ethersproject/address" "^5.0.10"
-    "@ethersproject/bignumber" "^5.0.14"
-    "@truffle/codec" "^0.12.7"
-    "@truffle/compile-common" "^0.7.30"
-    big.js "^6.0.3"
-    bignumber.js "^9.0.1"
-    bn.js "^5.1.3"
-    debug "^4.3.1"
-    lodash "^4.17.21"
-    web3-utils "1.5.3"
-
 "@truffle/preserve-fs@^0.2.7":
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/@truffle/preserve-fs/-/preserve-fs-0.2.7.tgz#e79b235e00425f9771c5b8eb80057d0a4b13ed71"


### PR DESCRIPTION
I think during a merge conflict an extra `version` field was left in the encoder and db-kit packages. This PR removes the extra `version` field.