### PR TITLE
Add --from to global command options

### DIFF
--- a/packages/core/lib/global-command-options.js
+++ b/packages/core/lib/global-command-options.js
@@ -7,7 +7,7 @@ const options = {
   from: {
     option: "--from <account>",
     description:
-      "Specify the account from which to make calls or send transactions."
+      "Specify the default account from which to make calls or send transactions."
   },
   config: {
     option: "--config <file>",

--- a/packages/core/lib/global-command-options.js
+++ b/packages/core/lib/global-command-options.js
@@ -4,6 +4,11 @@ const options = {
     description:
       "Specify the network to use. Network name must exist in the configuration."
   },
+  from: {
+    option: "--from <account>",
+    description:
+      "Specify the account from which to make calls or send transactions."
+  },
   config: {
     option: "--config <file>",
     description:


### PR DESCRIPTION
This PR adds `--from` option to truffle global command options list, which can be used to specify an account to make calls or send transactions. This is related to #5330, where it was discussed to be a separate PR.