### PR TITLE
Turn on strict null checks in compile-common

### DIFF
--- a/packages/compile-common/src/shims/LegacyToNew.ts
+++ b/packages/compile-common/src/shims/LegacyToNew.ts
@@ -38,8 +38,10 @@ export function forContract(contract: any): CompiledContract {
     ast,
     abi,
     metadata,
-    bytecode: forBytecode(bytecode),
-    deployedBytecode: forBytecode(deployedBytecode),
+    bytecode: bytecode ? forBytecode(bytecode) : undefined,
+    deployedBytecode: deployedBytecode
+      ? forBytecode(deployedBytecode)
+      : undefined,
     compiler,
     devdoc,
     userdoc,
@@ -51,9 +53,6 @@ export function forContract(contract: any): CompiledContract {
 }
 
 export function forBytecode(bytecode: string): Bytecode {
-  if (!bytecode) {
-    return undefined;
-  }
   if (typeof bytecode === "object") {
     return bytecode;
   }
@@ -63,7 +62,12 @@ export function forBytecode(bytecode: string): Bytecode {
   const bytes = bytecode
     .slice(2) // remove 0x prefix
     .replace(/__[^_]+_*/g, (linkReference, characterOffset) => {
-      const [, name] = linkReference.match(/__([^_]+)_*/);
+      const match = linkReference.match(/__([^_]+)_*/);
+      if (match === null) {
+        //this can't actually happen, but strictNullChecks requires it
+        throw new Error("Could not extract link reference name");
+      }
+      const name = match[1];
 
       const characterLength = linkReference.length;
 

--- a/packages/compile-common/tsconfig.json
+++ b/packages/compile-common/tsconfig.json
@@ -5,6 +5,8 @@
     "declaration": true,
     "target": "es2016",
     "noImplicitAny": true,
+    "skipLibCheck": true,
+    "strictNullChecks": true,
     "moduleResolution": "node",
     "sourceMap": true,
     "outDir": "dist",


### PR DESCRIPTION
People thought this was on, but it wasn't!  The `skipLibCheck` option is also turned on to prevent the usual problems with `contract-schema`.

As part of this, I had to make two more changes to get it to compile.  One was eliminating the `return undefined;` at the beginning of `LegacyToNew.forBytecode`, which meant also changing where it was invoked.  Fortunately, this function, though exported, is only presently used in `LegacyToNew.forContract`, so that was simple to update.

(*Arguably* that's a breaking change...?  I'm going to just not worry about it unless someone thinks I should.)

The other change was a nonfunctional change made just to satisfy Typescript.  That's it!