### PR TITLE
Simplify/fix when to check for designated invalid function

### DIFF
--- a/packages/source-map-utils/index.js
+++ b/packages/source-map-utils/index.js
@@ -210,10 +210,14 @@ var SourceMapUtils = {
         .map(instruction => {
           debug("instruction %O", instruction);
           const sourceIndex = instruction.file;
-          //first off, a special case: if the file is -1, check for designated
+          const findOverlappingRange = overlapFunctions[sourceIndex];
+          const ast = asts[sourceIndex];
+          //first off, if we can't get the AST, check for designated
           //invalid and if it's not that give up
-          //(designated invalid gets file -1 in some Solidity versions)
-          if (sourceIndex === -1) {
+          //(note that being unable to get the AST includes the case
+          //of source index -1; designated invalid has source index
+          //-1 in some Solidity versions)
+          if (!ast) {
             if (
               SourceMapUtils.isDesignatedInvalid(
                 instructions,
@@ -231,13 +235,6 @@ var SourceMapUtils = {
               //not designated invalid, filter it out
               return {};
             }
-          }
-          //now we proceed with the normal case
-          const findOverlappingRange = overlapFunctions[sourceIndex];
-          const ast = asts[sourceIndex];
-          if (!ast) {
-            //if we can't get the ast... filter it out I guess
-            return {};
           }
           const range = SourceMapUtils.getSourceRange(instruction);
           let { node, pointer } = SourceMapUtils.findRange(


### PR DESCRIPTION
I was going over this code with @cds-amal and realized it could be simplified.  I noticed that when the index is not `-1`, but we don't have an AST, we didn't check for the designated invalid function.  I was like, wait, why don't we?  I should add that check.  And then I realized these could be combined -- if the index is `-1`, then `ast` will necessarily be undefined, so checking if the index is `-1` really doesn't need to be separate.  So, now it's simplified a bit.

I only did manual testing of this since it requires old Solidity versions to hit this code.  I tested it on 0.5.0, it worked fine.