### PR TITLE
Further increase timeout on docker tag test

### DIFF
--- a/packages/core/test/lib/commands/compile.js
+++ b/packages/core/test/lib/commands/compile.js
@@ -100,7 +100,7 @@ describe("compile", function () {
     });
 
     it("prints a list of docker tags", async function () {
-      this.timeout(12000);
+      this.timeout(20000);
       const options = {
         list: "docker"
       };


### PR DESCRIPTION
It seems 12 seconds still wasn't enough.  Let's give it 20.