### PR TITLE
Internal improvement: Fix name of network in source-fetcher

### DIFF
--- a/packages/source-fetcher/lib/networks.ts
+++ b/packages/source-fetcher/lib/networks.ts
@@ -23,6 +23,7 @@ export const networkNamesById: { [id: number]: string } = {
   62320: "baklava-celo",
   43114: "avalanche",
   43113: "fuji-avalanche",
+  11111: "wagmi-avalanche",
   40: "telos",
   41: "testnet-telos",
   8: "ubiq",
@@ -57,8 +58,7 @@ export const networkNamesById: { [id: number]: string } = {
   43: "pangolin-darwinia",
   9001: "evmos",
   9000: "testnet-evmos",
-  62621: "multivac",
-  11111: "wagmi"
+  62621: "multivac"
 };
 
 export const networksByName: Types.SupportedNetworks = Object.fromEntries(

--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -58,6 +58,7 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "baklava-celo",
     "avalanche",
     "fuji-avalanche",
+    "wagmi-avalanche",
     "telos",
     "testnet-telos",
     "ubiq",
@@ -82,8 +83,7 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "pangolin-darwinia",
     "evmos",
     "testnet-evmos",
-    "multivac",
-    "wagmi"
+    "multivac"
   ]);
 
   constructor(networkId: number) {


### PR DESCRIPTION
Sorry, just a quick renaming, sorry about all these tiny source-fetcher PRs!  But it seems that this "wagmi" network is part of Avalanche?  So I figured I'd alter our name for it appropriately.  That's all.