### PR TITLE
hdwallet-provider: restrict access to internal fields

### DIFF
--- a/packages/hdwallet-provider/src/index.ts
+++ b/packages/hdwallet-provider/src/index.ts
@@ -48,8 +48,8 @@ const singletonNonceSubProvider = new NonceSubProvider();
 
 class HDWalletProvider {
   private walletHdpath: string;
-  private wallets: { [address: string]: Buffer };
-  private addresses: string[];
+  #wallets: { [address: string]: Buffer };
+  #addresses: string[];
   private chainId?: ChainId;
   private chainSettings: ChainSettings;
   private hardfork: Hardfork;
@@ -78,8 +78,8 @@ class HDWalletProvider {
     const privateKeys = getPrivateKeys(signingAuthority);
 
     this.walletHdpath = derivationPath;
-    this.wallets = {};
-    this.addresses = [];
+    this.#wallets = {};
+    this.#addresses = [];
     this.chainSettings = chainSettings;
     this.engine = new ProviderEngine({
       pollingInterval
@@ -99,7 +99,7 @@ class HDWalletProvider {
         [
           `No provider or an invalid provider was specified: '${providerToUse}'`,
           "Please specify a valid provider or URL, using the http, https, " +
-            "ws, or wss protocol.",
+          "ws, or wss protocol.",
           ""
         ].join("\n")
       );
@@ -116,15 +116,15 @@ class HDWalletProvider {
       this.ethUtilValidation(options);
     } // no need to handle else case here, since matchesNewOptions() covers it
 
-    if (this.addresses.length === 0) {
+    if (this.#addresses.length === 0) {
       throw new Error(
         `Could not create addresses from your mnemonic or private key(s). ` +
-          `Please check that your inputs are correct.`
+        `Please check that your inputs are correct.`
       );
     }
 
-    const tmpAccounts = this.addresses;
-    const tmpWallets = this.wallets;
+    const tmpAccounts = this.#addresses;
+    const tmpWallets = this.#wallets;
 
     // if user supplied the chain id, use that - otherwise fetch it
     if (
@@ -336,8 +336,8 @@ class HDWalletProvider {
       const addr = `0x${Buffer.from(
         uncompressedPublicKeyToAddress(wallet.publicKey)
       ).toString("hex")}`;
-      this.addresses.push(addr);
-      this.wallets[addr] = wallet.privateKey;
+      this.#addresses.push(addr);
+      this.#wallets[addr] = wallet.privateKey;
     }
   }
 
@@ -355,8 +355,8 @@ class HDWalletProvider {
       if (EthUtil.isValidPrivate(privateKey)) {
         const wallet = EthUtil.privateToAddress(privateKey);
         const address = `0x${wallet.toString("hex")}`;
-        this.addresses.push(address);
-        this.wallets[address] = privateKey;
+        this.#addresses.push(address);
+        this.#wallets[address] = privateKey;
       }
     }
   }
@@ -382,14 +382,14 @@ class HDWalletProvider {
 
   public getAddress(idx?: number): string {
     if (!idx) {
-      return this.addresses[0];
+      return this.#addresses[0];
     } else {
-      return this.addresses[idx];
+      return this.#addresses[idx];
     }
   }
 
   public getAddresses(): string[] {
-    return this.addresses;
+    return this.#addresses;
   }
 
   public static isValidProvider(provider: any): boolean {


### PR DESCRIPTION
This PR restricts access to hdwallet-provider's `wallets` and `addresses` using [Private class fields](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields) to prevent accidental inspection/leaking. 

Notice how `wallets` and `accounts` are no long visible using Private class fields  (see below)


## without private fields (current stable)

The fields are accessible.
<details><summary>click to expand</summary>

```console
> HDW = require("./dist")
> m = "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat";
'candy maple cake sugar pudding cream honey rich smooth crumble sweet treat'
>
> G = require("ganache")
> gp = G.provider({miner: {instamine: "strict"}, logging: {quiet: true}})
> h = new HDW(m, gp)
HDWalletProvider {
  walletHdpath: "m/44'/60'/0'/0/",
  wallets: {
    '0x627306090abab3a6e1400e9345bc60c78a8bef57': <Buffer c8 75 09 a1 c0 67 bb de 78 be b7 93 e6 fa 76 53 0b 63 82 a4 c0 24 1e 5e 4a 9e c0 a0 f4 4d c0 d3>,
    '0xf17f52151ebef6c7334fad080c5704d77216b732': <Buffer ae 6a e8 e5 cc bf b0 45 90 40 59 97 ee 2d 52 d2 b3 30 72 61 37 b8 75 05 3c 36 d9 4e 97 4d 16 2f>,
    '0xc5fdf4076b8f3a5357c5e395ab970b5b54098fef': <Buffer 0d bb e8 e4 ae 42 5a 6d 26 87 f1 a7 e3 ba 17 bc 98 c6 73 63 67 90 f1 b8 ad 91 19 3c 05 87 5e f1>,
    '0x821aea9a577a9b44299b9c15c88cf3087f3b5544': <Buffer c8 8b 70 3f b0 8c be a8 94 b6 ae ff 5a 54 4f b9 2e 78 a1 8e 19 81 4c d8 5d a8 3b 71 f7 72 aa 6c>,
    '0x0d1d4e623d10f9fba5db95830f7d3839406c6af2': <Buffer 38 8c 68 4f 0b a1 ef 50 17 71 6a db 5d 21 a0 53 ea 8e 90 27 7d 08 68 33 75 19 f9 7b ed e6 14 18>,
    '0x2932b7a2355d6fecc4b5c0b6bd44cc31df247a2e': <Buffer 65 9c bb 0e 24 11 a4 4d b6 37 78 98 7b 1e 22 15 3c 08 6a 95 eb 6b 18 bd f8 9d e0 78 91 7a bc 63>,
    '0x2191ef87e392377ec08e7c08eb105ef5448eced5': <Buffer 82 d0 52 c8 65 f5 76 3a ad 42 ad d4 38 56 92 76 c0 0d 3d 88 a2 d0 62 d3 6b 2b ae 91 4d 58 b8 c8>,
    '0x0f4f2ac550a1b4e2280d04c21cea7ebd822934b5': <Buffer aa 36 80 d5 d4 8a 82 83 41 3f 7a 10 83 67 c7 29 9c a7 3f 55 37 35 86 0a 87 b0 8f 39 39 56 18 b7>,
    '0x6330a553fc93768f612722bb8c2ec78ac90b3bbc': <Buffer 0f 62 d9 6d 66 75 f3 26 85 bb db 8a c1 3c da 7c 23 43 6f 63 ef bb 9d 07 70 0d 86 69 ff 12 b7 c4>,
    '0x5aeda56215b167893e80b4fe645ba6d5bab767de': <Buffer 8d 53 66 12 3c b5 60 bb 60 63 79 f9 0a 0b fd 47 69 ee cc 05 57 f1 b3 62 dc ae 90 12 b5 48 b1 e5>
  },
  addresses: [
    '0x627306090abab3a6e1400e9345bc60c78a8bef57',
    '0xf17f52151ebef6c7334fad080c5704d77216b732',
    '0xc5fdf4076b8f3a5357c5e395ab970b5b54098fef',
    '0x821aea9a577a9b44299b9c15c88cf3087f3b5544',
    '0x0d1d4e623d10f9fba5db95830f7d3839406c6af2',
    '0x2932b7a2355d6fecc4b5c0b6bd44cc31df247a2e',
    '0x2191ef87e392377ec08e7c08eb105ef5448eced5',
    '0x0f4f2ac550a1b4e2280d04c21cea7ebd822934b5',
    '0x6330a553fc93768f612722bb8c2ec78ac90b3bbc',
    '0x5aeda56215b167893e80b4fe645ba6d5bab767de'
  ],
  chainSettings: {},
  engine: Web3ProviderEngine {
    _events: [Object: null prototype] {
      block: [Array],
      start: [Array],
      stop: [Array]
    },
    _eventsCount: 3,
    _maxListeners: 30,
    _blockTracker: PollingBlockTracker {
      _events: [Object: null prototype],
      _eventsCount: 5,
      _maxListeners: undefined,
      _blockResetDuration: 4000,
      _currentBlock: null,
      _isRunning: true,
      _onNewListener: [Function: bound _onNewListener],
      _onRemoveListener: [Function: bound _onRemoveListener],
      _resetCurrentBlock: [Function: bound _resetCurrentBlock],
      _provider: [Object],
      _pollingInterval: 4000,
      _retryTimeout: 400,
      _keepEventLoopActive: true,
      _setSkipCacheFlag: true
    },
    _ready: Stoplight {
      _events: [Object: null prototype] {},
      _eventsCount: 0,
      _maxListeners: undefined,
      isLocked: false,
      [Symbol(kCapture)]: false
    },
    currentBlock: null,
    _providers: [
      [HookedWalletSubprovider],
      [NonceTrackerSubprovider],
      [SubscriptionsSubprovider],
      [ProviderSubprovider]
    ],
    _running: true,
    [Symbol(kCapture)]: false
  },
  initialized: Promise {
    <pending>,
    [Symbol(async_id_symbol)]: 2966,
    [Symbol(trigger_async_id_symbol)]: 5
  },
  hardfork: 'london'
}
> Object.keys(h)
[
  'walletHdpath',
  'wallets',
  'addresses',
  'chainSettings',
  'engine',
  'initialized',
  'hardfork',
  'chainId'
]
```
</details>

## with private fields (this PR)

The fields are not accessible.

<details><summary>click to expand</summary>

```console
> HDW = require("./dist")
> m = "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat";
'candy maple cake sugar pudding cream honey rich smooth crumble sweet treat'
>
> G = require("ganache")
> gp = G.provider({miner: {instamine: "strict"}, logging: {quiet: true}})
> h = new HDW(m, gp)
HDWalletProvider {
  walletHdpath: "m/44'/60'/0'/0/",
  chainSettings: {},
  engine: Web3ProviderEngine {
    _events: [Object: null prototype] {
      block: [Array],
      start: [Array],
      stop: [Array]
    },
    _eventsCount: 3,
    _maxListeners: 30,
    _blockTracker: PollingBlockTracker {
      _events: [Object: null prototype],
      _eventsCount: 5,
      _maxListeners: undefined,
      _blockResetDuration: 4000,
      _currentBlock: null,
      _isRunning: true,
      _onNewListener: [Function: bound _onNewListener],
      _onRemoveListener: [Function: bound _onRemoveListener],
      _resetCurrentBlock: [Function: bound _resetCurrentBlock],
      _provider: [Object],
      _pollingInterval: 4000,
      _retryTimeout: 400,
      _keepEventLoopActive: true,
      _setSkipCacheFlag: true
    },
    _ready: Stoplight {
      _events: [Object: null prototype] {},
      _eventsCount: 0,
      _maxListeners: undefined,
      isLocked: false,
      [Symbol(kCapture)]: false
    },
    currentBlock: null,
    _providers: [
      [HookedWalletSubprovider],
      [NonceTrackerSubprovider],
      [SubscriptionsSubprovider],
      [ProviderSubprovider]
    ],
    _running: true,
    [Symbol(kCapture)]: false
  },
  initialized: Promise {
    <pending>,
    [Symbol(async_id_symbol)]: 3448,
    [Symbol(trigger_async_id_symbol)]: 5
  },
  hardfork: 'london'
}

> Object.keys(h)
[
  'walletHdpath',
  'chainSettings',
  'engine',
  'initialized',
  'hardfork',
  'chainId'
]
```
</details>