### PR TITLE
Add hecoinfo testnet back in to source-fetcher

### DIFF
--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -74,6 +74,7 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
       "avalanche": "api.snowtrace.io",
       "fuji-avalanche": "api-testnet.snowtrace.io",
       "heco": "api.hecoinfo.com",
+      "testnet-heco": "api-testnet.hecoinfo.com",
       "moonbeam": "api-moonbeam.moonscan.io",
       "moonriver": "api-moonriver.moonscan.io",
       "moonbase-alpha": "api-moonbase.moonscan.io",

--- a/packages/source-fetcher/lib/networks.ts
+++ b/packages/source-fetcher/lib/networks.ts
@@ -45,7 +45,7 @@ export const networkNamesById: { [id: number]: string } = {
   250: "fantom",
   4002: "testnet-fantom",
   128: "heco",
-  256: "testnet-heco", //not presently supported by either fetcher, but formerly by etherscan
+  256: "testnet-heco",
   1284: "moonbeam",
   1285: "moonriver",
   1287: "moonbase-alpha",


### PR DESCRIPTION
I removed this in #5411, but, uh, it's back now?  So uh yean, adding it back in.

(Noting once again that hecoinfo is no longer actually an Etherscan project, but it still continues to use the same API, so we can still use our Etherscan fetcher with it, unlike say with hooscan.)