### PR TITLE
Partial memoize provider to reduce number of RPC calls on deployments

### DIFF
--- a/packages/config/src/configDefaults.ts
+++ b/packages/config/src/configDefaults.ts
@@ -2,7 +2,11 @@ import * as path from "path";
 import Provider from "@truffle/provider";
 import TruffleConfig from "./";
 
-let provider: any;
+let provider: any = null;
+
+export const resetProvider = () => {
+  provider = null;
+};
 
 export const getInitialConfig = ({
   truffleDirectory,
@@ -293,6 +297,8 @@ export const configProps = ({
         if (!provider) {
           console.log("No memo provider");
           provider = Provider.create(options);
+        } else {
+          console.log("Using memo provider");
         }
         return provider;
 

--- a/packages/config/src/configDefaults.ts
+++ b/packages/config/src/configDefaults.ts
@@ -295,14 +295,9 @@ export const configProps = ({
         options.events = configObject.events;
 
         if (!provider) {
-          console.log("No memo provider");
           provider = Provider.create(options);
-        } else {
-          console.log("Using memo provider");
         }
         return provider;
-
-        //return Provider.create(options);
       },
       set() {
         throw new Error(

--- a/packages/config/src/configDefaults.ts
+++ b/packages/config/src/configDefaults.ts
@@ -287,7 +287,7 @@ export const configProps = ({
         const options = configObject.network_config;
         options.verboseRpc = configObject.verboseRpc;
         options.events = configObject.events;
-
+        console.log(new Error("valuevaluevalue").stack);
         return Provider.create(options);
       },
       set() {

--- a/packages/config/src/configDefaults.ts
+++ b/packages/config/src/configDefaults.ts
@@ -2,6 +2,8 @@ import * as path from "path";
 import Provider from "@truffle/provider";
 import TruffleConfig from "./";
 
+let provider: any;
+
 export const getInitialConfig = ({
   truffleDirectory,
   workingDirectory,
@@ -287,8 +289,14 @@ export const configProps = ({
         const options = configObject.network_config;
         options.verboseRpc = configObject.verboseRpc;
         options.events = configObject.events;
-        console.log(new Error("valuevaluevalue").stack);
-        return Provider.create(options);
+
+        if (!provider) {
+          console.log("No memo provider");
+          provider = Provider.create(options);
+        }
+        return provider;
+
+        //return Provider.create(options);
       },
       set() {
         throw new Error(

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -5,7 +5,7 @@ import findUp from "find-up";
 import Conf from "conf";
 import TruffleError from "@truffle/error";
 import originalRequire from "original-require";
-import { getInitialConfig, configProps } from "./configDefaults";
+import { getInitialConfig, configProps, resetProvider } from "./configDefaults";
 import { EventManager } from "@truffle/events";
 
 const DEFAULT_CONFIG_FILENAME = "truffle-config.js";
@@ -91,6 +91,8 @@ class TruffleConfig {
   }
 
   public with(obj: any): TruffleConfig {
+    resetProvider();
+
     //Normalized, or shallow clowning only copies an object's own enumerable
     //properties ignoring properties up the prototype chain
     const current = this.normalize(this);

--- a/packages/config/test/methods.test.ts
+++ b/packages/config/test/methods.test.ts
@@ -38,6 +38,28 @@ describe("TruffleConfig.detect", () => {
   });
 });
 
+describe(".load", () => {
+  const config1 = `${__dirname}/testConfig.js`;
+  const config2 = `${__dirname}/testConfig2.js`; // identical to config1
+  const config3 = `${__dirname}/testConfig3.js`; // different mnemonic from 1&2
+
+  it("providers should not be ===", () => {
+    const Config1 = TruffleConfig.load(config1);
+    const Config2 = TruffleConfig.load(config2);
+    const Config3 = TruffleConfig.load(config3);
+
+    const prov1 = Config1.networks.develop.provider();
+    const prov2 = Config2.networks.develop.provider();
+    const prov3 = Config3.networks.develop.provider();
+
+    assert.equal(prov1 === prov2, false);
+    assert.equal(prov2 === prov3, false);
+
+    assert.notStrictEqual(prov1, prov2);
+    assert.notStrictEqual(prov2, prov3);
+  });
+});
+
 describe("when it can't find a config file", () => {
   beforeEach(() => {
     sinon.stub(TruffleConfig, "search").returns(null);

--- a/packages/config/test/testConfig.js
+++ b/packages/config/test/testConfig.js
@@ -1,0 +1,22 @@
+const bip39 = require("bip39");
+const mnemonic = bip39.entropyToMnemonic("00000000000000000000000000000000");
+const HDWalletProvider = require("@truffle/hdwallet-provider");
+
+module.exports = {
+  networks: {
+    develop: {
+      provider: function () {
+        return new HDWalletProvider(mnemonic, "http://127.0.0.1:8545/");
+      },
+      host: "127.0.0.1", // Localhost (default: none)
+      port: 8545, // Standard Ethereum port (default: none)
+      network_id: "*" // Any network (default: none)
+    },
+
+    compilers: {
+      solc: {
+        version: "0.8.12" // Fetch exact version from solc-bin (default: truffle's version)
+      }
+    }
+  }
+};

--- a/packages/config/test/testConfig2.js
+++ b/packages/config/test/testConfig2.js
@@ -1,0 +1,22 @@
+const bip39 = require("bip39");
+const mnemonic = bip39.entropyToMnemonic("00000000000000000000000000000000");
+const HDWalletProvider = require("@truffle/hdwallet-provider");
+
+module.exports = {
+  networks: {
+    develop: {
+      provider: function () {
+        return new HDWalletProvider(mnemonic, "http://127.0.0.1:8545/");
+      },
+      host: "127.0.0.1", // Localhost (default: none)
+      port: 8545, // Standard Ethereum port (default: none)
+      network_id: "*" // Any network (default: none)
+    },
+
+    compilers: {
+      solc: {
+        version: "0.8.12" // Fetch exact version from solc-bin (default: truffle's version)
+      }
+    }
+  }
+};

--- a/packages/config/test/testConfig3.js
+++ b/packages/config/test/testConfig3.js
@@ -1,0 +1,22 @@
+const bip39 = require("bip39");
+const mnemonic = bip39.entropyToMnemonic("00000000000000000000000000000001");
+const HDWalletProvider = require("@truffle/hdwallet-provider");
+
+module.exports = {
+  networks: {
+    develop: {
+      provider: function () {
+        return new HDWalletProvider(mnemonic, "http://127.0.0.1:8545/");
+      },
+      host: "127.0.0.1", // Localhost (default: none)
+      port: 8545, // Standard Ethereum port (default: none)
+      network_id: "*" // Any network (default: none)
+    },
+
+    compilers: {
+      solc: {
+        version: "0.8.12" // Fetch exact version from solc-bin (default: truffle's version)
+      }
+    }
+  }
+};

--- a/packages/core/lib/networks.js
+++ b/packages/core/lib/networks.js
@@ -205,7 +205,6 @@ const Networks = {
     };
 
     for (const networkName of networks) {
-      console.log("Networks asURIs");
       const provider = Provider.create(options.networks[networkName]);
       try {
         const uri = await BlockchainUtils.asURI(provider);
@@ -219,7 +218,6 @@ const Networks = {
   },
 
   matchesNetwork: async function (network_id, network_options) {
-    console.log("Networks matchesNetwork");
     const provider = Provider.create(network_options);
 
     const first = network_id + "";

--- a/packages/core/lib/networks.js
+++ b/packages/core/lib/networks.js
@@ -6,7 +6,7 @@ const Provider = require("@truffle/provider");
 const { createInterfaceAdapter } = require("@truffle/interface-adapter");
 
 const Networks = {
-  deployed: async function(options) {
+  deployed: async function (options) {
     let files;
     try {
       // Only read JSON files in directory
@@ -53,7 +53,7 @@ const Networks = {
     return networks;
   },
 
-  display: async function(config) {
+  display: async function (config) {
     const networks = await this.deployed(config);
     const { networkNames, starNetworks } = Object.keys(networks)
       .sort()
@@ -150,7 +150,7 @@ const Networks = {
     config.logger.log("");
   },
 
-  clean: async function(config) {
+  clean: async function (config) {
     // Only read JSON files in directory
     let files = fs
       .readdirSync(config.contracts_build_directory)
@@ -198,13 +198,14 @@ const Networks = {
   },
 
   // Try to connect to every named network except for "test" and "development"
-  asURIs: async function(options, networks) {
+  asURIs: async function (options, networks) {
     const result = {
       uris: {},
       failed: []
     };
 
     for (const networkName of networks) {
+      console.log("Networks asURIs");
       const provider = Provider.create(options.networks[networkName]);
       try {
         const uri = await BlockchainUtils.asURI(provider);
@@ -217,7 +218,8 @@ const Networks = {
     return result;
   },
 
-  matchesNetwork: async function(network_id, network_options) {
+  matchesNetwork: async function (network_id, network_options) {
+    console.log("Networks matchesNetwork");
     const provider = Provider.create(network_options);
 
     const first = network_id + "";

--- a/packages/provider/index.js
+++ b/packages/provider/index.js
@@ -4,16 +4,6 @@ const { createInterfaceAdapter } = require("@truffle/interface-adapter");
 const wrapper = require("./wrapper");
 const DEFAULT_NETWORK_CHECK_TIMEOUT = 5000;
 
-function memo(fn) {
-  return (...args) => {
-    if (!global.__truffleProvider) {
-      global.__truffleProvider = fn(...args);
-    }
-
-    return global.__truffleProvider;
-  };
-}
-
 module.exports = {
   wrap: function (provider, options) {
     return wrapper.wrap(provider, options);
@@ -54,6 +44,7 @@ module.exports = {
     } else {
       networkCheckTimeout = DEFAULT_NETWORK_CHECK_TIMEOUT;
     }
+
     const provider = this.getProvider(options);
     const { host } = provider;
     const interfaceAdapter = createInterfaceAdapter({ provider, networkType });
@@ -102,5 +93,3 @@ module.exports = {
     });
   }
 };
-
-exports.getProvider = memo(exports.getProvider);


### PR DESCRIPTION
### Description
From the investigating that has stemmed from #4814, this PR reduces the number of RPC calls during a migration by 80% - 90%. Working with @cds-amal, we've identified places in the config that will require optimization because parts of code depend on instantiating new providers. 

The issue was originally reported by a user deploying to Polygon's Mumbai testnet. (https://github.com/trufflesuite/truffle/issues/4814)

### Steps to Reproduce
1. Create an Infura account
2. `init` a truffle project, this test was run against truffle version `5.5.3`
3. Define a `matic` network pointing to your Infura endpoint using the recommended `matic` config.
``` javascript
matic: {
      provider: () => new HDWalletProvider(mnemonic, `https://polygon-mumbai.infura.io/v3/[INFURA_PROJECT_KEY]`),
      network_id: 80001,
      confirmations: 2,
      timeoutBlocks: 200,
      skipDryRun: true
    },
```
4. Run `truffle migrate --network matic`
5.  Observe the API calls:
![image](https://user-images.githubusercontent.com/6285466/163872958-73f2013e-fb98-4e5c-afd9-70ac7b4e71da.png)

6. Pull down and checkout this branch
7. `use-truffle-core` to set system truffle to project folder & this branch
8. Run `truffle migrate --network matic` again
9. Observe the API calls:
![image](https://user-images.githubusercontent.com/6285466/163873516-57da859e-ad71-4123-89ec-6a9fdcaf766d.png)

ER: API calls drop from ~400 (391 actual) to ~150 (151 actual)

10. Set Truffle back to stable `use-truffle-stable`
11. Change your `matic` network in truffle config:
``` javascript
      network_id: 80001,
      confirmations: 0,
      disableConfirmationListener: true,
      timeoutBlocks: 200,
      pollingInterval: 60000,
      skipDryRun: true,
    },
```
12. Run `truffle migrate --network matic`
13. Observe the API calls:
![image](https://user-images.githubusercontent.com/6285466/163874117-56554228-28a4-4d24-8b32-e8fde12ccfc4.png)
 
14. Set Truffle back to core `use-truffle-core`
15. Run `truffle migrate --network matic`
16. Observe the API calls:
![image](https://user-images.githubusercontent.com/6285466/163874447-d488de54-eea8-4bbe-9e43-2d6f3033cbb9.png)

ER: API calls drop from 224 to 54. ~87% reduction from the first test (54 vs 391).


### Related Issues
This new issue was discovered during work on this PR:
https://github.com/trufflesuite/truffle/issues/5026

These open issues mention similar problems:
https://github.com/trufflesuite/truffle/issues/852
https://github.com/trufflesuite/truffle/issues/3356
https://github.com/trufflesuite/truffle/issues/3468
https://github.com/trufflesuite/truffle/issues/3646
https://github.com/trufflesuite/truffle/issues/3471
https://github.com/trufflesuite/truffle/issues/4757

These closed issues may be related:
https://github.com/trufflesuite/truffle/issues/3200
https://github.com/trufflesuite/truffle/issues/4013
https://github.com/trufflesuite/truffle/issues/4288