### PR TITLE
Update 0x44 to PREVRANDAO|DIFFICULTY

### DIFF
--- a/packages/code-utils/src/opcodes.ts
+++ b/packages/code-utils/src/opcodes.ts
@@ -56,7 +56,7 @@ const codes: OpcodeTable = {
   0x41: "COINBASE",
   0x42: "TIMESTAMP",
   0x43: "NUMBER",
-  0x44: "DIFFICULTY",
+  0x44: "PREVRANDAO|DIFFICULTY",
   0x45: "GASLIMIT",
   0x46: "CHAINID",
   0x47: "SELFBALANCE",


### PR DESCRIPTION
So, the merge is complete, and 0x44 no longer means `DIFFICULTY`, rather it means `PREVRANDAO`.  Except, our disassembler is still likely to be used on pre-merge code, so just updating it to `PREVRANDAO` seems wrong.  Instead I've updated it to `PREVRANDAO|DIFFICULTY` to cover both.  I figure in the future, in cases where we know more about the code being disassembled, we can narrow it down using extra information (e.g., we can always return `PREVRANDAO` for code that's written in EOF, once that exists, and potentially the debugger could narrow things down further); but for now, we can just produce this ambiguous return to get up to date? :shrug: