### PR TITLE
Dependency update: Update yargs to ^13.3.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -83,7 +83,7 @@
     "web3": "1.5.3",
     "web3-utils": "1.5.3",
     "xregexp": "^4.2.4",
-    "yargs": "^8.0.2"
+    "yargs": "^13.3.0"
   },
   "devDependencies": {
     "@truffle/blockchain-utils": "^0.1.3",

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -68,7 +68,7 @@
     "webpack": "^5.21.2",
     "webpack-bundle-analyzer": "^3.0.3",
     "webpack-cli": "^4.9.1",
-    "yargs": "^8.0.2"
+    "yargs": "^13.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -32847,7 +32847,7 @@ yargs@^12.0.5:
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^11.1.1"
 
-yargs@^13.3.2:
+yargs@^13.3.0, yargs@^13.3.2:
   version "13.3.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.2.tgz#ad7ffefec1aa59565ac915f82dccb38a9c31a2dd"
   integrity sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==


### PR DESCRIPTION
Addresses #399 and its duplicate #1005; supersedes #4944 (apologies @percentcer, but thanks for bringing our attention to the issue!).

I tried updating `yargs` to a more recent version, and, hey, that solved the problem!  Why to 13.3.0 specifically, and not an even more recent version?  Simple: More recent versions didn't pass CI!  Note we're currently on 8.x, so going to 13.3.0 is blowing past a number of breaking releases... however, it seems to work, and this version passes CI, so I guess it's OK?