### PR TITLE
Add event log to debugger CLI

### DIFF
--- a/packages/core/lib/debug/interpreter.js
+++ b/packages/core/lib/debug/interpreter.js
@@ -619,6 +619,22 @@ class DebugInterpreter {
           await this.printer.printReturnValue();
         }
         break;
+      case "e":
+        if (cmdArgs) {
+          const eventsCount = parseInt(cmdArgs);
+          if (!isNaN(eventsCount) && eventsCount > 0) {
+            this.printer.eventsCount = eventsCount;
+          } else if (cmdArgs === "all") {
+            this.printer.eventsCount = Infinity;
+          } else {
+            this.printer.print(
+              'Invalid event count given, must be positive integer or "all"'
+            );
+            break;
+          }
+        }
+        this.printer.printEvents();
+        break;
       case ":":
         watchExpressionAnalytics(cmdArgs);
         this.printer.evalAndPrintExpression(cmdArgs);
@@ -763,7 +779,8 @@ class DebugInterpreter {
       cmd !== "g" &&
       cmd !== "G" &&
       cmd !== "s" &&
-      cmd !== "y"
+      cmd !== "y" &&
+      cmd !== "e"
     ) {
       this.lastCommand = cmd;
     }

--- a/packages/core/lib/debug/interpreter.js
+++ b/packages/core/lib/debug/interpreter.js
@@ -633,7 +633,11 @@ class DebugInterpreter {
             break;
           }
         }
-        this.printer.printEvents();
+        if (this.session.view(session.status.loaded)) {
+          this.printer.printEvents();
+        } else {
+          this.printer.print("No transaction loaded to print events for.");
+        }
         break;
       case ":":
         watchExpressionAnalytics(cmdArgs);

--- a/packages/core/lib/debug/interpreter.js
+++ b/packages/core/lib/debug/interpreter.js
@@ -761,27 +761,8 @@ class DebugInterpreter {
         this.printer.printHelp(this.lastCommand);
     }
 
-    if (
-      cmd !== "b" &&
-      cmd !== "B" &&
-      cmd !== "v" &&
-      cmd !== "h" &&
-      cmd !== "p" &&
-      cmd !== "l" &&
-      cmd !== "?" &&
-      cmd !== "!" &&
-      cmd !== ":" &&
-      cmd !== "+" &&
-      cmd !== "r" &&
-      cmd !== "-" &&
-      cmd !== "t" &&
-      cmd !== "T" &&
-      cmd !== "g" &&
-      cmd !== "G" &&
-      cmd !== "s" &&
-      cmd !== "y" &&
-      cmd !== "e"
-    ) {
+    const nonRepeatableCommands = "bBvhpl?!:+r-tTgGsye";
+    if (!nonRepeatableCommands.includes(cmd)) {
       this.lastCommand = cmd;
     }
   }

--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -3,6 +3,7 @@ const debug = debugModule("lib:debug:printer");
 
 const path = require("path");
 const util = require("util");
+const OS = require("os");
 
 const DebugUtils = require("@truffle/debug-utils");
 const Codec = require("@truffle/codec");
@@ -667,6 +668,13 @@ class DebugPrinter {
   }
 
   printEvents() {
+    const instances = this.session.view(session.info.affectedInstances); //used to look
+    const formatAddress = address => {
+      const name = instances[address]?.contractName;
+      const colorizedAddress = colors.yellow(address); //dull yellow
+      return name ? `${name}(${colorizedAddress})` : colorizedAddress;
+    };
+    //up what type of contract each address refers to
     const eventsToPrint = this.session
       .view(txlog.views.flattedEvents)
       .slice(-this.eventsCount);
@@ -678,14 +686,16 @@ class DebugPrinter {
       if (!event.status) {
         //mark it reverted if it's been reverted
         this.config.logger.log(
-          DebugUtils.truffleColors.yellow("Reverted event:")
+          DebugUtils.truffleColors.yellow("Reverted event:") //bright yellow :)
         );
       }
       if (event.codeAddress === event.address) {
-        this.config.logger.log(`Emitted by ${event.address}:`);
+        this.config.logger.log(`Emitted by ${formatAddress(event.address)}:`);
       } else {
         this.config.logger.log(
-          `Emitted by ${event.codeAddress} on behalf of ${event.address}:`
+          `Emitted by ${formatAddress(event.codeAddress)}${
+            OS.EOL
+          }on behalf of ${formatAddress(event.address)}:`
         );
       }
       if (event.decoding) {

--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -34,59 +34,61 @@ const verbosePanicTable = {
 };
 
 const commandReference = {
-  o: "step over",
-  i: "step line / step into",
-  u: "step out",
-  n: "step next",
+  "o": "step over",
+  "i": "step line / step into",
+  "u": "step out",
+  "n": "step next",
   ";": "step instruction (include number to step multiple)",
-  p: "print instruction & state (`p [mem|cal|sto]*`; see docs for more)",
-  l: "print additional source context (`l [+<lines-ahead>] [-<lines-back>]`)",
-  h: "print this help",
-  v: "print variables and values (`v [bui|glo|con|loc]*`)",
+  "p": "print instruction & state (`p [mem|cal|sto]*`; see docs for more)",
+  "l": "print additional source context (`l [+<lines-ahead>] [-<lines-back>]`)",
+  "h": "print this help",
+  "v": "print variables and values (`v [bui|glo|con|loc]*`)",
   ":": "evaluate expression - see `v`",
   "+": "add watch expression (`+:<expr>`)",
   "-": "remove watch expression (-:<expr>)",
   "?": "list existing watch expressions and breakpoints",
-  b: "add breakpoint (`b [[<source-file>:]<line-number>]`; see docs for more)",
-  B: "remove breakpoint (similar to adding, or `B all` to remove all)",
-  c: "continue until breakpoint",
-  q: "quit",
-  r: "reset",
-  t: "load new transaction",
-  T: "unload transaction",
-  s: "print stacktrace",
-  g: "turn on generated sources",
-  G: "turn off generated sources except via `;`",
-  y: "(if at end) reset & continue to final error",
-  Y: "reset & continue to previous error"
+  "b": "add breakpoint (`b [[<source-file>:]<line-number>]`; see docs for more)",
+  "B": "remove breakpoint (similar to adding, or `B all` to remove all)",
+  "c": "continue until breakpoint",
+  "q": "quit",
+  "r": "reset",
+  "t": "load new transaction",
+  "T": "unload transaction",
+  "s": "print stacktrace",
+  "g": "turn on generated sources",
+  "G": "turn off generated sources except via `;`",
+  "y": "(if at end) reset & continue to final error",
+  "Y": "reset & continue to previous error",
+  "e": "Print recent events (`e [<number>|all]`)"
 };
 
 const shortCommandReference = {
-  o: "step over",
-  i: "step into",
-  u: "step out",
-  n: "step next",
+  "o": "step over",
+  "i": "step into",
+  "u": "step out",
+  "n": "step next",
   ";": "step instruction",
-  p: "print state",
-  l: "print context",
-  h: "print help",
-  v: "print variables",
+  "p": "print state",
+  "l": "print context",
+  "h": "print help",
+  "v": "print variables",
   ":": "evaluate",
   "+": "add watch",
   "-": "remove watch",
   "?": "list watches & breakpoints",
-  b: "add breakpoint",
-  B: "remove breakpoint",
-  c: "continue",
-  q: "quit",
-  r: "reset",
-  t: "load",
-  T: "unload",
-  s: "stacktrace",
-  g: "turn on generated sources",
-  G: "turn off generated sources",
-  y: "reset & go to final error",
-  Y: "reset & go to previous error"
+  "b": "add breakpoint",
+  "B": "remove breakpoint",
+  "c": "continue",
+  "q": "quit",
+  "r": "reset",
+  "t": "load",
+  "T": "unload",
+  "s": "stacktrace",
+  "g": "turn on generated sources",
+  "G": "turn off generated sources",
+  "y": "reset & go to final error",
+  "Y": "reset & go to previous error",
+  "e": "print event log"
 };
 
 const truffleColors = {
@@ -107,69 +109,69 @@ const DEFAULT_TAB_WIDTH = 8;
 
 const trufflePalette = {
   /* base (chromafi special, not hljs) */
-  base: chalk,
-  lineNumbers: chalk,
-  trailingSpace: chalk,
+  "base": chalk,
+  "lineNumbers": chalk,
+  "trailingSpace": chalk,
   /* classes hljs-solidity actually uses */
-  keyword: truffleColors.mint,
-  number: truffleColors.red,
-  string: truffleColors.green,
-  params: truffleColors.pink,
-  builtIn: truffleColors.watermelon,
-  built_in: truffleColors.watermelon, //just to be sure
-  literal: truffleColors.watermelon,
-  function: truffleColors.orange,
-  title: truffleColors.orange,
-  class: truffleColors.orange,
-  comment: truffleColors.comment,
-  doctag: truffleColors.comment,
-  operator: truffleColors.blue,
-  punctuation: truffleColors.purple,
+  "keyword": truffleColors.mint,
+  "number": truffleColors.red,
+  "string": truffleColors.green,
+  "params": truffleColors.pink,
+  "builtIn": truffleColors.watermelon,
+  "built_in": truffleColors.watermelon, //just to be sure
+  "literal": truffleColors.watermelon,
+  "function": truffleColors.orange,
+  "title": truffleColors.orange,
+  "class": truffleColors.orange,
+  "comment": truffleColors.comment,
+  "doctag": truffleColors.comment,
+  "operator": truffleColors.blue,
+  "punctuation": truffleColors.purple,
   /* classes it might soon use! */
-  meta: truffleColors.pink,
-  metaString: truffleColors.green,
+  "meta": truffleColors.pink,
+  "metaString": truffleColors.green,
   "meta-string": truffleColors.green, //similar
   /* classes it doesn't currently use but notionally could */
-  type: truffleColors.orange,
-  symbol: truffleColors.orange,
-  metaKeyword: truffleColors.mint,
+  "type": truffleColors.orange,
+  "symbol": truffleColors.orange,
+  "metaKeyword": truffleColors.mint,
   "meta-keyword": truffleColors.mint, //again, to be sure
-  property: chalk, //not putting any highlighting here for now
+  "property": chalk, //not putting any highlighting here for now
   /* classes that don't make sense for Solidity */
-  regexp: chalk, //solidity does not have regexps
-  subst: chalk, //or string interpolation
-  name: chalk, //or s-expressions
-  builtInName: chalk, //or s-expressions, again
+  "regexp": chalk, //solidity does not have regexps
+  "subst": chalk, //or string interpolation
+  "name": chalk, //or s-expressions
+  "builtInName": chalk, //or s-expressions, again
   "builtin-name": chalk, //just to be sure
   /* classes for config, markup, CSS, templates, diffs (not programming) */
-  section: chalk,
-  tag: chalk,
-  attr: chalk,
-  attribute: chalk,
-  variable: chalk,
-  bullet: chalk,
-  code: chalk,
-  emphasis: chalk,
-  strong: chalk,
-  formula: chalk,
-  link: chalk,
-  quote: chalk,
-  selectorAttr: chalk, //lotta redundancy follows
+  "section": chalk,
+  "tag": chalk,
+  "attr": chalk,
+  "attribute": chalk,
+  "variable": chalk,
+  "bullet": chalk,
+  "code": chalk,
+  "emphasis": chalk,
+  "strong": chalk,
+  "formula": chalk,
+  "link": chalk,
+  "quote": chalk,
+  "selectorAttr": chalk, //lotta redundancy follows
   "selector-attr": chalk,
-  selectorClass: chalk,
+  "selectorClass": chalk,
   "selector-class": chalk,
-  selectorId: chalk,
+  "selectorId": chalk,
   "selector-id": chalk,
-  selectorPseudo: chalk,
+  "selectorPseudo": chalk,
   "selector-pseudo": chalk,
-  selectorTag: chalk,
+  "selectorTag": chalk,
   "selector-tag": chalk,
-  templateTag: chalk,
+  "templateTag": chalk,
   "template-tag": chalk,
-  templateVariable: chalk,
+  "templateVariable": chalk,
   "template-variable": chalk,
-  addition: chalk,
-  deletion: chalk
+  "addition": chalk,
+  "deletion": chalk
 };
 
 var DebugUtils = {
@@ -355,14 +357,14 @@ var DebugUtils = {
       ["g", "G"],
       ["p"],
       ["l"],
-      ["s", "h"],
+      ["s", "e"],
       ["q", "r", "t", "T"],
       ["b"],
       ["B"],
       ["+", "-"],
       ["?"],
       ["v"],
-      [":"]
+      [":", "h"]
     ].map(function (shortcuts) {
       return shortcuts.map(DebugUtils.formatCommandDescription).join(", ");
     });


### PR DESCRIPTION
Addresses #5323.  This PR adds an event log to the debugger CLI.  It's accessed with the new `e` command.  By default it shows the 3 most recent events.  (Not sure if this is a good default -- anyone have opinions?)  But you can put a number (or `all`) after the `e` to show more or fewer; this setting is then remembered while the debugger stays open.

There's not a lot to say about this PR; the hard work was done a while back.  This just adds a CLI interface.  As mentioned we print the N most recent events; note that this does include reverted events.  For each event we print the decoding (assuming we can decode it) and the address that emitted it.  If it was emitted from a delegatecall, we print both the address of the code that did the emitting, and the address of the contract it was emitted on behalf of.  And if it was reverted, we print "Reverted event:" before it in yellow.

I didn't include any means to print the raw event info.  Maybe that can come later?

There a few other things perhaps worth changing in here.  The decodings are printed in color, but if there's no arguments, there's not a lot of color.  Perhaps the emitting addresses should be colorized?

Also, it would be nice if the addresses had their contract classes beside them.  That might require going back and actually altering the `flattedEvents` selector that this relies on, but it might be worth doing.  Thoughts?  (Edit: Actually, I think I can do it without that, so maybe I should just do this...)

Regardless, I figured I'd put this up in this form and see what people think.

While I was at it, I simplified the non-repeatable-command check.  That was really getting out of hand.

Because this is a debugger CLI PR, I just did manual testing.