### PR TITLE
Interactive menu during `unbox` to select box 'recipe'.

### DIFF
--- a/packages/box/README.md
+++ b/packages/box/README.md
@@ -1,5 +1,4 @@
-@truffle/box
-===========
+# @truffle/box
 
 Truffle Box management functionality.
 
@@ -16,16 +15,21 @@ const unboxOptions = { force: false };
 
 // .unbox() validates & unboxes truffle box repos
 // pass the current working directory as directory to unbox into
-TruffleBox.unbox("https://github.com/trufflesuite/truffle-init-default", process.cwd(), unboxOptions);
+TruffleBox.unbox(
+  "https://github.com/trufflesuite/truffle-init-default",
+  process.cwd(),
+  unboxOptions
+);
 
 // or specify relative path to unbox into (path must already exist)
-TruffleBox.unbox("https://github.com/trufflesuite/truffle-init-default", "some/relativePath", unboxOptions);
-
+TruffleBox.unbox(
+  "https://github.com/trufflesuite/truffle-init-default",
+  "some/relativePath",
+  unboxOptions
+);
 ```
 
-
-Box Configuration
------------------
+## Box Configuration
 
 Truffle Boxes are configured via a required `truffle-box.json` file in the
 box repo's root directory.
@@ -78,8 +82,81 @@ properties:
   }
   ```
 
-Available Unbox Hooks
----------------------
+- `modifiers`
+
+  An object that describes two things:
+
+  - Prompts: Questions presented in an interactive menu, in which user creates a 'recipe key' by answering the questions).
+  - Recipes: Mapping from 'recipe key' to a set of files which make up the recipe.
+
+  Example:
+
+  ```json
+  "modifiers": {
+    // Prompts for user to answer.
+    "prompts": [
+      // Prompts follow inquirer.Questions format (from SBoudrias/Inquirer.js).
+      // Prompt 1
+      {
+        "type": "list",
+        "message": "Select a framework",
+        "name": "framework",
+        "choices": [
+          { "name": "React", "checked": true },
+          { "name": "Vue" }
+        ]
+      },
+      // Prompt 2
+      {
+        "type": "list",
+        "message": "TypeScript or JavaScript?",
+        "name": "package",
+        "choices": [
+          { "name": "TypeScript", "checked": true },
+          { "name": "JavaScript" }
+        ]
+      }
+    ],
+
+    // Files to be included in all recipes.
+    "recipe-common": [
+      "file-common-to-all-recipes-0.txt",
+      "file-common-to-all-recipes-1.txt",
+      "foo/nested-file-common-to-all-recipes.txt"
+    ],
+
+    // Recipe specs mapping.
+    // Mapping keys are prompt answers joined by "-",
+    // mapping values are lists of files specific to that recipe.
+    // A file can be represented as a string, or an object with `from` and `to` properties, which moves / renames the file.
+    "recipes": {
+      "React-TypeScript": [
+        "foo.ts",
+        "tsconfig.json",
+        { "from": "react-ts/package.json", "to": "package.json" },
+        { "from": "react-ts/src/some-react-ts-file.tsx", "to": "src/App.tsx" }
+      ],
+      "React-JavaScript": [
+        "foo.js",
+        { "from": "react-js/package.json", "to": "package.json" },
+        { "from": "react-js/src/some-react-js-file.jsx", "to": "src/App.jsx" }
+      ],
+      "Vue-TypeScript": [
+        "foo.ts",
+        "tsconfig.json",
+        { "from": "vue-ts/package.json", "to": "package.json" },
+        { "from": "vue-ts/src/some-vue-ts-file.vue", "to": "src/App.vue" }
+      ],
+      "Vue-JavaScript": [
+        "foo.js",
+        { "from": "vue-js/package.json", "to": "package.json" },
+        { "from": "vue-js/src/some-vue-js-file.vue", "to": "src/App.vue" }
+      ]
+    }
+  }
+  ```
+
+## Available Unbox Hooks
 
 - `post-unpack`
 

--- a/packages/box/box.ts
+++ b/packages/box/box.ts
@@ -46,30 +46,32 @@ export const normalizeSourcePath = (url = defaultPath) => {
     // digits and the underscore. Note \w has to be \\w to escape the backslash
     // in a string literal.
     //
-    const protocolRex = new RegExp([
-      // match either `htps://` or `git@`
-      "(?<protocol>(https://|git@))",
+    const protocolRex = new RegExp(
+      [
+        // match either `htps://` or `git@`
+        "(?<protocol>(https://|git@))",
 
-      // service is 1 or many (word, dot or dash)
-      "(?<service>[\\w.-]+)",
+        // service is 1 or many (word, dot or dash)
+        "(?<service>[\\w.-]+)",
 
-      // match either `/` or `:`
-      "(/|:)",
+        // match either `/` or `:`
+        "(/|:)",
 
-      // org is 1 or many (word, dot or dash)
-      "(?<org>[\\w.-]+)",
+        // org is 1 or many (word, dot or dash)
+        "(?<org>[\\w.-]+)",
 
-      "/",
+        "/",
 
-      // repo is 1 or many (word, dot or dash)
-      "(?<repo>[\\w.-]+)",
+        // repo is 1 or many (word, dot or dash)
+        "(?<repo>[\\w.-]+)",
 
-      // branch is 1 or many (word, dot or dash) and can be optional
-      "(?<branch>#[\\w./-]+)?",
+        // branch is 1 or many (word, dot or dash) and can be optional
+        "(?<branch>#[\\w./-]+)?",
 
-      // the input string must be consumed fully at this point to match
-      "$",
-    ].join(""));
+        // the input string must be consumed fully at this point to match
+        "$"
+      ].join("")
+    );
 
     const match = url.match(protocolRex);
     if (match) {
@@ -80,7 +82,7 @@ export const normalizeSourcePath = (url = defaultPath) => {
         debug({
           in: url,
           error: "InvalidFormat (protocol)",
-          hint: "branch is malformed",
+          hint: "branch is malformed"
         });
         throw new Error("Box specified with invalid format (git/https)");
       }
@@ -94,29 +96,31 @@ export const normalizeSourcePath = (url = defaultPath) => {
     debug({
       in: url,
       error: "InvalidFormat (protocol)",
-      hint: "did not match protocol",
+      hint: "did not match protocol"
     });
     throw new Error("Box specified with invalid format (git/https)");
   }
 
   // default case: process [org/] + repo + [ #branch/name/with/slashes ]
   //
-  const orgRepoBranchRex = new RegExp([
-    // start match at beginning
-    "^",
+  const orgRepoBranchRex = new RegExp(
+    [
+      // start match at beginning
+      "^",
 
-    // org is 1 or many (word, dot or dash) followed by a slash. org can be
-    // optional
-    "(?<org>[\\w.-]+/)?",
+      // org is 1 or many (word, dot or dash) followed by a slash. org can be
+      // optional
+      "(?<org>[\\w.-]+/)?",
 
-    // repo is 1 or many (word, dot or dash)
-    "(?<repo>[\\w.-]+)",
+      // repo is 1 or many (word, dot or dash)
+      "(?<repo>[\\w.-]+)",
 
-    // optional branch (undefined if unmatched)
-    "(?<branch>#[\\w./-]+)?",
+      // optional branch (undefined if unmatched)
+      "(?<branch>#[\\w./-]+)?",
 
-    "$",
-  ].join(""));
+      "$"
+    ].join("")
+  );
 
   const match = url.match(orgRepoBranchRex);
   if (match) {
@@ -130,7 +134,7 @@ export const normalizeSourcePath = (url = defaultPath) => {
       debug({
         in: url,
         error: "InvalidFormat (orgRepoBranch)",
-        hint: "branch is malformed",
+        hint: "branch is malformed"
       });
       throw new Error("Box specified with invalid format");
     }
@@ -139,7 +143,7 @@ export const normalizeSourcePath = (url = defaultPath) => {
 
     // Official Truffle boxes should have a `-box` suffix
     if (org.toLowerCase().startsWith("truffle-box")) {
-        repo = repo.endsWith("-box") ? repo : `${repo}-box`;
+      repo = repo.endsWith("-box") ? repo : `${repo}-box`;
     }
 
     const result = `https://github.com:${org}${repo}${branch}`;
@@ -161,7 +165,7 @@ const parseSandboxOptions = (options: sandboxOptions) => {
       unsafeCleanup: false,
       setGracefulCleanup: false,
       logger: console,
-      force: false,
+      force: false
     };
   } else if (typeof options === "object") {
     return {
@@ -169,7 +173,7 @@ const parseSandboxOptions = (options: sandboxOptions) => {
       unsafeCleanup: options.unsafeCleanup || false,
       setGracefulCleanup: options.setGracefulCleanup || false,
       logger: options.logger || console,
-      force: options.force || false,
+      force: options.force || false
     };
   }
 };
@@ -179,14 +183,13 @@ const Box = {
     url: string,
     destination: string,
     options: unboxOptions = {},
-    config: any,
+    config: any
   ) => {
     const { events } = config;
     let tempDirCleanup;
-    const logger = options.logger || { log: () => {} };
     const unpackBoxOptions = {
       logger: options.logger,
-      force: options.force,
+      force: options.force
     };
 
     try {
@@ -205,14 +208,15 @@ const Box = {
         tempDirPath,
         destination,
         boxConfig,
-        unpackBoxOptions,
+        unpackBoxOptions
       );
 
       events.emit("unbox:cleaningTempFiles:start");
       tempDirCleanup();
       events.emit("unbox:cleaningTempFiles:succeed");
 
-      utils.setUpBox(boxConfig, destination, events);
+      await utils.setUpBox(boxConfig, destination, events);
+      await utils.modifyBox(boxConfig, destination);
 
       return boxConfig;
     } catch (error) {
@@ -233,8 +237,8 @@ const Box = {
             type: "confirm",
             name: "proceed",
             message: `Proceed anyway?`,
-            default: true,
-          },
+            default: true
+          }
         ];
         const answer = await inquirer.prompt(prompt);
         if (!answer.proceed) {
@@ -250,13 +254,8 @@ const Box = {
   // options.setGracefulCleanup
   //   Cleanup temporary files even when an uncaught exception occurs
   sandbox: async (options: sandboxOptions) => {
-    const {
-      name,
-      unsafeCleanup,
-      setGracefulCleanup,
-      logger,
-      force,
-    } = parseSandboxOptions(options);
+    const { name, unsafeCleanup, setGracefulCleanup, logger, force } =
+      parseSandboxOptions(options);
 
     const boxPath = name.replace(/^default(?=#|$)/, defaultPath);
     //ordinarily, this line will have no effect.  however, if the name is "default",
@@ -271,7 +270,7 @@ const Box = {
     const unboxOptions = { logger, force };
     await Box.unbox(boxPath, tmpDir.name, unboxOptions, config);
     return Config.load(path.join(tmpDir.name, "truffle-config.js"), {});
-  },
+  }
 };
 
 export default Box;

--- a/packages/box/lib/config.ts
+++ b/packages/box/lib/config.ts
@@ -3,6 +3,7 @@ import type { boxConfig } from "typings";
 
 function setDefaults(config: any = {}): boxConfig {
   const hooks = config.hooks || {};
+  const modifiers = config.modifiers || {};
 
   return {
     ignore: config.ignore || [],
@@ -13,7 +14,8 @@ function setDefaults(config: any = {}): boxConfig {
     },
     hooks: {
       "post-unpack": hooks["post-unpack"] || ""
-    }
+    },
+    modifiers
   };
 }
 

--- a/packages/box/lib/utils/index.ts
+++ b/packages/box/lib/utils/index.ts
@@ -51,9 +51,14 @@ export = {
     await unbox.copyTempIntoDestination(tempDir, destination, unpackBoxOptions);
   },
 
-  setUpBox: (boxConfig: boxConfig, destination: string, events: any) => {
+  setUpBox: async (boxConfig: boxConfig, destination: string, events: any) => {
     events.emit("unbox:settingUpBox:start");
     unbox.installBoxDependencies(boxConfig, destination);
-    events.emit("unbox:settingUpBox:succeed");
+    await events.emit("unbox:settingUpBox:succeed");
+  },
+
+  // Should be run after setUpBox.
+  modifyBox: (boxConfig: boxConfig, destination: string) => {
+    return unbox.modifyBoxByRecipe(boxConfig, destination);
   }
 };

--- a/packages/box/test/utils-index.js
+++ b/packages/box/test/utils-index.js
@@ -7,8 +7,8 @@ describe("utils", () => {
   it("setUpBox throws when passed an invalid boxConfig", () => {
     let boxConfig = {};
 
-    assert.throws(() => {
-      utils.setUpBox(boxConfig);
+    assert.rejects(async () => {
+      await utils.setUpBox(boxConfig);
     }, "should have thrown!");
   });
 

--- a/packages/box/typings/index.d.ts
+++ b/packages/box/typings/index.d.ts
@@ -1,4 +1,5 @@
 import Console from "console";
+import inquirer from "inquirer";
 
 export type sandboxOptionsObject = {
   name?: string;
@@ -17,8 +18,20 @@ export type unboxOptions = {
   force?: boolean;
 };
 
+export type boxConfigMv = {
+  from: string;
+  to: string;
+};
+
 export interface boxConfig {
   ignore: Array<string>;
   commands: object;
   hooks: { "post-unpack": string };
+  modifiers: {
+    prompts?: inquirer.Question[];
+    "recipe-common"?: string[];
+    recipes?: {
+      [key: string]: Array<string | boxConfigMv>;
+    };
+  };
 }


### PR DESCRIPTION
# Feature

<div>
    <img height="220" alt="Screen Shot 2022-05-18 at 22 37 21" src="https://user-images.githubusercontent.com/41348973/169160173-34f9df32-f4c2-4d26-a20d-6f5a6dd0a27e.png">
    <img height="220" alt="Screen Shot 2022-05-18 at 22 47 11" src="https://user-images.githubusercontent.com/41348973/169161342-fee58d53-c51b-4171-85c4-af87d8ea2c96.png">
</div>

Let `truffle-box.json` declare `modifiers`, an object with the following three properties:
- `prompts`: Questions to be asked during `unbox`. A box `recipe` is determined depending on what the user answers.
- `recipe-common`: List of files common to every recipe.
- `recipes`: Specific recipe specs.

More details and example can be found in the [updated readme](https://github.com/trufflesuite/truffle/tree/unbox-recipe-inquirer/packages/box#box-configuration).

Try it out with `truffle unbox realcliffzhang/truffle-box-example`

# Intent

To make boxes more flexible by letting users cherry-pick what they want to have scaffolded into their box (E.g. truffle + react + typescript + drizzle, truffle + vue + javascript + web3.js, etc.), through an interactive menu during `unbox`.

# Limitation
- Subsequent prompts cannot rely on previous answers.
- Cannot handle invalid / undefined recipes.