### PR TITLE
codec: handle undefined index

### DIFF
--- a/packages/codec/lib/compilations/utils.ts
+++ b/packages/codec/lib/compilations/utils.ts
@@ -166,7 +166,7 @@ export function shimContracts(
       contractObject.primarySourceId = index.toString(); //HACK
     } else {
       //if neither was passed, attempt to determine it from the ast
-      let index: number;
+      let index: number | undefined;
       let needsAdding: boolean;
       if (sourceObject.ast) {
         //note: this works for both Solidity and Vyper
@@ -196,7 +196,7 @@ export function shimContracts(
         debug("else; index: %d", index);
       }
       //whether needed adding or not, set the source ID on the contract object
-      contractObject.primarySourceId = index?.toString(); //HACK
+      contractObject.primarySourceId = index.toString(); //HACK
       debug("(no index unless mentioned)");
     }
 
@@ -398,7 +398,7 @@ function inferLanguage(
 
 function getIndexToAddAt(
   sourceObject: Source,
-  index: number,
+  index: number | undefined,
   sources: Source[],
   unreliableSourceOrder: boolean
 ): { index: number; needsAdding: boolean; unreliableSourceOrder: boolean } {
@@ -411,38 +411,38 @@ function getIndexToAddAt(
     "sources: %o",
     sources.map(source => source.sourcePath)
   );
-  if (
-    sources.every(
-      existingSource =>
-        existingSource.sourcePath !== sourceObject.sourcePath ||
-        (!sourceObject.sourcePath &&
-          !existingSource.sourcePath &&
-          existingSource.source !== sourceObject.source)
-    )
-  ) {
+  const existingIndex = sources.findIndex(
+    existingSource =>
+      existingSource.sourcePath !== sourceObject.sourcePath ||
+      (!sourceObject.sourcePath &&
+        !existingSource.sourcePath &&
+        existingSource.source !== sourceObject.source)
+  );
+  if (existingIndex === -1) {
+    //it's not already there, let's add it
     if (unreliableSourceOrder || index === undefined || index in sources) {
       //if we can't add it at the correct spot, set the
       //unreliable source order flag
       debug("collision!");
       unreliableSourceOrder = true;
     }
-    //otherwise, just leave things alone
     if (unreliableSourceOrder) {
       //in case of unreliable source order, we'll ignore what indices
       //things are *supposed* to have and just append things to the end
       index = sources.length;
     }
+    //otherwise, just leave things alone
     return {
       index,
       needsAdding: true,
       unreliableSourceOrder
     };
   } else {
-    //return index: null indicates don't add this because it's
-    //already present
     debug("already present, not adding");
+    //note that index may be undefined in this case if it was passed
+    //in as undefined
     return {
-      index,
+      index: existingIndex,
       needsAdding: false,
       unreliableSourceOrder
     };

--- a/packages/codec/lib/compilations/utils.ts
+++ b/packages/codec/lib/compilations/utils.ts
@@ -413,7 +413,8 @@ function getIndexToAddAt(
   //contents if not)
   const existingIndex = sources.findIndex(
     existingSource =>
-      existingSource &&
+      existingSource && //findIndex treats absent as undefined, so we need this guard
+      // (array may be sparse)
       (existingSource.sourcePath === sourceObject.sourcePath ||
         (!sourceObject.sourcePath &&
           !existingSource.sourcePath &&

--- a/packages/codec/lib/compilations/utils.ts
+++ b/packages/codec/lib/compilations/utils.ts
@@ -196,7 +196,7 @@ export function shimContracts(
         debug("else; index: %d", index);
       }
       //whether needed adding or not, set the source ID on the contract object
-      contractObject.primarySourceId = index.toString(); //HACK
+      contractObject.primarySourceId = index?.toString(); //HACK
       debug("(no index unless mentioned)");
     }
 

--- a/packages/codec/lib/compilations/utils.ts
+++ b/packages/codec/lib/compilations/utils.ts
@@ -440,8 +440,6 @@ function getIndexToAddAt(
     };
   } else {
     debug("already present, not adding");
-    //note that index may be undefined in this case if it was passed
-    //in as undefined
     return {
       index: existingIndex,
       needsAdding: false,

--- a/packages/codec/lib/compilations/utils.ts
+++ b/packages/codec/lib/compilations/utils.ts
@@ -402,22 +402,22 @@ function getIndexToAddAt(
   sources: Source[],
   unreliableSourceOrder: boolean
 ): { index: number; needsAdding: boolean; unreliableSourceOrder: boolean } {
-  //first: is this already there? only add it if it's not.
-  //(we determine this by sourcePath if present, and the actual source
-  //contents if not)
   debug("sourcePath: %s", sourceObject.sourcePath);
   debug("given index: %d", index);
   debug(
     "sources: %o",
     sources.map(source => source.sourcePath)
   );
+  //first: is this already there? only add it if it's not.
+  //(we determine this by sourcePath if present, and the actual source
+  //contents if not)
   const existingIndex = sources.findIndex(
     existingSource =>
-      (existingSource &&
-        existingSource.sourcePath !== sourceObject.sourcePath) ||
-      (!sourceObject.sourcePath &&
-        !existingSource.sourcePath &&
-        existingSource.source !== sourceObject.source)
+      existingSource &&
+      (existingSource.sourcePath === sourceObject.sourcePath ||
+        (!sourceObject.sourcePath &&
+          !existingSource.sourcePath &&
+          existingSource.source === sourceObject.source))
   );
   if (existingIndex === -1) {
     //it's not already there, let's add it

--- a/packages/codec/lib/compilations/utils.ts
+++ b/packages/codec/lib/compilations/utils.ts
@@ -413,7 +413,8 @@ function getIndexToAddAt(
   );
   const existingIndex = sources.findIndex(
     existingSource =>
-      existingSource.sourcePath !== sourceObject.sourcePath ||
+      (existingSource &&
+        existingSource.sourcePath !== sourceObject.sourcePath) ||
       (!sourceObject.sourcePath &&
         !existingSource.sourcePath &&
         existingSource.source !== sourceObject.source)


### PR DESCRIPTION
## PR description

Bug fix - handle the case when `index` may be undefined in `shimContracts` to avoid an exception being thrown. This may occur under the circumstances described in https://github.com/trufflesuite/truffle/issues/5617

## Documentation

- No doc changes required.
