### PR TITLE
Run `lerna bootstrap` via yarn exec instead of npx

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "bootstrap": "npx lerna bootstrap",
+    "bootstrap": "yarn exec lerna bootstrap",
     "prepare": "lerna run prepare --stream --concurrency=1 && husky install",
     "publish-release": "./scripts/publish-release.sh",
     "publish-dist-tag": "./scripts/publish-dist-tag.sh",


### PR DESCRIPTION
# What this does

This change, albeit small, fixes a weird issue that causes `yarn bootstrap` to hang in my local dev environment.

# Why the hang occurs

During #5222, I opted to use a package called `npm-run-all` to avoid the `&&` operator in defining the build script command for `@truffle/require`. I did this because windows shells don't understand the `&&` operator, and I didn't want to introduce a change that would break the Windows build.

So instead of writing `"build": "yarn build:compile && yarn build:copyfiles`, I did `"build": "run-s build:compile build:copyfiles"`. These two script definitions are functionally identical in that the `run-s` command just executes the specified `package.json` scripts sequentially.

That worked great all through dev and test, but now that I've merged latest develop into my branch, I've found that running `yarn bootstrap` **locally** has a weird behavior. When it runs `yarn prepare` on `@truffle/require`, instead of executing the scripts sequentially, a file watch starts with the following output, causing the build to hang.

```
@truffle/require: Watching /Users/bburns/projects/truffle/packages/require and all sub-directories not excluded by your .gitignore. Will not monitor dotfiles.
@truffle/require: Found & ignored ./dist ; is listed in .gitignore
@truffle/require: Found & ignored ./node_modules ; is listed in .gitignore
@truffle/require: Starting: build:compile
@truffle/require: node:internal/modules/cjs/loader:936
@truffle/require:   throw err;
@truffle/require:   ^
@truffle/require: Error: Cannot find module '/Users/bburns/projects/truffle/packages/require/build:compile'
@truffle/require:     at Function.Module._resolveFilename (node:internal/modules/cjs/loader:933:15)
@truffle/require:     at Function.Module._load (node:internal/modules/cjs/loader:778:27)
@truffle/require:     at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:77:12)
@truffle/require:     at node:internal/main/run_main_module:17:47 {
@truffle/require:   code: 'MODULE_NOT_FOUND',
@truffle/require:   requireStack: []
@truffle/require: }
```

Strangely, if I `cd` into the `packages/require` directory and run `yarn prepare` it works fine. The code builds as expected and doesn't hang. Stranger still, if I run the same `lerna` command that is run by the top-level prepare script (`lerna run prepare --stream --concurrency=1`) from the root of the repo, that _also_ behaves normally.

Looking at how we execute that command, I see that we've done `npx lerna run prepare --stream --concurrency=1`. If I change that to `yarn exec lerna run prepare --stream --concurrency=1`, or remove the `npx` it works.

By looking at the process tree I think I figured out what's going on.

This is happening because `npm-run-all` has support for both yarn and npm, and to determine which executor it's using it checks the parent-level process name. In our case the parent process is `npx`, which is an alias for `npm exec`, so I wind up with the following process tree:

```
npm exec lerna run --scope @truffle/require --stream --concurrency=1 prepare
└─ node /Users/bburns/projects/truffle/node_modules/.bin/lerna run --scope @truffle/require --stream --concurrency=1 prepare
   └─ node /Users/bburns/.nvm/versions/node/v16.16.0/bin/yarn run prepare
      └─ /Users/bburns/.nvm/versions/node/v16.16.0/bin/node /Users/bburns/.nvm/versions/node/v16.16.0/bin/yarn build
         └─ /Users/bburns/.nvm/versions/node/v16.16.0/bin/node /Users/bburns/projects/truffle/packages/require/node_modules/.bin/run-s build:compile build:copyfiles
            └─ npm exec run build:compile
               └─ /Users/bburns/.nvm/versions/node/v16.16.0/bin/node /Users/bburns/.npm/_npx/755986f37193a6d8/node_modules/.bin/runjs build:compile
```

Note that the second to last process in that tree is `npm exec run build:compile`. I _think_ this is happening because `npm-run-all` is doing something equivalant to (pseudocode):

```javascript
const topLevelCommand = getTopLevelProcessName(); // returns "npx" rather than "npm" or "yarn"
for (const script of scriptsToRun) {
  exec(`${topLevelCommand} run ${script}`) // runs e.g. `npx run build:compile`
}
```

So `npx run build:compile` translates to `npm exec run build:compile`, which causes `npx` to go and fetch the `runjs` package, [which has a `bin` file called `run.js`](https://github.com/pawelgalazka/tasksfile/blob/v4.4.2/bin/run.js), and for whatever reason in my local environment that command is switching over into watch mode.

I have no idea why this happens locally, but doesn't happen in CI. Regardless, this fixes the problem, and makes our build script execution consistently use `yarn` instead of a mix of `yarn` and `npm`.