### PR TITLE
Add POA Core to sourcify fetcher

### DIFF
--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -65,7 +65,7 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
       "kovan-optimistic": "api-kovan-optimistic.etherscan.io",
       "goerli-optimistic": "api-goerli-optimism.etherscan.io", //yes this one is different!
       "arbitrum": "api.arbiscan.io",
-      "rinkeby-arbitrum": "api-testnet.arbiscan.io",
+      "rinkeby-arbitrum": "api-testnet.arbiscan.io", //hidden now, but it still works!
       "goerli-arbitrum": "api-goerli.arbiscan.io",
       "polygon": "api.polygonscan.com",
       "mumbai-polygon": "api-mumbai.polygonscan.com",

--- a/packages/source-fetcher/lib/networks.ts
+++ b/packages/source-fetcher/lib/networks.ts
@@ -17,7 +17,7 @@ export const networkNamesById: { [id: number]: string } = {
   80001: "mumbai-polygon",
   100: "gnosis", //formerly known as xdai
   300: "optimism-gnosis", //optimism on gnosis, not vice versa
-  99: "poa", //not presently supported by either fetcher, but...
+  99: "core-poa",
   77: "sokol-poa",
   56: "binance",
   97: "testnet-binance",

--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -56,7 +56,7 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "mumbai-polygon",
     "gnosis",
     "optimism-gnosis",
-    //sourcify does *not* support poa core...?
+    "core-poa",
     "sokol-poa",
     "binance",
     "testnet-binance",


### PR DESCRIPTION
Sourcify has added support for POA Core, so this PR adds that.  Note I already had it listed in `networks.ts` even though neither fetcher supported it.  I decided to rename it though from "poa" to "core-poa" as I've never seen it referred to as just "POA", only ever as "POA Core".  So yeah!

...also I added a comment about how Etherscan still supports Arbitrum Rinkeby even if they've hidden it. :P