### PR TITLE
Increase timeout on docker tags test

### DIFF
--- a/packages/core/test/lib/commands/compile.js
+++ b/packages/core/test/lib/commands/compile.js
@@ -100,7 +100,7 @@ describe("compile", function () {
     });
 
     it("prints a list of docker tags", async function () {
-      this.timeout(8000);
+      this.timeout(12000);
       const options = {
         list: "docker"
       };


### PR DESCRIPTION
CI has been timing out a bunch recently, but this particular test seems to be doing so especially often.  Upping it.