### PR TITLE
Enhancement: Truffle Test, ability to give multiple directories as an argument instead of only files.

### DIFF
--- a/packages/core/lib/commands/test/determineTestFilesToRun.js
+++ b/packages/core/lib/commands/test/determineTestFilesToRun.js
@@ -9,13 +9,13 @@ const determineTestFilesToRun = ({ inputFile, inputArgs = [], config }) => {
     filesToRun.push(inputFile);
   } else if (inputArgs.length > 0) {
     for (let fileOrDir of inputArgs) {
-      fileOrDir = path.join(fileOrDir);
-      walkdir.sync(fileOrDir, { follow_symlinks: true }, function (path, stat) {
-        const isFile = fs.statSync(path).isFile();
+      const results = walkdir.sync(fileOrDir, { follow_symlinks: true });
+      for (let fileOrDir of results) {
+        const isFile = fs.statSync(fileOrDir).isFile();
         if (isFile) {
-          filesToRun.push(path);
+          filesToRun.push(fileOrDir);
         }
-      });
+      }
     }
   }
   if (filesToRun.length === 0) {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -80,6 +80,7 @@
     "universal-analytics": "^0.4.17",
     "web3": "1.7.4",
     "web3-utils": "1.7.4",
+    "walkdir": "^0.4.1",
     "xregexp": "^4.2.4",
     "yargs": "^13.3.0"
   },

--- a/packages/core/test/lib/commands/test.js
+++ b/packages/core/test/lib/commands/test.js
@@ -8,6 +8,7 @@ const WorkflowCompile = require("@truffle/workflow-compile");
 const Test = require("../../../lib/testing/Test");
 const Config = require("@truffle/config");
 const tmp = require("tmp");
+const fs = require("fs");
 let config;
 let tempDir;
 
@@ -284,5 +285,169 @@ describe("test command", () => {
       testFilesCount + newTestFiles,
       "Wrong number of files discovered"
     );
+  });
+
+  //  Test with cycles and no missing directories, where all directories exist and all directories contain one or more files
+  it("Check with cycles plus if it follows symlinks outside of the test directory.", async () => {
+    // This allows to create customized directory structure to test more than one level of sub directories.
+    let fileStructrure = {
+      name: "sub_directory",
+      files: ["test1.sol", "test2.js"],
+      symlinks: [
+        {
+          name: "symlink1",
+          src: path.join(config.test_directory, "sub_directory"),
+          destination: path.join(
+            config.test_directory,
+            "sub_directory",
+            "sub_sub_directory"
+          )
+        },
+        {
+          name: "symlink2",
+          src: path.join(
+            config.test_directory,
+            "sub_directory",
+            "sub_sub_directory"
+          ),
+          destination: path.join(config.test_directory, "sub_directory")
+        },
+        {
+          name: "symlink3",
+          src: path.join(config.test_directory, "sub_directory"),
+          destination: path.join("../../fortesting") // ../../fortesting/random.sol testing whether it finds files outside of test directory through symlinks.
+        }
+      ],
+      subdirs: [
+        {
+          name: "sub_sub_directory",
+          files: ["test3.sol", "test4.js"]
+        },
+        {
+          name: "sub_sub_directory2",
+          files: ["test5.js", "test6.sol", "test7.sol"],
+          subdirs: [
+            {
+              name: "one_more_sub",
+              files: [
+                "test8.sol",
+                "test9.sol",
+                "test10.sol",
+                "test10.sol",
+                "test11.sol"
+              ]
+            },
+            {
+              name: "one_more_sub2",
+              files: [
+                "test12.sol",
+                "test13.sol",
+                "test14.sol",
+                "test14.sol",
+                "test15.sol"
+              ],
+              subdirs: [
+                {
+                  name: "solidity_only_subdir",
+                  files: ["test16.sol", "test17.sol", "test18.sol"]
+                },
+                {
+                  name: "js_only_subdir",
+                  files: ["test19.js", "test19.js", "test20.js"]
+                },
+                {
+                  name: "empty_sub_sub_directory",
+                  files: []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    };
+
+    // Create file in recursion. Used instead foreach since foreach loop doesn't wait for files to be created
+    // Function does not count already existing files.
+    function createFile(dirName, files, index) {
+      // return zero if there are no files to create
+      if (!files[index]) return 0;
+      var fileName = path.join(dirName, files[index]);
+      let filesCount = 0;
+      if (!fse.existsSync(fileName)) {
+        fse.createFileSync(fileName);
+        filesCount++;
+      }
+      if (files.length > index + 1) {
+        filesCount += createFile(dirName, files, index + 1);
+      }
+
+      return filesCount;
+    }
+
+    function createSymlinks(symlinks) {
+      console.log(
+        "Creating symlink: ",
+        path.join(config.test_directory, "symlink"),
+        " to ",
+        path.join(config.test_directory, "testsub")
+      );
+      fs.symlink(
+        symlinks.destination,
+        path.join(symlinks.src, symlinks.name),
+        err => {
+          console.log(err);
+        }
+      );
+    }
+
+    // Create files using dirStruct object. Count newly created files and skip existing files.
+    // Returns number of new files.
+    function createTestSubDir(dirName, dirStruct, symlink) {
+      var numOfFiles = 0;
+      if (symlink) {
+        createSymlinks(dirStruct);
+      } else {
+        numOfFiles = createFile(dirName, dirStruct.files, 0);
+      }
+
+      if (dirStruct.subdirs && !symlink) {
+        dirStruct.subdirs.forEach(val => {
+          numOfFiles += createTestSubDir(
+            path.join(dirName, dirStruct.name, val.name),
+            val,
+            false
+          );
+        });
+      }
+      if (dirStruct.symlinks) {
+        dirStruct.symlinks.forEach(val => {
+          console.log(val.destination);
+          createTestSubDir(val.destination, val, true);
+        });
+      }
+      return numOfFiles;
+    }
+    // Call method used by Test to discover existing test files. Then create subdirectories and test files in these
+    // subdirectories. Then run Test method again and check if number discovered increased.
+    let testFiles = determineTestFilesToRun({ config });
+    const testFilesCount = testFiles.length;
+
+    const newTestFiles = createTestSubDir(
+      config.test_directory,
+      fileStructrure
+    );
+
+    testFiles = determineTestFilesToRun({ config });
+    assert.equal(
+      testFiles.length,
+      testFilesCount + newTestFiles + 1, // +1 because of the ../fortesting/random.sol file that is outside of the test file structure.
+      "Wrong number of files discovered"
+    );
+  });
+
+  //  Test with no argument and empty directory
+  it("No argument and empty directory.", async () => {
+    let testFiles = determineTestFilesToRun({ config });
+    assert.equal(testFiles.length, 0, "Non-existing file was detected.");
   });
 }).timeout(1000);

--- a/packages/truffle/test/scenarios/commands/test.js
+++ b/packages/truffle/test/scenarios/commands/test.js
@@ -25,4 +25,64 @@ describe("truffle test", function () {
     const output = logger.contents();
     assert(output.includes("1 passing"));
   });
+
+  it("Test with only files specified where one or more file is missing.", async function () {
+    this.timeout(70000);
+    await CommandRunner.run("test not-existing.js not-existing.js", config);
+    const output = logger.contents();
+    assert(
+      output.includes(
+        "One or more of your specified files/directories don't exist."
+      )
+    );
+  });
+
+  it("Test with only directories specified where one or more directories are missing.", async function () {
+    this.timeout(70000);
+    await CommandRunner.run("test not-existing", config);
+    const output = logger.contents();
+    assert(
+      output.includes(
+        "One or more of your specified files/directories don't exist."
+      )
+    );
+  });
+
+  it("Test with files and directories specified where files and directories are missing.", async function () {
+    this.timeout(70000);
+    await CommandRunner.run(
+      "test not-existing not-existing.js not-existing.sol",
+      config
+    );
+    const output = logger.contents();
+    assert(
+      output.includes(
+        "One or more of your specified files/directories don't exist."
+      )
+    );
+  });
+
+  it("Test with only directories specified where one or more directory is empty.", async function () {
+    this.timeout(70000);
+    await CommandRunner.run(
+      "test not-existing not-existing.js not-existing.sol",
+      config
+    );
+    const output = logger.contents();
+    assert(
+      output.includes("One or more of your specified directories are empty.")
+    );
+  });
+
+  it("Test with only files specified, where one or more file is missing.", async function () {
+    this.timeout(70000);
+    await CommandRunner.run(
+      "test not-existing not-existing.js not-existing.sol",
+      config
+    );
+    const output = logger.contents();
+    assert(
+      output.includes("One or more of your specified directories are empty.")
+    );
+  });
 });


### PR DESCRIPTION
As of #5066 , I came up with the idea to allow one or multiple directories as an argument where all the files are being executed within those directories. It allows the sc-tester to organize the tests more thoroughly.

This is just a prototype and has to be thoroughly tested. Where do you guys locate unit tests of commands that do not have their own package in /truffle/packages? 

At the moment, the way it works is to recursively search for every file within the given directories. Then they are all added to filesToRun[].

Also, I am sure there is a lot to criticize about my code, just let me know if you see anything.

