### PR TITLE
Bug fix: Add `disableChecks` parameter to decoder type

### DIFF
--- a/packages/decoder/lib/types.ts
+++ b/packages/decoder/lib/types.ts
@@ -171,6 +171,10 @@ export interface EventOptions {
    * the event -- should be returned.  Defaults to `"off"`.
    */
   extras?: ExtrasAllowed;
+  /**
+   * Allows decodings that don't pass the re-encoding test.  Don't turn
+   * this on unless you know what you're doing!
+   */
   disableChecks?: boolean;
 }
 

--- a/packages/decoder/lib/types.ts
+++ b/packages/decoder/lib/types.ts
@@ -171,6 +171,7 @@ export interface EventOptions {
    * the event -- should be returned.  Defaults to `"off"`.
    */
   extras?: ExtrasAllowed;
+  disableChecks?: boolean;
 }
 
 /**


### PR DESCRIPTION
[Here](https://github.com/trufflesuite/truffle/blob/develop/packages/core/lib/testing/TestRunner.js#L149-L156) there is a call to a function which includes a parameter not included in the type [here](https://github.com/trufflesuite/truffle/blob/develop/packages/decoder/lib/types.ts#L146-L174). This PR adds the missing type.