### PR TITLE
Fix exception on deploying a contract with both constructor arguments and deploy options

### DIFF
--- a/packages/deployer/src/deployment.js
+++ b/packages/deployer/src/deployment.js
@@ -29,7 +29,7 @@ class Deployment {
   /**
    * Helper to parse a deploy statement's overwrite option
    * @private
-   * @param  {Arry}    args        arguments passed to deploy
+   * @param  {Array}    args       arguments passed to deploy
    * @param  {Boolean} isDeployed  is contract deployed?
    * @return {Boolean}             true if overwrite is ok
    */
@@ -39,7 +39,6 @@ class Deployment {
 
     const overwrite = isObject && isDeployed && lastArg.overwrite === false;
 
-    isObject && delete lastArg.overwrite;
     return !overwrite;
   }
 

--- a/packages/deployer/src/deployment.js
+++ b/packages/deployer/src/deployment.js
@@ -29,9 +29,9 @@ class Deployment {
   /**
    * Helper to parse a deploy statement's overwrite option
    * @private
-   * @param  {Array}    args       arguments passed to deploy
-   * @param  {Boolean} isDeployed  is contract deployed?
-   * @return {Boolean}             true if overwrite is ok
+   * @param  {Array}   args       arguments passed to deploy
+   * @param  {Boolean} isDeployed is contract deployed?
+   * @return {Boolean}            true if overwrite is ok
    */
   _canOverwrite(args, isDeployed) {
     const lastArg = args[args.length - 1];


### PR DESCRIPTION
## Remove the line that deletes overwrite property from options object

In later steps, we use the existence of `overwrite` property in the `isTxParams()` function. If we delete it, the `options` object will be considered as a constructor argument; Thus we will hit a runtime error because of an extra or wrong constructor argument.

### Environment
```sh
$ truffle version
Truffle v5.5.26 (core: 5.5.26)
Ganache v7.4.0
Solidity - 0.8.4 (solc-js)
Node v16.16.0
Web3.js v1.7.4
```

### Steps to reproduce

1. Write a smart contract that takes at least one argument in the constructor.
2. Add `deployer.deploy(MyContract, arg0, { overwrite: false })` to migrations setup.
3. Execute migration command.
4. Wait for the extra constructor argument exception to be thrown.

* The value of `arg0` is optional. (Except `null` and `undefined` which throws another exception)