### PR TITLE
Add new Sourcify networks for late September

### DIFF
--- a/packages/source-fetcher/lib/networks.ts
+++ b/packages/source-fetcher/lib/networks.ts
@@ -12,9 +12,11 @@ export const networkNamesById: { [id: number]: string } = {
   420: "goerli-optimistic",
   42161: "arbitrum",
   421611: "rinkeby-arbitrum",
+  421613: "goerli-arbitrum",
   137: "polygon",
   80001: "mumbai-polygon",
   100: "gnosis", //formerly known as xdai
+  300: "optimism-gnosis", //optimism on gnosis, not vice versa
   99: "poa", //not presently supported by either fetcher, but...
   77: "sokol-poa",
   56: "binance",
@@ -72,7 +74,8 @@ export const networkNamesById: { [id: number]: string } = {
   71402: "godwoken",
   71401: "testnet-godwoken",
   50: "xinfin", //not presently supported by either fetcher, but...
-  51: "apothem-xinfin"
+  51: "apothem-xinfin",
+  7700: "canto"
   //I'm not including crystaleum as it has network ID different from chain ID
   //not including kekchain for the same reason
 };

--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -47,13 +47,15 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "kovan",
     "sepolia",
     "optimistic",
-    "kovan-optimistic",
+    "kovan-optimistic", //can no longer verify but can still fetch existing
     "goerli-optimistic",
     "arbitrum",
     "rinkeby-arbitrum",
+    "goerli-arbitrum",
     "polygon",
     "mumbai-polygon",
     "gnosis",
+    "optimism-gnosis",
     //sourcify does *not* support poa core...?
     "sokol-poa",
     "binance",
@@ -101,7 +103,8 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "godwoken",
     "testnet-godwoken",
     //sourcify does *not* support xinfin mainnet...?
-    "apothem-xinfin"
+    "apothem-xinfin",
+    "canto"
     //I'm excluding crystaleum as it has network ID different from chain ID
   ]);
 


### PR DESCRIPTION
Sourcify added a few more networks.  They also removed one, but Sourcify's removed networks remain available (unlike Etherscan's), so I don't remove them from the fetcher in case someone wants to make use of them.