### PR TITLE
update gh-actions to use node 16

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -19,8 +19,10 @@ jobs:
   yarncheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - run: npm install -g yarn
       - run: yarn install --ignore-scripts --ignore-engines
       - run: test -z "$(git diff)" || (echo 'Please run yarn and commit all changes to yarn.lock'; false)
@@ -44,9 +46,9 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
 

--- a/packages/core/test/lib/commands/compile.js
+++ b/packages/core/test/lib/commands/compile.js
@@ -100,7 +100,9 @@ describe("compile", function () {
     });
 
     it("prints a list of docker tags", async function () {
-      this.timeout(20000);
+      this.timeout(
+        60000 * 2  // oh boy!
+      );
       const options = {
         list: "docker"
       };


### PR DESCRIPTION
## PR description

This PR bumps our action dependencies to address the following warnings for the `build` and `yarncheck` jobs:

> [yarncheck | build](https://github.com/trufflesuite/truffle/actions/runs/3304923000/jobs/5454669430)
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/setup-node, actions/setup-node, actions/checkout

## Notes
- [x] This PR also ups the timeout of [a unit test](https://github.com/trufflesuite/truffle/blob/gh/actions-bump/packages/core/test/lib/commands/compile.js#L103) because of #5639 

## Documentation

- [x] no documentation updates are required.
