### PR TITLE
fix slow ethers tests

### DIFF
--- a/packages/dashboard-provider/test/DashboardProvider.test.ts
+++ b/packages/dashboard-provider/test/DashboardProvider.test.ts
@@ -6,28 +6,26 @@ import { getMessageBusPorts } from "@truffle/dashboard-message-bus";
 import { DashboardProvider } from "../lib";
 import MockDashboard from "./MockDashboard";
 
-jest.setTimeout(200000);
+jest.setTimeout(45000);
 
 describe("DashboardProvider", () => {
-  const ganachePort = 8545;
   const dashboardPort = 8546;
 
   let dashboardProvider: DashboardProvider;
   let mockDashboard: MockDashboard;
   let messageBusPorts: any;
-  let ganacheServer: Ganache.Server;
+  let ganacheProvider: Ganache.Provider;
 
-  beforeAll(done => {
-    ganacheServer = Ganache.server();
-    ganacheServer.listen(ganachePort, done);
+  beforeAll(() => {
+    ganacheProvider = Ganache.provider();
   });
 
   afterAll(done => {
-    ganacheServer?.close(done);
+    ganacheProvider?.close(done);
   });
 
   beforeEach(async () => {
-    mockDashboard = new MockDashboard(ganacheServer.provider);
+    mockDashboard = new MockDashboard(ganacheProvider);
     dashboardProvider = new DashboardProvider({
       dashboardPort,
       autoOpen: false
@@ -114,13 +112,10 @@ describe("DashboardProvider", () => {
     let ethersProvider: providers.Web3Provider;
 
     beforeEach(() => {
-      ethersProvider = new providers.Web3Provider(dashboardProvider);
-    });
-
-    afterEach(async () => {
-      // Ethers sends a request to get the chainId on connection, so we await it
-      // to make sure that the provider is finished with that request as well
-      await ethersProvider.ready;
+      ethersProvider = new providers.Web3Provider(dashboardProvider, {
+        name: "ganache",
+        chainId: 1337
+      });
     });
 
     it("should retrieve unlocked accounts", async () => {

--- a/packages/dashboard/test/DashboardServer.test.ts
+++ b/packages/dashboard/test/DashboardServer.test.ts
@@ -5,27 +5,25 @@ import { getMessageBusPorts } from "@truffle/dashboard-message-bus";
 import MockDashboard from "./MockDashboard";
 import { DashboardServer } from "../lib";
 
-jest.setTimeout(200000);
+jest.setTimeout(45000);
 
 // TODO: These tests were copy-pasted from the browser-provider tests
 // We should figure out whether we want to make this DRYer
 describe("DashboardServer", () => {
-  const ganachePort = 8545;
   const dashboardPort = 8546;
   const rpcUrl = `http://localhost:${dashboardPort}/rpc`;
 
   let dashboardServer: DashboardServer;
   let mockDashboard: MockDashboard;
   let messageBusPorts: any;
-  let ganacheServer: Ganache.Server;
+  let ganacheProvider: Ganache.Provider;
 
-  beforeAll(done => {
-    ganacheServer = Ganache.server();
-    ganacheServer.listen(ganachePort, done);
+  beforeAll(() => {
+    ganacheProvider = Ganache.provider();
   });
 
   afterAll(done => {
-    ganacheServer?.close(done);
+    ganacheProvider?.close(done);
   });
 
   beforeEach(async () => {
@@ -36,7 +34,7 @@ describe("DashboardServer", () => {
 
     await dashboardServer.start();
 
-    mockDashboard = new MockDashboard(ganacheServer.provider);
+    mockDashboard = new MockDashboard(ganacheProvider);
     messageBusPorts = await getMessageBusPorts(dashboardPort);
   });
 
@@ -49,13 +47,10 @@ describe("DashboardServer", () => {
     let ethersProvider: providers.JsonRpcProvider;
 
     beforeEach(() => {
-      ethersProvider = new providers.JsonRpcProvider(rpcUrl);
-    });
-
-    afterEach(async () => {
-      // Ethers sends a request to get the chainId on connection, so we await it
-      // to make sure that the provider is finished with that request as well
-      await ethersProvider.ready;
+      ethersProvider = new providers.JsonRpcProvider(rpcUrl, {
+        name: "ganache",
+        chainId: 1337
+      });
     });
 
     it("should retrieve unlocked accounts", async () => {


### PR DESCRIPTION
Before this change the dashboard and dashboard provider tests took about 2 minutes each to run. Now they take around 20 seconds each.