### PR TITLE
Ensure subscriber is a function type when revoked

### DIFF
--- a/packages/environment/chain.js
+++ b/packages/environment/chain.js
@@ -84,7 +84,9 @@ class Logger {
     subscriberIDs.forEach(subscriberID => {
       const callback = this.subscribers[subscriberID];
 
-      callback(message);
+      if (typeof callback === 'function') {
+        callback(message);
+      }
     });
   }
 }


### PR DESCRIPTION
Cause we use `delete this.subscribers[subscriberID];` to unsubscribe a subscription. So when notify subscribers, we need to double check it's a function type.