### PR TITLE
Add non-testnet DFK to sourcify fetcher

### DIFF
--- a/packages/source-fetcher/lib/networks.ts
+++ b/packages/source-fetcher/lib/networks.ts
@@ -24,7 +24,7 @@ export const networkNamesById: { [id: number]: string } = {
   43114: "avalanche",
   43113: "fuji-avalanche",
   11111: "wagmi-avalanche",
-  53935: "dfk-avalanche", //not presently supported by either fetcher, but...
+  53935: "dfk-avalanche",
   335: "testnet-dfk-avalance",
   40: "telos",
   41: "testnet-telos",

--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -59,7 +59,7 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "avalanche",
     "fuji-avalanche",
     "wagmi-avalanche",
-    //sourcify does *not* support non-testnet dfk?
+    "dfk-avalanche",
     "testnet-dfk-avalanche",
     "telos",
     "testnet-telos",


### PR DESCRIPTION
Didn't include this one in #5156 because Sourcify didn't support it yet... but now it does.  So there you go.