### PR TITLE
Enhancement: Add `flattedEvents` selector to debugger

### DIFF
--- a/packages/debugger/lib/txlog/selectors/index.js
+++ b/packages/debugger/lib/txlog/selectors/index.js
@@ -450,7 +450,7 @@ let txlog = createSelectorTree({
               getFlattedEvents(subNode, node.origin, node.origin, status)
             );
           case "callexternal":
-            const subNodeStatus = ["return", "selfdestruct"].includes(
+            const subNodeStatus = !["revert", "unwind"].includes(
               node.returnKind
             );
             return node.actions.flatMap(subNode =>


### PR DESCRIPTION
This PR adds to the debugger the seletor `txlog.views.flattedEvents`.  This selector gives a flat list of all events emitted during the transaction so far; note that as a `txlog` selector it's meant primarily to be used at the end of a transaction.

The selector's return value is an array of all events emitted during the transaction so far, in order; note, however, that this includes events that may have reverted.  However, each event includes a `status` field to distinguish, so if you want you can filter down to just the events that were successfully emitted (and then you can put indices on them if you really want :) ).  (I thought about adding an additional selector that actually performed this filtering, but this seemed unnecessary so I skipped it.)  Note that if you look at this selector before the transaction has completed, then `status: true` will merely indicate that the event hasn't reverted *yet*; it may still revert in the future.

Each event contains the fields `decoding`, `raw` (with `topics` and `data`), `address`, `codeAddress`, and `status`.  The `decoding` is the same decoding from txlog; `raw` is the same as well.  The `address` field lists the address that officially emitted the event, while `codeAddress` is the address of the actual code that emitted the event; these may differ in the event of a delegate call (as it's the storage address, not the code address, that officially emits the event).  Note that if a constructor emits an event, the address being constructed is used for both `address` and `codeAddress`.  Also note as usual that if a constructor reverts, we may not be able to determine the address, and it may show up as zero instead.

I'll skip explaining how it works as it's just a straightforward recursive traversal of the txlog tree.  Note that an event will be marked as `status: false` if either the call that made it reverts, or if any containing call reverts, because either way it was not successfully emitted!

I also added a test.