### PR TITLE
Remove HECO testnet from Etherscan fetcher

### DIFF
--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -70,7 +70,6 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
       "avalanche": "api.snowtrace.io",
       "fuji-avalanche": "api-testnet.snowtrace.io",
       "heco": "api.hecoinfo.com",
-      "testnet-heco": "api-testnet.hecoinfo.com",
       "moonbeam": "api-moonbeam.moonscan.io",
       "moonriver": "api-moonriver.moonscan.io",
       "moonbase-alpha": "api-moonbase.moonscan.io",

--- a/packages/source-fetcher/lib/networks.ts
+++ b/packages/source-fetcher/lib/networks.ts
@@ -44,14 +44,14 @@ export const networkNamesById: { [id: number]: string } = {
   250: "fantom",
   4002: "testnet-fantom",
   128: "heco",
-  256: "testnet-heco",
+  256: "testnet-heco", //not presently supported by either fetcher, but formerly by etherscan
   1284: "moonbeam",
   1285: "moonriver",
   1287: "moonbase-alpha",
   122: "fuse",
   11297108109: "palm",
   11297108099: "testnet-palm",
-  70: "hoo", //not presently supported by ether fetcher, but formerly by etherscan
+  70: "hoo", //not presently supported by either fetcher, but formerly by etherscan
   25: "cronos",
   338: "testnet-cronos",
   199: "bttc",


### PR DESCRIPTION
Etherscan seems to have removed support for the HECO testnet?  Removing it here as well.

(More accurately, it seems like they've dumped hecoinfo.com entirely... except someone is still keeping it running with the same API, so we can still use it!  But they've removed support for the testnet.  IDK.)