### PR TITLE
Bug fix: move web3 and web3 types into regular dependencies for hdwallet-provider

### DIFF
--- a/packages/hdwallet-provider/package.json
+++ b/packages/hdwallet-provider/package.json
@@ -24,11 +24,13 @@
     "@ethereumjs/common": "^2.4.0",
     "@ethereumjs/tx": "^3.3.0",
     "@metamask/eth-sig-util": "4.0.1",
+    "@types/web3": "^1.0.20",
     "ethereum-cryptography": "1.1.2",
     "ethereum-protocol": "^1.0.1",
     "ethereumjs-util": "^7.1.5",
     "ethereumjs-wallet": "^1.0.2",
-    "web3-provider-engine": "16.0.3"
+    "web3-provider-engine": "16.0.3",
+    "web3": "1.7.4"
   },
   "devDependencies": {
     "@types/bip39": "^2.4.2",
@@ -39,8 +41,7 @@
     "ganache": "7.4.3",
     "mocha": "9.2.2",
     "ts-node": "10.7.0",
-    "typescript": "^4.7.4",
-    "web3": "1.7.4"
+    "typescript": "^4.7.4"
   },
   "keywords": [
     "etheruem",


### PR DESCRIPTION
Since Truffle exposes web3 types through the constructor arguments (https://github.com/trufflesuite/truffle/blob/develop/packages/hdwallet-provider/src/constructor/types.ts), web3 and its types should be part of the regular dependencies.