### PR TITLE
Silence Lerna's cycle dependency warnings

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -63,7 +63,6 @@
     "@truffle/compile-common": "^0.8.1",
     "@truffle/contract-schema": "^3.4.10",
     "@truffle/resolver": "^9.0.17",
-    "@truffle/migrate": "^3.3.12",
     "@types/debug": "^4.1.5",
     "@types/express": "^4.16.0",
     "@types/graphql": "^14.5.0",

--- a/packages/db/src/project/test/integration.spec.ts
+++ b/packages/db/src/project/test/integration.spec.ts
@@ -6,7 +6,7 @@ import gql from "graphql-tag";
 import { connect } from "@truffle/db";
 import { ArtifactsLoader } from "./artifacts";
 import { generateId } from "@truffle/db/system";
-import Migrate from "@truffle/migrate";
+const Migrate = require("@truffle/migrate");
 import { Environment } from "@truffle/environment";
 import Config from "@truffle/config";
 import Web3 from "web3";

--- a/packages/db/src/project/test/integration.spec.ts
+++ b/packages/db/src/project/test/integration.spec.ts
@@ -6,7 +6,7 @@ import gql from "graphql-tag";
 import { connect } from "@truffle/db";
 import { ArtifactsLoader } from "./artifacts";
 import { generateId } from "@truffle/db/system";
-const Migrate = require("@truffle/migrate");
+const Migrate = require("@truffle/migrate").default;
 import { Environment } from "@truffle/environment";
 import Config from "@truffle/config";
 import Web3 from "web3";


### PR DESCRIPTION
Remove `@truffle/db`'s devDep on `@truffle/migrate` to get rid of lerna's cycle dep error.
Note: uses CommonJS import to make get past compile and test.

This dependency exists only for a single integration test in truffle-db, and we feel it's better to not impact Lerna's dependency/ordering until we [remove the circular dependency in the near future](https://github.com/trufflesuite/truffle/issues/5600).