### PR TITLE
enable migration's  `save` option for yargs.

### DIFF
--- a/packages/core/lib/commands/compile/meta.js
+++ b/packages/core/lib/commands/compile/meta.js
@@ -41,7 +41,7 @@ module.exports = {
       },
       {
         option: "--save-intermediate <output-file>",
-        internal: true,
+        hidden: true,
         description:
           "Save the raw compiler results into <output-file>, overwriting any existing content."
       }

--- a/packages/core/lib/commands/help/displayCommandHelp.js
+++ b/packages/core/lib/commands/help/displayCommandHelp.js
@@ -35,7 +35,7 @@ module.exports = async function (selectedCommand, subCommand, options) {
 
     console.log(`  Options: `);
     for (const option of allValidOptions) {
-      if (option.internal) {
+      if (option.hidden) {
         continue;
       }
 

--- a/packages/core/lib/commands/migrate/meta.js
+++ b/packages/core/lib/commands/migrate/meta.js
@@ -18,6 +18,7 @@ module.exports = {
     },
     "--verbose-rpc": {
       describe: "Log communication between Truffle and the Ethereum client.",
+      type: "boolean",
       default: false
     },
     "dry-run": {

--- a/packages/core/lib/commands/migrate/meta.js
+++ b/packages/core/lib/commands/migrate/meta.js
@@ -48,7 +48,7 @@ module.exports = {
       describe: "Specify whether the migration will save on chain",
       type: "boolean",
       default: true,
-      hidden: true
+      hide: true
     }
   },
   help: {

--- a/packages/core/lib/commands/migrate/meta.js
+++ b/packages/core/lib/commands/migrate/meta.js
@@ -47,7 +47,8 @@ module.exports = {
     "save": {
       describe: "Specify whether the migration will save on chain",
       type: "boolean",
-      default: true
+      default: true,
+      hidden: true
     }
   },
   help: {

--- a/packages/core/lib/commands/migrate/meta.js
+++ b/packages/core/lib/commands/migrate/meta.js
@@ -48,7 +48,7 @@ module.exports = {
       describe: "Specify whether the migration will save on chain",
       type: "boolean",
       default: true,
-      hide: true
+      hidden: true
     }
   },
   help: {
@@ -111,8 +111,8 @@ module.exports = {
       },
       {
         option: "--save",
-        describe: "Specify whether the migration will save on chain",
-        hide: true
+        description: "Specify whether the migration will save on chain",
+        hidden: true
       }
     ],
     allowedGlobalOptions: ["network", "config", "quiet"]

--- a/packages/core/lib/commands/migrate/meta.js
+++ b/packages/core/lib/commands/migrate/meta.js
@@ -57,7 +57,7 @@ module.exports = {
       "                                " + // spacing to align with previous line
       "[--compile-all] [--compile-none] [--verbose-rpc] [--interactive]\n" +
       "                                " + // spacing to align with previous line
-      "[--skip-dry-run] [--describe-json] [--dry-run]",
+      "[--skip-dry-run] [--describe-json] [--dry-run] [--save <boolean>]",
     options: [
       {
         option: "--reset",
@@ -108,6 +108,11 @@ module.exports = {
         option: "--describe-json",
         description:
           "Adds extra verbosity to the status of an ongoing migration"
+      },
+      {
+        option: "--save",
+        describe: "Specify whether the migration will save on chain",
+        hide: true
       }
     ],
     allowedGlobalOptions: ["network", "config", "quiet"]

--- a/packages/core/lib/commands/migrate/meta.js
+++ b/packages/core/lib/commands/migrate/meta.js
@@ -43,6 +43,11 @@ module.exports = {
       describe: "Adds extra verbosity to the status of an ongoing migration",
       type: "boolean",
       default: false
+    },
+    "save": {
+      describe: "Specify whether the migration will save on chain",
+      type: "boolean",
+      default: true
     }
   },
   help: {

--- a/packages/core/lib/commands/migrate/meta.js
+++ b/packages/core/lib/commands/migrate/meta.js
@@ -16,6 +16,10 @@ module.exports = {
       type: "boolean",
       default: false
     },
+    "--verbose-rpc": {
+      describe: "Log communication between Truffle and the Ethereum client.",
+      default: false
+    },
     "dry-run": {
       describe: "Run migrations against an in-memory fork, for testing",
       type: "boolean",
@@ -57,7 +61,7 @@ module.exports = {
       "                                " + // spacing to align with previous line
       "[--compile-all] [--compile-none] [--verbose-rpc] [--interactive]\n" +
       "                                " + // spacing to align with previous line
-      "[--skip-dry-run] [--describe-json] [--dry-run] [--save <boolean>]",
+      "[--skip-dry-run] [--describe-json] [--dry-run]",
     options: [
       {
         option: "--reset",


### PR DESCRIPTION
Addresses #5495 
Previously, `Migration.js` allows users to run a migration without saving it on chain, but the option wasn't added for yargs. 

Since this is added in yargs now, `truffle migrate help` will also show this option, but do we want to document this on truffle website? 

I do feel these migrations are a bit abrupt at the end.  Should we add a nice message too to indicate again that the migrations weren't saved on chain? Similar to the ones for on chain migrations like this 

```
Summary
=======
 Migrations not saved on chain
```