### PR TITLE
Enhancement: Add even more networks to source-fetcher

### DIFF
--- a/packages/fetch-and-compile/test/fetch.test.ts
+++ b/packages/fetch-and-compile/test/fetch.test.ts
@@ -102,7 +102,7 @@ describe("Supported networks", function () {
   it("Lists supported networks for specified fetchers only", function () {
     const networks = getSupportedNetworks(["etherscan"]);
     assert.property(networks, "mainnet");
-    assert.notProperty(networks, "sokol"); //suported by sourcify but not etherscan
+    assert.notProperty(networks, "sokol-poa"); //suported by sourcify but not etherscan
     assert.deepEqual(networks.mainnet, {
       name: "mainnet",
       networkId: 1,

--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -49,45 +49,46 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
   private ready: Promise<void>; //always await this timer before making a request.
   //then, afterwards, start a new timer.
 
-  private static readonly supportedNetworks = new Set([
-    "mainnet",
-    "ropsten",
-    "kovan",
-    "rinkeby",
-    "goerli",
-    "optimistic",
-    "kovan-optimistic",
-    "arbitrum",
-    "rinkeby-arbitrum",
-    "polygon",
-    "mumbai-polygon",
-    "binance",
-    "testnet-binance",
-    "fantom",
-    "testnet-fantom",
-    "avalanche",
-    "fuji-avalanche",
-    "heco",
-    "testnet-heco",
-    "moonbeam",
-    "moonriver",
-    "moonbase-alpha",
-    "hoo",
-    "cronos",
-    "bttc",
-    "donau-bttc",
-    "aurora",
-    "testnet-aurora",
-    "celo",
-    "alfajores-celo",
-    "clover"
-  ]);
+  private static readonly apiDomainsByNetworkName: { [name: string]: string } =
+    {
+      "mainnet": "api.etherscan.io",
+      "ropsten": "api-ropsten.etherscan.io",
+      "kovan": "api-kovan.etherscan.io",
+      "rinkeby": "api-rinkeby.etherscan.io",
+      "goerli": "api-goerli.etherscan.io",
+      "optimistic": "api-optimistic.etherscan.io",
+      "kovan-optimistic": "api-kovan-optimistic.etherscan.io",
+      "arbitrum": "api.arbiscan.io",
+      "rinkeby-arbitrum": "api-testnet.arbiscan.io",
+      "polygon": "api.polygonscan.com",
+      "mumbai-polygon": "api-mumbai.polygonscan.com",
+      "binance": "api.bscscan.com",
+      "testnet-binance": "api-testnet.bscscan.com",
+      "fantom": "api.ftmscan.com",
+      "testnet-fantom": "api-testnet.ftmscan.com",
+      "avalanche": "api.snowtrace.io",
+      "fuji-avalanche": "api-testnet.snowtrace.io",
+      "heco": "api.hecoinfo.com",
+      "testnet-heco": "api-testnet.hecoinfo.com",
+      "moonbeam": "api-moonbeam.moonscan.io",
+      "moonriver": "api-moonriver.moonscan.io",
+      "moonbase-alpha": "api-moonbase.moonscan.io",
+      "hoo": "api.hooscan.com",
+      "cronos": "api.cronoscan.com",
+      "bttc": "api.bttcscan.com",
+      "donau-bttc": "api-testnet.bttcscan.com",
+      "aurora": "api.aurorascan.dev",
+      "testnet-aurora": "api-testnet.aurorascan.dev",
+      "celo": "api.celoscan.xyz",
+      "alfajores-celo": "api-alfajores.celoscan.xyz",
+      "clover": "api.clvscan.com"
+    };
 
   constructor(networkId: number, apiKey: string = "") {
     const networkName = networkNamesById[networkId];
     if (
       networkName === undefined ||
-      !EtherscanFetcher.supportedNetworks.has(networkName)
+      !(networkName in EtherscanFetcher.apiDomainsByNetworkName)
     ) {
       throw new InvalidNetworkError(networkId, "etherscan");
     }
@@ -102,8 +103,8 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
 
   static getSupportedNetworks(): Types.SupportedNetworks {
     return Object.fromEntries(
-      Object.entries(networksByName).filter(([name, _]) =>
-        EtherscanFetcher.supportedNetworks.has(name)
+      Object.entries(networksByName).filter(
+        ([name, _]) => name in EtherscanFetcher.apiDomainsByNetworkName
       )
     );
   }
@@ -126,53 +127,8 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
   }
 
   private determineUrl() {
-    const scanners: { [network: string]: string } = {
-      //etherscan.io is treated separately
-      polygon: "polygonscan.com",
-      arbitrum: "arbiscan.io",
-      binance: "bscscan.com",
-      fantom: "ftmscan.com",
-      avalanche: "snowtrace.io",
-      heco: "hecoinfo.com",
-      //moonscan.io is treated separately
-      hoo: "hooscan.com",
-      cronos: "cronoscan.com",
-      bttc: "bttcscan.com",
-      aurora: "aurorascan.dev",
-      celo: "celoscan.xyz",
-      clover: "clvscan.com"
-    };
-    const exceptionalTestnets = new Set([
-      "rinkeby-arbitrum",
-      "fuji-avalanche",
-      "donau-bttc"
-    ]);
-    const [part1, part2] = this.networkName.split("-");
-    if (part2 === undefined && this.networkName in scanners) {
-      //mainnet for one of the above scanners
-      return `https://api.${scanners[this.networkName]}/api`;
-    } else if (part2 in scanners) {
-      //a testnet for one of the above scanners;
-      //part1 is the testnet name, part2 is the broader mainnet name
-      let [testnet, network] = [part1, part2];
-      if (exceptionalTestnets.has(this.networkName)) {
-        //special case: certain exceptional testnets just use "testnet"
-        //rather than the specific testnet name
-        testnet = "testnet";
-      }
-      return `https://api-${testnet}.${scanners[network]}/api`;
-    } else if (part1.startsWith("moon")) {
-      //one of the moonbeam networks; here even the moonbeam mainnet
-      //gets a prefix (we use part1 to get moonbase, not moonbase-alpha)
-      const shortName = part1;
-      return `https://api-${shortName}.moonscan.io/api`;
-    } else if (this.networkName === "mainnet") {
-      //ethereum mainnet
-      return "https://api.etherscan.io/api";
-    } else {
-      //default case: an ethereum testnet, or an optimistic network (main or test)
-      return `https://api-${this.networkName}.etherscan.io/api`;
-    }
+    const domain = EtherscanFetcher.apiDomainsByNetworkName[this.networkName];
+    return `https://${domain}/api`;
   }
 
   private async makeRequest(address: string): Promise<EtherscanSuccess> {

--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -65,12 +65,22 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
     "testnet-binance",
     "fantom",
     "testnet-fantom",
-    //we don't support avalanche, even though etherscan has snowtrace.io
+    "avalanche",
+    "fuji-avalanche",
     "heco",
     "testnet-heco",
     "moonbeam",
     "moonriver",
-    "moonbase-alpha"
+    "moonbase-alpha",
+    "hoo",
+    "cronos",
+    "bttc",
+    "donau-bttc",
+    "aurora",
+    "testnet-aurora",
+    "celo",
+    "alfajores-celo",
+    "clover"
   ]);
 
   constructor(networkId: number, apiKey: string = "") {
@@ -122,10 +132,21 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
       arbitrum: "arbiscan.io",
       binance: "bscscan.com",
       fantom: "ftmscan.com",
-      //we don't support avalanche's snowtrace.io
-      heco: "hecoinfo.com"
+      avalanche: "snowtrace.io",
+      heco: "hecoinfo.com",
       //moonscan.io is treated separately
+      hoo: "hooscan.com",
+      cronos: "cronoscan.com",
+      bttc: "bttcscan.com",
+      aurora: "aurorascan.dev",
+      celo: "celoscan.xyz",
+      clover: "clvscan.com"
     };
+    const exceptionalTestnets = new Set([
+      "rinkeby-arbitrum",
+      "fuji-avalanche",
+      "donau-bttc"
+    ]);
     const [part1, part2] = this.networkName.split("-");
     if (part2 === undefined && this.networkName in scanners) {
       //mainnet for one of the above scanners
@@ -134,10 +155,9 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
       //a testnet for one of the above scanners;
       //part1 is the testnet name, part2 is the broader mainnet name
       let [testnet, network] = [part1, part2];
-      if (network === "arbitrum" && testnet === "rinkeby") {
-        //special case: arbitrum rinkeby is testnet.arbiscan.io,
-        //not rinkeby.arbiscan.io
-        //note: if we supported avalanche, it would have a similar special case
+      if (exceptionalTestnets.has(this.networkName)) {
+        //special case: certain exceptional testnets just use "testnet"
+        //rather than the specific testnet name
         testnet = "testnet";
       }
       return `https://api-${testnet}.${scanners[network]}/api`;

--- a/packages/source-fetcher/lib/networks.ts
+++ b/packages/source-fetcher/lib/networks.ts
@@ -6,6 +6,7 @@ export const networkNamesById: { [id: number]: string } = {
   4: "rinkeby",
   5: "goerli",
   42: "kovan",
+  11155111: "sepolia",
   10: "optimistic",
   69: "kovan-optimistic",
   42161: "arbitrum",
@@ -13,13 +14,15 @@ export const networkNamesById: { [id: number]: string } = {
   137: "polygon",
   80001: "mumbai-polygon",
   100: "xdai",
-  77: "sokol",
+  99: "poa", //not presently supported by either fetcher, but...
+  77: "sokol-poa",
   56: "binance",
   97: "testnet-binance",
   42220: "celo",
   44787: "alfajores-celo",
   62320: "baklava-celo",
-  //we don't support avalanche, so it's excluded
+  43114: "avalanche",
+  43113: "fuji-avalanche",
   40: "telos",
   41: "testnet-telos",
   8: "ubiq",
@@ -40,7 +43,15 @@ export const networkNamesById: { [id: number]: string } = {
   256: "testnet-heco",
   1284: "moonbeam",
   1285: "moonriver",
-  1287: "moonbase-alpha"
+  1287: "moonbase-alpha",
+  122: "fuse",
+  11297108109: "palm",
+  11297108099: "testnet-palm",
+  70: "hoo",
+  25: "cronos",
+  199: "bttc",
+  1029: "donau-bttc",
+  1024: "clover"
 };
 
 export const networksByName: Types.SupportedNetworks = Object.fromEntries(

--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -41,6 +41,7 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "rinkeby",
     "goerli",
     "kovan",
+    "sepolia",
     "optimistic",
     "kovan-optimistic",
     "arbitrum",
@@ -48,13 +49,15 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "polygon",
     "mumbai-polygon",
     "xdai",
-    "sokol",
+    //sourcify does *not* support poa core...?
+    "sokol-poa",
     "binance",
     "testnet-binance",
     "celo",
     "alfajores-celo",
     "baklava-celo",
-    //again, we don't support avalanche, even though sourcify does
+    "avalanche",
+    "fuji-avalanche",
     "telos",
     "testnet-telos",
     "ubiq",
@@ -68,7 +71,13 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "meter",
     "testnet-meter",
     "aurora",
-    "testnet-aurora"
+    "testnet-aurora",
+    "fuse",
+    "moonbeam",
+    "moonriver",
+    "moonbase-alpha",
+    "palm",
+    "testnet-palm"
   ]);
 
   constructor(networkId: number) {


### PR DESCRIPTION
So, it turns out that Sourcify and Etherscan (or rather, "Blockscan", to use the new more general name -- no, I didn't go changig our name for it) have added support for a bunch more networks; this PR updates source-fetcher to support them as well.

So, what's it do in more detail?

First off, it adds all these new networks to the big list of networks.  You'll notice there's another thing it adds to the big list of networks -- Avalanche.  I'd previously excluded Avalanche due to network ID / chain ID mismatches that would cause a problem for us; but as best I can tell, they've now changed their network IDs to match their chain IDs, so there's no reason to exclude them anymore.

Also, for consistency, I added POA Core to the big list, even though neither fetcher supports it.  This is for the same reason I earlier added OneLedger Mainnet to the big list -- it seems off to include a testnet but not include the mainnet.  I hadn't previously included POA Core for the simple reason that I didn't realize that Sokol was a testnet for it.  Now that I know, I'm including it.  As such I've renamed `"sokol"` to `"sokol-poa"` for consistency with our usual convention elsewhere.  I've therefore also updated the test that references it.

Secondly, it adds support to the Sourcify fetcher for the networks that have been added to Sourcify (and Avalanche, since we're no longer excluding that).  That part is straightforward.

Finally, it adds support to the Etherscan fetcher for the networks that have been added there (again, plus Avalanche).  Since Etherscan isn't nice and uniform like Sourcify is, this takes a bit more work; it requires also adding the various URLs for its other websites.  Also, the special case that was in place for Arbitrum Rinkeby has been expanded to also encompass Avalanche Fuji and BTTC Donau, with a variable holding the list of these special cases so that they don't all need to be written out individually in the code.  (Yes, I've left the `determineUrl` function in place rather than replace it by a lookup table.)

I didn't add any new tests; I think the existing tests cover things well enough, we don't need tests for every specific network we include.

And that's it!