### PR TITLE
Running truffle debug with appropriate flag (--vscode)

### DIFF
--- a/packages/core/lib/commands/debug/meta.js
+++ b/packages/core/lib/commands/debug/meta.js
@@ -33,7 +33,8 @@ module.exports = {
       default: false
     },
     "vscode": {
-      describe: "Starts the debug session on Truffle VSCode extension",
+      describe:
+        "Starts the debug session in VS Code using the Truffle for VS Code extension",
       type: "boolean",
       default: false
     }

--- a/packages/core/lib/commands/debug/meta.js
+++ b/packages/core/lib/commands/debug/meta.js
@@ -31,6 +31,11 @@ module.exports = {
       describe: "Force debugger to skip compilation (dangerous!)",
       type: "boolean",
       default: false
+    },
+    "vscode": {
+      describe: "Starts the debug session on Truffle VSCode extension",
+      type: "boolean",
+      default: false
     }
   },
   help: {
@@ -75,6 +80,10 @@ module.exports = {
         option: "--compile-none",
         description:
           "Forces the debugger to use artifacts even if it detects a problem.  Dangerous; may cause errors."
+      },
+      {
+        option: "--vscode",
+        description: "Starts the debug session on Truffle VSCode extension."
       }
     ],
     allowedGlobalOptions: ["config"]

--- a/packages/core/lib/commands/debug/meta.js
+++ b/packages/core/lib/commands/debug/meta.js
@@ -83,7 +83,8 @@ module.exports = {
       },
       {
         option: "--vscode",
-        description: "Starts the debug session on Truffle VSCode extension."
+        description:
+          "Starts the debug session in VS Code using the Truffle for VS Code extension."
       }
     ],
     allowedGlobalOptions: ["config"]

--- a/packages/core/lib/commands/debug/run.js
+++ b/packages/core/lib/commands/debug/run.js
@@ -67,7 +67,7 @@ module.exports = async function (options) {
     compilations
   });
 
-  // Checks if the user wants to debug in vscode
+  // Checks if the user wants to open the debugger in vscode
   if (config.vscode) {
     await cliDebugger.openVSCodeDebug();
     return;

--- a/packages/core/lib/commands/debug/run.js
+++ b/packages/core/lib/commands/debug/run.js
@@ -60,9 +60,17 @@ module.exports = async function (options) {
   if (config.compileAll && config.compileNone) {
     throw new Error("Incompatible options passed regarding what to compile");
   }
-  const interpreter = await new CLIDebugger(config, {
+
+  const cliDebugger = new CLIDebugger(config, {
     txHash,
     compilations
-  }).run();
+  });
+
+  if (config.vscode) {
+    await cliDebugger.openVSCodeDebug();
+    return;
+  }
+
+  const interpreter = await cliDebugger.run();
   return await promisify(interpreter.start.bind(interpreter))();
 };

--- a/packages/core/lib/commands/debug/run.js
+++ b/packages/core/lib/commands/debug/run.js
@@ -61,16 +61,19 @@ module.exports = async function (options) {
     throw new Error("Incompatible options passed regarding what to compile");
   }
 
+  // Create a new CLIDebugger instance
   const cliDebugger = new CLIDebugger(config, {
     txHash,
     compilations
   });
 
+  // Checks if the user wants to debug in vscode
   if (config.vscode) {
     await cliDebugger.openVSCodeDebug();
     return;
   }
 
+  // Starts the cli debugger
   const interpreter = await cliDebugger.run();
   return await promisify(interpreter.start.bind(interpreter))();
 };

--- a/packages/core/lib/debug/cli.js
+++ b/packages/core/lib/debug/cli.js
@@ -207,16 +207,17 @@ class CLIDebugger {
   }
 
   async openVSCodeDebug() {
-    // Sets the parameters
-    const params = new URLSearchParams({
-      txHash: this.txHash,
-      workingDirectory: this.config.working_directory,
-      providerUrl: this.config.provider.host
-    });
+    // Sets the URL
+    const url = new URL("/debug", "vscode://trufflesuite-csi.truffle-vscode");
+
+    // Sets the query parameters
+    url.searchParams.set("txHash", this.txHash);
+    url.searchParams.set("workingDirectory", this.config.working_directory);
+    url.searchParams.set("providerUrl", this.config.provider.host);
 
     // Opens VSCode based on the OS
     const openCommand = process.platform === "win32" ? `start ""` : `open`;
-    const commandLine = `${openCommand} "vscode://trufflesuite-csi.truffle-vscode/debug?${params}"`;
+    const commandLine = `${openCommand} "${url.toString()}"`;
 
     // Defines the options for the child process. An abort signal is used to cancel the process, if necessary.
     const controller = new AbortController();

--- a/packages/core/lib/debug/cli.js
+++ b/packages/core/lib/debug/cli.js
@@ -207,7 +207,7 @@ class CLIDebugger {
   }
 
   /**
-   * This function is responsible for opening the debug in vscode.
+   * This function is responsible for opening the debugger in vscode.
    */
   async openVSCodeDebug() {
     // Sets the URL

--- a/packages/core/lib/debug/cli.js
+++ b/packages/core/lib/debug/cli.js
@@ -206,6 +206,9 @@ class CLIDebugger {
     return contracts;
   }
 
+  /**
+   * This function is responsible for opening the debug in vscode.
+   */
   async openVSCodeDebug() {
     // Sets the URL
     const url = new URL("/debug", "vscode://trufflesuite-csi.truffle-vscode");
@@ -216,7 +219,7 @@ class CLIDebugger {
     url.searchParams.set("providerUrl", this.config.provider.host);
     url.searchParams.set("fetchExternal", this.config.fetchExternal);
 
-    // Opens VSCode based on the OS
+    // Opens VSCode based on OS
     const openCommand = process.platform === "win32" ? `start ""` : `open`;
     const commandLine = `${openCommand} "${url}"`;
 

--- a/packages/core/lib/debug/cli.js
+++ b/packages/core/lib/debug/cli.js
@@ -214,10 +214,11 @@ class CLIDebugger {
     url.searchParams.set("txHash", this.txHash);
     url.searchParams.set("workingDirectory", this.config.working_directory);
     url.searchParams.set("providerUrl", this.config.provider.host);
+    url.searchParams.set("fetchExternal", this.config.fetchExternal);
 
     // Opens VSCode based on the OS
     const openCommand = process.platform === "win32" ? `start ""` : `open`;
-    const commandLine = `${openCommand} "${url.toString()}"`;
+    const commandLine = `${openCommand} "${url}"`;
 
     // Defines the options for the child process. An abort signal is used to cancel the process, if necessary.
     const controller = new AbortController();
@@ -235,7 +236,6 @@ class CLIDebugger {
     });
 
     // Sends a message to the user
-    this.config.logger.log(commandLine);
     this.config.logger.log("Opening truffle debugger in VSCode...");
   }
 }


### PR DESCRIPTION
## PR description

This PR allows the user to debug a transaction using VSCode.

## Testing instructions

<!-- Don't forget instructions about how to test the PR! -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.

## Breaking changes and new features

- [ ] I have added any needed `breaking-change` and `new-feature` labels for the appropriate packages.
