### PR TITLE
Bug fix: Prevent crash that occurs when processing certain bad jumps

### DIFF
--- a/packages/source-map-utils/index.js
+++ b/packages/source-map-utils/index.js
@@ -493,29 +493,31 @@ var SourceMapUtils = {
       const jumpIndex = instructions.findIndex(
         instruction => instruction.pc === jumpAddress
       );
-      if (checkAgainstTemplate(instructions, jumpIndex, newSequence)) {
-        return true;
-      }
-      debug("indirect: %O", instructions.slice(index, index + 4));
-      debug("jumpAddress: %d", jumpAddress);
-      debug("jumpIndex: %d", jumpIndex);
-      debug("instr count: %d", instructions.length);
-      const jumpInstruction = instructions[jumpIndex];
-      const jumpFile = jumpInstruction.file;
-      if (jumpFile !== -1) {
-        const findOverlappingRange = overlapFunctions[jumpFile];
-        const range = SourceMapUtils.getSourceRange(jumpInstruction);
-        const { node: jumpNode } = SourceMapUtils.findRange(
-          findOverlappingRange,
-          range.start,
-          range.length
-        );
-        if (
-          jumpNode &&
-          jumpNode.nodeType === "YulFunctionDefinition" &&
-          jumpNode.name === "panic_error_0x51"
-        ) {
+      if (jumpIndex !== undefined) {
+        if (checkAgainstTemplate(instructions, jumpIndex, newSequence)) {
           return true;
+        }
+        debug("indirect: %O", instructions.slice(index, index + 4));
+        debug("jumpAddress: %d", jumpAddress);
+        debug("jumpIndex: %d", jumpIndex);
+        debug("instr count: %d", instructions.length);
+        const jumpInstruction = instructions[jumpIndex];
+        const jumpFile = jumpInstruction.file;
+        if (jumpFile !== -1) {
+          const findOverlappingRange = overlapFunctions[jumpFile];
+          const range = SourceMapUtils.getSourceRange(jumpInstruction);
+          const { node: jumpNode } = SourceMapUtils.findRange(
+            findOverlappingRange,
+            range.start,
+            range.length
+          );
+          if (
+            jumpNode &&
+            jumpNode.nodeType === "YulFunctionDefinition" &&
+            jumpNode.name === "panic_error_0x51"
+          ) {
+            return true;
+          }
         }
       }
     }


### PR DESCRIPTION
So @cds-amal happened to hit this crash while doing some unrelated work.  I haven't reproduced it myself, but I'm pretty sure the correct solution here is to just throw a guard around it, so I'm doing that.

So what's going on here in more detail?  This code is part of the function that attempts to determine whether a given `JUMPDEST` instruction is the start of the designated invalid function that Solidity sometimes inserts into contracts as the place that uninitialized internal function pointers will jump to.  In recent Solidity versions, though, determining this is complicated by the fact that an uninitialized internal function pointer will not jump *directly* to the code that throws the error, rather it jumps to code that *jumps* to code that throws the error.  So, we have to look at the destination of that second jump!

Thing is, the code I wrote assumes that said destination exists as an instruction, i.e., it's not past the end of the code and it's not in the data part of a `PUSH` instruction.  If it is, you could get a crash.  Instead, we should just return `false` in such cases.  So I threw a guard around it to check that the instruction exists, and if it doesn't, then we'll fall to the end where we return `false`.

I didn't add a test.  Coming up with a test for this seems difficult!  But, @cds-amal could test it with his example (assuming he can reproduce it, which he might not be able to), or he could send that to me for manual testing?  I thought I'd throw this up here anyway though in this form; normally I'd test first, but I figured in this case I'd just get it up here since it's so simple.