### PR TITLE
Remove jest-fast-check warning

### DIFF
--- a/packages/abi-utils/.eslintrc.json
+++ b/packages/abi-utils/.eslintrc.json
@@ -1,0 +1,11 @@
+{
+  "extends": ["../../.eslintrc.package.json"],
+  "overrides": [
+    {
+      "files": ["./lib/**/*.test.[tj]s"],
+      "env": {
+        "jest": true
+      }
+    }
+  ]
+}

--- a/packages/abi-utils/lib/arbitrary.test.ts
+++ b/packages/abi-utils/lib/arbitrary.test.ts
@@ -1,4 +1,4 @@
-import { testProp } from "jest-fast-check";
+import { testProp } from "@fast-check/jest";
 import * as abiSchema from "@truffle/contract-schema/spec/abi.spec.json";
 import { matchers } from "jest-json-schema";
 

--- a/packages/abi-utils/lib/arbitrary.ts
+++ b/packages/abi-utils/lib/arbitrary.ts
@@ -148,7 +148,9 @@ export const ConstructorEntry = () =>
         type: fc.constant("constructor"),
         inputs: fc.array(Parameter(), { maxLength: 10 }).filter(inputs => {
           // names that are not blank should be unique
-          const names = inputs.map(({ name }) => name).filter(name => name !== "");
+          const names = inputs
+            .map(({ name }) => name)
+            .filter(name => name !== "");
           return names.length === new Set(names).size;
         })
       }),
@@ -248,7 +250,7 @@ const Type: fc.Memo<string> = fc.memo(n =>
 
 const ArrayFixed = fc.memo(n =>
   fc
-    .tuple(Type(n - 1), fc.integer(1, 256))
+    .tuple(Type(n - 1), fc.integer({ min: 1, max: 256 }))
     .map(([type, length]) => `${type}[${length}]`)
 );
 
@@ -405,7 +407,7 @@ const fakerToArb = (template: string, transform = camelCase) => {
 };
 
 const ParameterName = () =>
-  fc.frequency(
+  fc.oneof(
     { arbitrary: fakerToArb("{{hacker.noun}}"), weight: 9 },
     { arbitrary: fc.constant(""), weight: 1 }
   );

--- a/packages/abi-utils/lib/normalize.test.ts
+++ b/packages/abi-utils/lib/normalize.test.ts
@@ -1,5 +1,5 @@
 import "jest-extended";
-import { testProp } from "jest-fast-check";
+import { testProp } from "@fast-check/jest";
 
 import * as Arbitrary from "./arbitrary";
 
@@ -48,9 +48,7 @@ describe("normalize", () => {
 
       expect(
         abi.filter(({ type }) => type !== "event" && type !== "error")
-      ).toSatisfyAll(
-        entry => "stateMutability" in entry
-      );
+      ).toSatisfyAll(entry => "stateMutability" in entry);
     }
   );
 

--- a/packages/abi-utils/package.json
+++ b/packages/abi-utils/package.json
@@ -26,16 +26,16 @@
   "dependencies": {
     "change-case": "3.0.2",
     "faker": "5.5.3",
-    "fast-check": "2.15.1"
+    "fast-check": "3.1.1"
   },
   "devDependencies": {
+    "@fast-check/jest": "^1.0.1",
     "@truffle/contract-schema": "^3.4.8",
     "@types/faker": "^5.1.2",
     "@types/jest": "27.4.1",
     "@types/jest-json-schema": "^2.1.2",
     "jest": "28.1.3",
     "jest-extended": "^0.11.5",
-    "jest-fast-check": "2.0.0",
     "jest-json-schema": "^2.1.0",
     "ts-jest": "28.0.6",
     "ts-node": "10.7.0",

--- a/packages/abi-utils/tsconfig.json
+++ b/packages/abi-utils/tsconfig.json
@@ -47,7 +47,7 @@
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    // "types": [],                           /* Type declaration files to be included in compilation. */
+    "types": ["node", "jest"],                /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -58,6 +58,7 @@
     "web3-utils": "1.7.4"
   },
   "devDependencies": {
+    "@fast-check/jest": "^1.0.1",
     "@gql2ts/from-schema": "^2.0.0-4",
     "@graphql-tools/utils": "^8.5.5",
     "@truffle/compile-common": "^0.7.32",
@@ -73,11 +74,10 @@
     "@types/pouchdb-adapter-leveldb": "^6.1.3",
     "@types/web3": "^1.0.20",
     "change-case": "3.0.2",
-    "fast-check": "2.15.1",
+    "fast-check": "3.1.1",
     "ganache": "7.4.0",
     "hkts": "^0.3.1",
     "jest": "28.1.3",
-    "jest-fast-check": "2.0.0",
     "madge": "^5.0.1",
     "ts-jest": "28.0.6",
     "ts-node": "10.7.0",

--- a/packages/db/src/network/test/index.spec.ts
+++ b/packages/db/src/network/test/index.spec.ts
@@ -2,7 +2,7 @@ import { logger } from "@truffle/db/logger";
 const debug = logger("db:network:test");
 
 import gql from "graphql-tag";
-import { testProp } from "jest-fast-check";
+import { testProp } from "@fast-check/jest";
 import * as fc from "fast-check";
 
 import * as Arbitrary from "test/arbitraries/networks";

--- a/packages/db/test/arbitraries/networks.ts
+++ b/packages/db/test/arbitraries/networks.ts
@@ -118,7 +118,7 @@ export const Networks = (): fc.Arbitrary<Model> =>
     .tuple(
       Commands.AddNetwork(),
       fc.array(
-        fc.frequency(
+        fc.oneof(
           {
             arbitrary: Commands.AddNetwork(),
             weight: 1

--- a/packages/encoder/package.json
+++ b/packages/encoder/package.json
@@ -38,6 +38,7 @@
     "web3-utils": "1.7.4"
   },
   "devDependencies": {
+    "@fast-check/jest": "^1.0.1",
     "@truffle/abi-utils": "^0.2.15",
     "@truffle/box": "^2.1.54",
     "@truffle/config": "^1.3.34",
@@ -56,11 +57,10 @@
     "@types/utf8": "^2.1.6",
     "@types/web3": "^1.0.20",
     "chai": "^4.2.0",
-    "fast-check": "2.15.1",
+    "fast-check": "3.1.1",
     "fs-extra": "^9.1.0",
     "ganache": "7.4.0",
     "jest": "28.1.3",
-    "jest-fast-check": "2.0.0",
     "jest-transform-stealthy-require": "^1.0.0",
     "ts-jest": "28.0.6",
     "typescript": "^4.1.4",

--- a/packages/encoder/test/wrap-fc.test.ts
+++ b/packages/encoder/test/wrap-fc.test.ts
@@ -12,7 +12,7 @@ import {
 import isNumber from "lodash/isNumber";
 
 import * as fc from "fast-check";
-import { testProp } from "jest-fast-check";
+import { testProp } from "@fast-check/jest";
 import Web3Utils from "web3-utils";
 import utf8 from "utf8";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3772,6 +3772,13 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.0"
 
+"@fast-check/jest@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@fast-check/jest/-/jest-1.0.1.tgz#125806b40919bcddef71b0b750dea7a2be291111"
+  integrity sha512-2k38LAEawqyKnsXvqNBrCByRKHELXBRGBxZV4Q4hVZsDb9Smf9anYc8zv184PvF4+gtMDzWlKRy6YCWDldf41Q==
+  dependencies:
+    fast-check "^3.0.0"
+
 "@ganache/ethereum-address@0.1.5":
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/@ganache/ethereum-address/-/ethereum-address-0.1.5.tgz#4b4994cf3b49b2f79bcd9fa9923f8217e956b99c"
@@ -14534,12 +14541,12 @@ faker@5.5.3:
   resolved "https://registry.yarnpkg.com/faker/-/faker-5.5.3.tgz#c57974ee484431b25205c2c8dc09fda861e51e0e"
   integrity sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==
 
-fast-check@2.15.1:
-  version "2.15.1"
-  resolved "https://registry.yarnpkg.com/fast-check/-/fast-check-2.15.1.tgz#a60c5ba0d5cba68a1176353c423c3733c02bb603"
-  integrity sha512-eNcOxh7iTLGwebRCRU+F+/Ne+41/7ra4qn1bhljAO+uqvxB9p4Qq/rqNeu3wls/ka9jnu9MvwUE/m1sTWcbGBg==
+fast-check@3.1.1, fast-check@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/fast-check/-/fast-check-3.1.1.tgz#72c5ae7022a4e86504762e773adfb8a5b0b01252"
+  integrity sha512-3vtXinVyuUKCKFKYcwXhGE6NtGWkqF8Yh3rvMZNzmwz8EPrgoc/v4pDdLHyLnCyCI5MZpZZkDEwFyXyEONOxpA==
   dependencies:
-    pure-rand "^4.1.1"
+    pure-rand "^5.0.1"
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -17858,11 +17865,6 @@ jest-extended@^0.11.5:
     expect "^24.1.0"
     jest-get-type "^22.4.3"
     jest-matcher-utils "^22.0.0"
-
-jest-fast-check@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/jest-fast-check/-/jest-fast-check-2.0.0.tgz#f1aae02c397913cce858866a1c13b9fd979cef0d"
-  integrity sha512-krHAj5Sdx4/Ytk/z9sbPU4C/mMSON+mDX6/e9a6LWlugd3+G9tT7aboyaXzUCNsjb/4xfJt2eXrQDPCq7TxdXA==
 
 jest-get-type@^22.4.3:
   version "22.4.3"
@@ -23877,10 +23879,10 @@ pure-color@^1.2.0:
   resolved "https://registry.yarnpkg.com/pure-color/-/pure-color-1.3.0.tgz#1fe064fb0ac851f0de61320a8bf796836422f33e"
   integrity sha1-H+Bk+wrIUfDeYTIKi/eWg2Qi8z4=
 
-pure-rand@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-4.1.1.tgz#9fca2d4af5c4e870bac337ed860977426ed17bf6"
-  integrity sha512-cZw4AL/KI6aDTdqHEbJPe2ZoHM3kSdpJRLJetv8c3tfq9o+PvQDXrHNEpB0AWukAGFx4fmeOerAGwkA4rtUgdA==
+pure-rand@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-5.0.1.tgz#97a287b4b4960b2a3448c0932bf28f2405cac51d"
+  integrity sha512-ksWccjmXOHU2gJBnH0cK1lSYdvSZ0zLoCMSz/nTGh6hDvCSgcRxDyIcOBD6KNxFz3xhMPm/T267Tbe2JRymKEQ==
 
 purgecss@^4.0.3:
   version "4.1.3"


### PR DESCRIPTION
Removes warning:

```
warning "workspace-aggregator-aed90a07-068f-443d-8404-55b7f884493e > @truffle/abi-utils > jest-fast-check@2.0.0" has incorrect peer dependency "fast-check@^3.0.0".
```