### PR TITLE
Add Sourcify networks for July 2022

### DIFF
--- a/packages/source-fetcher/lib/networks.ts
+++ b/packages/source-fetcher/lib/networks.ts
@@ -25,6 +25,7 @@ export const networkNamesById: { [id: number]: string } = {
   43113: "fuji-avalanche",
   11111: "wagmi-avalanche",
   53935: "dfk-avalanche",
+  432201: "dexalot-avalanche",
   335: "testnet-dfk-avalance",
   40: "telos",
   41: "testnet-telos",
@@ -64,7 +65,12 @@ export const networkNamesById: { [id: number]: string } = {
   534: "candle",
   192837465: "gather",
   486217935: "devnet-gather",
-  356256156: "testnet-gather"
+  356256156: "testnet-gather",
+  246: "energyweb",
+  73799: "volta-energyweb",
+  71402: "godwoken", //not presently supported by either fetcher, but...
+  71401: "testnet-godwoken"
+  //I'm not including crystaleum as it has network ID different from chain ID
 };
 
 export const networksByName: Types.SupportedNetworks = Object.fromEntries(

--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -36,8 +36,8 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
 
   private static readonly supportedNetworks = new Set([
     "mainnet",
-    "ropsten",
-    "kovan",
+    "ropsten", //can no longer verify but can still fetch existing
+    "kovan", //can no longer verify but can still fetch existing
     "rinkeby",
     "goerli",
     "kovan",
@@ -61,6 +61,7 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "wagmi-avalanche",
     "dfk-avalanche",
     "testnet-dfk-avalanche",
+    "dexalot-avalanche",
     "telos",
     "testnet-telos",
     "ubiq",
@@ -89,7 +90,12 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "candle",
     "gather",
     "devnet-gather",
-    "testnet-gather"
+    "testnet-gather",
+    "energyweb",
+    "volta-energyweb",
+    //sourcify does *not* support godwoken mainnet...?
+    "testnet-godwoken"
+    //I'm excluding crystaleum as it has network ID different from chain ID
   ]);
 
   constructor(networkId: number) {


### PR DESCRIPTION
This PR adds support to the Sourcify fetcher for the new networks that Sourcify has added support for this month (it looks to me like they may have gone on to a monthly update schedule? We'll see if that holds up).  I excluded Crystaleum, however, as it once again has network ID different from chain ID (it uses network ID 1), which we still can't handle.

As with the way I've done things in the past, since Sourcify has added support for the godwoken testnet, I've also put the godwoken mainnet in the networks file, even though neither fetcher presently supports it.

Sourcify has also partially *removed* support for ropsten and kovan with this update, but I've left those in; unlike when Etherscan removed support for hoo, Sourcify says existing verified contracts on ropsten or kovan will remain available (you just won't be able to verify new ones), so I don't see any reason to remove our support there.