### PR TITLE
Fix: set and enforce allowed truffle commands in REPL

### DIFF
--- a/packages/core/lib/commands/console/run.js
+++ b/packages/core/lib/commands/console/run.js
@@ -20,13 +20,14 @@ module.exports = async function (options) {
 
   let config = loadConfig(options);
 
-  const consoleCommands = commands.reduce((acc, name) => {
-    return !excludedCommands.has(name)
-      ? Object.assign(acc, { [name]: commands[name] })
-      : acc;
-  }, {});
+  const allowedConsoleCommands = commands.filter(
+    cmd => !excludedCommands.has(cmd)
+  );
 
   await Environment.detect(config);
-  const c = new Console(consoleCommands, config.with({ noAliases: true }));
+  const c = new Console(
+    allowedConsoleCommands,
+    config.with({ noAliases: true })
+  );
   return await c.start();
 };

--- a/packages/core/lib/commands/develop/run.js
+++ b/packages/core/lib/commands/develop/run.js
@@ -10,15 +10,15 @@ const runConsole = async (config, ganacheOptions) => {
   const { Environment } = require("@truffle/environment");
 
   const commands = require("../commands");
-
-  const consoleCommands = commands.reduce((acc, name) => {
-    return !excludedCommands.has(name)
-      ? Object.assign(acc, { [name]: commands[name] })
-      : acc;
-  }, {});
+  const allowedConsoleCommands = commands.filter(
+    cmd => !excludedCommands.has(cmd)
+  );
 
   await Environment.develop(config, ganacheOptions);
-  const c = new Console(consoleCommands, config.with({ noAliases: true }));
+  const c = new Console(
+    allowedConsoleCommands,
+    config.with({ noAliases: true })
+  );
   c.on("exit", () => process.exit());
   return await c.start();
 };

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -15,19 +15,24 @@ const spawnSync = require("child_process").spawnSync;
 const Require = require("@truffle/require");
 const debug = require("debug")("console");
 const { getCommand } = require("./command-utils");
+const validTruffleCommands = require("./commands/commands");
+
+// Create an expression that returns a string when evaluated
+// by the REPL
+const makeIIFE = str => `(() => "${str}")()`;
 
 const processInput = (input, allowedCommands) => {
   const words = input.trim().split(/\s+/);
   if (words.length === 0) return input;
 
   if (words[0] === "truffle") {
-    if (allowedCommands.includes(words[1])) {
-      return words.slice(1).join(" ");
+    const cmd = words[1];
+    if (validTruffleCommands.includes(cmd)) {
+      return allowedCommands.includes(cmd)
+        ? words.slice(1).join(" ")
+        : makeIIFE("ℹ️ : 'truffle ${cmd}' is not allowed within Truffle REPL");
     }
-    // Log friendly information
-    // return console.info expression which, when processed, will not modify
-    // the `_` variable.
-    return `console.info("ℹ️ : 'truffle ${words[1]}' is not allowed within Truffle REPL")`;
+    return makeIIFE("ℹ️ : 'truffle ${cmd}' is not a valid Truffle command");
   }
 
   return input.trim();

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -17,7 +17,7 @@ const debug = require("debug")("console");
 const { getCommand } = require("./command-utils");
 
 const processInput = (input, allowedCommands) => {
-  const positionals = input.trim().split(" ");
+  const positionals = input.trim().split(/\s+/);
   if (positionals.length === 0) return input;
 
   if (positionals[0] === "truffle") {

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -23,18 +23,30 @@ const makeIIFE = str => `(() => "${str}")()`;
 
 const processInput = (input, allowedCommands) => {
   const words = input.trim().split(/\s+/);
+
+  // empty input
   if (words.length === 0) return input;
 
-  if (words[0] === "truffle") {
+  // maybe truffle command
+  if (words[0].toLowerCase() === "truffle") {
     const cmd = words[1];
-    if (validTruffleCommands.includes(cmd)) {
-      return allowedCommands.includes(cmd)
-        ? words.slice(1).join(" ")
-        : makeIIFE(`ℹ️ : 'truffle ${cmd}' is not allowed within Truffle REPL`);
+
+    if (cmd === undefined) {
+      return makeIIFE(
+        `ℹ️ : 'Missing truffle command. Please include a valid truffle command.`
+      );
     }
-    return makeIIFE(`ℹ️ : 'truffle ${cmd}' is not a valid Truffle command`);
+
+    const normalizedCommand = cmd.toLowerCase();
+    if (validTruffleCommands.includes(normalizedCommand)) {
+      return allowedCommands.includes(normalizedCommand)
+        ? words.slice(1).join(" ")
+        : makeIIFE(`ℹ️ : '${cmd}' is not allowed within Truffle REPL`);
+    }
+    return makeIIFE(`ℹ️ : '${cmd}' is not a valid Truffle command`);
   }
 
+  // an expression
   return input.trim();
 };
 

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -30,9 +30,9 @@ const processInput = (input, allowedCommands) => {
     if (validTruffleCommands.includes(cmd)) {
       return allowedCommands.includes(cmd)
         ? words.slice(1).join(" ")
-        : makeIIFE("ℹ️ : 'truffle ${cmd}' is not allowed within Truffle REPL");
+        : makeIIFE(`ℹ️ : 'truffle ${cmd}' is not allowed within Truffle REPL`);
     }
-    return makeIIFE("ℹ️ : 'truffle ${cmd}' is not a valid Truffle command");
+    return makeIIFE(`ℹ️ : 'truffle ${cmd}' is not a valid Truffle command`);
   }
 
   return input.trim();

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -27,7 +27,7 @@ const processInput = input => {
 };
 
 class Console extends EventEmitter {
-  constructor(tasks, options) {
+  constructor(allowedCommands, options) {
     super();
     EventEmitter.call(this);
 
@@ -44,6 +44,7 @@ class Console extends EventEmitter {
       "build_directory"
     ]);
 
+    this.allowedCommands = allowedCommands;
     this.options = options;
 
     this.repl = null;
@@ -285,6 +286,7 @@ class Console extends EventEmitter {
     // processInput returns a sanitized string
     const processedInput = processInput(input);
     if (
+      processedInput in this.allowedCommands &&
       getCommand({
         inputStrings: processedInput.split(" "),
         options: {},

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -16,13 +16,16 @@ const Require = require("@truffle/require");
 const debug = require("debug")("console");
 const { getCommand } = require("./command-utils");
 
-const processInput = input => {
-  const inputComponents = input.trim().split(" ");
-  if (inputComponents.length === 0) return input;
+const processInput = (input, allowedCommands) => {
+  const positionals = input.trim().split(" ");
+  if (positionals.length === 0) return input;
 
-  if (inputComponents[0] === "truffle") {
-    return inputComponents.slice(1).join(" ");
+  if (positionals[0] === "truffle") {
+    return allowedCommands.includes(positionals[1])
+      ? positionals.slice(1).join(" ") // remove truffle prefix
+      : ""; // treat disallowed command as empty string
   }
+
   return input.trim();
 };
 
@@ -283,8 +286,7 @@ class Console extends EventEmitter {
   }
 
   interpret(input, context, filename, callback) {
-    // processInput returns a sanitized string
-    const processedInput = processInput(input);
+    const processedInput = processInput(input, this.allowedCommands);
     if (
       this.allowedCommands.includes(processedInput.split(" ")[0]) &&
       getCommand({

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -17,13 +17,17 @@ const debug = require("debug")("console");
 const { getCommand } = require("./command-utils");
 
 const processInput = (input, allowedCommands) => {
-  const positionals = input.trim().split(/\s+/);
-  if (positionals.length === 0) return input;
+  const words = input.trim().split(/\s+/);
+  if (words.length === 0) return input;
 
-  if (positionals[0] === "truffle") {
-    return allowedCommands.includes(positionals[1])
-      ? positionals.slice(1).join(" ") // remove truffle prefix
-      : ""; // treat disallowed command as empty string
+  if (words[0] === "truffle") {
+    if (allowedCommands.includes(words[1])) {
+      return words.slice(1).join(" ");
+    }
+    // Log friendly information
+    // return console.info expression which, when processed, will not modify
+    // the `_` variable.
+    return `console.info("ℹ️ : 'truffle ${words[1]}' is not allowed within Truffle REPL")`;
   }
 
   return input.trim();

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -286,7 +286,7 @@ class Console extends EventEmitter {
     // processInput returns a sanitized string
     const processedInput = processInput(input);
     if (
-      processedInput in this.allowedCommands &&
+      this.allowedCommands.includes(processedInput.split(" ")[0]) &&
       getCommand({
         inputStrings: processedInput.split(" "),
         options: {},

--- a/packages/core/test/lib/console.js
+++ b/packages/core/test/lib/console.js
@@ -8,7 +8,6 @@ const Web3 = require("web3");
 const { Resolver } = require("@truffle/resolver");
 const config = new Config();
 
-console.log(commands);
 const allowedConsoleCommands = Object.keys(commands).filter(
   cmd => !excludedCommands.has(cmd)
 );

--- a/packages/core/test/lib/console.js
+++ b/packages/core/test/lib/console.js
@@ -8,11 +8,10 @@ const Web3 = require("web3");
 const { Resolver } = require("@truffle/resolver");
 const config = new Config();
 
-const consoleCommands = Object.keys(commands).reduce((acc, name) => {
-  return !excludedCommands.has(name)
-    ? Object.assign(acc, { [name]: commands[name] })
-    : acc;
-}, {});
+console.log(commands);
+const allowedConsoleCommands = Object.keys(commands).filter(
+  cmd => !excludedCommands.has(cmd)
+);
 let truffleConsole, consoleOptions;
 
 describe("Console", function () {
@@ -42,7 +41,7 @@ describe("Console", function () {
         { path: pathToMoreUserJs },
         { path: pathToUserJs, as: "namespace" }
       ];
-      truffleConsole = new Console(consoleCommands, consoleOptions);
+      truffleConsole = new Console(allowedConsoleCommands, consoleOptions);
       sinon
         .stub(truffleConsole.interfaceAdapter, "getAccounts")
         .returns(["0x0"]);
@@ -88,7 +87,10 @@ describe("Console", function () {
           "test/sources/moreUserVariables.js"
         );
         otherConsoleOptions["require-none"] = true;
-        otherTruffleConsole = new Console(consoleCommands, otherConsoleOptions);
+        otherTruffleConsole = new Console(
+          allowedConsoleCommands,
+          otherConsoleOptions
+        );
       });
 
       it("won't load any user-defined JS", async function () {
@@ -117,7 +119,10 @@ describe("Console", function () {
           config.working_directory,
           "test/sources/nameConflicts.js"
         );
-        otherTruffleConsole = new Console(consoleCommands, otherConsoleOptions);
+        otherTruffleConsole = new Console(
+          allowedConsoleCommands,
+          otherConsoleOptions
+        );
       });
 
       it("won't let users clobber Truffle variables", async function () {
@@ -143,7 +148,10 @@ describe("Console", function () {
           provider: new Web3.providers.WebsocketProvider("ws://localhost:666"),
           resolver: new Resolver(config)
         });
-        otherTruffleConsole = new Console(consoleCommands, otherConsoleOptions);
+        otherTruffleConsole = new Console(
+          allowedConsoleCommands,
+          otherConsoleOptions
+        );
       });
 
       it("accepts options.r", async function () {

--- a/packages/truffle/test/scenarios/commands/develop.js
+++ b/packages/truffle/test/scenarios/commands/develop.js
@@ -68,6 +68,42 @@ describe("truffle develop", function () {
     });
   });
 
+  describe("Improper truffle commands", async function () {
+    this.timeout(7000);
+
+    [
+      {
+        cmd: "console",
+        expectedError: `ℹ️ : 'truffle console' is not allowed within Truffle REPL`
+      },
+      {
+        cmd: "develop",
+        expectedError: `ℹ️ : 'truffle develop' is not allowed within Truffle REPL`
+      },
+      {
+        cmd: "alakazam",
+        expectedError: `ℹ️ : 'truffle alakazam' is not a valid Truffle command`
+      }
+    ].forEach(({ cmd, expectedError }) => {
+      it(`alerts on 'truffle ${cmd}'`, async function () {
+        await CommandRunner.runInREPL({
+          inputCommands: [`truffle ${cmd}`],
+          config,
+          executableCommand: "develop",
+          displayHost: "develop"
+        });
+
+        const output = logger.contents();
+        assert(
+          output.includes(expectedError),
+          `Expected string in output: "${expectedError}"\n${formatLines(
+            output
+          )}`
+        );
+      });
+    });
+  });
+
   it("handles awaits", async function () {
     this.timeout(70000);
     const input = "await Promise.resolve(`${6*7} is probably not a prime`)";

--- a/packages/truffle/test/scenarios/commands/develop.js
+++ b/packages/truffle/test/scenarios/commands/develop.js
@@ -74,15 +74,23 @@ describe("truffle develop", function () {
     [
       {
         cmd: "console",
-        expectedError: `ℹ️ : 'truffle console' is not allowed within Truffle REPL`
+        expectedError: `ℹ️ : 'console' is not allowed within Truffle REPL`
+      },
+      {
+        cmd: "CONSOLE",
+        expectedError: `ℹ️ : 'CONSOLE' is not allowed within Truffle REPL`
       },
       {
         cmd: "develop",
-        expectedError: `ℹ️ : 'truffle develop' is not allowed within Truffle REPL`
+        expectedError: `ℹ️ : 'develop' is not allowed within Truffle REPL`
       },
       {
         cmd: "alakazam",
-        expectedError: `ℹ️ : 'truffle alakazam' is not a valid Truffle command`
+        expectedError: `ℹ️ : 'alakazam' is not a valid Truffle command`
+      },
+      {
+        cmd: "",
+        expectedError: `ℹ️ : 'Missing truffle command. Please include a valid truffle command.`
       }
     ].forEach(({ cmd, expectedError }) => {
       it(`alerts on 'truffle ${cmd}'`, async function () {

--- a/packages/truffle/test/sources/develop/contracts/Buffer.sol
+++ b/packages/truffle/test/sources/develop/contracts/Buffer.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.0;
+
+contract Buffer { }


### PR DESCRIPTION
This PR sets and enforces allowed truffle commands that should run in the `console` and `develop` REPLS. It should address #5578. Happy to include a test if anyone feels it is necessary.

## How to test

1. create new truffle project
1. `truffle develop`
    1. verify `develop` returns an error.
    1. verify `console` returns the JavaScript console object.
    1. verify  `truffle <unknown command> presents the appropriate message.
    1. verify `truffle [ console | develop ]` presents the appropriate message.
