### PR TITLE
Add --url option in truffle console command

### DIFF
--- a/packages/core/lib/commands/console/meta.js
+++ b/packages/core/lib/commands/console/meta.js
@@ -2,10 +2,20 @@ module.exports = {
   command: "console",
   description:
     "Run a console with contract abstractions and commands available",
-  builder: {},
+  builder: {
+    url: {
+      describe: "Use specified URL for provider",
+      type: "string"
+    }
+  },
   help: {
     usage: "truffle console [--verbose-rpc] [--require|-r <file>]",
     options: [
+      {
+        option: "--url",
+        description:
+          "Connects to a specified provider given via URL, ignoring networks in config. This option allows using the console outside of a Truffle project."
+      },
       {
         option: "--verbose-rpc",
         description:

--- a/packages/core/lib/commands/console/run.js
+++ b/packages/core/lib/commands/console/run.js
@@ -1,9 +1,13 @@
 module.exports = async function (options) {
-  const Config = require("@truffle/config");
   const Console = require("../../console");
+  const loadConfig = require("../debug/loadConfig");
   const { Environment } = require("@truffle/environment");
 
-  const config = Config.detect(options);
+  if (options.url && options.network) {
+    throw new Error("Url and Network options should not be specified together");
+  }
+
+  let config = loadConfig(options);
 
   const commands = require("../index");
   const excluded = new Set(["console", "init", "watch", "develop"]);


### PR DESCRIPTION
### ISSUE
`truffle console` should allow --url option like `truffle debug` does.

### SOLUTION
This PR adds an --url option to the `truffle console` command that connects to a specified url and can be used outside of Truffle project (with web3 object and accounts).