### PR TITLE
Update PR template to include note about features requiring documentation changes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+## PR description
+
+<!-- Enter PR description here -->
+
+## Documentation
+
+- [ ] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.


### PR DESCRIPTION
Add a PR template with a checklist item reminding contributors to check the `doc-change-required` label if their PR requires changes to the [Truffle documentation](https://trufflesuite.com/docs/truffle/). This is in line with the [documentation process for dev teams](https://docs.google.com/document/d/1u7YJon3-ZmZ3zgp070rufdKTwxm81KWeILqJl2cq0Fw/edit?usp=sharing) and helps our doc team identify and raise doc issues.