### PR TITLE
Specify --platform when running solc Docker image

### DIFF
--- a/packages/compile-solidity/src/compilerSupplier/loadingStrategies/Docker.ts
+++ b/packages/compile-solidity/src/compilerSupplier/loadingStrategies/Docker.ts
@@ -39,7 +39,7 @@ export class Docker {
 
     const versionString = await this.validateAndGetSolcVersion();
     const command =
-      "docker run --rm -i ethereum/solc:" +
+      "docker run --platform=linux/amd64 --rm -i ethereum/solc:" +
       this.config.version +
       " --standard-json";
 
@@ -147,7 +147,7 @@ export class Docker {
 
     // Get version & cache.
     const version = execSync(
-      "docker run ethereum/solc:" + image + " --version"
+      "docker run --platform=linux/amd64 ethereum/solc:" + image + " --version"
     );
     const normalized = normalizeSolcVersion(version);
     this.cache.add(normalized, fileName);


### PR DESCRIPTION
I noticed a warning when using Dockerized solc on M1 Macs, since the solc images are distributed for x64, and Docker throws a warning to suggest specifying `--platform` directly.

This PR does just that, and the warning goes away!

(In the future, if solc distributes Docker images for other platforms, we might want to revisit this... but I'm guessing that's pretty unlikely)