### PR TITLE
Internal improvement: remove property that seems to be unused

### DIFF
--- a/packages/migrate/ResolverIntercept.js
+++ b/packages/migrate/ResolverIntercept.js
@@ -23,11 +23,6 @@ class ResolverIntercept {
 
     this.cache.push(resolved);
 
-    // During migrations, we could be on a network that takes a long time to accept
-    // transactions (i.e., contract deployment close to block size). Because successful
-    // migration is more important than wait time in those cases, we'll synchronize "forever".
-    resolved.synchronization_timeout = 0;
-
     return resolved;
   }
 


### PR DESCRIPTION
While working on a project, I came across the `synchronization_timeout` property which seems to be unused. Some cursory investigation shows some history of this being used in some old files for contract, but currently there is no usage that I can find of this property in Truffle.

If you find that this is being used somewhere then please let me know.