### PR TITLE
Dev improvement: update prepare-release script to create a separate branch for releasing

### DIFF
--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -10,11 +10,11 @@ git checkout master
 git pull origin master
 git checkout develop
 git pull origin develop
-git checkout -b release-branch-$(date +%s)
+git checkout -b release-branch-"$(date +%s)"
 
 ## Build
 yarn bootstrap
 
 ## Get output of changes for release notes
-prs-merged-since --repo trufflesuite/truffle --tag v$LAST_PUBLISHED_TAG --format markdown
+prs-merged-since --repo trufflesuite/truffle --tag v"$LAST_PUBLISHED_TAG" --format markdown
 lerna changed

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -10,7 +10,7 @@ git checkout master
 git pull origin master
 git checkout develop
 git pull origin develop
-git checkout -b release-branch-"$(date +%s)"
+git checkout -b release/"$(date +%m-%d-%y.%S)"
 
 ## Build
 yarn bootstrap

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -10,6 +10,7 @@ git checkout master
 git pull origin master
 git checkout develop
 git pull origin develop
+git checkout -b release-branch-$(date +%s)
 
 ## Build
 yarn bootstrap

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -4,8 +4,7 @@
 set -ex
 
 ## Obtain/check npm access
-npm whoami
-if [ "$?" != "0" ];
+if ! npm whoami;
   then
     npm login
 fi
@@ -18,7 +17,7 @@ lerna publish from-package
 ## Update git branches
 RELEASE_BRANCH_NAME=$(git branch --show-current)
 git checkout master
-git merge $RELEASE_BRANCH_NAME
+git merge "$RELEASE_BRANCH_NAME"
 git push origin master
 git checkout develop
 git pull origin master

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -13,11 +13,12 @@ node ./scripts/npm-access.js
 
 ## Publish packages to npm
 lerna version
-lerna publish from-package 
+lerna publish from-package
 
 ## Update git branches
+RELEASE_BRANCH_NAME=$(git branch --show-current)
 git checkout master
-git merge develop
+git merge $RELEASE_BRANCH_NAME
 git push origin master
 git checkout develop
 git pull origin master


### PR DESCRIPTION
This PR update the prepare-release script. After pulling the latest from the `develop` branch, the script will now switch to a new branch to use for the release.