### PR TITLE
Internal improvements: Custom jest resolver for db

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -130,6 +130,7 @@
       "<rootDir>/test/**/test/index.(ts|js)",
       "<rootDir>/src/**/test/*\\.(spec|test)\\.(ts|js)",
       "<rootDir>/test/**/test/*\\.(spec|test)\\.(ts|js)"
-    ]
+    ],
+    "resolver": "<rootDir>/test/jest-resolver.js"
   }
 }

--- a/packages/db/test/jest-resolver.js
+++ b/packages/db/test/jest-resolver.js
@@ -1,0 +1,13 @@
+module.exports = (path, options) => {
+  return options.defaultResolver(path, {
+    ...options,
+    packageFilter: pkg => {
+      // See: https://github.com/microsoft/accessibility-insights-web/pull/5421#issuecomment-1109168149
+      if (pkg.name === "uuid") {
+        delete pkg.exports;
+        delete pkg.module;
+      }
+      return pkg;
+    }
+  });
+};


### PR DESCRIPTION
I'm not too sure why this isn't happening on develop, but take a look at [this failed ci run](https://github.com/trufflesuite/truffle/runs/7512994995).

We recently upgraded to jest 28, and it's trying to use an esm version of uuid (a pouchdb dep), things break because of that. So I added a custom jest resolver that forces jest to use the cjs version of uuid.

Others have run into this, here are some related resources:
- [Comment on microsoft/accessibility-insights-web pull#5421](https://github.com/microsoft/accessibility-insights-web/pull/5421#issuecomment-1109168149)
- [Jest's upgrade guide from 27 to 28 calls out uuid](https://jestjs.io/docs/upgrading-to-jest28#packagejson-exports)
