### PR TITLE
Eliminate circular dependency between compile-solidity and resolver

### DIFF
--- a/packages/compile-solidity/package.json
+++ b/packages/compile-solidity/package.json
@@ -40,7 +40,6 @@
   "devDependencies": {
     "@truffle/artifactor": "^4.0.169",
     "@truffle/box": "^2.1.57",
-    "@truffle/resolver": "^9.0.16",
     "@types/node": "~12.12.0",
     "@types/sinon": "^9.0.10",
     "babel-core": "^6.26.0",


### PR DESCRIPTION
Addresses #5244.  I believe #5445 was supposed to do this, but it looks like Tyler forgot to actually remove the dependency.  So, why not, I did it here.  And that should be that!