### PR TITLE
Refactor truffle develop and truffle test codes

### DIFF
--- a/packages/core/lib/commands/configureGanacheOptions.js
+++ b/packages/core/lib/commands/configureGanacheOptions.js
@@ -1,0 +1,52 @@
+const defaultNetworkIdForGanache = 5777;
+
+function sanitizeGanacheOptions(ganacheOptions) {
+  const network_id = ganacheOptions.network_id;
+
+  // Use default network_id if "*" is defined in config
+  if (network_id === "*") {
+    return { ...ganacheOptions, network_id: defaultNetworkIdForGanache };
+  }
+
+  const parsedNetworkId = parseInt(network_id, 10);
+  if (isNaN(parsedNetworkId)) {
+    const error =
+      `The network id specified in the truffle config ` +
+      `(${network_id}) is not valid. Please properly configure the network id as an integer value.`;
+    throw new Error(error);
+  }
+  return { ...ganacheOptions, network_id: parsedNetworkId };
+}
+
+const ConfigureGanache = {
+  getGanacheOptions: function (config, customConfig, mnemonic) {
+    const ganacheOptions = {
+      host: customConfig.host || "127.0.0.1", // Default host for managed ganache
+      port: customConfig.port || 9545, // Default port for managed ganache
+      network_id: customConfig.network_id || defaultNetworkIdForGanache,
+      total_accounts:
+        customConfig.accounts || customConfig.total_accounts || 10,
+      default_balance_ether:
+        customConfig.defaultEtherBalance ||
+        customConfig.default_balance_ether ||
+        100,
+      blockTime: customConfig.blockTime || 0,
+      fork: customConfig.fork,
+      mnemonic: mnemonic,
+      gasPrice: customConfig.gasPrice || 0x77359400,
+      time: config.genesis_time,
+      miner: {
+        instamine: "strict"
+      }
+    };
+
+    if (customConfig.hardfork !== null && customConfig.hardfork !== undefined) {
+      ganacheOptions["hardfork"] = customConfig.hardfork;
+    }
+
+    const sanitizedGanacheOptions = sanitizeGanacheOptions(ganacheOptions);
+    return sanitizedGanacheOptions;
+  }
+};
+
+module.exports = ConfigureGanache;

--- a/packages/core/lib/commands/develop/run.js
+++ b/packages/core/lib/commands/develop/run.js
@@ -1,5 +1,6 @@
 const emoji = require("node-emoji");
 const mnemonicInfo = require("../../mnemonics/mnemonic");
+const configureGanacheOptions = require("../configureGanacheOptions");
 
 const runConsole = async (config, ganacheOptions) => {
   const Console = require("../../console");
@@ -28,7 +29,7 @@ module.exports = async options => {
   const customConfig = config.networks.develop || {};
 
   const { mnemonic, accounts, privateKeys } = mnemonicInfo.getAccountsInfo(
-    customConfig.accounts || 10
+    customConfig.accounts || customConfig.total_accounts || 10
   );
 
   const onMissing = () => "**";
@@ -39,41 +40,11 @@ module.exports = async options => {
     "Ensure you do not use it on production blockchains, or else you risk losing funds.";
 
   const ipcOptions = { log: options.log };
-
-  const ganacheOptions = {
-    host: customConfig.host || "127.0.0.1",
-    port: customConfig.port || 9545,
-    network_id: customConfig.network_id || 5777,
-    total_accounts: customConfig.accounts || 10,
-    default_balance_ether: customConfig.defaultEtherBalance || 100,
-    blockTime: customConfig.blockTime || 0,
-    fork: customConfig.fork,
-    mnemonic,
-    gasLimit: customConfig.gas || 0x6691b7,
-    gasPrice: customConfig.gasPrice || 0x77359400,
-    time: config.genesis_time
-  };
-
-  if (customConfig.hardfork !== null && customConfig.hardfork !== undefined) {
-    ganacheOptions["hardfork"] = customConfig.hardfork;
-  }
-
-  function sanitizeNetworkID(network_id) {
-    if (network_id !== "*") {
-      if (!parseInt(network_id, 10)) {
-        const error =
-          `The network id specified in the truffle config ` +
-          `(${network_id}) is not valid. Please properly configure the network id as an integer value.`;
-        throw new Error(error);
-      }
-      return network_id;
-    } else {
-      // We have a "*" network. Return the default.
-      return 5777;
-    }
-  }
-
-  ganacheOptions.network_id = sanitizeNetworkID(ganacheOptions.network_id);
+  const ganacheOptions = configureGanacheOptions.getGanacheOptions(
+    config,
+    customConfig,
+    mnemonic
+  );
 
   const { started } = await Develop.connectOrStart(ipcOptions, ganacheOptions);
   const url = `http://${ganacheOptions.host}:${ganacheOptions.port}/`;


### PR DESCRIPTION
### ISSUE
Setting Ganache options for `truffle test` and `truffle develop `are not consistent and correct. See #4807 .

### SOLUTION
A new file `configureGanacheOptions.js` is added which consists of an adapter function `getGanacheOptions` which can be  used by both `truffle test` and `truffle develop` to configure managed **Ganache**.