### PR TITLE
Internal improvement: Add missing `buffer` import in `dashboard-message-bus-common`

### DIFF
--- a/packages/dashboard-message-bus-common/lib/utils.ts
+++ b/packages/dashboard-message-bus-common/lib/utils.ts
@@ -1,4 +1,5 @@
 import { Message } from "./messages";
+import { Buffer } from "buffer";
 
 /**
  * Convert any JS object or value to a base64 representation of it


### PR DESCRIPTION
It runs fine in node but not in the browser, which creates problems when dashboard's frontend uses it.