### PR TITLE
Fix broken imports

### DIFF
--- a/packages/dashboard-message-bus-client/package.json
+++ b/packages/dashboard-message-bus-client/package.json
@@ -42,12 +42,13 @@
     "axios": "^0.24.0",
     "debug": "^4.3.1",
     "delay": "^5.0.0",
-    "isomorphic-ws": "^4.0.1"
+    "isomorphic-ws": "^4.0.1",
+    "tiny-typed-emitter": "^2.1.0",
+    "ws": "^7.2.0"
   },
   "devDependencies": {
     "@types/debug": "^4.1.5",
     "@types/node": "^16.11.6",
-    "tiny-typed-emitter": "^2.1.0",
     "typescript": "^4.1.4"
   }
 }

--- a/packages/dashboard-message-bus-common/package.json
+++ b/packages/dashboard-message-bus-common/package.json
@@ -5,8 +5,11 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist/lib"
+    "dist"
   ],
+  "directories": {
+    "dist": "dist"
+  },
   "scripts": {
     "build": "tsc",
     "prepare": "yarn build"


### PR DESCRIPTION
## Related
[issue#5235](https://github.com/trufflesuite/truffle/issues/5235), [discussion#5237](https://github.com/trufflesuite/truffle/discussions/5237)

## At a glance
Some Dashboard-related packages were newly introduced in the latest release (v5.5.19), and due to misconfigured `package.json`, the following Truffle packages fail to import when individually installed.
<details>
<summary>Installable, but fail on import</summary>
<code>
@truffle/box @truffle/compile-michelson @truffle/compile-smartpy @truffle/compile-solidity @truffle/compile-vyper @truffle/config @truffle/dashboard @truffle/dashboard-message-bus @truffle/dashboard-message-bus-client @truffle/dashboard-message-bus-common @truffle/dashboard-provider @truffle/db @truffle/db-kit @truffle/environment @truffle/events @truffle/external-compile @truffle/fetch-and-compile @truffle/migrate @truffle/require @truffle/resolver @truffle/workflow-compile
</code>
</details>

This PR resolves this issue, packages should now be individually installable. Tested using Verdaccio.

This PR builds on [pull#5230](https://github.com/trufflesuite/truffle/pull/5230).
## Post-mortem
Two things:
1. To prevent broken imports.
    - Include other Truffle packages as deps in Truffle packages.
    - Dev deps should only be used in tests, not bundled into prod.
    - `package.json` should have `files` field properly configured, encompassing all necessary parts of the bundle and not just the entry point.
    - Remember peer deps.
3. To catch broken imports.
    - Currently CI doesn't include simulating install from registry. This is problematic because dep issue such as this are overlooked when testing from a Truffle dev environment, since package managers and lerna use magic to find the deps.
    - We should simulate installing from registry in CI, importing them, and testing compile when used in ts project.

## How to test
<details>
<summary>Setup Verdaccio</summary>
<ul>
<li><code>npm install -g verdaccio</code></li>
<li><code>htpasswd -bc htpasswd-file username password</code></li>
<li>Copy <a href="https://gist.github.com/cliffoo/df2d6f51179502fb4e2492ad2c8a75b9">this config</a>.</li>
<li><code>verdaccio -c path-to-config-file-you-copied</code></li>
</ul>
You can also reference <a href="https://verdaccio.org">their docs</a>.
</details>

<details>
<summary>Publish to Verdaccio</summary>
<ul>
<li><code>npm logout && yarn logout</code></li>
<li><code>npm adduser --registry http://localhost:4873</code></li>
<li><code>lerna publish from-package --no-push --registry http://localhost:4873</code></li>
</ul>
</details>

<details>
<summary>Test install</summary>
<ul>
<li>Copy <a href="https://gist.github.com/cliffoo/ad44137004c90e3fe6bba2a67590bebd">these two files</a> into an empty directory. Make sure directory is close enough to root that node can't traverse to other places to find deps.</li>
<li>In that directory <code>cat pkgs | xargs -n 1 ./auto-test-imports.sh</code></li>
<li>In another terminal <code>tail -f test.out</code></li>
</ul>
</details>

## Credits 🙏
Huge thanks to @cds-amal, @lsqproduction, and @haltman-at!