### PR TITLE
[internal improvement] from-hardhat: use jest to skip tests

### DIFF
--- a/packages/from-hardhat/package.json
+++ b/packages/from-hardhat/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "ttsc",
     "prepare": "yarn build",
-    "test": "exit 0"
+    "test": "jest --passWithNoTests"
   },
   "dependencies": {
     "@truffle/compile-common": "^0.8.1",
@@ -31,6 +31,7 @@
     "@types/find-up": "^2.1.0",
     "@types/node": "^18.6.5",
     "hardhat": "^2.10.1",
+    "jest": "28.1.3",
     "ttypescript": "1.5.13",
     "typescript": "^4.3.5",
     "typescript-transform-paths": "3.3.1"


### PR DESCRIPTION
This PR fixes an issue on OS X which caused `@truffle/from-hardhat` to error during `yarn test`

## Error
```console
$ $(yarn bin)/lerna run test --stream --concurrency=1 --scope @truffle/from-hardhat -- --colors
lerna notice cli v4.0.0
lerna info versioning independent
lerna notice filter including "@truffle/from-hardhat"
lerna info filter [ '@truffle/from-hardhat' ]
lerna info Executing command in 1 package: "yarn run test --colors"
yarn run v1.22.19
$ exit 0 --colors
@truffle/from-hardhat: /bin/sh: line 0: exit: too many arguments
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
lerna ERR! yarn run test --colors exited 1 in '@truffle/from-hardhat'
```

## With fix
```console
$ $(yarn bin)/lerna run test --stream --concurrency=1 --scope @truffle/from-hardhat -- --colors
lerna notice cli v4.0.0
lerna info versioning independent
lerna notice filter including "@truffle/from-hardhat"
lerna info filter [ '@truffle/from-hardhat' ]
lerna info Executing command in 1 package: "yarn run test --colors"
yarn run v1.22.19
$ jest --passWithNoTests --colors
@truffle/from-hardhat: No tests found, exiting with code 0
Done in 0.66s.
lerna success run Ran npm script 'test' in 1 package in 0.7s:
lerna success - @truffle/from-hardhat
```