### PR TITLE
Update abi-to-sol to ^0.6.6

### DIFF
--- a/packages/resolver/package.json
+++ b/packages/resolver/package.json
@@ -32,7 +32,7 @@
     "@truffle/contract-sources": "^0.2.0",
     "@truffle/expect": "^0.1.3",
     "@truffle/provisioner": "^0.2.60",
-    "abi-to-sol": "^0.6.5",
+    "abi-to-sol": "^0.6.6",
     "debug": "^4.3.1",
     "detect-installed": "^2.0.4",
     "fs-extra": "^9.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8458,13 +8458,12 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
-abi-to-sol@^0.6.5:
-  version "0.6.5"
-  resolved "https://registry.yarnpkg.com/abi-to-sol/-/abi-to-sol-0.6.5.tgz#3157e3098264fea84beb8b3d0223eef8438e5826"
-  integrity sha512-ep9YpGM7+QJs2hMvJOig/duOHBJUMEFC27WJAVNEa1ghN4vtBW4hrsZ9ZB5v9YDtv0Oexqdp3BqQ3dZdLcmdOQ==
+abi-to-sol@^0.6.6:
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/abi-to-sol/-/abi-to-sol-0.6.6.tgz#2f0b7ea949f7015c1a7939d200b9e8d07f2c3c6d"
+  integrity sha512-PRn81rSpv6NXFPYQSw7ujruqIP6UkwZ/XoFldtiqCX8+2kHVc73xVaUVvdbro06vvBVZiwnxhEIGdI4BRMwGHw==
   dependencies:
-    "@truffle/abi-utils" "^0.2.2"
-    "@truffle/codec" "^0.14.0"
+    "@truffle/abi-utils" "^0.3.0"
     "@truffle/contract-schema" "^3.3.1"
     ajv "^6.12.5"
     better-ajv-errors "^0.8.2"


### PR DESCRIPTION
This PR updates @truffle/resolver's abi-to-sol dependency from ^0.6.5 to ^0.6.6