### PR TITLE
Use latest node types, remove unused typeRoots

### DIFF
--- a/packages/artifactor/package.json
+++ b/packages/artifactor/package.json
@@ -30,7 +30,7 @@
     "@truffle/contract": "^4.5.18",
     "@types/fs-extra": "^8.1.0",
     "@types/lodash": "^4.14.179",
-    "@types/node": "12.12.21",
+    "@types/node": "^18.6.1",
     "chai": "^4.2.0",
     "debug": "^4.3.1",
     "ganache": "7.3.2",

--- a/packages/artifactor/tsconfig.json
+++ b/packages/artifactor/tsconfig.json
@@ -19,12 +19,7 @@
       ]
     },
     "rootDir": ".",
-    "typeRoots": [
-      "./typings",
-      "../../**/node_modules/@types/mocha",
-      "../../**/node_modules/@types/fs-extra",
-      "../../**/node_modules/@types/node"
-    ]
+    "types": ["node", "mocha"]
   },
   "include": [
     "./**/*.ts",

--- a/packages/blockchain-utils/package.json
+++ b/packages/blockchain-utils/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/assert": "^1.4.2",
     "@types/mocha": "^5.2.7",
-    "@types/node": "12.12.21",
+    "@types/node": "^18.6.1",
     "@types/web3": "^1.0.20",
     "mocha": "9.2.2",
     "ts-node": "10.7.0",

--- a/packages/blockchain-utils/tsconfig.json
+++ b/packages/blockchain-utils/tsconfig.json
@@ -17,8 +17,10 @@
       ]
     },
     "rootDir": ".",
+    "types": ["node", "mocha"],
     "typeRoots": [
       "./typings",
+      "../../node_modules/@types/node",
       "../../node_modules/@types/mocha",
       "../../node_modules/@types/assert"
     ]

--- a/packages/code-utils/package.json
+++ b/packages/code-utils/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@types/cbor": "^5.0.1",
     "@types/mocha": "^5.2.7",
-    "@types/node": "12.12.21",
+    "@types/node": "^18.6.1",
     "mocha": "9.2.2",
     "ts-node": "10.7.0",
     "typescript": "^4.1.4"

--- a/packages/code-utils/tsconfig.json
+++ b/packages/code-utils/tsconfig.json
@@ -17,12 +17,7 @@
       ]
     },
     "rootDir": ".",
-    "typeRoots": [
-      "./typings",
-      "node_modules/@types",
-      "../../node_modules/@types/mocha",
-      "../../node_modules/@types/node"
-    ]
+    "types": ["node", "mocha"]
   },
   "include": [
     "./src/**/*.ts",

--- a/packages/codec/tsconfig.json
+++ b/packages/codec/tsconfig.json
@@ -28,12 +28,7 @@
       }
     ],
     "rootDir": ".",
-    "typeRoots": [
-      "./typings",
-      "../../**/node_modules/@types/bn.js",
-      "../../**/node_modules/@types/debug",
-      "../../**/node_modules/@types/lodash"
-    ]
+    "types": ["node"]
   },
   "include": [
     "./lib/**/*.ts",

--- a/packages/compile-common/package.json
+++ b/packages/compile-common/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@truffle/contract-schema": "^3.4.8",
     "@types/mocha": "^5.2.7",
-    "@types/node": "12.12.21",
+    "@types/node": "^18.6.1",
     "mocha": "9.2.2",
     "ts-node": "10.7.0",
     "typescript": "^4.1.4"

--- a/packages/compile-solidity/tsconfig.json
+++ b/packages/compile-solidity/tsconfig.json
@@ -21,10 +21,7 @@
     },
     "rootDir": "src",
     "baseUrl": ".",
-    "typeRoots": ["../../node_modules/@types/node"],
-    "types": [
-      "mocha"
-    ],
+    "types": [ "mocha" ],
     "plugins": [
       { "transform": "typescript-transform-paths" },
       { "transform": "typescript-transform-paths", "afterDeclarations": true }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -24,7 +24,7 @@
     "@truffle/error": "^0.1.0",
     "@truffle/events": "^0.1.10",
     "@truffle/provider": "^0.2.58-typescript-migrations.0",
-    "conf": "^10.0.2",
+    "conf": "^10.1.2",
     "find-up": "^2.1.0",
     "lodash": "^4.17.21",
     "original-require": "^1.0.1"
@@ -33,7 +33,7 @@
     "@types/configstore": "^4.0.0",
     "@types/find-up": "^2.1.0",
     "@types/lodash": "^4.14.179",
-    "@types/node": "12.12.21",
+    "@types/node": "^18.6.1",
     "@types/sinon": "^9.0.10",
     "mocha": "9.2.2",
     "sinon": "^9.0.2",

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -12,6 +12,7 @@
     "baseUrl": ".",
     "lib": ["es2019", "dom"],
     "rootDir": "./src",
+    "types": ["node", "mocha"],
     "typeRoots": [
       "./typings",
       "node_modules/@types/node",

--- a/packages/dashboard-message-bus-client/package.json
+++ b/packages/dashboard-message-bus-client/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@types/debug": "^4.1.5",
-    "@types/node": "^16.11.6",
+    "@types/node": "^18.6.1",
     "typescript": "^4.1.4"
   }
 }

--- a/packages/dashboard-message-bus-common/package.json
+++ b/packages/dashboard-message-bus-common/package.json
@@ -29,7 +29,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@types/node": "^12.0.0",
+    "@types/node": "^18.6.1",
     "typescript": "^4.1.4"
   }
 }

--- a/packages/dashboard-message-bus-e2e-test/package.json
+++ b/packages/dashboard-message-bus-e2e-test/package.json
@@ -30,7 +30,7 @@
     "@truffle/dashboard-message-bus-common": "^0.1.2",
     "@types/debug": "^4.1.5",
     "@types/jest": "^27.0.3",
-    "@types/node": "^16.11.6",
+    "@types/node": "^18.6.1",
     "@types/web3": "^1.2.2",
     "ethers": "^5.6.2",
     "jest": "28.1.3",

--- a/packages/dashboard-message-bus/package.json
+++ b/packages/dashboard-message-bus/package.json
@@ -26,7 +26,7 @@
   },
   "types": "dist/lib/index.d.ts",
   "devDependencies": {
-    "@types/node": "^12.0.0",
+    "@types/node": "^18.6.1",
     "@types/promise.any": "^2.0.0",
     "@types/web3": "^1.2.2",
     "typescript": "^4.1.4"

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -54,7 +54,7 @@
     "@types/ethereum-protocol": "^1.0.2",
     "@types/express": "^4.17.13",
     "@types/jest": "27.4.1",
-    "@types/node": "^12.0.0",
+    "@types/node": "^18.6.1",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
     "@types/ws": "^7.2.0",

--- a/packages/db-kit/package.json
+++ b/packages/db-kit/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@types/jest": "27.4.1",
-    "@types/node": "12.12.21",
+    "@types/node": "^18.6.1",
     "@types/react": "^16.8.0",
     "@types/web3": "^1.0.20",
     "eslint-plugin-react-hooks": "^4.3.0",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -67,7 +67,7 @@
     "@types/express": "^4.16.0",
     "@types/graphql": "^14.5.0",
     "@types/jest": "27.4.1",
-    "@types/node": "12.12.21",
+    "@types/node": "^18.6.1",
     "@types/pluralize": "^0.0.29",
     "@types/pouchdb": "^6.4.0",
     "@types/pouchdb-adapter-leveldb": "^6.1.3",

--- a/packages/decoder/tsconfig.json
+++ b/packages/decoder/tsconfig.json
@@ -18,17 +18,7 @@
         "../../node_modules/@types/web3/index"
       ]
     },
-    "typeRoots": [
-      "./typings",
-      "../../**/node_modules/@types/bn.js",
-      "../../**/node_modules/@types/debug",
-      "../../**/node_modules/@types/lodash",
-      "../../**/node_modules/@types/lodash.clonedeep",
-      "../../**/node_modules/@types/lodash.isequal",
-      "../../**/node_modules/@types/lodash.merge",
-      "../../**/node_modules/@types/web3"
-    ]
-
+    "types": ["node", "mocha"]
   },
   "include": [
     "./lib/**/*.ts",

--- a/packages/encoder/package.json
+++ b/packages/encoder/package.json
@@ -52,7 +52,7 @@
     "@types/debug": "^4.1.5",
     "@types/jest": "27.4.1",
     "@types/lodash": "^4.14.179",
-    "@types/node": "12.12.21",
+    "@types/node": "^18.6.1",
     "@types/utf8": "^2.1.6",
     "@types/web3": "^1.0.20",
     "chai": "^4.2.0",

--- a/packages/error/tsconfig.json
+++ b/packages/error/tsconfig.json
@@ -8,7 +8,6 @@
     "rootDir": "./",
     "strict": true,
     "esModuleInterop": true,
-    "typeRoots": [
-    ]
+    "types": ["node"]
   }
 }

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -28,7 +28,7 @@
   },
   "types": "dist/src/index.d.ts",
   "devDependencies": {
-    "@types/node": "12.12.21",
+    "@types/node": "^18.6.1",
     "mocha": "9.2.2",
     "tsd": "^0.15.1",
     "ttypescript": "1.5.13",

--- a/packages/fetch-and-compile/package.json
+++ b/packages/fetch-and-compile/package.json
@@ -40,7 +40,7 @@
     "@types/chai": "^4.2.22",
     "@types/debug": "^4.1.7",
     "@types/mocha": "^9.0.0",
-    "@types/node": "^16.11.6",
+    "@types/node": "^18.6.1",
     "@types/semver": "^7.3.9",
     "chai": "^4.2.0",
     "mocha": "9.2.2",

--- a/packages/fetch-and-compile/tsconfig.json
+++ b/packages/fetch-and-compile/tsconfig.json
@@ -16,10 +16,6 @@
     "paths": {
     },
     "rootDir": "lib",
-    "typeRoots": [
-      "./typings",
-      "../../**/node_modules/@types/debug"
-    ],
     "types": ["node"]
   },
   "include": [

--- a/packages/hdwallet-provider/tsconfig.json
+++ b/packages/hdwallet-provider/tsconfig.json
@@ -12,11 +12,6 @@
     ],
     "outDir": "dist",
     "baseUrl": ".",
-    "typeRoots": [
-      "../../node_modules/@types/mocha",
-      "../../node_modules/@types/node",
-      "../../node_modules/@types/web3-provider-engine",
-    ],
     "types": [ "node", "mocha" ]
   },
   "include": [

--- a/packages/interface-adapter/tsconfig.json
+++ b/packages/interface-adapter/tsconfig.json
@@ -11,10 +11,7 @@
     "baseUrl": ".",
     "lib": ["es2019"],
     "rootDir": "lib",
-    "typeRoots": [
-      "../../node_modules/@types/bn.js",
-      "../../node_modules/@types/mocha"
-    ]
+    "types": ["node", "mocha"]
   },
   "include": [
     "./lib/**/*.ts"

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@types/jest": "27.4.1",
-    "@types/node": "^14.0.13",
+    "@types/node": "^18.6.1",
     "jest": "28.1.3",
     "ts-jest": "28.0.6",
     "typescript": "^4.1.4"

--- a/packages/profiler/package.json
+++ b/packages/profiler/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@truffle/config": "^1.3.33",
-    "@types/node": "12.12.21",
+    "@types/node": "^18.6.1",
     "ts-node": "10.7.0",
     "typescript": "^4.1.4"
   },

--- a/packages/promise-tracker/package.json
+++ b/packages/promise-tracker/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@types/jest": "^27.0.3",
-    "@types/node": "^16.11.6",
+    "@types/node": "^18.6.1",
     "delay": "^5.0.0",
     "jest": "28.1.3",
     "ts-jest": "28.0.6",

--- a/packages/provisioner/tsconfig.json
+++ b/packages/provisioner/tsconfig.json
@@ -8,7 +8,6 @@
       "rootDir": "./",
       "strict": true,
       "esModuleInterop": true,
-      "typeRoots": [
-      ]
+      "types": ["node"]
     }
   }

--- a/packages/require/package.json
+++ b/packages/require/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^9.0.0",
-    "@types/node": "^18.0.0",
+    "@types/node": "^18.6.1",
     "copyfiles": "^2.4.1",
     "mocha": "9.2.2",
     "npm-run-all": "^4.1.5",

--- a/packages/resolver/package.json
+++ b/packages/resolver/package.json
@@ -41,7 +41,7 @@
     "web3-utils": "1.7.4"
   },
   "devDependencies": {
-    "@types/node": "12.12.21",
+    "@types/node": "^18.6.1",
     "@types/sinon": "^9.0.10",
     "mocha": "9.2.2",
     "sinon": "^9.0.2",

--- a/packages/resolver/tsconfig.json
+++ b/packages/resolver/tsconfig.json
@@ -13,10 +13,7 @@
     "paths": {
     },
     "rootDir": ".",
-    "typeRoots": [
-      "../../node_modules/@types/mocha",
-      "../../node_modules/@types/node"
-    ]
+    "types": ["node", "mocha"]
   },
   "include": [
     "./lib/**/*.ts",

--- a/packages/source-fetcher/package.json
+++ b/packages/source-fetcher/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@types/async-retry": "^1.4.3",
     "@types/debug": "^4.1.5",
-    "@types/node": "^15.0.1",
+    "@types/node": "^18.6.1",
     "typescript": "^4.1.4"
   },
   "keywords": [

--- a/packages/spinners/package.json
+++ b/packages/spinners/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^9.0.0",
-    "@types/node": "^16.11.6",
+    "@types/node": "^18.6.1",
     "@types/semver": "^7.3.9",
     "mocha": "9.2.2",
     "ts-node": "10.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6610,7 +6610,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@12.12.21":
+"@types/node@*":
   version "12.12.21"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.21.tgz#aa44a6363291c7037111c47e4661ad210aded23f"
   integrity sha512-8sRGhbpU+ck1n0PGAUgVrWrWdjSW2aqNeyC15W88GRsMpSwzv6RJGlLhE7s2RhVSOdyDmxbqlWSeThq4/7xqlA==
@@ -6630,35 +6630,15 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.11.tgz#46ba035fb917b31c948280dbea22ab8838f386a4"
   integrity sha512-dNd2pp8qTzzNLAs3O8nH3iU9DG9866KHq9L3ISPB7DOGERZN81nW/5/g/KzMJpCU8jrbCiMRBzV9/sCEdRosig==
 
-"@types/node@^12.0.0":
-  version "12.20.45"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.45.tgz#f4980d177999299d99cd4b290f7f39366509a44f"
-  integrity sha512-1Jg2Qv5tuxBqgQV04+wO5u+wmSHbHgpORCJdeCLM+E+YdPElpdHhgywU+M1V1InL8rfOtpqtOjswk+uXTKwx7w==
-
 "@types/node@^12.12.6":
   version "12.12.67"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.67.tgz#4f86badb292e822e3b13730a1f9713ed2377f789"
   integrity sha512-R48tgL2izApf+9rYNH+3RBMbRpPeW3N8f0I9HMhggeq4UXwBDqumJ14SDs4ctTMhG11pIOduZ4z3QWGOiMc9Vg==
 
-"@types/node@^14.0.13":
-  version "14.14.14"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.14.tgz#f7fd5f3cc8521301119f63910f0fb965c7d761ae"
-  integrity sha512-UHnOPWVWV1z+VV8k6L1HhG7UbGBgIdghqF3l9Ny9ApPghbjICXkUJSd/b9gOgQfjM1r+37cipdw/HJ3F6ICEnQ==
-
-"@types/node@^15.0.1":
-  version "15.14.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.14.1.tgz#4f9d3689532499fdda1c898e19f4593718655e36"
-  integrity sha512-wF6hazbsnwaW3GhK4jFuw5NaLDQVRQ6pWQUGAUrJzxixFkTaODSiAKMPXuHwPEPkAKQWHAzj6uJ5h+3zU9gQxg==
-
-"@types/node@^16.11.6":
-  version "16.11.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.7.tgz#36820945061326978c42a01e56b61cd223dfdc42"
-  integrity sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw==
-
-"@types/node@^18.0.0":
-  version "18.0.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.0.0.tgz#67c7b724e1bcdd7a8821ce0d5ee184d3b4dd525a"
-  integrity sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==
+"@types/node@^18.6.1":
+  version "18.6.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.6.1.tgz#828e4785ccca13f44e2fb6852ae0ef11e3e20ba5"
+  integrity sha512-z+2vB6yDt1fNwKOeGbckpmirO+VBDuQqecXkgeIqDlaOtmKn6hPR/viQ8cxCfqLU4fTlvM3+YjM367TukWdxpg==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -8059,7 +8039,7 @@ ajv-errors@^1.0.0:
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
   integrity sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==
 
-ajv-formats@^2.0.2:
+ajv-formats@^2.0.2, ajv-formats@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.1.tgz#6e669400659eb74973bbf2e33327180a0996b520"
   integrity sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==
@@ -8110,6 +8090,16 @@ ajv@^8.0.1:
   version "8.10.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.10.0.tgz#e573f719bd3af069017e3b66538ab968d040e54d"
   integrity sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
+ajv@^8.6.3:
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
+  integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
@@ -11262,6 +11252,22 @@ conf@^10.0.2:
   dependencies:
     ajv "^8.1.0"
     ajv-formats "^2.0.2"
+    atomically "^1.7.0"
+    debounce-fn "^4.0.0"
+    dot-prop "^6.0.1"
+    env-paths "^2.2.1"
+    json-schema-typed "^7.0.3"
+    onetime "^5.1.2"
+    pkg-up "^3.1.0"
+    semver "^7.3.5"
+
+conf@^10.1.2:
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/conf/-/conf-10.1.2.tgz#50132158f388756fa9dea3048f6b47935315c14e"
+  integrity sha512-o9Fv1Mv+6A0JpoayQ8JleNp3hhkbOJP/Re/Q+QqxMPHPkABVsRjQGWZn9A5GcqLiTNC6d89p2PB5ZhHVDSMwyg==
+  dependencies:
+    ajv "^8.6.3"
+    ajv-formats "^2.1.1"
     atomically "^1.7.0"
     debounce-fn "^4.0.0"
     dot-prop "^6.0.1"


### PR DESCRIPTION
Also bumps the `conf` version to `v10.1.2` in `@truffle/config` for compatibility with latest node types.