### PR TITLE
Expose @truffle/compile-solidity's bytecode shims

### DIFF
--- a/packages/compile-solidity/src/index.js
+++ b/packages/compile-solidity/src/index.js
@@ -6,6 +6,7 @@ const { CompilerSupplier } = require("./compilerSupplier");
 const { run } = require("./run");
 const { normalizeOptions } = require("./normalizeOptions");
 const { compileWithPragmaAnalysis } = require("./compileWithPragmaAnalysis");
+const Shims = require("./shims");
 const { reportSources } = require("./reportSources");
 const { Compilations } = require("@truffle/compile-common");
 const expect = require("@truffle/expect");
@@ -192,5 +193,6 @@ const Compile = {
 
 module.exports = {
   Compile,
-  CompilerSupplier
+  CompilerSupplier,
+  Shims
 };

--- a/packages/compile-solidity/src/shims.ts
+++ b/packages/compile-solidity/src/shims.ts
@@ -1,0 +1,97 @@
+import type * as Common from "@truffle/compile-common";
+
+/**
+ * Converts solc's link references format into the @truffle/compile-common
+ * link references format.
+ */
+export const formatLinkReferences = (
+  /**
+   * @dev type matches solc's Compiler output JSON
+   */
+  linkReferences: {
+    [sourcePath: string]: {
+      [libraryName: string]: Array<{ start: 0; length: 20 }>;
+    };
+  }
+): Common.LinkReference[] => {
+  if (!linkReferences) {
+    return [];
+  }
+
+  // convert to flat list
+  const libraryLinkReferences = Object.values(linkReferences)
+    .map(fileLinks =>
+      Object.entries(fileLinks).map(([name, links]) => ({
+        name,
+        links
+      }))
+    )
+    .reduce((a, b) => [...a, ...b], []);
+
+  // convert to { offsets, length, name } format
+  return libraryLinkReferences.map(({ name, links }) => ({
+    offsets: links.map(({ start }) => start),
+    length: links[0].length, // HACK just assume they're going to be the same
+    name
+  }));
+};
+
+/**
+ * This function converts contract bytecodes' bytes strings from solc's native
+ * format into the @truffle/compile-common internal format.
+ *
+ * solc produces bytecodes where the bytes corresponding to link references are
+ * not necessarily zero, but Truffle's format requires that these bytes MUST be
+ * zero.
+ *
+ * To be forgiving to the full range of possible input, this function accepts
+ * `undefined` as value for `bytes`, e.g., for `abstract contract`s.
+ *
+ * This function produces a spec-compliant Common.Bytecode object or undefined.
+ */
+export const zeroLinkReferences = (options: {
+  /**
+   * Link references in compile-common format (not Solidity's format), for
+   * which `zeroLinkReferences()` will convert the corresponding bytes to zero.
+   */
+  linkReferences: Common.LinkReference[];
+
+  /**
+   * Hexadecimal string with NO prefix, straight from the Solidity output.
+   * For abstract contracts, this might be undefined
+   */
+  bytes: string | undefined;
+}): Common.Bytecode | undefined => {
+  const { linkReferences, bytes: inputBytes } = options;
+
+  if (inputBytes === undefined) {
+    return undefined;
+  }
+
+  // inline link references - start by flattening the offsets
+  const flattenedLinkReferences = linkReferences
+    // map each link ref to array of link refs with only one offset
+    .map(({ offsets, length, name }) =>
+      offsets.map(offset => ({ offset, length, name }))
+    )
+    // flatten
+    .reduce((a, b) => [...a, ...b], []);
+
+  // then overwite bytes with zeroes
+  const outputBytes = flattenedLinkReferences.reduce(
+    (bytes, { offset, length }) => {
+      // length is a byte offset
+      const characterLength = length * 2;
+      const start = offset * 2;
+
+      const zeroes = "0".repeat(characterLength);
+
+      return `${bytes.substring(0, start)}${zeroes}${bytes.substring(
+        start + characterLength
+      )}`;
+    },
+    inputBytes
+  );
+
+  return { linkReferences, bytes: outputBytes };
+};


### PR DESCRIPTION
_(spun out from #5410)_

This PR adds a new `const { Shims } = require("@truffle/compile-solidity");` to expose functions for converting bytecode in solc's format into bytecode in our format. These functions are already in use internally when processing solc output in compile-solidity itself, but I propose that this behavior is more widely useful across Truffle, and this warrants their becoming a proper export.

The usefulness of these functions stems from the view that solc's output format is used across the ecosystem, and many other tools expose data in solc's format. In prototyping #5410, I observed the need for this bytecode conversion because Hardhat stores their bytecode in the native solc format. Continuing from #5410, my hope is to use these new exports in perhaps a "@truffle/from-hardhat" package.

Considerations:
- In separating out the changes for this PR, I had the question in my mind of where to put these shims? I think @truffle/compile-solidity is the obvious answer, but I initially started adding these types to @truffle/compile-common as a `Common.Shims.FromSolc` sub-namespace in the existing `Common.Shims`. But clearly this is compile-solidity related and the functions should remain there. (I wasn't sure about types at first, since compile-solidity is semi-JS, but the exports seem fine! tsc is smart!)

- There's an argument that this sort of thing is putting the cart before the horse, so to speak: don't add the exports until something else needs them! Please advise during review if that approach has more merit... happy to turn this draft and/or get it against a feature branch. It just seemed innocuous enough to me to hit `develop` directly, cause, why not?

Addendum: sorry about the prettier changes. All I did was move two functions 😀 