### PR TITLE
Increase timeout on cyclic dependencies test

### DIFF
--- a/packages/truffle/test/scenarios/cyclic_dependencies/compiles.js
+++ b/packages/truffle/test/scenarios/cyclic_dependencies/compiles.js
@@ -37,7 +37,7 @@ describe("Cyclic Dependencies [ @standalone ]", function () {
   });
 
   it("compiles cyclic dependencies that Solidity is fine with (no `new`'s)", async function () {
-    this.timeout(20000);
+    this.timeout(25000);
 
     await CommandRunner.run("compile", config);
 


### PR DESCRIPTION
This test has been timing out quite a bit recently.  Giving it another 5 seconds.