### PR TITLE
Enhancement: Add cronos testnet to etherscan source fetcher

### DIFF
--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -75,6 +75,7 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
       "moonbase-alpha": "api-moonbase.moonscan.io",
       "hoo": "api.hooscan.com",
       "cronos": "api.cronoscan.com",
+      "testnet-cronos": "api-testnet.cronoscan.com",
       "bttc": "api.bttcscan.com",
       "donau-bttc": "api-testnet.bttcscan.com",
       "aurora": "api.aurorascan.dev",

--- a/packages/source-fetcher/lib/networks.ts
+++ b/packages/source-fetcher/lib/networks.ts
@@ -49,6 +49,7 @@ export const networkNamesById: { [id: number]: string } = {
   11297108099: "testnet-palm",
   70: "hoo",
   25: "cronos",
+  338: "testnet-cronos",
   199: "bttc",
   1029: "donau-bttc",
   1024: "clover"


### PR DESCRIPTION
Looks like Etherscan just added this network.  Adding it here.