### PR TITLE
remove db from dev deps in truffle

### DIFF
--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -46,7 +46,6 @@
     "@truffle/config": "^1.3.41",
     "@truffle/contract": "^4.6.5",
     "@truffle/core": "^5.6.3",
-    "@truffle/db": "^2.0.3",
     "@truffle/interface-adapter": "^0.5.23",
     "chai": "^4.2.0",
     "clean-webpack-plugin": "^3.0.0",


### PR DESCRIPTION
This PR removes @truffle/db from the `devDependencies` in truffle. It is already in `optionalDependencies`.