### PR TITLE
Internal improvement: Update geth script

### DIFF
--- a/scripts/geth.sh
+++ b/scripts/geth.sh
@@ -20,4 +20,4 @@ docker run \
 	--dev \
 	--dev.period 0 \
 	--allow-insecure-unlock \
-	js ./scripts/geth-accounts.js
+	--exec "loadScript('scripts/geth-accounts.js')" console


### PR DESCRIPTION
Geth just released a new version, yay! 🥇 However, in https://github.com/ethereum/go-ethereum/releases/tag/v1.10.20 (subsequently referred to as THE PR) they removed the `js` subcommand. 🤕 Now CI is broken, oh my!

This updates the geth script to use the option recommended as a drop in by THE PR. Bing, bam, boom...