### PR TITLE
Remove ts-node peer dep warning

### DIFF
--- a/packages/codec/package.json
+++ b/packages/codec/package.json
@@ -47,6 +47,7 @@
     "@types/semver": "^6.0.0",
     "@types/utf8": "^2.1.6",
     "@zerollup/ts-transform-paths": "^1.7.3",
+    "ts-node": "10.7.0",
     "ttypescript": "1.5.13",
     "typedoc": "0.20.37",
     "typedoc-plugin-remove-references": "^0.0.5",


### PR DESCRIPTION
Removes warning:

```
warning "workspace-aggregator-aed90a07-068f-443d-8404-55b7f884493e > @truffle/codec > ttypescript@1.5.13" has unmet peer dependency "ts-node@>=8.0.2".
```