### PR TITLE
Implement encoder/decoder-based `truffle call` command

### DIFF
--- a/packages/core/lib/commands/call/index.js
+++ b/packages/core/lib/commands/call/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  run: require("./run"),
+  meta: require("./meta")
+};

--- a/packages/core/lib/commands/call/meta.js
+++ b/packages/core/lib/commands/call/meta.js
@@ -21,7 +21,7 @@ module.exports = {
   },
   help: {
     usage:
-      "truffle call [<contract-address>] <contract-name> <function-name>|<function-signature>\n" +
+      "truffle call <contract-address>|<contract-name> <function-name>|<function-signature>\n" +
       "                             " + // spacing to align with previous line
       "[<args...>] [--fetch-external|-x] [--network <network>|--url <provider_url>]\n" +
       "                             " + // spacing to align with previous line
@@ -36,10 +36,11 @@ module.exports = {
         description:
           "The address of the contract to be called.\n" +
           "                    Mandatory if --fetch-external is passed."
-      },  
+      },
       {
         option: "<function-signature>",
-        description: "The function signature inside the specified contract to be called."
+        description:
+          "The function signature inside the specified contract to be called."
       },
       {
         option: "<args...>",

--- a/packages/core/lib/commands/call/meta.js
+++ b/packages/core/lib/commands/call/meta.js
@@ -7,30 +7,43 @@ module.exports = {
       type: "string"
     },
     "fetch-external": {
-      describe: "Allow debugging of external contracts",
+      describe: "Allow calling functions of external contracts",
       alias: "x",
       type: "boolean",
       default: false
+    },
+    "block-number": {
+      describe: "Allows calling functions of a contract from a specific block",
+      alias: "b",
+      type: "string",
+      default: "latest"
     }
   },
   help: {
     usage:
-      "truffle call [<contract-name>] [<function-name>] [<args...>]\n" +
+      "truffle call <contract-name>|<contract-address> <function-name>|<function-signature>\n" +
       "                             " + // spacing to align with previous line
-      "[--fetch-external|-x] [--network <network>|--url <provider_url>]\n" +
-      "                             ",
+      "[<args...>] [--fetch-external|-x] [--network <network>|--url <provider_url>]\n" +
+      "                             " + // spacing to align with previous line
+      "[--block-number|-b <block_number>]",
     options: [
       {
         option: "<contract-name>",
-        description: "The specified contract"
+        description: "The specified contract to be called."
+      },
+      {
+        option: "<contract-address>",
+        description:
+          "The address of the contract to be called.\n" +
+          "                    Mandatory if --fetch-external is passed."
       },
       {
         option: "<function-name>",
-        description: "The function inside the specified contract to be called"
+        description: "The function inside the specified contract to be called."
       },
       {
         option: "<args...>",
-        description: "List of arguments of the function to be called"
+        description: "List of arguments of the function to be called."
       },
       {
         option: "--fetch-external|-x",
@@ -47,6 +60,10 @@ module.exports = {
         option: "--network",
         description:
           "The network to connect to, as specified in the Truffle config."
+      },
+      {
+        option: "--block-number|-b",
+        description: "The block number from which the contract is to be called."
       }
     ],
     allowedGlobalOptions: ["from", "config"]

--- a/packages/core/lib/commands/call/meta.js
+++ b/packages/core/lib/commands/call/meta.js
@@ -33,9 +33,7 @@ module.exports = {
       },
       {
         option: "<contract-address>",
-        description:
-          "The address of the contract to be called.\n" +
-          "                    Mandatory if --fetch-external is passed."
+        description: "The address of the contract to be called.\n"
       },
       {
         option: "<function-name>",

--- a/packages/core/lib/commands/call/meta.js
+++ b/packages/core/lib/commands/call/meta.js
@@ -1,15 +1,54 @@
 module.exports = {
   command: "call",
   description: "Call read-only contract function with arguments",
-  builder: {},
+  builder: {
+    "url": {
+      describe: "Use specified URL for provider",
+      type: "string"
+    },
+    "fetch-external": {
+      describe: "Allow debugging of external contracts",
+      alias: "x",
+      type: "boolean",
+      default: false
+    }
+  },
   help: {
     usage:
-      "truffle call <contract-name> <function-name> [<function-args...>] [--network=<network-name>",
-    usage:
-      "truffle call <contract-name> <function-name> [<args...>]\n" +
-      "                                " + // spacing to align with previous line
-      "[--network=<network-name>] [--from=<account>]",
-    options: [],
-    allowedGlobalOptions: ["from", "network", "config"]
+      "truffle call [<contract-name>] [<function-name>] [<args...>]\n" +
+      "                             " + // spacing to align with previous line
+      "[--fetch-external|-x] [--network <network>|--url <provider_url>]\n" +
+      "                             ",
+    options: [
+      {
+        option: "<contract-name>",
+        description: "The specified contract"
+      },
+      {
+        option: "<function-name>",
+        description: "The function inside the specified contract to be called"
+      },
+      {
+        option: "<args...>",
+        description: "List of arguments of the function to be called"
+      },
+      {
+        option: "--fetch-external|-x",
+        description:
+          "Allows calling functions of external contracts with verified sources."
+      },
+      {
+        option: "--url",
+        description:
+          "Creates a provider using the given url and connects to the network.\n" +
+          "                    This can be used outside of a Truffle project."
+      },
+      {
+        option: "--network",
+        description:
+          "The network to connect to, as specified in the Truffle config."
+      }
+    ],
+    allowedGlobalOptions: ["from", "config"]
   }
 };

--- a/packages/core/lib/commands/call/meta.js
+++ b/packages/core/lib/commands/call/meta.js
@@ -21,7 +21,7 @@ module.exports = {
   },
   help: {
     usage:
-      "truffle call <contract-name>|<contract-address> <function-name>|<function-signature>\n" +
+      "truffle call [<contract-address>] <contract-name> <function-name>|<function-signature>\n" +
       "                             " + // spacing to align with previous line
       "[<args...>] [--fetch-external|-x] [--network <network>|--url <provider_url>]\n" +
       "                             " + // spacing to align with previous line
@@ -36,10 +36,10 @@ module.exports = {
         description:
           "The address of the contract to be called.\n" +
           "                    Mandatory if --fetch-external is passed."
-      },
+      },  
       {
-        option: "<function-name>",
-        description: "The function inside the specified contract to be called."
+        option: "<function-signature>",
+        description: "The function signature inside the specified contract to be called."
       },
       {
         option: "<args...>",

--- a/packages/core/lib/commands/call/meta.js
+++ b/packages/core/lib/commands/call/meta.js
@@ -1,0 +1,15 @@
+module.exports = {
+  command: "call",
+  description: "Call read-only contract function with arguments",
+  builder: {},
+  help: {
+    usage:
+      "truffle call <contract-name> <function-name> [<function-args...>] [--network=<network-name>",
+    usage:
+      "truffle call <contract-name> <function-name> [<args...>]\n" +
+      "                                " + // spacing to align with previous line
+      "[--network=<network-name>] [--from=<account>]",
+    options: [],
+    allowedGlobalOptions: ["from", "network", "config"]
+  }
+};

--- a/packages/core/lib/commands/call/meta.js
+++ b/packages/core/lib/commands/call/meta.js
@@ -38,6 +38,11 @@ module.exports = {
           "                    Mandatory if --fetch-external is passed."
       },
       {
+        option: "<function-name>",
+        description:
+          "The function name inside the specified contract to be called."
+      },
+      {
         option: "<function-signature>",
         description:
           "The function signature inside the specified contract to be called."

--- a/packages/core/lib/commands/call/run.js
+++ b/packages/core/lib/commands/call/run.js
@@ -3,14 +3,14 @@ module.exports = async function (options) {
   const util = require("util");
   const { Environment } = require("@truffle/environment");
   const OS = require("os");
+  //const Web3 = require("web3");
   const Codec = require("@truffle/codec");
   const Encoder = require("@truffle/encoder");
   const Decoder = require("@truffle/decoder");
   const TruffleError = require("@truffle/error");
   const { fetchAndCompile } = require("@truffle/fetch-and-compile");
+  //const reason = require("@truffle/contract/lib/reason");
   const loadConfig = require("../../loadConfig");
-
-  let settings;
 
   if (options.url && options.network) {
     const message =
@@ -27,70 +27,20 @@ module.exports = async function (options) {
   let config = loadConfig(options);
   await Environment.detect(config);
 
-  const [contractNameOrAddress, functionName, ...args] = config._;
-  let encoder, decoder, functionEntry, transaction;
+  const [contractNameOrAddress, functionNameOrSignature, ...args] = config._;
+  let functionEntry, transaction;
 
-  if (config.fetchExternal) {
-    const { compileResult } = await fetchAndCompile(
-      contractNameOrAddress,
-      config
-    );
-
-    const projectInfo = {
-      commonCompilations: compileResult.compilations
-    };
-    const projectEncoder = await Encoder.forProject({
-      provider: config.provider,
-      projectInfo
-    });
-    encoder = await projectEncoder.forAddress(contractNameOrAddress);
-
-    const projectDecoder = await Decoder.forProject({
-      provider: config.provider,
-      projectInfo
-    });
-
-    decoder = await projectDecoder.forAddress(contractNameOrAddress);
-  } else {
-    const contractNames = fs
-      .readdirSync(config.contracts_build_directory)
-      .filter(filename => filename.endsWith(".json"))
-      .map(filename => filename.slice(0, -".json".length));
-
-    const contracts = contractNames
-      .map(contractName => ({
-        [contractName]: config.resolver.require(contractName)
-      }))
-      .reduce((a, b) => ({ ...a, ...b }), {});
-
-    const isEmpty = Object.keys(contracts).length === 0;
-    if (isEmpty) {
-      throw new Error(
-        "No artifacts found! Please run `truffle compile` to compile your contracts"
-      );
-    } else {
-      settings = {
-        provider: config.provider,
-        projectInfo: {
-          artifacts: Object.values(contracts)
-        }
-      };
-    }
-
-    const contract = contracts[contractNameOrAddress];
-    // Error handling to remind users to run truffle migrate first
-    const instance = await contract.deployed();
-    encoder = await Encoder.forContractInstance(instance, settings);
-    decoder = await Decoder.forContractInstance(instance, settings);
-  }
+  const { encoder, decoder } = config.fetchExternal
+    ? await sourceFromExternal(contractNameOrAddress, config)
+    : await sourceFromLocal(contractNameOrAddress, config);
 
   ({ abi: functionEntry, tx: transaction } = await encoder.encodeTransaction(
-    functionName,
+    functionNameOrSignature,
     args
   ));
 
   if (functionEntry.stateMutability !== "view") {
-    console.log("WARNING!!! The function called is not read-only");
+    console.error("WARNING!!! The function called is not read-only");
   }
 
   // wrap provider for lazy EIP-1193 compatibility
@@ -113,8 +63,9 @@ module.exports = async function (options) {
   // Error handling for 0 returned value
   // Handles cases for more than 1 returned values
   const [decoding] = await decoder.decodeReturnValue(functionEntry, result);
+  //console.log("Decoding Result: ", decoding);
 
-  // Use ResultInspector instead of ReturndataDecodingInspector
+  // Use ReturndataDecodingInspector for logging
   config.logger.log(
     util.inspect(new Codec.Export.ReturndataDecodingInspector(decoding), {
       colors: true,
@@ -123,4 +74,67 @@ module.exports = async function (options) {
       breakLength: 79
     })
   );
+
+  // Alternative for ReturndataDecodingInspector, use ResultInspector for logging
+  for (const { value: result } of decoding.arguments) {
+    console.log(new Codec.Format.Utils.Inspect.ResultInspector(result), result);
+  }
+
+  async function sourceFromLocal(contractNameOrAddress, config) {
+    const contractNames = fs
+      .readdirSync(config.contracts_build_directory)
+      .filter(filename => filename.endsWith(".json"))
+      .map(filename => filename.slice(0, -".json".length));
+
+    const contracts = contractNames
+      .map(contractName => ({
+        [contractName]: config.resolver.require(contractName)
+      }))
+      .reduce((a, b) => ({ ...a, ...b }), {});
+
+    const isEmpty = Object.keys(contracts).length === 0;
+    if (isEmpty) {
+      throw new Error(
+        "No artifacts found! Please run `truffle compile` to compile your contracts"
+      );
+    }
+    const settings = {
+      provider: config.provider,
+      projectInfo: {
+        artifacts: Object.values(contracts)
+      }
+    };
+
+    const contract = contracts[contractNameOrAddress];
+    // Error handling to remind users to run truffle migrate first
+    const instance = await contract.deployed();
+    encoder = await Encoder.forContractInstance(instance, settings);
+    decoder = await Decoder.forContractInstance(instance, settings);
+    return { encoder, decoder };
+  }
+
+  async function sourceFromExternal(contractNameOrAddress, config) {
+    const { compileResult } = await fetchAndCompile(
+      contractNameOrAddress,
+      config
+    );
+
+    const projectInfo = {
+      commonCompilations: compileResult.compilations
+    };
+
+    const projectEncoder = await Encoder.forProject({
+      provider: config.provider,
+      projectInfo
+    });
+    const encoder = await projectEncoder.forAddress(contractNameOrAddress);
+
+    const projectDecoder = await Decoder.forProject({
+      provider: config.provider,
+      projectInfo
+    });
+
+    const decoder = await projectDecoder.forAddress(contractNameOrAddress);
+    return { encoder, decoder };
+  }
 };

--- a/packages/core/lib/commands/call/run.js
+++ b/packages/core/lib/commands/call/run.js
@@ -44,32 +44,40 @@ module.exports = async function (options) {
   // wrap provider for lazy EIP-1193 compatibility
   // replace the legacy provider API with EIP-1193?
   const provider = new Encoder.ProviderAdapter(config.provider);
-  const result = await provider.request({
-    method: "eth_call",
-    params: [
-      {
-        from: options.from,
-        to: transaction.to,
-        data: transaction.data
-      },
-      config.blockNumber
-    ]
-  });
+  let result;
+  try {
+    result = await provider.request({
+      method: "eth_call",
+      params: [
+        {
+          from: config.from,
+          to: transaction.to,
+          data: transaction.data
+        },
+        config.blockNumber
+      ]
+    });
+    console.log("Result: ", result);
+  } catch (error) {
+    console.log("Error: ", error.message);
+  }
 
   // Error handling for 0 returned value
   // Handles cases for more than 1 returned values
-  const [decoding] = await decoder.decodeReturnValue(functionEntry, result);
+  if (result) {
+    const [decoding] = await decoder.decodeReturnValue(functionEntry, result);
 
-  // Alternative for ReturndataDecodingInspector, use ResultInspector for logging
-  for (const { value: result } of decoding.arguments) {
-    console.log(
-      util.inspect(new Codec.Export.ResultInspector(result), {
-        colors: true,
-        depth: null,
-        maxArrayLength: null,
-        breakLength: 79
-      })
-    );
+    // Alternative for ReturndataDecodingInspector, use ResultInspector for logging
+    for (const { value: result } of decoding.arguments) {
+      console.log(
+        util.inspect(new Codec.Export.ResultInspector(result), {
+          colors: true,
+          depth: null,
+          maxArrayLength: null,
+          breakLength: 79
+        })
+      );
+    }
   }
 
   async function sourceFromLocal(contractNameOrAddress, config) {

--- a/packages/core/lib/commands/call/run.js
+++ b/packages/core/lib/commands/call/run.js
@@ -3,13 +3,11 @@ module.exports = async function (options) {
   const util = require("util");
   const { Environment } = require("@truffle/environment");
   const OS = require("os");
-  //const Web3 = require("web3");
   const Codec = require("@truffle/codec");
   const Encoder = require("@truffle/encoder");
   const Decoder = require("@truffle/decoder");
   const TruffleError = require("@truffle/error");
   const { fetchAndCompile } = require("@truffle/fetch-and-compile");
-  //const reason = require("@truffle/contract/lib/reason");
   const loadConfig = require("../../loadConfig");
 
   if (options.url && options.network) {
@@ -40,13 +38,12 @@ module.exports = async function (options) {
   ));
 
   if (functionEntry.stateMutability !== "view") {
-    console.error("WARNING!!! The function called is not read-only");
+    console.log("WARNING!!! The function called is not read-only");
   }
 
   // wrap provider for lazy EIP-1193 compatibility
   // replace the legacy provider API with EIP-1193?
   const provider = new Encoder.ProviderAdapter(config.provider);
-
   const result = await provider.request({
     method: "eth_call",
     params: [
@@ -57,23 +54,11 @@ module.exports = async function (options) {
       },
       config.blockNumber
     ]
-    //fields we don't allow overriding: to, data
   });
 
   // Error handling for 0 returned value
   // Handles cases for more than 1 returned values
   const [decoding] = await decoder.decodeReturnValue(functionEntry, result);
-  //console.log("Decoding Result: ", decoding);
-
-  // Use ReturndataDecodingInspector for logging
-  config.logger.log(
-    util.inspect(new Codec.Export.ReturndataDecodingInspector(decoding), {
-      colors: true,
-      depth: null,
-      maxArrayLength: null,
-      breakLength: 79
-    })
-  );
 
   // Alternative for ReturndataDecodingInspector, use ResultInspector for logging
   for (const { value: result } of decoding.arguments) {
@@ -159,13 +144,19 @@ module.exports = async function (options) {
       provider: config.provider,
       projectInfo
     });
-    const encoder = await projectEncoder.forAddress(contractNameOrAddress);
+    const encoder = await projectEncoder.forAddress(
+      contractNameOrAddress,
+      config.blockNumber
+    );
 
     const projectDecoder = await Decoder.forProject({
       provider: config.provider,
       projectInfo
     });
-    const decoder = await projectDecoder.forAddress(contractNameOrAddress);
+    const decoder = await projectDecoder.forAddress(
+      contractNameOrAddress,
+      config.blockNumber
+    );
 
     return { encoder, decoder };
   }

--- a/packages/core/lib/commands/call/run.js
+++ b/packages/core/lib/commands/call/run.js
@@ -77,7 +77,14 @@ module.exports = async function (options) {
 
   // Alternative for ReturndataDecodingInspector, use ResultInspector for logging
   for (const { value: result } of decoding.arguments) {
-    console.log(new Codec.Format.Utils.Inspect.ResultInspector(result), result);
+    console.log(
+      util.inspect(new Codec.Export.ResultInspector(result), {
+        colors: true,
+        depth: null,
+        maxArrayLength: null,
+        breakLength: 79
+      })
+    );
   }
 
   async function sourceFromLocal(contractNameOrAddress, config) {
@@ -95,7 +102,7 @@ module.exports = async function (options) {
     const isEmpty = Object.keys(contracts).length === 0;
     if (isEmpty) {
       throw new Error(
-        "No artifacts found! Please run `truffle compile` to compile your contracts"
+        "No artifacts found! Please run `truffle compile` first to compile your contracts"
       );
     }
     const settings = {
@@ -108,8 +115,8 @@ module.exports = async function (options) {
     const contract = contracts[contractNameOrAddress];
     // Error handling to remind users to run truffle migrate first
     const instance = await contract.deployed();
-    encoder = await Encoder.forContractInstance(instance, settings);
-    decoder = await Decoder.forContractInstance(instance, settings);
+    const encoder = await Encoder.forContractInstance(instance, settings);
+    const decoder = await Decoder.forContractInstance(instance, settings);
     return { encoder, decoder };
   }
 

--- a/packages/core/lib/commands/call/run.js
+++ b/packages/core/lib/commands/call/run.js
@@ -1,0 +1,61 @@
+module.exports = async function (options) {
+  const fs = require("fs");
+  const util = require("util");
+  const Config = require("@truffle/config");
+  const { Environment } = require("@truffle/environment");
+
+  const Codec = require("@truffle/codec");
+  const Encoder = require("@truffle/encoder");
+  const Decoder = require("@truffle/decoder");
+
+  const config = Config.detect(options);
+  await Environment.detect(config);
+
+  const [contractName, functionName, ...args] = config._;
+
+  const contractNames = fs
+    .readdirSync(config.contracts_build_directory)
+    .filter(filename => filename.endsWith(".json"))
+    .map(filename => filename.slice(0, -".json".length));
+  const contracts = contractNames
+    .map(contractName => ({
+      [contractName]: config.resolver.require(contractName)
+    }))
+    .reduce((a, b) => ({ ...a, ...b }), {});
+
+  const settings = {
+    provider: config.provider,
+    projectInfo: {
+      artifacts: Object.values(contracts)
+    }
+  };
+
+  const contract = contracts[contractName];
+  const instance = await contract.deployed();
+
+  const encoder = await Encoder.forContractInstance(instance, settings);
+
+  const { abi: functionEntry, tx: transaction } =
+    await encoder.encodeTransaction(functionName, args);
+
+  // wrap provider for lazy EIP-1193 compatibility
+  const provider = new Encoder.ProviderAdapter(config.provider);
+
+  const result = await provider.request({
+    method: "eth_call",
+    params: [transaction]
+  });
+
+  const decoder = await Decoder.forContractInstance(instance, settings);
+
+  const [decoding] = await decoder.decodeReturnValue(functionEntry, result);
+
+  config.logger.log(
+    util.inspect(new Codec.Export.ReturndataDecodingInspector(decoding), {
+      colors: true,
+      depth: null,
+      maxArrayLength: null,
+      breakLength: 79
+    })
+  );
+};

--- a/packages/core/lib/commands/commands.js
+++ b/packages/core/lib/commands/commands.js
@@ -1,6 +1,7 @@
 // The list of commands that Truffle supports
 module.exports = [
   "build",
+  "call",
   "compile",
   "config",
   "console",

--- a/packages/core/lib/commands/index.js
+++ b/packages/core/lib/commands/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   build: require("./build"),
+  call: require("./call"),
   compile: require("./compile"),
   config: require("./config"),
   console: require("./console"),

--- a/packages/encoder/lib/adapter.ts
+++ b/packages/encoder/lib/adapter.ts
@@ -147,7 +147,27 @@ export class ProviderAdapter {
     }
     let result;
     if (isEip1193Provider(this.provider)) {
-      result = await this.provider.request({ method, params });
+      result = await this.provider.request({
+        method,
+        params
+      });
+      /*result = await new Promise((accept, reject) => {
+        if (isEip1193Provider(this.provider)) {
+          this.provider.request({
+            method,
+            params
+          }), 
+          ((error: Error, response: JsonRPCResponse) => {
+            if (error) {
+              return reject(error);
+            }
+            if (response.error) {
+              return reject(response.error);
+            }
+            return accept(response);
+          }) as Callback<JsonRPCResponse>
+        }
+      });*/
     } else {
       // HACK MetaMask's injected provider doesn't allow `.send()` with
       // a callback, so prefer `.sendAsync()` if it's defined
@@ -169,10 +189,18 @@ export class ProviderAdapter {
             params
           },
           ((error: Error, response: JsonRPCResponse) => {
-            if (error) {
+            /*if (error) {
               return reject(error);
             }
 
+            const { result: res } = response;
+            accept(res);*/
+            if (error) {
+              return reject(error);
+            }
+            if (response.error) {
+              return reject(response.error);
+            }
             const { result: res } = response;
             accept(res);
           }) as Callback<JsonRPCResponse>

--- a/packages/encoder/lib/adapter.ts
+++ b/packages/encoder/lib/adapter.ts
@@ -137,7 +137,7 @@ export class ProviderAdapter {
     this.provider = provider;
   }
 
-  private async sendRequest({
+  public async request({
     method,
     params,
     formatOutput
@@ -188,7 +188,7 @@ export class ProviderAdapter {
     block: BlockSpecifier //making this one not regularized to support encoder
   ): Promise<string> {
     const blockToFetch = formatBlockSpecifier(block);
-    return await this.sendRequest({
+    return await this.request({
       method: "eth_getCode",
       params: [address, blockToFetch]
     });
@@ -198,7 +198,7 @@ export class ProviderAdapter {
     block: BlockSpecifier
   ): Promise<FormattedBlock> {
     const blockToFetch = formatBlockSpecifier(block);
-    return await this.sendRequest({
+    return await this.request({
       method: "eth_getBlockByNumber",
       params: [blockToFetch, false],
       formatOutput: formatBlock
@@ -210,14 +210,14 @@ export class ProviderAdapter {
     fromBlock,
     toBlock
   }: PastLogsOptions): Promise<Log[]> {
-    return await this.sendRequest({
+    return await this.request({
       method: "eth_getLogs",
       params: [{ fromBlock, toBlock, address }]
     });
   }
 
   public async getNetworkId(): Promise<number> {
-    return await this.sendRequest({
+    return await this.request({
       method: "net_version",
       params: [],
       formatOutput: result => parseInt(result)
@@ -225,7 +225,7 @@ export class ProviderAdapter {
   }
 
   public async getBlockNumber(): Promise<number> {
-    return await this.sendRequest({
+    return await this.request({
       method: "eth_blockNumber",
       params: [],
       formatOutput: result => parseInt(result)
@@ -236,7 +236,7 @@ export class ProviderAdapter {
     address: string,
     block: BlockSpecifier
   ): Promise<string> {
-    return await this.sendRequest({
+    return await this.request({
       method: "eth_getBalance",
       params: [address, formatBlockSpecifier(block)],
       formatOutput: result => parseInt(result).toString()
@@ -247,7 +247,7 @@ export class ProviderAdapter {
     address: string,
     block: BlockSpecifier
   ): Promise<string> {
-    return await this.sendRequest({
+    return await this.request({
       method: "eth_getTransactionCount",
       params: [address, formatBlockSpecifier(block)],
       formatOutput: result => parseInt(result).toString()
@@ -259,7 +259,7 @@ export class ProviderAdapter {
     position: BN,
     block: BlockSpecifier
   ): Promise<string> {
-    return await this.sendRequest({
+    return await this.request({
       method: "eth_getStorageAt",
       params: [
         address,


### PR DESCRIPTION
This draft PR adds a `truffle call` command leveraging Truffle's encoding and decoding functionality (including overload resolution :)
<img width="762" alt="Screen Shot 2022-07-19 at 9 12 26 PM" src="https://user-images.githubusercontent.com/151065/179877141-cdbf485d-a5f1-48e2-bad3-65e0818e10b9.png">

