### PR TITLE
Use TruffleError instead of Error while parsing mutually exclusive options

### DIFF
--- a/packages/core/lib/commands/console/run.js
+++ b/packages/core/lib/commands/console/run.js
@@ -1,11 +1,21 @@
 module.exports = async function (options) {
+  const OS = require("os");
   const { Console, excludedCommands } = require("../../console");
   const { Environment } = require("@truffle/environment");
+  const TruffleError = require("@truffle/error");
   const commands = require("../commands");
   const loadConfig = require("../../loadConfig");
 
   if (options.url && options.network) {
-    throw new Error("'url' and 'network' are mutually exclusive options");
+    const message =
+      "" +
+      "Mutually exclusive options, --url and --network detected!" +
+      OS.EOL +
+      "Please use either --url or --network and try again." +
+      OS.EOL +
+      "See: https://trufflesuite.com/docs/truffle/reference/truffle-commands/#console" +
+      OS.EOL;
+    throw new TruffleError(message);
   }
 
   let config = loadConfig(options);

--- a/packages/core/lib/commands/debug/run.js
+++ b/packages/core/lib/commands/debug/run.js
@@ -1,14 +1,21 @@
 module.exports = async function (options) {
+  const OS = require("os");
   const { promisify } = require("util");
-  const debugModule = require("debug");
   const loadConfig = require("../../loadConfig");
-  const debug = debugModule("lib:commands:debug");
-
   const { Environment } = require("@truffle/environment");
+  const TruffleError = require("@truffle/error");
   const { CLIDebugger } = require("../../debug");
 
   if (options.url && options.network) {
-    throw new Error("Url and Network options should not be specified together");
+    const message =
+      "" +
+      "Mutually exclusive options, --url and --network detected!" +
+      OS.EOL +
+      "Please use either --url or --network and try again." +
+      OS.EOL +
+      "See: https://trufflesuite.com/docs/truffle/reference/truffle-commands/#debug" +
+      OS.EOL;
+    throw new TruffleError(message);
   }
 
   let config = loadConfig(options);


### PR DESCRIPTION
### ISSUE
Truffle uses the generic `Error` type in some situations that provide a stack trace to the users that is unnecessary. 
For example: Using mutually exclusive options, `--url` and `--network` with `truffle console` and `truffle debug` includes a stack trace, which is irrelevant to the users, as Truffle doesn't allow these two options to be specified together. See #5296.

### SOLUTION
This PR resolves this issue by using `TruffleError` instead of the generic `Error` type while parsing the mutually exclusive options, `--url` and `--network` with `truffle console` and `truffle debug`.