### PR TITLE
Type opcodes table as const in @truffle/code-utils

### DIFF
--- a/packages/code-utils/src/index.ts
+++ b/packages/code-utils/src/index.ts
@@ -1,6 +1,7 @@
-import parseOpcode from "./opcodes";
-import type { Instruction, OpcodeTable, DisassemblyOptions } from "./types";
-export type { Instruction, OpcodeTable, DisassemblyOptions };
+import { parseOpcode, OpcodeTable } from "./opcodes";
+export type { OpcodeTable };
+import type { Instruction, DisassemblyOptions } from "./types";
+export type { Instruction, DisassemblyOptions };
 import * as cbor from "cbor";
 
 /**

--- a/packages/code-utils/src/opcodes.ts
+++ b/packages/code-utils/src/opcodes.ts
@@ -167,4 +167,4 @@ const codes = {
 export type OpcodeTable = typeof codes;
 
 export const parseOpcode = (op: number) =>
-  codes[op in codes ? (op as keyof OpcodeTable) : 0xfe];
+  op in codes ? codes[op as keyof OpcodeTable] : "INVALID";

--- a/packages/code-utils/src/opcodes.ts
+++ b/packages/code-utils/src/opcodes.ts
@@ -1,6 +1,4 @@
-import type { OpcodeTable } from "./types";
-
-const codes: OpcodeTable = {
+const codes = {
   0x00: "STOP",
   0x01: "ADD",
   0x02: "MUL",
@@ -162,8 +160,11 @@ const codes: OpcodeTable = {
   0xf5: "CREATE2",
   0xfa: "STATICCALL",
   0xfd: "REVERT",
-  //(we can omit 0xfe INVALID)
+  0xfe: "INVALID",
   0xff: "SELFDESTRUCT"
-};
+} as const;
 
-export = (op: number) => (codes[op] ? codes[op] : "INVALID");
+export type OpcodeTable = typeof codes;
+
+export const parseOpcode = (op: number) =>
+  codes[op in codes ? (op as keyof OpcodeTable) : 0xfe];

--- a/packages/code-utils/src/types.ts
+++ b/packages/code-utils/src/types.ts
@@ -4,10 +4,6 @@ export interface Instruction {
   pushData?: string;
 }
 
-export interface OpcodeTable {
-  [hex: number]: string;
-}
-
 export interface DisassemblyOptions {
   maxInstructionCount?: number;
   attemptStripMetadata?: boolean;

--- a/packages/code-utils/test/opcodes.test.ts
+++ b/packages/code-utils/test/opcodes.test.ts
@@ -1,10 +1,10 @@
-import opcodes from "../src/opcodes";
+import { parseOpcode } from "../src/opcodes";
 import assert from "assert";
 import { describe, it } from "mocha";
 
 describe("opcode parsing method", function () {
   it(`returns "INVALID" when passed an invalid opcode`, function () {
-    const returnValue = opcodes(0xbad);
+    const returnValue = parseOpcode(0xbad);
     assert.strictEqual("INVALID", returnValue);
   });
 });


### PR DESCRIPTION
I didn't like how this was needlessly clobbering type information, so this PR modifies @truffle/code-utils to preserve `const`-ness in its definition of the opcodes table.