### PR TITLE
Update babel-loader to 9.1.0

### DIFF
--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -47,7 +47,7 @@
     "@truffle/migrate": "^3.3.16",
     "@truffle/resolver": "^9.0.21",
     "@truffle/workflow-compile": "^4.0.39",
-    "babel-loader": "^8.2.3",
+    "babel-loader": "^9.1.0",
     "babel-runtime": "^6.26.0",
     "chai": "^4.2.0",
     "change-case": "3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9875,6 +9875,14 @@ babel-loader@^8.2.3:
     make-dir "^3.1.0"
     schema-utils "^2.6.5"
 
+babel-loader@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-9.1.0.tgz#839e9ae88aea930864ef9ec0f356dfca96ecf238"
+  integrity sha512-Antt61KJPinUMwHwIIz9T5zfMgevnfZkEVWYDWlG888fgdvRRGD0JTuf/fFozQnfT+uq64sk1bmdHDy/mOEWnA==
+  dependencies:
+    find-cache-dir "^3.3.2"
+    schema-utils "^4.0.0"
+
 babel-messages@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
@@ -15638,7 +15646,7 @@ find-cache-dir@^2.0.0:
     make-dir "^2.0.0"
     pkg-dir "^3.0.0"
 
-find-cache-dir@^3.2.0, find-cache-dir@^3.3.1:
+find-cache-dir@^3.2.0, find-cache-dir@^3.3.1, find-cache-dir@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.3.2.tgz#b30c5b6eff0730731aea9bbd9dbecbd80256d64b"
   integrity sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==


### PR DESCRIPTION
Updates the debugger's version of babel-loader to 9.1.0.  (Doing this to help resolve a dependabot alert that just popped up, although this won't fully resolve it.)  Let's see if it passes tests!

Btw: @gnidan, do we even really still need babel in the debugger?  Maybe we can just tear that out after this.  But I figured I'd start by putting up this PR because this is quick and easy.