### PR TITLE
Update @truffle/core in truffle and update yarn.lock

### DIFF
--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -45,7 +45,7 @@
     "@truffle/box": "^2.1.54",
     "@truffle/config": "^1.3.34",
     "@truffle/contract": "^4.5.19",
-    "@truffle/core": "^5.5.23",
+    "@truffle/core": "^5.5.24",
     "@truffle/interface-adapter": "^0.5.20",
     "clean-webpack-plugin": "^3.0.0",
     "copy-webpack-plugin": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5922,105 +5922,12 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
-"@truffle/core@^5.5.23":
-  version "5.5.23"
-  resolved "https://registry.yarnpkg.com/@truffle/core/-/core-5.5.23.tgz#8f36035a2c130f9247e52b3f97a686fceeb9ab45"
-  integrity sha512-e8JPHnRsKx6XD7yW0y6qfcbXMXUOdGUwOzuPKxMbS8kLYMjSO6L5SOTDDTzBRXZciFBhQmWI/9s39CATsz1k1g==
-  dependencies:
-    "@truffle/artifactor" "^4.0.162"
-    "@truffle/box" "^2.1.53"
-    "@truffle/codec" "^0.13.3"
-    "@truffle/compile-common" "^0.7.32"
-    "@truffle/compile-solidity" "^6.0.36"
-    "@truffle/config" "^1.3.33"
-    "@truffle/contract" "^4.5.18"
-    "@truffle/dashboard" "^0.1.10"
-    "@truffle/debug-utils" "^6.0.28"
-    "@truffle/debugger" "^11.0.1"
-    "@truffle/decoder" "^5.2.21"
-    "@truffle/deployer" "^3.2.89"
-    "@truffle/environment" "^0.2.116"
-    "@truffle/error" "^0.1.0"
-    "@truffle/expect" "^0.1.2"
-    "@truffle/fetch-and-compile" "^0.5.11"
-    "@truffle/interface-adapter" "^0.5.19"
-    "@truffle/migrate" "^3.3.3"
-    "@truffle/plugins" "^0.2.8"
-    "@truffle/preserve" "^0.2.7"
-    "@truffle/promise-tracker" "^0.1.1"
-    "@truffle/provider" "^0.2.57"
-    "@truffle/provisioner" "^0.2.56"
-    "@truffle/require" "^2.0.102"
-    "@truffle/resolver" "^9.0.9"
-    "@truffle/source-fetcher" "^1.0.12"
-    "@truffle/spinners" "^0.2.0"
-    "@truffle/workflow-compile" "^4.0.26"
-    address "^1.1.2"
-    chai "^4.2.0"
-    colors "1.4.0"
-    command-exists "^1.2.8"
-    conf "^10.0.2"
-    debug "^4.3.1"
-    del "^2.2.0"
-    ethereum-cryptography "1.1.2"
-    ethereumjs-wallet "^1.0.2"
-    fs-extra "^9.1.0"
-    ganache "7.3.2"
-    get-port "^5.1.1"
-    get-random-values "^1.2.2"
-    glob "^7.1.6"
-    inquirer "8.2.2"
-    js-interpreter "2.2.0"
-    lodash "^4.17.21"
-    mocha "9.2.2"
-    node-emoji "^1.8.1"
-    original-require "^1.0.1"
-    sane "^4.0.2"
-    semver "7.3.7"
-    source-map-support "^0.5.19"
-    spawn-args "0.2.0"
-    tmp "^0.2.1"
-    universal-analytics "^0.4.17"
-    web3 "1.7.4"
-    web3-utils "1.7.4"
-    xregexp "^4.2.4"
-    yargs "^13.3.0"
-
-"@truffle/interface-adapter@^0.5.19":
-  version "0.5.19"
-  resolved "https://registry.yarnpkg.com/@truffle/interface-adapter/-/interface-adapter-0.5.19.tgz#57529cacb09c72ebfd584ec003af55face18a3de"
-  integrity sha512-x7IZvsyx36DAJCJVZ9gUe1Lh8AhODhJoW7I+lJXIlGxj3EmZbao4/sHo+cN4u9i94yVTyGwYd78NzbP0a/LAog==
-  dependencies:
-    bn.js "^5.1.3"
-    ethers "^4.0.32"
-    web3 "1.7.4"
-
 "@truffle/preserve@^0.2.7":
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/@truffle/preserve/-/preserve-0.2.7.tgz#fd149e4d0f1594e400fea3453c898362655d8588"
   integrity sha512-A5pRuFre9IR2m2BB1JMF9CItgUSwR2eRhqHU2ltvPjWHNxbGAo4tMZat+124hed6zDBUduYsjmV5Yr5wo7kF8g==
   dependencies:
     spinnies "^0.5.1"
-
-"@truffle/provider@^0.2.57":
-  version "0.2.57"
-  resolved "https://registry.yarnpkg.com/@truffle/provider/-/provider-0.2.57.tgz#c6d079748c99427c1ce283a19921b450aa9920ee"
-  integrity sha512-O8VxF2uQwa+KB4HDg9lG7uhQ/+AOvchX+1STpQBSSAGfov1+EROM0iRZUNoPm71Pu0C9ji2WmXbNW/COjUMaMA==
-  dependencies:
-    "@truffle/error" "^0.1.0"
-    "@truffle/interface-adapter" "^0.5.19"
-    debug "^4.3.1"
-    web3 "1.7.4"
-
-"@truffle/require@^2.0.102":
-  version "2.0.102"
-  resolved "https://registry.yarnpkg.com/@truffle/require/-/require-2.0.102.tgz#45238d7dbd073d555623ca27616309969509d421"
-  integrity sha512-fLeEa54i/pXab99ouAB5o5IjKME3AOUivBUV1E2R+t4uB8avjPWQbALvkUJ2G7CgUeVanuYMSsxwoUMbLss/vg==
-  dependencies:
-    "@truffle/config" "^1.3.33"
-    "@truffle/expect" "^0.1.2"
-    "@truffle/interface-adapter" "^0.5.19"
-    original-require "^1.0.1"
 
 "@trufflesuite/bigint-buffer@1.1.10":
   version "1.1.10"
@@ -15414,23 +15321,6 @@ functions-have-names@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.2.tgz#98d93991c39da9361f8e50b337c4f6e41f120e21"
   integrity sha512-bLgc3asbWdwPbx2mNk2S49kmJCuQeu0nfmaOgbs8WIyzzkw3r4htszdIi9Q9EMezDPTYuJx2wvjZ/EwgAthpnA==
-
-ganache@7.3.2:
-  version "7.3.2"
-  resolved "https://registry.yarnpkg.com/ganache/-/ganache-7.3.2.tgz#f2cd9df8244851f3d62c19cb5a71cc0c782932eb"
-  integrity sha512-X1IXfqrFQuiMqrONvb4zQqXwjf2Skg8iuofYlFrzWnCI+JZN2hJA5V5Egu/go3YgD8IRpQyLP/Jny0fZM0A5UA==
-  dependencies:
-    "@trufflesuite/bigint-buffer" "1.1.10"
-    "@types/bn.js" "^5.1.0"
-    "@types/lru-cache" "5.1.1"
-    "@types/seedrandom" "3.0.1"
-    emittery "0.10.0"
-    keccak "3.0.1"
-    leveldown "6.1.0"
-    secp256k1 "4.0.2"
-  optionalDependencies:
-    bufferutil "4.0.5"
-    utf-8-validate "5.0.7"
 
 ganache@7.4.0:
   version "7.4.0"


### PR DESCRIPTION
There are some issues with Truffle release 5.5.24:

 * @truffle/core's version was not bumped in truffle/package.json devDeps appropriately
 * both truffle develop and master (post release) fail in CI, not getting past yarncheck

I think this PR will fix both of these issues and get things working again.

(but a proper post-mortem should be done)