### PR TITLE
Bug fix: Console child wait for outstanding promises

### DIFF
--- a/packages/core/lib/console-child.js
+++ b/packages/core/lib/console-child.js
@@ -33,7 +33,11 @@ function main() {
   });
 
   runCommand(command, options)
-    .then(() => process.exit(0))
+    .then(returnStatus => {
+      process.exitCode = returnStatus;
+      return require("@truffle/promise-tracker").waitForOutstandingPromises();
+    })
+    .then(() => process.exit())
     .catch(error => {
       // Perform error handling ourselves.
       if (error instanceof TruffleError) {


### PR DESCRIPTION
`core/lib/console-child.js` should wait for outstanding promises to resolve before exiting, using promise-tracker, [just like `core/cli.js`
](https://github.com/trufflesuite/truffle/blob/v5.6.3/packages/core/cli.js#L81-L85)

This issue is surfaced in [dashboard decoding PR](https://github.com/trufflesuite/truffle/pull/5621), where the browser doesn't have the necessary compilations to decode so it complains by asking the user to `truffle compile --all`, and `compile --all` in a truffle console (connected to dashboard network) doesn't do anything, because the [dashboard message bus client in the event system](https://github.com/trufflesuite/truffle/blob/v5.6.3/packages/events/defaultSubscribers/dashboard.js#L13) doesn't get a chance to send anything over the bus due to the process exiting prematurely.

@gnidan helped me debug this. It's improbable that I could dig this up myself.