### PR TITLE
Internal improvement: Remove leftover typings entry in contract's package.json

### DIFF
--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -20,7 +20,6 @@
     "prepare": "yarn compile",
     "publish:next": "node ../truffle/scripts/prereleaseVersion.js next next"
   },
-  "typings": "./typings/index.d.ts",
   "dependencies": {
     "@ensdomains/ensjs": "^2.0.1",
     "@truffle/blockchain-utils": "^0.1.3",


### PR DESCRIPTION
The broken types for @truffle/contract were removed in https://github.com/trufflesuite/truffle/pull/5142. There is still a reference to the types in its package.json that this PR removes.