### PR TITLE
Bug fix: Prevent intermediate state from appearing in final txlog

### DIFF
--- a/packages/debugger/lib/txlog/actions/index.js
+++ b/packages/debugger/lib/txlog/actions/index.js
@@ -7,11 +7,45 @@ export function internalCall(pointer, newPointer) {
   };
 }
 
+export const IDENTIFIED_INTERNAL_CALL = "TXLOG_IDENTIFIED_INTERNAL_CALL";
+export function identifiedInternalCall(
+  pointer,
+  newPointer,
+  functionNode,
+  contractNode,
+  variables
+) {
+  return {
+    type: IDENTIFIED_INTERNAL_CALL,
+    pointer,
+    newPointer,
+    functionNode,
+    contractNode,
+    variables
+  };
+}
+
 export const ABSORBED_CALL = "TXLOG_ABSORBED_CALL";
 export function absorbedCall(pointer) {
   return {
     type: ABSORBED_CALL,
     pointer
+  };
+}
+
+export const IDENTIFIED_ABSORBED_CALL = "TXLOG_IDENTIFIED_ABSORBED_CALL";
+export function identifiedAbsorbedCall(
+  pointer,
+  functionNode,
+  contractNode,
+  variables
+) {
+  return {
+    type: IDENTIFIED_ABSORBED_CALL,
+    pointer,
+    functionNode,
+    contractNode,
+    variables
   };
 }
 

--- a/packages/debugger/lib/txlog/actions/index.js
+++ b/packages/debugger/lib/txlog/actions/index.js
@@ -7,45 +7,11 @@ export function internalCall(pointer, newPointer) {
   };
 }
 
-export const IDENTIFIED_INTERNAL_CALL = "TXLOG_IDENTIFIED_INTERNAL_CALL";
-export function identifiedInternalCall(
-  pointer,
-  newPointer,
-  functionNode,
-  contractNode,
-  variables
-) {
-  return {
-    type: IDENTIFIED_INTERNAL_CALL,
-    pointer,
-    newPointer,
-    functionNode,
-    contractNode,
-    variables
-  };
-}
-
 export const ABSORBED_CALL = "TXLOG_ABSORBED_CALL";
 export function absorbedCall(pointer) {
   return {
     type: ABSORBED_CALL,
     pointer
-  };
-}
-
-export const IDENTIFIED_ABSORBED_CALL = "TXLOG_IDENTIFIED_ABSORBED_CALL";
-export function identifiedAbsorbedCall(
-  pointer,
-  functionNode,
-  contractNode,
-  variables
-) {
-  return {
-    type: IDENTIFIED_ABSORBED_CALL,
-    pointer,
-    functionNode,
-    contractNode,
-    variables
   };
 }
 

--- a/packages/debugger/lib/txlog/reducers.js
+++ b/packages/debugger/lib/txlog/reducers.js
@@ -295,7 +295,7 @@ function transactionLog(state = DEFAULT_TX_LOG, action) {
         ...node,
         waitingForFunctionDefinition: false
       };
-      //note: I don't handle the following in the object spread above
+      //note: I don't handle the following three fields in the object spread above
       //because I don't want undefined or null counting against it
       if (!modifiedNode.functionName) {
         modifiedNode.functionName = functionName;

--- a/packages/debugger/lib/txlog/reducers.js
+++ b/packages/debugger/lib/txlog/reducers.js
@@ -24,39 +24,6 @@ const DEFAULT_TX_LOG = {
 function transactionLog(state = DEFAULT_TX_LOG, action) {
   const { pointer, newPointer } = action;
   const node = state.byPointer[pointer];
-
-  const identify = (node, action) => {
-    const { functionNode, contractNode, variables } = action;
-    const functionName = functionNode.name || undefined; //replace "" with undefined
-    const contractName =
-      contractNode && contractNode.nodeType === "ContractDefinition"
-        ? contractNode.name
-        : null;
-    let modifiedNode = {
-      ...node,
-      waitingForFunctionDefinition: false
-    };
-    //note: I don't handle the following in the object spread above
-    //because I don't want undefined or null counting against it
-    if (!modifiedNode.functionName) {
-      modifiedNode.functionName = functionName;
-    }
-    if (!modifiedNode.contractName) {
-      modifiedNode.contractName = contractName;
-    }
-    if (!modifiedNode.arguments) {
-      modifiedNode.arguments = variables;
-    }
-    if (
-      modifiedNode.type === "callexternal" &&
-      modifiedNode.kind === "library"
-    ) {
-      modifiedNode.kind = "function";
-      delete modifiedNode.data;
-    }
-    return modifiedNode;
-  };
-
   switch (action.type) {
     case actions.RECORD_ORIGIN:
       if (node.type === "transaction") {
@@ -88,25 +55,6 @@ function transactionLog(state = DEFAULT_TX_LOG, action) {
           }
         }
       };
-    case actions.IDENTIFIED_INTERNAL_CALL:
-      const newNode = identify(
-        {
-          type: "callinternal",
-          actions: [],
-          waitingForFunctionDefinition: true
-        },
-        action
-      );
-      return {
-        byPointer: {
-          ...state.byPointer,
-          [pointer]: {
-            ...node,
-            actions: [...node.actions, newPointer]
-          },
-          [newPointer]: newNode
-        }
-      };
     case actions.ABSORBED_CALL:
       return {
         byPointer: {
@@ -117,19 +65,7 @@ function transactionLog(state = DEFAULT_TX_LOG, action) {
           }
         }
       };
-    case actions.IDENTIFIED_ABSORBED_CALL: {
-      const modifiedNode = identify(node, action);
-      return {
-        byPointer: {
-          ...state.byPointer,
-          [pointer]: {
-            ...modifiedNode,
-            absorbNextInternalCall: false
-          }
-        }
-      };
-    }
-    case actions.INTERNAL_RETURN: {
+    case actions.INTERNAL_RETURN:
       //pop the top call from the stack if it's internal (and set its return values)
       //if the top call is instead external, just set its return values if appropriate.
       //(this is how we handle internal/external return absorption)
@@ -152,7 +88,6 @@ function transactionLog(state = DEFAULT_TX_LOG, action) {
           [pointer]: modifiedNode
         }
       };
-    }
     case actions.INSTANT_EXTERNAL_CALL:
     case actions.EXTERNAL_CALL:
     case actions.INSTANT_CREATE:
@@ -350,7 +285,34 @@ function transactionLog(state = DEFAULT_TX_LOG, action) {
       return newState;
     }
     case actions.IDENTIFY_FUNCTION_CALL: {
-      const modifiedNode = identify(node, action);
+      const { functionNode, contractNode, variables } = action;
+      const functionName = functionNode.name || undefined; //replace "" with undefined
+      const contractName =
+        contractNode && contractNode.nodeType === "ContractDefinition"
+          ? contractNode.name
+          : null;
+      let modifiedNode = {
+        ...node,
+        waitingForFunctionDefinition: false
+      };
+      //note: I don't handle the following in the object spread above
+      //because I don't want undefined or null counting against it
+      if (!modifiedNode.functionName) {
+        modifiedNode.functionName = functionName;
+      }
+      if (!modifiedNode.contractName) {
+        modifiedNode.contractName = contractName;
+      }
+      if (!modifiedNode.arguments) {
+        modifiedNode.arguments = variables;
+      }
+      if (
+        modifiedNode.type === "callexternal" &&
+        modifiedNode.kind === "library"
+      ) {
+        modifiedNode.kind = "function";
+        delete modifiedNode.data;
+      }
       return {
         byPointer: {
           ...state.byPointer,

--- a/packages/debugger/lib/txlog/sagas/index.js
+++ b/packages/debugger/lib/txlog/sagas/index.js
@@ -60,7 +60,9 @@ function* updateTransactionLogSaga() {
       }
     } else if (jumpDirection === "o") {
       const internal = yield select(txlog.current.inInternalSourceOrYul); //don't log jumps out of internal sources or Yul
-      const astMatchesTxLog = yield select(txlog.current.currentFunctionIsAsExpected); //don't log returns from the wrong function...?
+      const astMatchesTxLog = yield select(
+        txlog.current.currentFunctionIsAsExpected
+      ); //don't log returns from the wrong function...?
       //(I've added this second check due to a strange case Amal found, hopefully this doesn't screw anything up)
       if (!internal && astMatchesTxLog) {
         //in this case, we have to do decoding & fn identification
@@ -179,10 +181,7 @@ function* updateTransactionLogSaga() {
         )
       );
     }
-  }
-  //we process this last in case jump & function def on same step
-  //(which is in fact how it typically goes!)
-  if (yield select(txlog.current.onFunctionDefinition)) {
+  } else if (yield select(txlog.current.onFunctionDefinition)) {
     if (yield select(txlog.current.waitingForFunctionDefinition)) {
       debug("identifying");
       const inputAllocations = yield select(
@@ -271,30 +270,34 @@ export function* begin() {
     const kind = callKind(context, calldata, false); //no insta-calls here!
     const absorb = yield select(txlog.transaction.absorbFirstInternalCall);
     debug("initial call: %o %o", pointer, newPointer);
-    yield put(actions.externalCall(
-      pointer,
-      newPointer,
-      address,
-      context,
-      value,
-      false, //initial call is never delegate
-      kind,
-      decoding,
-      calldata,
-      absorb
-    ));
+    yield put(
+      actions.externalCall(
+        pointer,
+        newPointer,
+        address,
+        context,
+        value,
+        false, //initial call is never delegate
+        kind,
+        decoding,
+        calldata,
+        absorb
+      )
+    );
   } else {
     debug("initial create: %o %o", pointer, newPointer);
-    yield put(actions.create(
-      pointer,
-      newPointer,
-      storageAddress,
-      context,
-      value,
-      null, //initial create never has salt
-      decoding,
-      binary
-    ));
+    yield put(
+      actions.create(
+        pointer,
+        newPointer,
+        storageAddress,
+        context,
+        value,
+        null, //initial create never has salt
+        decoding,
+        binary
+      )
+    );
   }
 }
 

--- a/packages/debugger/lib/txlog/sagas/index.js
+++ b/packages/debugger/lib/txlog/sagas/index.js
@@ -52,53 +52,10 @@ function* updateTransactionLogSaga() {
         if (!(yield select(txlog.current.waitingForInternalCallToAbsorb))) {
           const newPointer = yield select(txlog.current.nextCallPointer);
           debug("internal call: %o %o", pointer, newPointer);
-          if (yield select(txlog.current.onFunctionDefinition)) {
-            const inputAllocations = yield select(
-              txlog.current.inputParameterAllocations
-            );
-            if (inputAllocations) {
-              debug("identify [combined]: %o", pointer);
-              const { functionNode, contractNode, variables } =
-                yield* identifySaga();
-              yield put(
-                actions.identifiedInternalCall(
-                  pointer,
-                  newPointer,
-                  functionNode,
-                  contractNode,
-                  variables
-                )
-              );
-            } else {
-              yield put(actions.internalCall(pointer, newPointer));
-            }
-          } else {
-            yield put(actions.internalCall(pointer, newPointer));
-          }
+          yield put(actions.internalCall(pointer, newPointer));
         } else {
           debug("absorbed call: %o", pointer);
-          if (yield select(txlog.current.onFunctionDefinition)) {
-            const inputAllocations = yield select(
-              txlog.current.inputParameterAllocations
-            );
-            if (inputAllocations) {
-              debug("identify [combined]: %o", pointer);
-              const { functionNode, contractNode, variables } =
-                yield* identifySaga();
-              yield put(
-                actions.identifiedAbsorbedCall(
-                  pointer,
-                  functionNode,
-                  contractNode,
-                  variables
-                )
-              );
-            } else {
-              yield put(actions.absorbedCall(pointer));
-            }
-          } else {
-            yield put(actions.absorbedCall(pointer));
-          }
+          yield put(actions.absorbedCall(pointer));
         }
       }
     } else if (jumpDirection === "o") {
@@ -232,8 +189,20 @@ function* updateTransactionLogSaga() {
       );
       debug("inputAllocations: %O", inputAllocations);
       if (inputAllocations) {
-        debug("identify [standalone]: %o", pointer);
-        const { functionNode, contractNode, variables } = yield* identifySaga();
+        const functionNode = yield select(txlog.current.astNode);
+        const contractNode = yield select(txlog.current.contract);
+        const compilationId = yield select(txlog.current.compilationId);
+        //can't do a yield* inside a map, have to do this loop manually
+        let variables = [];
+        for (let { name, definition, pointer } of inputAllocations) {
+          const decodedValue = yield* data.decode(
+            definition,
+            pointer,
+            compilationId
+          );
+          variables.push({ name, value: decodedValue });
+        }
+        debug("identify: %o", pointer);
         yield put(
           actions.identifyFunctionCall(
             pointer,
@@ -245,23 +214,6 @@ function* updateTransactionLogSaga() {
       }
     }
   }
-}
-
-function* identifySaga() {
-  debug("identifying");
-  const inputAllocations = yield select(
-    txlog.current.inputParameterAllocations
-  );
-  const functionNode = yield select(txlog.current.astNode);
-  const contractNode = yield select(txlog.current.contract);
-  const compilationId = yield select(txlog.current.compilationId);
-  //can't do a yield* inside a map, have to do this loop manually
-  let variables = [];
-  for (const { name, definition, pointer } of inputAllocations) {
-    const decodedValue = yield* data.decode(definition, pointer, compilationId);
-    variables.push({ name, value: decodedValue });
-  }
-  return { functionNode, contractNode, variables };
 }
 
 function callKind(context, calldata, instant) {

--- a/packages/debugger/test/txlog.js
+++ b/packages/debugger/test/txlog.js
@@ -112,6 +112,16 @@ function byName(variables) {
   );
 }
 
+function verifyNoIntermediates(untied) {
+  for (const node of Object.values(untied)) {
+    assert.notProperty(node, "waitingForFunctionDefinition"); //should be deleted by finish
+    assert.notProperty(node, "absorbNextInternalCall"); //should be deleted by finish
+    if (node.type === "callexternal") {
+      assert.notEqual(node.kind, "library"); //should be changed to something else by finish
+    }
+  }
+}
+
 describe("Transaction log (visualizer)", function () {
   let provider;
   let abstractions;
@@ -150,6 +160,9 @@ describe("Transaction log (visualizer)", function () {
     });
 
     await bugger.runToEnd();
+
+    const untied = bugger.view(txlog.proc.transactionLog);
+    verifyNoIntermediates(untied);
 
     const root = bugger.view(txlog.views.transactionLog);
     assert.equal(root.type, "transaction");
@@ -207,6 +220,9 @@ describe("Transaction log (visualizer)", function () {
 
     await bugger.runToEnd();
 
+    const untied = bugger.view(txlog.proc.transactionLog);
+    verifyNoIntermediates(untied);
+
     const root = bugger.view(txlog.views.transactionLog);
     assert.equal(root.type, "transaction");
     assert.lengthOf(root.actions, 1);
@@ -260,6 +276,9 @@ describe("Transaction log (visualizer)", function () {
 
     await bugger.runToEnd();
 
+    const untied = bugger.view(txlog.proc.transactionLog);
+    verifyNoIntermediates(untied);
+
     const root = bugger.view(txlog.views.transactionLog);
     assert.equal(root.type, "transaction");
     assert.lengthOf(root.actions, 1);
@@ -308,6 +327,9 @@ describe("Transaction log (visualizer)", function () {
 
     await bugger.runToEnd();
 
+    const untied = bugger.view(txlog.proc.transactionLog);
+    verifyNoIntermediates(untied);
+
     const root = bugger.view(txlog.views.transactionLog);
     assert.equal(root.type, "transaction");
     let origin = root.origin;
@@ -342,6 +364,9 @@ describe("Transaction log (visualizer)", function () {
     });
 
     await bugger.runToEnd();
+
+    const untied = bugger.view(txlog.proc.transactionLog);
+    verifyNoIntermediates(untied);
 
     const root = bugger.view(txlog.views.transactionLog);
     assert.equal(root.type, "transaction");
@@ -394,6 +419,9 @@ describe("Transaction log (visualizer)", function () {
     });
 
     await bugger.runToEnd();
+
+    const untied = bugger.view(txlog.proc.transactionLog);
+    verifyNoIntermediates(untied);
 
     const root = bugger.view(txlog.views.transactionLog);
     assert.equal(root.type, "transaction");


### PR DESCRIPTION
Addresses #3884.

This PR fixes a problem where intermediate state -- specifically, the `waitingForFunctionDefinition` field -- was appearing in final txlogs.  Why was this problem occurring?  Basically, we had a case where the conditions for a jump out and for an identify were triggered on the same step.  So an action was triggered for each, and, uh, I guess these things don't always work synchronously?  IDK, I'm a little unclear on that point.  Regardless, the jump out action deleted the `waitingForFunctionDefinition` intermediate state... and then the identify added it back in (setting it to `false`).  Oops.

So, in order to prevent this from happening, I had to make the identify case exclusive of the other cases.  Why wasn't it exclusive before?  Well, what if we have a simultaneous jump-in and identify?  When I wrote txlog, actually, I incorrectly thought that was the usual case.  It isn't, and, well, how would that ever happen?  You jump in, *then* you're on the function... simultaneous doesn't make sense.

~~In order to make sure we can handle that case, I also created combined jump-in/identify actions.  This meant factoring the identification code a bit.  Anyway so now jump-in w/o identify, identified-jump in, identify w/o jump-in are three exclusive cases using three different actions.  (Five, actually, since jump-ins can be absorbed or not absorbed.)  Rather than relying on two actions for the jump-in and identify case.  (Not that I've seen any cases of this, but I want to be able to handle it.)~~

In order to make sure this problem doesn't crop up again, this PR also adds tests.  Or rather, it adds to the existing tests, since the situation that was leading to the problem was among our existing tests already, so I didn't create any new tests.  Rather, I just added to all of the existing tests a check that there's no intermediate state left at the end.  And that's it!

This'll cause merge conflicts with #4882, I'm sure. :-/  Also: `prettier` made a bunch of changes on this PR.  Sorry.