### PR TITLE
Internal improvement: Eliminate another for-in loop

### DIFF
--- a/packages/codec/lib/format/utils/inspect.ts
+++ b/packages/codec/lib/format/utils/inspect.ts
@@ -546,7 +546,7 @@ function unsafeNativizeWithTable(
         let output: any[] = [...coercedResult.value];
         //now, we can't use a map here, or we'll screw things up!
         //we want to *mutate* output, not replace it with a new object
-        for (let index in output) {
+        for (let index = 0; index < output.length; index++) {
           output[index] = unsafeNativizeWithTable(output[index], [
             output,
             ...seenSoFar


### PR DESCRIPTION
Did a review of other for-in loops in debugger and codec.  This one was the only one I found that seemed likely to cause trouble, so I'm getting rid of it pre-emptively.  @michaeljohnbennett let me know if you encounter problems with any others and I can get rid of those too, but this was the only one that seemed worth changing pre-emptively.