### PR TITLE
Bug fix: Correctly return value for `foo = await bar` in console

### DIFF
--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -356,6 +356,18 @@ class Console extends EventEmitter {
       assignment = assign
         ? `${assign.trim()} global.${RESULT}; void delete global.${RESULT};`
         : null;
+
+      //finally, if the assignment did not use var, const, or let, make sure to
+      //return the result afterward
+      if (assign) {
+        const bareAssignmentMatch = assign.match(
+          /^\s*([a-zA-Z_$][0-9a-zA-Z_$]*)\s*=\s*/
+        );
+        if (bareAssignmentMatch) {
+          const varName = bareAssignmentMatch[1];
+          assignment += varName;
+        }
+      }
     }
 
     const runScript = script => {

--- a/packages/truffle/test/scenarios/commands/develop.js
+++ b/packages/truffle/test/scenarios/commands/develop.js
@@ -78,6 +78,25 @@ describe("truffle develop", function () {
     );
   });
 
+  it("returns values after assignments with await", async function () {
+    this.timeout(70000);
+    const input = "x = await Promise.resolve('This is an example of a string')";
+
+    await CommandRunner.runInREPL({
+      inputCommands: [input],
+      config,
+      executableCommand: "develop",
+      displayHost: "develop"
+    });
+
+    const output = logger.contents();
+    const expectedValue = "This is an example of a string";
+    assert(
+      output.includes(expectedValue),
+      `Expected "${expectedValue}" in output:\n${formatLines(output)}`
+    );
+  });
+
   it("loads snippets", async function () {
     this.timeout(70000);
 


### PR DESCRIPTION
Addresses #3349.

This PR fixes the issue where expressions of the form `foo = await bar`, when entered in the Truffle Console, would perform the assignment but then not return the resulting value.  Note that this PR does **not** fix the more general issues with the use of `await` in the Truffle Console, which is issue #1546.  Fixing the broader problems are probably going to have to wait until we have removed support for both Node 12 and Node 14.

The fundamental problem, and the reason for #1546, is that all our `await`-handling code in the console is a bunch of hacks.  The ultimate solution to all of this, once we don't need to support Node 12 and Node 14 anymore, will be to remove all these hacks and do things the straightforward way that Node 16 will allow us to do it.  However, in the meantime, I still wanted to fix the particular issue of #3349.  To accomplish that, this PR uses... more hacks.  But, it's not worse than the already existing hacks surrounding it, so I think it's fine.

The reason that we get `undefined` in this case is because we have special handling for this particular case, and that special handling involves creating a little assignment script and then passing it to a VM to run; we do get the return value from our script, but the problem is that we wrote the script in a way such that it always returns `undefined`.  So, I've modified it to (conditionally) return the assigned value instead.

Specifically, if we are doing a bare assignment (so no `let` or `const`, those shouldn't return values), I modify the assignment script by appending the variable name to the end of it, so that the value is returned.  This solves the problem!  Or the narrow problem of #3349, anyway.  The broad problem of #1546 will have to wait...

(Although, you can do things beyond *just* `foo = await bar` with it... e.g., `x = (await web3.eth.net.getId()) + 1` will work fine!)

I didn't include any tests in this PR because um I'm not sure how to test this programmatically.  But potentially tests could be added if people think it's necessary (and if anyone can give me an idea for how, or point me to where we already do this sort of thing...)