### PR TITLE
Make most tests use ganache provider instead of server

### DIFF
--- a/packages/db/src/project/test/compilationSources/.eslintrc.json
+++ b/packages/db/src/project/test/compilationSources/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": ["../../../../../.eslintrc.truffle.json"]
+  "extends": ["../../../../../../.eslintrc.truffle.json"]
 }

--- a/packages/db/src/project/test/compilationSources/truffle-config.js
+++ b/packages/db/src/project/test/compilationSources/truffle-config.js
@@ -1,13 +1,21 @@
+const Ganache = require("ganache");
+
+const provider = Ganache.provider({
+  // note instamine must be set to eager (default) with vmErrorsOnRPCResponse enabled
+  vmErrorsOnRPCResponse: true,
+  logging: {
+    quiet: true
+  }
+});
+
 module.exports = {
   networks: {
     development: {
-      host: "127.0.0.1",
-      port: 8545,
+      provider,
       network_id: "*"
     },
     test: {
-      host: "127.0.0.1",
-      port: 8545,
+      provider,
       network_id: "*"
     }
   },

--- a/packages/db/src/project/test/integration.spec.ts
+++ b/packages/db/src/project/test/integration.spec.ts
@@ -9,7 +9,6 @@ import { generateId } from "@truffle/db/system";
 import Migrate from "@truffle/migrate";
 import { Environment } from "@truffle/environment";
 import Config from "@truffle/config";
-import Ganache from "ganache";
 import Web3 from "web3";
 import * as fse from "fs-extra";
 import * as tmp from "tmp";
@@ -17,20 +16,9 @@ import { Shims } from "@truffle/compile-common";
 import type { DataModel, Resource, IdObject } from "@truffle/db/resources";
 import type { Query, Mutation } from "@truffle/db/process";
 
-let server;
-const port = 8545;
-// @ts-ignore jest-specific pedantry
-beforeAll(async () => {
-  server = Ganache.server({
-    // note instamine must be set to eager (default) with vmErrorsOnRPCResponse enabled
-    vmErrorsOnRPCResponse: true
-  });
-  await server.listen(port);
-});
-
 afterAll(async () => {
   tempDir.removeCallback();
-  await server.close();
+  await migrationConfig.provider.disconnect();
 });
 
 const compilationResult = require(path.join(

--- a/packages/deployer/test/ens.js
+++ b/packages/deployer/test/ens.js
@@ -6,9 +6,8 @@ const ENS = require("../ens");
 const sinon = require("sinon");
 const ENSJS = require("@ensdomains/ensjs").default;
 
-let ganacheOptions,
+let providerOptions,
   options,
-  server,
   ens,
   fromAddress,
   provider,
@@ -19,7 +18,7 @@ let ganacheOptions,
 
 describe("ENS class", () => {
   before(() => {
-    ganacheOptions = {
+    providerOptions = {
       // note that when vmErrorsOnRPCResponse is true, `"eager"` instamine must be enabled (default)
       vmErrorsOnRPCResponse: true,
       mnemonic:
@@ -28,18 +27,12 @@ describe("ENS class", () => {
       default_ether_balance: 100,
       logging: { quiet: true }
     };
-    server = Ganache.server(ganacheOptions);
-    server.listen(8545, () => {});
-    let providerOptions = Object.assign({}, ganacheOptions, {
-      port: "8545",
-      host: "127.0.0.1"
-    });
     provider = Ganache.provider(providerOptions);
   });
   after(async () => {
-    if (server) {
-      await server.close();
-      server = null;
+    if (provider) {
+      await provider.disconnect();
+      provider = null;
     }
   });
   beforeEach(async () => {

--- a/packages/hdwallet-provider/test/provider.test.ts
+++ b/packages/hdwallet-provider/test/provider.test.ts
@@ -3,16 +3,15 @@ import Ganache from "ganache";
 import * as EthUtil from "ethereumjs-util";
 import Web3 from "web3";
 import HDWalletProvider from "..";
-import { describe, it } from "mocha";
+import { describe, it, before, after, afterEach } from "mocha";
 
 describe("HD Wallet Provider", function () {
   const web3 = new Web3();
-  const port = 8545;
-  let server: any;
+  let ganacheProvider: any;
   let provider: HDWalletProvider;
 
-  before(async () => {
-    server = Ganache.server({
+  before(() => {
+    ganacheProvider = Ganache.provider({
       miner: {
         instamine: "strict"
       },
@@ -20,15 +19,14 @@ describe("HD Wallet Provider", function () {
         quiet: true
       }
     });
-    await server.listen(port);
   });
 
   after(async () => {
-    await server.close();
+    await ganacheProvider.disconnect();
   });
 
   afterEach(() => {
-    web3.setProvider(new Web3.providers.HttpProvider("ws://localhost:8545"));
+    web3.setProvider(null);
     if (provider) {
       provider.engine.stop();
     }
@@ -51,7 +49,7 @@ describe("HD Wallet Provider", function () {
 
       const mnemonic =
         "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat";
-      provider = new HDWalletProvider(mnemonic, `http://localhost:${port}`);
+      provider = new HDWalletProvider(mnemonic, ganacheProvider);
 
       assert.deepEqual(provider.getAddresses(), truffleDevAccounts);
       web3.setProvider(provider);
@@ -85,7 +83,7 @@ describe("HD Wallet Provider", function () {
           "9549f39decea7b7504e15572b2c6a72766df0281cea22bd1a3bc87166b1ca290"
       };
 
-      provider = new HDWalletProvider(privateKeys, `http://localhost:${port}`);
+      provider = new HDWalletProvider(privateKeys, ganacheProvider);
       web3.setProvider(provider);
 
       const addresses = provider.getAddresses();
@@ -114,7 +112,7 @@ describe("HD Wallet Provider", function () {
     it("provides for a private key", async () => {
       const privateKey =
         "3f841bf589fdf83a521e55d51afddc34fa65351161eead24f064855fc29c9580"; //random valid private key generated with ethkey
-      provider = new HDWalletProvider(privateKey, `http://localhost:${port}`);
+      provider = new HDWalletProvider(privateKey, ganacheProvider);
       web3.setProvider(provider);
 
       const addresses = provider.getAddresses();
@@ -149,7 +147,7 @@ describe("HD Wallet Provider", function () {
         mnemonic: {
           phrase: mnemonicPhrase
         },
-        url: `http://localhost:${port}`
+        provider: ganacheProvider
       });
 
       assert.deepEqual(provider.getAddresses(), truffleDevAccounts);
@@ -177,7 +175,7 @@ describe("HD Wallet Provider", function () {
         "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat";
       provider = new HDWalletProvider({
         mnemonic: mnemonicPhrase,
-        url: `http://localhost:${port}`
+        provider: ganacheProvider
       });
 
       assert.deepEqual(provider.getAddresses(), truffleDevAccounts);
@@ -207,7 +205,7 @@ describe("HD Wallet Provider", function () {
           phrase: mnemonicPhrase,
           password: "yummy"
         },
-        url: `http://localhost:${port}`
+        provider: ganacheProvider
       });
 
       assert.deepEqual(provider.getAddresses(), accounts);
@@ -224,19 +222,19 @@ describe("HD Wallet Provider", function () {
         mnemonic: {
           phrase: mnemonicPhrase
         },
-        url: `http://localhost:${port}`,
+        provider: ganacheProvider
         // polling interval is unspecified
       });
-      assert.ok(provider.engine,
-        "Web3ProviderEngine instantiated");
-      // @ts-ignore - _blockTracker is not officially part of the interface
-      assert.ok(provider.engine._blockTracker,
-        "PollingBlockTracker instantiated");
+      assert.ok(provider.engine, "Web3ProviderEngine instantiated");
+      assert.ok(
+        (provider.engine as any)._blockTracker,
+        "PollingBlockTracker instantiated"
+      );
       assert.deepEqual(
-        // @ts-ignore
-        provider.engine._blockTracker._pollingInterval,
+        (provider.engine as any)._blockTracker._pollingInterval,
         4000,
-        "PollingBlockTracker with expected pollingInterval");
+        "PollingBlockTracker with expected pollingInterval"
+      );
     });
 
     it("provides for a custom polling interval", () => {
@@ -246,20 +244,20 @@ describe("HD Wallet Provider", function () {
         mnemonic: {
           phrase: mnemonicPhrase
         },
-        url: `http://localhost:${port}`,
+        provider: ganacheProvider,
         // double the default value, for less chatty JSON-RPC
-        pollingInterval: 8000,
+        pollingInterval: 8000
       });
-      assert.ok(provider.engine,
-        "Web3ProviderEngine instantiated");
-      // @ts-ignore
-      assert.ok(provider.engine._blockTracker,
-        "PollingBlockTracker instantiated");
+      assert.ok(provider.engine, "Web3ProviderEngine instantiated");
+      assert.ok(
+        (provider.engine as any)._blockTracker,
+        "PollingBlockTracker instantiated"
+      );
       assert.deepEqual(
-        // @ts-ignore
-        provider.engine._blockTracker._pollingInterval,
+        (provider.engine as any)._blockTracker._pollingInterval,
         8000,
-        "PollingBlockTracker with expected pollingInterval");
+        "PollingBlockTracker with expected pollingInterval"
+      );
     });
 
     it("provides for an array of private keys", async () => {
@@ -277,7 +275,7 @@ describe("HD Wallet Provider", function () {
 
       provider = new HDWalletProvider({
         privateKeys,
-        url: `http://localhost:${port}`
+        provider: ganacheProvider
       });
       web3.setProvider(provider);
 
@@ -309,7 +307,8 @@ describe("HD Wallet Provider", function () {
         try {
           provider = new HDWalletProvider({
             mnemonic: {
-              phrase: "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat"
+              phrase:
+                "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat"
             },
             // @ts-ignore we gotta do the bad thing here to get the test right
             provider: { junk: "in", an: "object" }
@@ -324,7 +323,8 @@ describe("HD Wallet Provider", function () {
         try {
           provider = new HDWalletProvider({
             mnemonic: {
-              phrase: "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat"
+              phrase:
+                "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat"
             },
             url: "justABunchOfJunk"
           });

--- a/packages/hdwallet-provider/tsconfig.json
+++ b/packages/hdwallet-provider/tsconfig.json
@@ -16,7 +16,8 @@
       "../../node_modules/@types/mocha",
       "../../node_modules/@types/node",
       "../../node_modules/@types/web3-provider-engine",
-    ]
+    ],
+    "types": [ "node", "mocha" ]
   },
   "include": [
     "./src/**/*.ts"


### PR DESCRIPTION
Makes it so that the tests in question don't require open ports to listen on, and are therefore easier to execute in parallel.