### PR TITLE
Add integration tests for debug command

### DIFF
--- a/packages/truffle/test/scenarios/commandRunner.js
+++ b/packages/truffle/test/scenarios/commandRunner.js
@@ -54,13 +54,11 @@ module.exports = {
     displayHost
   } = {}) {
     const cmdLine = `${this.getExecString()} ${executableCommand} ${executableArgs}`;
-    let readyPrompt;
 
-    if (executableCommand === "debug") {
-      readyPrompt = `debug(${displayHost})>`;
-    } else {
-      readyPrompt = `truffle(${displayHost})>`;
-    }
+    const readyPrompt =
+      executableCommand === "debug"
+        ? `debug(${displayHost})>`
+        : `truffle(${displayHost})>`;
 
     let seenChildPrompt = false;
     let outputBuffer = "";

--- a/packages/truffle/test/scenarios/commandRunner.js
+++ b/packages/truffle/test/scenarios/commandRunner.js
@@ -54,7 +54,13 @@ module.exports = {
     displayHost
   } = {}) {
     const cmdLine = `${this.getExecString()} ${executableCommand} ${executableArgs}`;
-    const readyPrompt = `truffle(${displayHost})>`;
+    let readyPrompt;
+
+    if (executableCommand === "debug") {
+      readyPrompt = `debug(${displayHost})>`;
+    } else {
+      readyPrompt = `truffle(${displayHost})>`;
+    }
 
     let seenChildPrompt = false;
     let outputBuffer = "";

--- a/packages/truffle/test/scenarios/commands/debug.js
+++ b/packages/truffle/test/scenarios/commands/debug.js
@@ -1,0 +1,90 @@
+const CommandRunner = require("../commandRunner");
+const Server = require("../server");
+const MemoryLogger = require("../MemoryLogger");
+const assert = require("assert");
+const path = require("path");
+const sandbox = require("../sandbox");
+const tmp = require("tmp");
+
+describe("truffle debug", () => {
+  let config;
+  const logger = new MemoryLogger();
+  const project = path.join(__dirname, "../../sources/debug");
+
+  before(async () => {
+    config = await sandbox.create(project);
+    config.network = "development";
+    config.logger = logger;
+    await Server.start();
+  });
+  after(async () => await Server.stop());
+
+  describe("when runs with network option with a config", () => {
+    it("displays the network name in the prompt", async () => {
+      const networkName = config.network;
+      await CommandRunner.runInREPL({
+        inputCommands: [],
+        config,
+        executableCommand: "debug",
+        executableArgs: `--network ${networkName}`,
+        displayHost: networkName
+      });
+
+      const output = logger.contents();
+      const expectedValue = `debug(${networkName})>`;
+      assert(
+        output.includes(expectedValue),
+        `Expected "${expectedValue}" in output`
+      );
+    }).timeout(90000);
+  });
+
+  describe("when runs with url option", () => {
+    const url = "http://localhost:8545";
+    const parsedUrl = new URL(url);
+    const displayHost = parsedUrl.host;
+    describe("with a config", () => {
+      it("displays the url hostname in the prompt", async () => {
+        await CommandRunner.runInREPL({
+          inputCommands: [],
+          config,
+          executableCommand: "debug",
+          executableArgs: `--url ${url}`,
+          displayHost
+        });
+
+        const output = logger.contents();
+        const expectedValue = `debug(${displayHost})>`;
+        assert(
+          output.includes(expectedValue),
+          `Expected "${expectedValue}" in output`
+        );
+      }).timeout(90000);
+    });
+
+    describe("without a config", () => {
+      let sandlot;
+      before(() => {
+        sandlot = tmp.dirSync({ unsafeCleanup: true });
+        config = { working_directory: sandlot.name };
+        config.logger = logger;
+      });
+
+      it("displays the url hostname in the prompt", async () => {
+        await CommandRunner.runInREPL({
+          inputCommands: [],
+          config,
+          executableCommand: "debug",
+          executableArgs: `--url ${url}`,
+          displayHost
+        });
+        const output = logger.contents();
+        const expectedValue = `debug(${displayHost})>`;
+        assert(
+          output.includes(expectedValue),
+          `Expected "${expectedValue}" in output`
+        );
+      }).timeout(90000);
+    });
+  });
+});

--- a/packages/truffle/test/scenarios/commands/debug.js
+++ b/packages/truffle/test/scenarios/commands/debug.js
@@ -19,7 +19,7 @@ describe("truffle debug", () => {
   });
   after(async () => await Server.stop());
 
-  describe("when runs with network option with a config", () => {
+  describe("when run with network option with a config", () => {
     it("displays the network name in the prompt", async () => {
       const networkName = config.network;
       await CommandRunner.runInREPL({
@@ -39,7 +39,7 @@ describe("truffle debug", () => {
     }).timeout(90000);
   });
 
-  describe("when runs with url option", () => {
+  describe("when run with url option", () => {
     const url = "http://localhost:8545";
     const parsedUrl = new URL(url);
     const displayHost = parsedUrl.host;

--- a/packages/truffle/test/sources/debug/truffle-config.js
+++ b/packages/truffle/test/sources/debug/truffle-config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  networks: {
+    development: {
+      host: "127.0.0.1",
+      port: 8545,
+      network_id: "*",
+      gas: 4700000,
+      gasPrice: 20000000000
+    }
+  }
+};


### PR DESCRIPTION
This PR includes few integration tests for `truffle debug` which includes the following scenarios -

- when runs with `--network` option with a config file.
- when runs with `--url` option -
       1) with a config file.
       2) without a config file (outside a truffle project).

