### PR TITLE
Enhancement: Add `instance.estimateGas()` and `instance.call()`

### DIFF
--- a/packages/contract-tests/test/methods.js
+++ b/packages/contract-tests/test/methods.js
@@ -589,7 +589,7 @@ describe("Methods", function () {
     });
   });
 
-  describe("sendTransaction() / send() [ @geth ]", function () {
+  describe("sendTransaction() / call() / estimateGas() / send() [ @geth ]", function () {
     it("should trigger the fallback function when calling sendTransaction()", async function () {
       const example = await Example.new(1);
       let triggered = await example.fallbackTriggered();
@@ -624,6 +624,26 @@ describe("Methods", function () {
 
       triggered = await example.fallbackTriggered();
       assert.isTrue(triggered, "Fallback should now have been triggered");
+    });
+
+    it("should trigger the fallback function when calling call()", async function () {
+      const example = await Example.new(1);
+
+      const result = await example.call({ data: "0x01234567" });
+      assert.strictEqual(
+        result,
+        "0x0123" //fallback function cuts the input in half
+      );
+    });
+
+    it("should trigger the fallback function when calling estimateGas()", async function () {
+      const example = await Example.new(1);
+
+      const result = await example.estimateGas({});
+      //I'm not sure what to test about this, so let's just test that it's a finite positive integer
+      assert.isFinite(result, "Gas estimate should be a finite number");
+      assert(result > 0, "Gas estimate should be positive");
+      assert(Number.isInteger(result), "Gas estimate should be an integer");
     });
 
     it("should accept tx params (send)", async function () {

--- a/packages/contract-tests/test/methods.js
+++ b/packages/contract-tests/test/methods.js
@@ -592,7 +592,7 @@ describe("Methods", function () {
   describe("sendTransaction() / send() [ @geth ]", function () {
     it("should trigger the fallback function when calling sendTransaction()", async function () {
       const example = await Example.new(1);
-      const triggered = await example.fallbackTriggered();
+      let triggered = await example.fallbackTriggered();
 
       assert.isFalse(triggered, "Fallback should not have been triggered yet");
 
@@ -606,11 +606,14 @@ describe("Methods", function () {
         web3.utils.toWei("1", "ether"),
         "Balance should be 1 ether"
       );
+
+      triggered = await example.fallbackTriggered();
+      assert.isTrue(triggered, "Fallback should now have been triggered");
     });
 
     it("should trigger the fallback function when calling send() (shorthand notation)", async function () {
       const example = await Example.new(1);
-      const triggered = await example.fallbackTriggered();
+      let triggered = await example.fallbackTriggered();
 
       assert.isFalse(triggered, "Fallback should not have been triggered yet");
 
@@ -618,6 +621,9 @@ describe("Methods", function () {
 
       const balance = await web3.eth.getBalance(example.address);
       assert.strictEqual(balance, web3.utils.toWei("1", "ether"));
+
+      triggered = await example.fallbackTriggered();
+      assert.isTrue(triggered, "Fallback should now have been triggered");
     });
 
     it("should accept tx params (send)", async function () {

--- a/packages/contract-tests/test/methods.js
+++ b/packages/contract-tests/test/methods.js
@@ -594,18 +594,16 @@ describe("Methods", function () {
       const example = await Example.new(1);
       const triggered = await example.fallbackTriggered();
 
-      assert(
-        triggered === false,
-        "Fallback should not have been triggered yet"
-      );
+      assert.isFalse(triggered, "Fallback should not have been triggered yet");
 
       await example.sendTransaction({
         value: web3.utils.toWei("1", "ether")
       });
 
       const balance = await web3.eth.getBalance(example.address);
-      assert(
-        balance === web3.utils.toWei("1", "ether"),
+      assert.strictEqual(
+        balance,
+        web3.utils.toWei("1", "ether"),
         "Balance should be 1 ether"
       );
     });
@@ -614,15 +612,12 @@ describe("Methods", function () {
       const example = await Example.new(1);
       const triggered = await example.fallbackTriggered();
 
-      assert(
-        triggered === false,
-        "Fallback should not have been triggered yet"
-      );
+      assert.isFalse(triggered, "Fallback should not have been triggered yet");
 
       await example.send(web3.utils.toWei("1", "ether"));
 
       const balance = await web3.eth.getBalance(example.address);
-      assert(balance === web3.utils.toWei("1", "ether"));
+      assert.strictEqual(balance, web3.utils.toWei("1", "ether"));
     });
 
     it("should accept tx params (send)", async function () {
@@ -636,7 +631,7 @@ describe("Methods", function () {
       const finalSenderBalance = await web3.eth.getBalance(sender);
       const contractBalance = await web3.eth.getBalance(example.address);
 
-      assert(contractBalance === eth, "Contract should receive eth");
+      assert.strictEqual(contractBalance, eth, "Contract should receive eth");
 
       const initialBN = new web3.utils.BN(initialSenderBalance);
       const finalBN = new web3.utils.BN(finalSenderBalance);

--- a/packages/contract-tests/test/sources/Example.sol
+++ b/packages/contract-tests/test/sources/Example.sol
@@ -207,7 +207,8 @@ contract Example {
     return arr;
   }
 
-  fallback() external payable {
+  fallback(bytes calldata input) external payable returns (bytes memory) {
     fallbackTriggered = true;
+    return bytes(input[0 : input.length / 2]);
   }
 }

--- a/packages/contract/lib/contract/index.js
+++ b/packages/contract/lib/contract/index.js
@@ -116,7 +116,7 @@ if (typeof Web3 === "object" && Object.keys(Web3).length === 0) {
       }
     });
 
-    // sendTransaction / send
+    // instance.{sendTransaction, estimateGas, call, send}
     instance.sendTransaction = execute.send.call(
       constructor,
       null,
@@ -124,10 +124,27 @@ if (typeof Web3 === "object" && Object.keys(Web3).length === 0) {
       instance.address
     );
 
+    instance.estimateGas = execute.estimate.call(
+      constructor,
+      null,
+      null,
+      instance.address
+    );
+
+    // Prefer user defined `call`
+    if (!instance.call) {
+      instance.call = execute.call.call(
+        constructor,
+        null,
+        null,
+        instance.address
+      );
+    }
+
     // Prefer user defined `send`
     if (!instance.send) {
       instance.send = (value, txParams = {}) => {
-        const packet = Object.assign({value: value}, txParams);
+        const packet = Object.assign({ value: value }, txParams);
         return instance.sendTransaction(packet);
       };
     }

--- a/packages/contract/lib/execute.js
+++ b/packages/contract/lib/execute.js
@@ -121,15 +121,15 @@ const execute = {
    * to execute a call at.
    * @param  {Array}  args      `arguments` that were passed to method
    * @param  {Any}    lastArg    terminal argument passed to method
-   * @param  {Array}  inputs     ABI segment defining method arguments
+   * @param  {Array}  methodABI  ABI for the method; null for ABI-less calls
    * @return {Boolean}           true if final argument is `defaultBlock`
    */
   hasDefaultBlock: function (args, lastArg, methodABI) {
-    const expectedArgs = methodABI ? methodABI.inputs.length : 0;
+    const expectedArgsCount = methodABI ? methodABI.inputs.length : 0;
     const hasDefaultBlock =
-      !execute.hasTxParams(lastArg) && args.length > expectedArgs;
+      !execute.hasTxParams(lastArg) && args.length > expectedArgsCount;
     const hasDefaultBlockWithParams =
-      execute.hasTxParams(lastArg) && args.length - 1 > expectedArgs;
+      execute.hasTxParams(lastArg) && args.length - 1 > expectedArgsCount;
     return hasDefaultBlock || hasDefaultBlockWithParams;
   },
 

--- a/packages/contract/lib/execute.js
+++ b/packages/contract/lib/execute.js
@@ -163,17 +163,13 @@ const execute = {
 
           params.to = address;
 
-          if (methodABI) {
-            //note: in the future there should also be an event for non-method
-            //case, but that applies to all of these!
-            promiEvent.eventEmitter.emit("execute:call:method", {
-              fn: fn,
-              args: args,
-              address: address,
-              abi: methodABI,
-              contract: constructor
-            });
-          }
+          promiEvent.eventEmitter.emit("execute:call:method", {
+            fn: fn,
+            args: args,
+            address: address,
+            abi: methodABI,
+            contract: constructor
+          });
 
           result = fn //null fn is used for instance.call()
             ? await fn(...args).call(params, defaultBlock)


### PR DESCRIPTION
Addresses #5374.  Also, while I was at it, I improved some existing tests and fixed a bug.

This PR adds support for `instance.estimateGas()` and `instance.call()`, much like we currently have `instance.sendTransaction()`.  This was mostly pretty straightforward.  First off, in `contract/index.js`, where `instance.sendTransaction` and `instance.send` are set up, I also set up `estimateGas` and `call` in the same way.  Note I put `call` behind a guard like `send` to make sure it doesn't overwrite a user method of the same name, because A. that might plausibly exist, and B. `instance.call` honestly isn't that useful, I just included it for completeness :P  I didn't bother with such a thing for `estimateGas` as I figured that is pretty unlikely to break anything, although we could if we want to be certain.

You'll notice that the way that `instance.sendTransaction` works is by calling `execute.send` but with passing `null` for the `fn` and `methodABI` arguments.  That strikes me as not a great way of doing things, but I didn't want to redo it, so I did the others in the same way for consistency.

However, this meant that `call` and `estimate` had to be updated to account for the possibility that `fn` and `methodABI` might be null.  Also, `estimate` had to take an `address` parameter like the others, which previously it didn't.  (Although, `method.estimateGas()` was passing it one... there just wasn't any parameter there to receive it!)  This is basically all straightforward -- if `fn` is present we do the existing thing, if it isn't we just invoke web3.  Note that in `estimate` we make sure to set the address appropriately; this was already accounted for in `call`, but needed to be set up explicitly in `estimate`.  There are other appropriate adjustments which I won't detail.

There are two more particular things I want to note, though.  First, note that I put explicit `await`s in `estimate` where they weren't any before.  This may not seem to matter, but it's actually important for improving error behavior (there should have been one all along).  Second, I *didn't* put an `if (methodABI)` guard around the call event emission.  On inspecting the code that uses it, I'm pretty sure it should work fine without one (and adding one would reduce its functionality, anyway!).

Anyway, with that done, it was just a matter of adding tests... and improving the existing tests!  I noticed that the existing tests of `sendTransaction` and `send` checked that `fallbackTriggered` was `false` before, but not that it was `true` afterward, so I added checks for that.  (I also changed the asserts to make better use of chai!)  And then I also added similar tests for `call` (altering the fallback function so that it returns a value) and `estimateGas` (I didn't know what to checked for this so I just checked that the output is a finite positive integer).

And that's it!  Nothing too complicated. :)

(And yeah, I deleted the geth tag when running the tests locally so that these tests would actually run. :P )