### PR TITLE
make the `develop:ganache` debug prefix orange

### DIFF
--- a/packages/environment/develop.js
+++ b/packages/environment/develop.js
@@ -43,6 +43,9 @@ const Develop = {
     const debugServer = debug("develop:ipc:server");
     const debugClient = debug("develop:ipc:client");
     const debugRPC = debug("develop:ganache");
+    // make the `develop:ganache` debug prefix orange
+    // 215 is Xterm number for "SandyBrown" (#ffaf5f)
+    debugRPC.color = 215;
 
     options.retry = options.retry || false;
     options.log = options.log || false;


### PR DESCRIPTION
![giphy](https://user-images.githubusercontent.com/187813/181841916-334c0b42-9261-4e33-93a8-0cce64b41275.gif)
> This is the best PR Truffle has ever seen. You will merge it.

---

To test you should run `truffle develop` then send some requests at it (running `truffle migrate` against the `truffle develop` instance will do the trick)

Before :vomiting_face: :
![image](https://user-images.githubusercontent.com/187813/181841532-2f6f2bbd-aa7f-473e-81dc-aabe0b7b4ccd.png)

After:
![image](https://user-images.githubusercontent.com/187813/181841606-86c7188f-8065-4aa0-957d-436d445eca68.png)

Ganache Logo for ref:
<img alt="Ganache" src="https://trufflesuite.github.io/ganache/assets/img/ganache-logo-dark.svg" alt="Ganache" width="160"/>