### PR TITLE
Internal improvement: Remove unnecessary config entry in dev deps for compile-solidity

### DIFF
--- a/packages/compile-solidity/package.json
+++ b/packages/compile-solidity/package.json
@@ -42,7 +42,6 @@
     "@truffle/artifactor": "^4.0.166",
     "@truffle/box": "^2.1.56",
     "@truffle/resolver": "^9.0.13",
-    "@truffle/config": "^1.3.34",
     "@types/node": "~12.12.0",
     "babel-core": "^6.26.0",
     "babel-polyfill": "^6.26.0",


### PR DESCRIPTION
An entry for @truffle/config was made in the `devDependencies` for compile-solidity accidentally as it was already in the regular dependencies. This PR corrects this error.