### PR TITLE
Update truffle create

### DIFF
--- a/packages/core/lib/commands/create/helpers.js
+++ b/packages/core/lib/commands/create/helpers.js
@@ -105,6 +105,7 @@ const Create = {
       throw new Error("Can not create " + filename + ": file exists");
     }
     fse.copySync(from, to);
+    replaceContents(to, templates.contract.name, name);
   }
 };
 

--- a/packages/core/lib/commands/create/templates/Example.sol
+++ b/packages/core/lib/commands/create/templates/Example.sol
@@ -2,6 +2,8 @@
 pragma solidity >=0.4.22 <0.9.0;
 
 contract Example {
-  constructor() public {
+  constructor() {
+    // Remove this and implement your contracts/Example.sol Smart Contract logic.
+    require(block.chainid != 1337, "You have to implement contracts/Example.sol's logic");
   }
 }

--- a/packages/core/lib/commands/create/templates/migration.js
+++ b/packages/core/lib/commands/create/templates/migration.js
@@ -1,5 +1,5 @@
 const Example = artifacts.require("Example");
 module.exports = function(deployer /*, network, accounts */) {
-  //TODO: orchestrate you migration logic using deployer.deploy
+  //TODO: orchestrate your migration logic using deployer.deploy
   deployer.deploy(Example);
 };

--- a/packages/core/lib/commands/create/templates/migration.js
+++ b/packages/core/lib/commands/create/templates/migration.js
@@ -1,3 +1,5 @@
-module.exports = function(_deployer) {
-  // Use deployer to state migration tasks.
+const Example = artifacts.require("Example");
+module.exports = function(deployer /*, network, accounts */) {
+  //TODO: orchestrate you migration logic using deployer.deploy
+  deployer.deploy(Example);
 };


### PR DESCRIPTION
## PR description

The visibility warning, and the bare migrations file when using create to buildout a new project is not a good DX experience. This PR tries to make the process easier. Note, I added a revert in the Solidity Template to let the test and deploy workflow act as a next step reminder.

- migration.js : import the contract-abstraction and use it in the deployer
- Example.sol  : add revert in CSTR and remove public visibility to silence solc warning.
- helpers.js : search/replace `Example` in generated migration files.

## Testing instructions

Verify the various `truffle create` options. 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.
  - It seems this will need website docs because the current [how-to-create-a-project](https://trufflesuite.com/docs/truffle/how-to/create-a-project/) doesn't cover scaffolding for bare projects.

## Breaking changes and new features

- [x] I have added any needed `breaking-change` and `new-feature` labels for the appropriate packages.
