### PR TITLE
Allow adding compilations to an existing `ProjectDecoder`

### DIFF
--- a/packages/codec/lib/compilations/utils.ts
+++ b/packages/codec/lib/compilations/utils.ts
@@ -674,7 +674,8 @@ function projectInfoIsArtifacts(
 }
 
 export function infoToCompilations(
-  projectInfo: ProjectInfo | undefined
+  projectInfo: ProjectInfo | undefined,
+  nonceString?: string
 ): Compilation[] {
   if (!projectInfo) {
     throw new NoProjectInfoError();
@@ -682,8 +683,8 @@ export function infoToCompilations(
   if (projectInfoIsCodecStyle(projectInfo)) {
     return projectInfo.compilations;
   } else if (projectInfoIsCommonStyle(projectInfo)) {
-    return shimCompilations(projectInfo.commonCompilations);
+    return shimCompilations(projectInfo.commonCompilations, nonceString);
   } else if (projectInfoIsArtifacts(projectInfo)) {
-    return shimArtifacts(projectInfo.artifacts);
+    return shimArtifacts(projectInfo.artifacts, undefined, nonceString);
   }
 }

--- a/packages/codec/lib/compilations/utils.ts
+++ b/packages/codec/lib/compilations/utils.ts
@@ -688,3 +688,16 @@ export function infoToCompilations(
     return shimArtifacts(projectInfo.artifacts, undefined, nonceString);
   }
 }
+
+export function findRepeatCompilationId(
+  compilations: Compilation[]
+): string | null {
+  for (let i = 0; i < compilations.length; i++) {
+    for (let j = i + 1; j < compilations.length; j++) {
+      if (compilations[i].id === compilations[j].id) {
+        return compilations[i].id;
+      }
+    }
+  }
+  return null;
+}

--- a/packages/codec/lib/compilations/utils.ts
+++ b/packages/codec/lib/compilations/utils.ts
@@ -689,15 +689,16 @@ export function infoToCompilations(
   }
 }
 
-export function findRepeatCompilationId(
+export function findRepeatCompilationIds(
   compilations: Compilation[]
-): string | null {
+): Set<string> {
+  let repeats: Set<string> = new Set();
   for (let i = 0; i < compilations.length; i++) {
     for (let j = i + 1; j < compilations.length; j++) {
       if (compilations[i].id === compilations[j].id) {
-        return compilations[i].id;
+        repeats.add(compilations[i].id);
       }
     }
   }
-  return null;
+  return repeats;
 }

--- a/packages/codec/lib/errors.ts
+++ b/packages/codec/lib/errors.ts
@@ -76,3 +76,16 @@ export class NoProjectInfoError extends Error {
     this.name = "NoProjectInfoError";
   }
 }
+
+/**
+ * This error indicates there was an attempt to add multiple compilations
+ * with the same ID, or a compilation whose ID was already in use.
+ */
+export class RepeatCompilationIdError extends Error {
+  public id: string;
+  constructor(id: string) {
+    super(`Compilation id ${id} already in use.`);
+    this.id = id;
+    this.name = "RepeatCompilationIdError";
+  }
+}

--- a/packages/codec/lib/errors.ts
+++ b/packages/codec/lib/errors.ts
@@ -82,10 +82,10 @@ export class NoProjectInfoError extends Error {
  * with the same ID, or a compilation whose ID was already in use.
  */
 export class RepeatCompilationIdError extends Error {
-  public id: string;
-  constructor(id: string) {
-    super(`Compilation id ${id} already in use.`);
-    this.id = id;
+  public ids: string[];
+  constructor(ids: string[]) {
+    super(`Compilation id(s) ${ids.join(", ")} repeated or already in use.`);
+    this.ids = ids;
     this.name = "RepeatCompilationIdError";
   }
 }

--- a/packages/codec/lib/index.ts
+++ b/packages/codec/lib/index.ts
@@ -77,7 +77,12 @@ export {
   decodeReturndata,
   decodeRevert
 } from "./core";
-export { DecodingError, StopDecodingError, NoProjectInfoError } from "./errors";
+export {
+  DecodingError,
+  StopDecodingError,
+  NoProjectInfoError,
+  RepeatCompilationIdError
+} from "./errors";
 
 //now: what types should we export? (other than the ones from ./format)
 //public-facing types for the interface

--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -167,7 +167,9 @@ export class ProjectDecoder {
 
     const { contexts, deployedContexts, contractsAndContexts, allocationInfo } =
       AbiData.Allocate.Utils.collectAllocationInfo(compilations);
-    Object.assign(this.contexts, contexts);
+    this.contexts = Object.assign(contexts, this.contexts); //HACK: we want to
+    //prioritize new contexts over old contexts, so we do this.  a proper timestamp
+    //system would be better, but this should hopefully do for now.
     Object.assign(this.deployedContexts, deployedContexts);
     this.contractsAndContexts = [
       ...this.contractsAndContexts,

--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -68,6 +68,8 @@ export class ProjectDecoder {
 
   private ensSettings: DecoderTypes.EnsSettings;
 
+  private addProjectInfoNonce: number = 0;
+
   /**
    * @protected
    */
@@ -223,6 +225,30 @@ export class ProjectDecoder {
       userDefinedTypes,
       this.allocations.abi //we're doing this for merged result, so use merged input!
     );
+  }
+
+  /**
+   * **This function is asynchronous.**
+   *
+   * Adds additional compilations to the decoder like [[addCompilations]],
+   * but allows it to be specified in more general forms.
+   *
+   * @param projectInfo Information about the additional compilations or
+   * contracts to be decoded.  This may come in several forms; see the type
+   * documentation for more information.  If passing in `{ compilations: ... }`,
+   * take care that the compilations have different IDs from others passed in
+   * so far.  If passed in in another form, an ID will be assigned automatically,
+   * which should generally avoid any collisions.
+   */
+  public async addAdditionalProjectInfo(
+    projectInfo: Compilations.ProjectInfo
+  ): Promise<void> {
+    const compilations = Compilations.Utils.infoToCompilations(
+      projectInfo,
+      `decoderAdditionalShimmedCompilationGroup(${this.addProjectInfoNonce})`
+    );
+    this.addProjectInfoNonce++;
+    await this.addCompilations(compilations);
   }
 
   /**

--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -82,10 +82,10 @@ export class ProjectDecoder {
       throw new NoProviderError();
     }
     //check for repeat compilation IDs
-    const repeatId =
-      Codec.Compilations.Utils.findRepeatCompilationId(compilations);
-    if (repeatId !== null) {
-      throw new Codec.RepeatCompilationIdError(repeatId);
+    const repeatIds =
+      Codec.Compilations.Utils.findRepeatCompilationIds(compilations);
+    if (repeatIds.size !== 0) {
+      throw new Codec.RepeatCompilationIdError([...repeatIds]);
     }
     this.providerAdapter = new ProviderAdapter(provider);
     this.compilations = compilations;
@@ -158,18 +158,17 @@ export class ProjectDecoder {
     const existingIds = new Set(
       this.compilations.map(compilation => compilation.id)
     );
+    const newIds = new Set(compilations.map(compilation => compilation.id));
     //we use a find() rather than a some() so that we can put the ID in the error
-    const conflictingCompilation = compilations.find(compilation =>
-      existingIds.has(compilation.id)
-    );
-    if (conflictingCompilation !== undefined) {
-      throw new Codec.RepeatCompilationIdError(conflictingCompilation.id);
+    const overlappingIds = [...newIds].filter(id => existingIds.has(id));
+    if (overlappingIds.length !== 0) {
+      throw new Codec.RepeatCompilationIdError(overlappingIds);
     }
     //also: check for repeats among the ones we're adding
-    const repeatId =
-      Codec.Compilations.Utils.findRepeatCompilationId(compilations);
-    if (repeatId !== null) {
-      throw new Codec.RepeatCompilationIdError(repeatId);
+    const repeatIds =
+      Codec.Compilations.Utils.findRepeatCompilationIds(compilations);
+    if (repeatIds.size !== 0) {
+      throw new Codec.RepeatCompilationIdError([...repeatIds]);
     }
 
     //now: checks are over, start adding stuff

--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -41,8 +41,7 @@ import {
   VariableNotFoundError,
   MemberNotFoundError,
   ArrayIndexOutOfBoundsError,
-  NoProviderError,
-  RepeatCompilationIdError
+  NoProviderError
 } from "./errors";
 import { Shims } from "@truffle/compile-common";
 //sorry for the untyped import, but...
@@ -83,12 +82,10 @@ export class ProjectDecoder {
       throw new NoProviderError();
     }
     //check for repeat compilation IDs
-    for (let i = 0; i < compilations.length; i++) {
-      for (let j = i + 1; j < compilations.length; j++) {
-        if (compilations[i].id === compilations[j].id) {
-          throw new RepeatCompilationIdError(compilations[i].id);
-        }
-      }
+    const repeatId =
+      Codec.Compilations.Utils.findRepeatCompilationId(compilations);
+    if (repeatId !== null) {
+      throw new Codec.RepeatCompilationIdError(repeatId);
     }
     this.providerAdapter = new ProviderAdapter(provider);
     this.compilations = compilations;
@@ -166,15 +163,13 @@ export class ProjectDecoder {
       existingIds.has(compilation.id)
     );
     if (conflictingCompilation !== undefined) {
-      throw new RepeatCompilationIdError(conflictingCompilation.id);
+      throw new Codec.RepeatCompilationIdError(conflictingCompilation.id);
     }
     //also: check for repeats among the ones we're adding
-    for (let i = 0; i < compilations.length; i++) {
-      for (let j = i + 1; j < compilations.length; j++) {
-        if (compilations[i].id === compilations[j].id) {
-          throw new RepeatCompilationIdError(compilations[i].id);
-        }
-      }
+    const repeatId =
+      Codec.Compilations.Utils.findRepeatCompilationId(compilations);
+    if (repeatId !== null) {
+      throw new Codec.RepeatCompilationIdError(repeatId);
     }
 
     //now: checks are over, start adding stuff

--- a/packages/decoder/lib/errors.ts
+++ b/packages/decoder/lib/errors.ts
@@ -174,16 +174,3 @@ export class NoProviderError extends Error {
     this.name = "NoProviderError";
   }
 }
-
-/**
- * This error indicates there was an attempt to add multiple compilations
- * with the same ID, or a compilation whose ID was already in use.
- */
-export class RepeatCompilationIdError extends Error {
-  public id: string;
-  constructor(id: string) {
-    super(`Compilation id ${id} already in use.`);
-    this.id = id;
-    this.name = "RepeatCompilationIdError";
-  }
-}

--- a/packages/decoder/lib/errors.ts
+++ b/packages/decoder/lib/errors.ts
@@ -174,3 +174,16 @@ export class NoProviderError extends Error {
     this.name = "NoProviderError";
   }
 }
+
+/**
+ * This error indicates there was an attempt to add multiple compilations
+ * with the same ID, or a compilation whose ID was already in use.
+ */
+export class RepeatCompilationIdError extends Error {
+  public id: string;
+  constructor(id: string) {
+    super(`Compilation id ${id} already in use.`);
+    this.id = id;
+    this.name = "RepeatCompilationIdError";
+  }
+}

--- a/packages/decoder/test/current/test/additional-test.js
+++ b/packages/decoder/test/current/test/additional-test.js
@@ -1,0 +1,78 @@
+const debug = require("debug")("decoder:test:additional-test");
+const assert = require("chai").assert;
+const Ganache = require("ganache");
+const path = require("path");
+const Web3 = require("web3");
+
+const Decoder = require("../../..");
+
+const { prepareContracts } = require("../../helpers");
+
+describe("Adding compilations", function () {
+  let provider;
+  let abstractions;
+  let web3;
+
+  let Contracts;
+
+  before("Create Provider", async function () {
+    provider = Ganache.provider({
+      miner: { instamine: "strict" },
+      seed: "decoder",
+      gasLimit: 7000000,
+      logging: { quiet: true }
+    });
+    web3 = new Web3(provider);
+  });
+
+  after(async () => {
+    provider && (await provider.disconnect());
+  });
+
+  before("Prepare contracts and artifacts", async function () {
+    this.timeout(30000);
+
+    const prepared = await prepareContracts(
+      provider,
+      path.resolve(__dirname, "..")
+    );
+    abstractions = prepared.abstractions;
+
+    Contracts = [
+      abstractions.WireTest,
+      abstractions.WireTestParent,
+      abstractions.WireTestLibrary,
+      abstractions.WireTestAbstract
+    ];
+  });
+
+  it("should allow adding compilations", async function () {
+    const deployedContract = await abstractions.WireTestRedHerring.deployed();
+
+    const decoder = await Decoder.forProject({
+      provider: web3.currentProvider,
+      projectInfo: { artifacts: Contracts }
+    });
+
+    //emit an event we can't decode
+    const { receipt } = await deployedContract.run();
+    //attempt to decode it; this should fail
+    const failingEvents = await decoder.events({
+      fromBlock: receipt.blockNumber,
+      toBlock: receipt.blockNumber
+    });
+    assert.lengthOf(failingEvents, 1);
+    assert.lengthOf(failingEvents[0].decodings, 0);
+    //now add more info
+    await decoder.addAdditionalProjectInfo({
+      artifacts: [abstractions.WireTestRedHerring]
+    });
+    //attempt to decode it again, it should succeed
+    const suceedingEvents = await decoder.events({
+      fromBlock: receipt.blockNumber,
+      toBlock: receipt.blockNumber
+    });
+    assert.lengthOf(suceedingEvents, 1);
+    assert.lengthOf(suceedingEvents[0].decodings, 1);
+  });
+});

--- a/packages/decoder/test/current/test/additional-test.js
+++ b/packages/decoder/test/current/test/additional-test.js
@@ -89,6 +89,7 @@ describe("Adding compilations", function () {
       if (error.name !== "RepeatCompilationIdError") {
         throw error; //rethrow unexpected errors
       }
+      assert.lengthOf(error.ids, 1);
     }
   });
 
@@ -106,6 +107,7 @@ describe("Adding compilations", function () {
       if (error.name !== "RepeatCompilationIdError") {
         throw error; //rethrow unexpected errors
       }
+      assert.lengthOf(error.ids, 1);
     }
   });
 
@@ -121,6 +123,7 @@ describe("Adding compilations", function () {
       if (error.name !== "RepeatCompilationIdError") {
         throw error; //rethrow unexpected errors
       }
+      assert.lengthOf(error.ids, 1);
     }
   });
 });

--- a/packages/encoder/lib/encoders.ts
+++ b/packages/encoder/lib/encoders.ts
@@ -97,11 +97,11 @@ export class ProjectEncoder {
         throw new NoInternalInfoError();
       }
       //check for repeat compilation IDs
-      const repeatId = Codec.Compilations.Utils.findRepeatCompilationId(
+      const repeatIds = Codec.Compilations.Utils.findRepeatCompilationIds(
         info.compilations
       );
-      if (repeatId !== null) {
-        throw new Codec.RepeatCompilationIdError(repeatId);
+      if (repeatIds.size !== 0) {
+        throw new Codec.RepeatCompilationIdError([...repeatIds]);
       }
       //since that's good, save it and continue
       this.compilations = info.compilations;

--- a/packages/encoder/lib/encoders.ts
+++ b/packages/encoder/lib/encoders.ts
@@ -96,6 +96,14 @@ export class ProjectEncoder {
       if (!info.compilations) {
         throw new NoInternalInfoError();
       }
+      //check for repeat compilation IDs
+      const repeatId = Codec.Compilations.Utils.findRepeatCompilationId(
+        info.compilations
+      );
+      if (repeatId !== null) {
+        throw new Codec.RepeatCompilationIdError(repeatId);
+      }
+      //since that's good, save it and continue
       this.compilations = info.compilations;
       ({
         definitions: this.referenceDeclarations,


### PR DESCRIPTION
This PR addresses #5602 by making it possible to add compilations to an already existing `ProjectDecoder`.  (It doesn't do this for `ContractDecoder` or `ContractInstanceDecoder`.)  To do this, it adds two methods to `ProjectDecoder`, namely, `addCompilations` and `addAdditionalProjectInfo`.

The `addCompilations` interface assumes you are adding codec-style compilations.  It also assumes that none of these has an ID that collides with the IDs of any of the compilations it already knows about.  It's on the user to ensure that.

The `addAdditionalProjectInfo` interface is more general and allows also adding compile-common style compilations, or just a list of artifacts.  If you use it to add codec-style compilations, it's still up to you to avoid ID collisions.  If you use compile-common style compilations, or just a list of artifacts, then an ID will be assigned; to prevent collisions, I've given the `ProjectDecoder` a new state variable which serves as a nonce to be incorporated into the ID and which is incremented each time you call `addAdditionalProjectInfo`.  I'm not sure how truly robust this system is, but it shouldn't encounter collisions in normal use at least, I figure.

Anyway, how does `addCompilations` work under the hood?  Well, it's mostly pretty simple.  It takes the new compilations and merges them with the existing ones.  Then it performs the various decoder startup computations on the new compilations, and merges the results with what it already has.  Usually the form of the merge is very simple, just `[...old, ...new]` or `{ ...old, ...new}` (actually those latter cases are done as `Object.assign(old, new)` since we intend to alter things here!).  There is one case where it's slightly more complicated, which is calldata allocations, but it's still pretty simple.

There were two cases, however -- returndata allocations and event allocations -- where correctly performing a merge on the results would have been quite difficult.  So to handle those, instead of running the allocation computations on just the new compilations and then merging the results, it instead reruns the relevant computations on the whole set of both old and new compilations.  Oh well, it'll do I figure.

And that's it!  This PR also adds a quick test of this new capability.