### PR TITLE
Add optimistic goerli to etherscan fetcher

### DIFF
--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -63,6 +63,7 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
       "sepolia": "api-sepolia.etherscan.io",
       "optimistic": "api-optimistic.etherscan.io",
       "kovan-optimistic": "api-kovan-optimistic.etherscan.io",
+      "goerli-optimistic": "api-goerli-optimistic.etherscan.io",
       "arbitrum": "api.arbiscan.io",
       "rinkeby-arbitrum": "api-testnet.arbiscan.io",
       "polygon": "api.polygonscan.com",


### PR DESCRIPTION
It looks like https://goerli-optimistic.etherscan.io/ is now up!  It doesn't seem to be entirely public yet, Etherscan has yet to link it from their other pages, like the main optimistic site... but it's there and it works. :)  So why not add it here? :)