### PR TITLE
Enhancement: Add new interface for fetch-and-compile that doesn't require a Truffle config

### DIFF
--- a/packages/fetch-and-compile/README.md
+++ b/packages/fetch-and-compile/README.md
@@ -87,6 +87,37 @@ for (const address in failures) {
 }
 ```
 
+### Alternate input format
+
+Instead of using a Truffle Config as input, you can instead pass in a `FetchAndCompileOptions` anwyhere that
+a `config` is used above. The format is as follows:
+
+```ts
+export interface FetchAndCompileOptions {
+  network: {
+    networkId: number;
+  };
+  fetch?: {
+    precedence?: string[]; //which fetchers to use and in what order; defaults
+    //to ["etherscan", "sourcify"]
+    fetcherOptions?: {
+      etherscan?: {
+        apiKey: string; //etherscan API key if you have one to speed things up
+      };
+      sourcify?: {
+        //nothing to go here at present
+      };
+      //potentially options for other fetchers in the future
+    };
+  };
+  compile?: {
+    docker?: boolean; //indicates that compilation should use dockerized solc;
+    //note this won't work with contracts compiled with prerelease versions
+    //of solidity
+  };
+}
+```
+
 ### `getSupportedNetworks`
 
 If you want a list of supported networks, you can call `getSupportedNetworks`:
@@ -105,14 +136,14 @@ const networks = getSupportedNetworks();
 //}
 ```
 
-If you have a config with the `sourceFetchers` property set, you can call `getSupportedNetworks(config)`
-and the output will be restricted to the networks supported by the fetchers listed there.
+You can also pass in a list of fetchers if you want to restrict the output to the networks
+supported by the fetchers you list. (You can also pass in a config and it will use the `sourceFetchers`
+property if set, or a `FetchAndCompileOptions` and it will use the `fetch.precedence` field if set.)
 
 ```ts
 import { getSupportedNetworks } from "@truffle/fetch-and-compile";
 import Config from "@truffle/config";
-const config = Config.default().with({ sourceFetchers: ["etherscan"] });
-const networks = getSupportedNetworks(config); //will only list those supported by etherscan fetcher
+const networks = getSupportedNetworks(["etherscan"]); //will only list those supported by etherscan fetcher
 // networks = {
 //  mainnet: {
 //    name: "mainnet",

--- a/packages/fetch-and-compile/lib/fetch.ts
+++ b/packages/fetch-and-compile/lib/fetch.ts
@@ -12,15 +12,18 @@ import Config from "@truffle/config";
 const { Compile } = require("@truffle/compile-solidity"); //sorry for untyped import!
 import type { Recognizer, FailureType, FetchAndCompileOptions } from "./types";
 import type { WorkflowCompileResult } from "@truffle/compile-common";
-import { normalizeInput } from "./utils";
+import {
+  normalizeFetchAndCompileOptions,
+  normalizeFetcherNames
+} from "./utils";
 
 export async function fetchAndCompileForRecognizer(
   recognizer: Recognizer,
   options: FetchAndCompileOptions | Config
 ): Promise<void> {
-  const normalizedOptions = normalizeInput(options);
+  const normalizedOptions = normalizeFetchAndCompileOptions(options);
   const fetcherConstructors: FetcherConstructor[] =
-    getSortedFetcherConstructors(normalizedOptions);
+    getSortedFetcherConstructors(normalizeFetcherNames(normalizedOptions));
   const fetchers = await getFetchers(
     fetcherConstructors,
     normalizedOptions,
@@ -40,11 +43,8 @@ export async function fetchAndCompileForRecognizer(
 
 //sort/filter fetchers by user's order, if given; otherwise use default order
 export function getSortedFetcherConstructors(
-  options?: FetchAndCompileOptions
+  userFetcherNames?: string[]
 ): FetcherConstructor[] {
-  const userFetcherNames: string[] | undefined = (
-    (options || { fetch: undefined }).fetch || { precedence: undefined }
-  ).precedence;
   let sortedFetchers: FetcherConstructor[] = [];
   if (userFetcherNames) {
     for (let name of userFetcherNames) {

--- a/packages/fetch-and-compile/lib/fetch.ts
+++ b/packages/fetch-and-compile/lib/fetch.ts
@@ -8,32 +8,43 @@ import {
   Fetcher,
   SourceInfo
 } from "@truffle/source-fetcher";
-import type Config from "@truffle/config";
+import Config from "@truffle/config";
 const { Compile } = require("@truffle/compile-solidity"); //sorry for untyped import!
-import type { Recognizer, FailureType } from "./types";
+import type { Recognizer, FailureType, FetchAndCompileOptions } from "./types";
 import type { WorkflowCompileResult } from "@truffle/compile-common";
+import { normalizeInput } from "./utils";
 
 export async function fetchAndCompileForRecognizer(
   recognizer: Recognizer,
-  config: Config
+  options: FetchAndCompileOptions | Config
 ): Promise<void> {
+  const normalizedOptions = normalizeInput(options);
   const fetcherConstructors: FetcherConstructor[] =
-    getSortedFetcherConstructors(config);
-  const fetchers = await getFetchers(fetcherConstructors, config, recognizer);
+    getSortedFetcherConstructors(normalizedOptions);
+  const fetchers = await getFetchers(
+    fetcherConstructors,
+    normalizedOptions,
+    recognizer
+  );
   //now: the main loop!
   let address: string | undefined;
   while ((address = recognizer.getAnUnrecognizedAddress()) !== undefined) {
-    await tryFetchAndCompileAddress(address, fetchers, recognizer, config);
+    await tryFetchAndCompileAddress(
+      address,
+      fetchers,
+      recognizer,
+      normalizedOptions
+    );
   }
 }
 
 //sort/filter fetchers by user's order, if given; otherwise use default order
 export function getSortedFetcherConstructors(
-  config?: Config
+  options?: FetchAndCompileOptions
 ): FetcherConstructor[] {
   const userFetcherNames: string[] | undefined = (
-    config || { sourceFetchers: undefined }
-  ).sourceFetchers;
+    (options || { fetch: undefined }).fetch || { precedence: undefined }
+  ).precedence;
   let sortedFetchers: FetcherConstructor[] = [];
   if (userFetcherNames) {
     for (let name of userFetcherNames) {
@@ -52,10 +63,10 @@ export function getSortedFetcherConstructors(
 
 async function getFetchers(
   fetcherConstructors: FetcherConstructor[],
-  config: Config,
+  options: FetchAndCompileOptions,
   recognizer: Recognizer
 ): Promise<Fetcher[]> {
-  const networkId: number = config.network_id;
+  const networkId: number = options.network.networkId;
   //make fetcher instances. we'll filter out ones that don't support this
   //network (and note ones that yielded errors)
   return (
@@ -64,7 +75,7 @@ async function getFetchers(
         try {
           return await Fetcher.forNetworkId(
             networkId,
-            config[Fetcher.fetcherName]
+            ((options.fetch || {}).fetcherOptions || {})[Fetcher.fetcherName]
           );
         } catch (error) {
           if (!(error instanceof InvalidNetworkError)) {
@@ -83,7 +94,7 @@ async function tryFetchAndCompileAddress(
   address: string,
   fetchers: Fetcher[],
   recognizer: Recognizer,
-  config: Config
+  fetchAndCompileOptions: FetchAndCompileOptions
 ): Promise<void> {
   let found: boolean = false;
   let failureReason: FailureType | undefined; //undefined if no failure
@@ -109,7 +120,7 @@ async function tryFetchAndCompileAddress(
     }
     //if we do have it, extract sources & options
     debug("got sources!");
-    const { sources, options } = result;
+    const { sources, options } = result; //not same options as above, sorry for name confusion
     if (options.language === "Vyper") {
       //if it's not Solidity, bail out now
       debug("found Vyper, bailing out!");
@@ -118,13 +129,16 @@ async function tryFetchAndCompileAddress(
       break;
     }
     //set up the config
-    let externalConfig: Config = config.with({
+    let externalConfig: Config = Config.default().with({
       compilers: {
         solc: options
       }
     });
     //if using docker, transform it (this does nothing if not using docker)
-    externalConfig = transformIfUsingDocker(externalConfig, config);
+    externalConfig = transformIfUsingDocker(
+      externalConfig,
+      fetchAndCompileOptions
+    );
     //compile the sources
     let compileResult: WorkflowCompileResult;
     try {
@@ -171,11 +185,9 @@ async function tryFetchAndCompileAddress(
 
 function transformIfUsingDocker(
   externalConfig: Config,
-  projectConfig: Config
+  fetchAndCompileOptions: FetchAndCompileOptions
 ): Config {
-  const useDocker = Boolean(
-    ((projectConfig.compilers || {}).solc || {}).docker
-  );
+  const useDocker = Boolean((fetchAndCompileOptions.compile || {}).docker);
   if (!useDocker) {
     //if they're not using docker, no need to transform anything :)
     return externalConfig;

--- a/packages/fetch-and-compile/lib/index.ts
+++ b/packages/fetch-and-compile/lib/index.ts
@@ -9,15 +9,17 @@ import {
   getSortedFetcherConstructors
 } from "./fetch";
 import type * as Types from "./types";
+import { normalizeInput } from "./utils";
 
 export { fetchAndCompileForRecognizer };
 
 export async function fetchAndCompile(
   address: string,
-  config: Config
+  options: Types.FetchAndCompileOptions | Config
 ): Promise<Types.FetchAndCompileResult> {
+  const normalizedOptions = normalizeInput(options);
   const recognizer = new SingleRecognizer(address);
-  await fetchAndCompileForRecognizer(recognizer, config);
+  await fetchAndCompileForRecognizer(recognizer, normalizedOptions);
   return recognizer.getResult();
 }
 
@@ -29,10 +31,11 @@ export async function fetchAndCompile(
  */
 export async function fetchAndCompileMultiple(
   addresses: string[],
-  config: Config
+  options: Types.FetchAndCompileOptions | Config
 ): Promise<Types.FetchAndCompileMultipleResult> {
+  const normalizedOptions = normalizeInput(options);
   const recognizer = new MultipleRecognizer(addresses);
-  await fetchAndCompileForRecognizer(recognizer, config);
+  await fetchAndCompileForRecognizer(recognizer, normalizedOptions);
   return recognizer.getResults();
 }
 
@@ -40,15 +43,19 @@ export async function fetchAndCompileMultiple(
 //(i.e. adding compilations to the debugger), NOT its return value!
 export async function fetchAndCompileForDebugger(
   bugger: any, //sorry; this should be a debugger object
-  config: Config
+  options: Types.FetchAndCompileOptions | Config
 ): Promise<Types.FetchExternalErrors> {
+  const normalizedOptions = normalizeInput(options);
   const recognizer = new DebugRecognizer(bugger);
-  await fetchAndCompileForRecognizer(recognizer, config);
+  await fetchAndCompileForRecognizer(recognizer, normalizedOptions);
   return recognizer.getErrors();
 }
 
-export function getSupportedNetworks(config?: Config): Types.SupportedNetworks {
-  const fetchers = getSortedFetcherConstructors(config);
+export function getSupportedNetworks(
+  options?: Types.FetchAndCompileOptions | Config
+): Types.SupportedNetworks {
+  const normalizedOptions = options ? normalizeInput(options) : options;
+  const fetchers = getSortedFetcherConstructors(normalizedOptions);
   //strictly speaking these are fetcher constructors, but since we
   //won't be using fetcher instances in this function, I'm not going
   //to worry about the difference

--- a/packages/fetch-and-compile/lib/index.ts
+++ b/packages/fetch-and-compile/lib/index.ts
@@ -9,7 +9,10 @@ import {
   getSortedFetcherConstructors
 } from "./fetch";
 import type * as Types from "./types";
-import { normalizeInput } from "./utils";
+import {
+  normalizeFetchAndCompileOptions,
+  normalizeFetcherNames
+} from "./utils";
 
 export { fetchAndCompileForRecognizer };
 
@@ -17,7 +20,7 @@ export async function fetchAndCompile(
   address: string,
   options: Types.FetchAndCompileOptions | Config
 ): Promise<Types.FetchAndCompileResult> {
-  const normalizedOptions = normalizeInput(options);
+  const normalizedOptions = normalizeFetchAndCompileOptions(options);
   const recognizer = new SingleRecognizer(address);
   await fetchAndCompileForRecognizer(recognizer, normalizedOptions);
   return recognizer.getResult();
@@ -33,7 +36,7 @@ export async function fetchAndCompileMultiple(
   addresses: string[],
   options: Types.FetchAndCompileOptions | Config
 ): Promise<Types.FetchAndCompileMultipleResult> {
-  const normalizedOptions = normalizeInput(options);
+  const normalizedOptions = normalizeFetchAndCompileOptions(options);
   const recognizer = new MultipleRecognizer(addresses);
   await fetchAndCompileForRecognizer(recognizer, normalizedOptions);
   return recognizer.getResults();
@@ -45,17 +48,17 @@ export async function fetchAndCompileForDebugger(
   bugger: any, //sorry; this should be a debugger object
   options: Types.FetchAndCompileOptions | Config
 ): Promise<Types.FetchExternalErrors> {
-  const normalizedOptions = normalizeInput(options);
+  const normalizedOptions = normalizeFetchAndCompileOptions(options);
   const recognizer = new DebugRecognizer(bugger);
   await fetchAndCompileForRecognizer(recognizer, normalizedOptions);
   return recognizer.getErrors();
 }
 
 export function getSupportedNetworks(
-  options?: Types.FetchAndCompileOptions | Config
+  optionsOrFetcherNames?: Types.FetchAndCompileOptions | Config | string[]
 ): Types.SupportedNetworks {
-  const normalizedOptions = options ? normalizeInput(options) : options;
-  const fetchers = getSortedFetcherConstructors(normalizedOptions);
+  const fetcherNames = normalizeFetcherNames(optionsOrFetcherNames);
+  const fetchers = getSortedFetcherConstructors(fetcherNames);
   //strictly speaking these are fetcher constructors, but since we
   //won't be using fetcher instances in this function, I'm not going
   //to worry about the difference

--- a/packages/fetch-and-compile/lib/types.ts
+++ b/packages/fetch-and-compile/lib/types.ts
@@ -1,8 +1,24 @@
 import type { WorkflowCompileResult } from "@truffle/compile-common";
 import type {
   SourceInfo,
-  NetworkInfo as FetcherNetworkInfo
+  NetworkInfo as FetcherNetworkInfo,
+  FetcherOptions
 } from "@truffle/source-fetcher";
+
+export interface FetchAndCompileOptions {
+  network: {
+    networkId: number;
+  };
+  fetch?: {
+    precedence?: string[]; // eg. ["etherscan", "sourcify"]
+    fetcherOptions: {
+      [fetcherName: string]: FetcherOptions;
+    };
+  };
+  compile?: {
+    docker?: boolean;
+  };
+}
 
 export interface NetworkInfo extends FetcherNetworkInfo {
   fetchers: string[];

--- a/packages/fetch-and-compile/lib/types.ts
+++ b/packages/fetch-and-compile/lib/types.ts
@@ -11,7 +11,7 @@ export interface FetchAndCompileOptions {
   };
   fetch?: {
     precedence?: string[]; // eg. ["etherscan", "sourcify"]
-    fetcherOptions: {
+    fetcherOptions?: {
       [fetcherName: string]: FetcherOptions;
     };
   };

--- a/packages/fetch-and-compile/lib/utils.ts
+++ b/packages/fetch-and-compile/lib/utils.ts
@@ -2,7 +2,7 @@ import Config from "@truffle/config";
 import type { FetchAndCompileOptions } from "./types";
 import Fetchers from "@truffle/source-fetcher";
 
-export function normalizeInput(
+export function normalizeFetchAndCompileOptions(
   options: FetchAndCompileOptions | Config
 ): FetchAndCompileOptions {
   if (options instanceof Config) {
@@ -27,5 +27,18 @@ export function normalizeInput(
     return normalizedOptions;
   } else {
     return options;
+  }
+}
+
+export function normalizeFetcherNames(
+  optionsOrFetcherNames?: FetchAndCompileOptions | Config | string[]
+): string[] | undefined {
+  if (Array.isArray(optionsOrFetcherNames)) {
+    return optionsOrFetcherNames;
+  } else if (!optionsOrFetcherNames) {
+    return optionsOrFetcherNames;
+  } else {
+    const options = normalizeFetchAndCompileOptions(optionsOrFetcherNames);
+    return ((options || {}).fetch || {}).precedence;
   }
 }

--- a/packages/fetch-and-compile/lib/utils.ts
+++ b/packages/fetch-and-compile/lib/utils.ts
@@ -1,0 +1,31 @@
+import Config from "@truffle/config";
+import type { FetchAndCompileOptions } from "./types";
+import Fetchers from "@truffle/source-fetcher";
+
+export function normalizeInput(
+  options: FetchAndCompileOptions | Config
+): FetchAndCompileOptions {
+  if (options instanceof Config) {
+    let normalizedOptions: FetchAndCompileOptions = {
+      network: {
+        networkId: options.network_id
+      },
+      compile: {
+        docker: ((options.compilers || {}).solc || {}).docker
+      },
+      fetch: {
+        precedence: options.sourceFetchers,
+        fetcherOptions: {}
+      }
+    };
+    for (const fetcher of Fetchers) {
+      const fetcherName = fetcher.fetcherName;
+      const fetcherOptions = options[fetcherName];
+      //@ts-ignore TS can't recognize that the objects we just set up are definitely not undefined :-/
+      normalizedOptions.fetch.fetcherOptions[fetcherName] = fetcherOptions;
+    }
+    return normalizedOptions;
+  } else {
+    return options;
+  }
+}

--- a/packages/fetch-and-compile/test/fetch.test.ts
+++ b/packages/fetch-and-compile/test/fetch.test.ts
@@ -98,6 +98,18 @@ describe("Supported networks", function () {
       fetchers: ["etherscan", "sourcify"]
     });
   });
+
+  it("Lists supported networks for specified fetchers only", function () {
+    const networks = getSupportedNetworks(["etherscan"]);
+    assert.property(networks, "mainnet");
+    assert.notProperty(networks, "sokol"); //suported by sourcify but not etherscan
+    assert.deepEqual(networks.mainnet, {
+      name: "mainnet",
+      networkId: 1,
+      chainId: 1,
+      fetchers: ["etherscan"] //should not include sourcify if that fetcher not requested
+    });
+  });
 });
 
 describe("Etherscan single-source Solidity case", function () {

--- a/packages/source-fetcher/lib/index.ts
+++ b/packages/source-fetcher/lib/index.ts
@@ -1,6 +1,7 @@
 import type {
   Fetcher,
   FetcherConstructor,
+  FetcherOptions,
   SourceInfo,
   NetworkInfo
 } from "./types";
@@ -8,6 +9,7 @@ import { InvalidNetworkError } from "./common";
 export {
   Fetcher,
   FetcherConstructor,
+  FetcherOptions,
   InvalidNetworkError,
   SourceInfo,
   NetworkInfo


### PR DESCRIPTION
Addresses #4485.

This PR alters the interface for `fetch-and-compile` so that its functions now, instead of a Truffle Config, take either a Truffle Config *or* a new type of object containing the necessary info.  All the exported functions now accept this alternate input (which is intended to now be the primary input).  The new input type is based on the one suggested by @gnidan in the commentson #4485, although there have been some minor alterations for typing convenience.

To accomplish this, all the functions now run their input first through a `normalizeInput` function which normalizes things to the new format.  Since `Config` is a class rather than just a type, we detect if the input is a `Config` with a simple `instanceof` check.

The rest of the code has been altered appropriately.  Out of an abundance of caution, I'm still avoiding using `?.` for now, even though it should be fine here. :P  But, uh, I can change that and just use it if people would prefer...

I also had to use a `//@ts-ignore` in one place where TS couldn't tell that something was defined but it very obviously is.

There is still one bit of remaining interface awkwardness -- `getSupportedNetworks`.  I updated it to also take this new form of input; but this new input type still requires specifying a network ID, which is irrelevant for `getSupportedNetworks`.  I've suggested in the past that `getSupportedNetworks` should allow passing in a simple `string[]` instead of this more complicated input; I didn't go and implement that here, but I could go back and do so?

(We could also make it so that `network` and `networkId` aren't actually required in `FetchAndCompileOptions`, and instead we explicitly check for them and throw if they're not present?  That would resolve a little bit of the awkwardness, anyway, without having to go accept a whole third type of input for this one function...)