### PR TITLE
Fix deployer teardown test logic

### DIFF
--- a/packages/contract/lib/handlers.js
+++ b/packages/contract/lib/handlers.js
@@ -41,7 +41,7 @@ const handlers = {
    * @param {Object}       context  execution state
    * @param {PromiEvent}   emitter  promiEvent returned by a web3 method call
    */
-  setup: function(emitter, context) {
+  setup: function (emitter, context) {
     emitter.on("error", handlers.error.bind(emitter, context));
     emitter.on("transactionHash", handlers.hash.bind(emitter, context));
     // web3 block polls if the confirmation listener is enabled so we want to
@@ -59,7 +59,7 @@ const handlers = {
    * @param  {Object} context   execution state
    * @param  {Object} error     error
    */
-  error: function(context, error) {
+  error: function (context, error) {
     if (!handlers.ignoreTimeoutError(context, error)) {
       context.promiEvent.eventEmitter.emit("error", error);
       this.removeListener("error", handlers.error);
@@ -72,15 +72,18 @@ const handlers = {
    * @param  {Object} context   execution state
    * @param  {String} hash      transaction hash
    */
-  hash: function(context, hash) {
+  hash: function (context, hash) {
     context.transactionHash = hash;
     context.promiEvent.eventEmitter.emit("transactionHash", hash);
     this.removeListener("transactionHash", handlers.hash);
   },
 
-  confirmation: function(context, number, receipt) {
+  confirmation: function (context, number, receipt) {
     context.promiEvent.eventEmitter.emit("confirmation", number, receipt);
 
+    console.log(
+      `confirmation # is curently ${number}/${handlers.maxConfirmations + 1}`
+    );
     // Per web3: initial confirmation index is 0
     if (number === handlers.maxConfirmations + 1) {
       this.removeListener("confirmation", handlers.confirmation);
@@ -93,7 +96,7 @@ const handlers = {
    * @param  {Object} context   execution state
    * @param  {Object} receipt   transaction receipt
    */
-  receipt: async function(context, receipt) {
+  receipt: async function (context, receipt) {
     // keep around the raw (not decoded) logs in the raw logs field as a
     // stopgap until we can get the ABI for all events, not just the current
     // contract

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -16,7 +16,8 @@
   "main": "index.js",
   "scripts": {
     "prepare": "exit 0",
-    "test": "mocha --no-warnings --timeout 10000 --exit"
+    "test": "mocha --no-warnings --timeout 10000",
+    "testx": "why-is-node-running $(yarn bin)/mocha --no-warnings --timeout 10000"
   },
   "dependencies": {
     "@ensdomains/ensjs": "^2.1.0",

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -16,8 +16,7 @@
   "main": "index.js",
   "scripts": {
     "prepare": "exit 0",
-    "test": "mocha --no-warnings --timeout 10000",
-    "testx": "why-is-node-running $(yarn bin)/mocha --no-warnings --timeout 10000"
+    "test": "mocha --no-warnings --timeout 10000 test/ens.js"
   },
   "dependencies": {
     "@ensdomains/ensjs": "^2.1.0",

--- a/packages/deployer/test/await.js
+++ b/packages/deployer/test/await.js
@@ -11,13 +11,22 @@ describe("Deployer (async / await)", function () {
   let example;
   let options;
   let networkId;
-  const provider = ganache.provider({
-    miner: {
-      instamine: "strict"
-    },
-    logging: { quiet: true }
+  let provider, web3;
+
+  before(() => {
+    provider = ganache.provider({
+      miner: {
+        instamine: "strict"
+      },
+      logging: { quiet: true }
+    });
+    web3 = new Web3(provider);
   });
-  const web3 = new Web3(provider);
+
+  after(async () => {
+    provider && (await provider.disconnect());
+    provider = web3 = null;
+  });
 
   beforeEach(async function () {
     this.timeout(20000);

--- a/packages/deployer/test/deployer.js
+++ b/packages/deployer/test/deployer.js
@@ -14,7 +14,7 @@ const {
   linkingOccurred
 } = require("./helpers/eventSystem");
 
-describe.only("Deployer (sync)", function () {
+describe("Deployer (sync)", function () {
   let owner;
   let options;
   let networkId;
@@ -35,11 +35,10 @@ describe.only("Deployer (sync)", function () {
     web3 = new Web3(provider);
   });
 
-  //TODO: provider.disconnect() causes the tests to hang for some unknown reason
   // see outstanding Ganache issue: https://github.com/trufflesuite/ganache/issues/3293
   // Leaving it commented out for now.
   after(async () => {
-    // provider && await provider.disconnect();
+    provider && (await provider.disconnect());
     provider = web3 = null;
   });
 

--- a/packages/deployer/test/deployer.js
+++ b/packages/deployer/test/deployer.js
@@ -14,7 +14,7 @@ const {
   linkingOccurred
 } = require("./helpers/eventSystem");
 
-describe("Deployer (sync)", function () {
+describe.only("Deployer (sync)", function () {
   let owner;
   let options;
   let networkId;
@@ -24,14 +24,24 @@ describe("Deployer (sync)", function () {
   let IsLibrary;
   let UsesLibrary;
 
-  const provider = ganache.provider({
-    miner: {
-      instamine: "strict"
-    },
-    logging: { quiet: true }
+  let provider, web3;
+  before(() => {
+    provider = ganache.provider({
+      miner: {
+        instamine: "strict"
+      },
+      logging: { quiet: true }
+    });
+    web3 = new Web3(provider);
   });
 
-  const web3 = new Web3(provider);
+  //TODO: provider.disconnect() causes the tests to hang for some unknown reason
+  // see outstanding Ganache issue: https://github.com/trufflesuite/ganache/issues/3293
+  // Leaving it commented out for now.
+  after(async () => {
+    // provider && await provider.disconnect();
+    provider = web3 = null;
+  });
 
   beforeEach(async function () {
     networkId = await web3.eth.net.getId();
@@ -322,7 +332,7 @@ describe("Deployer (sync)", function () {
         deployer.then(async function () {
           await deployer._startBlockPolling(interfaceAdapter);
           await utils.waitMS(9000);
-          await deployer._startBlockPolling(interfaceAdapter);
+          await deployer._stopBlockPolling(interfaceAdapter);
         });
       };
 

--- a/packages/deployer/test/ens.js
+++ b/packages/deployer/test/ens.js
@@ -35,12 +35,12 @@ describe.only("ENS class", () => {
   //TODO: provider.disconnect() causes the tests to hang for some unknown reason
   // see outstanding Ganache issue: https://github.com/trufflesuite/ganache/issues/3293
   // Leaving it commented out for now.
-  // after(async () => {
-  //   if (provider) {
-  //     await provider.disconnect();
-  //     provider = null;
-  //   }
-  // });
+  after(async () => {
+    if (provider) {
+      await provider.disconnect();
+      provider = null;
+    }
+  });
 
   beforeEach(async () => {
     options = {
@@ -58,9 +58,9 @@ describe.only("ENS class", () => {
     ens = ens.provider = ens.ens = null;
   });
 
-  // it('blanks', async () => {
-  //   await ens.deployNewDevENSRegistry(fromAddress);
-  // });
+  it.only("blanks", async () => {
+    await ens.deployNewDevENSRegistry(fromAddress);
+  });
 
   describe("deployNewDevENSRegistry", () => {
     it("deploys a new registry and returns the registry object", async () => {

--- a/packages/deployer/test/ens.js
+++ b/packages/deployer/test/ens.js
@@ -4,6 +4,7 @@ const assert = require("assert");
 const Ganache = require("ganache");
 const ENS = require("../ens");
 const sinon = require("sinon");
+const { afterEach } = require("mocha");
 const ENSJS = require("@ensdomains/ensjs").default;
 
 let providerOptions,
@@ -16,9 +17,10 @@ let providerOptions,
   ensjs,
   registry;
 
-describe("ENS class", () => {
+describe.only("ENS class", () => {
   before(() => {
     providerOptions = {
+      miner: { instamine: "eager" }, //default
       // note that when vmErrorsOnRPCResponse is true, `"eager"` instamine must be enabled (default)
       vmErrorsOnRPCResponse: true,
       mnemonic:
@@ -29,12 +31,17 @@ describe("ENS class", () => {
     };
     provider = Ganache.provider(providerOptions);
   });
-  after(async () => {
-    if (provider) {
-      await provider.disconnect();
-      provider = null;
-    }
-  });
+
+  //TODO: provider.disconnect() causes the tests to hang for some unknown reason
+  // see outstanding Ganache issue: https://github.com/trufflesuite/ganache/issues/3293
+  // Leaving it commented out for now.
+  // after(async () => {
+  //   if (provider) {
+  //     await provider.disconnect();
+  //     provider = null;
+  //   }
+  // });
+
   beforeEach(async () => {
     options = {
       provider,
@@ -46,6 +53,14 @@ describe("ENS class", () => {
     // First address generated from the above mnemonic
     fromAddress = "0x627306090abaB3A6e1400e9345bC60c78a8BEf57";
   });
+
+  afterEach(() => {
+    ens = ens.provider = ens.ens = null;
+  });
+
+  // it('blanks', async () => {
+  //   await ens.deployNewDevENSRegistry(fromAddress);
+  // });
 
   describe("deployNewDevENSRegistry", () => {
     it("deploys a new registry and returns the registry object", async () => {

--- a/packages/deployer/test/errors.js
+++ b/packages/deployer/test/errors.js
@@ -6,7 +6,7 @@ const utils = require("./helpers/utils");
 const Config = require("@truffle/config");
 const { Environment } = require("@truffle/environment");
 
-describe("Error cases", function () {
+describe.only("Error cases", function () {
   let owner;
   let accounts;
   let options;
@@ -20,17 +20,24 @@ describe("Error cases", function () {
   let UsesExample;
   let IsLibrary;
   let UsesLibrary;
+  let provider, web3;
 
-  const provider = ganache.provider({
-    gasLimit: "0x6691b7",
-    hardfork: "istanbul",
-    miner: {
-      instamine: "strict"
-    },
-    logging: { quiet: true }
+  before(() => {
+    provider = ganache.provider({
+      gasLimit: "0x6691b7",
+      hardfork: "istanbul",
+      miner: {
+        instamine: "strict"
+      },
+      logging: { quiet: true }
+    });
+    web3 = new Web3(provider);
   });
 
-  const web3 = new Web3(provider);
+  after(async () => {
+    provider && (await provider.disconnect());
+    provider = web3 = null;
+  });
 
   beforeEach(async function () {
     networkId = await web3.eth.net.getId();


### PR DESCRIPTION
This PR aims to remove mocha's `--exit` flag from the deployer tests. We shouldn't be using this flag because it hides potential issues with Ganache and Truffle's interaction.

Currently, there is a blocker, an issue with how Ganache.Provider eager mode and `provider.disconnect()` works, or Truffle's usage of it! See: https://github.com/trufflesuite/ganache/issues/3293