### PR TITLE
Add GHA dependency check

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -56,7 +56,7 @@ jobs:
 
     - run: yarn bootstrap
     
-    - run: yarn depcheck || (echo 'Please add missing dependencies to appropriate package'; false)
+    - run: yarn depcheck
     
     - run: ${{ matrix.env }} yarn ci
       env:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           channel: '#truffle-ci-notifications'
           status: ${{ job.status }}
-          fields: commit,author,pullRequest
+          fields: job,commit,author,pullRequest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -65,9 +65,10 @@ jobs:
       with:
         channel: '#truffle-ci-notifications'
         status: ${{ job.status }}
-        fields: commit,author,pullRequest
+        fields: job,commit,author,pullRequest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        MATRIX_CONTEXT: ${{ toJson(matrix) }} # required for matrix field: job
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       if: failure()
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -21,9 +21,18 @@ jobs:
       - run: npm install -g yarn
       - run: yarn install --ignore-scripts --ignore-engines
       - run: test -z "$(git diff)" || (echo 'Please run yarn and commit all changes to yarn.lock'; false)
-
+      - uses: 8398a7/action-slack@v3
+        with:
+          channel: '#truffle-ci-notifications'
+          status: ${{ job.status }}
+          fields: commit,author,pullRequest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: failure()
 
   build:
+    needs: yarncheck
     strategy:
       matrix:
         platform: [ubuntu-latest]
@@ -44,14 +53,19 @@ jobs:
       run: npm -g install npm@6
 
     - run: npm install -g yarn
+
     - run: yarn bootstrap
+    
+    - run: yarn depcheck || (echo 'Please add missing dependencies to appropriate package'; false)
+    
     - run: ${{ matrix.env }} yarn ci
       env:
         CI: true
-    - uses: 8398a7/action-slack@v1.1.1
+    - uses: 8398a7/action-slack@v3
       with:
-        type: failure
-        failedMenthon: ""
+        channel: '#truffle-ci-notifications'
+        status: ${{ job.status }}
+        fields: commit,author,pullRequest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -60,13 +74,11 @@ jobs:
   slack_notification:
     needs: [yarncheck, build]
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: 8398a7/action-slack@v3
-        continue-on-error: true
         with:
           channel: '#truffle-ci-notifications'
-          status: ${{ job.status }}
+          status: success
           fields: commit,author,pullRequest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR builds on #5230 to address #5236 by adding a GitHub action to CI. I didn't create a separate job for the dependency check because it would require the expensive `yarn bootstrap` command and I don't want CI to take longer. Instead, I inserted the dependency-check into the matrix strategy `build` job to take advantage of the matrix's short-circuiting behavior.  If one matrix job fails, it cancels all others. I also updated the Slack-app config and made the matrix-build job a dependency of `yarncheck`. `yarncheck` resolves in ~2.5 minutes and then the matrix job runs, followed by Slack notification.

If this is approved, I will rebase to remove all simulated errors