### PR TITLE
Remove unnecessary CI guard

### DIFF
--- a/packages/compile-solidity/test/test_supplier.js
+++ b/packages/compile-solidity/test/test_supplier.js
@@ -189,13 +189,10 @@ describe("CompilerSupplier", function () {
 
       assert(NewPragma.contractName === "NewPragma", "Should have compiled");
 
-      // atime is not getting updatd on read in CI.
-      if (!process.env.TEST) {
-        assert(
-          initialAccessTime < finalAccessTime,
-          "Should have used cached compiler"
-        );
-      }
+      assert(
+        initialAccessTime < finalAccessTime,
+        "Should have used cached compiler"
+      );
     });
 
     describe("native / docker [ @native ]", function () {


### PR DESCRIPTION
compile-solidity: remove process.env.TEST guard

This guard is not necessary for Github actions. It was previously needed for TravisCI.