### PR TITLE
Internal improvement: Remove hardcoded path to `webpack` in packages/truffle

### DIFF
--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "analyze": "./scripts/analyze.sh",
     "build": "yarn build:cli",
-    "build:cli": "node --max-old-space-size=8192 ./node_modules/webpack/bin/webpack.js --config ./webpack.config.js",
+    "build:cli": "NODE_OPTIONS=\"--max-old-space-size=8192\" webpack --config ./webpack.config.js",
     "postinstall": "node ./scripts/postinstall.js",
     "prepare": "yarn build",
     "publish:byoc": "node ./scripts/prereleaseVersion.js byoc-safe byoc",


### PR DESCRIPTION
Currently the truffle package is built with this command:

`node --max-old-space-size=8192 ./node_modules/webpack/bin/webpack.js --config ./webpack.config.js`

But wait! When lerna realizes that another package in the monorepo has `webpack` as a dependency, that relative path to `webpack.js` won't work, because the dependecy would be moved one level up to the root `node_modules` directory.

Naturally we want this instead:

`webpack --config ./webpack.config.js`

Of course we still want the build process to have enough memory, so:

`NODE_OPTIONS="--max-old-space-size=8192" webpack --config ./webpack.config.js`

That's what this PR changes the build command to!

\* Long branch name to reflect the frustrating way I found out about this issue