### PR TITLE
Bug fix: don't clobber repl context variables when setting up repl context

### DIFF
--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -47,7 +47,7 @@ class Console extends EventEmitter {
     this.options = options;
 
     this.repl = null;
-    // we need to keep tract of name conflicts that occur between contracts and
+    // we need to keep track of name conflicts that occur between contracts and
     // repl context objects so as not to overwrite them - this is to prevent
     // overwriting Node native objects like Buffer, number, etc.
     this.replContextNameConflicts = [];
@@ -62,7 +62,7 @@ class Console extends EventEmitter {
     });
   }
 
-  detectNameConflicts(abstractions) {
+  recordNameConflicts(abstractions) {
     for (const abstraction of abstractions) {
       if (
         Object.getOwnPropertyNames(this.repl.context.global).includes(
@@ -243,7 +243,7 @@ class Console extends EventEmitter {
     });
 
     if (initialProvision) {
-      this.detectNameConflicts(abstractions);
+      this.recordNameConflicts(abstractions);
     }
 
     this.resetContractsInConsoleContext(abstractions);
@@ -256,7 +256,7 @@ class Console extends EventEmitter {
     const contextVars = {};
 
     abstractions.forEach(abstraction => {
-      // don't overwrite Node's native objects - we detect name conflicts
+      // don't overwrite Node's native objects - we record name conflicts
       // on the first call to `provision`
       if (!this.replContextNameConflicts.includes(abstraction.contract_name)) {
         contextVars[abstraction.contract_name] = abstraction;

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -64,7 +64,11 @@ class Console extends EventEmitter {
 
   detectNameConflicts(abstractions) {
     for (const abstraction of abstractions) {
-      if (this.repl.context[abstraction.contract_name] !== undefined) {
+      if (
+        Object.getOwnPropertyNames(this.repl.context.global).includes(
+          abstraction.contract_name
+        )
+      ) {
         this.replContextNameConflicts.push(abstraction.contract_name);
       }
     }
@@ -260,7 +264,7 @@ class Console extends EventEmitter {
       const contractNames =
         this.replContextNameConflicts === 1
           ? this.replContextNameConflicts[0]
-          : this.replContextNameConflicts.join(" ,");
+          : this.replContextNameConflicts.join(", ");
       console.log(
         `\n > Warning: One or more of your contract(s) has a name conflict ` +
           `with something in the current repl context and was not loaded by ` +

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -256,6 +256,21 @@ class Console extends EventEmitter {
       }
     });
 
+    if (this.replContextNameConflicts.length > 0) {
+      const contractNames =
+        this.replContextNameConflicts === 1
+          ? this.replContextNameConflicts[0]
+          : this.replContextNameConflicts.join(" ,");
+      console.log(
+        `\n > Warning: One or more of your contract(s) has a name conflict ` +
+          `with something in the current repl context and was not loaded by ` +
+          `default. \n > You can use 'artifacts.require("<artifactName>")' ` +
+          `to obtain a reference to your contract(s). \n > Truffle recommends ` +
+          `that you rename your contract to avoid problems. \n > The following ` +
+          `name conflicts exist: ${contractNames}.`
+      );
+    }
+
     // make sure the repl gets the new contracts in its context
     Object.keys(contextVars || {}).forEach(key => {
       this.repl.context[key] = contextVars[key];

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -242,10 +242,8 @@ class Console extends EventEmitter {
     Object.keys(contextVars || {}).forEach(key => {
       if (overwriteReplContextVars) {
         this.repl.context[key] = contextVars[key];
-      } else {
-        if (this.repl.context[key] === undefined) {
-          this.repl.context[key] = contextVars[key];
-        }
+      } else if (this.repl.context[key] === undefined) {
+        this.repl.context[key] = contextVars[key];
       }
     });
   }

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -177,7 +177,8 @@ class Console extends EventEmitter {
     const truffleGlobals = {
       web3: this.web3,
       interfaceAdapter: this.interfaceAdapter,
-      accounts
+      accounts,
+      artifacts: this.options.resolver
     };
 
     // we insert user variables first so as to not clobber Truffle's

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -91,10 +91,13 @@ class Console extends EventEmitter {
 
       // repl is ready - set and display prompt
       this.repl.setPrompt("truffle(" + this.options.network + ")> ");
-      this.repl.displayPrompt();
 
       // hydrate the environment with the user's contracts
       this.provision(true);
+
+      // provision first before displaying prompt so that if
+      // there is a warning the user will end up at the prompt
+      this.repl.displayPrompt();
 
       this.repl.on("exit", () => {
         process.exit();

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -207,7 +207,7 @@ class Console extends EventEmitter {
     };
   }
 
-  provision(initialProvision = false) {
+  provision(recordNameConflicts = false) {
     let files;
     try {
       const unfilteredFiles = fse.readdirSync(
@@ -242,7 +242,7 @@ class Console extends EventEmitter {
       return abstraction;
     });
 
-    if (initialProvision) {
+    if (recordNameConflicts) {
       this.recordNameConflicts(abstractions);
     }
 

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -271,10 +271,7 @@ class Console extends EventEmitter {
     });
 
     if (this.newReplNameConflicts.size > 0) {
-      let contractNames = [];
-      for (const name of this.newReplNameConflicts.keys()) {
-        contractNames.push(name);
-      }
+      const contractNames = [...this.newReplNameConflicts.keys()];
       this.newReplNameConflicts.clear();
       console.log(
         `\n > Warning: One or more of your contract(s) has a name conflict ` +
@@ -282,7 +279,7 @@ class Console extends EventEmitter {
           `default. \n > You can use 'artifacts.require("<artifactName>")' ` +
           `to obtain a reference to your contract(s). \n > Truffle recommends ` +
           `that you rename your contract to avoid problems. \n > The following ` +
-          `name conflicts exist: ${contractNames.join(", ")}.`
+          `name conflicts exist: ${contractNames.join(", ")}.\n`
       );
     }
 

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -67,9 +67,10 @@ class Console extends EventEmitter {
   recordNameConflicts(abstractions) {
     for (const abstraction of abstractions) {
       const name = abstraction.contract_name;
-      if (this.knownReplNameConflicts.has(name)) {
-        continue;
-      } else if (this.replGlobals.has(name)) {
+      if (
+        !this.knownReplNameConflicts.has(name) &&
+        this.replGlobals.has(name)
+      ) {
         this.newReplNameConflicts.add(name);
         this.knownReplNameConflicts.add(name);
       }
@@ -271,9 +272,8 @@ class Console extends EventEmitter {
 
     if (this.newReplNameConflicts.size > 0) {
       let contractNames = [];
-      for (const name of this.newReplNameConflicts.entries()) {
-        // when iterating like this, each item is of the form [value, value]
-        contractNames.push(name[0]);
+      for (const name of this.newReplNameConflicts.keys()) {
+        contractNames.push(name);
       }
       this.newReplNameConflicts.clear();
       console.log(

--- a/packages/truffle/test/sources/consoleWithConflicts/build/contracts/Buffer.json
+++ b/packages/truffle/test/sources/consoleWithConflicts/build/contracts/Buffer.json
@@ -1,0 +1,116 @@
+{
+  "contractName": "Buffer",
+  "abi": [],
+  "metadata": "{\"compiler\":{\"version\":\"0.5.16+commit.9c3226ce\"},\"language\":\"Solidity\",\"output\":{\"abi\":[],\"devdoc\":{\"methods\":{}},\"userdoc\":{\"methods\":{}}},\"settings\":{\"compilationTarget\":{\"project:/contracts/Buffer.sol\":\"Buffer\"},\"evmVersion\":\"istanbul\",\"libraries\":{},\"optimizer\":{\"enabled\":false,\"runs\":200},\"remappings\":[]},\"sources\":{\"project:/contracts/Buffer.sol\":{\"keccak256\":\"0x8d7320bab7da7b3242c1974d1aedd140d88cdbd9e6c1402381aa888659d7f1f8\",\"urls\":[\"bzz-raw://7cd4609ec3ae5b1968f20f00d68a60595b6f34b8022bf42dd241a1a98c760f3f\",\"dweb:/ipfs/QmRbyGrEHX4RvG1VUbfPogxh5RkAcKjsvotk8d5h9H7gDQ\"]}},\"version\":1}",
+  "bytecode": "0x6080604052348015600f57600080fd5b50603e80601d6000396000f3fe6080604052600080fdfea265627a7a72315820b747e2d0eadbf379334d5117f6d60b7ebffe62830beba83dfe7784cf26bfb10964736f6c63430005100032",
+  "deployedBytecode": "0x6080604052600080fdfea265627a7a72315820b747e2d0eadbf379334d5117f6d60b7ebffe62830beba83dfe7784cf26bfb10964736f6c63430005100032",
+  "sourceMap": "25:18:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;25:18:0;;;;;;;",
+  "deployedSourceMap": "25:18:0:-;;;;;",
+  "source": "pragma solidity >0.5.0;\n\ncontract Buffer {}\n",
+  "sourcePath": "/Users/radish/projects/truffle/packages/truffle/test/sources/consoleWithConflicts/contracts/Buffer.sol",
+  "ast": {
+    "absolutePath": "project:/contracts/Buffer.sol",
+    "exportedSymbols": {
+      "Buffer": [
+        2
+      ]
+    },
+    "id": 3,
+    "nodeType": "SourceUnit",
+    "nodes": [
+      {
+        "id": 1,
+        "literals": [
+          "solidity",
+          ">",
+          "0.5",
+          ".0"
+        ],
+        "nodeType": "PragmaDirective",
+        "src": "0:23:0"
+      },
+      {
+        "baseContracts": [],
+        "contractDependencies": [],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "id": 2,
+        "linearizedBaseContracts": [
+          2
+        ],
+        "name": "Buffer",
+        "nodeType": "ContractDefinition",
+        "nodes": [],
+        "scope": 3,
+        "src": "25:18:0"
+      }
+    ],
+    "src": "0:44:0"
+  },
+  "legacyAST": {
+    "attributes": {
+      "absolutePath": "project:/contracts/Buffer.sol",
+      "exportedSymbols": {
+        "Buffer": [
+          2
+        ]
+      }
+    },
+    "children": [
+      {
+        "attributes": {
+          "literals": [
+            "solidity",
+            ">",
+            "0.5",
+            ".0"
+          ]
+        },
+        "id": 1,
+        "name": "PragmaDirective",
+        "src": "0:23:0"
+      },
+      {
+        "attributes": {
+          "baseContracts": [
+            null
+          ],
+          "contractDependencies": [
+            null
+          ],
+          "contractKind": "contract",
+          "documentation": null,
+          "fullyImplemented": true,
+          "linearizedBaseContracts": [
+            2
+          ],
+          "name": "Buffer",
+          "nodes": [
+            null
+          ],
+          "scope": 3
+        },
+        "id": 2,
+        "name": "ContractDefinition",
+        "src": "25:18:0"
+      }
+    ],
+    "id": 3,
+    "name": "SourceUnit",
+    "src": "0:44:0"
+  },
+  "compiler": {
+    "name": "solc",
+    "version": "0.5.16+commit.9c3226ce.Emscripten.clang"
+  },
+  "networks": {},
+  "schemaVersion": "3.4.10",
+  "updatedAt": "2022-10-07T17:15:45.263Z",
+  "devdoc": {
+    "methods": {}
+  },
+  "userdoc": {
+    "methods": {}
+  }
+}

--- a/packages/truffle/test/sources/consoleWithConflicts/contracts/Buffer.sol
+++ b/packages/truffle/test/sources/consoleWithConflicts/contracts/Buffer.sol
@@ -1,0 +1,3 @@
+pragma solidity >0.5.0;
+
+contract Buffer {}

--- a/packages/truffle/test/sources/consoleWithConflicts/truffle-config.js
+++ b/packages/truffle/test/sources/consoleWithConflicts/truffle-config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  networks: {
+    development: {
+      host: "127.0.0.1",
+      port: 8545,
+      network_id: "*"
+    }
+  }
+};


### PR DESCRIPTION
As mentioned in https://github.com/trufflesuite/truffle/issues/3329, if a user has a contract name that conflicts with one of Node's native objects (such as `Buffer`) then it will overwrite that object. This could cause things to break. In order to fix this, this PR provides an implementation where Truffle will not overwrite objects found in the context the first time it loads the repl and sets up the environment. The `provision` method is where these things are set up, and on subsequent calls to `provision` it will overwrite things it finds in the repl context as it will need to update contracts that have changed etc.