### PR TITLE
Enhancement: Add more networks to sourcify source fetcher

### DIFF
--- a/packages/source-fetcher/lib/networks.ts
+++ b/packages/source-fetcher/lib/networks.ts
@@ -26,7 +26,7 @@ export const networkNamesById: { [id: number]: string } = {
   40: "telos",
   41: "testnet-telos",
   8: "ubiq",
-  311752642: "oneledger", //not presently supported by either fetcher, but...
+  311752642: "oneledger",
   4216137055: "frankenstein-oneledger",
   57: "syscoin",
   5700: "tanenbaum-syscoin",
@@ -52,7 +52,13 @@ export const networkNamesById: { [id: number]: string } = {
   338: "testnet-cronos",
   199: "bttc",
   1029: "donau-bttc",
-  1024: "clover"
+  1024: "clover",
+  44: "crab-darwinia",
+  43: "pangolin-darwinia",
+  9001: "evmos",
+  9000: "testnet-evmos",
+  62621: "multivac",
+  11111: "wagmi"
 };
 
 export const networksByName: Types.SupportedNetworks = Object.fromEntries(

--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -61,7 +61,7 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "telos",
     "testnet-telos",
     "ubiq",
-    //sourcify does *not* support oneledger mainnet...?
+    "oneledger",
     "frankenstein-oneledger",
     "syscoin",
     "tanenbaum-syscoin",
@@ -77,7 +77,13 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "moonriver",
     "moonbase-alpha",
     "palm",
-    "testnet-palm"
+    "testnet-palm",
+    "crab-darwinia",
+    "pangolin-darwinia",
+    "evmos",
+    "testnet-evmos",
+    "multivac",
+    "wagmi"
   ]);
 
   constructor(networkId: number) {


### PR DESCRIPTION
Looks like Sourcify just added a bunch of networks.  (Including finally adding Oneledger mainnet; I don't know why previously they only supported the testnet.)  Adding them.  (Would have combined this with #5113 had I realized!)