### PR TITLE
Disable internal function pointer decoding for contracts compiled with `viaIR`

### DIFF
--- a/packages/codec/lib/compilations/types.ts
+++ b/packages/codec/lib/compilations/types.ts
@@ -43,6 +43,11 @@ export interface Compilation {
    * specified on each source and contract, but please don't actually do that.
    */
   compiler?: Compiler.CompilerVersion;
+  /**
+   * The settings used in the compilation.  Works similarly to the compiler field.
+   * May be omitted.
+   */
+  settings?: Compiler.Settings;
 }
 
 /**
@@ -78,6 +83,12 @@ export interface Source {
    * compilation as a whole; please don't do that.)
    */
   compiler?: Compiler.CompilerVersion; //compatibility hack!
+  /**
+   * This field is a compatibility hack only intended for internal use.
+   * (It allows the settings to be set on a source if none is set on the
+   * compilation as a whole; please don't do that.)
+   */
+  settings?: Compiler.Settings; //compatibility hack!
 }
 
 /**
@@ -123,6 +134,12 @@ export interface Contract {
    * compilation as a whole; please don't do that.)
    */
   compiler?: Compiler.CompilerVersion; //compatibility hack!
+  /**
+   * This field is a compatibility hack only intended for internal use.
+   * (It allows the settings to be set on a source if none is set on the
+   * compilation as a whole; please don't do that.)
+   */
+  settings?: Compiler.Settings; //compatibility hack!
   /**
    * The ID of the contract's primary source.
    */

--- a/packages/codec/lib/compiler/types.ts
+++ b/packages/codec/lib/compiler/types.ts
@@ -15,3 +15,10 @@ export type SolidityFamily =
   | "0.8.x"
   | "0.8.7+"
   | "0.8.9+";
+
+export interface Settings {
+  //this type is deliberately incomplete,
+  //it only includes the settings that Codec cares about,
+  //of which at present this is the only one.
+  viaIR?: boolean;
+}

--- a/packages/debugger/lib/data/sagas/index.js
+++ b/packages/debugger/lib/data/sagas/index.js
@@ -1047,7 +1047,7 @@ export function* decode(definition, ref, compilationId) {
   const contexts = yield select(data.views.contexts);
   const currentContext = yield select(data.current.context);
   const internalFunctionsTable = yield select(
-    data.current.functionsByProgramCounter
+    data.current.internalFunctionsTable
   );
 
   debug("definition: %o");
@@ -1105,7 +1105,7 @@ export function* decodeReturnValue() {
   const returnAllocation = yield select(data.current.returnAllocation); //may be null
   const errorId = yield select(data.current.errorId);
   const internalFunctionsTable = yield select(
-    data.current.functionsByProgramCounter
+    data.current.internalFunctionsTable
   );
   debug("returnAllocation: %O", returnAllocation);
 
@@ -1218,7 +1218,7 @@ export function* decodeLog() {
   const currentContext = yield select(data.current.context);
   const eventId = yield select(data.current.eventId);
   const internalFunctionsTable = yield select(
-    data.current.functionsByProgramCounter
+    data.current.internalFunctionsTable
   );
 
   const decoder = Codec.decodeEvent(

--- a/packages/debugger/lib/data/selectors/index.js
+++ b/packages/debugger/lib/data/selectors/index.js
@@ -1058,6 +1058,19 @@ const data = createSelectorTree({
     ),
 
     /**
+     * data.current.internalFunctionsTable
+     */
+    internalFunctionsTable: createLeaf(
+      [evm.current.isIR, "./functionsByProgramCounter"],
+      //for Solidity compiled with IR turned on, internal function pointers
+      //are encoded by index rather than by PC value.  unfortunately the
+      //indices are hard to predict and so at present we can't decode these
+      //(at least, not without a fair bit more effort).  As such we won't set
+      //up an internal functions table if IR is turned on.
+      (isIR, byPC) => (isIR ? undefined : byPC)
+    ),
+
+    /**
      * data.current.context
      */
     context: createLeaf([evm.current.context], debuggerContextToDecoderContext),

--- a/packages/debugger/lib/evm/selectors/index.js
+++ b/packages/debugger/lib/evm/selectors/index.js
@@ -607,6 +607,16 @@ const evm = createSelectorTree({
     ),
 
     /**
+     * evm.current.isIR
+     * was the current context compield with IR on?
+     * currently, this defaults to false; in the future the default
+     * may depend on the Solidity version
+     */
+    isIR: createLeaf(["./context"], context =>
+      context.settings ? Boolean(context.settings.viaIR) : false
+    ),
+
+    /**
      * evm.current.state
      *
      * evm state info: as of last operation, before op defined in step

--- a/packages/debugger/lib/session/index.js
+++ b/packages/debugger/lib/session/index.js
@@ -139,6 +139,7 @@ export default class Session {
         );
       }
       const compiler = compilation.compiler; //note: we'll prefer one listed on contract or source
+      const settings = compilation.settings; //same note
       sources.user[compilation.id] = [];
       contracts[compilation.id] = {};
       for (let index in compilation.sources) {
@@ -157,6 +158,7 @@ export default class Session {
           ...source,
           ast,
           compiler: source.compiler || compiler,
+          settings: source.settings || settings,
           compilationId: compilation.id,
           index,
           id: makeSourceId(compilation.id, null, index),
@@ -174,6 +176,7 @@ export default class Session {
           immutableReferences,
           abi,
           compiler,
+          settings,
           primarySourceId,
           generatedSources,
           deployedGeneratedSources
@@ -260,6 +263,7 @@ export default class Session {
             primarySource: primarySourceIndex,
             abi,
             compiler,
+            settings,
             compilationId: compilation.id,
             contractId,
             contractKind,
@@ -277,6 +281,7 @@ export default class Session {
                 sources.internal[contextHash][index] = {
                   ...source,
                   compiler: source.compiler || compiler,
+                  settings: source.settings || settings,
                   compilationId: compilation.id,
                   index,
                   id: makeSourceId(compilation.id, contextHash, index),
@@ -308,6 +313,7 @@ export default class Session {
             immutableReferences,
             abi,
             compiler,
+            settings,
             compilationId: compilation.id,
             contractId,
             contractKind,
@@ -325,6 +331,7 @@ export default class Session {
                 sources.internal[contextHash][index] = {
                   ...source,
                   compiler: source.compiler || compiler,
+                  settings: source.settings || settings,
                   compilationId: compilation.id,
                   index,
                   id: makeSourceId(compilation.id, contextHash, index),

--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -1499,9 +1499,14 @@ export class ContractInstanceDecoder {
     //some sort of fake table if we don't have a source map, or if any ASTs are missing
     //(if a whole *source* is missing, we'll consider that OK)
     //note: we don't attempt to handle Vyper source maps!
+    //we also (for now) don't attempt this if viaIR is set, since we can't
+    //currently handle decoding by index
     const compiler = this.compilation.compiler || this.contract.compiler;
+    const viaIR =
+      this.compilation?.settings?.viaIR || this.contract?.settings?.viaIR;
     if (
       !this.compilation.unreliableSourceOrder &&
+      !viaIR &&
       this.contract.deployedSourceMap &&
       compiler.name === "solc" &&
       this.compilation.sources.every(source => !source || source.ast)

--- a/packages/source-map-utils/index.js
+++ b/packages/source-map-utils/index.js
@@ -450,12 +450,20 @@ var SourceMapUtils = {
         return null;
       }
       index++;
-      while (instructions[index].name.match(/^PUSH\d*/)) {
+      while (
+        instructions[index] &&
+        instructions[index].name.match(/^PUSH\d*/)
+      ) {
         index++;
         if (index > startingIndex + 3) {
           //check: are there more than 2 PUSHes?
           return null;
         }
+      }
+      if (!instructions[index]) {
+        //covers both the case where we ran off already,
+        //and where we're about to run off
+        return null;
       }
       if (instructions[index].name === "JUMP") {
         if (index === startingIndex + 1) {


### PR DESCRIPTION
So, the original plan for this PR was for it to address #5466.  Unfortunately, that turned out to be rather more difficult than anticipated.  As such, I've put up this PR as a stopgap.  (I did do a bunch of work on the original plan before I realized the problem; if people are interested, I can push that branch as well so people can see it.  I *am* intending to still use a lot of that work in the future when we attempt to handle this more properly, but the time for that is not now.)

So, anyway, as a stopgap, if `viaIR` is turned on, instead of decoding using indices like I was hoping to do, we just disable decoding of internal function pointers.  That way at least we don't get silly errors that don't apply.

There's more to that than it sounds, though, because -- just as if we wanted to switch to index based-decoding when appropriate -- we still have to actually determine if `viaIR` is turned on!  We've often in the past made switches based on compiler version, but never before on compilation settings.  That means that we need to get that information to the debugger and decoder, where we've never had to before.

Doing this isn't that hard, because after all we can parse it out of the `metadata` (if available).  Note that for now we default to `viaIR` off, but in the future we may default it differently for different Solidity versions.  But the big thing to note here is that I've made alterations to the `Compilation`, `Contract`, and `Source` types, so @gnidan take note!

Note I didn't use a `Settings` type from elsewhere, I just made a custom one and included `viaIR` as the only setting because, well, it's the only one that matters right now.

There is one caveat to this PR, which is that, when decoding of internal function pointers is disabled, the unhelpful value you get still lists a pair of PC values, even though in fact that doesn't apply in these cases.  But I didn't see that as being worth changing until we're actually decoding index-based values.  Again, on my `newtable` branch I did do the work to support this kind of thing, so if you want to see that branch, I can push it and you can see what that looks like.  In this PR though I left all that out.

So yeah, a bit of a disappointment, but better than doing nothing for now I guess...

(I didn't add any tests; the way the debugger and decoder tests are set up make it a pain to use multiple different compilation settings.  But I did test this manually.)

(Oh, also, I fixed an unrelated crash that came up in testing.  Um, that maybe should have been a separate PR.  Oh well.  It's a separate commit at least, so we can always cherry-pick it if need be.)