### PR TITLE
Internal improvement: Move selector computation from `codec` into `abi-utils`

### DIFF
--- a/packages/abi-utils/README.md
+++ b/packages/abi-utils/README.md
@@ -8,6 +8,7 @@ This package contains a few different components:
 
 - [Normalize ABIs](#normalize-abis)
 - [TypeScript types](#typescript-types)
+- [Selector and signature computation](#selector-and-signature-computation)
 - [Arbitrary random ABIs](#arbitrary-random-abis)
 
 ## Normalize ABIs
@@ -17,12 +18,14 @@ This package contains a few different components:
 > const isFunctionEntry = entry.type === "function" || !("type" in entry);
 >
 > // handle:        v--- new way                           v--- old way     v--- default
-> const isPayable = entry.stateMutability === "payable" || entry.payable || false;
+> const isPayable =
+>   entry.stateMutability === "payable" || entry.payable || false;
 >
 > // handle "outputs" possibly being undefined
 > const outputs = entry.outputs || [];
 > ```
-_^ Have you ever had to do this sort of thing?_ :scream:
+>
+> _^ Have you ever had to do this sort of thing?_ :scream:
 
 Solidity's official [JSON ABI specification](https://solidity.readthedocs.io/en/v0.7.3/abi-spec.html)
 is rather permissive, since it remains backwards compatible with older
@@ -41,6 +44,7 @@ import { normalize } from "@truffle/abi-utils";
 ```
 
 Specifically, this normalizes by:
+
 - Ensuring every ABI entry has a `type` field, since it's optional for
   `type: "function"`
 - Populating default value `[]` for function `outputs` field
@@ -58,7 +62,6 @@ const abi = normalize([{"type": "constructor"/*, ...*/}/*, ...*/);
 const isFunctionEntry = entry.type === "function";
 const isPayable = entry.stateMutability === "payable";
 ```
-
 
 ## TypeScript types
 
@@ -79,11 +82,32 @@ above.
 ```typescript
 import * as Abi from "@truffle/abi-utils";
 
-const abi: Abi.Abi = [{"type": "constructor"/*, ...*/}/*, ...*/];
-const parameter: Abi.Parameter = {"type": "tuple[]", "components": [/*...*/]};
+const abi: Abi.Abi = [{ type: "constructor" /*, ...*/ } /*, ...*/];
+const parameter: Abi.Parameter = {
+  type: "tuple[]",
+  components: [
+    /*...*/
+  ]
+};
 // etc.
 ```
 
+## Selector and signature computation
+
+This package exports the following functions for computing signatures and selectors:
+
+- `abiSelector`: This function takes a `FunctionEntry`, `EventEntry`, or
+  `ErrorEntry` and computes its selector, returned as a hex string. This will
+  be 4 bytes for a function or error, and 32 bytes for an event.
+- `abiSignature`: This function takes a `FunctionEntry`, `EventEntry`, or
+  `ErrorEntry` and computes its written-out signature (e.g., `"setStoredValue(uint256)"`).
+- `abiTupleSignature`: This function takes a `Parameter[]` and computes the signature
+  of that tuple on its own; e.g., `"(uint256,string)"` for a `uint` and a `string`.
+- `abiTypeSignature`: This function takes an individual `Parameter` and computes
+  the signature of that type on its own; e.g., `uint256` for a `uint`.
+
+In addition, the package also exports the constant `ShortSelectorSize`, which
+is equal to 4 (the number of bytes in a function or event selector).
 
 ## Arbitrary random ABIs
 

--- a/packages/abi-utils/lib/index.ts
+++ b/packages/abi-utils/lib/index.ts
@@ -1,4 +1,5 @@
 export * from "./types";
 export * from "./normalize";
+export * from "./signature";
 import * as Arbitrary from "./arbitrary";
 export { Arbitrary };

--- a/packages/abi-utils/lib/signature.test.ts
+++ b/packages/abi-utils/lib/signature.test.ts
@@ -1,0 +1,187 @@
+import * as Signature from "./signature";
+import { FunctionEntry, EventEntry, ErrorEntry } from "./types";
+import assert from "assert";
+
+describe("signature computation", () => {
+  it("computes simple signatures", () => {
+    const entry: EventEntry = {
+      type: "event",
+      anonymous: false,
+      name: "ThingsDone",
+      inputs: [
+        {
+          name: "a",
+          indexed: false,
+          type: "uint256",
+          internalType: "uint256"
+        },
+        {
+          name: "b",
+          indexed: false,
+          type: "bytes32",
+          internalType: "bytes32"
+        },
+        {
+          name: "c",
+          indexed: true,
+          type: "address",
+          internalType: "address payable"
+        }
+      ]
+    };
+    const expected = "ThingsDone(uint256,bytes32,address)";
+    const signature = Signature.abiSignature(entry);
+    assert.equal(signature, expected);
+  });
+
+  it("computes signatures with empty inputs", () => {
+    const entry: ErrorEntry = {
+      type: "error",
+      name: "ThingsNotDone",
+      inputs: []
+    };
+    const expected = "ThingsNotDone()";
+    const signature = Signature.abiSignature(entry);
+    assert.equal(signature, expected);
+  });
+
+  it("computes signatures with arrays", () => {
+    const entry: FunctionEntry = {
+      type: "function",
+      stateMutability: "nonpayable",
+      outputs: [],
+      name: "doThings",
+      inputs: [
+        {
+          name: "a",
+          type: "uint256[2]",
+          internalType: "uint256"
+        },
+        {
+          name: "b",
+          type: "bytes32[4][4]",
+          internalType: "bytes32"
+        },
+        {
+          name: "c",
+          type: "string[]",
+          internalType: "string[]"
+        }
+      ]
+    };
+    const expected = "doThings(uint256[2],bytes32[4][4],string[])";
+    const signature = Signature.abiSignature(entry);
+    assert.equal(signature, expected);
+  });
+
+  it("computes signatures with tuples", () => {
+    const entry: FunctionEntry = {
+      type: "function",
+      stateMutability: "nonpayable",
+      outputs: [],
+      name: "doSillyThings",
+      inputs: [
+        {
+          name: "a",
+          type: "tuple",
+          internalType: "struct Contract.Struct1",
+          components: [
+            {
+              name: "aa",
+              type: "bool",
+              internalType: "bool"
+            },
+            {
+              name: "ab",
+              type: "address[]",
+              internalType: "address payable[]"
+            }
+          ]
+        },
+        {
+          name: "b",
+          type: "tuple",
+          internalType: "struct Contract.Struct2",
+          components: [
+            {
+              name: "ba",
+              type: "function",
+              internalType:
+                "function(bytes memory) external pure returns (bytes)"
+            },
+            {
+              name: "ab",
+              type: "tuple",
+              internalType: "struct Contract.Struct3",
+              components: [
+                {
+                  name: "aba",
+                  type: "string",
+                  internalType: "string"
+                },
+                {
+                  name: "abb",
+                  type: "bytes[2]",
+                  internalType: "bytes[2]"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    };
+    const expected =
+      "doSillyThings((bool,address[]),(function,(string,bytes[2])))";
+    const signature = Signature.abiSignature(entry);
+    assert.equal(signature, expected);
+  });
+
+  it("computes signatures with arrays of tuples", () => {
+    const entry: FunctionEntry = {
+      type: "function",
+      stateMutability: "nonpayable",
+      outputs: [],
+      name: "doVerySillyThings",
+      inputs: [
+        {
+          name: "a",
+          type: "tuple[2][][2]",
+          internalType: "struct Contract.Struct1",
+          components: [
+            {
+              name: "aa",
+              type: "bool",
+              internalType: "bool"
+            },
+            {
+              name: "ab",
+              type: "address[]",
+              internalType: "address payable[]"
+            }
+          ]
+        },
+        {
+          name: "b",
+          type: "tuple[][2][]",
+          internalType: "struct Contract.Struct1",
+          components: [
+            {
+              name: "ba",
+              type: "string",
+              internalType: "string"
+            },
+            {
+              name: "bb",
+              type: "int256",
+              internalType: "address payable[]"
+            }
+          ]
+        }
+      ]
+    };
+    const expected =
+      "doVerySillyThings((bool,address[])[2][][2],(string,int256)[][2][])";
+    const signature = Signature.abiSignature(entry);
+    assert.equal(signature, expected);
+  });
+});

--- a/packages/abi-utils/lib/signature.ts
+++ b/packages/abi-utils/lib/signature.ts
@@ -1,0 +1,46 @@
+import { Parameter, FunctionEntry, EventEntry, ErrorEntry } from "./types";
+import { soliditySha3 } from "web3-utils";
+
+export const ShortSelectorSize = 4;
+
+//NOTE: this function returns the written out SIGNATURE, not the SELECTOR
+export function abiSignature(
+  abiEntry: FunctionEntry | EventEntry | ErrorEntry
+): string {
+  return abiEntry.name + abiTupleSignature(abiEntry.inputs);
+}
+
+export function abiTupleSignature(parameters: Parameter[]): string {
+  const components = parameters.map(abiTypeSignature);
+  return "(" + components.join(",") + ")";
+}
+
+export function abiTypeSignature(parameter: Parameter): string {
+  const tupleMatch = parameter.type.match(/tuple(.*)/);
+  if (tupleMatch === null) {
+    //does not start with "tuple"
+    return parameter.type;
+  } else {
+    const tail = tupleMatch[1]; //everything after "tuple"
+    const tupleSignature = abiTupleSignature(
+      parameter.components as Parameter[]
+    ); //it won't be undefined
+    return tupleSignature + tail;
+  }
+}
+
+export function abiSelector(
+  abiEntry: FunctionEntry | EventEntry | ErrorEntry
+): string {
+  const signature = abiSignature(abiEntry);
+  //NOTE: web3's soliditySha3 has a problem if the empty
+  //string is passed in.  Fortunately, that should never happen here.
+  const hash = soliditySha3({ type: "string", value: signature }) as string;
+  switch (abiEntry.type) {
+    case "event":
+      return hash;
+    case "function":
+    case "error":
+      return hash.slice(0, 2 + 2 * ShortSelectorSize); //arithmetic to account for hex string
+  }
+}

--- a/packages/abi-utils/lib/signature.ts
+++ b/packages/abi-utils/lib/signature.ts
@@ -16,7 +16,7 @@ export function abiTupleSignature(parameters: Parameter[]): string {
 }
 
 export function abiTypeSignature(parameter: Parameter): string {
-  const tupleMatch = parameter.type.match(/tuple(.*)/);
+  const tupleMatch = parameter.type.match(/^tuple(.*)/);
   if (tupleMatch === null) {
     //does not start with "tuple"
     return parameter.type;

--- a/packages/abi-utils/package.json
+++ b/packages/abi-utils/package.json
@@ -26,7 +26,8 @@
   "dependencies": {
     "change-case": "3.0.2",
     "faker": "5.5.3",
-    "fast-check": "3.1.1"
+    "fast-check": "3.1.1",
+    "web3-utils": "1.7.4"
   },
   "devDependencies": {
     "@fast-check/jest": "^1.0.1",

--- a/packages/codec/lib/evm/utils.ts
+++ b/packages/codec/lib/evm/utils.ts
@@ -4,10 +4,11 @@ const debug = debugModule("codec:evm:utils");
 import BN from "bn.js";
 import Web3Utils from "web3-utils";
 import * as Conversion from "@truffle/codec/conversion";
+import { ShortSelectorSize } from "@truffle/abi-utils";
 
 export const WORD_SIZE = 0x20;
 export const ADDRESS_SIZE = 20;
-export const SELECTOR_SIZE = 4; //function selectors, not event selectors
+export const SELECTOR_SIZE = ShortSelectorSize; //equals 4; function & error selectors, not event selectors
 export const PC_SIZE = 4;
 export const MAX_WORD = new BN(-1).toTwos(WORD_SIZE * 8);
 export const ZERO_ADDRESS = "0x" + "00".repeat(ADDRESS_SIZE);


### PR DESCRIPTION
This PR moves code for computing signatures and selectors from `codec` into `abi-utils`.  Note that we continue to re-export these functions from Codec, in order to avoid a breaking change.  I also added a few tests of these functions in `abi-utils` -- not property-based, sorry, I couldn't figure out a good way to do that.  On top of that, I expanded the `abi-utils` README to cover this new functionality.

Since this PR is mostly just moving code around and not changing it, there's not a lot to say here about the code itself.  However, I wanted to record why I'm doing this.

Basically, it comes back to the abi-to-sol problem.  I want to be able to make breakiing changes to Codec without a repeat of the problem that caused last time (see #5396 for an explanation).  This is the only code from Codec that abi-to-sol uses.  Moving it to abi-utils will of course not get rid of the problem, but it reduces it, since it means that the problem will only come up when we break abi-utils rather than when we break codec.  Since we break abi-utils hardly ever, and break codec somewhat frequently, this acts as a stopgap to allow us to avoid problems until we figure out a better solution.