### PR TITLE
Internal improvement: Set quoteProps to 'consistent' in prettierrc

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,6 @@
 {
   "arrowParens": "avoid",
   "trailingComma": "none",
-  "bracketSpacing": true
+  "bracketSpacing": true,
+  "quoteProps": "consistent"
 }


### PR DESCRIPTION
So, right now we don't have anything set for `quoteProps` in our `.prettierrc.json`.  That means it *should* default to `"as-needed"`, but for some reason instead it keeps going back and forth on this.  I don't know what's up with that, but it's annoying how it keeps introducing unrelated changes in PRs.  So I figured the best thing to do was give it an explicit value and hope that stops the problem.

I set it to `"consistent"` rather than `"as-needed"`, though, because, well, I prefer it that way.  (Docs are [here](https://prettier.io/docs/en/options.html#quote-props), if you want to know the difference.)  If people would prefer it be `"as-needed"`, though, it can be that way too!  I guess arguably it ought to be @gnidan's call but well he's not here so whatever. :P