### PR TITLE
Internal improvement: remove spinners dep from compile-solidity and activate spinners in events package

### DIFF
--- a/packages/compile-solidity/package.json
+++ b/packages/compile-solidity/package.json
@@ -24,7 +24,6 @@
     "@truffle/contract-sources": "^0.2.0",
     "@truffle/expect": "^0.1.3",
     "@truffle/profiler": "^0.1.34",
-    "@truffle/spinners": "^0.2.2",
     "axios": "0.27.2",
     "axios-retry": "^3.1.9",
     "debug": "^4.3.1",

--- a/packages/compile-solidity/src/compilerSupplier/loadingStrategies/Docker.ts
+++ b/packages/compile-solidity/src/compilerSupplier/loadingStrategies/Docker.ts
@@ -35,6 +35,7 @@ export class Docker {
     }
 
     const versionString = await this.validateAndGetSolcVersion();
+
     const command =
       "docker run --platform=linux/amd64 --rm -i ethereum/solc:" +
       this.config.version +
@@ -136,7 +137,6 @@ export class Docker {
       execSync("docker inspect --type=image ethereum/solc:" + image);
     } catch (error) {
       console.log(`${image} does not exist locally.\n`);
-      console.log("Attempting to download the Docker image.");
       this.downloadDockerImage(image);
     }
 

--- a/packages/compile-solidity/src/compilerSupplier/loadingStrategies/Docker.ts
+++ b/packages/compile-solidity/src/compilerSupplier/loadingStrategies/Docker.ts
@@ -1,5 +1,3 @@
-import { Spinner } from "@truffle/spinners";
-
 // must polyfill AbortController to use axios >=0.20.0, <=0.27.2 on node <= v14.x
 import "../../polyfill";
 import axios from "axios";
@@ -105,14 +103,12 @@ export class Docker {
         `Please ensure that ${image} is a valid docker image name.`;
       throw new Error(message);
     }
-    const spinner = new Spinner("compile-solidity:docker-download", {
-      text: "Downloading Docker image",
-      prefixColor: "red"
-    });
+    this.config.events.emit("compile:downloadDockerImage:start");
     try {
       execSync(`docker pull ethereum/solc:${image}`);
-    } finally {
-      spinner.remove();
+      this.config.events.emit("compile:downloadDockerImage:succeed");
+    } catch (error) {
+      this.config.events.emit("compile:downloadDockerImage:fail", { error });
     }
   }
 

--- a/packages/events/defaultSubscribers/compile.js
+++ b/packages/events/defaultSubscribers/compile.js
@@ -1,5 +1,4 @@
 const OS = require("os");
-const { Spinner } = require("@truffle/spinners");
 
 module.exports = {
   initialization: function () {
@@ -80,22 +79,19 @@ module.exports = {
     "compile:downloadDockerImage:start": [
       function () {
         if (this.quiet) return;
-        this.spinner = new Spinner("compile-solidity:docker-download", {
-          text: "Downloading Docker image",
-          prefixColor: "red"
-        });
+        this.logger.log("Attempting to download the Docker image.");
       }
     ],
     "compile:downloadDockerImage:succeed": [
       function () {
         if (this.quiet) return;
-        this.spinner.succeed("Download successful!");
+        this.logger.log("Download successful!");
       }
     ],
     "compile:downloadDockerImage:fail": [
       function ({ error }) {
         if (this.quiet) return;
-        this.spinner.fail(
+        this.logger.log(
           `There was a problem downloading the Docker image. \n${error}.`
         );
       }

--- a/packages/events/defaultSubscribers/compile.js
+++ b/packages/events/defaultSubscribers/compile.js
@@ -1,4 +1,5 @@
 const OS = require("os");
+const { Spinner } = require("@truffle/spinners");
 
 module.exports = {
   initialization: function () {
@@ -73,6 +74,29 @@ module.exports = {
         if (this.quiet) return;
         this.logger.log(
           `> Compilation skipped because --compile-none option was passed.`
+        );
+      }
+    ],
+    "compile:downloadDockerImage:start": [
+      function () {
+        if (this.quiet) return;
+        this.spinner = new Spinner("compile-solidity:docker-download", {
+          text: "Downloading Docker image",
+          prefixColor: "red"
+        });
+      }
+    ],
+    "compile:downloadDockerImage:succeed": [
+      function () {
+        if (this.quiet) return;
+        this.spinner.succeed("Download successful!");
+      }
+    ],
+    "compile:downloadDockerImage:fail": [
+      function ({ error }) {
+        if (this.quiet) return;
+        this.spinner.fail(
+          `There was a problem downloading the Docker image. \n${error}.`
         );
       }
     ]


### PR DESCRIPTION
## PR description

This PR removes the dependency of compile-solidity on the events package. Instead the spinners are started/stopped through the emitting of events.

## Testing instructions

To test this you can simply create a new Truffle project and configure it to use docker for compilation. Then run `truffle compile` to verify that the logging/spinner appears. To test the error path you can throw an error inside the `try` and verify that the error you threw appears in the logging.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.

## Breaking changes and new features

- [x] I have added any needed `breaking-change` and `new-feature` labels for the appropriate packages.
