### PR TITLE
Add Arbitrum Nova to Etherscan fetcher

### DIFF
--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -65,6 +65,7 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
       "kovan-optimistic": "api-kovan-optimistic.etherscan.io",
       "goerli-optimistic": "api-goerli-optimism.etherscan.io", //yes this one is different!
       "arbitrum": "api.arbiscan.io",
+      "nova-arbitrum": "api-nova.arbiscan.io",
       "rinkeby-arbitrum": "api-testnet.arbiscan.io", //hidden now, but it still works!
       "goerli-arbitrum": "api-goerli.arbiscan.io",
       "polygon": "api.polygonscan.com",

--- a/packages/source-fetcher/lib/networks.ts
+++ b/packages/source-fetcher/lib/networks.ts
@@ -11,6 +11,7 @@ export const networkNamesById: { [id: number]: string } = {
   69: "kovan-optimistic",
   420: "goerli-optimistic",
   42161: "arbitrum",
+  42170: "nova-arbitrum",
   421611: "rinkeby-arbitrum",
   421613: "goerli-arbitrum",
   137: "polygon",


### PR DESCRIPTION
Etherscan has added Arbitrum Nova, so I've added it to the fetcher.

Etherscan has also added the Aptos network, along with its testnet and devnet; but as best I can tell those don't presently allow contract verification (assuming this is even a concept that applies to them), so I haven't added those.