### PR TITLE
Add raw storage writes to txlog

### DIFF
--- a/packages/debugger/lib/txlog/actions/index.js
+++ b/packages/debugger/lib/txlog/actions/index.js
@@ -211,6 +211,19 @@ export function logEvent(pointer, newPointer, step, decoding, rawEventInfo) {
   };
 }
 
+//this may be replaced once decoding info was added
+export const STORE = "TXLOG_STORE";
+export function store(pointer, newPointer, step, rawSlot, rawValue) {
+  return {
+    type: STORE,
+    pointer,
+    newPointer, //does not actually affect current pointer!
+    step,
+    rawSlot,
+    rawValue
+  };
+}
+
 export const RECORD_ORIGIN = "TXLOG_RECORD_ORIGIN";
 export function recordOrigin(pointer, address) {
   return {

--- a/packages/debugger/lib/txlog/actions/index.js
+++ b/packages/debugger/lib/txlog/actions/index.js
@@ -211,7 +211,7 @@ export function logEvent(pointer, newPointer, step, decoding, rawEventInfo) {
   };
 }
 
-//this may be replaced once decoding info was added
+//this may be replaced once decoding info is added
 export const STORE = "TXLOG_STORE";
 export function store(pointer, newPointer, step, rawSlot, rawValue) {
   return {

--- a/packages/debugger/lib/txlog/reducers.js
+++ b/packages/debugger/lib/txlog/reducers.js
@@ -58,6 +58,29 @@ function transactionLog(state = DEFAULT_TX_LOG, action) {
         }
       };
 
+    case actions.STORE:
+      //this case will likely need to be redone when decoding is added
+      //(likely split into multiple cases)
+      //for now, there is no combining of different writes, but when decoding
+      //is added there will need to be!
+      return {
+        byPointer: {
+          ...state.byPointer,
+          [pointer]: {
+            ...node,
+            actions: [...node.actions, newPointer]
+          },
+          [newPointer]: {
+            type: "write",
+            raw: {
+              [action.rawSlot]: action.rawValue
+            },
+            steps: {
+              [action.rawSlot]: step
+            }
+          }
+        }
+      };
     case actions.INTERNAL_CALL:
       return {
         byPointer: {
@@ -387,7 +410,7 @@ function currentNodePointer(state = "", action) {
     case actions.UNLOAD_TRANSACTION:
       return "";
     default:
-      //includes events
+      //includes events & stores
       return state;
   }
 }
@@ -408,7 +431,7 @@ function pointerStack(state = [], action) {
     case actions.UNLOAD_TRANSACTION:
       return [];
     default:
-      //includes events
+      //includes events & stores
       return state;
   }
 }

--- a/packages/debugger/lib/txlog/sagas/index.js
+++ b/packages/debugger/lib/txlog/sagas/index.js
@@ -196,6 +196,13 @@ function* updateTransactionLogSaga() {
     const rawInfo = yield select(txlog.current.rawEventInfo);
     const newPointer = yield select(txlog.current.nextActionPointer);
     yield put(actions.logEvent(pointer, newPointer, step, decoding, rawInfo));
+  } else if (yield select(txlog.current.isStore)) {
+    //note: in the future this is going to get much more complicated so as to
+    //include decoded info and combining things...
+    const newPointer = yield select(txlog.current.nextActionPointer);
+    const rawSlot = yield select(txlog.current.rawStorageSlot);
+    const rawValue = yield select(txlog.current.rawStorageValue);
+    yield put(actions.store(pointer, newPointer, step, rawSlot, rawValue));
   } else if (yield select(txlog.current.onFunctionDefinition)) {
     if (yield select(txlog.current.waitingForFunctionDefinition)) {
       debug("identifying");

--- a/packages/debugger/lib/txlog/selectors/index.js
+++ b/packages/debugger/lib/txlog/selectors/index.js
@@ -270,6 +270,28 @@ let txlog = createSelectorTree({
     isLog: createLeaf([evm.current.step.isLog], identity),
 
     /**
+     * txlog.current.isStore
+     */
+    isStore: createLeaf([evm.current.step.isStore], identity),
+
+    /**
+     * txlog.current.rawStorageSlot
+     * note we prepend 0x
+     */
+    rawStorageSlot: createLeaf(
+      [evm.current.step.isStore, evm.current.step.storageAffected],
+      (isStore, slot) => (isStore ? "0x" + slot : null)
+    ),
+
+    /**
+     * txlog.current.rawStorageValue
+     * note we prepend 0x
+     */
+    rawStorageValue: createLeaf([evm.current.step.valueStored], value =>
+      value !== null ? "0x" + value : null
+    ),
+
+    /**
      * txlog.current.rawEventInfo
      */
     rawEventInfo: {


### PR DESCRIPTION
This PR adds a new type of action to txlog, `write`.  Like events, it does not have subactions.  It represents a write to a storage variable -- or at least, the intent is that it eventually will; right now it just represents a write to a storage slot.  Decoding storage writes is hard, so this PR just contains the raw storage info, with nothing decoded.

Each `write` action presently has two fields, `raw` and `steps`.  The `raw` field contains an object mapping storage slots to the values written to them; presently, each `write` action represents only a single storage write, so each `raw` field will only have a single entry.  However, the intent is that in the future, multiple raw storage writes may be consolidated into a single `write` action when they represent a single logical write to a storage variable (e.g. if you store a new value in a string and it takes up multiple storage slots).

The `steps` field similarly contains an object keyed with storage slots, but this time the value is the step when that slot was written to.

And that's it; the hard part is all going to be in decoding but this PR doesn't have that.

There's also a test.