### PR TITLE
Internal improvement: Re-fix sporadically failing encoder test

### DIFF
--- a/packages/encoder/test/wrap-fc.test.ts
+++ b/packages/encoder/test/wrap-fc.test.ts
@@ -312,17 +312,10 @@ const BoolInput = (value: boolean) => {
 };
 
 function testDecimalAgreementWithTolerance(actual: Big, expected: Big): void {
-  const negativeLog10OfRelativeTolerance = Math.floor(
-    Math.log10(Number.MAX_SAFE_INTEGER)
-  ); //15
-  const firstDecimalPlace = expected.e; //note: decreases, not increases, to the right of the decimal point
-  const firstDifferingDecimalPlace = actual.minus(expected).e; //note: will be 0 if difference is 0, so don't trust it in that case
-  const approximateNegativeLog10OfDifference =
-    firstDecimalPlace - firstDifferingDecimalPlace; //don't trust this if they're equal!
   assert(
-    actual.eq(expected) ||
-      approximateNegativeLog10OfDifference >= negativeLog10OfRelativeTolerance,
-    `Wrapped Big ${actual.toFixed()} was not within relative tolerance 10^-${negativeLog10OfRelativeTolerance} of original value ${expected.toFixed()}, difference approximately 10^-${approximateNegativeLog10OfDifference} of original value`
+    actual.eq(expected) || //next check will fail for zero, so need this one
+      actual.minus(expected).abs().lt(expected.abs().times(Number.EPSILON)),
+    `Wrapped Big ${actual.toFixed()} was not within relative epsilon of original value ${expected.toFixed()}`
   );
 }
 

--- a/packages/encoder/test/wrap-fc.test.ts
+++ b/packages/encoder/test/wrap-fc.test.ts
@@ -312,7 +312,9 @@ const BoolInput = (value: boolean) => {
 };
 
 function testDecimalAgreementWithTolerance(actual: Big, expected: Big): void {
-  const negativeLog10OfRelativeTolerance = (2 ** 53).toString().length - 1; //15
+  const negativeLog10OfRelativeTolerance = Math.floor(
+    Math.log10(Number.MAX_SAFE_INTEGER)
+  ); //15
   const firstDecimalPlace = expected.e; //note: decreases, not increases, to the right of the decimal point
   const firstDifferingDecimalPlace = actual.minus(expected).e; //note: will be 0 if difference is 0, so don't trust it in that case
   const approximateNegativeLog10OfDifference =


### PR DESCRIPTION
So, #4932 was supposed to fix this, but didn't quite.  Hopefully this one actually does.  So why do I think that this one will work where the previous one failed?

Well, the problem with #4932 is that it assumed that the discrepancy would be at most a certain *absolute* size.  However, after looking at more counterexamples, it's clearer what's actually going on.  If there is a discrepancy, it always begins in the 15th decimal place after the first nonzero one.  It's the relative error, not the absolute error, that matters.

So why the 15th decimal place?  Well, why are discrepancies occurring at all?  Well, it's because we're converting from `Big` (decimal) to `number` (binary) and then back to `Big`.  That's necessarily going to be a bit lossy, especially as `number` has limited precision.  How much precision?  53 bits.  That's inbetween 15 and 16 decimal places.  Thus the problem; sometimes there isn't enough precision and things will slip a bit.  (Of course, things shouldn't slip any when dealing with integers, so I've altered the check to only allow this wiggle room when dealing with non-integers.)

Anyway I altered the test to go based on how far out the first differing decimal place is compared to the first nonzero decimal place, and check that it's at least 15 decimal places further out (or that they're equal).  The resulting code looks a bit wonky, because `Big`s are a bit wonky, but oh well.

Anyway hopefully this is fixed now!  As a check, I ran this test 512 times...