### PR TITLE
Refactor console-child.js to make the network settings more robust

### DIFF
--- a/packages/core/lib/console-child.js
+++ b/packages/core/lib/console-child.js
@@ -23,33 +23,43 @@ global.crypto = {
 const { network, config, url } = yargs(input[0]).argv;
 const detectedConfig = Config.detect({ network, config });
 
-if (url) {
-  detectedConfig.networks[network] = {
-    network_id: "*",
-    provider: function () {
-      return new Web3.providers.HttpProvider(url, { keepAlive: false });
-    }
-  };
-} else {
-  const customConfig = detectedConfig.networks.develop || {};
-
-  //need host and port for provider url
-  const ganacheOptions = {
+function getConfiguredNetworkUrl(customConfig) {
+  const configuredNetworkOptions = {
     host: customConfig.host || managedGanacheDefaultHost,
     port: customConfig.port || managedGanacheDefaultPort
   };
-  const ganacheUrl = `http://${ganacheOptions.host}:${ganacheOptions.port}/`;
+  return `http://${configuredNetworkOptions.host}:${configuredNetworkOptions.port}/`;
+}
 
-  //set up the develop network to use, including setting up provider
-  detectedConfig.networks.develop = {
+let configuredNetwork;
+
+if (url) {
+  // implies not "develop"
+  // Use "url" to configure network
+  configuredNetwork = {
+    network_id: "*",
+    url
+  };
+} else {
+  // Otherwise derive network settings
+  const customConfig = detectedConfig.networks[network] || {};
+
+  configuredNetwork = {
     host: customConfig.host || managedGanacheDefaultHost,
     port: customConfig.port || managedGanacheDefaultPort,
     network_id: customConfig.network_id || managedGanacheDefaultNetworkId,
-    provider: function () {
-      return new Web3.providers.HttpProvider(ganacheUrl, { keepAlive: false });
-    }
+    url: getConfiguredNetworkUrl(customConfig)
   };
 }
+
+detectedConfig.networks[network] = {
+  ...configuredNetwork,
+  provider: function () {
+    return new Web3.providers.HttpProvider(configuredNetwork.url, {
+      keepAlive: false
+    });
+  }
+};
 
 const { getCommand, prepareOptions, runCommand } = require("./command-utils");
 const command = getCommand({ inputStrings, options: {}, noAliases: false });

--- a/packages/core/lib/console-child.js
+++ b/packages/core/lib/console-child.js
@@ -34,8 +34,7 @@ function getConfiguredNetworkUrl(customConfig) {
 let configuredNetwork;
 
 if (url) {
-  // implies not "develop"
-  // Use "url" to configure network
+  // Use "url" to configure network (implies not "develop")
   configuredNetwork = {
     network_id: "*",
     url

--- a/packages/truffle/test/scenarios/commands/console.js
+++ b/packages/truffle/test/scenarios/commands/console.js
@@ -1,23 +1,32 @@
 const CommandRunner = require("../commandRunner");
 const Server = require("../server");
-const Config = require("@truffle/config");
 const MemoryLogger = require("../MemoryLogger");
 const assert = require("assert");
+const path = require("path");
+const Reporter = require("../reporter");
+const sandbox = require("../sandbox");
 
 describe("truffle console", () => {
-  let config;
+  let config, project;
   const logger = new MemoryLogger();
 
   before(async () => await Server.start());
   after(async () => await Server.stop());
 
-  before("before all setup", () => {
-    config = Config.default();
+  project = path.join(__dirname, "../../sources/console");
+
+  before(async function () {
+    this.timeout(10000);
+    config = await sandbox.create(project);
+    config.network = "development";
     config.logger = logger;
+    config.mocha = {
+      reporter: new Reporter(logger)
+    };
   });
 
-  describe("when run with --url option", () => {
-    it("displays the hostname in the prompt", async () => {
+  describe("when run with options", () => {
+    it("displays the url hostname in the prompt", async () => {
       const url = "http://localhost:8545";
       const parsedUrl = new URL(url);
       const displayHost = parsedUrl.host;
@@ -32,6 +41,24 @@ describe("truffle console", () => {
 
       const output = logger.contents();
       const expectedValue = `truffle(${displayHost})>`;
+      assert(
+        output.includes(expectedValue),
+        `Expected "${expectedValue}" in output`
+      );
+    }).timeout(90000);
+
+    it("displays the network name in the prompt", async () => {
+      const networkName = config.network;
+      await CommandRunner.runInREPL({
+        inputCommands: [],
+        config,
+        executableCommand: "console",
+        executableArgs: `--network ${networkName}`,
+        displayHost: networkName
+      });
+
+      const output = logger.contents();
+      const expectedValue = `truffle(${networkName})>`;
       assert(
         output.includes(expectedValue),
         `Expected "${expectedValue}" in output`

--- a/packages/truffle/test/scenarios/commands/console.js
+++ b/packages/truffle/test/scenarios/commands/console.js
@@ -3,7 +3,6 @@ const Server = require("../server");
 const MemoryLogger = require("../MemoryLogger");
 const assert = require("assert");
 const path = require("path");
-const Reporter = require("../reporter");
 const sandbox = require("../sandbox");
 const tmp = require("tmp");
 
@@ -21,9 +20,6 @@ describe("truffle console", () => {
     config = await sandbox.create(project);
     config.network = "development";
     config.logger = logger;
-    config.mocha = {
-      reporter: new Reporter(logger)
-    };
   });
 
   describe("when runs with network option with a config", () => {
@@ -76,12 +72,6 @@ describe("truffle console", () => {
         sandlot = tmp.dirSync({ unsafeCleanup: true });
         config = { working_directory: sandlot.name };
         config.logger = logger;
-        config.mocha = {
-          reporter: new Reporter(logger)
-        };
-      });
-      after(() => {
-        sandlot.removeCallback();
       });
 
       it("displays the url hostname in the prompt", async () => {

--- a/packages/truffle/test/scenarios/commands/console.js
+++ b/packages/truffle/test/scenarios/commands/console.js
@@ -73,6 +73,9 @@ describe("truffle console", () => {
         config = { working_directory: sandlot.name };
         config.logger = logger;
       });
+      after("clear working_directory", () => {
+        sandlot.removeCallback();
+      });
 
       it("displays the url hostname in the prompt", async () => {
         const url = "http://localhost:8545";

--- a/packages/truffle/test/scenarios/commands/console.js
+++ b/packages/truffle/test/scenarios/commands/console.js
@@ -43,12 +43,11 @@ describe("truffle console", () => {
   });
 
   describe("when runs with url option", () => {
+    const url = "http://localhost:8545";
+    const parsedUrl = new URL(url);
+    const displayHost = parsedUrl.host;
     describe("with a config", () => {
       it("displays the url hostname in the prompt", async () => {
-        const url = "http://localhost:8545";
-        const parsedUrl = new URL(url);
-        const displayHost = parsedUrl.host;
-
         await CommandRunner.runInREPL({
           inputCommands: [],
           config,
@@ -78,10 +77,6 @@ describe("truffle console", () => {
       });
 
       it("displays the url hostname in the prompt", async () => {
-        const url = "http://localhost:8545";
-        const parsedUrl = new URL(url);
-        const displayHost = parsedUrl.host;
-
         await CommandRunner.runInREPL({
           inputCommands: [],
           config,

--- a/packages/truffle/test/sources/console/truffle-config.js
+++ b/packages/truffle/test/sources/console/truffle-config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  networks: {
+    development: {
+      host: "127.0.0.1",
+      port: 8545,
+      network_id: "*",
+      gas: 4700000,
+      gasPrice: 20000000000
+    }
+  }
+};


### PR DESCRIPTION
### ISSUE
PR #5087 broke `truffle console --network` because it [hardcoded the `network name` to be `develop`
](https://github.com/trufflesuite/truffle/blob/b7896bb42b932eaf506369315f43405e5762535f/packages/core/lib/console-child.js#L45)
This was because `console-child.js` had logic exclusively used by the `truffle develop` command. When `truffle console --network <network_name>` is used, it adds the `develop` network into `config` which is not required. This behaviour doesn't make sense after PR #5087 because `console-child.js` has to satisfy more code paths such as:
- `truffle console --network`
- `truffle console --url` 
- `truffle develop`

### SOLUTION
This PR  makes `console-child.js` more robust to handle the above cases. And also adds an integration test for the `truffle console --network` option.

**NOTE:** It needs to be merged before the next release so that it doesn't break the use of `--network` options with the `truffle console` command.