### PR TITLE
Dependency update: Update solc dependencies to 0.8.16 in truffle packages

### DIFF
--- a/packages/compile-solidity/package.json
+++ b/packages/compile-solidity/package.json
@@ -35,7 +35,7 @@
     "original-require": "^1.0.1",
     "require-from-string": "^2.0.2",
     "semver": "7.3.7",
-    "solc": "0.8.15"
+    "solc": "0.8.16"
   },
   "devDependencies": {
     "@truffle/artifactor": "^4.0.164",

--- a/packages/contract-schema/package.json
+++ b/packages/contract-schema/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "json-schema-to-typescript": "^5.5.0",
     "mocha": "9.2.2",
-    "solc": "0.8.15"
+    "solc": "0.8.16"
   },
   "keywords": [
     "artifacts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25924,10 +25924,10 @@ socks@^2.3.3, socks@^2.6.1:
     ip "^1.1.5"
     smart-buffer "^4.1.0"
 
-solc@0.8.15:
-  version "0.8.15"
-  resolved "https://registry.yarnpkg.com/solc/-/solc-0.8.15.tgz#d274dca4d5a8b7d3c9295d4cbdc9291ee1c52152"
-  integrity sha512-Riv0GNHNk/SddN/JyEuFKwbcWcEeho15iyupTSHw5Np6WuXA5D8kEHbyzDHi6sqmvLzu2l+8b1YmL8Ytple+8w==
+solc@0.8.16:
+  version "0.8.16"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.8.16.tgz#120f992357e236d99e6cf3445bf2c2dca3384f96"
+  integrity sha512-6oZg7FAhIouj2zYLvoR3Q4fMP/+BGPR7sY7GcrEXKIp+DRd8RmpDEFO1LUBKpClUiaYguNgmthTFmnPl4MeiMQ==
   dependencies:
     command-exists "^1.2.8"
     commander "^8.1.0"


### PR DESCRIPTION
This PR upgrades the `solc` version dependencies to latest **0.8.16** in `contract-schema` and `compile-solidity` packages.