### PR TITLE
Remove abi-util node types warning

### DIFF
--- a/packages/abi-utils/package.json
+++ b/packages/abi-utils/package.json
@@ -33,6 +33,7 @@
     "@types/faker": "^5.1.2",
     "@types/jest": "27.4.1",
     "@types/jest-json-schema": "^2.1.2",
+    "@types/node": "12.12.21",
     "jest": "28.1.3",
     "jest-extended": "^0.11.5",
     "jest-fast-check": "2.0.0",


### PR DESCRIPTION
Removes warning:

```
warning "workspace-aggregator-aed90a07-068f-443d-8404-55b7f884493e > @truffle/abi-utils > ts-node@10.7.0" has unmet peer dependency "@types/node@*".
```