### PR TITLE
Correctly check for non-integer credentials

### DIFF
--- a/packages/hdwallet-provider/src/constructor/getOptions.ts
+++ b/packages/hdwallet-provider/src/constructor/getOptions.ts
@@ -24,7 +24,7 @@ const isPrivateKeyLike = (
   // this is added since parseInt(mnemonic) should equal NaN (unless it starts
   // with a-f) and private keys should parse into a valid number - this will
   // also parse with the largest hex value, namely "f" * 64
-  parseInt(credentials, 16) !== NaN &&
+  isFinite(parseInt(credentials, 16)) &&
   !credentials.includes(" ");
 
 // turn polymorphic first argument into { mnemonic } or { privateKeys }


### PR DESCRIPTION
Values in JavaScript are never equal to `NaN`, so this check wasn't doing anything. Found with TypeScript 4.9.