### PR TITLE
Use canonical URL for goerli-optimistic

### DIFF
--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -63,7 +63,7 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
       "sepolia": "api-sepolia.etherscan.io",
       "optimistic": "api-optimistic.etherscan.io",
       "kovan-optimistic": "api-kovan-optimistic.etherscan.io",
-      "goerli-optimistic": "api-goerli-optimistic.etherscan.io",
+      "goerli-optimistic": "api-goerli-optimism.etherscan.io", //yes this one is different!
       "arbitrum": "api.arbiscan.io",
       "rinkeby-arbitrum": "api-testnet.arbiscan.io",
       "polygon": "api.polygonscan.com",

--- a/packages/source-fetcher/lib/networks.ts
+++ b/packages/source-fetcher/lib/networks.ts
@@ -74,6 +74,7 @@ export const networkNamesById: { [id: number]: string } = {
   50: "xinfin", //not presently supported by either fetcher, but...
   51: "apothem-xinfin"
   //I'm not including crystaleum as it has network ID different from chain ID
+  //not including kekchain for the same reason
 };
 
 export const networksByName: Types.SupportedNetworks = Object.fromEntries(


### PR DESCRIPTION
It turns out that Etherscan's explorer for Optimistic Goerli canonically lives at https://goerli-optimism.etherscan.io/ rather than https://goerli-optimistic.etherscan.io/ ; both work but the former seems to be the canonical one.  Yes, this is inconsistent, but that's the way it is!  So I changed it to that.

Also Sourcify added support for kekchain but since that's another one with chain ID different from network ID I have left it out and added a comment about it.