### PR TITLE
pin geth to v1.10.19

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -10,7 +10,7 @@ run_geth() {
 		-p 8545:8545 \
 		-p 8546:8546 \
 		-p 30303:30303 \
-		ethereum/client-go:stable \
+		ethereum/client-go:v1.10.19 \
 		--http \
 		--http.addr '0.0.0.0' \
 		--http.port 8545 \
@@ -39,7 +39,7 @@ if [ "$INTEGRATION" = true ]; then
 elif [ "$GETH" = true ]; then
 
 	sudo apt install -y jq
-	docker pull ethereum/client-go:stable
+	docker pull ethereum/client-go:v1.10.19
 	run_geth
 	sleep 30
 	lerna run --scope truffle test --stream -- --exit

--- a/scripts/geth.sh
+++ b/scripts/geth.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-docker pull ethereum/client-go:stable
+docker pull ethereum/client-go:v1.10.19
 
 docker run \
 	-v /$PWD/scripts:/scripts \
@@ -8,7 +8,7 @@ docker run \
 	-p 8545:8545 \
 	-p 8546:8546 \
 	-p 30303:30303 \
-	ethereum/client-go:stable \
+	ethereum/client-go:v1.10.19 \
 	--http \
 	--http.addr '0.0.0.0' \
 	--http.port 8545 \


### PR DESCRIPTION
Geth just released a new version, yay! 🥇 However, in https://github.com/ethereum/go-ethereum/releases/tag/v1.10.20 they removed the `js` subcommand. 🤕 Now CI is broken, oh my!

This pins Geth to v1.10.19 until we can find out what the proper fix is.