### PR TITLE
Dependency update: Update solc version to 0.8.15

### DIFF
--- a/packages/compile-solidity/package.json
+++ b/packages/compile-solidity/package.json
@@ -1,4 +1,4 @@
-{
+  {
   "name": "@truffle/compile-solidity",
   "description": "Compiler helper and artifact manager for Solidity files",
   "license": "MIT",
@@ -35,7 +35,7 @@
     "original-require": "^1.0.1",
     "require-from-string": "^2.0.2",
     "semver": "^7.3.4",
-    "solc": "0.8.12"
+    "solc": "0.8.15"
   },
   "devDependencies": {
     "@truffle/artifactor": "^4.0.158",

--- a/packages/compile-solidity/package.json
+++ b/packages/compile-solidity/package.json
@@ -1,4 +1,4 @@
-  {
+{
   "name": "@truffle/compile-solidity",
   "description": "Compiler helper and artifact manager for Solidity files",
   "license": "MIT",

--- a/packages/contract-schema/package.json
+++ b/packages/contract-schema/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "json-schema-to-typescript": "^5.5.0",
     "mocha": "9.2.2",
-    "solc": "0.8.13"
+    "solc": "0.8.15"
   },
   "keywords": [
     "artifacts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -26519,10 +26519,10 @@ socks@^2.3.3, socks@^2.6.1:
     ip "^1.1.5"
     smart-buffer "^4.1.0"
 
-solc@0.8.12:
-  version "0.8.12"
-  resolved "https://registry.yarnpkg.com/solc/-/solc-0.8.12.tgz#3002ed3092ee2f7672f1a2ab80c0d8df8df3ef2b"
-  integrity sha512-TU3anAhKWBQ/WrerJ9EcHrNwGOA1y5vIk5Flz7dBNamLDkX9VQTIwcKd3FiZsT0Ew8rSU7RTmJyGNHRGzP5TBA==
+solc@0.8.13:
+  version "0.8.13"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.8.13.tgz#bafc7fcc11a627e2281e489076b80497123bb704"
+  integrity sha512-C0yTN+rjEOGO6uVOXI8+EKa75SFMuZpQ2tryex4QxWIg0HRWZvCHKfVPuLZ5wx06Sb6GBp6uQA5yqQyXZnXOJw==
   dependencies:
     command-exists "^1.2.8"
     commander "^8.1.0"
@@ -26532,10 +26532,10 @@ solc@0.8.12:
     semver "^5.5.0"
     tmp "0.0.33"
 
-solc@0.8.13:
-  version "0.8.13"
-  resolved "https://registry.yarnpkg.com/solc/-/solc-0.8.13.tgz#bafc7fcc11a627e2281e489076b80497123bb704"
-  integrity sha512-C0yTN+rjEOGO6uVOXI8+EKa75SFMuZpQ2tryex4QxWIg0HRWZvCHKfVPuLZ5wx06Sb6GBp6uQA5yqQyXZnXOJw==
+solc@0.8.15:
+  version "0.8.15"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.8.15.tgz#d274dca4d5a8b7d3c9295d4cbdc9291ee1c52152"
+  integrity sha512-Riv0GNHNk/SddN/JyEuFKwbcWcEeho15iyupTSHw5Np6WuXA5D8kEHbyzDHi6sqmvLzu2l+8b1YmL8Ytple+8w==
   dependencies:
     command-exists "^1.2.8"
     commander "^8.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -26519,19 +26519,6 @@ socks@^2.3.3, socks@^2.6.1:
     ip "^1.1.5"
     smart-buffer "^4.1.0"
 
-solc@0.8.13:
-  version "0.8.13"
-  resolved "https://registry.yarnpkg.com/solc/-/solc-0.8.13.tgz#bafc7fcc11a627e2281e489076b80497123bb704"
-  integrity sha512-C0yTN+rjEOGO6uVOXI8+EKa75SFMuZpQ2tryex4QxWIg0HRWZvCHKfVPuLZ5wx06Sb6GBp6uQA5yqQyXZnXOJw==
-  dependencies:
-    command-exists "^1.2.8"
-    commander "^8.1.0"
-    follow-redirects "^1.12.1"
-    js-sha3 "0.8.0"
-    memorystream "^0.3.1"
-    semver "^5.5.0"
-    tmp "0.0.33"
-
 solc@0.8.15:
   version "0.8.15"
   resolved "https://registry.yarnpkg.com/solc/-/solc-0.8.15.tgz#d274dca4d5a8b7d3c9295d4cbdc9291ee1c52152"


### PR DESCRIPTION
This PR updates the `solc` version to latest `0.8.15` in the `compile-solidity` and `contract-schema` packages.