### PR TITLE
Enhancement: Add support for XinFin Apothem testnet to sourcify fetcher

### DIFF
--- a/packages/source-fetcher/lib/networks.ts
+++ b/packages/source-fetcher/lib/networks.ts
@@ -69,7 +69,9 @@ export const networkNamesById: { [id: number]: string } = {
   246: "energyweb",
   73799: "volta-energyweb",
   71402: "godwoken", //not presently supported by either fetcher, but...
-  71401: "testnet-godwoken"
+  71401: "testnet-godwoken",
+  50: "xinfin", //not presently supported by either fetcher, but...
+  51: "apothem-xinfin"
   //I'm not including crystaleum as it has network ID different from chain ID
 };
 

--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -94,7 +94,9 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "energyweb",
     "volta-energyweb",
     //sourcify does *not* support godwoken mainnet...?
-    "testnet-godwoken"
+    "testnet-godwoken",
+    //sourcify does *not* support xinfin mainnet...?
+    "apothem-xinfin"
     //I'm excluding crystaleum as it has network ID different from chain ID
   ]);
 


### PR DESCRIPTION
I guess I was at least partly wrong about Sourcify going to a monthly schedule, because they just added this network.  As with other testnets where they only support the testnet but not the mainnet, I listed both the mainnet and the testnet in `networks.ts` even though only the testnet got added to `sourcify.ts`.