### PR TITLE
switch ganache to use 'eager' mode in test environment

### DIFF
--- a/packages/core/lib/configAdapter.js
+++ b/packages/core/lib/configAdapter.js
@@ -88,7 +88,7 @@ function configureManagedGanache(config, networkConfig, mnemonic) {
     gasPrice,
     time: genesisTime,
     miner: {
-      instamine: "strict"
+      instamine: "eager"
     }
   };
 


### PR DESCRIPTION
Ganache 7 introduced 2 instamine modes: 'strict' and 'eager'. In eager mode, Ganache would receive a tx, mine it, and then send a response. This is not an accurate representation of how nodes behave in the wild so 'strict' mode was implemented in the test flow in Truffle in order to more accurately reflect this behabvior. However, this caused test suites to run a lot slower because of polling behavior in web3. We believe it does something like poll every 1 second to see if the tx has been included (after a tx is submitted). So this would cause each tx in a test to take at least that polling delay to complete. With 'eager' mode enabled (even though this behavior is innaccurate), it was always immediately available and therefore ran much faster. In the interest of speed for testing, we have decided to re-enable 'eager' mode