### PR TITLE
Devise new experimental @truffle/from-hardhat package for compatibility translation

### DIFF
--- a/packages/from-hardhat/.eslintrc.json
+++ b/packages/from-hardhat/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../.eslintrc.package.json"]
+}

--- a/packages/from-hardhat/.gitignore
+++ b/packages/from-hardhat/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/packages/from-hardhat/README.md
+++ b/packages/from-hardhat/README.md
@@ -1,0 +1,8 @@
+# @truffle/from-hardhat
+
+> :warning: **This package is experimental and FOR INTERNAL USE ONLY.**
+
+This package translates Hardhat project information into Truffle's own formats.
+
+For information on using this package (until we get it more ready for public
+use), please see [`./src/api.ts`](src/api.ts).

--- a/packages/from-hardhat/package.json
+++ b/packages/from-hardhat/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@truffle/from-hardhat",
+  "description": "Import Hardhat project information into Truffle-native formats",
+  "license": "MIT",
+  "author": "g. nicholas d'andrea <gnidan@trufflesuite.com>",
+  "homepage": "https://github.com/trufflesuite/truffle/tree/master/packages/from-hardhat#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/from-hardhat"
+  },
+  "bugs": {
+    "url": "https://github.com/trufflesuite/truffle/issues"
+  },
+  "version": "0.1.0-0",
+  "main": "dist/src/index.js",
+  "scripts": {
+    "build": "ttsc",
+    "prepare": "yarn build",
+    "test": "exit 0"
+  },
+  "dependencies": {
+    "@truffle/compile-common": "^0.7.32",
+    "@truffle/compile-solidity": "^6.0.38",
+    "@truffle/config": "^1.3.34",
+    "debug": "^4.3.1",
+    "find-up": "^2.1.0",
+    "semver": "^5.7.1"
+  },
+  "devDependencies": {
+    "@types/find-up": "^2.1.0",
+    "@types/node": "^18.6.5",
+    "hardhat": "^2.10.1",
+    "ttypescript": "1.5.13",
+    "typescript": "^4.3.5",
+    "typescript-transform-paths": "3.3.1"
+  },
+  "keywords": [
+    "ethereum",
+    "solidity",
+    "truffle",
+    "hardhat"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/from-hardhat/src/api.ts
+++ b/packages/from-hardhat/src/api.ts
@@ -1,0 +1,142 @@
+import { promises as fs } from "fs";
+import semver from "semver";
+
+import type * as Hardhat from "hardhat/types";
+import type * as Common from "@truffle/compile-common";
+import type TruffleConfig from "@truffle/config";
+
+import { supportedHardhatVersionRange } from "./constants";
+import * as Compilation from "./compilation";
+import * as Config from "./config";
+
+import {
+  checkHardhat,
+  askHardhatConsole,
+  askHardhatVersion
+} from "./ask-hardhat";
+import { EnvironmentOptions } from "./options";
+
+/**
+ * Checks for the existence of a Hardhat project configuration and asserts
+ * that the local installed version of Hardhat matches this package's
+ * supported version range.
+ *
+ * @param options to control process environment (e.g. working directory)
+ * @return Promise<void> when expectation holds
+ * @throws NotHardhatError when not in a Hardhat project directory
+ * @throws IncompatibleHardhatError if Hardhat has unsupported version
+ */
+export const expectHardhat = async (
+  options?: EnvironmentOptions
+): Promise<void> => {
+  const isHardhat = await checkHardhat(options);
+
+  if (!isHardhat) {
+    throw new NotHardhatError();
+  }
+
+  const hardhatVersion = await askHardhatVersion(options);
+
+  if (!semver.satisfies(hardhatVersion, supportedHardhatVersionRange)) {
+    throw new IncompatibleHardhatError(hardhatVersion);
+  }
+};
+
+/**
+ * Thrown when no Hardhat project is found
+ */
+export class NotHardhatError extends Error {
+  constructor() {
+    super("Current working directory is not part of a Hardhat project");
+  }
+}
+
+/**
+ * Thrown when Hardhat was detected but with an incompatible version
+ */
+export class IncompatibleHardhatError extends Error {
+  constructor(detectedVersion: string) {
+    super(
+      `Expected Hardhat version compatible with ${supportedHardhatVersionRange}, got: ${detectedVersion}`
+    );
+  }
+}
+
+/**
+ * Constructs a @truffle/config object based on the Hardhat config.
+ *
+ * WARNING: except for fields documented here, the values present on the
+ * returned @truffle/config object MUST be regarded as unsafe to use.
+ *
+ * The returned `config` is defined to contain the following:
+ *
+ *   - `config.networks` with configurations for all Hardhat-configured
+ *     networks, provided:
+ *       - The configured network is not the built-in `hardhat` network
+ *       - The configured network defines a `url` property
+ *
+ *     Note: this function ignores all properties other than `url`,
+ *     including any information that can be used for computing
+ *     cryptographic signatures. THIS FUNCTION DOES NOT READ PRIVATE KEYS.
+ *
+ * Suffice to say:
+ *
+ * THIS FUNCTION'S BEHAVIOR IS EXPERIMENTAL AND SHOULD ONLY BE USED IN
+ * SPECIFICALLY KNOWN-SUPPORTED USE CASES (like reading for configured
+ * network urls)
+ *
+ * @param options to control process environment (e.g. working directory)
+ * @return Promise<TruffleConfig>
+ *
+ * @dev This function shells out to `npx hardhat console` to ask the Hardhat
+ *      runtime environment for a fully populated config object.
+ */
+export const prepareConfig = async (
+  options?: EnvironmentOptions
+): Promise<TruffleConfig> => {
+  const hardhatConfig = (await askHardhatConsole(
+    `hre.config`,
+    options
+  )) as Hardhat.HardhatConfig;
+
+  return Config.fromHardhatConfig(hardhatConfig);
+};
+
+/**
+ * Constructs an array of @truffle/compile-common `Compilation` objects
+ * corresponding one-to-one with Hardhat's persisted results of each solc
+ * compilation.
+ *
+ * WARNING: this function only supports Hardhat projects written entirely
+ * in solc-compatible languages (Solidity, Yul). Behavior of this function
+ * for Hardhat projects using other languages is undefined.
+ *
+ * @param options to control process environment (e.g. working directory)
+ * @return Promise<Compilation[]> from @truffle/compile-common
+ *
+ * @dev This function shells out to `npx hardhat console` to ask the Hardhat
+ *      runtime environment for the location of the project build info
+ *      files
+ */
+export const prepareCompilations = async (
+  options?: EnvironmentOptions
+): Promise<Common.Compilation[]> => {
+  const compilations = [];
+
+  const buildInfoPaths = (await askHardhatConsole(
+    `artifacts.getBuildInfoPaths()`,
+    options
+  )) as string[];
+
+  for (const buildInfoPath of buildInfoPaths) {
+    const buildInfo: Hardhat.BuildInfo = JSON.parse(
+      (await fs.readFile(buildInfoPath)).toString()
+    );
+
+    const compilation = Compilation.fromBuildInfo(buildInfo);
+
+    compilations.push(compilation);
+  }
+
+  return compilations;
+};

--- a/packages/from-hardhat/src/ask-hardhat.ts
+++ b/packages/from-hardhat/src/ask-hardhat.ts
@@ -1,0 +1,108 @@
+import { spawn } from "child_process";
+
+import findUp from "find-up";
+
+import { validHardhatConfigFilenames } from "./constants";
+import { EnvironmentOptions, withDefaultEnvironmentOptions } from "./options";
+
+/**
+ * Returns a Promise to a boolean that is true if and only if
+ * the detected or specified environment is part of a Hardhat project.
+ *
+ * (i.e., if the working directory or any of its parents has a Hardhat config)
+ */
+export const checkHardhat = async (
+  options?: EnvironmentOptions
+): Promise<boolean> => {
+  const { workingDirectory } = withDefaultEnvironmentOptions(options);
+
+  // search recursively up for a hardhat config
+  const hardhatConfigPath = await findUp(validHardhatConfigFilenames, {
+    cwd: workingDirectory
+  });
+
+  return !!hardhatConfigPath;
+};
+
+/**
+ * Reads version information via `npx hardhat --version`
+ */
+export const askHardhatVersion = async (
+  options?: EnvironmentOptions
+): Promise<string> =>
+  new Promise((accept, reject) => {
+    const { workingDirectory } = withDefaultEnvironmentOptions(options);
+
+    const hardhat = spawn(`npx`, ["hardhat", "--version"], {
+      stdio: "pipe",
+      cwd: workingDirectory
+    });
+
+    let output = "";
+    hardhat.stdout.on("data", data => {
+      output = `${output}${data}`;
+    });
+
+    // setup close event before writing to stdin because we're sending eof
+    hardhat.on("close", code => {
+      if (code !== 0) {
+        return reject(new Error(`Hardhat exited with non-zero code ${code}`));
+      }
+
+      return accept(output);
+    });
+  });
+
+export interface AskHardhatConsoleOptions {
+  // turn off json stringify/parse
+  raw?: boolean;
+}
+
+export const askHardhatConsole = async (
+  expression: string,
+  {
+    raw = false,
+    ...options
+  }: AskHardhatConsoleOptions & EnvironmentOptions = {}
+): Promise<string | unknown> =>
+  new Promise((accept, reject) => {
+    const { workingDirectory } = withDefaultEnvironmentOptions(options);
+
+    const hardhat = spawn(`npx`, ["hardhat", "console"], {
+      stdio: ["pipe", "pipe", "inherit"],
+      cwd: workingDirectory
+    });
+
+    // we'll capture the stdout
+    let output = "";
+    hardhat.stdout.on("data", data => {
+      output = `${output}${data}`;
+    });
+
+    // setup close event before writing to stdin because we're sending eof
+    hardhat.on("close", code => {
+      if (code !== 0) {
+        return reject(new Error(`Hardhat exited with non-zero code ${code}`));
+      }
+
+      if (raw) {
+        return accept(output);
+      }
+
+      try {
+        return accept(JSON.parse(output));
+      } catch (error) {
+        return reject(error);
+      }
+    });
+
+    hardhat.stdin.write(`
+      Promise.resolve(${expression})
+        .then(${
+          raw
+            ? `console.log`
+            : `(resolved) => console.log(JSON.stringify(resolved))`
+        })
+    `);
+    hardhat.stdin.end();
+  });

--- a/packages/from-hardhat/src/ask-hardhat.ts
+++ b/packages/from-hardhat/src/ask-hardhat.ts
@@ -43,7 +43,7 @@ export const askHardhatVersion = async (
       output = `${output}${data}`;
     });
 
-    hardhat.on("close", code => {
+    hardhat.once("close", code => {
       if (code !== 0) {
         return reject(new Error(`Hardhat exited with non-zero code ${code}`));
       }
@@ -79,7 +79,7 @@ export const askHardhatConsole = async (
     });
 
     // setup close event before writing to stdin because we're sending eof
-    hardhat.on("close", code => {
+    hardhat.once("close", code => {
       if (code !== 0) {
         return reject(new Error(`Hardhat exited with non-zero code ${code}`));
       }

--- a/packages/from-hardhat/src/ask-hardhat.ts
+++ b/packages/from-hardhat/src/ask-hardhat.ts
@@ -34,7 +34,7 @@ export const askHardhatVersion = async (
     const { workingDirectory } = withDefaultEnvironmentOptions(options);
 
     const hardhat = spawn(`npx`, ["hardhat", "--version"], {
-      stdio: "pipe",
+      stdio: ["pipe", "pipe", "inherit"],
       cwd: workingDirectory
     });
 
@@ -43,7 +43,6 @@ export const askHardhatVersion = async (
       output = `${output}${data}`;
     });
 
-    // setup close event before writing to stdin because we're sending eof
     hardhat.on("close", code => {
       if (code !== 0) {
         return reject(new Error(`Hardhat exited with non-zero code ${code}`));

--- a/packages/from-hardhat/src/compilation.ts
+++ b/packages/from-hardhat/src/compilation.ts
@@ -1,0 +1,121 @@
+import type * as Hardhat from "hardhat/types";
+
+import type { Compilation, CompiledContract } from "@truffle/compile-common";
+import * as CompileSolidity from "@truffle/compile-solidity";
+
+import { supportedHardhatBuildInfoFormats } from "./constants";
+
+export const fromBuildInfo = (buildInfo: Hardhat.BuildInfo): Compilation => {
+  const { _format } = buildInfo;
+
+  if (!supportedHardhatBuildInfoFormats.has(_format)) {
+    throw new Error(`Unsupported build info format: ${_format}`);
+  }
+
+  const sourceIndexes = SourceIndexes.fromBuildInfo(buildInfo);
+
+  return {
+    sourceIndexes,
+    sources: Sources.fromBuildInfo(buildInfo, sourceIndexes),
+    contracts: Contracts.fromBuildInfo(buildInfo),
+    compiler: {
+      name: "solc",
+      version: buildInfo.solcLongVersion
+    }
+  };
+};
+
+namespace SourceIndexes {
+  export const fromBuildInfo = (
+    buildInfo: Hardhat.BuildInfo
+  ): Compilation["sourceIndexes"] => {
+    const sourceIndexes = [];
+    for (const { index, sourcePath } of Object.entries(
+      buildInfo.output.sources
+    ).map(([sourcePath, source]) => ({ index: source.id, sourcePath }))) {
+      sourceIndexes[index] = sourcePath;
+    }
+
+    return sourceIndexes;
+  };
+}
+
+namespace Sources {
+  export const fromBuildInfo = (
+    buildInfo: Hardhat.BuildInfo,
+    sourceIndexes: Compilation["sourceIndexes"]
+  ): Compilation["sources"] =>
+    sourceIndexes.map(sourcePath => {
+      // to handle if sourceIndexes is a sparse array
+      if (!sourcePath) {
+        return;
+      }
+
+      const inputSource = buildInfo.input.sources[sourcePath];
+      const outputSource = buildInfo.output.sources[sourcePath];
+
+      return {
+        sourcePath,
+        contents: inputSource.content,
+        ast: outputSource.ast,
+        language: buildInfo.input.language
+      };
+    });
+}
+
+namespace Contracts {
+  export const fromBuildInfo = (
+    buildInfo: Hardhat.BuildInfo
+  ): CompiledContract[] => {
+    const contracts = [];
+    for (const [sourcePath, sourceContracts] of Object.entries(
+      buildInfo.output.contracts
+    )) {
+      for (const [contractName, compilerOutputContract] of Object.entries(
+        sourceContracts
+      )) {
+        const contract: CompiledContract = {
+          contractName,
+          sourcePath,
+          source: buildInfo.input.sources[sourcePath].content,
+          sourceMap: compilerOutputContract.evm.bytecode.sourceMap,
+          deployedSourceMap:
+            compilerOutputContract.evm.deployedBytecode.sourceMap,
+          legacyAST: undefined,
+          ast: buildInfo.output.sources[sourcePath].ast,
+          abi: compilerOutputContract.abi,
+          metadata: (compilerOutputContract as any).metadata,
+          bytecode: CompileSolidity.Shims.zeroLinkReferences({
+            bytes: compilerOutputContract.evm.bytecode.object,
+            linkReferences: CompileSolidity.Shims.formatLinkReferences(
+              compilerOutputContract.evm.bytecode.linkReferences
+            )
+          }),
+          deployedBytecode: CompileSolidity.Shims.zeroLinkReferences({
+            bytes: compilerOutputContract.evm.deployedBytecode.object,
+            linkReferences: CompileSolidity.Shims.formatLinkReferences(
+              compilerOutputContract.evm.deployedBytecode.linkReferences
+            )
+          }),
+          compiler: {
+            name: "solc",
+            version: buildInfo.solcLongVersion
+          },
+          devdoc: undefined,
+          userdoc: undefined,
+          immutableReferences:
+            compilerOutputContract.evm.deployedBytecode.immutableReferences,
+          generatedSources: (compilerOutputContract.evm.bytecode as any)
+            .generatedSources,
+          deployedGeneratedSources: (
+            compilerOutputContract.evm.deployedBytecode as any
+          ).generatedSources
+        };
+
+        contracts.push(contract);
+      }
+    }
+
+    return contracts;
+  };
+}

--- a/packages/from-hardhat/src/compilation.ts
+++ b/packages/from-hardhat/src/compilation.ts
@@ -3,15 +3,7 @@ import type * as Hardhat from "hardhat/types";
 import type { Compilation, CompiledContract } from "@truffle/compile-common";
 import * as CompileSolidity from "@truffle/compile-solidity";
 
-import { supportedHardhatBuildInfoFormats } from "./constants";
-
 export const fromBuildInfo = (buildInfo: Hardhat.BuildInfo): Compilation => {
-  const { _format } = buildInfo;
-
-  if (!supportedHardhatBuildInfoFormats.has(_format)) {
-    throw new Error(`Unsupported build info format: ${_format}`);
-  }
-
   const sourceIndexes = SourceIndexes.fromBuildInfo(buildInfo);
 
   return {

--- a/packages/from-hardhat/src/compilation.ts
+++ b/packages/from-hardhat/src/compilation.ts
@@ -38,11 +38,6 @@ namespace Sources {
     sourceIndexes: Compilation["sourceIndexes"]
   ): Compilation["sources"] =>
     sourceIndexes.map(sourcePath => {
-      // to handle if sourceIndexes is a sparse array
-      if (!sourcePath) {
-        return;
-      }
-
       const inputSource = buildInfo.input.sources[sourcePath];
       const outputSource = buildInfo.output.sources[sourcePath];
 

--- a/packages/from-hardhat/src/config.ts
+++ b/packages/from-hardhat/src/config.ts
@@ -1,0 +1,36 @@
+import type { HardhatConfig } from "hardhat/types";
+
+import Config from "@truffle/config";
+
+export const fromHardhatConfig = (hardhatConfig: HardhatConfig): Config => {
+  return Config.default().merge({
+    networks: Networks.fromHardhatConfig(hardhatConfig)
+  });
+};
+
+namespace Networks {
+  export const fromHardhatConfig = (hardhatConfig: HardhatConfig) =>
+    Object.entries(hardhatConfig.networks)
+      .flatMap(([networkName, networkConfig]) => {
+        // exclude hardhat network as not supported
+        if (networkName === "hardhat") {
+          return [];
+        }
+
+        // only accept netowrks that specify `url`
+        if (!networkConfig || !("url" in networkConfig)) {
+          return [];
+        }
+
+        const { url } = networkConfig;
+        return [
+          {
+            [networkName]: {
+              url,
+              network_id: "*"
+            }
+          }
+        ];
+      })
+      .reduce((a, b) => ({ ...a, ...b }), {});
+}

--- a/packages/from-hardhat/src/constants.ts
+++ b/packages/from-hardhat/src/constants.ts
@@ -1,0 +1,8 @@
+export const validHardhatConfigFilenames = [
+  "hardhat.config.js",
+  "hardhat.config.ts"
+];
+export const supportedHardhatVersionRange = "^2.10.1";
+export const supportedHardhatBuildInfoFormats = new Set([
+  "hh-sol-build-info-1"
+]);

--- a/packages/from-hardhat/src/index.ts
+++ b/packages/from-hardhat/src/index.ts
@@ -1,0 +1,9 @@
+export type { EnvironmentOptions } from "./options";
+
+export {
+  expectHardhat,
+  NotHardhatError,
+  IncompatibleHardhatError,
+  prepareConfig,
+  prepareCompilations
+} from "./api";

--- a/packages/from-hardhat/src/index.ts
+++ b/packages/from-hardhat/src/index.ts
@@ -3,7 +3,8 @@ export type { EnvironmentOptions } from "./options";
 export {
   expectHardhat,
   NotHardhatError,
-  IncompatibleHardhatError,
+  IncompatibleHardhatVersionError,
+  IncompatibleHardhatBuildInfoFormatError,
   prepareConfig,
   prepareCompilations
 } from "./api";

--- a/packages/from-hardhat/src/options.ts
+++ b/packages/from-hardhat/src/options.ts
@@ -1,0 +1,14 @@
+export interface EnvironmentOptions {
+  /**
+   * Working directory from which to interact with Hardhat
+   *
+   * @default process.cwd()
+   */
+  workingDirectory?: string;
+}
+
+export const withDefaultEnvironmentOptions = ({
+  workingDirectory = process.cwd()
+}: EnvironmentOptions = {}): EnvironmentOptions => ({
+  workingDirectory
+});

--- a/packages/from-hardhat/tsconfig.json
+++ b/packages/from-hardhat/tsconfig.json
@@ -1,0 +1,39 @@
+{
+  "compilerOptions": {
+    "sourceMap": true,
+    "declaration": true,
+    "allowJs": false,
+    "esModuleInterop": true,
+    "lib": ["esnext", "dom"],
+    "skipLibCheck": true,
+    "target": "es2016",
+    "moduleResolution": "node",
+    "downlevelIteration": true,
+    "allowSyntheticDefaultImports": true,
+    "module": "commonjs",
+    "outDir": "./dist",
+    "strictBindCallApply": true,
+    "paths": {
+      "@truffle/from-hardhat": ["./src"],
+      "@truffle/from-hardhat/*": ["./src/*"],
+      "test/*": ["./test/*"]
+    },
+    "rootDir": ".",
+    "baseUrl": ".",
+    "typeRoots": ["../../node_modules/@types/node"],
+    "types": [
+      "mocha"
+    ],
+    "plugins": [
+      { "transform": "typescript-transform-paths" },
+      { "transform": "typescript-transform-paths", "afterDeclarations": true }
+    ]
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules"
+  ]
+}

--- a/packages/from-hardhat/tsconfig.json
+++ b/packages/from-hardhat/tsconfig.json
@@ -10,6 +10,7 @@
     "moduleResolution": "node",
     "downlevelIteration": true,
     "allowSyntheticDefaultImports": true,
+    "noImplicitAny": true,
     "module": "commonjs",
     "outDir": "./dist",
     "strictBindCallApply": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2580,6 +2580,16 @@
     ethereumjs-util "^7.1.4"
     merkle-patricia-tree "^4.2.4"
 
+"@ethereumjs/block@^3.6.3":
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/block/-/block-3.6.3.tgz#d96cbd7af38b92ebb3424223dbf773f5ccd27f84"
+  integrity sha512-CegDeryc2DVKnDkg5COQrE0bJfw/p0v3GBk2W5/Dj5dOVfEmb50Ux0GLnSPypooLnfqjwFaorGuT9FokWB3GRg==
+  dependencies:
+    "@ethereumjs/common" "^2.6.5"
+    "@ethereumjs/tx" "^3.5.2"
+    ethereumjs-util "^7.1.5"
+    merkle-patricia-tree "^4.2.4"
+
 "@ethereumjs/blockchain@^5.5.0":
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/@ethereumjs/blockchain/-/blockchain-5.5.2.tgz#1848abd9dc1ee56acf8cec4c84304d7f4667d027"
@@ -2590,6 +2600,20 @@
     "@ethereumjs/ethash" "^1.1.0"
     debug "^4.3.3"
     ethereumjs-util "^7.1.4"
+    level-mem "^5.0.1"
+    lru-cache "^5.1.1"
+    semaphore-async-await "^1.5.1"
+
+"@ethereumjs/blockchain@^5.5.2", "@ethereumjs/blockchain@^5.5.3":
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/blockchain/-/blockchain-5.5.3.tgz#aa49a6a04789da6b66b5bcbb0d0b98efc369f640"
+  integrity sha512-bi0wuNJ1gw4ByNCV56H0Z4Q7D+SxUbwyG12Wxzbvqc89PXLRNR20LBcSUZRKpN0+YCPo6m0XZL/JLio3B52LTw==
+  dependencies:
+    "@ethereumjs/block" "^3.6.2"
+    "@ethereumjs/common" "^2.6.4"
+    "@ethereumjs/ethash" "^1.1.0"
+    debug "^4.3.3"
+    ethereumjs-util "^7.1.5"
     level-mem "^5.0.1"
     lru-cache "^5.1.1"
     semaphore-async-await "^1.5.1"
@@ -2625,6 +2649,14 @@
   dependencies:
     crc-32 "^1.2.0"
     ethereumjs-util "^7.1.4"
+
+"@ethereumjs/common@^2.6.4", "@ethereumjs/common@^2.6.5":
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/common/-/common-2.6.5.tgz#0a75a22a046272579d91919cb12d84f2756e8d30"
+  integrity sha512-lRyVQOeCDaIVtgfbowla32pzeDv2Obr8oR8Put5RdUBNRGr1VGPGQNGP6elWIpgK3YdpzqTOh4GyUGOureVeeA==
+  dependencies:
+    crc-32 "^1.2.0"
+    ethereumjs-util "^7.1.5"
 
 "@ethereumjs/ethash@^1.1.0":
   version "1.1.0"
@@ -2669,6 +2701,14 @@
     "@ethereumjs/common" "^2.6.3"
     ethereumjs-util "^7.1.4"
 
+"@ethereumjs/tx@^3.5.2":
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/tx/-/tx-3.5.2.tgz#197b9b6299582ad84f9527ca961466fce2296c1c"
+  integrity sha512-gQDNJWKrSDGu2w7w0PzVXVBNMzb7wwdDOmOqczmhNjqFxFuIbhVJDwiGEnxFNC2/b8ifcZzY7MLcluizohRzNw==
+  dependencies:
+    "@ethereumjs/common" "^2.6.4"
+    ethereumjs-util "^7.1.5"
+
 "@ethereumjs/vm@5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@ethereumjs/vm/-/vm-5.6.0.tgz#e0ca62af07de820143674c30b776b86c1983a464"
@@ -2685,6 +2725,24 @@
     functional-red-black-tree "^1.0.1"
     mcl-wasm "^0.7.1"
     merkle-patricia-tree "^4.2.2"
+    rustbn.js "~0.2.0"
+
+"@ethereumjs/vm@^5.9.0":
+  version "5.9.3"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/vm/-/vm-5.9.3.tgz#6d69202e4c132a4a1e1628ac246e92062e230823"
+  integrity sha512-Ha04TeF8goEglr8eL7hkkYyjhzdZS0PsoRURzYlTF6I0VVId5KjKb0N7MrA8GMgheN+UeTncfTgYx52D/WhEmg==
+  dependencies:
+    "@ethereumjs/block" "^3.6.3"
+    "@ethereumjs/blockchain" "^5.5.3"
+    "@ethereumjs/common" "^2.6.5"
+    "@ethereumjs/tx" "^3.5.2"
+    async-eventemitter "^0.2.4"
+    core-js-pure "^3.0.1"
+    debug "^4.3.3"
+    ethereumjs-util "^7.1.5"
+    functional-red-black-tree "^1.0.1"
+    mcl-wasm "^0.7.1"
+    merkle-patricia-tree "^4.2.4"
     rustbn.js "~0.2.0"
 
 "@ethersproject/abi@5.0.7":
@@ -2732,6 +2790,21 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.0"
 
+"@ethersproject/abi@^5.1.2", "@ethersproject/abi@^5.6.3":
+  version "5.6.4"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.6.4.tgz#f6e01b6ed391a505932698ecc0d9e7a99ee60362"
+  integrity sha512-TTeZUlCeIHG6527/2goZA6gW5F8Emoc7MrZDC7hhP84aRGvW3TEdTnZR08Ls88YXM1m2SuK42Osw/jSi3uO8gg==
+  dependencies:
+    "@ethersproject/address" "^5.6.1"
+    "@ethersproject/bignumber" "^5.6.2"
+    "@ethersproject/bytes" "^5.6.1"
+    "@ethersproject/constants" "^5.6.1"
+    "@ethersproject/hash" "^5.6.1"
+    "@ethersproject/keccak256" "^5.6.1"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/strings" "^5.6.1"
+
 "@ethersproject/abi@^5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.6.0.tgz#ea07cbc1eec2374d32485679c12408005895e9f3"
@@ -2746,21 +2819,6 @@
     "@ethersproject/logger" "^5.6.0"
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.0"
-
-"@ethersproject/abi@^5.6.3":
-  version "5.6.4"
-  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.6.4.tgz#f6e01b6ed391a505932698ecc0d9e7a99ee60362"
-  integrity sha512-TTeZUlCeIHG6527/2goZA6gW5F8Emoc7MrZDC7hhP84aRGvW3TEdTnZR08Ls88YXM1m2SuK42Osw/jSi3uO8gg==
-  dependencies:
-    "@ethersproject/address" "^5.6.1"
-    "@ethersproject/bignumber" "^5.6.2"
-    "@ethersproject/bytes" "^5.6.1"
-    "@ethersproject/constants" "^5.6.1"
-    "@ethersproject/hash" "^5.6.1"
-    "@ethersproject/keccak256" "^5.6.1"
-    "@ethersproject/logger" "^5.6.0"
-    "@ethersproject/properties" "^5.6.0"
-    "@ethersproject/strings" "^5.6.1"
 
 "@ethersproject/abstract-provider@5.1.0", "@ethersproject/abstract-provider@^5.1.0":
   version "5.1.0"
@@ -5282,7 +5340,7 @@
     npmlog "^4.1.2"
     write-file-atomic "^3.0.3"
 
-"@metamask/eth-sig-util@4.0.1":
+"@metamask/eth-sig-util@4.0.1", "@metamask/eth-sig-util@^4.0.0":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@metamask/eth-sig-util/-/eth-sig-util-4.0.1.tgz#3ad61f6ea9ad73ba5b19db780d40d9aae5157088"
   integrity sha512-tghyZKLHZjcdlDqCA3gNZmLeR0XvOE9U1qoQO9ohyAZT6Pya+H9vkBPcsyXytmYLNgVoin7CKCmweo/R43V+tQ==
@@ -5692,6 +5750,74 @@
     "@noble/hashes" "~1.1.1"
     "@scure/base" "~1.1.0"
 
+"@sentry/core@5.30.0":
+  version "5.30.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.30.0.tgz#6b203664f69e75106ee8b5a2fe1d717379b331f3"
+  integrity sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==
+  dependencies:
+    "@sentry/hub" "5.30.0"
+    "@sentry/minimal" "5.30.0"
+    "@sentry/types" "5.30.0"
+    "@sentry/utils" "5.30.0"
+    tslib "^1.9.3"
+
+"@sentry/hub@5.30.0":
+  version "5.30.0"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.30.0.tgz#2453be9b9cb903404366e198bd30c7ca74cdc100"
+  integrity sha512-2tYrGnzb1gKz2EkMDQcfLrDTvmGcQPuWxLnJKXJvYTQDGLlEvi2tWz1VIHjunmOvJrB5aIQLhm+dcMRwFZDCqQ==
+  dependencies:
+    "@sentry/types" "5.30.0"
+    "@sentry/utils" "5.30.0"
+    tslib "^1.9.3"
+
+"@sentry/minimal@5.30.0":
+  version "5.30.0"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.30.0.tgz#ce3d3a6a273428e0084adcb800bc12e72d34637b"
+  integrity sha512-BwWb/owZKtkDX+Sc4zCSTNcvZUq7YcH3uAVlmh/gtR9rmUvbzAA3ewLuB3myi4wWRAMEtny6+J/FN/x+2wn9Xw==
+  dependencies:
+    "@sentry/hub" "5.30.0"
+    "@sentry/types" "5.30.0"
+    tslib "^1.9.3"
+
+"@sentry/node@^5.18.1":
+  version "5.30.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-5.30.0.tgz#4ca479e799b1021285d7fe12ac0858951c11cd48"
+  integrity sha512-Br5oyVBF0fZo6ZS9bxbJZG4ApAjRqAnqFFurMVJJdunNb80brh7a5Qva2kjhm+U6r9NJAB5OmDyPkA1Qnt+QVg==
+  dependencies:
+    "@sentry/core" "5.30.0"
+    "@sentry/hub" "5.30.0"
+    "@sentry/tracing" "5.30.0"
+    "@sentry/types" "5.30.0"
+    "@sentry/utils" "5.30.0"
+    cookie "^0.4.1"
+    https-proxy-agent "^5.0.0"
+    lru_map "^0.3.3"
+    tslib "^1.9.3"
+
+"@sentry/tracing@5.30.0":
+  version "5.30.0"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-5.30.0.tgz#501d21f00c3f3be7f7635d8710da70d9419d4e1f"
+  integrity sha512-dUFowCr0AIMwiLD7Fs314Mdzcug+gBVo/+NCMyDw8tFxJkwWAKl7Qa2OZxLQ0ZHjakcj1hNKfCQJ9rhyfOl4Aw==
+  dependencies:
+    "@sentry/hub" "5.30.0"
+    "@sentry/minimal" "5.30.0"
+    "@sentry/types" "5.30.0"
+    "@sentry/utils" "5.30.0"
+    tslib "^1.9.3"
+
+"@sentry/types@5.30.0":
+  version "5.30.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.30.0.tgz#19709bbe12a1a0115bc790b8942917da5636f402"
+  integrity sha512-R8xOqlSTZ+htqrfteCWU5Nk0CDN5ApUTvrlvBuiH1DyP6czDZ4ktbZB0hAgBlVcK0U+qpD3ag3Tqqpa5Q67rPw==
+
+"@sentry/utils@5.30.0":
+  version "5.30.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.30.0.tgz#9a5bd7ccff85ccfe7856d493bffa64cabc41e980"
+  integrity sha512-zaYmoH0NWWtvnJjC9/CBseXMtKHm/tm40sz3YfJRxeQjyzRqNQPgivpd9R/oDJCYj999mzdW382p/qi2ypjLww==
+  dependencies:
+    "@sentry/types" "5.30.0"
+    tslib "^1.9.3"
+
 "@sinclair/typebox@^0.24.1":
   version "0.24.20"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.20.tgz#11a657875de6008622d53f56e063a6347c51a6dd"
@@ -5757,7 +5883,7 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
-"@solidity-parser/parser@^0.14.3":
+"@solidity-parser/parser@^0.14.2", "@solidity-parser/parser@^0.14.3":
   version "0.14.3"
   resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.14.3.tgz#0d627427b35a40d8521aaa933cc3df7d07bfa36f"
   integrity sha512-29g2SZ29HtsqA58pLCtopI1P/cPy5/UAzlcAXO6T/CNJimG6yA8kx4NaseMyJULiC+TEs02Y9/yeHzClqoA0hw==
@@ -6472,7 +6598,7 @@
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
   integrity sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
 
-"@types/lru-cache@5.1.1":
+"@types/lru-cache@5.1.1", "@types/lru-cache@^5.1.0":
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-5.1.1.tgz#c48c2e27b65d2a153b19bfc1a317e30872e01eef"
   integrity sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==
@@ -6550,6 +6676,11 @@
   version "12.12.67"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.67.tgz#4f86badb292e822e3b13730a1f9713ed2377f789"
   integrity sha512-R48tgL2izApf+9rYNH+3RBMbRpPeW3N8f0I9HMhggeq4UXwBDqumJ14SDs4ctTMhG11pIOduZ4z3QWGOiMc9Vg==
+
+"@types/node@^18.6.5":
+  version "18.6.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.6.5.tgz#06caea822caf9e59d5034b695186ee74154d2802"
+  integrity sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==
 
 "@types/node@~12.12.0":
   version "12.12.70"
@@ -7729,7 +7860,7 @@ abi-to-sol@^0.6.5:
     prettier "^2.7.1"
     prettier-plugin-solidity "^1.0.0-dev.23"
 
-abort-controller@3.0.0:
+abort-controller@3.0.0, abort-controller@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
   integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
@@ -7894,6 +8025,11 @@ adjust-sourcemap-loader@3.0.0:
   dependencies:
     loader-utils "^2.0.0"
     regex-parser "^2.2.11"
+
+adm-zip@^0.4.16:
+  version "0.4.16"
+  resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.4.16.tgz#cf4c508fdffab02c269cbc7f471a875f05570365"
+  integrity sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg==
 
 aes-js@3.0.0:
   version "3.0.0"
@@ -10515,7 +10651,7 @@ cheerio@^1.0.0-rc.2:
     lodash "^4.15.0"
     parse5 "^3.0.1"
 
-chokidar@3.5.3, chokidar@^3.4.1, chokidar@^3.5.2:
+chokidar@3.5.3, chokidar@^3.4.0, chokidar@^3.4.1, chokidar@^3.5.2:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
@@ -10949,6 +11085,11 @@ command-exists@^1.2.8:
   resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.8.tgz#715acefdd1223b9c9b37110a149c6392c2852291"
   integrity sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw==
 
+commander@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-3.0.2.tgz#6837c3fb677ad9933d1cfba42dd14d5117d6b39e"
+  integrity sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==
+
 commander@^2.16.0, commander@^2.18.0, commander@^2.20.0, commander@^2.20.3, commander@^2.8.1:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
@@ -11287,6 +11428,11 @@ cookie@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
+
+cookie@^0.4.1:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
+  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
 
 cookiejar@^2.1.1:
   version "2.1.2"
@@ -11966,7 +12112,7 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.3:
+debug@4, debug@4.3.4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.3:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -12294,6 +12440,11 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
+
+depd@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
+  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
 depd@^1.1.2, depd@~1.1.2:
   version "1.1.2"
@@ -13056,7 +13207,7 @@ enhanced-resolve@^5.9.3:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
 
-enquirer@^2.3.5, enquirer@^2.3.6:
+enquirer@^2.3.0, enquirer@^2.3.5, enquirer@^2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
   integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
@@ -13878,7 +14029,7 @@ ethereum-common@^0.0.18:
   resolved "https://registry.yarnpkg.com/ethereum-common/-/ethereum-common-0.0.18.tgz#2fdc3576f232903358976eb39da783213ff9523f"
   integrity sha1-L9w1dvIykDNYl26znaeDIT/5Uj8=
 
-ethereum-cryptography@1.1.2:
+ethereum-cryptography@1.1.2, ethereum-cryptography@^1.0.3:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/ethereum-cryptography/-/ethereum-cryptography-1.1.2.tgz#74f2ac0f0f5fe79f012c889b3b8446a9a6264e6d"
   integrity sha512-XDSJlg4BD+hq9N2FjvotwUET9Tfxpxc3kWGE2AqUG5vcbeunnbImVk3cj6e/xT3phdW21mE8R5IugU4fspQDcQ==
@@ -15033,6 +15184,16 @@ forwarded@~0.1.2:
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
   integrity sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=
 
+fp-ts@1.19.3:
+  version "1.19.3"
+  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-1.19.3.tgz#261a60d1088fbff01f91256f91d21d0caaaaa96f"
+  integrity sha512-H5KQDspykdHuztLTg+ajGN0Z2qUjcEf3Ybxc6hLt0k7/zPkn29XnKnxlBPyW2XIddWrGaJBzBl4VLYOtk39yZg==
+
+fp-ts@^1.0.0:
+  version "1.19.5"
+  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-1.19.5.tgz#3da865e585dfa1fdfd51785417357ac50afc520a"
+  integrity sha512-wDNqTimnzs8QqpldiId9OavWK2NptormjXnRJTQecNjzwfyp6P/8s/zG8e4h3ja3oqkKaY72UlTjQYt/1yXf9A==
+
 fragment-cache@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
@@ -15092,7 +15253,7 @@ fs-extra@^4.0.2:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^7.0.0:
+fs-extra@^7.0.0, fs-extra@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
   integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
@@ -15829,6 +15990,60 @@ hard-rejection@^2.1.0:
   resolved "https://registry.yarnpkg.com/hard-rejection/-/hard-rejection-2.1.0.tgz#1c6eda5c1685c63942766d79bb40ae773cecd883"
   integrity sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==
 
+hardhat@^2.10.1:
+  version "2.10.1"
+  resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.10.1.tgz#37fdc0c96d6a5d16b322269db2ad8f9f115c4046"
+  integrity sha512-0FN9TyCtn7Lt25SB2ei2G7nA2rZjP+RN6MvFOm+zYwherxLZNo6RbD8nDz88eCbhRapevmXqOiL2nM8INKsjmA==
+  dependencies:
+    "@ethereumjs/block" "^3.6.2"
+    "@ethereumjs/blockchain" "^5.5.2"
+    "@ethereumjs/common" "^2.6.4"
+    "@ethereumjs/tx" "^3.5.1"
+    "@ethereumjs/vm" "^5.9.0"
+    "@ethersproject/abi" "^5.1.2"
+    "@metamask/eth-sig-util" "^4.0.0"
+    "@sentry/node" "^5.18.1"
+    "@solidity-parser/parser" "^0.14.2"
+    "@types/bn.js" "^5.1.0"
+    "@types/lru-cache" "^5.1.0"
+    abort-controller "^3.0.0"
+    adm-zip "^0.4.16"
+    aggregate-error "^3.0.0"
+    ansi-escapes "^4.3.0"
+    chalk "^2.4.2"
+    chokidar "^3.4.0"
+    ci-info "^2.0.0"
+    debug "^4.1.1"
+    enquirer "^2.3.0"
+    env-paths "^2.2.0"
+    ethereum-cryptography "^1.0.3"
+    ethereumjs-abi "^0.6.8"
+    ethereumjs-util "^7.1.4"
+    find-up "^2.1.0"
+    fp-ts "1.19.3"
+    fs-extra "^7.0.1"
+    glob "7.2.0"
+    immutable "^4.0.0-rc.12"
+    io-ts "1.10.4"
+    lodash "^4.17.11"
+    merkle-patricia-tree "^4.2.4"
+    mnemonist "^0.38.0"
+    mocha "^10.0.0"
+    p-map "^4.0.0"
+    qs "^6.7.0"
+    raw-body "^2.4.1"
+    resolve "1.17.0"
+    semver "^6.3.0"
+    slash "^3.0.0"
+    solc "0.7.3"
+    source-map-support "^0.5.13"
+    stacktrace-parser "^0.1.10"
+    "true-case-path" "^2.2.1"
+    tsort "0.0.1"
+    undici "^5.4.0"
+    uuid "^8.3.2"
+    ws "^7.4.6"
+
 harmony-reflect@^1.4.6:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/harmony-reflect/-/harmony-reflect-1.6.2.tgz#31ecbd32e648a34d030d86adb67d4d47547fe710"
@@ -16199,6 +16414,17 @@ http-errors@1.8.1:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.1"
 
+http-errors@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.0.tgz#b7774a1486ef73cf7667ac9ae0858c012c57b9d3"
+  integrity sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==
+  dependencies:
+    depd "2.0.0"
+    inherits "2.0.4"
+    setprototypeof "1.2.0"
+    statuses "2.0.1"
+    toidentifier "1.0.1"
+
 http-errors@~1.6.2:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
@@ -16421,6 +16647,11 @@ immer@8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.1.tgz#9c73db683e2b3975c424fb0572af5889877ae656"
   integrity sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==
+
+immutable@^4.0.0-rc.12:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.1.0.tgz#f795787f0db780183307b9eb2091fcac1f6fafef"
+  integrity sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==
 
 import-cwd@^2.0.0:
   version "2.1.0"
@@ -16723,6 +16954,13 @@ invert-kv@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
   integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
+
+io-ts@1.10.4:
+  version "1.10.4"
+  resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-1.10.4.tgz#cd5401b138de88e4f920adbcb7026e2d1967e6e2"
+  integrity sha512-b23PteSnYXSONJ6JQXRAlvJhuw8KOtkqa87W4wDtvMrud/DTJd5X+NpOOI+O/zZwVq6v0VLAaJ+1EDViKEuN9g==
+  dependencies:
+    fp-ts "^1.0.0"
 
 ip-regex@^2.1.0:
   version "2.1.0"
@@ -19733,6 +19971,11 @@ lru-queue@0.1:
   dependencies:
     es5-ext "~0.10.2"
 
+lru_map@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
+  integrity sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==
+
 ltgt@2.2.1, ltgt@^2.1.2, ltgt@~2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ltgt/-/ltgt-2.2.1.tgz#f35ca91c493f7b73da0e07495304f17b31f87ee5"
@@ -20349,6 +20592,13 @@ minimatch@4.2.1:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.0.1.tgz#fb9022f7528125187c92bd9e9b6366be1cf3415b"
+  integrity sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimatch@^3.0.3, minimatch@^3.1.1:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
@@ -20506,6 +20756,13 @@ mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.5, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.5"
 
+mnemonist@^0.38.0:
+  version "0.38.5"
+  resolved "https://registry.yarnpkg.com/mnemonist/-/mnemonist-0.38.5.tgz#4adc7f4200491237fe0fa689ac0b86539685cade"
+  integrity sha512-bZTFT5rrPKtPJxj8KSV0WkPyNxl72vQepqqVUAW2ARUpUSF2qXMB6jZj7hW5/k7C1rtpzqbD/IIbJwLXUjCHeg==
+  dependencies:
+    obliterator "^2.0.0"
+
 mocha@9.2.2:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-9.2.2.tgz#d70db46bdb93ca57402c809333e5a84977a88fb9"
@@ -20532,6 +20789,34 @@ mocha@9.2.2:
     supports-color "8.1.1"
     which "2.0.2"
     workerpool "6.2.0"
+    yargs "16.2.0"
+    yargs-parser "20.2.4"
+    yargs-unparser "2.0.0"
+
+mocha@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.0.0.tgz#205447d8993ec755335c4b13deba3d3a13c4def9"
+  integrity sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==
+  dependencies:
+    "@ungap/promise-all-settled" "1.1.2"
+    ansi-colors "4.1.1"
+    browser-stdout "1.3.1"
+    chokidar "3.5.3"
+    debug "4.3.4"
+    diff "5.0.0"
+    escape-string-regexp "4.0.0"
+    find-up "5.0.0"
+    glob "7.2.0"
+    he "1.2.0"
+    js-yaml "4.1.0"
+    log-symbols "4.1.0"
+    minimatch "5.0.1"
+    ms "2.1.3"
+    nanoid "3.3.3"
+    serialize-javascript "6.0.0"
+    strip-json-comments "3.1.1"
+    supports-color "8.1.1"
+    workerpool "6.2.1"
     yargs "16.2.0"
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
@@ -20722,6 +21007,11 @@ nanoid@3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.1.tgz#6347a18cac88af88f58af0b3594b723d5e99bb35"
   integrity sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==
+
+nanoid@3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
+  integrity sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==
 
 nanoid@^3.1.22, nanoid@^3.2.0:
   version "3.2.0"
@@ -21567,6 +21857,11 @@ object.values@^1.1.0, object.values@^1.1.5:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
     es-abstract "^1.19.1"
+
+obliterator@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/obliterator/-/obliterator-2.0.4.tgz#fa650e019b2d075d745e44f1effeb13a2adbe816"
+  integrity sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ==
 
 oboe@2.1.5:
   version "2.1.5"
@@ -23939,6 +24234,13 @@ qs@6.9.7:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.7.tgz#4610846871485e1e048f44ae3b94033f0e675afe"
   integrity sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==
 
+qs@^6.7.0:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
+  integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
+  dependencies:
+    side-channel "^1.0.4"
+
 qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
@@ -24059,6 +24361,16 @@ raw-body@2.4.3:
   dependencies:
     bytes "3.1.2"
     http-errors "1.8.1"
+    iconv-lite "0.4.24"
+    unpipe "1.0.0"
+
+raw-body@^2.4.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.5.1.tgz#fe1b1628b181b700215e5fd42389f98b71392857"
+  integrity sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==
+  dependencies:
+    bytes "3.1.2"
+    http-errors "2.0.0"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
@@ -24843,7 +25155,7 @@ require-from-string@^1.1.0:
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-1.2.1.tgz#529c9ccef27380adfec9a2f965b649bbee636418"
   integrity sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=
 
-require-from-string@^2.0.2:
+require-from-string@^2.0.0, require-from-string@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
@@ -24963,6 +25275,13 @@ resolve.exports@^1.1.0:
   resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-1.1.0.tgz#5ce842b94b05146c0e03076985d1d0e7e48c90c9"
   integrity sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==
 
+resolve@1.17.0, resolve@^1.3.2, resolve@^1.8.1:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
+  integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
+  dependencies:
+    path-parse "^1.0.6"
+
 resolve@1.18.1:
   version "1.18.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.18.1.tgz#018fcb2c5b207d2a6424aee361c5a266da8f4130"
@@ -25018,13 +25337,6 @@ resolve@^1.20.0:
     is-core-module "^2.8.1"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
-
-resolve@^1.3.2, resolve@^1.8.1:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
-  integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
-  dependencies:
-    path-parse "^1.0.6"
 
 resolve@^2.0.0-next.3:
   version "2.0.0-next.3"
@@ -25901,6 +26213,21 @@ socks@^2.3.3, socks@^2.6.1:
     ip "^1.1.5"
     smart-buffer "^4.1.0"
 
+solc@0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.7.3.tgz#04646961bd867a744f63d2b4e3c0701ffdc7d78a"
+  integrity sha512-GAsWNAjGzIDg7VxzP6mPjdurby3IkGCjQcM8GFYZT6RyaoUZKmMU6Y7YwG+tFGhv7dwZ8rmR4iwFDrrD99JwqA==
+  dependencies:
+    command-exists "^1.2.8"
+    commander "3.0.2"
+    follow-redirects "^1.12.1"
+    fs-extra "^0.30.0"
+    js-sha3 "0.8.0"
+    memorystream "^0.3.1"
+    require-from-string "^2.0.0"
+    semver "^5.5.0"
+    tmp "0.0.33"
+
 solc@0.8.16:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/solc/-/solc-0.8.16.tgz#120f992357e236d99e6cf3445bf2c2dca3384f96"
@@ -26235,6 +26562,13 @@ stackframe@^1.1.1:
   resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.2.0.tgz#52429492d63c62eb989804c11552e3d22e779303"
   integrity sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==
 
+stacktrace-parser@^0.1.10:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/stacktrace-parser/-/stacktrace-parser-0.1.10.tgz#29fb0cae4e0d0b85155879402857a1639eb6051a"
+  integrity sha512-KJP1OCML99+8fhOHxwwzyWrlUuVX5GQ0ZpJTd1DFXhdkrvg1szxfHhawXUZ3g9TkXORQd4/WG68jMlQZ2p8wlg==
+  dependencies:
+    type-fest "^0.7.1"
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -26242,6 +26576,11 @@ static-extend@^0.1.1:
   dependencies:
     define-property "^0.2.5"
     object-copy "^0.1.0"
+
+statuses@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
+  integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
 
 "statuses@>= 1.4.0 < 2", "statuses@>= 1.5.0 < 2", statuses@~1.5.0:
   version "1.5.0"
@@ -27276,6 +27615,11 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
+"true-case-path@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/true-case-path/-/true-case-path-2.2.1.tgz#c5bf04a5bbec3fd118be4084461b3a27c4d796bf"
+  integrity sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q==
+
 tryer@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
@@ -27422,6 +27766,11 @@ tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
+tslib@^1.9.3:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
 tslib@^2.0.0, tslib@^2.1.0, tslib@~2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
@@ -27431,6 +27780,11 @@ tslib@^2.0.3, tslib@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+
+tsort@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/tsort/-/tsort-0.0.1.tgz#e2280f5e817f8bf4275657fd0f9aebd44f5a2786"
+  integrity sha512-Tyrf5mxF8Ofs1tNoxA13lFeZ2Zrbd6cKbuH3V+MQ5sb6DtBj5FjrXVsRWT8YvNAQTqNoz66dz1WsbigI22aEnw==
 
 tsutils@^3.17.1, tsutils@^3.21.0:
   version "3.21.0"
@@ -27542,6 +27896,11 @@ type-fest@^0.6.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
   integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
 
+type-fest@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.7.1.tgz#8dda65feaf03ed78f0a3f9678f1869147f7c5c48"
+  integrity sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==
+
 type-fest@^0.8.0, type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
@@ -27629,7 +27988,7 @@ typescript@^3.9.7:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
   integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
-typescript@^4.7.4:
+typescript@^4.3.5, typescript@^4.7.4:
   version "4.7.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
   integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
@@ -27686,6 +28045,11 @@ underscore@1.9.1, underscore@>=1.8.3, underscore@^1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
   integrity sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==
+
+undici@^5.4.0:
+  version "5.8.2"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.8.2.tgz#071fc8a6a5d24db0ad510ad442f607d9b09d5eec"
+  integrity sha512-3KLq3pXMS0Y4IELV045fTxqz04Nk9Ms7yfBBHum3yxsTR4XNn+ZCaUbf/mWitgYDAhsplQ0B1G4S5D345lMO3A==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"
@@ -29343,6 +29707,11 @@ workerpool@6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.0.tgz#827d93c9ba23ee2019c3ffaff5c27fccea289e8b"
   integrity sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==
+
+workerpool@6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
+  integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
 wrap-ansi@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
_(spun out from #5410... please see #5434 for the work to actually provide `truffle debug` support)_

## Overview

This PR introduces a new, _experimental_ package **@truffle/from-hardhat** to provide the following interfaces:

- `expectHardhat()`, which returns successfully iff the working directory is part of a Hardhat project, and iff the installed Hardhat version is supported (`^2.10.1`, current as of this PR). Exceptions are thrown to distinguish these failure modes. (This function is intended for use inside a `try`/`catch`) 

- `prepareCompilations()` that translates Hardhat "BuildInfo" into our native @truffle/compile-common "Compilation"

- `prepareConfig()` which _minimally_ reads the Hardhat config and converts it into a @truffle/config. Basically this only contains plain `url` networks. 🔍 **See documented caveats**: https://github.com/trufflesuite/truffle/blob/e9da6d97810d12041e6ecc21a7a62bd932b72fe5/packages/from-hardhat/src/api.ts#L65-L94

## Intended use

This PR intends for this package to be used by specific **read-only** Truffle commands, primarily `truffle debug`. At this time, this PR does not seek to provide any kind of support for `truffle compile`, `migrate`, `test`, etc. This package does not likely even provide enough information for most of other read-only commands, e.g. `truffle networks`, because no attempt is made to encode a means by which to convert deployment information into Truffle's artifacts.

🤔 Why so limited? Because even `truffle debug` is heckin' useful, and **I posit that we should do this despite its being scrappy and experimental because it's** 🔥 🔥 🔥

## Approach

This PR seeks to avoid intermixing Truffle's and Hardhat's Node.js runtimes. This new package includes Hardhat as a `devDependency` for its types, and keeps this dev- guarantee by not exposing any reference to these types. This ensures that we're not at risk of users' Truffle installations inadvertently including a full install of Hardhat as well.

How? This shells out to `npx hardhat`! Information about the Hardhat project is requested via `npx hardhat console` and passed along stdio via minified JSON. This ensures that Truffle's [likely polluted] Node.js runtime does not cause any conflicts with Hardhat's own [likely polluted] Node.js runtime.

These are necessary because neither Truffle nor Hardhat were really built to be library-first, and it seems prudent to treat Hardhat like a regular system executable on the PATH. (Well, `npx` is the executable on the PATH, but Hardhat specifically only supports running via `npx`)

