### PR TITLE
Wrap meaningful `hardhat console` output in sigils

### DIFF
--- a/packages/from-hardhat/src/ask-hardhat.ts
+++ b/packages/from-hardhat/src/ask-hardhat.ts
@@ -67,6 +67,12 @@ export const askHardhatConsole = async (
   new Promise((accept, reject) => {
     const { workingDirectory } = withDefaultEnvironmentOptions(options);
 
+    // Latin-1 Supplemental block control codes
+    const sos = String.fromCodePoint(0x0098); // start of string
+    const st = String.fromCodePoint(0x009c); // string terminator
+    const prefix = `${sos}truffle-start${st}`;
+    const suffix = `${sos}truffle-end${st}`;
+
     const hardhat = spawn(`npx`, ["hardhat", "console"], {
       stdio: ["pipe", "pipe", "inherit"],
       cwd: workingDirectory
@@ -84,12 +90,19 @@ export const askHardhatConsole = async (
         return reject(new Error(`Hardhat exited with non-zero code ${code}`));
       }
 
+      const data = output.slice(
+        output.indexOf(prefix) + prefix.length,
+        output.indexOf(suffix)
+      );
+
       if (raw) {
-        return accept(output);
+        return accept(data);
       }
 
       try {
-        return accept(JSON.parse(output));
+        const result = JSON.parse(data);
+
+        return accept(result);
       } catch (error) {
         return reject(error);
       }
@@ -99,8 +112,12 @@ export const askHardhatConsole = async (
       Promise.resolve(${expression})
         .then(${
           raw
-            ? `console.log`
-            : `(resolved) => console.log(JSON.stringify(resolved))`
+            ? `(resolved) => console.log(
+                \`${prefix}$\{resolved}${suffix}\`
+              )`
+            : `(resolved) => console.log(
+                \`${prefix}$\{JSON.stringify(resolved)}${suffix}\`
+              )`
         })
     `);
     hardhat.stdin.end();


### PR DESCRIPTION
This addresses the concern surfaced in #5459, where we discovered that many Hardhat project configurations are setup to produce console output while executing ("reading") their hardhat config.

This breaks the existing experimental implementation of Hardhat support in `truffle debug` because the @truffle/from-hardhat support relies on the stdout produced by `npx hardhat console`. Since Hardhat config files might produce stdout of their own, and the Hardhat console necessarily executes those config files, we need some way of distinguishing Truffle-specific output from any config noise.

The solution this PR takes is to use sigils: Truffle instructs `npx hardhat console` to wrap the answers to Truffle's questions in a start/end delimiter. On the receiving side, Truffle then only interprets the response between those delimiters. To minimize risk of string collision with user code, this PR uses the strings `truffle-start` and `truffle-end`, wrapped with control characters from the Latin-1 supplemental block.