### PR TITLE
Bug fix: Ensure deployment error events always return the message

### DIFF
--- a/packages/deployer/test/errors.js
+++ b/packages/deployer/test/errors.js
@@ -75,7 +75,8 @@ describe("Error cases", function () {
           provider
         }
       },
-      network: "test"
+      network: "test",
+      quiet: true //want to test that errors still work when quiet turned on
     });
     await Environment.detect(options);
     deployer = new Deployer(options);

--- a/packages/events/defaultSubscribers/migrate/index.js
+++ b/packages/events/defaultSubscribers/migrate/index.js
@@ -75,18 +75,20 @@ module.exports = {
 
     "deployment:error": [
       async function (data) {
-        if (this.config.quiet) return;
         const message = await this.reporter.error(data);
-        this.logger.error(message);
-        return message;
+        if (!this.config.quiet) {
+          this.logger.error(message);
+        }
+        return message; //we want to return the message no matter what for use in errors
       }
     ],
     "deployment:failed": [
       async function (data) {
-        if (this.config.quiet) return;
         const message = await this.reporter.deployFailed(data);
-        this.logger.log(message);
-        return message;
+        if (!this.config.quiet) {
+          this.logger.log(message);
+        }
+        return message; //we want to return the message no matter what for use in errors
       }
     ],
     "deployment:start": [


### PR DESCRIPTION
Addresses #5297.

If `quiet` is set, then errors during deployment will have no message.  This PR fixes this by having the relevant events *return* the message regardless of the `quiet` setting, just only *print* it when `quiet` is false.  (I thought about using shorter messages when `quiet` is turned on, as the full messages can be kind of long sometimes, but this seemed simpler.)