### PR TITLE
Compiler plugins returns compiler object

### DIFF
--- a/packages/plugins/lib/Plugins.ts
+++ b/packages/plugins/lib/Plugins.ts
@@ -102,7 +102,7 @@ export class Plugins {
     const definitions = Plugins.loadPluginDefinitions(plugins);
 
     return Object.entries(definitions).map(
-      ([module, definition]) => new Plugin({ module, definition })
+      ([module, definition]) => require(path.join(module, definition.compile)).Compile
     );
   }
 }


### PR DESCRIPTION
This PR is for compiler plugin to return the plugin compiler object.

Currently, the truffle compiler plugin returns the caller with plugin module and definition and the caller needs to determine the compiler object in order to execute compilation.  From design view point, it might make more sense for truffle compiler plugin to return the compiler object instead.  In this way, the caller can invoke the object to execute compilation without knowing the plugin module and definition.