### PR TITLE
Add a check to help prevent generated files being checked into source control

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -53,6 +53,7 @@ jobs:
     - run: npm install -g yarn
 
     - run: yarn bootstrap
+    - run: test -z "$(git diff)" || (echo 'Did you check in a generated file to source control?  Please remove it if so'; false)
     
     - run: yarn depcheck
     


### PR DESCRIPTION
We had a problem recently where a generated file was accidentally checked into source control and it caused a problem (see #5608) where bootstrapping resulted in changes to tracked files.  I figured it would be good to add this measure to help prevent this.  So I added a check for this in CI.  Note that because this check requires bootstrapping, like `depcheck` it goes in the jobs that *aren't* `yarncheck`.  Obviously this won't catch every case, but it should help, I figure.