### PR TITLE
Enhancement: Add `allowJson` and `strictBooleans` options to encoder

### DIFF
--- a/packages/codec/lib/wrap/bool.ts
+++ b/packages/codec/lib/wrap/bool.ts
@@ -70,18 +70,18 @@ function* boolFromString(
   const lowerCasedInput = input.toLowerCase();
   if (
     wrapOptions.strictBooleans &&
-    !["true", "false"].includes(lowerCasedInput)
+    !["true", "false", "1", "0"].includes(lowerCasedInput)
   ) {
     throw new TypeMismatchError(
       dataType,
       input,
       wrapOptions.name,
       5,
-      "Input was neither 'true' nor 'false'"
+      "Input was not 'true', 'false', '1', or '0'"
     );
   }
-  //strings are true unless they're falsy or the case-insensitive string "false"
-  const asBoolean = Boolean(input) && input.toLowerCase() !== "false";
+  //strings are true unless they're falsy or the case-insensitive strings "false" or "0"
+  const asBoolean = Boolean(input) && !["false", "0"].includes(lowerCasedInput);
   return {
     type: dataType,
     kind: "value" as const,

--- a/packages/codec/lib/wrap/bool.ts
+++ b/packages/codec/lib/wrap/bool.ts
@@ -14,6 +14,7 @@ const boolCasesBasic: Case<
   Format.Values.BoolValue,
   never
 >[] = [
+  boolFromBoolean, //needed due to strictBooleans mode
   boolFromString,
   boolFromBoxedPrimitive,
   boolFromCodecBoolValue,
@@ -27,10 +28,30 @@ export const boolCases: Case<
   Format.Types.BoolType,
   Format.Values.BoolValue,
   never
->[] = [
-  boolFromTypeValueInput,
-  ...boolCasesBasic
-];
+>[] = [boolFromTypeValueInput, ...boolCasesBasic];
+
+function* boolFromBoolean(
+  dataType: Format.Types.BoolType,
+  input: unknown,
+  wrapOptions: WrapOptions
+): Generator<never, Format.Values.BoolValue, WrapResponse> {
+  if (typeof input !== "boolean") {
+    throw new TypeMismatchError(
+      dataType,
+      input,
+      wrapOptions.name,
+      1,
+      "Input was not a boolean"
+    );
+  }
+  return {
+    type: dataType,
+    kind: "value" as const,
+    value: {
+      asBoolean: input
+    }
+  };
+}
 
 function* boolFromString(
   dataType: Format.Types.BoolType,
@@ -44,6 +65,19 @@ function* boolFromString(
       wrapOptions.name,
       1,
       "Input was not a string"
+    );
+  }
+  const lowerCasedInput = input.toLowerCase();
+  if (
+    wrapOptions.strictBooleans &&
+    !["true", "false"].includes(lowerCasedInput)
+  ) {
+    throw new TypeMismatchError(
+      dataType,
+      input,
+      wrapOptions.name,
+      5,
+      "Input was neither 'true' nor 'false'"
     );
   }
   //strings are true unless they're falsy or the case-insensitive string "false"
@@ -72,7 +106,12 @@ function* boolFromBoxedPrimitive(
     );
   }
   //unbox and try again
-  return yield* wrapWithCases(dataType, input.valueOf(), wrapOptions, boolCases);
+  return yield* wrapWithCases(
+    dataType,
+    input.valueOf(),
+    wrapOptions,
+    boolCases
+  );
 }
 
 function* boolFromCodecBoolValue(
@@ -215,9 +254,7 @@ function* boolFromCodecUdvtValue(
       "Input was not a wrapped result"
     );
   }
-  if (
-    input.type.typeClass !== "userDefinedValueType"
-  ) {
+  if (input.type.typeClass !== "userDefinedValueType") {
     throw new TypeMismatchError(
       dataType,
       input,
@@ -252,9 +289,7 @@ function* boolFromCodecUdvtError(
       "Input was not a wrapped result"
     );
   }
-  if (
-    input.type.typeClass !== "userDefinedValueType"
-  ) {
+  if (input.type.typeClass !== "userDefinedValueType") {
     throw new TypeMismatchError(
       dataType,
       input,
@@ -282,7 +317,11 @@ function* boolFromCodecUdvtError(
       Messages.errorResultMessage
     );
   }
-  return yield* boolFromCodecBoolError(dataType, input.error.error, wrapOptions);
+  return yield* boolFromCodecBoolError(
+    dataType,
+    input.error.error,
+    wrapOptions
+  );
 }
 
 function* boolFromOther(
@@ -313,6 +352,16 @@ function* boolFromOther(
       wrapOptions.name,
       1,
       "Input was a type/value pair"
+    );
+  }
+  //...and also we don't do this case if strictBooleans is turned on
+  if (wrapOptions.strictBooleans) {
+    throw new TypeMismatchError(
+      dataType,
+      input,
+      wrapOptions.name,
+      2,
+      "Input was neither a boolean nor a boolean string"
     );
   }
   const asBoolean = Boolean(input);

--- a/packages/codec/lib/wrap/index.ts
+++ b/packages/codec/lib/wrap/index.ts
@@ -84,7 +84,7 @@ function wrappingToResolution(
 function* wrapForMethodRaw(
   method: Method,
   inputs: unknown[],
-  { userDefinedTypes, allowOptions }: ResolveOptions,
+  { userDefinedTypes, allowOptions, allowJson, strictBooleans }: ResolveOptions,
   loose: boolean = false
 ): Generator<WrapRequest, Format.Values.Value[], WrapResponse> {
   debug("wrapping for method");
@@ -95,7 +95,9 @@ function* wrapForMethodRaw(
       userDefinedTypes,
       oldOptionsBehavior: true, //HACK
       loose,
-      name: "<arguments>"
+      name: "<arguments>",
+      allowJson,
+      strictBooleans
     });
   } else if (allowOptions && method.inputs.length === inputs.length - 1) {
     //options case
@@ -108,7 +110,9 @@ function* wrapForMethodRaw(
       userDefinedTypes,
       oldOptionsBehavior: true, //HACK
       loose,
-      name: "<arguments>"
+      name: "<arguments>",
+      allowJson,
+      strictBooleans
     });
   } else {
     //invalid length case
@@ -128,7 +132,7 @@ function* wrapForMethodRaw(
 export function* resolveAndWrap(
   methods: Method[],
   inputs: unknown[],
-  { userDefinedTypes, allowOptions }: ResolveOptions
+  { userDefinedTypes, allowOptions, allowJson, strictBooleans }: ResolveOptions
 ): Generator<WrapRequest, Resolution, WrapResponse> {
   //despite us having a good system for overload resolution, we want to
   //use it as little as possible!  That's because using it means we don't
@@ -140,7 +144,9 @@ export function* resolveAndWrap(
     //this is important for good error messages in this case
     return yield* wrapForMethod(methods[0], inputs, {
       userDefinedTypes,
-      allowOptions
+      allowOptions,
+      allowJson,
+      strictBooleans
     });
   }
   //OK, so, there are multiple possibilities then.  let's try to filter things down by length.
@@ -162,7 +168,9 @@ export function* resolveAndWrap(
           name: "<options>",
           loose: true,
           oldOptionsBehavior: true, //HACK
-          userDefinedTypes
+          userDefinedTypes,
+          allowJson,
+          strictBooleans
         })
       );
       possibleOptions = wrappedOptions.value;
@@ -192,7 +200,9 @@ export function* resolveAndWrap(
       arguments: yield* wrapMultiple(method.inputs, inputs, {
         userDefinedTypes,
         loose: true,
-        name: "<arguments>"
+        name: "<arguments>",
+        allowJson,
+        strictBooleans
       }),
       options: {}
     };
@@ -209,7 +219,9 @@ export function* resolveAndWrap(
       arguments: yield* wrapMultiple(method.inputs, inputs, {
         userDefinedTypes,
         loose: true,
-        name: "<arguments>"
+        name: "<arguments>",
+        allowJson,
+        strictBooleans
       }),
       options: possibleOptions
     };
@@ -233,7 +245,9 @@ export function* resolveAndWrap(
       //although yes this means options will be re-wrapped, oh well
       wrapped = yield* wrapForMethodRaw(method, inputs, {
         userDefinedTypes,
-        allowOptions
+        allowOptions,
+        allowJson,
+        strictBooleans
       });
     } catch (error) {
       //if there's an error, don't add it

--- a/packages/codec/lib/wrap/types.ts
+++ b/packages/codec/lib/wrap/types.ts
@@ -1,7 +1,7 @@
 import type * as Format from "@truffle/codec/format";
 import type * as Abi from "@truffle/abi-utils";
 import type * as Common from "@truffle/codec/common";
-import type { WrapRequest, WrapResponse } from "../types";
+import type { WrapResponse } from "../types";
 
 /**
  * @Category Interfaces
@@ -43,16 +43,22 @@ export interface WrapOptions {
   loose?: boolean;
   oldOptionsBehavior?: boolean; //to not break Truffle Contract
   specificityFloor?: number; //raise all specificities to at least this much... should *not* propagate!
+  allowJson?: boolean;
+  strictBooleans?: boolean;
 }
 
 export interface ResolveOptions {
   userDefinedTypes?: Format.Types.TypesById;
   allowOptions?: boolean;
+  allowJson?: boolean;
+  strictBooleans?: boolean;
 }
 
-export type Case<TypeType, ValueType, RequestType> =
-  (dataType: TypeType, input: unknown, options: WrapOptions)
-    => Generator<RequestType, ValueType, WrapResponse>;
+export type Case<TypeType, ValueType, RequestType> = (
+  dataType: TypeType,
+  input: unknown,
+  options: WrapOptions
+) => Generator<RequestType, ValueType, WrapResponse>;
 
 export interface ContractInput {
   address: string;

--- a/packages/codec/lib/wrap/wrap.ts
+++ b/packages/codec/lib/wrap/wrap.ts
@@ -27,7 +27,12 @@ const arrayCasesBasic: Case<
   Format.Types.ArrayType,
   Format.Values.ArrayValue,
   WrapRequest
->[] = [arrayFromArray, arrayFromCodecArrayValue, arrayFailureCase];
+>[] = [
+  arrayFromArray,
+  arrayFromCodecArrayValue,
+  arrayFromJson,
+  arrayFailureCase
+];
 
 export const arrayCases: Case<
   Format.Types.ArrayType,
@@ -39,6 +44,7 @@ const tupleCasesBasic: Case<TupleLikeType, TupleLikeValue, WrapRequest>[] = [
   tupleFromArray,
   tupleFromCodecTupleLikeValue,
   tupleFromObject,
+  tupleFromJson,
   tupleFailureCase
 ];
 
@@ -229,6 +235,44 @@ function* arrayFromCodecArrayValue(
   //where the type is not the same but is compatible
   const value = (<Format.Values.ArrayValue>input).value;
   return yield* arrayFromArray(dataType, value, wrapOptions);
+}
+
+function* arrayFromJson(
+  dataType: Format.Types.ArrayType,
+  input: unknown,
+  wrapOptions: WrapOptions
+): Generator<WrapRequest, Format.Values.ArrayValue, WrapResponse> {
+  if (!wrapOptions.allowJson) {
+    throw new TypeMismatchError(
+      dataType,
+      input,
+      wrapOptions.name,
+      1,
+      "JSON input must be explicitly enabled"
+    );
+  }
+  if (typeof input !== "string") {
+    throw new TypeMismatchError(
+      dataType,
+      input,
+      wrapOptions.name,
+      1,
+      "Input was not a string"
+    );
+  }
+  let parsedInput: unknown;
+  try {
+    parsedInput = JSON.parse(input);
+  } catch {
+    throw new TypeMismatchError(
+      dataType,
+      input,
+      wrapOptions.name,
+      5,
+      "Input was not valid JSON"
+    );
+  }
+  return yield* arrayFromArray(dataType, parsedInput, wrapOptions);
 }
 
 function* arrayFromTypeValueInput(
@@ -430,6 +474,49 @@ function* tupleFromObject(
     kind: "value" as const,
     value
   };
+}
+
+function* tupleFromJson(
+  dataType: TupleLikeType,
+  input: unknown,
+  wrapOptions: WrapOptions
+): Generator<WrapRequest, TupleLikeValue, WrapResponse> {
+  if (!wrapOptions.allowJson) {
+    throw new TypeMismatchError(
+      dataType,
+      input,
+      wrapOptions.name,
+      1,
+      "JSON input must be explicitly enabled"
+    );
+  }
+  if (typeof input !== "string") {
+    throw new TypeMismatchError(
+      dataType,
+      input,
+      wrapOptions.name,
+      1,
+      "Input was not a string"
+    );
+  }
+  let parsedInput: unknown;
+  try {
+    parsedInput = JSON.parse(input);
+  } catch {
+    throw new TypeMismatchError(
+      dataType,
+      input,
+      wrapOptions.name,
+      5,
+      "Input was not valid JSON"
+    );
+  }
+  debug("input is JSON");
+  debug("parses to: %O", parsedInput);
+  return yield* wrapWithCases(dataType, parsedInput, wrapOptions, [
+    tupleFromObject,
+    tupleFromArray
+  ]);
 }
 
 function* tupleFromCodecTupleLikeValue(

--- a/packages/codec/lib/wrap/wrap.ts
+++ b/packages/codec/lib/wrap/wrap.ts
@@ -263,13 +263,13 @@ function* arrayFromJson(
   let parsedInput: unknown;
   try {
     parsedInput = JSON.parse(input);
-  } catch {
+  } catch (error) {
     throw new TypeMismatchError(
       dataType,
       input,
       wrapOptions.name,
       5,
-      "Input was not valid JSON"
+      `Input was not valid JSON: ${error.message}`
     );
   }
   return yield* arrayFromArray(dataType, parsedInput, wrapOptions);
@@ -502,13 +502,13 @@ function* tupleFromJson(
   let parsedInput: unknown;
   try {
     parsedInput = JSON.parse(input);
-  } catch {
+  } catch (error) {
     throw new TypeMismatchError(
       dataType,
       input,
       wrapOptions.name,
       5,
-      "Input was not valid JSON"
+      `Input was not valid JSON: ${error.message}`
     );
   }
   debug("input is JSON");

--- a/packages/encoder/lib/encoders.ts
+++ b/packages/encoder/lib/encoders.ts
@@ -1149,11 +1149,14 @@ export class ContractEncoder {
    * [[Format.Values.ContractValue|ContractValue]]; the specific type
    * does not matter.
    *
-   * **Booleans**: Almost any input is accepted (as long as it's not type/value
-   * input for a different type), but how it is interpreted depends on the
-   * input.  A boolean will be interpreted in the obvious way, and a `Boolean`
-   * will be unwrapped.  A string will be considered true unless it is falsy or
-   * is equal (ignoring case) to the string `"false"`.  A `String` will be
+   * **Booleans**: Unless the `strictBooleans` option is passed, almost any
+   * input is accepted (as long as it's not type/value input for a different
+   * type), but how it is interpreted depends on the input.  A boolean will be
+   * interpreted in the obvious way, and a `Boolean` will be unwrapped.  A
+   * string will be considered true unless it is falsy or is equal (ignoring
+   * case) to the string `"false"`; however, if `strictBooleans` is passed, then
+   * only strings that are (ignoring case) equal to `"true"` or `"false"` will
+   * be accepted.  A `String` will be
    * considered true if and only if the underlying string is.  A number will be
    * considered true so long as it is truthy, and a `Number` will be considered
    * true if and only if the underlying number is.  A
@@ -1172,7 +1175,8 @@ export class ContractEncoder {
    * [[Format.Values.BoolValue|BoolValues]] or a
    * [[Format.Values.UserDefinedTypeValue|UserDefinedTypeValue]] on top of one,
    * will be rejected.  All other inputs will be considered true so long as
-   * they are truthy.
+   * they are truthy, unless `strictBooleans` is passed, in which case they will
+   * be rejected.
    *
    * **Decimal fixed-point types**: Input for fixed-point decimal types is
    * similar to input for integer types.  The differences are as follows:
@@ -1198,12 +1202,16 @@ export class ContractEncoder {
    * **Arrays**: The input may be an array, or it may be a
    * [[Format.Values.ArrayValue|ArrayValue]].  In the latter case,
    * whether it is static-length or dynamic-length does not need to match
-   * (unless strict checking is on, see [[resolveAndWrap]]).
+   * (unless strict checking is on, see [[resolveAndWrap]]).  If the `allowJson`
+   * option is passed, the array may also be a JSON string.  Note that any allowed
+   * format is allowed for the individual elements.
    *
    * **Structs and tuples**: The input can be given either as an array or as an
-   * object.  If given as an array, the elements should be the members of the
-   * struct/tuple, in order.  If given as an object, it should be keyed by the
-   * struct or tuple's field names; if any of the elements of the tuple are
+   * object; if the `allowJson` option is passed, it may also be given as a
+   * JSON string for one of these (any format is allowed for the individual
+   * elements).  If given as an array, the elements should be the members of
+   * the struct/tuple, in order.  If given as an object, it should be keyed by
+   * the struct or tuple's field names; if any of the elements of the tuple are
    * unnamed, then input cannot be given as an object.  Additional keys are
    * also allowed unless strict checking is on.  Input may also be given as a
    * [[Format.Values.StructValue|StructValue]] or

--- a/packages/encoder/lib/encoders.ts
+++ b/packages/encoder/lib/encoders.ts
@@ -227,7 +227,7 @@ export class ProjectEncoder {
     return await this.driveGenerator(
       Codec.Wrap.wrapForMethod(method, inputs, {
         userDefinedTypes: this.userDefinedTypes,
-        allowOptions: Boolean(options.allowOptions)
+        ...options
       })
     );
   }
@@ -243,7 +243,7 @@ export class ProjectEncoder {
     return await this.driveGenerator(
       Codec.Wrap.resolveAndWrap(methods, inputs, {
         userDefinedTypes: this.userDefinedTypes,
-        allowOptions: Boolean(options.allowOptions)
+        ...options
       })
     );
   }

--- a/packages/encoder/lib/types.ts
+++ b/packages/encoder/lib/types.ts
@@ -17,6 +17,17 @@ export interface ResolveOptions {
    * argument after the other arguments.
    */
   allowOptions?: boolean;
+  /**
+   * This field, if set to true, allows JSON strings to be used for structs,
+   * tuples, and arrays.  Note that this does *not* allow JSON to be used for
+   * elementary types like strings!
+   */
+  allowJson?: boolean;
+  /**
+   * This field, if set to true, disallows accepting arbitrary input as
+   * booleans.
+   */
+  strictBooleans?: boolean;
 }
 
 /**

--- a/packages/encoder/test/array.test.ts
+++ b/packages/encoder/test/array.test.ts
@@ -101,6 +101,17 @@ describe("Encoding", () => {
         );
       });
 
+      it("Encodes JSON when enabled", async () => {
+        const { data } = await encoder.encodeTxNoResolution(abi, ['[1, "2"]'], {
+          allowJson: true
+        });
+        assert.strictEqual(
+          data,
+          selector +
+            "00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002"
+        );
+      });
+
       it("Encodes type/value pairs", async () => {
         const { data } = await encoder.encodeTxNoResolution(abi, [
           {
@@ -196,6 +207,43 @@ describe("Encoding", () => {
         try {
           await encoder.encodeTxNoResolution(abi, [[1]]);
           assert.fail("Short array got encoded");
+        } catch (error) {
+          if (error.name !== "TypeMismatchError") {
+            throw error;
+          }
+        }
+      });
+
+      it("Rejects JSON when not enabled", async () => {
+        try {
+          await encoder.encodeTxNoResolution(abi, ["[1,2]"]);
+          assert.fail("JSON should not be accepted unless explicitly enabled");
+        } catch (error) {
+          if (error.name !== "TypeMismatchError") {
+            throw error;
+          }
+        }
+      });
+
+      it("Rejects invalid JSON", async () => {
+        try {
+          await encoder.encodeTxNoResolution(abi, ["[1,2"], {
+            allowJson: true
+          });
+          assert.fail("Bad JSON was accepted");
+        } catch (error) {
+          if (error.name !== "TypeMismatchError") {
+            throw error;
+          }
+        }
+      });
+
+      it("Rejects JSON that doesn't match", async () => {
+        try {
+          await encoder.encodeTxNoResolution(abi, ["[1,2,3]"], {
+            allowJson: true
+          });
+          assert.fail("JSON of wrong length was accepted");
         } catch (error) {
           if (error.name !== "TypeMismatchError") {
             throw error;

--- a/packages/encoder/test/bool.test.ts
+++ b/packages/encoder/test/bool.test.ts
@@ -91,7 +91,9 @@ describe("Encoding", () => {
     });
 
     it("Encodes booleans (true)", async () => {
-      const { data } = await encoder.encodeTxNoResolution(abi, [true]);
+      const { data } = await encoder.encodeTxNoResolution(abi, [true], {
+        strictBooleans: true
+      });
       assert.strictEqual(
         data,
         selector +
@@ -100,7 +102,9 @@ describe("Encoding", () => {
     });
 
     it("Encodes booleans (false)", async () => {
-      const { data } = await encoder.encodeTxNoResolution(abi, [false]);
+      const { data } = await encoder.encodeTxNoResolution(abi, [false], {
+        strictBooleans: true
+      });
       assert.strictEqual(
         data,
         selector +
@@ -109,13 +113,26 @@ describe("Encoding", () => {
     });
 
     it("Encodes boxed booleans", async () => {
-      const { data } = await encoder.encodeTxNoResolution(abi, [
-        new Boolean(false)
-      ]);
+      const { data } = await encoder.encodeTxNoResolution(
+        abi,
+        [new Boolean(false)],
+        { strictBooleans: true }
+      );
       assert.strictEqual(
         data,
         selector +
           "0000000000000000000000000000000000000000000000000000000000000000"
+      );
+    });
+
+    it("Encodes variations of 'true' as true", async () => {
+      const { data } = await encoder.encodeTxNoResolution(abi, ["tRue"], {
+        strictBooleans: true
+      });
+      assert.strictEqual(
+        data,
+        selector +
+          "0000000000000000000000000000000000000000000000000000000000000001"
       );
     });
 
@@ -138,7 +155,9 @@ describe("Encoding", () => {
     });
 
     it("Encodes variations of 'false' as false", async () => {
-      const { data } = await encoder.encodeTxNoResolution(abi, ["FaLsE"]);
+      const { data } = await encoder.encodeTxNoResolution(abi, ["FaLsE"], {
+        strictBooleans: true
+      });
       assert.strictEqual(
         data,
         selector +
@@ -158,9 +177,11 @@ describe("Encoding", () => {
     });
 
     it("Encodes boxed variations of 'false' as false", async () => {
-      const { data } = await encoder.encodeTxNoResolution(abi, [
-        new String("FaLsE")
-      ]);
+      const { data } = await encoder.encodeTxNoResolution(
+        abi,
+        [new String("FaLsE")],
+        { strictBooleans: true }
+      );
       assert.strictEqual(
         data,
         selector +
@@ -412,6 +433,19 @@ describe("Encoding", () => {
         assert.fail(
           "Error result (of general sort) for UDVT got encoded as bool"
         );
+      } catch (error) {
+        if (error.name !== "TypeMismatchError") {
+          throw error;
+        }
+      }
+    });
+
+    it("Rejects general strings with strictBooleans turned on", async () => {
+      try {
+        await encoder.encodeTxNoResolution(abi, ["moobytooble"], {
+          strictBooleans: true
+        });
+        assert.fail("General string got encoded as bool despite strict option");
       } catch (error) {
         if (error.name !== "TypeMismatchError") {
           throw error;

--- a/packages/encoder/test/bool.test.ts
+++ b/packages/encoder/test/bool.test.ts
@@ -165,6 +165,28 @@ describe("Encoding", () => {
       );
     });
 
+    it("Encodes '1' as true", async () => {
+      const { data } = await encoder.encodeTxNoResolution(abi, ["1"], {
+        strictBooleans: true
+      });
+      assert.strictEqual(
+        data,
+        selector +
+          "0000000000000000000000000000000000000000000000000000000000000001"
+      );
+    });
+
+    it("Encodes '0' as false", async () => {
+      const { data } = await encoder.encodeTxNoResolution(abi, ["0"], {
+        strictBooleans: true
+      });
+      assert.strictEqual(
+        data,
+        selector +
+          "0000000000000000000000000000000000000000000000000000000000000000"
+      );
+    });
+
     it("Encodes boxed empty strings as false", async () => {
       const { data } = await encoder.encodeTxNoResolution(abi, [
         new String("")


### PR DESCRIPTION
This PR adds two new options to the encoder, intended for use with `truffle call` (#5330).  It also adds tests of these and updates the documentation.  (Edit: **This PR now contains breaking changes to `@truffle/codec` and `@truffle/encoder`.**)

The first option, `allowJson`, allows arrays and tuples/structs to be given as JSON strings.  Note that this *only applies* to arrays and tuples, not more elementary types like strings!  So you can pass `'["abc","def"]'` for `["abc","def"]`, but not `'"abc"'` for `"abc"` on its own.  For tuples/structs, the JSON can be either for an array or for an object (since both arrays and objects are allowed as input for these).  The JSON cannot be for some other form of input; e.g., you can't put in JSON for a type/value pair or a codec `Value` or what have you.

Note that the individual elements can, within the JSON, be given in any form allowed; e.g., you can pass `'[1, "2"]'` for an array of two uints, for instance.

Also, note that JSON input must be a `string` and not a `String`; I didn't see any reason to bother with the latter given the intended use case. :P

The second option, `strictBooleans`, makes it so that the only strings that will be accepted as booleans are `"true"` and `"false"` (ignoring case).  I considered also allowing `"0"` and `"1"`, but decided against it for now... @gnidan, let me know if you think that should be changed.  Note that having `"0"` be treated as false would be a breaking change, but I don't think that should stop us if you think it's the right thing.  Turning on `strictBooleans` also makes it so that you can't just use arbitrary input as a boolean like you could previously.

Now, because the catch-all I turned off was previously used to handle all sorts of things, that actually made `strictBooleans` stricter than intended... you couldn't use an actual `boolean` anymore!  So I added a new case to handle that.  It also makes it so that you can't use a `number` either, since those were also handled by the catch-all!  I didn't bother adding a case for that, though, because the intended use-case doesn't require it.  I mean, OK, the intended use-case doesn't require `boolean`s to work as input either, but rejecting those would just be ridiculous, so, yeah.  Again, @gnidan, let me know if you want this changed.

Anyway, this is mostly pretty straightforward -- just adding cases to `wrap` in the existing style.  I think if `truffle call` passes these two options, it should be able to use `encoder` pretty well!