### PR TITLE
Bug fix: Fix debugger crash on ancient Solidity versions

### DIFF
--- a/packages/codec/lib/compilations/utils.ts
+++ b/packages/codec/lib/compilations/utils.ts
@@ -145,9 +145,13 @@ export function shimContracts(
     //ast needs to be coerced because schema doesn't quite match our types here...
 
     //if files or sources was passed, trust that to determine the source index
-    if (files || inputSources) {
+    //(assuming we have a sourcePath!)
+    if ((files || inputSources) && sourcePath) {
       //note: we never set the unreliableSourceOrder flag in this branch;
       //we just trust files/sources.  If this info is bad, then, uh, too bad.
+      debug("inputSources: %O", inputSources);
+      debug("files: %O", files);
+      debug("sourcePath: %O", sourcePath);
       const index = inputSources
         ? inputSources.findIndex(source => source.sourcePath === sourcePath)
         : files.indexOf(sourcePath);
@@ -156,6 +160,7 @@ export function shimContracts(
         sourceObject.id = index.toString(); //HACK
         sources[index] = sourceObject;
       }
+      debug("files || inputSources; index: %d", index);
       contractObject.primarySourceId = index.toString(); //HACK
     } else {
       //if neither was passed, attempt to determine it from the ast
@@ -185,6 +190,7 @@ export function shimContracts(
         //if we're in this case, inputSources was not passed
         sourceObject.id = index.toString(); //HACK
         sources[index] = sourceObject;
+        debug("else; index: %d", index);
         contractObject.primarySourceId = index.toString();
       }
     }
@@ -615,7 +621,7 @@ export function findCompilationAndContract(
   return {
     compilation: defaultCompilation,
     contract: defaultContract
-  }
+  };
 }
 
 function projectInfoIsCodecStyle(


### PR DESCRIPTION
Addresses #5007.

This PR fixes a debugger crash that would occur when using `--fetch-external` to debug contracts written with Solidity versions prior to 0.4.9.

Now, we basically don't support Solidity versions that old... but ideally the debugger wouldn't crash, at least.  Especially as a person using `--fetch-external` doesn't necessarily know in advance which Solidity versions would be involved!

(Frankly I'm surprised that `compile-solidity` doesn't run into problems in such cases... I thought that's where the problem was...)

Because we don't really support Solidity that old, this PR isn't intended as any sort of full fix; it's basically just meant to patch over the problem.  Actually truly making such old versions work, issue #1679, is another matter.

Long story short, it turns out that the branch of the `shimContracts` function in codec that gets taken if `sources` or `files` is present relies on `sourcePath` also being present, but with these ancient Solidity versions it's missing (with the current `compile-solidity`, that is; I don't remember offhand if this would still necessarily be the case if we were to do something about #1679).  So, I added a check for `sourcePath`; if it's missing, we go down the other code path instead, because that one doesn't make use of `sourcePath`.  And then after that, things work out.

Ideally, of course, I'd fix the problem by going back even further, and actually getting `sourcePath` to be present; but since that comes from `compile-solidity`, I'd consider that to be a problem for when we handle #1679, and out of scope for this PR.  So, apologies if this doesn't go quite as far back as would be ideal.