### PR TITLE
Enhancement: Include raw call data in txlog in all cases

### DIFF
--- a/packages/debugger/lib/txlog/reducers.js
+++ b/packages/debugger/lib/txlog/reducers.js
@@ -185,6 +185,14 @@ function transactionLog(state = DEFAULT_TX_LOG, action) {
           (kind === "function" || kind === "library") &&
           action.absorbNextInternalCall;
       }
+      //include raw data regardless
+      call.raw = {};
+      if (calldata) {
+        call.raw.calldata = calldata;
+      }
+      if (binary) {
+        call.raw.binary = binary;
+      }
       return {
         byPointer: {
           ...state.byPointer,

--- a/packages/debugger/test/txlog.js
+++ b/packages/debugger/test/txlog.js
@@ -12,6 +12,7 @@ import {
 } from "./helpers";
 import Debugger from "lib/debugger";
 import * as Codec from "@truffle/codec";
+import Web3 from "web3";
 
 import txlog from "lib/txlog/selectors";
 
@@ -228,6 +229,15 @@ describe("Transaction log (visualizer)", function () {
     assert.equal(call.functionName, "testCall");
     assert.equal(call.contractName, "VizTest");
     assert.equal(call.returnKind, "return");
+    const expectedSelector = Web3.utils
+      .soliditySha3("testCall(uint256)")
+      .slice(0, 2 + 2 * Codec.Evm.Utils.SELECTOR_SIZE);
+    const expectedArgument = Codec.Conversion.toHexString(
+      108,
+      Codec.Evm.Utils.WORD_SIZE
+    ).slice(2);
+    assert.equal(call.raw.calldata, expectedSelector + expectedArgument);
+    assert.notProperty(call.raw, "binary");
     debug("arguments: %O", call.arguments);
     let inputs = Codec.Export.unsafeNativizeVariables(byName(call.arguments));
     debug("nativized: %O", inputs);
@@ -281,6 +291,13 @@ describe("Transaction log (visualizer)", function () {
     assert.isUndefined(call.functionName);
     assert.equal(call.contractName, "Secondary");
     assert.equal(call.returnKind, "return");
+    const expectedBytecode = abstractions.Secondary.binary;
+    const expectedArgument = Codec.Conversion.toHexString(
+      108,
+      Codec.Evm.Utils.WORD_SIZE
+    ).slice(2);
+    assert.equal(call.raw.binary, expectedBytecode + expectedArgument);
+    assert.notProperty(call.raw, "calldata");
     let inputs = Codec.Export.unsafeNativizeVariables(byName(call.arguments));
     assert.deepEqual(inputs, {
       y: 108


### PR DESCRIPTION
Does part, but not all, of #5334.  Specifically the calls part; ignored the returns part for the reasons discussed there.

Adds to `externalreturn` actions a `raw` field, with either `raw.calldata` or `raw.binary` (for creations).  Originally I was going to make it just a single field, but I thought it was worth distinguishing?  IDK.

Btw, a thing I'd forgotten: For calls and creations that can't be decoded, we actually already include the raw data!  So uh now we're including it twice in such cases.  Oh well?

I wish I'd remembered that though when thinking about how to handle return values / errors / events in the first place!  It would have been sensible to do those that way initially... oh well.  Well, we can figure out exactly how we want this to work...

Also I updated two tests to test this stuff.