### PR TITLE
Bug fix: Ensure errors are rethrown in deferred-chain deployment

### DIFF
--- a/packages/deployer/src/deferredchain.js
+++ b/packages/deployer/src/deferredchain.js
@@ -1,33 +1,34 @@
 function DeferredChain() {
   var self = this;
-  this.chain = new Promise(function(accept, reject) {
+  this.chain = new Promise(function (accept, reject) {
     self._accept = accept;
     self._reject = reject;
   });
 
-  this.await = new Promise(function() {
+  this.await = new Promise(function () {
     self._done = arguments[0];
     self._error = arguments[1];
   });
   this.started = false;
 }
 
-DeferredChain.prototype.then = function(fn) {
+DeferredChain.prototype.then = function (fn) {
   var self = this;
-  this.chain = this.chain.then(function() {
+  this.chain = this.chain.then(function () {
     var args = Array.prototype.slice.call(arguments);
 
     return fn.apply(null, args);
   });
-  this.chain = this.chain.catch(function(e) {
+  this.chain = this.chain.catch(function (e) {
     self._error(e);
+    throw e;
   });
 
   return this;
 };
 
-DeferredChain.prototype.catch = function(fn) {
-  this.chain = this.chain.catch(function() {
+DeferredChain.prototype.catch = function (fn) {
+  this.chain = this.chain.catch(function () {
     var args = Array.prototype.slice.call(arguments);
 
     return fn.apply(null, args);
@@ -36,7 +37,7 @@ DeferredChain.prototype.catch = function(fn) {
   return this;
 };
 
-DeferredChain.prototype.start = function() {
+DeferredChain.prototype.start = function () {
   this.started = true;
   this.chain = this.chain.then(this._done);
   this._accept();

--- a/packages/truffle/test/scenarios/migrations/deferred-chain.js
+++ b/packages/truffle/test/scenarios/migrations/deferred-chain.js
@@ -1,0 +1,50 @@
+const MemoryLogger = require("../MemoryLogger");
+const CommandRunner = require("../commandRunner");
+const path = require("path");
+const assert = require("assert");
+const Server = require("../server");
+const Reporter = require("../reporter");
+const sandbox = require("../sandbox");
+
+describe("migrate (empty)", function () {
+  let config;
+  const project = path.join(
+    __dirname,
+    "../../sources/migrations/deferred-chain"
+  );
+  const logger = new MemoryLogger();
+
+  before(async function () {
+    await Server.start();
+  });
+  after(async function () {
+    await Server.stop();
+  });
+
+  before(async function () {
+    this.timeout(10000);
+    config = await sandbox.create(project);
+    config.network = "development";
+    config.logger = logger;
+    config.mocha = {
+      reporter: new Reporter(logger)
+    };
+  });
+
+  it("Correctly handles control flow in deployments", async function () {
+    this.timeout(70000);
+
+    try {
+      //the migration fails (due to me being unable to fully fix the
+      //problem), so we have to put it in a try
+      await CommandRunner.run("migrate", config);
+    } catch {
+      //do nothing
+    }
+    const output = logger.contents();
+
+    console.log(output);
+    assert(output.includes("Error in migration:"));
+    assert(!output.includes("succeeded"));
+  });
+});

--- a/packages/truffle/test/scenarios/migrations/deferred-chain.js
+++ b/packages/truffle/test/scenarios/migrations/deferred-chain.js
@@ -31,7 +31,7 @@ describe("migrate (empty)", function () {
     };
   });
 
-  it("Correctly handles control flow in deployments", async function () {
+  it("Correctly handles control flow on rejection in deployment", async function () {
     this.timeout(70000);
 
     try {

--- a/packages/truffle/test/scenarios/migrations/deferred-chain.js
+++ b/packages/truffle/test/scenarios/migrations/deferred-chain.js
@@ -35,8 +35,9 @@ describe("migrate (empty)", function () {
     this.timeout(70000);
 
     try {
-      //the migration fails (due to me being unable to fully fix the
-      //problem), so we have to put it in a try
+      //the migration fails due to
+      //https://github.com/trufflesuite/truffle/issues/5225
+      //so we have to put it in a try
       await CommandRunner.run("migrate", config);
     } catch {
       //do nothing

--- a/packages/truffle/test/sources/migrations/deferred-chain/.eslintrc.json
+++ b/packages/truffle/test/sources/migrations/deferred-chain/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../../../../.eslintrc.truffle.json"]
+}

--- a/packages/truffle/test/sources/migrations/deferred-chain/migrations/1_initial_migration.js
+++ b/packages/truffle/test/sources/migrations/deferred-chain/migrations/1_initial_migration.js
@@ -1,0 +1,12 @@
+module.exports = function (deployer) {
+  deployer
+    .then(function () {
+      return Promise.reject("This first migration step just fails.");
+    })
+    .then(function () {
+      console.log("First migration step appears to have succeeded.");
+    })
+    .catch(function (err) {
+      console.log("Error in migration:", err);
+    });
+};

--- a/packages/truffle/test/sources/migrations/deferred-chain/truffle-config.js
+++ b/packages/truffle/test/sources/migrations/deferred-chain/truffle-config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  // See <http://trufflesuite.com/docs/advanced/configuration>
+  // to customize your Truffle configuration!
+  networks: {
+    development: {
+      host: "127.0.0.1",
+      port: 8545,
+      network_id: "*",
+      gas: 4700000,
+      gasPrice: 20000000000
+    }
+  }
+};


### PR DESCRIPTION
Addresses #3066.

So, normally here I'd explain how the PR works... but the fact is, after spending a lot of time looking at the deployer, I still can't really claim to understand it to any real extent.  I can tell you why this was a plausible thing to try; I can't tell you why it was the right thing to do.

So why was this a plausible thing to try?  Well, when you do `.then()` with the deferred chain, it not only adds a `.then()` to the chain, it also adds a `.catch()`.  This `.catch` apparently doesn't properly rethrow the error, so it results in the promise being accepted, not rejected.  This causes issue #3066 where you advance to the `.then()` instead of the `.catch()`.  So, I added a `throw` to the end, and now it works.

That's my best understanding, anyway!

I didn't include any tests here, but I can go back and add tests if people want.  Thought I'd just put this up without tests for now.  I certainly have tested it manually though!  That's the only way I know it works!

Note: Line 24 is the only real change here, the rest is all just `prettier` doing its thing.