### PR TITLE
core: error better on scenarios with incorrect truffle command

### DIFF
--- a/packages/core/cli.js
+++ b/packages/core/cli.js
@@ -63,6 +63,15 @@ const command = getCommand({
   options: {},
   noAliases: false
 });
+
+//getCommand() will return null if a command not recognized by truffle is used.
+if (command === null) {
+  console.log(
+    `\`truffle ${inputStrings}\` is not a valid truffle command. Please see \`truffle help\` for available commands.`
+  );
+  process.exit(1);
+}
+
 const options = prepareOptions({
   command,
   inputStrings,

--- a/packages/core/lib/command-utils.js
+++ b/packages/core/lib/command-utils.js
@@ -47,7 +47,7 @@ const getCommand = ({ inputStrings, options, noAliases }) => {
     }
   }
 
-  if (chosenCommand == null) {
+  if (chosenCommand === null) {
     return null;
   }
 


### PR DESCRIPTION
Address #5186, truffle crashes when an invalid truffle command is used. 
For example `truffle --version` or `truffle liang`
Added a better error and prompts the user to use `truffle help` to see the list of available valid commands. 

I thought it is cleaner looking to just display the error message instead of the error message and stack trace together, do let me know if you think otherwise. Or if you have a better suggestion on how to handle this error. 