### PR TITLE
Enhancement: Allow encoder to look up functions by full signature

### DIFF
--- a/packages/encoder/lib/errors.ts
+++ b/packages/encoder/lib/errors.ts
@@ -4,7 +4,9 @@
  */
 export class NoInternalInfoError extends Error {
   constructor() {
-    super("No compilations provided, but userDefinedTypes or allocations is missing");
+    super(
+      "No compilations provided, but userDefinedTypes or allocations is missing"
+    );
     this.name = "NoInternalInfoError";
   }
 }
@@ -25,14 +27,14 @@ export class NoCompilationsForSpawnerError extends Error {
  * @protected
  */
 export class NoFunctionByThatNameError extends Error {
-  public functionName: string;
+  public functionNameOrSig: string;
   public contractName: string | undefined;
-  constructor(functionName: string, contractName: string) {
+  constructor(functionNameOrSig: string, contractName: string) {
     const message = contractName
-      ? `Contract ${contractName} has no function named ${functionName}`
-      : `This contract has no function named ${functionName}`
+      ? `Contract ${contractName} has no function with name or signature ${functionNameOrSig}`
+      : `This contract has no function with name or signature ${functionNameOrSig}`;
     super(message);
-    this.functionName = functionName;
+    this.functionNameOrSig = functionNameOrSig;
     this.contractName = contractName;
     this.name = "NoFunctionByThatNameError";
   }
@@ -64,13 +66,8 @@ export class InvalidAddressError extends Error {
 export class UnlinkedContractError extends Error {
   public contractName: string | undefined;
   public bytecode: string | undefined;
-  constructor(
-    contractName: string | undefined,
-    bytecode: string | undefined,
-  ) {
-    const nameString = contractName !== undefined
-      ? contractName + " "
-      : "";
+  constructor(contractName: string | undefined, bytecode: string | undefined) {
+    const nameString = contractName !== undefined ? contractName + " " : "";
     super(`Contract ${nameString}has not had all its libraries linked`);
     this.contractName = contractName;
     this.bytecode = bytecode;
@@ -86,14 +83,11 @@ export class UnlinkedContractError extends Error {
 export class ContractNotDeployedError extends Error {
   public contractName: string | undefined;
   public networkId: number;
-  constructor(
-    contractName: string | undefined,
-    networkId: number
-  ) {
-    const nameString = contractName !== undefined
-      ? contractName + " "
-      : "";
-    super(`Contract ${nameString}has not been deployed to network ${networkId} with deployer; address must be given explicitly`);
+  constructor(contractName: string | undefined, networkId: number) {
+    const nameString = contractName !== undefined ? contractName + " " : "";
+    super(
+      `Contract ${nameString}has not been deployed to network ${networkId} with deployer; address must be given explicitly`
+    );
     this.contractName = contractName;
     this.name = "ContractNotDeployedError";
   }
@@ -106,12 +100,8 @@ export class ContractNotDeployedError extends Error {
  */
 export class NoBytecodeError extends Error {
   public contractName: string | undefined;
-  constructor(
-    contractName: string | undefined,
-  ) {
-    const nameString = contractName !== undefined
-      ? contractName + " "
-      : "";
+  constructor(contractName: string | undefined) {
+    const nameString = contractName !== undefined ? contractName + " " : "";
     super(`Contract ${nameString}has missing or empty constructor bytecode`);
     this.contractName = contractName;
     this.name = "NoBytecodeError";

--- a/packages/encoder/test/overload.test.ts
+++ b/packages/encoder/test/overload.test.ts
@@ -787,4 +787,31 @@ describe("Overload resolution", () => {
       );
     });
   });
+
+  describe("Manual overload resolution by signature", () => {
+    it("Allows specifying functions by signature", async () => {
+      const { abi, tx } = await encoder.encodeTransaction("overloaded(bool)", [
+        1
+      ]);
+      assert.lengthOf(abi.inputs, 1);
+      assert.strictEqual(abi.inputs[0].type, "bool");
+      const selector = Codec.AbiData.Utils.abiSelector(abi);
+      assert.strictEqual(
+        tx.data,
+        selector +
+          "0000000000000000000000000000000000000000000000000000000000000001"
+      );
+    });
+
+    it("Rejects when no overload matches specified signature", async () => {
+      try {
+        await encoder.encodeTransaction("overloaded(uint192)", [1]);
+        assert.fail("Should reject when specified signature does not exist");
+      } catch (error) {
+        if (error.name !== "NoFunctionByThatNameError") {
+          throw error;
+        }
+      }
+    });
+  });
 });


### PR DESCRIPTION
Previously, `encodeTransaction` allowed either a list of abi entries as input, or a function name.  I've expanded it to allow function signature as well.  This is pretty straightforward so I don't have much to say about this.  I also added tests of this functionality.

This is intended to support #5330, providing a way of performing manual resolution of overloads on the command line.

I thought about also allowing this for `encodeTxNoResolution`, but decided against it... it'd be a bit awkward.

Note that the error you get if lookup fails is still called a `NoFunctionByThatNameError`; however, the message has been updated.

Also `prettier` made some changes.