### PR TITLE
core: set grep option as a string

### DIFF
--- a/packages/core/lib/commands/test/meta.js
+++ b/packages/core/lib/commands/test/meta.js
@@ -34,6 +34,13 @@ module.exports = {
       type: "boolean",
       default: false
     },
+    "grep": {
+      alias: "g",
+      type: "string",
+      describe:
+        `Use mocha's "grep" option while running tests. This ` +
+        `option only runs tests that match the supplied regex/string.`
+    },
     "stacktrace": {
       alias: "t",
       describe: "Produce Solidity stacktraces",


### PR DESCRIPTION
`truffle test --grep <pattern>` should run only tests that match <pattern>, however for some reason passing in an argument like `truffle test --grep "10000"` throws an error. The pattern should be interpreted as a string. I specified grep as a string in `yargs` builder structure to enforce this.

<details>
<summary>broken behavior: truffle test --grep "10000"</summary>

```console

╭─amal@falafel  ~/.scratch/2022/08/09/grep-string/mc ‹node-16.16.0› ‹truffle-stable›
╰─$ truffle test --grep "10000"

Compiling your contracts...
===========================
> Compiling ./contracts/ConvertLib.sol
> Compiling ./contracts/MetaCoin.sol
> Compiling ./test/TestMetaCoin.sol
> Artifacts written to /tmp/test--78754-PIfppPZPxpuN
> Compiled successfully using:
   - solc: 0.8.13+commit.abaa5c0e.Emscripten.clang
TypeError: self._grep.test is not a function
    at /home/amal/.nvm/versions/node/v16.16.0/lib/node_modules/truffle/node_modules/mocha/lib/runner.js:333:28
    at Array.forEach (<anonymous>)
    at Suite.eachTest (/home/amal/.nvm/versions/node/v16.16.0/lib/node_modules/truffle/build/webpack:/node_modules/mocha/lib/suite.js:427:1)
    at /home/amal/.nvm/versions/node/v16.16.0/lib/node_modules/truffle/node_modules/mocha/lib/suite.js:429:11
    at Array.forEach (<anonymous>)
    at Suite.eachTest (/home/amal/.nvm/versions/node/v16.16.0/lib/node_modules/truffle/node_modules/mocha/lib/suite.js:428:15)
    at Runner.grepTotal (/home/amal/.nvm/versions/node/v16.16.0/lib/node_modules/truffle/node_modules/mocha/lib/runner.js:332:9)
    at Runner.grep (/home/amal/.nvm/versions/node/v16.16.0/lib/node_modules/truffle/node_modules/mocha/lib/runner.js:315:21)
    at Mocha.run (/home/amal/.nvm/versions/node/v16.16.0/lib/node_modules/truffle/node_modules/mocha/lib/mocha.js:1035:12)
    at /home/amal/.nvm/versions/node/v16.16.0/lib/node_modules/truffle/build/webpack:/packages/core/lib/testing/Test.js:156:1
    at new Promise (<anonymous>)
    at Object.run (/home/amal/.nvm/versions/node/v16.16.0/lib/node_modules/truffle/build/webpack:/packages/core/lib/testing/Test.js:155:1)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at startGanacheAndRunTests (/home/amal/.nvm/versions/node/v16.16.0/lib/node_modules/truffle/build/webpack:/packages/core/lib/commands/test/run.js:49:1)
    at Object.module.exports [as run] (/home/amal/.nvm/versions/node/v16.16.0/lib/node_modules/truffle/build/webpack:/packages/core/lib/commands/test/run.js:106:1)
    at runCommand (/home/amal/.nvm/versions/node/v16.16.0/lib/node_modules/truffle/build/webpack:/packages/core/lib/command-utils.js:190:1)
Truffle v5.5.25 (core: 5.5.25)
Node v16.16.0
```
</details>


<details>
<summary>fixed behavior: truffle test --grep "10000"</summary>

```console
╭─amal@falafel  ~/.scratch/2022/08/09/grep-string/mc ‹node-16.16.0› ‹truffle-core›
╰─$ truffle test --grep "10000"

Compiling your contracts...
===========================
> Compiling ./contracts/ConvertLib.sol
> Compiling ./contracts/MetaCoin.sol
> Compiling ./test/TestMetaCoin.sol
> Artifacts written to /tmp/test--78925-nM2uwfAPGizp
> Compiled successfully using:
   - solc: 0.8.13+commit.abaa5c0e.Emscripten.clang


  Contract: MetaCoin
    ✔ should put 10000 MetaCoin in the first account


  1 passing (114ms)


```
</details>

## How to test
- unbox metacoin
- verify `truffle test --grep 10000` works, finds 1 test with the string "10000". This should work in both the command line as well as the truffle develop REPL.
