### PR TITLE
Internal improvement: Remove node check in cli.js

### DIFF
--- a/packages/core/cli.js
+++ b/packages/core/cli.js
@@ -1,10 +1,8 @@
 #!/usr/bin/env node
 require("source-map-support/register");
 
-const semver = require("semver"); // to validate Node version
 const TruffleError = require("@truffle/error");
 const TaskError = require("./lib/errors/taskerror");
-const analytics = require("./lib/services/analytics");
 const version = require("./lib/version");
 const versionInfo = version.info();
 const XRegExp = require("xregexp");
@@ -15,25 +13,6 @@ const XRegExp = require("xregexp");
 global.crypto = {
   getRandomValues: require("get-random-values")
 };
-
-// pre-flight check: Node version compatibility
-const minimumNodeVersion = "12.0.0";
-if (!semver.gte(process.version, minimumNodeVersion)) {
-  console.log(
-    "Error: Node version not supported. You are currently using version " +
-      process.version.slice(1) +
-      " of Node. Truffle requires Node v" +
-      minimumNodeVersion +
-      " or higher."
-  );
-
-  analytics.send({
-    exception: "wrong node version",
-    version: versionInfo.bundle || "(unbundled) " + versionInfo.core
-  });
-
-  process.exit(1);
-}
 
 const Command = require("./lib/command");
 const command = new Command(require("./lib/commands"));
@@ -58,6 +37,7 @@ command
   .run(inputArguments, options)
   .then(returnStatus => process.exit(returnStatus))
   .catch(error => {
+    const analytics = require("./lib/services/analytics");
     if (error instanceof TaskError) {
       analytics.send({
         exception: "TaskError - display general help message",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -94,6 +94,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "authors": [
     {
       "name": "Tim Coulter",

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -78,6 +78,9 @@
       "url": "https://github.com/tcoulter"
     }
   ],
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "gitHead": "ad57ef2ef13380c7923d5c6682540540755a0435",
   "namespace": "consensys"
 }


### PR DESCRIPTION
In the interest of cleaning up and optimizing Truffle, this PR removes the Node version check in `cli.js`.