### PR TITLE
Bug fix: Allow use of ENS with mapping key watching in decoder

### DIFF
--- a/packages/encoder/lib/encoders.ts
+++ b/packages/encoder/lib/encoders.ts
@@ -89,6 +89,7 @@ export class ProjectEncoder {
   constructor(info: Types.EncoderInfoInternal) {
     //first, set up the basic info that we need to run
     if (info.userDefinedTypes && info.allocations) {
+      debug("internal route!");
       this.userDefinedTypes = info.userDefinedTypes;
       this.allocations = info.allocations;
     } else {
@@ -117,11 +118,14 @@ export class ProjectEncoder {
         this.userDefinedTypes,
         this.allocations.abi
       );
-      this.provider = info.provider || null;
-      if (info.registryAddress !== undefined) {
-        this.registryAddress = info.registryAddress;
-      }
     }
+
+    this.provider = info.provider || null;
+    debug("provider: %o", this.provider);
+    if (info.registryAddress !== undefined) {
+      this.registryAddress = info.registryAddress;
+    }
+    debug("registryAddress: %o", this.registryAddress);
 
     this.networkId = info.networkId || null;
   }
@@ -131,7 +135,9 @@ export class ProjectEncoder {
    */
   public async init(): Promise<void> {
     if (this.provider) {
+      debug("provider given!");
       if (this.registryAddress !== undefined) {
+        debug("using custom registry address: %o", this.registryAddress);
         this.ens = new ENS({
           provider: this.provider,
           ensAddress: this.registryAddress
@@ -141,6 +147,7 @@ export class ProjectEncoder {
         //but what is that?  We have to look it up.
         //NOTE: ENS is supposed to do this for us in the constructor,
         //but due to a bug it doesn't.
+        debug("using default registry address");
         const networkId = await new ProviderAdapter(
           this.provider
         ).getNetworkId();
@@ -156,6 +163,7 @@ export class ProjectEncoder {
         }
       }
     } else {
+      debug("no provider given, ens off");
       this.ens = null;
     }
   }


### PR DESCRIPTION
Thanks to @gnidan for catching this.  So here's a fairly dumb mistake on my part.  The decoder uses the encoder for watching mapping keys.  The encoder allows the use of ENS for addresses (if this is turned on), and the decoder, by default, turns it on.  Yet ENS wasn't working; in the encoder, it wasn't actually getting turned on.  What's the problem?

Well, so, the decoder uses a special route for creating the encoder that avoids repeating certain work.  And, I accidentally restricted the encoder's ENS setup code to the normal route, rather than running it uncondtionally.  Oops.  Anyway, this PR moves that code out of the conditional so it'll run regardless.

I had meant to include an automated test of this, but I ran into some trouble setting it up, so I just excluded it for now.  But if people think it's worth it I can try again; I will likely need to get some help with that though.  It worked when I tried it manually, at least -- well, OK, it didn't exactly *work* as such, because I ran into some connection issues, but it made the call; and I've seen the encoder's ENS functionality work plenty of other times, so, um, this ought to be correct?