### PR TITLE
Internal improvement: Properly time REPL inputs

### DIFF
--- a/packages/truffle/test/scenarios/commandRunner.js
+++ b/packages/truffle/test/scenarios/commandRunner.js
@@ -84,7 +84,7 @@ module.exports = {
         // count prompt
         const foundPrompts = (outputBuffer.match(readyPromptRex) || []).length;
         if (foundPrompts > numSeenPrompts) {
-          numSeenPrompts++;
+          numSeenPrompts = foundPrompts;
           if (inputCommands.length === 0) {
             // commands exhausted, close stdin
             child.stdin.end();

--- a/packages/truffle/test/scenarios/commandRunner.js
+++ b/packages/truffle/test/scenarios/commandRunner.js
@@ -81,7 +81,10 @@ module.exports = {
         outputBuffer += data;
 
         if (readyPromptRex.test(outputBuffer)) {
-          // set outputBuffer to remaining segment after final match
+          // Set outputBuffer to remaining segment after final match.
+          // This will match the next prompt. There can only ever be one
+          // readyPrompt as the prompt is presented only after the REPL
+          // *evaluates* a command.
           const segments = outputBuffer.split(readyPromptRex);
           outputBuffer = segments.pop();
 
@@ -89,7 +92,8 @@ module.exports = {
             // commands exhausted, close stdin
             child.stdin.end();
           } else {
-            // fifo pop next command and submit
+            // fifo pop next command and let the REPL evaluate the next
+            // command.
             const nextCmd = inputCommands.shift();
             child.stdin.write(nextCmd + EOL);
           }

--- a/packages/truffle/test/scenarios/commands/develop.js
+++ b/packages/truffle/test/scenarios/commands/develop.js
@@ -25,18 +25,27 @@ describe("truffle develop", function () {
   });
 
   describe("Globals", function () {
+    const cunningWord = "contrafibularities";
     let output;
+
     before(async function () {
       this.timeout(10000);
-      const input = "Object.keys(global)";
+      const inputs = [`dict = "${cunningWord}"`, "Object.keys(global)"];
 
       await CommandRunner.runInREPL({
-        inputCommands: [input],
+        inputCommands: inputs,
         config,
         executableCommand: "develop",
         displayHost: "develop"
       });
       output = logger.contents();
+    });
+
+    it("Sends multiple commands to REPL", () => {
+      assert(
+        output.includes(cunningWord),
+        "It seems the `runInREPL` does not handle multiple inputs!"
+      );
     });
 
     [


### PR DESCRIPTION
Currently, `runInREPL` sends all queued commands to the child process on the first detected REPL prompt and then closes the input stream, which terminates the child process (bad).

This PR reworks the logic to send one queued command per REPL prompt.