### PR TITLE
Add two more reminders to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,10 @@
 
 <!-- Enter PR description here -->
 
+## Testing instructions
+
+<!-- Don't forget instructions about how to test the PR! -->
+
 ## Documentation
 
 - [ ] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,3 +5,7 @@
 ## Documentation
 
 - [ ] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.
+
+## Breaking changes and new features
+
+- [ ] I have added any needed `breaking-change` and `new-feature` labels for the appropriate packages.


### PR DESCRIPTION
Per @dongmingh's suggestion, I've added a reminder to include testing instructions.  Also, I added a reminder to add any needed `breaking-change` or `new-feature` labels.