### PR TITLE
add `dependabot.yml` to monitor ganache releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "ganache"
+    reviewers:
+      - "trufflesuite/truffle-core-devs"


### PR DESCRIPTION
This is tricky to test, and I haven't tested it. I followed the docs at https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates, but YAML is weird and there is a good chance I got something wrong.