### PR TITLE
Bump typescript to 4.7.2 and @types/node to 18.6.1

### DIFF
--- a/packages/abi-utils/package.json
+++ b/packages/abi-utils/package.json
@@ -39,7 +39,7 @@
     "jest-json-schema": "^2.1.0",
     "ts-jest": "28.0.6",
     "ts-node": "10.7.0",
-    "typescript": "^4.1.4"
+    "typescript": "^4.7.4"
   },
   "keywords": [
     "abi",

--- a/packages/artifactor/package.json
+++ b/packages/artifactor/package.json
@@ -30,7 +30,7 @@
     "@truffle/contract": "^4.5.18",
     "@types/fs-extra": "^8.1.0",
     "@types/lodash": "^4.14.179",
-    "@types/node": "12.12.21",
+    "@types/node": "^18.6.1",
     "chai": "^4.2.0",
     "debug": "^4.3.1",
     "ganache": "7.3.2",

--- a/packages/artifactor/package.json
+++ b/packages/artifactor/package.json
@@ -39,7 +39,7 @@
     "sinon": "^9.0.2",
     "tmp": "^0.2.1",
     "ts-node": "10.7.0",
-    "typescript": "^4.1.4",
+    "typescript": "^4.7.4",
     "web3": "1.7.4"
   },
   "publishConfig": {

--- a/packages/artifactor/tsconfig.json
+++ b/packages/artifactor/tsconfig.json
@@ -19,12 +19,7 @@
       ]
     },
     "rootDir": ".",
-    "typeRoots": [
-      "./typings",
-      "../../**/node_modules/@types/mocha",
-      "../../**/node_modules/@types/fs-extra",
-      "../../**/node_modules/@types/node"
-    ]
+    "types": ["node", "mocha"]
   },
   "include": [
     "./**/*.ts",

--- a/packages/blockchain-utils/package.json
+++ b/packages/blockchain-utils/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/assert": "^1.4.2",
     "@types/mocha": "^5.2.7",
-    "@types/node": "12.12.21",
+    "@types/node": "^18.6.1",
     "@types/web3": "^1.0.20",
     "mocha": "9.2.2",
     "ts-node": "10.7.0",

--- a/packages/blockchain-utils/package.json
+++ b/packages/blockchain-utils/package.json
@@ -27,7 +27,7 @@
     "@types/web3": "^1.0.20",
     "mocha": "9.2.2",
     "ts-node": "10.7.0",
-    "typescript": "^4.1.4"
+    "typescript": "^4.7.4"
   },
   "keywords": [
     "blockchain",

--- a/packages/blockchain-utils/tsconfig.json
+++ b/packages/blockchain-utils/tsconfig.json
@@ -17,8 +17,10 @@
       ]
     },
     "rootDir": ".",
+    "types": ["node", "mocha"],
     "typeRoots": [
       "./typings",
+      "../../node_modules/@types/node",
       "../../node_modules/@types/mocha",
       "../../node_modules/@types/assert"
     ]

--- a/packages/box/package.json
+++ b/packages/box/package.json
@@ -38,7 +38,7 @@
     "mocha": "9.2.2",
     "sinon": "^9.0.2",
     "ts-node": "10.7.0",
-    "typescript": "^4.1.4"
+    "typescript": "^4.7.4"
   },
   "keywords": [
     "boilerplate",

--- a/packages/code-utils/package.json
+++ b/packages/code-utils/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@types/cbor": "^5.0.1",
     "@types/mocha": "^5.2.7",
-    "@types/node": "12.12.21",
+    "@types/node": "^18.6.1",
     "mocha": "9.2.2",
     "ts-node": "10.7.0",
     "typescript": "^4.1.4"

--- a/packages/code-utils/package.json
+++ b/packages/code-utils/package.json
@@ -29,7 +29,7 @@
     "@types/node": "^18.6.1",
     "mocha": "9.2.2",
     "ts-node": "10.7.0",
-    "typescript": "^4.1.4"
+    "typescript": "^4.7.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/code-utils/tsconfig.json
+++ b/packages/code-utils/tsconfig.json
@@ -17,12 +17,7 @@
       ]
     },
     "rootDir": ".",
-    "typeRoots": [
-      "./typings",
-      "node_modules/@types",
-      "../../node_modules/@types/mocha",
-      "../../node_modules/@types/node"
-    ]
+    "types": ["node", "mocha"]
   },
   "include": [
     "./src/**/*.ts",

--- a/packages/codec/package.json
+++ b/packages/codec/package.json
@@ -46,11 +46,11 @@
     "@types/lodash": "^4.14.179",
     "@types/semver": "^6.0.0",
     "@types/utf8": "^2.1.6",
-    "@zerollup/ts-transform-paths": "^1.7.3",
+    "typescript-transform-paths": "3.3.1",
     "ttypescript": "1.5.13",
-    "typedoc": "0.20.37",
+    "typedoc": "0.22.18",
     "typedoc-plugin-remove-references": "^0.0.5",
-    "typescript": "^4.1.4"
+    "typescript": "^4.7.4"
   },
   "keywords": [
     "abi",

--- a/packages/codec/tsconfig.json
+++ b/packages/codec/tsconfig.json
@@ -22,10 +22,8 @@
       ]
     },
     "plugins": [
-      {
-        "transform": "@zerollup/ts-transform-paths",
-        "exclude": "*"
-      }
+      { "transform": "typescript-transform-paths" },
+      { "transform": "typescript-transform-paths", "afterDeclarations": true }
     ],
     "rootDir": ".",
     "types": ["node"]

--- a/packages/codec/tsconfig.json
+++ b/packages/codec/tsconfig.json
@@ -28,12 +28,7 @@
       }
     ],
     "rootDir": ".",
-    "typeRoots": [
-      "./typings",
-      "../../**/node_modules/@types/bn.js",
-      "../../**/node_modules/@types/debug",
-      "../../**/node_modules/@types/lodash"
-    ]
+    "types": ["node"]
   },
   "include": [
     "./lib/**/*.ts",

--- a/packages/compile-common/package.json
+++ b/packages/compile-common/package.json
@@ -30,7 +30,7 @@
     "@types/node": "^18.6.1",
     "mocha": "9.2.2",
     "ts-node": "10.7.0",
-    "typescript": "^4.1.4"
+    "typescript": "^4.7.4"
   },
   "gitHead": "6b84be7849142588ef2e3224d8a9d7c2ceeb6e4a"
 }

--- a/packages/compile-common/package.json
+++ b/packages/compile-common/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@truffle/contract-schema": "^3.4.8",
     "@types/mocha": "^5.2.7",
-    "@types/node": "12.12.21",
+    "@types/node": "^18.6.1",
     "mocha": "9.2.2",
     "ts-node": "10.7.0",
     "typescript": "^4.1.4"

--- a/packages/compile-solidity/package.json
+++ b/packages/compile-solidity/package.json
@@ -50,7 +50,7 @@
     "sinon": "^9.0.2",
     "tmp": "^0.2.1",
     "ttypescript": "1.5.13",
-    "typescript": "^4.3.5",
+    "typescript": "^4.7.4",
     "typescript-transform-paths": "3.3.1"
   },
   "keywords": [

--- a/packages/compile-solidity/tsconfig.json
+++ b/packages/compile-solidity/tsconfig.json
@@ -21,10 +21,7 @@
     },
     "rootDir": "src",
     "baseUrl": ".",
-    "typeRoots": ["../../node_modules/@types/node"],
-    "types": [
-      "mocha"
-    ],
+    "types": [ "mocha" ],
     "plugins": [
       { "transform": "typescript-transform-paths" },
       { "transform": "typescript-transform-paths", "afterDeclarations": true }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -24,7 +24,7 @@
     "@truffle/error": "^0.1.0",
     "@truffle/events": "^0.1.10",
     "@truffle/provider": "^0.2.58-typescript-migrations.0",
-    "conf": "^10.0.2",
+    "conf": "^10.1.2",
     "find-up": "^2.1.0",
     "lodash": "^4.17.21",
     "original-require": "^1.0.1"
@@ -33,7 +33,7 @@
     "@types/configstore": "^4.0.0",
     "@types/find-up": "^2.1.0",
     "@types/lodash": "^4.14.179",
-    "@types/node": "12.12.21",
+    "@types/node": "^18.6.1",
     "@types/sinon": "^9.0.10",
     "mocha": "9.2.2",
     "sinon": "^9.0.2",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -38,7 +38,7 @@
     "mocha": "9.2.2",
     "sinon": "^9.0.2",
     "ts-node": "10.7.0",
-    "typescript": "^4.1.4"
+    "typescript": "^4.7.4"
   },
   "keywords": [
     "config",

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -12,6 +12,7 @@
     "baseUrl": ".",
     "lib": ["es2019", "dom"],
     "rootDir": "./src",
+    "types": ["node", "mocha"],
     "typeRoots": [
       "./typings",
       "node_modules/@types/node",

--- a/packages/dashboard-message-bus-client/package.json
+++ b/packages/dashboard-message-bus-client/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@types/debug": "^4.1.5",
-    "@types/node": "^16.11.6",
+    "@types/node": "^18.6.1",
     "typescript": "^4.1.4"
   }
 }

--- a/packages/dashboard-message-bus-client/package.json
+++ b/packages/dashboard-message-bus-client/package.json
@@ -49,6 +49,6 @@
   "devDependencies": {
     "@types/debug": "^4.1.5",
     "@types/node": "^18.6.1",
-    "typescript": "^4.1.4"
+    "typescript": "^4.7.4"
   }
 }

--- a/packages/dashboard-message-bus-common/package.json
+++ b/packages/dashboard-message-bus-common/package.json
@@ -30,6 +30,6 @@
   },
   "devDependencies": {
     "@types/node": "^18.6.1",
-    "typescript": "^4.1.4"
+    "typescript": "^4.7.4"
   }
 }

--- a/packages/dashboard-message-bus-common/package.json
+++ b/packages/dashboard-message-bus-common/package.json
@@ -29,7 +29,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@types/node": "^12.0.0",
+    "@types/node": "^18.6.1",
     "typescript": "^4.1.4"
   }
 }

--- a/packages/dashboard-message-bus-e2e-test/package.json
+++ b/packages/dashboard-message-bus-e2e-test/package.json
@@ -30,7 +30,7 @@
     "@truffle/dashboard-message-bus-common": "^0.1.2",
     "@types/debug": "^4.1.5",
     "@types/jest": "^27.0.3",
-    "@types/node": "^16.11.6",
+    "@types/node": "^18.6.1",
     "@types/web3": "^1.2.2",
     "ethers": "^5.6.2",
     "jest": "28.1.3",

--- a/packages/dashboard-message-bus/package.json
+++ b/packages/dashboard-message-bus/package.json
@@ -29,7 +29,7 @@
     "@types/node": "^18.6.1",
     "@types/promise.any": "^2.0.0",
     "@types/web3": "^1.2.2",
-    "typescript": "^4.1.4"
+    "typescript": "^4.7.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/dashboard-message-bus/package.json
+++ b/packages/dashboard-message-bus/package.json
@@ -26,7 +26,7 @@
   },
   "types": "dist/lib/index.d.ts",
   "devDependencies": {
-    "@types/node": "^12.0.0",
+    "@types/node": "^18.6.1",
     "@types/promise.any": "^2.0.0",
     "@types/web3": "^1.2.2",
     "typescript": "^4.1.4"

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -74,7 +74,7 @@
     "tailwindcss": "npm:@tailwindcss/postcss7-compat",
     "ts-jest": "28.0.6",
     "ts-node": "10.7.0",
-    "typescript": "^4.1.4",
+    "typescript": "^4.7.4",
     "wagmi": "^0.2.21"
   },
   "publishConfig": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -54,7 +54,7 @@
     "@types/ethereum-protocol": "^1.0.2",
     "@types/express": "^4.17.13",
     "@types/jest": "27.4.1",
-    "@types/node": "^12.0.0",
+    "@types/node": "^18.6.1",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
     "@types/ws": "^7.2.0",

--- a/packages/db-kit/package.json
+++ b/packages/db-kit/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@types/jest": "27.4.1",
-    "@types/node": "12.12.21",
+    "@types/node": "^18.6.1",
     "@types/react": "^16.8.0",
     "@types/web3": "^1.0.20",
     "eslint-plugin-react-hooks": "^4.3.0",

--- a/packages/db-kit/package.json
+++ b/packages/db-kit/package.json
@@ -66,8 +66,8 @@
     "ts-node": "10.7.0",
     "tsconfig-paths": "^3.9.0",
     "ttypescript": "1.5.13",
-    "typedoc": "0.20.37",
-    "typescript": "^4.1.4",
+    "typedoc": "0.22.18",
+    "typescript": "^4.7.4",
     "typescript-transform-paths": "3.3.1",
     "web3-core": "1.7.4"
   },

--- a/packages/db-loader/package.json
+++ b/packages/db-loader/package.json
@@ -34,6 +34,6 @@
     "@truffle/db": "^1.0.15"
   },
   "devDependencies": {
-    "typescript": "^4.1.4"
+    "typescript": "^4.7.4"
   }
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -84,9 +84,9 @@
     "ts-node-dev": "^1.0.0-pre.32",
     "tsconfig-paths": "^3.9.0",
     "ttypescript": "1.5.13",
-    "typedoc": "0.20.37",
+    "typedoc": "0.22.18",
     "typedoc-neo-theme": "^1.1.0",
-    "typescript": "^4.1.4",
+    "typescript": "^4.7.4",
     "typescript-transform-paths": "3.3.1",
     "web3": "1.7.4"
   },

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -67,7 +67,7 @@
     "@types/express": "^4.16.0",
     "@types/graphql": "^14.5.0",
     "@types/jest": "27.4.1",
-    "@types/node": "12.12.21",
+    "@types/node": "^18.6.1",
     "@types/pluralize": "^0.0.29",
     "@types/pouchdb": "^6.4.0",
     "@types/pouchdb-adapter-leveldb": "^6.1.3",

--- a/packages/db/src/meta/process/run.ts
+++ b/packages/db/src/meta/process/run.ts
@@ -25,39 +25,39 @@ export type ProcessorRunner<C extends Collections> = <
   ...args: A
 ) => Promise<T>;
 
-export const runForDefinitions = <C extends Collections>(
-  _definitions: Definitions<C> // this is only used for type inference
-) => (
-  db: Db<C>
-): {
-  forProvider(
-    provider: Provider
+export const runForDefinitions =
+  <C extends Collections>(
+    _definitions: Definitions<C> // this is only used for type inference
+  ) =>
+  (
+    db: Db<C>
   ): {
+    forProvider(provider: Provider): {
+      run: ProcessorRunner<C>;
+    };
     run: ProcessorRunner<C>;
-  };
-  run: ProcessorRunner<C>;
-} => {
-  const connections = {
-    db
-  };
+  } => {
+    const connections = {
+      db
+    };
 
-  return {
-    run(processor, ...args) {
-      return run(connections, processor, ...args);
-    },
+    return {
+      run(processor, ...args) {
+        return run(connections, processor, ...args);
+      },
 
-    forProvider(provider) {
-      const connections = {
-        db,
-        provider
-      };
+      forProvider(provider) {
+        const connections = {
+          db,
+          provider
+        };
 
-      return {
-        run: (processor, ...args) => run(connections, processor, ...args)
-      };
-    }
+        return {
+          run: (processor, ...args) => run(connections, processor, ...args)
+        };
+      }
+    };
   };
-};
 
 const run = async <
   C extends Collections,
@@ -107,7 +107,9 @@ const run = async <
         break;
       }
       default: {
-        throw new Error(`Unknown request type ${loadRequest.type}`);
+        throw new Error(
+          `Unknown request type ${(loadRequest as { type: any }).type}`
+        );
       }
     }
   }

--- a/packages/decoder/package.json
+++ b/packages/decoder/package.json
@@ -49,7 +49,7 @@
     "lodash": "^4.17.21",
     "mocha": "9.2.2",
     "tmp": "^0.2.1",
-    "typescript": "^4.1.4",
+    "typescript": "^4.7.4",
     "web3": "1.7.4"
   },
   "keywords": [

--- a/packages/decoder/tsconfig.json
+++ b/packages/decoder/tsconfig.json
@@ -18,17 +18,7 @@
         "../../node_modules/@types/web3/index"
       ]
     },
-    "typeRoots": [
-      "./typings",
-      "../../**/node_modules/@types/bn.js",
-      "../../**/node_modules/@types/debug",
-      "../../**/node_modules/@types/lodash",
-      "../../**/node_modules/@types/lodash.clonedeep",
-      "../../**/node_modules/@types/lodash.isequal",
-      "../../**/node_modules/@types/lodash.merge",
-      "../../**/node_modules/@types/web3"
-    ]
-
+    "types": ["node", "mocha"]
   },
   "include": [
     "./lib/**/*.ts",

--- a/packages/encoder/package.json
+++ b/packages/encoder/package.json
@@ -63,7 +63,7 @@
     "jest-fast-check": "2.0.0",
     "jest-transform-stealthy-require": "^1.0.0",
     "ts-jest": "28.0.6",
-    "typescript": "^4.1.4",
+    "typescript": "^4.7.4",
     "utf8": "^3.0.0",
     "web3": "1.7.4"
   },

--- a/packages/encoder/package.json
+++ b/packages/encoder/package.json
@@ -52,7 +52,7 @@
     "@types/debug": "^4.1.5",
     "@types/jest": "27.4.1",
     "@types/lodash": "^4.14.179",
-    "@types/node": "12.12.21",
+    "@types/node": "^18.6.1",
     "@types/utf8": "^2.1.6",
     "@types/web3": "^1.0.20",
     "chai": "^4.2.0",

--- a/packages/error/package.json
+++ b/packages/error/package.json
@@ -32,6 +32,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "typescript": "^4.1.4"
+    "typescript": "^4.7.4"
   }
 }

--- a/packages/error/tsconfig.json
+++ b/packages/error/tsconfig.json
@@ -8,7 +8,6 @@
     "rootDir": "./",
     "strict": true,
     "esModuleInterop": true,
-    "typeRoots": [
-    ]
+    "types": ["node"]
   }
 }

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -28,7 +28,7 @@
   },
   "types": "dist/src/index.d.ts",
   "devDependencies": {
-    "@types/node": "12.12.21",
+    "@types/node": "^18.6.1",
     "mocha": "9.2.2",
     "tsd": "^0.15.1",
     "ttypescript": "1.5.13",

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -32,7 +32,7 @@
     "mocha": "9.2.2",
     "tsd": "^0.15.1",
     "ttypescript": "1.5.13",
-    "typescript": "^4.1.4",
+    "typescript": "^4.7.4",
     "typescript-transform-paths": "3.3.1"
   },
   "keywords": [

--- a/packages/fetch-and-compile/package.json
+++ b/packages/fetch-and-compile/package.json
@@ -40,7 +40,7 @@
     "@types/chai": "^4.2.22",
     "@types/debug": "^4.1.7",
     "@types/mocha": "^9.0.0",
-    "@types/node": "^16.11.6",
+    "@types/node": "^18.6.1",
     "@types/semver": "^7.3.9",
     "chai": "^4.2.0",
     "mocha": "9.2.2",

--- a/packages/fetch-and-compile/package.json
+++ b/packages/fetch-and-compile/package.json
@@ -45,7 +45,7 @@
     "chai": "^4.2.0",
     "mocha": "9.2.2",
     "ts-node": "10.7.0",
-    "typescript": "^4.1.4"
+    "typescript": "^4.7.4"
   },
   "keywords": [
     "compile",

--- a/packages/fetch-and-compile/tsconfig.json
+++ b/packages/fetch-and-compile/tsconfig.json
@@ -16,10 +16,6 @@
     "paths": {
     },
     "rootDir": "lib",
-    "typeRoots": [
-      "./typings",
-      "../../**/node_modules/@types/debug"
-    ],
     "types": ["node"]
   },
   "include": [

--- a/packages/hdwallet-provider/package.json
+++ b/packages/hdwallet-provider/package.json
@@ -39,7 +39,7 @@
     "ganache": "7.3.2",
     "mocha": "9.2.2",
     "ts-node": "10.7.0",
-    "typescript": "^4.1.4",
+    "typescript": "^4.7.4",
     "web3": "1.7.4"
   },
   "keywords": [

--- a/packages/hdwallet-provider/test/provider.test.ts
+++ b/packages/hdwallet-provider/test/provider.test.ts
@@ -65,7 +65,7 @@ describe("HD Wallet Provider", function () {
           "http://localhost:8545"
         );
         assert.fail("Should throw on invalid mnemonic");
-      } catch (e) {
+      } catch (e: any) {
         assert(e.message.includes("Mnemonic invalid or undefined"));
       }
     });
@@ -314,7 +314,7 @@ describe("HD Wallet Provider", function () {
             provider: { junk: "in", an: "object" }
           });
           assert.fail("Should throw on invalid provider");
-        } catch (e) {
+        } catch (e: any) {
           assert(e.message.includes("invalid provider was specified"));
         }
       });
@@ -329,7 +329,7 @@ describe("HD Wallet Provider", function () {
             url: "justABunchOfJunk"
           });
           assert.fail("Should throw on invalid url");
-        } catch (e) {
+        } catch (e: any) {
           assert(e.message.includes("invalid provider was specified"));
         }
       });
@@ -343,7 +343,7 @@ describe("HD Wallet Provider", function () {
             url: "http://localhost:8545"
           });
           assert.fail("Should throw on invalid mnemonic");
-        } catch (e) {
+        } catch (e: any) {
           assert(e.message.includes("Mnemonic invalid or undefined"));
         }
       });

--- a/packages/hdwallet-provider/test/urlValidation.test.ts
+++ b/packages/hdwallet-provider/test/urlValidation.test.ts
@@ -21,7 +21,7 @@ describe("HD Wallet Provider Validator", () => {
     try {
       new WalletProvider(mnemonic, badUrl, 0, 100);
       assert.fail("did not throw!");
-    } catch (e) {
+    } catch (e: any) {
       const expectedMessage = [
         `No provider or an invalid provider was specified: '${badUrl}'`,
         "Please specify a valid provider or URL, using the http, https, ws, or wss protocol.",
@@ -36,7 +36,7 @@ describe("HD Wallet Provider Validator", () => {
     try {
       new WalletProvider(mnemonic, badUrl, 0, 100);
       assert.fail("did not throw!");
-    } catch (e) {
+    } catch (e: any) {
       const expectedMessage = [
         `No provider or an invalid provider was specified: '${badUrl}'`,
         "Please specify a valid provider or URL, using the http, https, ws, or wss protocol.",

--- a/packages/hdwallet-provider/tsconfig.json
+++ b/packages/hdwallet-provider/tsconfig.json
@@ -12,11 +12,6 @@
     ],
     "outDir": "dist",
     "baseUrl": ".",
-    "typeRoots": [
-      "../../node_modules/@types/mocha",
-      "../../node_modules/@types/node",
-      "../../node_modules/@types/web3-provider-engine",
-    ],
     "types": [ "node", "mocha" ]
   },
   "include": [

--- a/packages/interface-adapter/package.json
+++ b/packages/interface-adapter/package.json
@@ -36,7 +36,7 @@
     "ganache": "7.3.2",
     "mocha": "9.2.2",
     "ts-node": "10.7.0",
-    "typescript": "^4.1.4"
+    "typescript": "^4.7.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/interface-adapter/tsconfig.json
+++ b/packages/interface-adapter/tsconfig.json
@@ -11,10 +11,7 @@
     "baseUrl": ".",
     "lib": ["es2019"],
     "rootDir": "lib",
-    "typeRoots": [
-      "../../node_modules/@types/bn.js",
-      "../../node_modules/@types/mocha"
-    ]
+    "types": ["node", "mocha"]
   },
   "include": [
     "./lib/**/*.ts"

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -33,7 +33,7 @@
     "@types/node": "^18.6.1",
     "jest": "28.1.3",
     "ts-jest": "28.0.6",
-    "typescript": "^4.1.4"
+    "typescript": "^4.7.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@types/jest": "27.4.1",
-    "@types/node": "^14.0.13",
+    "@types/node": "^18.6.1",
     "jest": "28.1.3",
     "ts-jest": "28.0.6",
     "typescript": "^4.1.4"

--- a/packages/profiler/package.json
+++ b/packages/profiler/package.json
@@ -28,7 +28,7 @@
     "@truffle/config": "^1.3.33",
     "@types/node": "^18.6.1",
     "ts-node": "10.7.0",
-    "typescript": "^4.1.4"
+    "typescript": "^4.7.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/profiler/package.json
+++ b/packages/profiler/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@truffle/config": "^1.3.33",
-    "@types/node": "12.12.21",
+    "@types/node": "^18.6.1",
     "ts-node": "10.7.0",
     "typescript": "^4.1.4"
   },

--- a/packages/promise-tracker/package.json
+++ b/packages/promise-tracker/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@types/jest": "^27.0.3",
-    "@types/node": "^16.11.6",
+    "@types/node": "^18.6.1",
     "delay": "^5.0.0",
     "jest": "28.1.3",
     "ts-jest": "28.0.6",

--- a/packages/promise-tracker/package.json
+++ b/packages/promise-tracker/package.json
@@ -43,6 +43,6 @@
     "delay": "^5.0.0",
     "jest": "28.1.3",
     "ts-jest": "28.0.6",
-    "typescript": "^4.1.4"
+    "typescript": "^4.7.4"
   }
 }

--- a/packages/provisioner/package.json
+++ b/packages/provisioner/package.json
@@ -32,7 +32,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "typescript": "^4.1.4"
+    "typescript": "^4.7.4"
   },
   "dependencies": {
     "@truffle/config": "^1.3.33"

--- a/packages/provisioner/tsconfig.json
+++ b/packages/provisioner/tsconfig.json
@@ -8,7 +8,6 @@
       "rootDir": "./",
       "strict": true,
       "esModuleInterop": true,
-      "typeRoots": [
-      ]
+      "types": ["node"]
     }
   }

--- a/packages/require/package.json
+++ b/packages/require/package.json
@@ -43,7 +43,7 @@
     "mocha": "9.2.2",
     "npm-run-all": "^4.1.5",
     "ts-node": "10.7.0",
-    "typescript": "^4.1.4",
+    "typescript": "^4.7.4",
     "web3": "1.7.4"
   },
   "peerDependencies": {

--- a/packages/require/package.json
+++ b/packages/require/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^9.0.0",
-    "@types/node": "^18.0.0",
+    "@types/node": "^18.6.1",
     "copyfiles": "^2.4.1",
     "mocha": "9.2.2",
     "npm-run-all": "^4.1.5",

--- a/packages/resolver/package.json
+++ b/packages/resolver/package.json
@@ -41,7 +41,7 @@
     "web3-utils": "1.7.4"
   },
   "devDependencies": {
-    "@types/node": "12.12.21",
+    "@types/node": "^18.6.1",
     "@types/sinon": "^9.0.10",
     "mocha": "9.2.2",
     "sinon": "^9.0.2",

--- a/packages/resolver/package.json
+++ b/packages/resolver/package.json
@@ -46,7 +46,7 @@
     "mocha": "9.2.2",
     "sinon": "^9.0.2",
     "ts-node": "10.7.0",
-    "typescript": "^4.1.4"
+    "typescript": "^4.7.4"
   },
   "keywords": [
     "dependencies",

--- a/packages/resolver/tsconfig.json
+++ b/packages/resolver/tsconfig.json
@@ -13,10 +13,7 @@
     "paths": {
     },
     "rootDir": ".",
-    "typeRoots": [
-      "../../node_modules/@types/mocha",
-      "../../node_modules/@types/node"
-    ]
+    "types": ["node", "mocha"]
   },
   "include": [
     "./lib/**/*.ts",

--- a/packages/source-fetcher/package.json
+++ b/packages/source-fetcher/package.json
@@ -35,7 +35,7 @@
     "@types/async-retry": "^1.4.3",
     "@types/debug": "^4.1.5",
     "@types/node": "^18.6.1",
-    "typescript": "^4.1.4"
+    "typescript": "^4.7.4"
   },
   "keywords": [
     "ethereum",

--- a/packages/source-fetcher/package.json
+++ b/packages/source-fetcher/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@types/async-retry": "^1.4.3",
     "@types/debug": "^4.1.5",
-    "@types/node": "^15.0.1",
+    "@types/node": "^18.6.1",
     "typescript": "^4.1.4"
   },
   "keywords": [

--- a/packages/spinners/package.json
+++ b/packages/spinners/package.json
@@ -34,7 +34,7 @@
     "@types/semver": "^7.3.9",
     "mocha": "9.2.2",
     "ts-node": "10.7.0",
-    "typescript": "^4.1.4"
+    "typescript": "^4.7.4"
   },
   "keywords": [
     "compile",

--- a/packages/spinners/package.json
+++ b/packages/spinners/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^9.0.0",
-    "@types/node": "^16.11.6",
+    "@types/node": "^18.6.1",
     "@types/semver": "^7.3.9",
     "mocha": "9.2.2",
     "ts-node": "10.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7778,20 +7778,6 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-"@zerollup/ts-helpers@^1.7.4":
-  version "1.7.4"
-  resolved "https://registry.yarnpkg.com/@zerollup/ts-helpers/-/ts-helpers-1.7.4.tgz#59ac8c643b8cc6def5449691630091226991da36"
-  integrity sha512-8JLREeiO6MtmJhU8kw/eNwi+HKlh/K3cMlpH6HVbW53bqhAgTvt8KnIqFh9FMNbCL3QDht35g8VJHVWYkMEt2A==
-  dependencies:
-    resolve "^1.12.0"
-
-"@zerollup/ts-transform-paths@^1.7.3":
-  version "1.7.8"
-  resolved "https://registry.yarnpkg.com/@zerollup/ts-transform-paths/-/ts-transform-paths-1.7.8.tgz#e9de4ed23e9b6f584b9a625141326456f71d0a8a"
-  integrity sha512-xh6KZRF3cD/pYeQypADTh7U9zAU8vgG7PvUT9m20mW8rsiUF69OKDM+9CsR483ceXVh5PC5AHUA/GAvsJ1iVbw==
-  dependencies:
-    "@zerollup/ts-helpers" "^1.7.4"
-
 JSONStream@^1.0.3, JSONStream@^1.0.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
@@ -9833,6 +9819,13 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+brace-expansion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
+  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  dependencies:
+    balanced-match "^1.0.0"
 
 braces@^2.3.1, braces@^2.3.2:
   version "2.3.2"
@@ -15745,6 +15738,17 @@ glob@^7.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.0.3.tgz#415c6eb2deed9e502c68fa44a272e6da6eeca42e"
+  integrity sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^5.0.1"
+    once "^1.3.0"
+
 global-dirs@^2.0.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-2.1.0.tgz#e9046a49c806ff04d6c1825e196c8f0091e8df4d"
@@ -16025,7 +16029,7 @@ handle-thing@^2.0.0:
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.1.tgz#857f79ce359580c340d43081cc648970d0bb234e"
   integrity sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==
 
-handlebars@^4.1.2, handlebars@^4.7.6, handlebars@^4.7.7:
+handlebars@^4.1.2, handlebars@^4.7.6:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
   integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
@@ -20188,10 +20192,10 @@ marked@^1.2.9:
   resolved "https://registry.yarnpkg.com/marked/-/marked-1.2.9.tgz#53786f8b05d4c01a2a5a76b7d1ec9943d29d72dc"
   integrity sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw==
 
-marked@~2.0.3:
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-2.0.7.tgz#bc5b857a09071b48ce82a1f7304913a993d4b7d1"
-  integrity sha512-BJXxkuIfJchcXOJWTT2DOL+yFWifFv2yGYOUzvXg8Qz610QKw+sHCvTMYwA+qWGhlA2uivBezChZ/pBy1tWdkQ==
+marked@^4.0.16:
+  version "4.0.18"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.18.tgz#cd0ac54b2e5610cfb90e8fd46ccaa8292c9ed569"
+  integrity sha512-wbLDJ7Zh0sqA0Vdg6aqlbT+yPxqLblpAZh1mK2+AO2twQkPywvvqQNfEPVwSSRjZ7dZcdeVBIAgiO7MMp3Dszw==
 
 mcl-wasm@0.9.0:
   version "0.9.0"
@@ -20632,6 +20636,13 @@ minimatch@^3.0.3, minimatch@^3.1.1:
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimatch@^5.0.1, minimatch@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.0.tgz#1717b464f4971b144f6aabe8f2d0b8e4511e09c7"
+  integrity sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==
+  dependencies:
+    brace-expansion "^2.0.1"
 
 minimist-options@4.1.0, minimist-options@^4.0.2:
   version "4.1.0"
@@ -26063,6 +26074,15 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
+shiki@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.10.1.tgz#6f9a16205a823b56c072d0f1a0bcd0f2646bef14"
+  integrity sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==
+  dependencies:
+    jsonc-parser "^3.0.0"
+    vscode-oniguruma "^1.6.1"
+    vscode-textmate "5.2.0"
+
 shiki@^0.9.2:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.9.2.tgz#b9e660b750d38923275765c4dc4c92b23877b115"
@@ -26070,15 +26090,6 @@ shiki@^0.9.2:
   dependencies:
     onigasm "^2.2.5"
     vscode-textmate "^5.2.0"
-
-shiki@^0.9.3:
-  version "0.9.15"
-  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.9.15.tgz#2481b46155364f236651319d2c18e329ead6fa44"
-  integrity sha512-/Y0z9IzhJ8nD9nbceORCqu6NgT9X6I8Fk8c3SICHI5NbZRLdZYFaB233gwct9sU0vvSypyaL/qaKvzyQGJBZSw==
-  dependencies:
-    jsonc-parser "^3.0.0"
-    vscode-oniguruma "^1.6.1"
-    vscode-textmate "5.2.0"
 
 side-channel@^1.0.4:
   version "1.0.4"
@@ -28006,11 +28017,6 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typedoc-default-themes@^0.12.10:
-  version "0.12.10"
-  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.12.10.tgz#614c4222fe642657f37693ea62cad4dafeddf843"
-  integrity sha512-fIS001cAYHkyQPidWXmHuhs8usjP5XVJjWB8oZGqkTowZaz3v7g3KDZeeqE82FBrmkAnIBOY3jgy7lnPnqATbA==
-
 typedoc-default-themes@^0.12.7:
   version "0.12.7"
   resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.12.7.tgz#d44f68d40a3e90a19b5ea7be4cc6ed949afe768d"
@@ -28029,22 +28035,16 @@ typedoc-plugin-remove-references@^0.0.5:
   resolved "https://registry.yarnpkg.com/typedoc-plugin-remove-references/-/typedoc-plugin-remove-references-0.0.5.tgz#08b129d2697e50208c807e06c3662fd2fc86a925"
   integrity sha512-DSZ7kM/Y90CgZUKt8MiDsoi4fvrJyleHydj3ncGyqDqMdhuMes2E/4I6mSmXBrVdTjYhVH6BeoOFSbj2pQ821g==
 
-typedoc@0.20.37:
-  version "0.20.37"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.20.37.tgz#9b9417149cb815e3d569fc300b5d2c6e4e6c5d93"
-  integrity sha512-9+qDhdc4X00qTNOtii6QX2z7ndAeWVOso7w3MPSoSJdXlVhpwPfm1yEp4ooKuWA9fiQILR8FKkyjmeqa13hBbw==
+typedoc@0.22.18:
+  version "0.22.18"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.22.18.tgz#1d000c33b66b88fd8cdfea14a26113a83b7e6591"
+  integrity sha512-NK9RlLhRUGMvc6Rw5USEYgT4DVAUFk7IF7Q6MYfpJ88KnTZP7EneEa4RcP+tX1auAcz7QT1Iy0bUSZBYYHdoyA==
   dependencies:
-    colors "^1.4.0"
-    fs-extra "^9.1.0"
-    handlebars "^4.7.7"
-    lodash "^4.17.21"
+    glob "^8.0.3"
     lunr "^2.3.9"
-    marked "~2.0.3"
-    minimatch "^3.0.0"
-    progress "^2.0.3"
-    shelljs "^0.8.4"
-    shiki "^0.9.3"
-    typedoc-default-themes "^0.12.10"
+    marked "^4.0.16"
+    minimatch "^5.1.0"
+    shiki "^0.10.1"
 
 typedoc@~0.20.13:
   version "0.20.23"
@@ -28099,15 +28099,10 @@ typescript@^3.9.7:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
   integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
-typescript@^4.1.4:
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.4.tgz#f058636e2f4f83f94ddaae07b20fd5e14598432f"
-  integrity sha512-+Uru0t8qIRgjuCpiSPpfGuhHecMllk5Zsazj5LZvVsEStEjmIRRBZe+jHjGQvsgS7M1wONy2PQXd67EMyV6acg==
-
-typescript@^4.3.5:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
-  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+typescript@^4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 ua-parser-js@^0.7.30:
   version "0.7.31"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6610,7 +6610,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@12.12.21":
+"@types/node@*":
   version "12.12.21"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.21.tgz#aa44a6363291c7037111c47e4661ad210aded23f"
   integrity sha512-8sRGhbpU+ck1n0PGAUgVrWrWdjSW2aqNeyC15W88GRsMpSwzv6RJGlLhE7s2RhVSOdyDmxbqlWSeThq4/7xqlA==
@@ -6630,35 +6630,15 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.11.tgz#46ba035fb917b31c948280dbea22ab8838f386a4"
   integrity sha512-dNd2pp8qTzzNLAs3O8nH3iU9DG9866KHq9L3ISPB7DOGERZN81nW/5/g/KzMJpCU8jrbCiMRBzV9/sCEdRosig==
 
-"@types/node@^12.0.0":
-  version "12.20.45"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.45.tgz#f4980d177999299d99cd4b290f7f39366509a44f"
-  integrity sha512-1Jg2Qv5tuxBqgQV04+wO5u+wmSHbHgpORCJdeCLM+E+YdPElpdHhgywU+M1V1InL8rfOtpqtOjswk+uXTKwx7w==
-
 "@types/node@^12.12.6":
   version "12.12.67"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.67.tgz#4f86badb292e822e3b13730a1f9713ed2377f789"
   integrity sha512-R48tgL2izApf+9rYNH+3RBMbRpPeW3N8f0I9HMhggeq4UXwBDqumJ14SDs4ctTMhG11pIOduZ4z3QWGOiMc9Vg==
 
-"@types/node@^14.0.13":
-  version "14.14.14"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.14.tgz#f7fd5f3cc8521301119f63910f0fb965c7d761ae"
-  integrity sha512-UHnOPWVWV1z+VV8k6L1HhG7UbGBgIdghqF3l9Ny9ApPghbjICXkUJSd/b9gOgQfjM1r+37cipdw/HJ3F6ICEnQ==
-
-"@types/node@^15.0.1":
-  version "15.14.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.14.1.tgz#4f9d3689532499fdda1c898e19f4593718655e36"
-  integrity sha512-wF6hazbsnwaW3GhK4jFuw5NaLDQVRQ6pWQUGAUrJzxixFkTaODSiAKMPXuHwPEPkAKQWHAzj6uJ5h+3zU9gQxg==
-
-"@types/node@^16.11.6":
-  version "16.11.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.7.tgz#36820945061326978c42a01e56b61cd223dfdc42"
-  integrity sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw==
-
-"@types/node@^18.0.0":
-  version "18.0.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.0.0.tgz#67c7b724e1bcdd7a8821ce0d5ee184d3b4dd525a"
-  integrity sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==
+"@types/node@^18.6.1":
+  version "18.6.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.6.1.tgz#828e4785ccca13f44e2fb6852ae0ef11e3e20ba5"
+  integrity sha512-z+2vB6yDt1fNwKOeGbckpmirO+VBDuQqecXkgeIqDlaOtmKn6hPR/viQ8cxCfqLU4fTlvM3+YjM367TukWdxpg==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -8059,7 +8039,7 @@ ajv-errors@^1.0.0:
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
   integrity sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==
 
-ajv-formats@^2.0.2:
+ajv-formats@^2.0.2, ajv-formats@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.1.tgz#6e669400659eb74973bbf2e33327180a0996b520"
   integrity sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==
@@ -8110,6 +8090,16 @@ ajv@^8.0.1:
   version "8.10.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.10.0.tgz#e573f719bd3af069017e3b66538ab968d040e54d"
   integrity sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
+ajv@^8.6.3:
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
+  integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
@@ -11262,6 +11252,22 @@ conf@^10.0.2:
   dependencies:
     ajv "^8.1.0"
     ajv-formats "^2.0.2"
+    atomically "^1.7.0"
+    debounce-fn "^4.0.0"
+    dot-prop "^6.0.1"
+    env-paths "^2.2.1"
+    json-schema-typed "^7.0.3"
+    onetime "^5.1.2"
+    pkg-up "^3.1.0"
+    semver "^7.3.5"
+
+conf@^10.1.2:
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/conf/-/conf-10.1.2.tgz#50132158f388756fa9dea3048f6b47935315c14e"
+  integrity sha512-o9Fv1Mv+6A0JpoayQ8JleNp3hhkbOJP/Re/Q+QqxMPHPkABVsRjQGWZn9A5GcqLiTNC6d89p2PB5ZhHVDSMwyg==
+  dependencies:
+    ajv "^8.6.3"
+    ajv-formats "^2.1.1"
     atomically "^1.7.0"
     debounce-fn "^4.0.0"
     dot-prop "^6.0.1"


### PR DESCRIPTION
Also includes minimal code & dependency changes necessary to support latest TypeScript and @types/node