### PR TITLE
Add step information to txlog

### DIFF
--- a/packages/debugger/lib/txlog/actions/index.js
+++ b/packages/debugger/lib/txlog/actions/index.js
@@ -1,9 +1,10 @@
 export const INTERNAL_CALL = "TXLOG_INTERNAL_CALL";
-export function internalCall(pointer, newPointer) {
+export function internalCall(pointer, newPointer, step) {
   return {
     type: INTERNAL_CALL,
     pointer,
-    newPointer
+    newPointer,
+    step
   };
 }
 
@@ -16,11 +17,12 @@ export function absorbedCall(pointer) {
 }
 
 export const INTERNAL_RETURN = "TXLOG_INTERNAL_RETURN";
-export function internalReturn(pointer, newPointer, variables) {
+export function internalReturn(pointer, newPointer, step, variables) {
   return {
     type: INTERNAL_RETURN,
     pointer,
     newPointer,
+    step,
     variables
   };
 }
@@ -29,6 +31,7 @@ export const EXTERNAL_CALL = "TXLOG_EXTERNAL_CALL";
 export function externalCall(
   pointer,
   newPointer,
+  step,
   address,
   context,
   value,
@@ -42,6 +45,7 @@ export function externalCall(
     type: EXTERNAL_CALL,
     pointer,
     newPointer,
+    step,
     address,
     context,
     value,
@@ -57,6 +61,7 @@ export const INSTANT_EXTERNAL_CALL = "TXLOG_INSTANT_EXTERNAL_CALL";
 export function instantExternalCall(
   pointer,
   newPointer, //does not actually affect the current pointer!
+  step,
   address,
   context,
   value,
@@ -71,6 +76,7 @@ export function instantExternalCall(
     type: INSTANT_EXTERNAL_CALL,
     pointer,
     newPointer,
+    step,
     address,
     context,
     value,
@@ -87,6 +93,7 @@ export const CREATE = "TXLOG_CREATE";
 export function create(
   pointer,
   newPointer,
+  step,
   address,
   context,
   value,
@@ -98,6 +105,7 @@ export function create(
     type: CREATE,
     pointer,
     newPointer,
+    step,
     address,
     context,
     value,
@@ -111,6 +119,7 @@ export const INSTANT_CREATE = "TXLOG_INSTANT_CREATE";
 export function instantCreate(
   pointer,
   newPointer, //does not actually affect the current pointer!
+  step,
   address,
   context,
   value,
@@ -123,6 +132,7 @@ export function instantCreate(
     type: INSTANT_CREATE,
     pointer,
     newPointer,
+    step,
     address,
     context,
     value,
@@ -134,32 +144,41 @@ export function instantCreate(
 }
 
 export const EXTERNAL_RETURN = "TXLOG_EXTERNAL_RETURN";
-export function externalReturn(pointer, newPointer, decodings, returnData) {
+export function externalReturn(
+  pointer,
+  newPointer,
+  step,
+  decodings,
+  returnData
+) {
   return {
     type: EXTERNAL_RETURN,
     pointer,
     newPointer,
+    step,
     decodings,
     returnData
   };
 }
 
 export const SELFDESTRUCT = "TXLOG_SELFDESTRUCT";
-export function selfdestruct(pointer, newPointer, beneficiary) {
+export function selfdestruct(pointer, newPointer, step, beneficiary) {
   return {
     type: SELFDESTRUCT,
     pointer,
     newPointer,
+    step,
     beneficiary
   };
 }
 
 export const REVERT = "TXLOG_REVERT";
-export function revert(pointer, newPointer, error) {
+export function revert(pointer, newPointer, step, error) {
   return {
     type: REVERT,
     pointer,
     newPointer,
+    step,
     error
   };
 }
@@ -181,11 +200,12 @@ export function identifyFunctionCall(
 }
 
 export const LOG_EVENT = "TXLOG_LOG_EVENT";
-export function logEvent(pointer, newPointer, decoding, rawEventInfo) {
+export function logEvent(pointer, newPointer, step, decoding, rawEventInfo) {
   return {
     type: LOG_EVENT,
     pointer,
     newPointer, //does not actually affect current pointer!
+    step,
     decoding,
     rawEventInfo
   };

--- a/packages/debugger/lib/txlog/selectors/index.js
+++ b/packages/debugger/lib/txlog/selectors/index.js
@@ -120,6 +120,19 @@ let txlog = createSelectorTree({
     ),
 
     /**
+     * txlog.current.step
+     */
+    step: createLeaf(
+      [trace.index, trace.steps],
+      (index, steps) =>
+        steps.length === 0
+          ? -1 //special case: we use step -1 to mean before the steps start;
+          : //so if there are no steps, that's what we want to report. trace.index
+            //won't do that, though, so we special-case it in here.
+            index //normal case
+    ),
+
+    /**
      * txlog.current.waitingForFunctionDefinition
      * This selector indicates whether there's a call (internal or external)
      * that is waiting to have its function definition identified when we hit

--- a/packages/debugger/lib/txlog/selectors/index.js
+++ b/packages/debugger/lib/txlog/selectors/index.js
@@ -494,6 +494,7 @@ let txlog = createSelectorTree({
               {
                 decoding: node.decoding,
                 raw: node.raw,
+                step: node.step,
                 address,
                 codeAddress,
                 status


### PR DESCRIPTION
This PR adds step information to the `callinternal`, `callexternal`, and `event` txlog node types.  For events, this consists of a single `step` field, with the index of the step where the event was emitted.  For calls, there's a `beginStep` and an `endStep` field, which are the indices of the steps where the call begins and ends, respectively.  Event step information is also included in `flattedEvents`.  Indices are zero-indexed, so take note of that if you want to test this out with the CLI debugger (which displays them 1-indexed).

Now these latter two require some interpretation, so let me explain.  The `beginStep` is the step of the instruction that initiated the call, so strictly speaking it's the last step *before* the call began.  For the initial call, since there is no such instruction, the `beginStep` is set to `-1` instead, i.e., right before the call.  Meanwhile, the `endStep` is the step of the last instruction within the call, and therefore normally is greater than `beginStep`; however, if the call contains no instructions, then it will instead be equal to `beginStep`.

As for how this works internally -- it's largely a pretty straightforward modification of the existing code.  Events get a `step` field, not much to say about that.  For calls, the `beginStep` is set when they begin (this is `-1` for the initial call), and if it's an instant call, then the `endStep` is also set immediately.  Otherwise it's set upon return; note that for reverts from an internal call, each of the functions that is concluding will have its `endStep` set as the stack is unwound, not just the particular function that is reverting.

So yeah not a lot to say about this one.  I also added some tests, although they're fairly rudimentary, as how am I to predict exact steps most of the time?  I did also do some manual testing though to check out that part.