### PR TITLE
Dependency Update: Upgrade solc dependencies to latest 0.8.17 in compile-solidity and contract-schema packages

### DIFF
--- a/packages/compile-solidity/package.json
+++ b/packages/compile-solidity/package.json
@@ -36,7 +36,7 @@
     "original-require": "^1.0.1",
     "require-from-string": "^2.0.2",
     "semver": "7.3.7",
-    "solc": "0.8.16"
+    "solc": "0.8.17"
   },
   "devDependencies": {
     "@truffle/artifactor": "^4.0.168",

--- a/packages/contract-schema/package.json
+++ b/packages/contract-schema/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "json-schema-to-typescript": "^5.5.0",
     "mocha": "9.2.2",
-    "solc": "0.8.16"
+    "solc": "0.8.17"
   },
   "keywords": [
     "artifacts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -26184,10 +26184,10 @@ solc@0.7.3:
     semver "^5.5.0"
     tmp "0.0.33"
 
-solc@0.8.16:
-  version "0.8.16"
-  resolved "https://registry.yarnpkg.com/solc/-/solc-0.8.16.tgz#120f992357e236d99e6cf3445bf2c2dca3384f96"
-  integrity sha512-6oZg7FAhIouj2zYLvoR3Q4fMP/+BGPR7sY7GcrEXKIp+DRd8RmpDEFO1LUBKpClUiaYguNgmthTFmnPl4MeiMQ==
+solc@0.8.17:
+  version "0.8.17"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.8.17.tgz#c748fec6a64bf029ec406aa9b37e75938d1115ae"
+  integrity sha512-Dtidk2XtTTmkB3IKdyeg6wLYopJnBVxdoykN8oP8VY3PQjN16BScYoUJTXFm2OP7P0hXNAqWiJNmmfuELtLf8g==
   dependencies:
     command-exists "^1.2.8"
     commander "^8.1.0"


### PR DESCRIPTION
This PR upgrades the `solc` version dependencies to latest **v0.8.17** in `compile-solidity` and `contract-schema` packages.