### PR TITLE
Remove tsutils peer dep warning on bootstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "lint-staged": "^12.1.2",
     "nyc": "15.1.0",
     "prettier": "^2.5.1",
-    "prs-merged-since": "^1.1.0"
+    "prs-merged-since": "^1.1.0",
+    "typescript": "^4.1.4"
   },
   "workspaces": {
     "packages": [


### PR DESCRIPTION
Removes the following warning:

```
warning "@typescript-eslint/eslint-plugin > tsutils@3.21.0" has unmet peer dependency "typescript@>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta".
```