### PR TITLE
Add support for compiler plugin

### DIFF
--- a/packages/plugins/.eslintrc.json
+++ b/packages/plugins/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../.eslintrc.package.json"]
+}

--- a/packages/plugins/lib/Plugin.ts
+++ b/packages/plugins/lib/Plugin.ts
@@ -69,7 +69,7 @@ export class Plugin {
   loadCompiler(): any {
     if (!this.definesCompiler()) {
       throw new TruffleError(
-        `Plugin ${this.module} does not define a \`truffle plugin\` compiler.`
+        `Plugin ${this.module} does not define a \`truffle compiler plugin\`.`
       );
     }
 

--- a/packages/plugins/lib/Plugin.ts
+++ b/packages/plugins/lib/Plugin.ts
@@ -63,7 +63,7 @@ export class Plugin {
    */
 
   definesCompiler(): boolean {
-    return !!this.definition.compile;
+    return !!this.definition.compiler;
   }
 
   loadCompiler(): any {
@@ -73,7 +73,7 @@ export class Plugin {
       );
     }
 
-    return this.loadModule(this.definition.compile).Compile;
+    return this.loadModule(this.definition.compiler).Compile;
   }
 
   /*

--- a/packages/plugins/lib/Plugin.ts
+++ b/packages/plugins/lib/Plugin.ts
@@ -73,7 +73,11 @@ export class Plugin {
       );
     }
 
-    return this.loadModule(this.definition.compiler).Compile;
+    const compilerPath = this.loadModule(this.definition.compiler);
+    if (!compilerPath.Compile) {
+      throw new TruffleError(`Plugin ${this.module}: Compile is not defined.`);
+    }
+    return compilerPath.Compile;
   }
 
   /*

--- a/packages/plugins/lib/Plugin.ts
+++ b/packages/plugins/lib/Plugin.ts
@@ -59,6 +59,24 @@ export class Plugin {
   }
 
   /*
+   * compiler
+   */
+
+  definesCompiler(): boolean {
+    return !!this.definition.compile;
+  }
+
+  loadCompiler(): any {
+    if (!this.definesCompiler()) {
+      throw new TruffleError(
+        `Plugin ${this.module} does not define a \`truffle plugin\` compiler.`
+      );
+    }
+
+    return this.loadModule(this.definition.compile).Compile;
+  }
+
+  /*
    * internals
    */
 

--- a/packages/plugins/lib/Plugins.ts
+++ b/packages/plugins/lib/Plugins.ts
@@ -58,6 +58,17 @@ export class Plugins {
     return recipes;
   }
 
+  /**
+   * Given a truffle-config-like, find and return all plugins that define a compiler
+   */
+  static listAllCompilers(config: TruffleConfig): Plugin[] {
+    const allPlugins = Plugins.listAll(config);
+
+    const compilers = allPlugins.filter(plugin => plugin.definesCompiler());
+
+    return compilers;
+  }
+
   /*
    * internals
    */

--- a/packages/plugins/lib/types.ts
+++ b/packages/plugins/lib/types.ts
@@ -39,6 +39,6 @@ export interface PluginDefinition {
     loader?: string;
   };
 
-  // `truffle compile` plugin
-  compile?: string;
+  // `truffle compiler` plugin
+  compiler?: string;
 }

--- a/packages/plugins/test/Plugin.test.ts
+++ b/packages/plugins/test/Plugin.test.ts
@@ -199,4 +199,38 @@ describe("Plugin", () => {
       expect(() => plugin.loadRecipe()).toThrow(expectedError);
     });
   });
+
+  describe("loadCompiler()", () => {
+    it("should load compiler defined in the plugin definition", () => {
+      const plugin = new Plugin({
+        module: "dummy-compiler",
+        definition: { compile: "index.js" }
+      });
+
+      const loadedCompiler = plugin.loadCompiler();
+      const expectedResult = "Successfully called dummy-compiler:compile()";
+      expect(loadedCompiler.compile()).toEqual(expectedResult);
+    });
+
+    it("should throw when compiler plugin definition is an absolute path", () => {
+      const plugin = new Plugin({
+        module: "dummy-compiler",
+        definition: { compile: "/index.js" }
+      });
+
+      const expectedError = "Absolute paths not allowed!";
+      expect(() => plugin.loadCompiler()).toThrow(expectedError);
+    });
+
+    it("should throw when compiler plugin definition is missing", () => {
+      const plugin = new Plugin({
+        module: "dummy-noDefinition",
+        definition: {}
+      });
+
+      const expectedError =
+        "Plugin dummy-noDefinition does not define a `truffle plugin` compiler.";
+      expect(() => plugin.loadCompiler()).toThrow(expectedError);
+    });
+  });
 });

--- a/packages/plugins/test/Plugin.test.ts
+++ b/packages/plugins/test/Plugin.test.ts
@@ -204,7 +204,7 @@ describe("Plugin", () => {
     it("should load compiler defined in the plugin definition", () => {
       const plugin = new Plugin({
         module: "dummy-compiler",
-        definition: { compile: "index.js" }
+        definition: { compiler: "index.js" }
       });
 
       const loadedCompiler = plugin.loadCompiler();
@@ -215,7 +215,7 @@ describe("Plugin", () => {
     it("should throw when compiler plugin definition is an absolute path", () => {
       const plugin = new Plugin({
         module: "dummy-compiler",
-        definition: { compile: "/index.js" }
+        definition: { compiler: "/index.js" }
       });
 
       const expectedError = "Absolute paths not allowed!";

--- a/packages/plugins/test/Plugin.test.ts
+++ b/packages/plugins/test/Plugin.test.ts
@@ -229,7 +229,7 @@ describe("Plugin", () => {
       });
 
       const expectedError =
-        "Plugin dummy-noDefinition does not define a `truffle plugin` compiler.";
+        "Plugin dummy-noDefinition does not define a `truffle compiler plugin`.";
       expect(() => plugin.loadCompiler()).toThrow(expectedError);
     });
   });

--- a/packages/plugins/test/Plugins.test.ts
+++ b/packages/plugins/test/Plugins.test.ts
@@ -40,7 +40,7 @@ describe("Plugins", () => {
         }),
         new Plugin({
           module: "dummy-compiler",
-          definition: { compile: "index.js" }
+          definition: { compiler: "index.js" }
         })
       ];
 
@@ -208,7 +208,7 @@ describe("Plugins", () => {
       const expectedPlugins = [
         new Plugin({
           module: "dummy-compiler",
-          definition: { compile: "index.js" }
+          definition: { compiler: "index.js" }
         })
       ];
 

--- a/packages/plugins/test/Plugins.test.ts
+++ b/packages/plugins/test/Plugins.test.ts
@@ -12,7 +12,12 @@ describe("Plugins", () => {
     it("should list all plugins defined in a Truffle config object", () => {
       const config = {
         working_directory: __dirname,
-        plugins: ["dummy-plugin-1", "dummy-plugin-2", "dummy-recipe"]
+        plugins: [
+          "dummy-plugin-1",
+          "dummy-plugin-2",
+          "dummy-recipe",
+          "dummy-compiler"
+        ]
       };
 
       const allPlugins = Plugins.listAll(config);
@@ -32,6 +37,10 @@ describe("Plugins", () => {
             tag: "dummy-recipe",
             preserve: { tag: "dummy-recipe", recipe: "." }
           }
+        }),
+        new Plugin({
+          module: "dummy-compiler",
+          definition: { compile: "index.js" }
         })
       ];
 
@@ -40,7 +49,7 @@ describe("Plugins", () => {
 
     it("should list no plugins if none are defined in a Truffle config object", () => {
       const config = {
-        working_directory: __dirname,
+        working_directory: __dirname
       };
 
       const allPlugins = Plugins.listAll(config as TruffleConfig);
@@ -72,7 +81,8 @@ describe("Plugins", () => {
         plugins: ["non-existent-plugin"]
       };
 
-      const expectedError = /listed as a plugin, but not found in global or local node modules/;
+      const expectedError =
+        /listed as a plugin, but not found in global or local node modules/;
 
       expect(() => Plugins.listAll(config)).toThrow(expectedError);
     });
@@ -179,6 +189,26 @@ describe("Plugins", () => {
           definition: {
             preserve: { recipe: "." }
           }
+        })
+      ];
+
+      expect(foundPlugins).toEqual(expectedPlugins);
+    });
+  });
+
+  describe("listAllCompilers()", () => {
+    it("should list all plugins that implement a compiler", () => {
+      const config = {
+        working_directory: __dirname,
+        plugins: ["dummy-compiler"]
+      };
+
+      const foundPlugins = Plugins.listAllCompilers(config);
+
+      const expectedPlugins = [
+        new Plugin({
+          module: "dummy-compiler",
+          definition: { compile: "index.js" }
         })
       ];
 

--- a/packages/plugins/test/fixture/dummy-compiler/index.js
+++ b/packages/plugins/test/fixture/dummy-compiler/index.js
@@ -1,0 +1,7 @@
+const Compile = {
+  compile() {
+    return "Successfully called dummy-compiler:compile()";
+  }
+};
+
+module.exports = { Compile };

--- a/packages/plugins/test/fixture/dummy-compiler/package.json
+++ b/packages/plugins/test/fixture/dummy-compiler/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "dummy-compiler",
+  "version": "0.1.0",
+  "description": "Dummy compiler for testing",
+  "main": "index.js",
+  "license": "MIT"
+}

--- a/packages/plugins/test/fixture/dummy-compiler/truffle-plugin.json
+++ b/packages/plugins/test/fixture/dummy-compiler/truffle-plugin.json
@@ -1,3 +1,3 @@
 {
-  "compile": "index.js"
+  "compiler": "index.js"
 }

--- a/packages/plugins/test/fixture/dummy-compiler/truffle-plugin.json
+++ b/packages/plugins/test/fixture/dummy-compiler/truffle-plugin.json
@@ -1,0 +1,3 @@
+{
+  "compile": "index.js"
+}


### PR DESCRIPTION
This PR adds two APIs, definesCompiler() and loadCompiler(), to the Plugin class to support compiler plugin. These APIs are exposed to workflow-compile that it can access the plugin compiler.  There are on-going work on workflow-compile to obtain the Plugin object and access compiler.

