### PR TITLE
Bug fix: patch/wrap the `sendAsync` method when wrapping provider

### DIFF
--- a/packages/provider/wrapper.js
+++ b/packages/provider/wrapper.js
@@ -27,7 +27,7 @@ module.exports = {
 
     /* overwrite method */
     provider.send = this.send(originalSend, preHook, postHook);
-    // path sendAsync when sendAsync is used.
+    // overwrite sendAsync only when sendAsync is used.
     if (provider.sendAsync) {
       const originalSendAsync = provider.sendAsync.bind(provider);
       provider.sendAsync = this.send(originalSendAsync, preHook, postHook);

--- a/packages/provider/wrapper.js
+++ b/packages/provider/wrapper.js
@@ -27,7 +27,7 @@ module.exports = {
 
     /* overwrite method */
     provider.send = this.send(originalSend, preHook, postHook);
-
+    provider.sendAsync = this.send(originalSend, preHook, postHook);
     /* mark as wrapped */
     provider._alreadyWrapped = true;
 

--- a/packages/provider/wrapper.js
+++ b/packages/provider/wrapper.js
@@ -1,5 +1,5 @@
-var debug = require("debug")("provider:wrapper"); // eslint-disable-line no-unused-vars
-var ProviderError = require("./error");
+const debug = require("debug")("provider:wrapper"); // eslint-disable-line no-unused-vars
+const ProviderError = require("./error");
 
 module.exports = {
   /*
@@ -20,16 +20,16 @@ module.exports = {
     options.verbose = options.verbose || options.verboseRpc || false;
 
     /* create wrapper functions for before/after send/sendAsync */
-    var preHook = this.preHook(options);
-    var postHook = this.postHook(options);
+    const preHook = this.preHook(options);
+    const postHook = this.postHook(options);
 
-    var originalSend = provider.send.bind(provider);
+    const originalSend = provider.send.bind(provider);
 
     /* overwrite method */
     provider.send = this.send(originalSend, preHook, postHook);
     // path sendAsync when sendAsync is used.
     if (provider.sendAsync) {
-      let originalSendAsync = provider.sendAsync.bind(provider);
+      const originalSendAsync = provider.sendAsync.bind(provider);
       provider.sendAsync = this.send(originalSendAsync, preHook, postHook);
     }
     /* mark as wrapped */
@@ -115,7 +115,7 @@ module.exports = {
       payload = preHook(payload);
 
       originalSend(payload, function (error, result) {
-        var modified = postHook(payload, error, result);
+        const modified = postHook(payload, error, result);
         payload = modified[0];
         error = modified[1];
         result = modified[2];

--- a/packages/provider/wrapper.js
+++ b/packages/provider/wrapper.js
@@ -19,7 +19,7 @@ module.exports = {
     // to see what web3 is sending and receiving.
     options.verbose = options.verbose || options.verboseRpc || false;
 
-    /* create wrapper functions for before/after send */
+    /* create wrapper functions for before/after send/sendAsync */
     var preHook = this.preHook(options);
     var postHook = this.postHook(options);
 
@@ -27,7 +27,11 @@ module.exports = {
 
     /* overwrite method */
     provider.send = this.send(originalSend, preHook, postHook);
-    provider.sendAsync = this.send(originalSend, preHook, postHook);
+    // path sendAsync when sendAsync is used.
+    if (provider.sendAsync) {
+      let originalSendAsync = provider.sendAsync.bind(provider);
+      provider.sendAsync = this.send(originalSendAsync, preHook, postHook);
+    }
     /* mark as wrapped */
     provider._alreadyWrapped = true;
 


### PR DESCRIPTION
Addresses #3412, to log for `--verbose-rpc` with HDWalletProvider.

Currently, the logging from `--verbose-rpc` is added onto the provider from wrapper.js's `pre` and `post` hook methods by patching the `send` method. Sometimes web3 uses the  `sendAsync` method, which we have not pathed, causing the lack of logging. 

We need to execute the `pre` and `post` hooks when `sendAsync` is called.

For testing:
Set up goerli via HDWalletProvider
run `truffle console --verbose-rpc --network goerli`

