### PR TITLE
Internal improvement: return cleanup callback from sandbox test utility and update tests

### DIFF
--- a/packages/truffle/test/scenarios/commandRunner.js
+++ b/packages/truffle/test/scenarios/commandRunner.js
@@ -70,7 +70,6 @@ module.exports = {
         data = data.toString().replace(/\n$/, "");
         shouldLog && Log(data, true);
         config.logger.log(data);
-        console.log(data);
       });
 
       child.on("close", code => {

--- a/packages/truffle/test/scenarios/commandRunner.js
+++ b/packages/truffle/test/scenarios/commandRunner.js
@@ -70,6 +70,7 @@ module.exports = {
         data = data.toString().replace(/\n$/, "");
         shouldLog && Log(data, true);
         config.logger.log(data);
+        console.log(data);
       });
 
       child.on("close", code => {

--- a/packages/truffle/test/scenarios/commands/build.js
+++ b/packages/truffle/test/scenarios/commands/build.js
@@ -6,7 +6,7 @@ const path = require("path");
 
 describe("truffle build [ @standalone ]", () => {
   const logger = new MemoryLogger();
-  let config, project;
+  let config, project, cleanupCallback;
 
   describe("when there is no build script in config", () => {
     beforeEach("set up sandbox", async function () {
@@ -14,8 +14,12 @@ describe("truffle build [ @standalone ]", () => {
         __dirname,
         "../../sources/build/projectWithoutBuildScript"
       );
-      config = await sandbox.create(project);
+      ({ config, cleanupCallback } = await sandbox.create(project));
       config.logger = logger;
+    });
+
+    afterEach(function () {
+      cleanupCallback();
     });
 
     it("should not error", async () => {
@@ -39,8 +43,12 @@ describe("truffle build [ @standalone ]", () => {
         __dirname,
         "../../sources/build/projectWithBuildScript"
       );
-      config = await sandbox.create(project);
+      ({ config, cleanupCallback } = await sandbox.create(project));
       config.logger = logger;
+    });
+
+    afterEach(function () {
+      cleanupCallback();
     });
 
     it("runs the build script", async function () {
@@ -56,8 +64,12 @@ describe("truffle build [ @standalone ]", () => {
         __dirname,
         "../../sources/build/projectWithObjectInBuildScript"
       );
-      config = await sandbox.create(project);
+      ({ config, cleanupCallback } = await sandbox.create(project));
       config.logger = logger;
+    });
+
+    afterEach(function () {
+      cleanupCallback();
     });
 
     it("tells the user it shouldn't use an object", async function () {

--- a/packages/truffle/test/scenarios/commands/build.js
+++ b/packages/truffle/test/scenarios/commands/build.js
@@ -6,7 +6,7 @@ const path = require("path");
 
 describe("truffle build [ @standalone ]", () => {
   const logger = new MemoryLogger();
-  let config, project, cleanupCallback;
+  let config, project, cleanupSandboxDir;
 
   describe("when there is no build script in config", () => {
     beforeEach("set up sandbox", async function () {
@@ -14,12 +14,12 @@ describe("truffle build [ @standalone ]", () => {
         __dirname,
         "../../sources/build/projectWithoutBuildScript"
       );
-      ({ config, cleanupCallback } = await sandbox.create(project));
+      ({ config, cleanupSandboxDir } = await sandbox.create(project));
       config.logger = logger;
     });
 
     afterEach(function () {
-      cleanupCallback();
+      cleanupSandboxDir();
     });
 
     it("should not error", async () => {
@@ -43,12 +43,12 @@ describe("truffle build [ @standalone ]", () => {
         __dirname,
         "../../sources/build/projectWithBuildScript"
       );
-      ({ config, cleanupCallback } = await sandbox.create(project));
+      ({ config, cleanupSandboxDir } = await sandbox.create(project));
       config.logger = logger;
     });
 
     afterEach(function () {
-      cleanupCallback();
+      cleanupSandboxDir();
     });
 
     it("runs the build script", async function () {
@@ -64,12 +64,12 @@ describe("truffle build [ @standalone ]", () => {
         __dirname,
         "../../sources/build/projectWithObjectInBuildScript"
       );
-      ({ config, cleanupCallback } = await sandbox.create(project));
+      ({ config, cleanupSandboxDir } = await sandbox.create(project));
       config.logger = logger;
     });
 
     afterEach(function () {
-      cleanupCallback();
+      cleanupSandboxDir();
     });
 
     it("tells the user it shouldn't use an object", async function () {

--- a/packages/truffle/test/scenarios/commands/compile.js
+++ b/packages/truffle/test/scenarios/commands/compile.js
@@ -6,15 +6,16 @@ const { assert } = require("chai");
 const Server = require("../server");
 
 describe("truffle compile", function () {
-  let config;
+  let config, cleanupCallback;
   const project = path.join(__dirname, "../../sources/toyProject");
 
   before(async () => {
     await Server.start();
-    config = await sandbox.create(project);
+    ({ config, cleanupCallback } = await sandbox.create(project));
   });
   after(async function () {
     await Server.stop();
+    cleanupCallback();
   });
 
   it("compiles", async function () {

--- a/packages/truffle/test/scenarios/commands/compile.js
+++ b/packages/truffle/test/scenarios/commands/compile.js
@@ -6,16 +6,16 @@ const { assert } = require("chai");
 const Server = require("../server");
 
 describe("truffle compile", function () {
-  let config, cleanupCallback;
+  let config, cleanupSandboxDir;
   const project = path.join(__dirname, "../../sources/toyProject");
 
   before(async () => {
     await Server.start();
-    ({ config, cleanupCallback } = await sandbox.create(project));
+    ({ config, cleanupSandboxDir } = await sandbox.create(project));
   });
   after(async function () {
     await Server.stop();
-    cleanupCallback();
+    cleanupSandboxDir();
   });
 
   it("compiles", async function () {

--- a/packages/truffle/test/scenarios/commands/console.js
+++ b/packages/truffle/test/scenarios/commands/console.js
@@ -7,7 +7,7 @@ const sandbox = require("../sandbox");
 const tmp = require("tmp");
 
 describe("truffle console", () => {
-  let config;
+  let config, cleanupCallback;
   const logger = new MemoryLogger();
   const project = path.join(__dirname, "../../sources/console");
 
@@ -15,9 +15,13 @@ describe("truffle console", () => {
   after(async () => await Server.stop());
 
   beforeEach(async () => {
-    config = await sandbox.create(project);
+    ({ config, cleanupCallback } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
+  });
+
+  afterEach(function () {
+    cleanupCallback();
   });
 
   describe("when runs with network option with a config", () => {

--- a/packages/truffle/test/scenarios/commands/console.js
+++ b/packages/truffle/test/scenarios/commands/console.js
@@ -7,7 +7,7 @@ const sandbox = require("../sandbox");
 const tmp = require("tmp");
 
 describe("truffle console", () => {
-  let config, cleanupCallback;
+  let config, cleanupSandboxDir;
   const logger = new MemoryLogger();
   const project = path.join(__dirname, "../../sources/console");
 
@@ -15,13 +15,13 @@ describe("truffle console", () => {
   after(async () => await Server.stop());
 
   beforeEach(async () => {
-    ({ config, cleanupCallback } = await sandbox.create(project));
+    ({ config, cleanupSandboxDir } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
   });
 
   afterEach(function () {
-    cleanupCallback();
+    cleanupSandboxDir();
   });
 
   describe("when runs with network option with a config", () => {
@@ -53,9 +53,15 @@ describe("truffle console", () => {
         __dirname,
         "../../sources/consoleWithConflicts"
       );
-      config = await sandbox.create(projectWithConflicts);
+      ({ config, cleanupSandboxDir } = await sandbox.create(
+        projectWithConflicts
+      ));
       config.network = "development";
       config.logger = logger;
+    });
+
+    afterEach(function () {
+      cleanupSandboxDir();
     });
 
     it("warns the user", async function () {

--- a/packages/truffle/test/scenarios/commands/debug.js
+++ b/packages/truffle/test/scenarios/commands/debug.js
@@ -7,17 +7,20 @@ const sandbox = require("../sandbox");
 const tmp = require("tmp");
 
 describe("truffle debug", () => {
-  let config;
+  let config, cleanupCallback;
   const logger = new MemoryLogger();
   const project = path.join(__dirname, "../../sources/debug");
 
   before(async () => {
-    config = await sandbox.create(project);
+    ({ config, cleanupCallback } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
     await Server.start();
   });
-  after(async () => await Server.stop());
+  after(async () => {
+    await Server.stop();
+    cleanupCallback();
+  });
 
   describe("when run with network option with a config", () => {
     it("displays the network name in the prompt", async () => {

--- a/packages/truffle/test/scenarios/commands/debug.js
+++ b/packages/truffle/test/scenarios/commands/debug.js
@@ -7,19 +7,19 @@ const sandbox = require("../sandbox");
 const tmp = require("tmp");
 
 describe("truffle debug", () => {
-  let config, cleanupCallback;
+  let config, cleanupSandboxDir;
   const logger = new MemoryLogger();
   const project = path.join(__dirname, "../../sources/debug");
 
   before(async () => {
-    ({ config, cleanupCallback } = await sandbox.create(project));
+    ({ config, cleanupSandboxDir } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
     await Server.start();
   });
   after(async () => {
     await Server.stop();
-    cleanupCallback();
+    cleanupSandboxDir();
   });
 
   describe("when run with network option with a config", () => {

--- a/packages/truffle/test/scenarios/commands/deploy.js
+++ b/packages/truffle/test/scenarios/commands/deploy.js
@@ -4,18 +4,18 @@ const Server = require("../server");
 const path = require("path");
 
 describe("truffle deploy (alias for migrate)", () => {
-  let config, projectPath, cleanupCallback;
+  let config, projectPath, cleanupSandboxDir;
 
   before(async function () {
     projectPath = path.join(__dirname, "../../sources/migrations/init");
-    ({ config, cleanupCallback } = await sandbox.create(projectPath));
+    ({ config, cleanupSandboxDir } = await sandbox.create(projectPath));
     config.network = "development";
     config.logger = { log: () => {} };
     await Server.start();
   });
   after(async function () {
     await Server.stop();
-    cleanupCallback();
+    cleanupSandboxDir();
   });
 
   describe("when run on the most basic truffle project", () => {

--- a/packages/truffle/test/scenarios/commands/deploy.js
+++ b/packages/truffle/test/scenarios/commands/deploy.js
@@ -4,17 +4,18 @@ const Server = require("../server");
 const path = require("path");
 
 describe("truffle deploy (alias for migrate)", () => {
-  let config, projectPath;
+  let config, projectPath, cleanupCallback;
 
   before(async function () {
     projectPath = path.join(__dirname, "../../sources/migrations/init");
-    config = await sandbox.create(projectPath);
+    ({ config, cleanupCallback } = await sandbox.create(projectPath));
     config.network = "development";
     config.logger = { log: () => {} };
     await Server.start();
   });
   after(async function () {
     await Server.stop();
+    cleanupCallback();
   });
 
   describe("when run on the most basic truffle project", () => {

--- a/packages/truffle/test/scenarios/commands/develop.js
+++ b/packages/truffle/test/scenarios/commands/develop.js
@@ -5,7 +5,7 @@ const assert = require("assert");
 const sandbox = require("../sandbox");
 
 const logger = new MemoryLogger();
-let config, project;
+let config, project, cleanupCallback;
 
 //prepare a helpful message to standout in CI log noise
 const formatLines = lines =>
@@ -19,9 +19,13 @@ describe("truffle develop", function () {
 
   before(async function () {
     this.timeout(10000);
-    config = await sandbox.create(project);
+    ({ config, cleanupCallback } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
+  });
+
+  after(function () {
+    cleanupCallback();
   });
 
   describe("Globals", function () {

--- a/packages/truffle/test/scenarios/commands/develop.js
+++ b/packages/truffle/test/scenarios/commands/develop.js
@@ -5,7 +5,7 @@ const assert = require("assert");
 const sandbox = require("../sandbox");
 
 const logger = new MemoryLogger();
-let config, project, cleanupCallback;
+let config, project, cleanupSandboxDir;
 
 //prepare a helpful message to standout in CI log noise
 const formatLines = lines =>
@@ -19,13 +19,13 @@ describe("truffle develop", function () {
 
   before(async function () {
     this.timeout(10000);
-    ({ config, cleanupCallback } = await sandbox.create(project));
+    ({ config, cleanupSandboxDir } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
   });
 
   after(function () {
-    cleanupCallback();
+    cleanupSandboxDir();
   });
 
   describe("Globals", function () {

--- a/packages/truffle/test/scenarios/commands/exec.js
+++ b/packages/truffle/test/scenarios/commands/exec.js
@@ -7,20 +7,20 @@ const Server = require("../server");
 const sandbox = require("../sandbox");
 
 describe("truffle exec [ @standalone ]", function () {
-  let config, cleanupCallback;
+  let config, cleanupSandboxDir;
   const project = path.join(__dirname, "../../sources/exec");
   const logger = new MemoryLogger();
 
   beforeEach(async function () {
     this.timeout(10000);
-    ({ config, cleanupCallback } = await sandbox.create(project));
+    ({ config, cleanupSandboxDir } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
     await Server.start();
   });
 
   afterEach(function () {
-    cleanupCallback();
+    cleanupSandboxDir();
   });
 
   after(async function () {

--- a/packages/truffle/test/scenarios/commands/exec.js
+++ b/packages/truffle/test/scenarios/commands/exec.js
@@ -7,17 +7,22 @@ const Server = require("../server");
 const sandbox = require("../sandbox");
 
 describe("truffle exec [ @standalone ]", function () {
-  let config;
+  let config, cleanupCallback;
   const project = path.join(__dirname, "../../sources/exec");
   const logger = new MemoryLogger();
 
   beforeEach(async function () {
     this.timeout(10000);
-    config = await sandbox.create(project);
+    ({ config, cleanupCallback } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
     await Server.start();
   });
+
+  afterEach(function () {
+    cleanupCallback();
+  });
+
   after(async function () {
     await Server.stop();
   });

--- a/packages/truffle/test/scenarios/commands/migrate.js
+++ b/packages/truffle/test/scenarios/commands/migrate.js
@@ -5,11 +5,11 @@ const path = require("path");
 const { assert } = require("chai");
 
 describe("truffle migrate", () => {
-  let config, projectPath, cleanupCallback;
+  let config, projectPath, cleanupSandboxDir;
 
   before(async function () {
     projectPath = path.join(__dirname, "../../sources/migrations/init");
-    ({ config, cleanupCallback } = await sandbox.create(projectPath));
+    ({ config, cleanupSandboxDir } = await sandbox.create(projectPath));
     config.network = "development";
     config.logger = {
       log: function (stuffToLog) {
@@ -21,7 +21,7 @@ describe("truffle migrate", () => {
   });
   after(async function () {
     await Server.stop();
-    cleanupCallback();
+    cleanupSandboxDir();
   });
 
   describe("when run on the most basic truffle project", () => {

--- a/packages/truffle/test/scenarios/commands/migrate.js
+++ b/packages/truffle/test/scenarios/commands/migrate.js
@@ -5,11 +5,11 @@ const path = require("path");
 const { assert } = require("chai");
 
 describe("truffle migrate", () => {
-  let config, projectPath;
+  let config, projectPath, cleanupCallback;
 
   before(async function () {
     projectPath = path.join(__dirname, "../../sources/migrations/init");
-    config = await sandbox.create(projectPath);
+    ({ config, cleanupCallback } = await sandbox.create(projectPath));
     config.network = "development";
     config.logger = {
       log: function (stuffToLog) {
@@ -21,6 +21,7 @@ describe("truffle migrate", () => {
   });
   after(async function () {
     await Server.stop();
+    cleanupCallback();
   });
 
   describe("when run on the most basic truffle project", () => {

--- a/packages/truffle/test/scenarios/commands/networks.js
+++ b/packages/truffle/test/scenarios/commands/networks.js
@@ -5,19 +5,19 @@ const sandbox = require("../sandbox");
 const path = require("path");
 
 describe("truffle networks", () => {
-  let config, projectPath, cleanupCallback;
+  let config, projectPath, cleanupSandboxDir;
 
   before(async function () {
     this.timeout(10000);
     projectPath = path.join(__dirname, "../../sources/networks/metacoin");
-    ({ cleanupCallback, config } = await sandbox.create(projectPath));
+    ({ cleanupSandboxDir, config } = await sandbox.create(projectPath));
     config.network = "development";
     config.logger = { log: () => {} };
     await Server.start();
   });
   after(async function () {
     await Server.stop();
-    cleanupCallback();
+    cleanupSandboxDir();
   });
 
   describe("when run on a simple project", () => {

--- a/packages/truffle/test/scenarios/commands/networks.js
+++ b/packages/truffle/test/scenarios/commands/networks.js
@@ -5,18 +5,19 @@ const sandbox = require("../sandbox");
 const path = require("path");
 
 describe("truffle networks", () => {
-  let config, projectPath;
+  let config, projectPath, cleanupCallback;
 
   before(async function () {
     this.timeout(10000);
     projectPath = path.join(__dirname, "../../sources/networks/metacoin");
-    config = await sandbox.create(projectPath);
+    ({ cleanupCallback, config } = await sandbox.create(projectPath));
     config.network = "development";
     config.logger = { log: () => {} };
     await Server.start();
   });
   after(async function () {
     await Server.stop();
+    cleanupCallback();
   });
 
   describe("when run on a simple project", () => {

--- a/packages/truffle/test/scenarios/commands/obtain.js
+++ b/packages/truffle/test/scenarios/commands/obtain.js
@@ -6,7 +6,7 @@ const path = require("path");
 const assert = require("assert");
 const sandbox = require("../sandbox");
 
-let logger, config, project, compilersCacheDirectory, cleanupCallback;
+let logger, config, project, compilersCacheDirectory, cleanupSandboxDir;
 
 describe("truffle obtain", function () {
   project = path.join(__dirname, "../../sources/obtain");
@@ -18,7 +18,7 @@ describe("truffle obtain", function () {
       "node_modules"
     );
     this.timeout(10000);
-    ({ cleanupCallback, config } = await sandbox.create(project));
+    ({ cleanupSandboxDir, config } = await sandbox.create(project));
     logger = new MemoryLogger();
     config.logger = logger;
 
@@ -32,7 +32,7 @@ describe("truffle obtain", function () {
     if (fse.existsSync(compilersCacheDirectory)) {
       fse.removeSync(compilersCacheDirectory);
     }
-    cleanupCallback();
+    cleanupSandboxDir();
   });
 
   it("fetches the solc version specified", async function () {

--- a/packages/truffle/test/scenarios/commands/obtain.js
+++ b/packages/truffle/test/scenarios/commands/obtain.js
@@ -6,7 +6,7 @@ const path = require("path");
 const assert = require("assert");
 const sandbox = require("../sandbox");
 
-let logger, config, project, compilersCacheDirectory;
+let logger, config, project, compilersCacheDirectory, cleanupCallback;
 
 describe("truffle obtain", function () {
   project = path.join(__dirname, "../../sources/obtain");
@@ -18,7 +18,7 @@ describe("truffle obtain", function () {
       "node_modules"
     );
     this.timeout(10000);
-    config = await sandbox.create(project);
+    ({ cleanupCallback, config } = await sandbox.create(project));
     logger = new MemoryLogger();
     config.logger = logger;
 
@@ -32,6 +32,7 @@ describe("truffle obtain", function () {
     if (fse.existsSync(compilersCacheDirectory)) {
       fse.removeSync(compilersCacheDirectory);
     }
+    cleanupCallback();
   });
 
   it("fetches the solc version specified", async function () {

--- a/packages/truffle/test/scenarios/commands/preserve.js
+++ b/packages/truffle/test/scenarios/commands/preserve.js
@@ -5,18 +5,18 @@ const sandbox = require("../sandbox");
 const path = require("path");
 
 const logger = new MemoryLogger();
-let config, project, cleanupCallback;
+let config, project, cleanupSandboxDir;
 
 const loadSandboxLogger = async function (source) {
   project = path.join(__dirname, source);
-  ({ cleanupCallback, config } = await sandbox.load(project));
+  ({ cleanupSandboxDir, config } = await sandbox.load(project));
   config.logger = logger;
   return config;
 };
 
 describe("truffle preserve [ @standalone @>=12 ]", () => {
   afterEach(function () {
-    cleanupCallback();
+    cleanupSandboxDir();
   });
 
   // These tests are basically duplicates from "truffle run", but for "truffle preserve"

--- a/packages/truffle/test/scenarios/commands/preserve.js
+++ b/packages/truffle/test/scenarios/commands/preserve.js
@@ -5,20 +5,16 @@ const sandbox = require("../sandbox");
 const path = require("path");
 
 const logger = new MemoryLogger();
-let config, project, cleanupSandboxDir;
+let config, project;
 
 const loadSandboxLogger = async function (source) {
   project = path.join(__dirname, source);
-  ({ cleanupSandboxDir, config } = await sandbox.load(project));
+  config = await sandbox.load(project);
   config.logger = logger;
   return config;
 };
 
 describe("truffle preserve [ @standalone @>=12 ]", () => {
-  afterEach(function () {
-    cleanupSandboxDir();
-  });
-
   // These tests are basically duplicates from "truffle run", but for "truffle preserve"
   describe("plugin error handling", () => {
     it("throws when plugins are configured but not installed", async () => {

--- a/packages/truffle/test/scenarios/commands/preserve.js
+++ b/packages/truffle/test/scenarios/commands/preserve.js
@@ -5,16 +5,20 @@ const sandbox = require("../sandbox");
 const path = require("path");
 
 const logger = new MemoryLogger();
-let config, project;
+let config, project, cleanupCallback;
 
 const loadSandboxLogger = async function (source) {
   project = path.join(__dirname, source);
-  config = await sandbox.load(project);
+  ({ cleanupCallback, config } = await sandbox.load(project));
   config.logger = logger;
   return config;
 };
 
 describe("truffle preserve [ @standalone @>=12 ]", () => {
+  afterEach(function () {
+    cleanupCallback();
+  });
+
   // These tests are basically duplicates from "truffle run", but for "truffle preserve"
   describe("plugin error handling", () => {
     it("throws when plugins are configured but not installed", async () => {

--- a/packages/truffle/test/scenarios/commands/run.js
+++ b/packages/truffle/test/scenarios/commands/run.js
@@ -5,19 +5,15 @@ const sandbox = require("../sandbox");
 const path = require("path");
 
 const logger = new MemoryLogger();
-let config, cleanupSandboxDir, project;
+let config, project;
 
 const loadSandboxLogger = async function (source) {
   project = path.join(__dirname, source);
-  ({ config, cleanupSandboxDir } = await sandbox.load(project));
+  config = await sandbox.load(project);
   config.logger = logger;
 };
 
 describe("truffle run [ @standalone ]", () => {
-  afterEach(function () {
-    cleanupSandboxDir();
-  });
-
   describe("when run without arguments", () => {
     beforeEach(async function () {
       return await loadSandboxLogger("../../sources/run/mockProjectWithPlugin");

--- a/packages/truffle/test/scenarios/commands/run.js
+++ b/packages/truffle/test/scenarios/commands/run.js
@@ -5,17 +5,17 @@ const sandbox = require("../sandbox");
 const path = require("path");
 
 const logger = new MemoryLogger();
-let config, cleanupCallback, project;
+let config, cleanupSandboxDir, project;
 
 const loadSandboxLogger = async function (source) {
   project = path.join(__dirname, source);
-  ({ config, cleanupCallback } = await sandbox.load(project));
+  ({ config, cleanupSandboxDir } = await sandbox.load(project));
   config.logger = logger;
 };
 
 describe("truffle run [ @standalone ]", () => {
   afterEach(function () {
-    cleanupCallback();
+    cleanupSandboxDir();
   });
 
   describe("when run without arguments", () => {

--- a/packages/truffle/test/scenarios/commands/test.js
+++ b/packages/truffle/test/scenarios/commands/test.js
@@ -6,17 +6,18 @@ const { assert } = require("chai");
 const Server = require("../server");
 
 describe("truffle test", function () {
-  let config;
+  let config, cleanupCallback;
   const logger = new MemoryLogger();
   const project = path.join(__dirname, "../../sources/toyProject");
 
   before(async () => {
     await Server.start();
-    config = await sandbox.create(project);
+    ({ cleanupCallback, config } = await sandbox.create(project));
     config.logger = logger;
   });
   after(async function () {
     await Server.stop();
+    cleanupCallback();
   });
 
   it("runs tests", async function () {

--- a/packages/truffle/test/scenarios/commands/test.js
+++ b/packages/truffle/test/scenarios/commands/test.js
@@ -6,18 +6,18 @@ const { assert } = require("chai");
 const Server = require("../server");
 
 describe("truffle test", function () {
-  let config, cleanupCallback;
+  let config, cleanupSandboxDir;
   const logger = new MemoryLogger();
   const project = path.join(__dirname, "../../sources/toyProject");
 
   before(async () => {
     await Server.start();
-    ({ cleanupCallback, config } = await sandbox.create(project));
+    ({ cleanupSandboxDir, config } = await sandbox.create(project));
     config.logger = logger;
   });
   after(async function () {
     await Server.stop();
-    cleanupCallback();
+    cleanupSandboxDir();
   });
 
   it("runs tests", async function () {

--- a/packages/truffle/test/scenarios/commands/unbox.js
+++ b/packages/truffle/test/scenarios/commands/unbox.js
@@ -12,6 +12,7 @@ describe("truffle unbox [ @standalone ]", () => {
 
   beforeEach(() => {
     tempDir = tmp.dirSync({ unsafeCleanup: true });
+    cleanupSandboxDir = tempDir.removeCallback;
     config = { working_directory: tempDir.name };
     config.logger = logger;
     config = Config.default().merge(config);

--- a/packages/truffle/test/scenarios/commands/unbox.js
+++ b/packages/truffle/test/scenarios/commands/unbox.js
@@ -7,7 +7,7 @@ const path = require("path");
 const Config = require("@truffle/config");
 
 describe("truffle unbox [ @standalone ]", () => {
-  let config, tempDir;
+  let config, cleanupCallback, tempDir;
   const logger = new MemoryLogger();
 
   beforeEach(() => {
@@ -15,6 +15,10 @@ describe("truffle unbox [ @standalone ]", () => {
     config = { working_directory: tempDir.name };
     config.logger = logger;
     config = Config.default().merge(config);
+  });
+
+  afterEach(function () {
+    cleanupCallback();
   });
 
   describe("when run without arguments", () => {

--- a/packages/truffle/test/scenarios/commands/unbox.js
+++ b/packages/truffle/test/scenarios/commands/unbox.js
@@ -7,7 +7,7 @@ const path = require("path");
 const Config = require("@truffle/config");
 
 describe("truffle unbox [ @standalone ]", () => {
-  let config, cleanupCallback, tempDir;
+  let config, cleanupSandboxDir, tempDir;
   const logger = new MemoryLogger();
 
   beforeEach(() => {
@@ -18,7 +18,7 @@ describe("truffle unbox [ @standalone ]", () => {
   });
 
   afterEach(function () {
-    cleanupCallback();
+    cleanupSandboxDir();
   });
 
   describe("when run without arguments", () => {

--- a/packages/truffle/test/scenarios/compile/compile.js
+++ b/packages/truffle/test/scenarios/compile/compile.js
@@ -9,7 +9,7 @@ const { connect } = require("@truffle/db");
 const gql = require("graphql-tag");
 const pascalCase = require("pascal-case");
 const Config = require("@truffle/config");
-let config, artifactPaths, initialTimes, finalTimes, output;
+let config, artifactPaths, initialTimes, finalTimes, output, cleanupCallback;
 
 describe("repeated compilation of contracts with inheritance [ @standalone ]", function () {
   const mapping = {};
@@ -73,7 +73,7 @@ describe("repeated compilation of contracts with inheritance [ @standalone ]", f
 
   beforeEach("set up sandbox and do initial compile", async function () {
     this.timeout(30000);
-    config = await sandbox.create(project);
+    ({ config, cleanupCallback } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
 
@@ -101,6 +101,10 @@ describe("repeated compilation of contracts with inheritance [ @standalone ]", f
 
     // mTime resolution on 6.9.1 is 1 sec.
     await waitSecond();
+  });
+
+  afterEach(function () {
+    cleanupCallback();
   });
 
   // -------------Inheritance Graph -----------------------------
@@ -340,7 +344,7 @@ describe("compilation with db enabled", async () => {
     this.timeout(30000);
 
     project = path.join(__dirname, "../../sources/db_enabled");
-    config = await sandbox.create(project);
+    ({ config, cleanupCallback } = await sandbox.create(project));
 
     try {
       await CommandRunner.run("compile", config);
@@ -349,6 +353,10 @@ describe("compilation with db enabled", async () => {
       console.log(output);
       throw new Error(error);
     }
+  });
+
+  afterEach(function () {
+    cleanupCallback();
   });
 
   it("creates a populated .db directory when db is enabled", async function () {

--- a/packages/truffle/test/scenarios/compile/compile.js
+++ b/packages/truffle/test/scenarios/compile/compile.js
@@ -9,7 +9,7 @@ const { connect } = require("@truffle/db");
 const gql = require("graphql-tag");
 const pascalCase = require("pascal-case");
 const Config = require("@truffle/config");
-let config, artifactPaths, initialTimes, finalTimes, output, cleanupCallback;
+let config, artifactPaths, initialTimes, finalTimes, output, cleanupSandboxDir;
 
 describe("repeated compilation of contracts with inheritance [ @standalone ]", function () {
   const mapping = {};
@@ -73,7 +73,7 @@ describe("repeated compilation of contracts with inheritance [ @standalone ]", f
 
   beforeEach("set up sandbox and do initial compile", async function () {
     this.timeout(30000);
-    ({ config, cleanupCallback } = await sandbox.create(project));
+    ({ config, cleanupSandboxDir } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
 
@@ -104,7 +104,7 @@ describe("repeated compilation of contracts with inheritance [ @standalone ]", f
   });
 
   afterEach(function () {
-    cleanupCallback();
+    cleanupSandboxDir();
   });
 
   // -------------Inheritance Graph -----------------------------
@@ -344,7 +344,7 @@ describe("compilation with db enabled", async () => {
     this.timeout(30000);
 
     project = path.join(__dirname, "../../sources/db_enabled");
-    ({ config, cleanupCallback } = await sandbox.create(project));
+    ({ config, cleanupSandboxDir } = await sandbox.create(project));
 
     try {
       await CommandRunner.run("compile", config);
@@ -356,7 +356,7 @@ describe("compilation with db enabled", async () => {
   });
 
   afterEach(function () {
-    cleanupCallback();
+    cleanupSandboxDir();
   });
 
   it("creates a populated .db directory when db is enabled", async function () {

--- a/packages/truffle/test/scenarios/compile/vyper-compile.js
+++ b/packages/truffle/test/scenarios/compile/vyper-compile.js
@@ -9,7 +9,12 @@ const log = console.log;
 
 //NOTE: this file is copypasted with modifications from compile.js
 describe("Repeated compilation of Vyper contracts with imports [ @standalone ]", function () {
-  let config, cleanupCallback, artifactPaths, initialTimes, finalTimes, output;
+  let config,
+    cleanupSandboxDir,
+    artifactPaths,
+    initialTimes,
+    finalTimes,
+    output;
   const mapping = {};
 
   const project = path.join(__dirname, "../../sources/vyper-imports");
@@ -62,7 +67,7 @@ describe("Repeated compilation of Vyper contracts with imports [ @standalone ]",
   beforeEach("set up sandbox and do initial compile", async function () {
     this.timeout(30000);
 
-    ({ config, cleanupCallback } = await sandbox.create(project));
+    ({ config, cleanupSandboxDir } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
 
@@ -93,7 +98,7 @@ describe("Repeated compilation of Vyper contracts with imports [ @standalone ]",
   });
 
   afterEach(function () {
-    cleanupCallback();
+    cleanupSandboxDir();
   });
 
   // -------------Inheritance Graph -------

--- a/packages/truffle/test/scenarios/compile/vyper-compile.js
+++ b/packages/truffle/test/scenarios/compile/vyper-compile.js
@@ -9,7 +9,7 @@ const log = console.log;
 
 //NOTE: this file is copypasted with modifications from compile.js
 describe("Repeated compilation of Vyper contracts with imports [ @standalone ]", function () {
-  let config, artifactPaths, initialTimes, finalTimes, output;
+  let config, cleanupCallback, artifactPaths, initialTimes, finalTimes, output;
   const mapping = {};
 
   const project = path.join(__dirname, "../../sources/vyper-imports");
@@ -62,8 +62,7 @@ describe("Repeated compilation of Vyper contracts with imports [ @standalone ]",
   beforeEach("set up sandbox and do initial compile", async function () {
     this.timeout(30000);
 
-    const conf = await sandbox.create(project);
-    config = conf;
+    ({ config, cleanupCallback } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
 
@@ -91,6 +90,10 @@ describe("Repeated compilation of Vyper contracts with imports [ @standalone ]",
 
     // mTime resolution on 6.9.1 is 1 sec.
     await waitSecond();
+  });
+
+  afterEach(function () {
+    cleanupCallback();
   });
 
   // -------------Inheritance Graph -------

--- a/packages/truffle/test/scenarios/contract_names/test_imports.js
+++ b/packages/truffle/test/scenarios/contract_names/test_imports.js
@@ -8,19 +8,20 @@ const Server = require("../server");
 const sandbox = require("../sandbox");
 
 describe("Contract names", function () {
-  let config;
+  let config, cleanupCallback;
   const logger = new MemoryLogger();
   const project = path.join(__dirname, "../../sources/contract_names");
 
   before(async function () {
     this.timeout(10000);
-    config = await sandbox.create(project);
+    ({ config, cleanupCallback } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
     await Server.start();
   });
   after(async function () {
     await Server.stop();
+    cleanupCallback();
   });
 
   it("compiles if file names do not match contract names", async function () {

--- a/packages/truffle/test/scenarios/contract_names/test_imports.js
+++ b/packages/truffle/test/scenarios/contract_names/test_imports.js
@@ -8,20 +8,20 @@ const Server = require("../server");
 const sandbox = require("../sandbox");
 
 describe("Contract names", function () {
-  let config, cleanupCallback;
+  let config, cleanupSandboxDir;
   const logger = new MemoryLogger();
   const project = path.join(__dirname, "../../sources/contract_names");
 
   before(async function () {
     this.timeout(10000);
-    ({ config, cleanupCallback } = await sandbox.create(project));
+    ({ config, cleanupSandboxDir } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
     await Server.start();
   });
   after(async function () {
     await Server.stop();
-    cleanupCallback();
+    cleanupSandboxDir();
   });
 
   it("compiles if file names do not match contract names", async function () {

--- a/packages/truffle/test/scenarios/cyclic_dependencies/compiles.js
+++ b/packages/truffle/test/scenarios/cyclic_dependencies/compiles.js
@@ -7,11 +7,13 @@ const Ganache = require("ganache");
 const sandbox = require("../sandbox");
 
 describe("Cyclic Dependencies [ @standalone ]", function () {
-  let config;
+  let config, cleanupCallback;
   const logger = new MemoryLogger();
 
   before("set up sandbox", async () => {
-    config = await sandbox.create(path.join(__dirname, "../../sources/init"));
+    ({ config, cleanupCallback } = await sandbox.create(
+      path.join(__dirname, "../../sources/init")
+    ));
     config.logger = logger;
     config.networks = {
       development: {
@@ -34,6 +36,10 @@ describe("Cyclic Dependencies [ @standalone ]", function () {
       path.join(__dirname, "Pong.sol"),
       path.join(config.contracts_directory, "Pong.sol")
     );
+  });
+
+  after(function () {
+    cleanupCallback();
   });
 
   it("compiles cyclic dependencies that Solidity is fine with (no `new`'s)", async function () {

--- a/packages/truffle/test/scenarios/cyclic_dependencies/compiles.js
+++ b/packages/truffle/test/scenarios/cyclic_dependencies/compiles.js
@@ -7,11 +7,11 @@ const Ganache = require("ganache");
 const sandbox = require("../sandbox");
 
 describe("Cyclic Dependencies [ @standalone ]", function () {
-  let config, cleanupCallback;
+  let config, cleanupSandboxDir;
   const logger = new MemoryLogger();
 
   before("set up sandbox", async () => {
-    ({ config, cleanupCallback } = await sandbox.create(
+    ({ config, cleanupSandboxDir } = await sandbox.create(
       path.join(__dirname, "../../sources/init")
     ));
     config.logger = logger;
@@ -39,7 +39,7 @@ describe("Cyclic Dependencies [ @standalone ]", function () {
   });
 
   after(function () {
-    cleanupCallback();
+    cleanupSandboxDir();
   });
 
   it("compiles cyclic dependencies that Solidity is fine with (no `new`'s)", async function () {

--- a/packages/truffle/test/scenarios/db/integration.js
+++ b/packages/truffle/test/scenarios/db/integration.js
@@ -7,7 +7,7 @@ const Ganache = require("ganache");
 const sandbox = require("../sandbox");
 const gql = require("graphql-tag");
 const { Resolver } = require("@truffle/resolver");
-let config, server1, server2, run;
+let config, cleanupSandboxDir, server1, server2, run;
 
 describe("truffle db", function () {
   // we really don't need to test this when running CI against Geth - there is
@@ -17,7 +17,7 @@ describe("truffle db", function () {
   before(async function () {
     this.timeout(60000);
     const projectPath = path.join(__dirname, "..", "..", "sources", "db");
-    config = await sandbox.create(projectPath);
+    ({ config, cleanupSandboxDir } = await sandbox.create(projectPath));
     server1 = await Ganache.server({
       logging: {
         quiet: true
@@ -38,6 +38,7 @@ describe("truffle db", function () {
   });
 
   after(async function () {
+    cleanupSandboxDir();
     await server1.close();
     await server2.close();
   });

--- a/packages/truffle/test/scenarios/external_compilers/truffle-compile.js
+++ b/packages/truffle/test/scenarios/external_compilers/truffle-compile.js
@@ -12,20 +12,20 @@ describe("`truffle compile` as external", function () {
   // You can run them locally with `CI=true npm test`
   if (!process.env.CI) return;
 
-  let config, cleanupCallback;
+  let config, cleanupSandboxDir;
   const project = path.join(__dirname, "../../sources/external_compile");
   const logger = new MemoryLogger();
 
   before(async function () {
     this.timeout(10000);
     await Server.start();
-    ({ cleanupCallback, config } = await sandbox.create(project));
+    ({ cleanupSandboxDir, config } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
   });
   after(async function () {
     await Server.stop();
-    cleanupCallback();
+    cleanupSandboxDir();
   });
 
   it("compiles", async function () {

--- a/packages/truffle/test/scenarios/external_compilers/truffle-compile.js
+++ b/packages/truffle/test/scenarios/external_compilers/truffle-compile.js
@@ -12,19 +12,20 @@ describe("`truffle compile` as external", function () {
   // You can run them locally with `CI=true npm test`
   if (!process.env.CI) return;
 
-  let config;
+  let config, cleanupCallback;
   const project = path.join(__dirname, "../../sources/external_compile");
   const logger = new MemoryLogger();
 
   before(async function () {
     this.timeout(10000);
     await Server.start();
-    config = await sandbox.create(project);
+    ({ cleanupCallback, config } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
   });
   after(async function () {
     await Server.stop();
+    cleanupCallback();
   });
 
   it("compiles", async function () {

--- a/packages/truffle/test/scenarios/genesis_time/genesis_time_invalid.js
+++ b/packages/truffle/test/scenarios/genesis_time/genesis_time_invalid.js
@@ -8,7 +8,7 @@ const fs = require("fs-extra");
 
 describe("Genesis time config for truffle test, failing tests [ @standalone ]", function () {
   const logger = new MemoryLogger();
-  let config;
+  let config, cleanupCallback;
 
   before(async function () {
     await Server.start();
@@ -24,11 +24,15 @@ describe("Genesis time config for truffle test, failing tests [ @standalone ]", 
         __dirname,
         "../../sources/genesis_time/genesis_time_invalid"
       );
-      config = await sandbox.create(project);
+      ({ config, cleanupCallback } = await sandbox.create(project));
       config.network = "test";
       config.logger = logger;
       // create test directory
       await fs.ensureDir(config.test_directory);
+    });
+
+    after(function () {
+      cleanupCallback();
     });
 
     it("runs test and output whines about invalid date", async function () {

--- a/packages/truffle/test/scenarios/genesis_time/genesis_time_invalid.js
+++ b/packages/truffle/test/scenarios/genesis_time/genesis_time_invalid.js
@@ -8,7 +8,7 @@ const fs = require("fs-extra");
 
 describe("Genesis time config for truffle test, failing tests [ @standalone ]", function () {
   const logger = new MemoryLogger();
-  let config, cleanupCallback;
+  let config, cleanupSandboxDir;
 
   before(async function () {
     await Server.start();
@@ -24,7 +24,7 @@ describe("Genesis time config for truffle test, failing tests [ @standalone ]", 
         __dirname,
         "../../sources/genesis_time/genesis_time_invalid"
       );
-      ({ config, cleanupCallback } = await sandbox.create(project));
+      ({ config, cleanupSandboxDir } = await sandbox.create(project));
       config.network = "test";
       config.logger = logger;
       // create test directory
@@ -32,7 +32,7 @@ describe("Genesis time config for truffle test, failing tests [ @standalone ]", 
     });
 
     after(function () {
-      cleanupCallback();
+      cleanupSandboxDir();
     });
 
     it("runs test and output whines about invalid date", async function () {

--- a/packages/truffle/test/scenarios/genesis_time/genesis_time_undefined.js
+++ b/packages/truffle/test/scenarios/genesis_time/genesis_time_undefined.js
@@ -8,7 +8,7 @@ const fs = require("fs-extra");
 
 describe("Genesis time config for truffle test, option undefined [ @standalone ]", function () {
   const logger = new MemoryLogger();
-  let config, cleanupCallback;
+  let config, cleanupSandboxDir;
 
   before(async function () {
     await Server.start();
@@ -24,14 +24,14 @@ describe("Genesis time config for truffle test, option undefined [ @standalone ]
         __dirname,
         "../../sources/genesis_time/genesis_time_undefined"
       );
-      ({ config, cleanupCallback } = await sandbox.create(project));
+      ({ config, cleanupSandboxDir } = await sandbox.create(project));
       config.network = "test";
       config.logger = logger;
       // create test dir
       await fs.ensureDir(config.test_directory);
     });
     after(function () {
-      cleanupCallback();
+      cleanupSandboxDir();
     });
 
     it("runs test and doesn't whine about invalid date", async function () {

--- a/packages/truffle/test/scenarios/genesis_time/genesis_time_undefined.js
+++ b/packages/truffle/test/scenarios/genesis_time/genesis_time_undefined.js
@@ -8,7 +8,7 @@ const fs = require("fs-extra");
 
 describe("Genesis time config for truffle test, option undefined [ @standalone ]", function () {
   const logger = new MemoryLogger();
-  let config;
+  let config, cleanupCallback;
 
   before(async function () {
     await Server.start();
@@ -24,11 +24,14 @@ describe("Genesis time config for truffle test, option undefined [ @standalone ]
         __dirname,
         "../../sources/genesis_time/genesis_time_undefined"
       );
-      config = await sandbox.create(project);
+      ({ config, cleanupCallback } = await sandbox.create(project));
       config.network = "test";
       config.logger = logger;
       // create test dir
       await fs.ensureDir(config.test_directory);
+    });
+    after(function () {
+      cleanupCallback();
     });
 
     it("runs test and doesn't whine about invalid date", async function () {

--- a/packages/truffle/test/scenarios/genesis_time/genesis_time_valid.js
+++ b/packages/truffle/test/scenarios/genesis_time/genesis_time_valid.js
@@ -7,7 +7,7 @@ const fs = require("fs-extra");
 
 describe("Genesis time config for truffle test, passing tests [ @standalone ]", function () {
   const logger = new MemoryLogger();
-  let config, cleanupCallback;
+  let config, cleanupSandboxDir;
 
   before(async function () {
     await Server.start();
@@ -23,7 +23,7 @@ describe("Genesis time config for truffle test, passing tests [ @standalone ]", 
         __dirname,
         "../../sources/genesis_time/genesis_time_valid"
       );
-      ({ config, cleanupCallback } = await sandbox.create(project));
+      ({ config, cleanupSandboxDir } = await sandbox.create(project));
       config.network = "test";
       config.logger = logger;
       // create test dir
@@ -31,7 +31,7 @@ describe("Genesis time config for truffle test, passing tests [ @standalone ]", 
     });
 
     after(function () {
-      cleanupCallback();
+      cleanupSandboxDir();
     });
 
     it("runs test and won't error", async function () {

--- a/packages/truffle/test/scenarios/genesis_time/genesis_time_valid.js
+++ b/packages/truffle/test/scenarios/genesis_time/genesis_time_valid.js
@@ -7,7 +7,7 @@ const fs = require("fs-extra");
 
 describe("Genesis time config for truffle test, passing tests [ @standalone ]", function () {
   const logger = new MemoryLogger();
-  let config;
+  let config, cleanupCallback;
 
   before(async function () {
     await Server.start();
@@ -23,11 +23,15 @@ describe("Genesis time config for truffle test, passing tests [ @standalone ]", 
         __dirname,
         "../../sources/genesis_time/genesis_time_valid"
       );
-      config = await sandbox.create(project);
+      ({ config, cleanupCallback } = await sandbox.create(project));
       config.network = "test";
       config.logger = logger;
       // create test dir
       await fs.ensureDir(config.test_directory);
+    });
+
+    after(function () {
+      cleanupCallback();
     });
 
     it("runs test and won't error", async function () {

--- a/packages/truffle/test/scenarios/javascript_testing/assertions.js
+++ b/packages/truffle/test/scenarios/javascript_testing/assertions.js
@@ -6,19 +6,20 @@ const Server = require("../server");
 const sandbox = require("../sandbox");
 
 describe("Javascript testing", function () {
-  let config;
+  let config, cleanupCallback;
   const project = path.join(__dirname, "../../sources/javascript_testing");
   const logger = new MemoryLogger();
 
   before(async function () {
     this.timeout(10000);
-    config = await sandbox.create(project);
+    ({ config, cleanupCallback } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
     await Server.start();
   });
   after(async function () {
     await Server.stop();
+    cleanupCallback();
   });
 
   it("allows use of isAddress", async function () {

--- a/packages/truffle/test/scenarios/javascript_testing/assertions.js
+++ b/packages/truffle/test/scenarios/javascript_testing/assertions.js
@@ -6,20 +6,20 @@ const Server = require("../server");
 const sandbox = require("../sandbox");
 
 describe("Javascript testing", function () {
-  let config, cleanupCallback;
+  let config, cleanupSandboxDir;
   const project = path.join(__dirname, "../../sources/javascript_testing");
   const logger = new MemoryLogger();
 
   before(async function () {
     this.timeout(10000);
-    ({ config, cleanupCallback } = await sandbox.create(project));
+    ({ config, cleanupSandboxDir } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
     await Server.start();
   });
   after(async function () {
     await Server.stop();
-    cleanupCallback();
+    cleanupSandboxDir();
   });
 
   it("allows use of isAddress", async function () {

--- a/packages/truffle/test/scenarios/migrations/deferred-chain.js
+++ b/packages/truffle/test/scenarios/migrations/deferred-chain.js
@@ -6,7 +6,7 @@ const Server = require("../server");
 const sandbox = require("../sandbox");
 
 describe("migrate (empty)", function () {
-  let config;
+  let config, cleanupCallback;
   const project = path.join(
     __dirname,
     "../../sources/migrations/deferred-chain"
@@ -16,12 +16,13 @@ describe("migrate (empty)", function () {
   before(async function () {
     this.timeout(10000);
     await Server.start();
-    config = await sandbox.create(project);
+    ({ config, cleanupCallback } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
   });
   after(async function () {
     await Server.stop();
+    cleanupCallback();
   });
 
   it("Correctly handles control flow on rejection in deployment", async function () {

--- a/packages/truffle/test/scenarios/migrations/deferred-chain.js
+++ b/packages/truffle/test/scenarios/migrations/deferred-chain.js
@@ -6,7 +6,7 @@ const Server = require("../server");
 const sandbox = require("../sandbox");
 
 describe("migrate (empty)", function () {
-  let config, cleanupCallback;
+  let config, cleanupSandboxDir;
   const project = path.join(
     __dirname,
     "../../sources/migrations/deferred-chain"
@@ -16,13 +16,13 @@ describe("migrate (empty)", function () {
   before(async function () {
     this.timeout(10000);
     await Server.start();
-    ({ config, cleanupCallback } = await sandbox.create(project));
+    ({ config, cleanupSandboxDir } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
   });
   after(async function () {
     await Server.stop();
-    cleanupCallback();
+    cleanupSandboxDir();
   });
 
   it("Correctly handles control flow on rejection in deployment", async function () {

--- a/packages/truffle/test/scenarios/migrations/describe-json.js
+++ b/packages/truffle/test/scenarios/migrations/describe-json.js
@@ -76,12 +76,12 @@ function verifyMigrationStatuses(statuses, deployingStatusString) {
 }
 
 describe("truffle migrate --describe-json", () => {
-  let config, projectPath;
+  let config, projectPath, cleanupCallback;
   let logger = new MemoryLogger();
 
   before(async function () {
     projectPath = path.join(__dirname, "../../sources/migrations/init");
-    config = await sandbox.create(projectPath);
+    ({ cleanupCallback, config } = await sandbox.create(projectPath));
     config.network = "development";
     config.logger = logger;
     await Server.start();
@@ -89,6 +89,7 @@ describe("truffle migrate --describe-json", () => {
 
   after(async function () {
     await Server.stop();
+    cleanupCallback();
   });
 
   describe("when run on the most basic truffle project without --describe-json", () => {
@@ -128,9 +129,13 @@ describe("truffle migrate --describe-json", () => {
 
       before(async () => {
         projectPath = path.join(__dirname, "../../sources/migrations/init");
-        config = await sandbox.create(projectPath);
+        ({ config, cleanupCallback } = await sandbox.create(projectPath));
         config.network = "development";
         config.logger = logger;
+      });
+
+      after(function () {
+        cleanupCallback();
       });
 
       it("runs the migration without throwing", async () => {

--- a/packages/truffle/test/scenarios/migrations/describe-json.js
+++ b/packages/truffle/test/scenarios/migrations/describe-json.js
@@ -76,12 +76,12 @@ function verifyMigrationStatuses(statuses, deployingStatusString) {
 }
 
 describe("truffle migrate --describe-json", () => {
-  let config, projectPath, cleanupCallback;
+  let config, projectPath, cleanupSandboxDir;
   let logger = new MemoryLogger();
 
   before(async function () {
     projectPath = path.join(__dirname, "../../sources/migrations/init");
-    ({ cleanupCallback, config } = await sandbox.create(projectPath));
+    ({ cleanupSandboxDir, config } = await sandbox.create(projectPath));
     config.network = "development";
     config.logger = logger;
     await Server.start();
@@ -89,7 +89,7 @@ describe("truffle migrate --describe-json", () => {
 
   after(async function () {
     await Server.stop();
-    cleanupCallback();
+    cleanupSandboxDir();
   });
 
   describe("when run on the most basic truffle project without --describe-json", () => {
@@ -129,13 +129,13 @@ describe("truffle migrate --describe-json", () => {
 
       before(async () => {
         projectPath = path.join(__dirname, "../../sources/migrations/init");
-        ({ config, cleanupCallback } = await sandbox.create(projectPath));
+        ({ config, cleanupSandboxDir } = await sandbox.create(projectPath));
         config.network = "development";
         config.logger = logger;
       });
 
       after(function () {
-        cleanupCallback();
+        cleanupSandboxDir();
       });
 
       it("runs the migration without throwing", async () => {

--- a/packages/truffle/test/scenarios/migrations/dryrun.js
+++ b/packages/truffle/test/scenarios/migrations/dryrun.js
@@ -6,19 +6,20 @@ const Server = require("../server");
 const sandbox = require("../sandbox");
 
 describe("migrate (dry-run)", function () {
-  let config;
+  let config, cleanupCallback;
   const project = path.join(__dirname, "../../sources/migrations/success");
   const logger = new MemoryLogger();
 
   before(async function () {
     this.timeout(10000);
     await Server.start();
-    config = await sandbox.create(project);
+    ({ config, cleanupCallback } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
   });
   after(async function () {
     await Server.stop();
+    cleanupCallback();
   });
 
   it("uses the dry-run option", async function () {

--- a/packages/truffle/test/scenarios/migrations/dryrun.js
+++ b/packages/truffle/test/scenarios/migrations/dryrun.js
@@ -6,20 +6,20 @@ const Server = require("../server");
 const sandbox = require("../sandbox");
 
 describe("migrate (dry-run)", function () {
-  let config, cleanupCallback;
+  let config, cleanupSandboxDir;
   const project = path.join(__dirname, "../../sources/migrations/success");
   const logger = new MemoryLogger();
 
   before(async function () {
     this.timeout(10000);
     await Server.start();
-    ({ config, cleanupCallback } = await sandbox.create(project));
+    ({ config, cleanupSandboxDir } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
   });
   after(async function () {
     await Server.stop();
-    cleanupCallback();
+    cleanupSandboxDir();
   });
 
   it("uses the dry-run option", async function () {

--- a/packages/truffle/test/scenarios/migrations/empty.js
+++ b/packages/truffle/test/scenarios/migrations/empty.js
@@ -6,20 +6,20 @@ const Server = require("../server");
 const sandbox = require("../sandbox");
 
 describe("migrate (empty)", function () {
-  let config, cleanupCallback;
+  let config, cleanupSandboxDir;
   const project = path.join(__dirname, "../../sources/migrations/empty");
   const logger = new MemoryLogger();
 
   before(async function () {
     this.timeout(10000);
     await Server.start();
-    ({ config, cleanupCallback } = await sandbox.create(project));
+    ({ config, cleanupSandboxDir } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
   });
   after(async function () {
     await Server.stop();
-    cleanupCallback();
+    cleanupSandboxDir();
   });
 
   it("indicates no ETH was spent on migration", async function () {

--- a/packages/truffle/test/scenarios/migrations/empty.js
+++ b/packages/truffle/test/scenarios/migrations/empty.js
@@ -6,19 +6,20 @@ const Server = require("../server");
 const sandbox = require("../sandbox");
 
 describe("migrate (empty)", function () {
-  let config;
+  let config, cleanupCallback;
   const project = path.join(__dirname, "../../sources/migrations/empty");
   const logger = new MemoryLogger();
 
   before(async function () {
     this.timeout(10000);
     await Server.start();
-    config = await sandbox.create(project);
+    ({ config, cleanupCallback } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
   });
   after(async function () {
     await Server.stop();
+    cleanupCallback();
   });
 
   it("indicates no ETH was spent on migration", async function () {

--- a/packages/truffle/test/scenarios/migrations/errors.js
+++ b/packages/truffle/test/scenarios/migrations/errors.js
@@ -6,20 +6,20 @@ const Server = require("../server");
 const sandbox = require("../sandbox");
 
 describe("migration errors", function () {
-  let config;
-  let networkId;
+  let config, networkId, cleanupCallback;
   const project = path.join(__dirname, "../../sources/migrations/error");
   const logger = new MemoryLogger(true);
 
   before(async function () {
     this.timeout(10000);
     await Server.start();
-    config = await sandbox.create(project);
+    ({ config, cleanupCallback } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
   });
   after(async function () {
     await Server.stop();
+    cleanupCallback();
   });
 
   it("errors and stops", async function () {

--- a/packages/truffle/test/scenarios/migrations/errors.js
+++ b/packages/truffle/test/scenarios/migrations/errors.js
@@ -6,20 +6,20 @@ const Server = require("../server");
 const sandbox = require("../sandbox");
 
 describe("migration errors", function () {
-  let config, networkId, cleanupCallback;
+  let config, networkId, cleanupSandboxDir;
   const project = path.join(__dirname, "../../sources/migrations/error");
   const logger = new MemoryLogger(true);
 
   before(async function () {
     this.timeout(10000);
     await Server.start();
-    ({ config, cleanupCallback } = await sandbox.create(project));
+    ({ config, cleanupSandboxDir } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
   });
   after(async function () {
     await Server.stop();
-    cleanupCallback();
+    cleanupSandboxDir();
   });
 
   it("errors and stops", async function () {

--- a/packages/truffle/test/scenarios/migrations/fabric-evm.js
+++ b/packages/truffle/test/scenarios/migrations/fabric-evm.js
@@ -8,12 +8,12 @@ const { createInterfaceAdapter } = require("@truffle/interface-adapter");
 
 describe("migrate with [ @fabric-evm ] interface", () => {
   if (!process.env.FABRICEVM) return;
-  let config, interfaceAdapter, networkId, cleanupCallback;
+  let config, interfaceAdapter, networkId, cleanupSandboxDir;
   const project = path.join(__dirname, "../../sources/migrations/fabric-evm");
   const logger = new MemoryLogger();
 
   before(async () => {
-    ({ config, cleanupCallback } = await sandbox.create(project));
+    ({ config, cleanupSandboxDir } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
     const provider = new Web3.providers.HttpProvider("http://localhost:5000", {
@@ -28,7 +28,7 @@ describe("migrate with [ @fabric-evm ] interface", () => {
   });
 
   after(function () {
-    cleanupCallback();
+    cleanupSandboxDir();
   });
 
   it("runs migrations (sync & async/await)", async () => {

--- a/packages/truffle/test/scenarios/migrations/fabric-evm.js
+++ b/packages/truffle/test/scenarios/migrations/fabric-evm.js
@@ -8,14 +8,12 @@ const { createInterfaceAdapter } = require("@truffle/interface-adapter");
 
 describe("migrate with [ @fabric-evm ] interface", () => {
   if (!process.env.FABRICEVM) return;
-  let config;
-  let interfaceAdapter;
-  let networkId;
+  let config, interfaceAdapter, networkId, cleanupCallback;
   const project = path.join(__dirname, "../../sources/migrations/fabric-evm");
   const logger = new MemoryLogger();
 
   before(async () => {
-    config = await sandbox.create(project);
+    ({ config, cleanupCallback } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
     const provider = new Web3.providers.HttpProvider("http://localhost:5000", {
@@ -27,6 +25,10 @@ describe("migrate with [ @fabric-evm ] interface", () => {
       networkType: "fabric-evm"
     });
     networkId = await interfaceAdapter.getNetworkId();
+  });
+
+  after(function () {
+    cleanupCallback();
   });
 
   it("runs migrations (sync & async/await)", async () => {

--- a/packages/truffle/test/scenarios/migrations/migrate.js
+++ b/packages/truffle/test/scenarios/migrations/migrate.js
@@ -7,7 +7,7 @@ const sandbox = require("../sandbox");
 const Web3 = require("web3");
 
 describe("migrate (success)", function () {
-  let config;
+  let config, cleanupCallback;
   let web3;
   let networkId;
   const project = path.join(__dirname, "../../sources/migrations/success");
@@ -16,7 +16,7 @@ describe("migrate (success)", function () {
   before(async function () {
     this.timeout(10000);
     await Server.start();
-    config = await sandbox.create(project);
+    ({ config, cleanupCallback } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
     web3 = new Web3("http://localhost:8545");
@@ -24,6 +24,7 @@ describe("migrate (success)", function () {
   });
   after(async function () {
     await Server.stop();
+    cleanupCallback();
   });
 
   it("runs migrations (sync & async/await)", async function () {

--- a/packages/truffle/test/scenarios/migrations/migrate.js
+++ b/packages/truffle/test/scenarios/migrations/migrate.js
@@ -7,7 +7,7 @@ const sandbox = require("../sandbox");
 const Web3 = require("web3");
 
 describe("migrate (success)", function () {
-  let config, cleanupCallback;
+  let config, cleanupSandboxDir;
   let web3;
   let networkId;
   const project = path.join(__dirname, "../../sources/migrations/success");
@@ -16,7 +16,7 @@ describe("migrate (success)", function () {
   before(async function () {
     this.timeout(10000);
     await Server.start();
-    ({ config, cleanupCallback } = await sandbox.create(project));
+    ({ config, cleanupSandboxDir } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
     web3 = new Web3("http://localhost:8545");
@@ -24,7 +24,7 @@ describe("migrate (success)", function () {
   });
   after(async function () {
     await Server.stop();
-    cleanupCallback();
+    cleanupSandboxDir();
   });
 
   it("runs migrations (sync & async/await)", async function () {

--- a/packages/truffle/test/scenarios/migrations/production.js
+++ b/packages/truffle/test/scenarios/migrations/production.js
@@ -62,19 +62,21 @@ describe("production", function () {
   describe("{ production: true, skipDryRun: true } [ @geth ]", function () {
     if (!process.env.GETH) return;
 
-    let config;
-    let web3;
-    let networkId;
+    let config, cleanupSandboxDir, web3, networkId;
     const project = path.join(__dirname, "../../sources/migrations/production");
     const logger = new MemoryLogger();
 
     before(async function () {
       this.timeout(10000);
-      config = await sandbox.create(project);
+      ({ config, cleanupSandboxDir } = await sandbox.create(project));
       config.network = "fakeRopsten";
       config.logger = logger;
       web3 = new Web3("http://localhost:8545");
       networkId = await web3.eth.net.getId();
+    });
+
+    after(function () {
+      cleanupSandboxDir();
     });
 
     it("migrates without dry-run", async function () {

--- a/packages/truffle/test/scenarios/migrations/production.js
+++ b/packages/truffle/test/scenarios/migrations/production.js
@@ -9,19 +9,21 @@ describe("production", function () {
   describe("{ production: true, confirmations: 2 } [ @geth ]", function () {
     if (!process.env.GETH) return;
 
-    let config;
-    let web3;
-    let networkId;
+    let config, cleanupCallback, web3, networkId;
     const project = path.join(__dirname, "../../sources/migrations/production");
     const logger = new MemoryLogger();
 
     before(async function () {
       this.timeout(10000);
-      config = await sandbox.create(project);
+      ({ config, cleanupCallback } = await sandbox.create(project));
       config.network = "ropsten";
       config.logger = logger;
       web3 = new Web3("http://localhost:8545");
       networkId = await web3.eth.net.getId();
+    });
+
+    after(function () {
+      cleanupCallback();
     });
 
     it("auto dry-runs and honors confirmations option", async function () {

--- a/packages/truffle/test/scenarios/migrations/production.js
+++ b/packages/truffle/test/scenarios/migrations/production.js
@@ -9,13 +9,13 @@ describe("production", function () {
   describe("{ production: true, confirmations: 2 } [ @geth ]", function () {
     if (!process.env.GETH) return;
 
-    let config, cleanupCallback, web3, networkId;
+    let config, cleanupSandboxDir, web3, networkId;
     const project = path.join(__dirname, "../../sources/migrations/production");
     const logger = new MemoryLogger();
 
     before(async function () {
       this.timeout(10000);
-      ({ config, cleanupCallback } = await sandbox.create(project));
+      ({ config, cleanupSandboxDir } = await sandbox.create(project));
       config.network = "ropsten";
       config.logger = logger;
       web3 = new Web3("http://localhost:8545");
@@ -23,7 +23,7 @@ describe("production", function () {
     });
 
     after(function () {
-      cleanupCallback();
+      cleanupSandboxDir();
     });
 
     it("auto dry-runs and honors confirmations option", async function () {

--- a/packages/truffle/test/scenarios/migrations/typescript.js
+++ b/packages/truffle/test/scenarios/migrations/typescript.js
@@ -7,14 +7,14 @@ const sandbox = require("../sandbox");
 const Web3 = require("web3");
 
 describe("migrate (typescript)", function () {
-  let config, web3, networkId, cleanupCallback;
+  let config, web3, networkId, cleanupSandboxDir;
   const project = path.join(__dirname, "../../sources/migrations/typescript");
   const logger = new MemoryLogger();
 
   before(async function () {
     this.timeout(10000);
     await Server.start();
-    ({ config, cleanupCallback } = await sandbox.create(project));
+    ({ config, cleanupSandboxDir } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
     web3 = new Web3("http://localhost:8545");
@@ -22,7 +22,7 @@ describe("migrate (typescript)", function () {
   });
   after(async function () {
     await Server.stop();
-    cleanupCallback();
+    cleanupSandboxDir();
   });
 
   it("runs migrations (sync & async/await)", async function () {

--- a/packages/truffle/test/scenarios/migrations/typescript.js
+++ b/packages/truffle/test/scenarios/migrations/typescript.js
@@ -7,16 +7,14 @@ const sandbox = require("../sandbox");
 const Web3 = require("web3");
 
 describe("migrate (typescript)", function () {
-  let config;
-  let web3;
-  let networkId;
+  let config, web3, networkId, cleanupCallback;
   const project = path.join(__dirname, "../../sources/migrations/typescript");
   const logger = new MemoryLogger();
 
   before(async function () {
     this.timeout(10000);
     await Server.start();
-    config = await sandbox.create(project);
+    ({ config, cleanupCallback } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
     web3 = new Web3("http://localhost:8545");
@@ -24,6 +22,7 @@ describe("migrate (typescript)", function () {
   });
   after(async function () {
     await Server.stop();
+    cleanupCallback();
   });
 
   it("runs migrations (sync & async/await)", async function () {

--- a/packages/truffle/test/scenarios/migrations/unhandled-rejection.js
+++ b/packages/truffle/test/scenarios/migrations/unhandled-rejection.js
@@ -6,7 +6,7 @@ const Server = require("../server");
 const sandbox = require("../sandbox");
 
 describe("unhandledRejection detection", function () {
-  let config;
+  let config, cleanupCallback;
   const project = path.join(
     __dirname,
     "../../sources/migrations/unhandled-rejection"
@@ -16,12 +16,13 @@ describe("unhandledRejection detection", function () {
   before(async function () {
     this.timeout(10000);
     await Server.start();
-    config = await sandbox.create(project);
+    ({ config, cleanupCallback } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
   });
   after(async function () {
     await Server.stop();
+    cleanupCallback();
   });
 
   it("should detect unhandled-rejection", async function () {

--- a/packages/truffle/test/scenarios/migrations/unhandled-rejection.js
+++ b/packages/truffle/test/scenarios/migrations/unhandled-rejection.js
@@ -6,7 +6,7 @@ const Server = require("../server");
 const sandbox = require("../sandbox");
 
 describe("unhandledRejection detection", function () {
-  let config, cleanupCallback;
+  let config, cleanupSandboxDir;
   const project = path.join(
     __dirname,
     "../../sources/migrations/unhandled-rejection"
@@ -16,13 +16,13 @@ describe("unhandledRejection detection", function () {
   before(async function () {
     this.timeout(10000);
     await Server.start();
-    ({ config, cleanupCallback } = await sandbox.create(project));
+    ({ config, cleanupSandboxDir } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
   });
   after(async function () {
     await Server.stop();
-    cleanupCallback();
+    cleanupSandboxDir();
   });
 
   it("should detect unhandled-rejection", async function () {

--- a/packages/truffle/test/scenarios/resolver/resolver.js
+++ b/packages/truffle/test/scenarios/resolver/resolver.js
@@ -6,7 +6,7 @@ const Server = require("../server");
 const sandbox = require("../sandbox");
 
 describe("Solidity Imports [ @standalone ]", function () {
-  let config;
+  let config, cleanupCallback;
   const project = path.join(__dirname, "../../sources/monorepo");
   const logger = new MemoryLogger();
 
@@ -47,9 +47,16 @@ describe("Solidity Imports [ @standalone ]", function () {
   describe("success", function () {
     before(async function () {
       this.timeout(10000);
-      config = await sandbox.create(project, "truffleproject");
+      ({ config, cleanupCallback } = await sandbox.create(
+        project,
+        "truffleproject"
+      ));
       config.network = "development";
       config.logger = logger;
+    });
+
+    after(function () {
+      cleanupCallback();
     });
 
     it("resolves solidity imports located outside the working directory", async function () {
@@ -69,9 +76,16 @@ describe("Solidity Imports [ @standalone ]", function () {
   describe("failure", function () {
     before(async function () {
       this.timeout(10000);
-      config = await sandbox.create(project, "errorproject");
+      ({ config, cleanupCallback } = await sandbox.create(
+        project,
+        "errorproject"
+      ));
       config.network = "development";
       config.logger = logger;
+    });
+
+    after(function () {
+      cleanupCallback();
     });
 
     it("exposes compile error if an import is not found", async function () {

--- a/packages/truffle/test/scenarios/resolver/resolver.js
+++ b/packages/truffle/test/scenarios/resolver/resolver.js
@@ -6,7 +6,7 @@ const Server = require("../server");
 const sandbox = require("../sandbox");
 
 describe("Solidity Imports [ @standalone ]", function () {
-  let config, cleanupCallback;
+  let config, cleanupSandboxDir;
   const project = path.join(__dirname, "../../sources/monorepo");
   const logger = new MemoryLogger();
 
@@ -47,7 +47,7 @@ describe("Solidity Imports [ @standalone ]", function () {
   describe("success", function () {
     before(async function () {
       this.timeout(10000);
-      ({ config, cleanupCallback } = await sandbox.create(
+      ({ config, cleanupSandboxDir } = await sandbox.create(
         project,
         "truffleproject"
       ));
@@ -56,7 +56,7 @@ describe("Solidity Imports [ @standalone ]", function () {
     });
 
     after(function () {
-      cleanupCallback();
+      cleanupSandboxDir();
     });
 
     it("resolves solidity imports located outside the working directory", async function () {
@@ -76,7 +76,7 @@ describe("Solidity Imports [ @standalone ]", function () {
   describe("failure", function () {
     before(async function () {
       this.timeout(10000);
-      ({ config, cleanupCallback } = await sandbox.create(
+      ({ config, cleanupSandboxDir } = await sandbox.create(
         project,
         "errorproject"
       ));
@@ -85,7 +85,7 @@ describe("Solidity Imports [ @standalone ]", function () {
     });
 
     after(function () {
-      cleanupCallback();
+      cleanupSandboxDir();
     });
 
     it("exposes compile error if an import is not found", async function () {

--- a/packages/truffle/test/scenarios/sandbox.js
+++ b/packages/truffle/test/scenarios/sandbox.js
@@ -17,7 +17,7 @@ module.exports = {
     );
     return {
       config,
-      cleanupCallback: tempDir.removeCallback
+      cleanupSandboxDir: tempDir.removeCallback
     };
   },
 

--- a/packages/truffle/test/scenarios/sandbox.js
+++ b/packages/truffle/test/scenarios/sandbox.js
@@ -15,7 +15,10 @@ module.exports = {
       path.join(tempDir.name, subPath, "truffle-config.js"),
       {}
     );
-    return config;
+    return {
+      config,
+      cleanupCallback: tempDir.removeCallback
+    };
   },
 
   async load(source) {

--- a/packages/truffle/test/scenarios/solidity_testing/solidityTests.js
+++ b/packages/truffle/test/scenarios/solidity_testing/solidityTests.js
@@ -8,7 +8,7 @@ const sandbox = require("../sandbox");
 
 describe("Solidity Tests", function () {
   const logger = new MemoryLogger();
-  let config;
+  let config, cleanupCallback;
 
   /**
    * Installs a bare truffle project and deposits a solidity test target
@@ -17,7 +17,9 @@ describe("Solidity Tests", function () {
    * @param  {String}   file Solidity test target
    */
   async function initSandbox(file) {
-    config = await sandbox.create(path.join(__dirname, "../../sources/init"));
+    ({ config, cleanupCallback } = await sandbox.create(
+      path.join(__dirname, "../../sources/init")
+    ));
     config.logger = logger;
     config.network = "development";
     const from = path.join(__dirname, file);
@@ -36,6 +38,9 @@ describe("Solidity Tests", function () {
   describe("test with balance", function () {
     before(async () => {
       await initSandbox("TestWithBalance.sol");
+    });
+    after(function () {
+      cleanupCallback();
     });
 
     it("runs the tests and has the correct balance", function () {

--- a/packages/truffle/test/scenarios/solidity_testing/solidityTests.js
+++ b/packages/truffle/test/scenarios/solidity_testing/solidityTests.js
@@ -8,7 +8,7 @@ const sandbox = require("../sandbox");
 
 describe("Solidity Tests", function () {
   const logger = new MemoryLogger();
-  let config, cleanupCallback;
+  let config, cleanupSandboxDir;
 
   /**
    * Installs a bare truffle project and deposits a solidity test target
@@ -17,7 +17,7 @@ describe("Solidity Tests", function () {
    * @param  {String}   file Solidity test target
    */
   async function initSandbox(file) {
-    ({ config, cleanupCallback } = await sandbox.create(
+    ({ config, cleanupSandboxDir } = await sandbox.create(
       path.join(__dirname, "../../sources/init")
     ));
     config.logger = logger;
@@ -40,7 +40,7 @@ describe("Solidity Tests", function () {
       await initSandbox("TestWithBalance.sol");
     });
     after(function () {
-      cleanupCallback();
+      cleanupSandboxDir();
     });
 
     it("runs the tests and has the correct balance", function () {

--- a/packages/truffle/test/scenarios/solidity_testing/testEventsAndMixedTests.js
+++ b/packages/truffle/test/scenarios/solidity_testing/testEventsAndMixedTests.js
@@ -6,20 +6,20 @@ const Server = require("../server");
 const sandbox = require("../sandbox");
 
 describe("TestEvents and mixed sol/js testing", function () {
-  let config, cleanupCallback;
+  let config, cleanupSandboxDir;
   const project = path.join(__dirname, "../../sources/mixed_testing");
   const logger = new MemoryLogger();
 
   before(async function () {
     this.timeout(10000);
     await Server.start();
-    ({ config, cleanupCallback } = await sandbox.create(project));
+    ({ config, cleanupSandboxDir } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
   });
   after(async function () {
     await Server.stop();
-    cleanupCallback();
+    cleanupSandboxDir();
   });
 
   it("will correctly decode events as appropriate", async function () {

--- a/packages/truffle/test/scenarios/solidity_testing/testEventsAndMixedTests.js
+++ b/packages/truffle/test/scenarios/solidity_testing/testEventsAndMixedTests.js
@@ -6,19 +6,20 @@ const Server = require("../server");
 const sandbox = require("../sandbox");
 
 describe("TestEvents and mixed sol/js testing", function () {
-  let config;
+  let config, cleanupCallback;
   const project = path.join(__dirname, "../../sources/mixed_testing");
   const logger = new MemoryLogger();
 
   before(async function () {
     this.timeout(10000);
     await Server.start();
-    config = await sandbox.create(project);
+    ({ config, cleanupCallback } = await sandbox.create(project));
     config.network = "development";
     config.logger = logger;
   });
   after(async function () {
     await Server.stop();
+    cleanupCallback();
   });
 
   it("will correctly decode events as appropriate", async function () {

--- a/packages/truffle/test/scenarios/stacktracing/stacktrace.js
+++ b/packages/truffle/test/scenarios/stacktracing/stacktrace.js
@@ -26,11 +26,11 @@ module.exports = function(deployer) {
 `;
 
 describe("Stack tracing", function () {
-  let config, cleanupCallback;
+  let config, cleanupSandboxDir;
   const logger = new MemoryLogger();
 
   before(async function () {
-    ({ config, cleanupCallback } = await sandbox.create(
+    ({ config, cleanupSandboxDir } = await sandbox.create(
       path.join(__dirname, "../../sources/init")
     ));
     config.network = "development";
@@ -57,7 +57,7 @@ describe("Stack tracing", function () {
   });
   after(async function () {
     await Server.stop();
-    cleanupCallback();
+    cleanupSandboxDir();
   });
 
   it("runs tests and produces stacktraces", async function () {

--- a/packages/truffle/test/scenarios/stacktracing/stacktrace.js
+++ b/packages/truffle/test/scenarios/stacktracing/stacktrace.js
@@ -26,11 +26,13 @@ module.exports = function(deployer) {
 `;
 
 describe("Stack tracing", function () {
-  let config;
+  let config, cleanupCallback;
   const logger = new MemoryLogger();
 
   before(async function () {
-    config = await sandbox.create(path.join(__dirname, "../../sources/init"));
+    ({ config, cleanupCallback } = await sandbox.create(
+      path.join(__dirname, "../../sources/init")
+    ));
     config.network = "development";
     config.logger = logger;
     await fse.ensureDir(config.test_directory);
@@ -55,6 +57,7 @@ describe("Stack tracing", function () {
   });
   after(async function () {
     await Server.stop();
+    cleanupCallback();
   });
 
   it("runs tests and produces stacktraces", async function () {


### PR DESCRIPTION
While performing some testing locally I noticed that some of the temporary test project files were getting left on my computer and not deleted. tmp is supposed to clean up after itself but perhaps in some cases, say when an error is thrown, it doesn't. In order to try and tidy things up, this PR returns the manual cleanup callback from tmp from the sandbox utility. It then adds the call to the cleanup function in all tests that utilize the sandbox utility.