### PR TITLE
Add arbitrum goerli support to Etherscan fetcher

### DIFF
--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -66,6 +66,7 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
       "goerli-optimistic": "api-goerli-optimism.etherscan.io", //yes this one is different!
       "arbitrum": "api.arbiscan.io",
       "rinkeby-arbitrum": "api-testnet.arbiscan.io",
+      "goerli-arbitrum": "api-goerli.arbiscan.io",
       "polygon": "api.polygonscan.com",
       "mumbai-polygon": "api-mumbai.polygonscan.com",
       "binance": "api.bscscan.com",


### PR DESCRIPTION
Seems Etherscan added support for Arbitrum Goerli at some point, but I didn't notice till now.  Well, I've updated the source fetcher with it.