### PR TITLE
define how package versioning works for the truffle package

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ Please make pull requests against `develop`.
 
 There is a bit more information in the [CONTRIBUTING.md](./CONTRIBUTING.md) file.
 
+### Versioning
+
+The truffle package itself does not follow Semantic Versioning 2.0.0. Truffle increases its major version when there are breaking changes, the minor version sometimes, and the patch version most of the time.
+
 ### License
 
 [MIT](./LICENSE)


### PR DESCRIPTION
Since truffle doesn't follow Semantic Versioning 2.0.0, which is expected by users of npm, it should define what its versioning scheme is. Let's codify this! This PR will serve this purpose.