### PR TITLE
Enhancement: Include raw event data in txlog

### DIFF
--- a/packages/debugger/lib/txlog/actions/index.js
+++ b/packages/debugger/lib/txlog/actions/index.js
@@ -181,12 +181,13 @@ export function identifyFunctionCall(
 }
 
 export const LOG_EVENT = "TXLOG_LOG_EVENT";
-export function logEvent(pointer, newPointer, decoding) {
+export function logEvent(pointer, newPointer, decoding, rawEventInfo) {
   return {
     type: LOG_EVENT,
     pointer,
     newPointer, //does not actually affect current pointer!
-    decoding
+    decoding,
+    rawEventInfo
   };
 }
 

--- a/packages/debugger/lib/txlog/reducers.js
+++ b/packages/debugger/lib/txlog/reducers.js
@@ -51,7 +51,8 @@ function transactionLog(state = DEFAULT_TX_LOG, action) {
           },
           [newPointer]: {
             type: "event",
-            decoding: action.decoding
+            decoding: action.decoding,
+            raw: action.rawEventInfo
           }
         }
       };

--- a/packages/debugger/lib/txlog/sagas/index.js
+++ b/packages/debugger/lib/txlog/sagas/index.js
@@ -184,8 +184,9 @@ function* updateTransactionLogSaga() {
   } else if (yield select(txlog.current.isLog)) {
     const decoding = (yield* data.decodeLog())[0]; //just assume first decoding is correct
     //(note: because we know the event ID, there should typically only be one decoding)
+    const rawInfo = yield select(txlog.current.rawEventInfo);
     const newPointer = yield select(txlog.current.nextActionPointer);
-    yield put(actions.logEvent(pointer, newPointer, decoding));
+    yield put(actions.logEvent(pointer, newPointer, decoding, rawInfo));
   } else if (yield select(txlog.current.onFunctionDefinition)) {
     if (yield select(txlog.current.waitingForFunctionDefinition)) {
       debug("identifying");

--- a/packages/debugger/lib/txlog/selectors/index.js
+++ b/packages/debugger/lib/txlog/selectors/index.js
@@ -261,19 +261,6 @@ let txlog = createSelectorTree({
      */
     rawEventInfo: {
       /**
-       * txlog.current.rawEventInfo.address
-       */
-      address: createLeaf([evm.current.call], call => call.storageAddress),
-
-      /**
-       * txlog.current.rawEventInfo.codeAddress
-       */
-      codeAddress: createLeaf(
-        [evm.current.call],
-        call => call.address || call.storageAddress
-      ),
-
-      /**
        * txlog.current.rawEventInfo.topics
        */
       topics: createLeaf([evm.current.step.logTopics], identity),

--- a/packages/debugger/lib/txlog/selectors/index.js
+++ b/packages/debugger/lib/txlog/selectors/index.js
@@ -257,6 +257,34 @@ let txlog = createSelectorTree({
     isLog: createLeaf([evm.current.step.isLog], identity),
 
     /**
+     * txlog.current.rawEventInfo
+     */
+    rawEventInfo: {
+      /**
+       * txlog.current.rawEventInfo.address
+       */
+      address: createLeaf([evm.current.call], call => call.storageAddress),
+
+      /**
+       * txlog.current.rawEventInfo.codeAddress
+       */
+      codeAddress: createLeaf(
+        [evm.current.call],
+        call => call.address || call.storageAddress
+      ),
+
+      /**
+       * txlog.current.rawEventInfo.topics
+       */
+      topics: createLeaf([evm.current.step.logTopics], identity),
+
+      /**
+       * txlog.current.rawEventInfo.data
+       */
+      data: createLeaf([evm.current.step.logData], identity)
+    },
+
+    /**
      * txlog.current.isCall
      */
     isCall: createLeaf([evm.current.step.isCall], identity),

--- a/packages/debugger/test/txlog.js
+++ b/packages/debugger/test/txlog.js
@@ -529,7 +529,7 @@ describe("Transaction log (visualizer)", function () {
       //let's check the first event
       let event = call.actions[0];
       assert.equal(event.type, "event");
-      let decoding = event.decoding;
+      let { decoding, raw } = event;
       assert.equal(decoding.kind, "event");
       assert.equal(decoding.decodingMode, "full");
       assert.equal(decoding.class.typeName, "VizTest");
@@ -547,10 +547,20 @@ describe("Transaction log (visualizer)", function () {
         byName(decoding.arguments)
       );
       assert.deepEqual(args, { x: 1, y: 2 });
+      assert.equal(raw.address, instance.address);
+      assert.equal(raw.codeAddress, instance.address);
+      assert.deepEqual(raw.topics, [
+        Codec.AbiData.Utils.abiSelector(decoding.abi),
+        "0x0000000000000000000000000000000000000000000000000000000000000001"
+      ]);
+      assert.equal(
+        raw.data,
+        "0x0000000000000000000000000000000000000000000000000000000000000002"
+      );
       //now for the second event
       event = call.actions[1];
       assert.equal(event.type, "event");
-      decoding = event.decoding;
+      ({ decoding, raw } = event);
       assert.equal(decoding.kind, "event");
       assert.equal(decoding.decodingMode, "full");
       assert.equal(decoding.class.typeName, "VizTest");
@@ -558,6 +568,12 @@ describe("Transaction log (visualizer)", function () {
       assert.equal(decoding.abi.name, "Bloop");
       assert.lengthOf(decoding.abi.inputs, 0);
       assert.lengthOf(decoding.arguments, 0);
+      assert.equal(raw.address, instance.address);
+      assert.equal(raw.codeAddress, instance.address);
+      assert.deepEqual(raw.topics, [
+        Codec.AbiData.Utils.abiSelector(decoding.abi)
+      ]);
+      assert.equal(raw.data, "0x");
     });
 
     it("Correctly logs an event inside a constructor", async function () {
@@ -588,7 +604,7 @@ describe("Transaction log (visualizer)", function () {
       assert.lengthOf(call.actions, 2); //call to another, then log of Set
       const event = call.actions[1];
       assert.equal(event.type, "event");
-      const decoding = event.decoding;
+      const { decoding, raw } = event;
       assert.equal(decoding.kind, "event");
       assert.equal(decoding.decodingMode, "full");
       assert.equal(decoding.class.typeName, "Secondary");
@@ -603,6 +619,15 @@ describe("Transaction log (visualizer)", function () {
         Codec.Export.unsafeNativize(decoding.arguments[0].value),
         683
       );
+      assert.equal(raw.address, instance.address);
+      assert.equal(raw.codeAddress, instance.address);
+      assert.deepEqual(raw.topics, [
+        Codec.AbiData.Utils.abiSelector(decoding.abi)
+      ]);
+      assert.equal(
+        raw.data,
+        "0x00000000000000000000000000000000000000000000000000000000000002ab"
+      ); //683 in hex
     });
 
     it("Correctly logs an event inside a library", async function () {
@@ -644,7 +669,7 @@ describe("Transaction log (visualizer)", function () {
       assert.lengthOf(libCall.actions, 1);
       const event = libCall.actions[0];
       assert.equal(event.type, "event");
-      const decoding = event.decoding;
+      const { decoding, raw } = event;
       assert.equal(decoding.kind, "event");
       assert.equal(decoding.decodingMode, "full");
       assert.equal(decoding.class.typeName, "VizLibrary");
@@ -652,6 +677,12 @@ describe("Transaction log (visualizer)", function () {
       assert.equal(decoding.abi.name, "Noise");
       assert.lengthOf(decoding.abi.inputs, 0);
       assert.lengthOf(decoding.arguments, 0);
+      assert.equal(raw.address, instance.address);
+      assert.equal(raw.codeAddress, library.address);
+      assert.deepEqual(raw.topics, [
+        Codec.AbiData.Utils.abiSelector(decoding.abi)
+      ]);
+      assert.equal(raw.data, "0x");
     });
 
     it("Correctly disambiguates ambiguous events", async function () {

--- a/packages/debugger/test/txlog.js
+++ b/packages/debugger/test/txlog.js
@@ -547,8 +547,6 @@ describe("Transaction log (visualizer)", function () {
         byName(decoding.arguments)
       );
       assert.deepEqual(args, { x: 1, y: 2 });
-      assert.equal(raw.address, instance.address);
-      assert.equal(raw.codeAddress, instance.address);
       assert.deepEqual(raw.topics, [
         Codec.AbiData.Utils.abiSelector(decoding.abi),
         "0x0000000000000000000000000000000000000000000000000000000000000001"
@@ -568,8 +566,6 @@ describe("Transaction log (visualizer)", function () {
       assert.equal(decoding.abi.name, "Bloop");
       assert.lengthOf(decoding.abi.inputs, 0);
       assert.lengthOf(decoding.arguments, 0);
-      assert.equal(raw.address, instance.address);
-      assert.equal(raw.codeAddress, instance.address);
       assert.deepEqual(raw.topics, [
         Codec.AbiData.Utils.abiSelector(decoding.abi)
       ]);
@@ -619,8 +615,6 @@ describe("Transaction log (visualizer)", function () {
         Codec.Export.unsafeNativize(decoding.arguments[0].value),
         683
       );
-      assert.equal(raw.address, instance.address);
-      assert.equal(raw.codeAddress, instance.address);
       assert.deepEqual(raw.topics, [
         Codec.AbiData.Utils.abiSelector(decoding.abi)
       ]);
@@ -677,8 +671,6 @@ describe("Transaction log (visualizer)", function () {
       assert.equal(decoding.abi.name, "Noise");
       assert.lengthOf(decoding.abi.inputs, 0);
       assert.lengthOf(decoding.arguments, 0);
-      assert.equal(raw.address, instance.address);
-      assert.equal(raw.codeAddress, library.address);
       assert.deepEqual(raw.topics, [
         Codec.AbiData.Utils.abiSelector(decoding.abi)
       ]);


### PR DESCRIPTION
This one is pretty straightforward. It adds a `raw` field to `event` actions in the txlog, so there will be info even if decoding failed.  The `raw` field has four subfields: `address`, `codeAddress`, `topics`, and `data`.  The `topics` and `data` fields are what you expect.  The `address` is the address that officially omitted the event, and `codeAddress` is the address of the *code* that emitted the event.  These can be different if the event was emitted from a delegatecall (e.g. a library), as officially it's the caller of the library that emits the event, but I thought it was good to include the `codeAddress` as well to tell you what contract's *code* emitted the event.

Note that if an event is emitted from a constructor, both `address` and `codeAddress` will be equal to the address that the contract was being created at (barring some cases where we can't determine it, in which case they'll show as zero instead, sorry -- although this will only ever happen for reverted events).

I also expanded the existing tests to test this new functionality.

(Actually, wait, thought, now that I've done this -- should `address` and `codeAddress` be dropped?  They're derivable from the rest of the txlog, which seems to go against how txlog works in general; it generally doesn't include derivable info like that.  Like if you think about the original purpose of `txlog` as a visualization tool, this address info wouldn't be used, because it would already be implicit from the diagram.  Should I remove those?)