### PR TITLE
Bug fix: Fix behavior of stepOver and stepOut on function definitions

### DIFF
--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -35,7 +35,7 @@ const verbosePanicTable = {
 
 const commandReference = {
   "o": "step over",
-  "i": "step into",
+  "i": "step line / step into",
   "u": "step out",
   "n": "step next",
   ";": "step instruction (include number to step multiple)",

--- a/packages/debugger/lib/controller/sagas/index.js
+++ b/packages/debugger/lib/controller/sagas/index.js
@@ -188,13 +188,16 @@ function* stepOver() {
   let finished;
 
   //special case: what if you're on a function definition?
-  //note that we exclude base constructors here, because we don't have a
-  //good way to go to the end of a base constructor; we'll just perform
-  //an ordinary stepOver in that case
   if (
     startingNode &&
-    startingNode.nodeType === "FunctionDefinition" &&
-    !(yield select(controller.current.onBaseConstructorDefinition))
+    ((startingNode.nodeType === "FunctionDefinition" &&
+      //note that we exclude base constructors here, because we don't have a
+      //good way to go to the end of a base constructor; we'll just perform
+      //an ordinary stepOver in that case
+      !(yield select(controller.current.onBaseConstructorDefinition))) ||
+      //for Yul functions, we use a special selector to make sure we're seeing
+      //the function definition as we enter it rather than as it's defined
+      (yield select(controller.current.onYulFunctionDefinitionWhileEntering)))
   ) {
     yield* stepOut();
     return;

--- a/packages/debugger/lib/controller/selectors/index.js
+++ b/packages/debugger/lib/controller/selectors/index.js
@@ -3,6 +3,7 @@ const debug = debugModule("debugger:controller:selectors"); //eslint-disable-lin
 
 import { createSelectorTree, createLeaf } from "reselect-tree";
 import { isSkippedNodeType } from "lib/helpers";
+import * as Codec from "@truffle/codec";
 
 import evm from "lib/evm/selectors";
 import sourcemapping from "lib/sourcemapping/selectors";
@@ -65,6 +66,26 @@ const controller = createSelectorTree({
      * controller.current.willJump
      */
     willJump: createLeaf([evm.current.step.isJump], identity),
+
+    /**
+     * controller.current.onBaseConstructorDefinition
+     */
+    onBaseConstructorDefinition: createLeaf(
+      [
+        "./location/node",
+        evm.current.context,
+        sourcemapping.current.contractNode
+      ],
+      (node, context, contract) =>
+        node &&
+        node.nodeType === "FunctionDefinition" &&
+        Codec.Ast.Utils.functionKind(node) === "constructor" &&
+        context.contractId !== contract.id //when are we on a *base* constructor
+      //definition?  precisely when the contract we're in according to the source
+      //mapping is different from the contract whose bytecode is executing
+      //(note that we don't need to check whether the compilation IDs are different,
+      //since these will always be the same)
+    ),
 
     /**
      * controller.current.location

--- a/packages/debugger/lib/controller/selectors/index.js
+++ b/packages/debugger/lib/controller/selectors/index.js
@@ -88,6 +88,14 @@ const controller = createSelectorTree({
     ),
 
     /**
+     * controller.current.location.onYulFunctionDefinitionWhileEntering
+     */
+    onYulFunctionDefinitionWhileEntering: createLeaf(
+      [sourcemapping.current.onYulFunctionDefinitionWhileEntering],
+      identity
+    ),
+
+    /**
      * controller.current.location
      */
     location: {

--- a/packages/debugger/lib/data/sagas/index.js
+++ b/packages/debugger/lib/data/sagas/index.js
@@ -217,22 +217,9 @@ function* variablesAndMappingsSaga() {
 
     case "YulFunctionDefinition": {
       const nextPointer = yield select(data.next.pointer);
-      if (
-        nextPointer === null ||
-        !(
-          nextPointer.startsWith(`${pointer}/body/`) ||
-          nextPointer.startsWith(`${pointer}/returnVariables`)
-        )
-      ) {
-        //in this case, we're seeing the function
-        //as it's being defined, rather than as it's
-        //being called
-        //notice the final slash; when you enter a function, you go *strictly inside*
-        //its body (if you hit the body node itself you are seeing the definition)
-        //(as of Solidity 0.8.4, you may also go to the return parameters; rather
-        //than switch on the version, and use a different mechanism for that,
-        //we'll use the same mechanism but alter the condition above to account
-        //for that)
+      if (!(yield select(data.current.onYulFunctionDefinitionWhileEntering))) {
+        //in this case, we're seeing the function as it's being defined, rather
+        //than as it's being called
         break;
       }
       //yul parameters are a bit weird.

--- a/packages/debugger/lib/data/selectors/index.js
+++ b/packages/debugger/lib/data/selectors/index.js
@@ -1303,6 +1303,14 @@ const data = createSelectorTree({
     ),
 
     /**
+     * data.current.onYulFunctionDefinitionWhileEntering
+     */
+    onYulFunctionDefinitionWhileEntering: createLeaf(
+      [sourcemapping.current.onYulFunctionDefinitionWhileEntering],
+      identity
+    ),
+
+    /**
      * data.current.identifiers (namespace)
      */
     identifiers: {

--- a/packages/debugger/lib/sourcemapping/selectors/index.js
+++ b/packages/debugger/lib/sourcemapping/selectors/index.js
@@ -380,6 +380,24 @@ let sourcemapping = createSelectorTree({
     ),
 
     /**
+     * sourcemapping.current.onYulFunctionDefinitionWhileEntering
+     */
+    onYulFunctionDefinitionWhileEntering: createLeaf(
+      ["./node", "./pointer", "../next/pointer"],
+      (node, pointer, nextPointer) =>
+        node &&
+        node.nodeType === "YulFunctionDefinition" &&
+        nextPointer !== null &&
+        (nextPointer.startsWith(`${pointer}/body/`) ||
+          nextPointer.startsWith(`${pointer}/returnVariables`))
+      //if neither of these conditions hold, we're seeing the function
+      //as it's being defined, rather than as it's being called.
+      //notice the final slash; when you enter a function, you go *strictly inside*
+      //its body (if you hit the body node itself you are seeing the definition)
+      //(as of Solidity 0.8.4, you may also go to the return parameters)
+    ),
+
+    /**
      * sourcemapping.current.willJump
      */
     willJump: createLeaf([evm.current.step.isJump], isJump => isJump),

--- a/packages/debugger/lib/sourcemapping/selectors/index.js
+++ b/packages/debugger/lib/sourcemapping/selectors/index.js
@@ -6,6 +6,7 @@ import SourceMapUtils from "@truffle/source-map-utils";
 import * as Codec from "@truffle/codec";
 
 import semver from "semver";
+import jsonpointer from "json-pointer";
 
 import evm from "lib/evm/selectors";
 import trace from "lib/trace/selectors";
@@ -121,6 +122,22 @@ function createMultistepSelectors(stepSelector) {
       ["./source", "./pointerAndNode"],
 
       ({ ast }, pointerAndNode) => (pointerAndNode ? pointerAndNode.node : ast)
+    ),
+
+    /**
+     * .contractNode
+     * WARNING: ad-hoc selector only meant to be used
+     * when you're on a function node!
+     * should probably be replaced by something better;
+     * the data submodule handles these things a better way
+     */
+    contractNode: createLeaf(["./source", "./pointer"], ({ ast }, pointer) =>
+      pointer
+        ? jsonpointer.get(
+            ast,
+            pointer.replace(/\/nodes\/\d+$/, "") //cut off end
+          )
+        : ast
     )
   };
 }

--- a/packages/debugger/lib/stacktrace/selectors/index.js
+++ b/packages/debugger/lib/stacktrace/selectors/index.js
@@ -7,7 +7,6 @@ import trace from "lib/trace/selectors";
 import evm from "lib/evm/selectors";
 import sourcemapping from "lib/sourcemapping/selectors";
 
-import jsonpointer from "json-pointer";
 import zipWith from "lodash/zipWith";
 import { popNWhere } from "lib/helpers";
 import * as Codec from "@truffle/codec";
@@ -126,21 +125,10 @@ function createMultistepSelectors(stepSelector) {
 
     /**
      * .contractNode
-     * WARNING: ad-hoc selector only meant to be used
-     * when you're on a function node!
-     * should probably be replaced by something better;
-     * the data submodule handles these things a better way
+     * WARNING: see the warning in sourcemapping before
+     * using this selector!
      */
-    contractNode: createLeaf(
-      ["./location/source", "./location/pointer"],
-      ({ ast }, pointer) =>
-        pointer
-          ? jsonpointer.get(
-              ast,
-              pointer.replace(/\/nodes\/\d+$/, "") //cut off end
-            )
-          : ast
-    )
+    contractNode: createLeaf([stepSelector.contractNode], identity)
   };
 }
 

--- a/packages/debugger/test/step.js
+++ b/packages/debugger/test/step.js
@@ -1,0 +1,246 @@
+import debugModule from "debug";
+const debug = debugModule("debugger:test:step");
+
+import { assert } from "chai";
+
+import Ganache from "ganache";
+
+import { prepareContracts, lineOf } from "./helpers";
+import Debugger from "lib/debugger";
+
+import controller from "lib/controller/selectors";
+
+const __STEPPY = `
+pragma solidity ^0.8.0;
+
+contract Steppy {
+  function run() public {
+    this.called(1); //CALL LINE
+    emit Num(23); //AFTER LINE
+  }
+
+  event Num(uint);
+
+  function called(uint x) public { //CALLED LINE
+    //we include an argument here to ensure there's a generated source
+    emit Num(x); //INSIDE LINE
+  }
+}
+`;
+
+let sources = {
+  "Steppy.sol": __STEPPY
+};
+
+describe("Stepping functions", function () {
+  let provider;
+  let abstractions;
+  let compilations;
+
+  before("Create Provider", async function () {
+    provider = Ganache.provider({
+      seed: "debugger",
+      gasLimit: 7000000,
+      logging: {
+        quiet: true
+      },
+      miner: {
+        instamine: "strict"
+      }
+    });
+  });
+
+  before("Prepare contracts and artifacts", async function () {
+    this.timeout(30000);
+
+    let prepared = await prepareContracts(provider, sources);
+    abstractions = prepared.abstractions;
+    compilations = prepared.compilations;
+  });
+
+  it("Steps correctly with step next", async function () {
+    this.timeout(4000);
+    let instance = await abstractions.Steppy.deployed();
+    let receipt = await instance.run();
+    let txHash = receipt.tx;
+
+    let bugger = await Debugger.forTx(txHash, {
+      provider,
+      compilations
+    });
+
+    let previousSourceRange = bugger.view(
+      controller.current.location.sourceRange
+    );
+    let previousSource = bugger.view(controller.current.location.source);
+    await bugger.stepNext();
+    let currentSourceRange = bugger.view(
+      controller.current.location.sourceRange
+    );
+    let currentSource = bugger.view(controller.current.location.source);
+
+    while (!bugger.view(controller.current.trace.finished)) {
+      //check: we never end up back in the same place after a step
+      assert(
+        previousSourceRange.start !== currentSourceRange.start ||
+          previousSourceRange.length !== currentSourceRange.length ||
+          previousSource.id !== currentSource.id ||
+          previousSource.compilationId !== currentSource.compilationId
+      );
+      //check: we don't step into an internal source w/o asking for it
+      assert(!currentSource.internal);
+
+      //set things up for next iteration
+      previousSourceRange = currentSourceRange;
+      await bugger.stepNext();
+      currentSourceRange = bugger.view(controller.current.location.sourceRange);
+    }
+  });
+
+  it("Steps correctly with step into", async function () {
+    this.timeout(4000);
+    let instance = await abstractions.Steppy.deployed();
+    let receipt = await instance.run();
+    let txHash = receipt.tx;
+
+    let bugger = await Debugger.forTx(txHash, {
+      provider,
+      compilations
+    });
+
+    let previousSourceRange = bugger.view(
+      controller.current.location.sourceRange
+    );
+    let previousSource = bugger.view(controller.current.location.source);
+    await bugger.stepInto();
+    let currentSourceRange = bugger.view(
+      controller.current.location.sourceRange
+    );
+    let currentSource = bugger.view(controller.current.location.source);
+
+    while (!bugger.view(controller.current.trace.finished)) {
+      //check: we're always on a different line after step into
+      assert(
+        previousSourceRange.lines.start.line !==
+          currentSourceRange.lines.start.line ||
+          previousSource.id !== currentSource.id ||
+          previousSource.compilationId !== currentSource.compilationId
+      );
+      //check: we don't step into an internal source w/o asking for it
+      assert(!currentSource.internal);
+
+      //set things up for next iteration
+      previousSourceRange = currentSourceRange;
+      await bugger.stepInto();
+      currentSourceRange = bugger.view(controller.current.location.sourceRange);
+    }
+  });
+
+  it("Steps over a function from the call site", async function () {
+    this.timeout(4000);
+    let instance = await abstractions.Steppy.deployed();
+    let receipt = await instance.run();
+    let txHash = receipt.tx;
+
+    let bugger = await Debugger.forTx(txHash, {
+      provider,
+      compilations
+    });
+
+    let sourceId = bugger.view(controller.current.location.source).id;
+    let source = bugger.view(controller.current.location.source).source;
+
+    await bugger.addBreakpoint({
+      sourceId,
+      line: lineOf("CALL LINE", source)
+    });
+    await bugger.continueUntilBreakpoint();
+    //now: do we step over correctly?
+    await bugger.stepOver();
+    assert.equal(
+      bugger.view(controller.current.location.sourceRange).lines.start.line,
+      lineOf("AFTER LINE", source)
+    );
+  });
+
+  it("Steps over a function from the definition", async function () {
+    this.timeout(4000);
+    let instance = await abstractions.Steppy.deployed();
+    let receipt = await instance.run();
+    let txHash = receipt.tx;
+
+    let bugger = await Debugger.forTx(txHash, {
+      provider,
+      compilations
+    });
+
+    let sourceId = bugger.view(controller.current.location.source).id;
+    let source = bugger.view(controller.current.location.source).source;
+
+    await bugger.addBreakpoint({
+      sourceId,
+      line: lineOf("CALLED LINE", source)
+    });
+    await bugger.continueUntilBreakpoint();
+    //now: do we step over correctly?
+    await bugger.stepOver();
+    assert.equal(
+      bugger.view(controller.current.location.sourceRange).lines.start.line,
+      lineOf("CALL LINE", source)
+    );
+  });
+
+  it("Steps out of a function", async function () {
+    this.timeout(4000);
+    let instance = await abstractions.Steppy.deployed();
+    let receipt = await instance.run();
+    let txHash = receipt.tx;
+
+    let bugger = await Debugger.forTx(txHash, {
+      provider,
+      compilations
+    });
+
+    let sourceId = bugger.view(controller.current.location.source).id;
+    let source = bugger.view(controller.current.location.source).source;
+
+    await bugger.addBreakpoint({
+      sourceId,
+      line: lineOf("INSIDE LINE", source)
+    });
+    await bugger.continueUntilBreakpoint();
+    //now: do we step over correctly?
+    await bugger.stepOut();
+    assert.equal(
+      bugger.view(controller.current.location.sourceRange).lines.start.line,
+      lineOf("CALL LINE", source)
+    );
+  });
+
+  it("Steps out of a function from the definition", async function () {
+    this.timeout(4000);
+    let instance = await abstractions.Steppy.deployed();
+    let receipt = await instance.run();
+    let txHash = receipt.tx;
+
+    let bugger = await Debugger.forTx(txHash, {
+      provider,
+      compilations
+    });
+
+    let sourceId = bugger.view(controller.current.location.source).id;
+    let source = bugger.view(controller.current.location.source).source;
+
+    await bugger.addBreakpoint({
+      sourceId,
+      line: lineOf("CALLED LINE", source)
+    });
+    await bugger.continueUntilBreakpoint();
+    //now: do we step over correctly?
+    await bugger.stepOut();
+    assert.equal(
+      bugger.view(controller.current.location.sourceRange).lines.start.line,
+      lineOf("CALL LINE", source)
+    );
+  });
+});


### PR DESCRIPTION
Addresses #4561, supersedes #4677.

This PR fixes some longstanding problems with the debugger's stepOver and stepOut functionality.  Specifically:
1. `stepOut` now behaves consistently; the unnecessary special case it had has been removed
2. When `stepOver` is used while on a function definition, the function will (usually) be stepped over rather than into

How does this work?  Well, (1) there's not much to say about... I just removed the special case that shouldn't have been there.

As for (2), I made it so that, if you are on a function definition, then `stepOver` will defer to `stepOut` instead.  Note that this relies on being able to *determine* that you're on a function definition, so this won't work with Vyper (or with Solidity older than 0.4.12, or assembly/Yul older than 0.6.0).

It also requires some wonky logic for Yul functions, to ensure that this is only applied when we're actually *entering* the Yul function, but this is just the same logic we were already using for this purpose in `data`; said logic has now been factored out into a selector in `sourcemapping`.

There is a special case on top of this special case, though.  If you're on the definition of a base constructor, then we don't have a good way to step over *only* that base constructor; so as a fallback we just don't apply our special case here.  (You might expect we could use modifier depth for this, but, well, modifier depth has a number of problems...)  That means we'll step into the base constructor rather than over it in any way, which is not entirely satisfactory, but I don't see a better alternative.  (Stepping over the entire constructor would be going too far, I think; better to not go far enough than to do that.)

To check for this, we check whether you're on a constructor definition, and whether the ID of the contract you're in (in terms of source location) matches the contract ID of the context you're in; if you're on a constructor definition but the IDs differ, you're in a base constructor.  (Since this means that you're on the definition of a constructor for a contract other than the one you're actually constructing.)

Also note that since we can't use `data` in the controller, to get the contract definition, we use the same hack we use in `stacktrace` (which has been moved over to `sourcemapping`, and both `stacktrace` and `controller` pull it from there, so we don't have the same logic in two places).

Other changes:
1. I clarified the help text for `(i)`.  Yeah, OK, that probably should have been a separate PR, but whatever, it's so minor...
2. I added tests!  We just didn't really have any tests for stepping.  So I added some rudimentary tests for `stepNext` and `stepInto`, and tests of the improved `stepOver` and `stepOut` functionality, both for Soliidty and for Yul.  There could probably be more here, but I figured this was a good start.