### PR TITLE
Internal improvement: Up timeout on decoder test

### DIFF
--- a/packages/decoder/test/current/test/compatible-nativize.js
+++ b/packages/decoder/test/current/test/compatible-nativize.js
@@ -39,6 +39,7 @@ describe("nativize (ethers format)", function () {
   });
 
   it("should compatibly nativize return values and event arguments", async function () {
+    this.timeout(4000);
     const { CompatibleNativizeTest } = abstractions;
     const instance = await CompatibleNativizeTest.new();
 


### PR DESCRIPTION
This test has been timing out a bunch recently for whatever reason, so I'm turning up the timeout to 4 seconds.  Hopefully that's enough!