### PR TITLE
Implement console.log in Truffle

### DIFF
--- a/packages/config/src/configDefaults.ts
+++ b/packages/config/src/configDefaults.ts
@@ -30,7 +30,7 @@ export const getInitialConfig = ({
     verboseRpc: false,
     solidityLog: {
       displayPrefix: "",
-      disableMigration: false
+      disableMigrate: false
     },
     gas: null,
     gasPrice: null,

--- a/packages/config/src/configDefaults.ts
+++ b/packages/config/src/configDefaults.ts
@@ -30,7 +30,7 @@ export const getInitialConfig = ({
     verboseRpc: false,
     solidityLog: {
       displayPrefix: "",
-      disableMigration: true
+      disableMigration: false
     },
     gas: null,
     gasPrice: null,

--- a/packages/config/src/configDefaults.ts
+++ b/packages/config/src/configDefaults.ts
@@ -28,6 +28,9 @@ export const getInitialConfig = ({
       }
     },
     verboseRpc: false,
+    solidityLog: {
+      prefix: ""
+    },
     gas: null,
     gasPrice: null,
     maxFeePerGas: null,
@@ -93,6 +96,7 @@ export const configProps = ({
     network() {},
     networks() {},
     verboseRpc() {},
+    solidityLog() {},
     build() {},
     resolver() {},
     artifactor() {},

--- a/packages/config/src/configDefaults.ts
+++ b/packages/config/src/configDefaults.ts
@@ -29,7 +29,8 @@ export const getInitialConfig = ({
     },
     verboseRpc: false,
     solidityLog: {
-      prefix: ""
+      displayPrefix: "",
+      disableMigration: true
     },
     gas: null,
     gasPrice: null,

--- a/packages/config/src/configDefaults.ts
+++ b/packages/config/src/configDefaults.ts
@@ -30,7 +30,7 @@ export const getInitialConfig = ({
     verboseRpc: false,
     solidityLog: {
       displayPrefix: "",
-      disableMigrate: false
+      preventConsoleLogMigration: false
     },
     gas: null,
     gasPrice: null,

--- a/packages/config/test/unit.test.ts
+++ b/packages/config/test/unit.test.ts
@@ -12,7 +12,7 @@ describe("TruffleConfig unit tests", async () => {
 
     it("solidityLog", () => {
       const expectedSolidityLog = {
-        displyPrefix: "",
+        displayPrefix: "",
         disableMigration: false
       };
       assert.deepStrictEqual(truffleConfig.solidityLog, expectedSolidityLog);

--- a/packages/config/test/unit.test.ts
+++ b/packages/config/test/unit.test.ts
@@ -3,52 +3,65 @@ import TruffleConfig from "../dist";
 import { describe, it } from "mocha";
 
 describe("TruffleConfig unit tests", async () => {
-  describe("with", async () => {
-    let truffleConfig: TruffleConfig;
+  let truffleConfig: TruffleConfig;
 
-    beforeEach(() => {
+  describe("Defaults", async () => {
+    before(() => {
       truffleConfig = TruffleConfig.default();
     });
 
-    it("a simple object", async () => {
-      const expectedRandom = 42;
-      const expectedFoo = "bar";
-      const obj = {
-        random: expectedRandom,
-        foo: expectedFoo
+    it("solidityLog", () => {
+      const expectedSolidityLog = {
+        displyPrefix: "",
+        disableMigration: false
       };
-      const newConfig = truffleConfig.with(obj);
-      assert.equal(expectedRandom, newConfig.random);
-      assert.equal(expectedFoo, newConfig.foo);
+      assert.deepStrictEqual(truffleConfig.solidityLog, expectedSolidityLog);
     });
-
-    it("overwrites a known property", () => {
-      const expectedProvider = { a: "propertyA", b: "propertyB" };
-      const newConfig = truffleConfig.with({ provider: expectedProvider });
-      assert.deepEqual(expectedProvider, newConfig.provider);
-    });
-
-    it("ignores properties that throw", () => {
-      const expectedSurvivor = "BatMan";
-      const minefield = { who: expectedSurvivor };
-
-      const hits = ["boom", "pow", "crash", "zonk"];
-      hits.forEach(hit => {
-        Object.defineProperty(minefield, hit, {
-          get() {
-            throw new Error("BOOM!");
-          },
-          enumerable: true //must be enumerable
-        });
+  }),
+    describe("with", async () => {
+      beforeEach(() => {
+        truffleConfig = TruffleConfig.default();
       });
 
-      const newConfig = truffleConfig.with(minefield);
+      it("a simple object", async () => {
+        const expectedRandom = 42;
+        const expectedFoo = "bar";
+        const obj = {
+          random: expectedRandom,
+          foo: expectedFoo
+        };
+        const newConfig = truffleConfig.with(obj);
+        assert.strictEqual(expectedRandom, newConfig.random);
+        assert.strictEqual(expectedFoo, newConfig.foo);
+      });
 
-      //one survivor
-      assert.equal(expectedSurvivor, newConfig.who);
+      it("overwrites a known property", () => {
+        const expectedProvider = { a: "propertyA", b: "propertyB" };
+        const newConfig = truffleConfig.with({ provider: expectedProvider });
+        assert.deepStrictEqual(expectedProvider, newConfig.provider);
+      });
 
-      //these jokers shouldn't be included
-      hits.forEach(hit => assert.equal(undefined, newConfig[hit]));
+      it("ignores properties that throw", () => {
+        const expectedSurvivor = "BatMan";
+        const minefield = { who: expectedSurvivor };
+
+        const hits = ["boom", "pow", "crash", "zonk"];
+        hits.forEach(hit => {
+          Object.defineProperty(minefield, hit, {
+            get() {
+              throw new Error("BOOM!");
+            },
+            enumerable: true //must be enumerable
+          });
+        });
+
+        const newConfig = truffleConfig.with(minefield);
+
+        //one survivor
+        assert.strictEqual(expectedSurvivor, newConfig.who);
+
+        //these jokers shouldn't be included
+        hits.forEach(hit => assert.strictEqual(undefined, newConfig[hit]));
+      });
     });
-  });
 });

--- a/packages/config/test/unit.test.ts
+++ b/packages/config/test/unit.test.ts
@@ -13,7 +13,7 @@ describe("TruffleConfig unit tests", async () => {
     it("solidityLog", () => {
       const expectedSolidityLog = {
         displayPrefix: "",
-        disableMigration: false
+        disableMigrate: false
       };
       assert.deepStrictEqual(truffleConfig.solidityLog, expectedSolidityLog);
     });

--- a/packages/config/test/unit.test.ts
+++ b/packages/config/test/unit.test.ts
@@ -13,7 +13,7 @@ describe("TruffleConfig unit tests", async () => {
     it("solidityLog", () => {
       const expectedSolidityLog = {
         displayPrefix: "",
-        disableMigrate: false
+        preventConsoleLogMigration: false
       };
       assert.deepStrictEqual(truffleConfig.solidityLog, expectedSolidityLog);
     });

--- a/packages/contract/lib/contract/index.js
+++ b/packages/contract/lib/contract/index.js
@@ -5,6 +5,7 @@ const execute = require("../execute");
 const bootstrap = require("./bootstrap");
 const constructorMethods = require("./constructorMethods");
 const properties = require("./properties");
+const util = require("util");
 
 // For browserified version. If browserify gave us an empty version,
 // look for the one provided by the user.
@@ -155,6 +156,10 @@ if (typeof Web3 === "object" && Object.keys(Web3).length === 0) {
   }
 
   Contract._constructorMethods = constructorMethods(Contract);
+
+  Contract.prototype[util.inspect.custom] = function (/* _depth , _options */) {
+    return `Contract at: ${this.address}`;
+  };
 
   // Getter functions are scoped to Contract object.
   Contract._properties = properties;

--- a/packages/contract/lib/contract/index.js
+++ b/packages/contract/lib/contract/index.js
@@ -5,7 +5,6 @@ const execute = require("../execute");
 const bootstrap = require("./bootstrap");
 const constructorMethods = require("./constructorMethods");
 const properties = require("./properties");
-const util = require("util");
 
 // For browserified version. If browserify gave us an empty version,
 // look for the one provided by the user.
@@ -157,7 +156,7 @@ if (typeof Web3 === "object" && Object.keys(Web3).length === 0) {
 
   Contract._constructorMethods = constructorMethods(Contract);
 
-  Contract.prototype[util.inspect.custom] = function (/* _depth , _options */) {
+  Contract.prototype[Symbol.for("nodejs.util.inspect.custom")] = function () {
     return `Contract at: ${this.address}`;
   };
 

--- a/packages/contract/lib/contract/index.js
+++ b/packages/contract/lib/contract/index.js
@@ -156,10 +156,6 @@ if (typeof Web3 === "object" && Object.keys(Web3).length === 0) {
 
   Contract._constructorMethods = constructorMethods(Contract);
 
-  Contract.prototype[Symbol.for("nodejs.util.inspect.custom")] = function () {
-    return `Contract at: ${this.address}`;
-  };
-
   // Getter functions are scoped to Contract object.
   Contract._properties = properties;
 

--- a/packages/core/lib/commands/develop/run.js
+++ b/packages/core/lib/commands/develop/run.js
@@ -45,14 +45,23 @@ module.exports = async options => {
     "This mnemonic was created for you by Truffle. It is not secure.\n" +
     "Ensure you do not use it on production blockchains, or else you risk losing funds.";
 
-  const ipcOptions = { log: options.log };
+  const ipcOptions = {};
+
+  if (options.log) {
+    ipcOptions.log = options.log;
+  }
+
   const ganacheOptions = configureManagedGanache(
     config,
     customConfig,
     mnemonic
   );
 
-  const { started } = await Develop.connectOrStart(ipcOptions, ganacheOptions);
+  const { started } = await Develop.connectOrStart(
+    ipcOptions,
+    ganacheOptions,
+    config
+  );
   const url = `http://${ganacheOptions.host}:${ganacheOptions.port}/`;
 
   if (started) {

--- a/packages/core/lib/commands/migrate/runMigrations.js
+++ b/packages/core/lib/commands/migrate/runMigrations.js
@@ -71,7 +71,7 @@ module.exports = async function (config) {
 
       debugLog(`${dirtyArtifacts.length} consoleLog artifacts detected`);
       debugLog(
-        `config.solidityLog.disableMigrate: ${config.solidityLog.disableMigrate}`
+        `config.solidityLog.preventConsoleLogMigration: ${config.solidityLog.preventConsoleLogMigration}`
       );
 
       if (dirtyArtifacts.length) {
@@ -81,11 +81,11 @@ module.exports = async function (config) {
         console.warn(dirtyArtifacts.join(", "));
         console.warn();
 
-        if (config.solidityLog.disableMigrate) {
+        if (config.solidityLog.preventConsoleLogMigration) {
           throw new TruffleError(
             "You are trying to deploy contracts that use console.log." +
               os.EOL +
-              "Please fix, or disable this check by setting solidityLog.disableMigrate to false" +
+              "Please fix, or disable this check by setting solidityLog.preventConsoleLogMigration to false" +
               os.EOL
           );
         }

--- a/packages/core/lib/commands/migrate/runMigrations.js
+++ b/packages/core/lib/commands/migrate/runMigrations.js
@@ -61,9 +61,8 @@ async function getDirtyArtifactFiles(buildDir) {
 }
 
 module.exports = async function (config) {
-  // only check if deploying on MAINNET
   const debugLog = debug.extend("guard");
-
+  // only check if deploying on MAINNET
   if (config.network_id === 1) {
     debugLog("solidityLog guard for mainnet");
     try {

--- a/packages/core/lib/commands/migrate/runMigrations.js
+++ b/packages/core/lib/commands/migrate/runMigrations.js
@@ -1,46 +1,54 @@
-const { open } = require("fs/promises");
+const { createReadStream } = require("fs");
 const { readdir } = require("fs/promises");
 const path = require("path");
 const JSONStream = require("JSONStream");
 const Migrate = require("@truffle/migrate").default;
 const TruffleError = require("@truffle/error");
 const os = require("os");
+const debug = require("debug")("migrate:run");
 
 // Search for Push1 (60) to Push(32) 7F + console.log
 //                      60 ---- 7F  C O N S O L E . L O G
 const consoleLogRex = /[67][0-9a-f]636F6e736F6c652e6c6f67/i;
 
 async function usesConsoleLog(artifactJson) {
-  const fd = await open(artifactJson);
+  const debugLog = debug.extend("test");
+  debugLog("Artifact: %o", artifactJson);
 
   //create a parser to get the value of jsonpath .deployedBytecode
   const parser = JSONStream.parse(["deployedBytecode"]);
-  const stream = fd.createReadStream().pipe(parser);
+  const stream = createReadStream(artifactJson).pipe(parser);
 
   return new Promise((resolve, reject) => {
     stream.on("data", data => {
       //JSONParse will emit the entire string/value
       //so initiate stream cleanup here
       stream.destroy();
-      resolve(consoleLogRex.test(data));
+      const usesConsoleLog = consoleLogRex.test(data);
+      debugLog("usesConsoleLog:", usesConsoleLog);
+      resolve(usesConsoleLog);
     });
 
     stream.on("error", err => {
-      fd.close();
+      stream.destroy();
+      debugLog("onError: %o", err);
       reject(err);
     });
-
-    stream.on("close", () => fd.close());
   });
 }
 
 module.exports = async function (config) {
   // only check if deploying on MAINNET
+  const dirtyArtifacts = [];
+  let continueTesting = true;
+  const debugLog = debug.extend("guard");
+  debugLog("config.network_id", config.network_id);
+  debugLog("config.solidityLog", config.solidityLog);
   if (config.network_id === 1) {
+    debugLog("solidityLog guard for mainnet");
     try {
       const buildDir = config.contracts_build_directory;
       const maybeArtifacts = await readdir(buildDir);
-      const dirtyArtifacts = [];
       for (let i = 0, L = maybeArtifacts.length; i < L; i++) {
         const fn = maybeArtifacts[i];
         if (
@@ -50,29 +58,40 @@ module.exports = async function (config) {
           dirtyArtifacts.push(fn);
         }
       }
-
-      if (dirtyArtifacts.length) {
-        //TODO:
-        //- get messaging right
-        //- emit truffle event indicating dirty contracts detected
-        //
-        console.warn("Solidity console.log detected in the following assets:");
-        console.warn(dirtyArtifacts.join(", "));
-
-        if (config.solidityLog.disableMigration) {
-          throw new TruffleError(
-            "You are trying to deploy contracts that use console.log." +
-              os.EOL +
-              "Please fix, or disable this check by setting solidityLog.disableMigration to false"
-          );
-        }
-      }
     } catch (err) {
+      debugLog("Unexpected error %o:", err);
       // Something went wrong while inspecting for console log.
-      // log and error, but don't throw.
+      // log and warning and skip the remaining logic in this
+      // branch
+      continueTesting = false;
+      console.warn();
       console.warn(
         "Failed to detect Solidity console.log usage:" + os.EOL + err
       );
+    }
+
+    debugLog("continueTesting", continueTesting);
+    debugLog("dirtyArtifacts.length", dirtyArtifacts.length);
+    debugLog(
+      "config.solidityLog.disableMigrate",
+      config.solidityLog.disableMigrate
+    );
+
+    if (continueTesting && dirtyArtifacts.length) {
+      console.warn(
+        `${os.EOL}Solidity console.log detected in the following assets:`
+      );
+      console.warn(dirtyArtifacts.join(", "));
+      console.warn();
+
+      if (config.solidityLog.disableMigrate) {
+        throw new TruffleError(
+          "You are trying to deploy contracts that use console.log." +
+            os.EOL +
+            "Please fix, or disable this check by setting solidityLog.disableMigrate to false" +
+            os.EOL
+        );
+      }
     }
   }
 

--- a/packages/core/lib/commands/migrate/runMigrations.js
+++ b/packages/core/lib/commands/migrate/runMigrations.js
@@ -1,6 +1,81 @@
+const { open } = require("node:fs/promises");
+const { readdir } = require("node:fs/promises");
+const path = require("path");
+const JSONStream = require("JSONStream");
 const Migrate = require("@truffle/migrate").default;
+const TruffleError = require("@truffle/error");
+const os = require("os");
+
+// Search for Push1 (60) to Push(32) 7F + console.log
+//                      60 ---- 7F  C O N S O L E . L O G
+const consoleLogRex = /[67][0-9a-f]636F6e736F6c652e6c6f67/i;
+
+async function usesConsoleLog(artifactJson) {
+  const fd = await open(artifactJson);
+
+  //create a parser to get the value of jsonpath .deployedBytecode
+  const parser = JSONStream.parse(["deployedBytecode"]);
+  const stream = fd.createReadStream().pipe(parser);
+
+  return new Promise((resolve, reject) => {
+    stream.on("data", data => {
+      //JSONParse will emit the entire string/value
+      //so initiate stream cleanup here
+      stream.destroy();
+      resolve(consoleLogRex.test(data));
+    });
+
+    stream.on("error", err => {
+      fd.close();
+      reject(err);
+    });
+
+    stream.on("close", () => fd.close());
+  });
+}
 
 module.exports = async function (config) {
+  // only check if deploying on MAINNET
+  if (config.network_id === 1) {
+    try {
+      const buildDir = config.contracts_build_directory;
+      const maybeArtifacts = await readdir(buildDir);
+      const dirtyArtifacts = [];
+      for (let i = 0, L = maybeArtifacts.length; i < L; i++) {
+        const fn = maybeArtifacts[i];
+        if (
+          fn.endsWith(".json") &&
+          (await usesConsoleLog(path.join(buildDir, fn)))
+        ) {
+          dirtyArtifacts.push(fn);
+        }
+      }
+
+      if (dirtyArtifacts.length) {
+        //TODO:
+        //- get messaging right
+        //- emit truffle event indicating dirty contracts detected
+        //
+        console.warn("Solidity console.log detected in the following assets:");
+        console.warn(dirtyArtifacts.join(", "));
+
+        if (config.solidityLog.disableMigration) {
+          throw new TruffleError(
+            "You are trying to deploy contracts that use console.log." +
+              os.EOL +
+              "Please fix, or disable this check by setting solidityLog.disableMigration to false"
+          );
+        }
+      }
+    } catch (err) {
+      // Something went wrong while inspecting for console log.
+      // log and error, but don't throw.
+      console.warn(
+        "Failed to detect Solidity console.log usage:" + os.EOL + err
+      );
+    }
+  }
+
   if (config.f) {
     return await Migrate.runFrom(config.f, config);
   } else {

--- a/packages/core/lib/commands/migrate/runMigrations.js
+++ b/packages/core/lib/commands/migrate/runMigrations.js
@@ -37,7 +37,7 @@ async function usesConsoleLog(artifactJson) {
   });
 }
 
-async function getDirtyArtifactFiles(buildDir) {
+async function findArtifactsThatUseConsoleLog(buildDir) {
   const debugLog = debug.extend("dirty-files");
   const files = await readdir(buildDir);
 
@@ -67,7 +67,7 @@ module.exports = async function (config) {
     debugLog("solidityLog guard for mainnet");
     try {
       const buildDir = config.contracts_build_directory;
-      const dirtyArtifacts = await getDirtyArtifactFiles(buildDir);
+      const dirtyArtifacts = await findArtifactsThatUseConsoleLog(buildDir);
 
       debugLog(`${dirtyArtifacts.length} consoleLog artifacts detected`);
       debugLog(

--- a/packages/core/lib/commands/migrate/runMigrations.js
+++ b/packages/core/lib/commands/migrate/runMigrations.js
@@ -39,16 +39,16 @@ async function usesConsoleLog(artifactJson) {
 
 async function findArtifactsThatUseConsoleLog(buildDir) {
   const debugLog = debug.extend("dirty-files");
-  const files = await readdir(buildDir);
+  const filenames = await readdir(buildDir);
 
   const artifacts = [];
   await Promise.allSettled(
-    files.map(async fn => {
-      if (fn.endsWith(".json")) {
+    filenames.map(async filename => {
+      if (filename.endsWith(".json")) {
         try {
-          const itLogs = await usesConsoleLog(path.join(buildDir, fn));
+          const itLogs = await usesConsoleLog(path.join(buildDir, filename));
           if (itLogs) {
-            artifacts.push(fn);
+            artifacts.push(filename);
           }
         } catch (e) {
           debugLog("Promise failure: %o", e.message);

--- a/packages/core/lib/commands/migrate/runMigrations.js
+++ b/packages/core/lib/commands/migrate/runMigrations.js
@@ -1,5 +1,5 @@
-const { open } = require("node:fs/promises");
-const { readdir } = require("node:fs/promises");
+const { open } = require("fs/promises");
+const { readdir } = require("fs/promises");
 const path = require("path");
 const JSONStream = require("JSONStream");
 const Migrate = require("@truffle/migrate").default;

--- a/packages/core/lib/commands/test/run.js
+++ b/packages/core/lib/commands/test/run.js
@@ -38,16 +38,21 @@ module.exports = async function (options) {
   }
 
   // Start managed ganache network
-  async function startGanacheAndRunTests(ipcOptions, ganacheOptions, config) {
+  async function startGanacheAndRunTests(
+    ipcOptions,
+    ganacheOptions,
+    truffleConfig
+  ) {
     const { disconnect } = await Develop.connectOrStart(
       ipcOptions,
-      ganacheOptions
+      ganacheOptions,
+      truffleConfig
     );
     const ipcDisconnect = disconnect;
-    await Environment.develop(config, ganacheOptions);
-    const { temporaryDirectory } = await copyArtifactsToTempDir(config);
+    await Environment.develop(truffleConfig, ganacheOptions);
+    const { temporaryDirectory } = await copyArtifactsToTempDir(truffleConfig);
     const numberOfFailures = await prepareConfigAndRunTests({
-      config,
+      config: truffleConfig,
       files,
       temporaryDirectory
     });
@@ -103,6 +108,7 @@ module.exports = async function (options) {
     );
 
     const ipcOptions = { network: "test" };
+
     numberOfFailures = await startGanacheAndRunTests(
       ipcOptions,
       ganacheOptions,

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -329,7 +329,7 @@ class Console extends EventEmitter {
 
     const spawnInput = `${settings} -- ${inputStrings}`;
 
-    const sid = spawn(
+    const spawnedProcess = spawn(
       "node",
       ["--no-deprecation", childPath, spawnInput],
       spawnOptions
@@ -342,17 +342,17 @@ class Console extends EventEmitter {
     // interrupt stdout, and present it as a complete
     // string at the end of the spawned process.
     let bufferedError = "";
-    sid.stderr.on("data", data => {
+    spawnedProcess.stderr.on("data", data => {
       bufferedError += data.toString();
     });
 
-    sid.stdout.on("data", data => {
+    spawnedProcess.stdout.on("data", data => {
       // remove extra newline in `truffle develop` console
       console.log(data.toString().trim());
     });
 
     return new Promise((resolve, reject) => {
-      sid.on("close", code => {
+      spawnedProcess.on("close", code => {
         // dump bufferedError
         debug(bufferedError);
 

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -353,7 +353,7 @@ class Console extends EventEmitter {
 
           //display prompt when child repl process is finished
           this.repl.displayPrompt();
-          void resolve();
+          return void resolve();
         }
         reject(code);
       });

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -241,7 +241,8 @@ class Console extends EventEmitter {
   }
 
   provision() {
-    let files;
+    let files = [];
+    let jsonBlobs = [];
     try {
       files = fse.readdirSync(this.options.contracts_build_directory);
     } catch (error) {
@@ -251,10 +252,10 @@ class Console extends EventEmitter {
       // doesn't exist" 99.9% of the time.
     }
 
-    let jsonBlobs = [];
-    files = files || [];
-
     files.forEach(file => {
+      // filter out non artifacts
+      if (!file.endsWith(".json")) return;
+
       try {
         const body = fse.readFileSync(
           path.join(this.options.contracts_build_directory, file),

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -335,7 +335,7 @@ class Console extends EventEmitter {
     );
 
     // Theoretically stderr can contain multiple errors.
-    // So let's jsut print it instaed of throwing through
+    // So let's just print it instead of throwing through
     // the error handling mechanism. Bad call?
     sid.stderr.on("data", data => {
       debug(data.toString());

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -342,6 +342,7 @@ class Console extends EventEmitter {
     });
 
     sid.stdout.on("data", data => {
+      // remove extra newline in `truffle develop` console
       console.log(data.toString().trim());
     });
 

--- a/packages/core/lib/debug/compiler.js
+++ b/packages/core/lib/debug/compiler.js
@@ -12,9 +12,7 @@ class DebugCompiler {
     let compileConfig = this.config.with({ quiet: true });
 
     if (withTests) {
-      const testResolver = new Resolver(this.config, {
-        includeTruffleSources: true
-      });
+      const testResolver = new Resolver(this.config);
       const testFiles = glob
         .sync(`${this.config.test_directory}/**/*.sol`)
         .map(filePath => path.resolve(filePath));

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,6 +54,7 @@
     "@truffle/spinners": "^0.2.3",
     "@truffle/test": "^0.1.4",
     "@truffle/workflow-compile": "^4.0.43",
+    "JSONStream": "^1.3.5",
     "address": "^1.1.2",
     "chai": "^4.2.0",
     "colors": "1.4.0",

--- a/packages/environment/develop.js
+++ b/packages/environment/develop.js
@@ -103,7 +103,7 @@ const Develop = {
     // enable output/logger for solidity console.log
     loggers.solidity = sanitizeAndCallFn(
       createSolidityLogger(
-        truffleConfig.solidityLog && truffleConfig.solidityLog.prefix
+        truffleConfig.solidityLog && truffleConfig.solidityLog.displayPrefix
       )
     );
 

--- a/packages/environment/develop.js
+++ b/packages/environment/develop.js
@@ -2,9 +2,10 @@ const { IPC } = require("node-ipc");
 const path = require("path");
 const { spawn } = require("child_process");
 const debug = require("debug");
+const chalk = require("chalk");
 
 const Develop = {
-  start: async function (ipcNetwork, options = {}) {
+  start: async function (ipcNetwork, ganacheOptions = {}) {
     let chainPath;
 
     // The path to the dev env process depends on whether or not
@@ -18,10 +19,11 @@ const Develop = {
       chainPath = path.join(__dirname, "./", "chain.js");
     }
 
-    const logger = options.logger || console;
-    //check that genesis-time config option passed through the truffle-config.js file is a valid time.
-    if (options.time && isNaN(Date.parse(options.time))) {
-      options.time = Date.now();
+    const logger = ganacheOptions.logger || console;
+    //check that genesis-time config option passed through the
+    //truffle-config.js file is a valid time.
+    if (ganacheOptions.time && isNaN(Date.parse(ganacheOptions.time))) {
+      ganacheOptions.time = Date.now();
       logger.log(
         "\x1b[31m%s\x1b[0m",
         "Invalid Date passed to genesis-time, using current Date instead",
@@ -29,7 +31,7 @@ const Develop = {
       );
     }
 
-    const stringifiedOptions = JSON.stringify(options);
+    const stringifiedOptions = JSON.stringify(ganacheOptions);
     const optionsBuffer = Buffer.from(stringifiedOptions);
     const base64OptionsString = optionsBuffer.toString("base64");
 
@@ -39,18 +41,20 @@ const Develop = {
     });
   },
 
-  connect: function (options) {
+  connect: function (ipcOptions, truffleConfig) {
     const debugServer = debug("develop:ipc:server");
     const debugClient = debug("develop:ipc:client");
     const debugRPC = debug("develop:ganache");
-    // make the `develop:ganache` debug prefix orange
-    // 215 is Xterm number for "SandyBrown" (#ffaf5f)
-    debugRPC.color = 215;
+    const ganacheColor = {
+      hex: "#ffaf5f", // ganache's color in hex
+      xterm: 215 // Xterm's number equivalent
+    };
+    debugRPC.color = ganacheColor.xterm;
 
-    options.retry = options.retry || false;
-    options.log = options.log || false;
-    options.network = options.network || "develop";
-    var ipcNetwork = options.network;
+    ipcOptions.retry = ipcOptions.retry || false;
+    ipcOptions.log = ipcOptions.log || false;
+    ipcOptions.network = ipcOptions.network || "develop";
+    var ipcNetwork = ipcOptions.network;
 
     var ipc = new IPC();
     ipc.config.appspace = "truffle.";
@@ -59,22 +63,16 @@ const Develop = {
     var dirname = ipc.config.socketRoot;
     var basename = `${ipc.config.appspace}${ipcNetwork}`;
     var connectPath = path.join(dirname, basename);
+    var loggers = {};
 
     ipc.config.silent = !debugClient.enabled;
     ipc.config.logger = debugClient;
 
-    var loggers = {};
-
-    if (debugServer.enabled) {
-      loggers.ipc = debugServer;
-    }
-
-    if (options.log) {
-      debugRPC.enabled = true;
-
-      loggers.ganache = function () {
+    const sanitizeAndCallFn =
+      fn =>
+      (...args) => {
         // HACK-y: replace `{}` that is getting logged instead of ""
-        var args = Array.prototype.slice.call(arguments);
+        // var args = Array.prototype.slice.call(arguments);
         if (
           args.length === 1 &&
           typeof args[0] === "object" &&
@@ -82,12 +80,39 @@ const Develop = {
         ) {
           args[0] = "";
         }
-
-        debugRPC.apply(undefined, args);
+        fn.apply(undefined, args);
       };
+
+    if (debugServer.enabled) {
+      loggers.ipc = debugServer;
     }
 
-    if (!options.retry) {
+    // create a logger to present Ganache's console log messages
+    const createSolidityLogger = prefix => {
+      if (prefix == null || typeof prefix !== "string") {
+        prefix = "";
+      }
+
+      return maybeMultipleLines =>
+        maybeMultipleLines.split("\n").forEach(
+          // decorate each line's prefix.
+          line => console.log(chalk.hex(ganacheColor.hex)(` ${prefix}`), line)
+        );
+    };
+
+    // enable output/logger for solidity console.log
+    loggers.solidity = sanitizeAndCallFn(
+      createSolidityLogger(
+        truffleConfig.solidityLog && truffleConfig.solidityLog.prefix
+      )
+    );
+
+    if (ipcOptions.log) {
+      debugRPC.enabled = true;
+      loggers.ganache = sanitizeAndCallFn(debugRPC);
+    }
+
+    if (!ipcOptions.retry) {
       ipc.config.maxRetries = 0;
     }
 
@@ -116,20 +141,31 @@ const Develop = {
     });
   },
 
-  connectOrStart: async function (options, ganacheOptions) {
-    options.retry = false;
+  /**
+   * Connect to a managed Ganache service. This will connect to an existing
+   * Ganache service if one exists, or, create a new one to connect to.
+   *
+   * @param {Object} ipcOptions
+   * @param {string} ipcOptions.network the network name.
+   * @param {Object} ganacheOptions to be used if starting a Ganache service is
+   *        necessary.
+   * @param {TruffleConfig} truffleConfig the truffle config.
+   * @returns void
+   */
+  connectOrStart: async function (ipcOptions, ganacheOptions, truffleConfig) {
+    ipcOptions.retry = false;
 
-    const ipcNetwork = options.network || "develop";
+    const ipcNetwork = ipcOptions.network || "develop";
 
     let started = false;
     let disconnect;
 
     try {
-      disconnect = await this.connect(options);
+      disconnect = await this.connect(ipcOptions, truffleConfig);
     } catch (_error) {
       await this.start(ipcNetwork, ganacheOptions);
-      options.retry = true;
-      disconnect = await this.connect(options);
+      ipcOptions.retry = true;
+      disconnect = await this.connect(ipcOptions, truffleConfig);
       started = true;
     } finally {
       return {

--- a/packages/environment/develop.js
+++ b/packages/environment/develop.js
@@ -72,7 +72,6 @@ const Develop = {
       fn =>
       (...args) => {
         // HACK-y: replace `{}` that is getting logged instead of ""
-        // var args = Array.prototype.slice.call(arguments);
         if (
           args.length === 1 &&
           typeof args[0] === "object" &&

--- a/packages/environment/package.json
+++ b/packages/environment/package.json
@@ -27,6 +27,7 @@
     "@truffle/provider": "^0.2.64",
     "@truffle/resolver": "^9.0.25",
     "ganache": "7.5.0",
+    "chalk": "^4.1.2",
     "node-ipc": "9.2.1",
     "source-map-support": "^0.5.19",
     "web3": "1.7.4"

--- a/packages/environment/package.json
+++ b/packages/environment/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@truffle/artifactor": "^4.0.177",
+    "@truffle/config": "^1.3.42",
     "@truffle/error": "^0.1.1",
     "@truffle/expect": "^0.1.4",
     "@truffle/interface-adapter": "^0.5.25",
@@ -33,7 +34,8 @@
     "web3": "1.7.4"
   },
   "devDependencies": {
-    "debug": "^4.3.1"
+    "debug": "^4.3.1",
+    "mocha": "9.2.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/environment/package.json
+++ b/packages/environment/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@truffle/artifactor": "^4.0.177",
-    "@truffle/config": "^1.3.42",
+    "@truffle/config": "^1.3.45",
     "@truffle/error": "^0.1.1",
     "@truffle/expect": "^0.1.4",
     "@truffle/interface-adapter": "^0.5.25",

--- a/packages/environment/test/connectOrStartTest.js
+++ b/packages/environment/test/connectOrStartTest.js
@@ -1,5 +1,6 @@
 const assert = require("chai").assert;
 const Develop = require("../develop");
+const TruffleConfig = require("@truffle/config");
 
 describe("connectOrStart test network", async function () {
   const ipcOptions = { network: "test" };
@@ -12,7 +13,11 @@ describe("connectOrStart test network", async function () {
   it("starts Ganache when no Ganache instance is running", async function () {
     let connection;
     try {
-      connection = await Develop.connectOrStart(ipcOptions, ganacheOptions);
+      connection = await Develop.connectOrStart(
+        ipcOptions,
+        ganacheOptions,
+        TruffleConfig.default()
+      );
       assert.isTrue(connection.started, "A new Ganache server did not spin up");
       assert.isFunction(connection.disconnect, "disconnect is not a function");
     } finally {
@@ -29,13 +34,20 @@ describe("connectOrStart test network", async function () {
     try {
       //Establish IPC Ganache service
       spawnedGanache = await Develop.start(ipcOptions.network, ganacheOptions);
-      connectionOneDisconnect = await Develop.connect({
-        ...ipcOptions,
-        retry: true
-      });
+      connectionOneDisconnect = await Develop.connect(
+        {
+          ...ipcOptions,
+          retry: true
+        },
+        TruffleConfig.default()
+      );
 
       //Test
-      connectionTwo = await Develop.connectOrStart(ipcOptions, ganacheOptions);
+      connectionTwo = await Develop.connectOrStart(
+        ipcOptions,
+        ganacheOptions,
+        TruffleConfig.default()
+      );
 
       //Validate
       assert.isFalse(connectionTwo.started);

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -27,6 +27,7 @@
     "@truffle/interface-adapter": "^0.5.25",
     "@truffle/require": "^2.1.15",
     "@truffle/resolver": "^9.0.25",
+    "JSONStream": "^1.3.5",
     "glob": "^7.1.6",
     "inquirer": "8.2.4"
   },

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -27,7 +27,6 @@
     "@truffle/interface-adapter": "^0.5.25",
     "@truffle/require": "^2.1.15",
     "@truffle/resolver": "^9.0.25",
-    "JSONStream": "^1.3.5",
     "glob": "^7.1.6",
     "inquirer": "8.2.4"
   },

--- a/packages/resolver/.eslintrc.json
+++ b/packages/resolver/.eslintrc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../.eslintrc.package.json"]
+}
+

--- a/packages/resolver/lib/resolver.ts
+++ b/packages/resolver/lib/resolver.ts
@@ -53,15 +53,16 @@ export class Resolver {
     import_path: string,
     search_path?: string
   ): ReturnType<typeof contract> {
-    let abstraction;
-    this.sources.forEach((source: ResolverSource) => {
+    for (const source of this.sources) {
       const result = source.require(import_path, search_path);
       if (result) {
-        abstraction = contract(result);
+        let abstraction = contract(result);
         provision(abstraction, this.options);
+        return abstraction;
       }
-    });
-    if (abstraction) return abstraction;
+    }
+
+    // exhausted sources and could not resolve
     throw new Error(
       "Could not find artifacts for " + import_path + " from any sources"
     );

--- a/packages/resolver/lib/resolver.ts
+++ b/packages/resolver/lib/resolver.ts
@@ -1,6 +1,3 @@
-import debugModule from "debug";
-const debug = debugModule("resolver");
-
 const contract = require("@truffle/contract");
 const expect = require("@truffle/expect");
 const provision = require("@truffle/provisioner");
@@ -16,7 +13,10 @@ export class Resolver {
   options: any;
   sources: ResolverSource[];
 
-  constructor(options: any, resolverOptions: ResolverOptions = {}) {
+  constructor(
+    options: any,
+    resolverOptions: ResolverOptions = { includeTruffleSources: true }
+  ) {
     expect.options(options, [
       "working_directory",
       "contracts_build_directory",

--- a/packages/resolver/lib/resolver.ts
+++ b/packages/resolver/lib/resolver.ts
@@ -56,7 +56,7 @@ export class Resolver {
     for (const source of this.sources) {
       const result = source.require(import_path, search_path);
       if (result) {
-        let abstraction = contract(result);
+        const abstraction = contract(result);
         provision(abstraction, this.options);
         return abstraction;
       }

--- a/packages/resolver/lib/sources/truffle/index.ts
+++ b/packages/resolver/lib/sources/truffle/index.ts
@@ -73,7 +73,13 @@ export class Truffle implements ResolverSource {
         this.options.compilers
       );
       return { body: addressSource, filePath: importPath };
-    } else if (importPath === `truffle${path.sep}Console.sol`) {
+    }
+
+    // Match both Camel and Pascal casing for console.sol
+    if (
+      importPath === `truffle${path.sep}Console.sol` ||
+      importPath === `truffle${path.sep}console.sol`
+    ) {
       // calculating this in webpack env breaks
       let unbundledGanacheConsoleSol;
       // @ts-ignore

--- a/packages/resolver/lib/sources/truffle/index.ts
+++ b/packages/resolver/lib/sources/truffle/index.ts
@@ -79,12 +79,7 @@ export class Truffle implements ResolverSource {
       // @ts-ignore
       if (typeof BUNDLE_VERSION === "undefined") {
         unbundledGanacheConsoleSol = path.resolve(
-          path.join(
-            require.resolve("@ganache/console.log"),
-            "..",
-            "..",
-            "console.sol"
-          )
+          require.resolve("@ganache/console.log/console.sol")
         );
       }
       const actualImportPath =

--- a/packages/resolver/package.json
+++ b/packages/resolver/package.json
@@ -27,6 +27,7 @@
   },
   "types": "dist/lib/index.d.ts",
   "dependencies": {
+    "@ganache/console.log": "0.2.0",
     "@truffle/compile-solidity": "^6.0.52",
     "@truffle/contract": "^4.6.9",
     "@truffle/contract-sources": "^0.2.0",

--- a/packages/resolver/test/truffle.js
+++ b/packages/resolver/test/truffle.js
@@ -7,7 +7,6 @@ const { Truffle } = require("../dist/lib/sources/truffle");
 const resolver = new Truffle({});
 
 describe("truffle resolve", function () {
-
   describe("assertion contracts", () => {
     [
       "Assert",
@@ -24,6 +23,8 @@ describe("truffle resolve", function () {
       "AssertUint",
       "AssertUintArray",
       "SafeSend",
+      "console",
+      "Console"
     ].forEach(lib => {
       it(`resolves truffle/${lib}.sol`, async () => {
         const dependency = path.join("truffle", `${lib}.sol`);
@@ -32,7 +33,7 @@ describe("truffle resolve", function () {
           result.filePath.includes(dependency),
           `should have resovled 'truffle${path.sep}${lib}.sol'`
         );
-      })
-    })
+      });
+    });
   });
 });

--- a/packages/test/src/SolidityTest.ts
+++ b/packages/test/src/SolidityTest.ts
@@ -138,7 +138,8 @@ export const SolidityTest = {
       "truffle/AssertUint.sol",
       "truffle/AssertUintArray.sol",
       "truffle/DeployedAddresses.sol",
-      `truffle/SafeSend.sol`
+      "truffle/SafeSend.sol",
+      "truffle/Console.sol"
     ];
 
     const { compilations } = await Compile.sourcesWithDependencies({
@@ -195,7 +196,8 @@ export const SolidityTest = {
       "AssertString",
       "AssertUint",
       "AssertUintArray",
-      "DeployedAddresses"
+      "DeployedAddresses",
+      "Console"
     ];
 
     const testAbstractions = testLibraries.map(name =>

--- a/packages/test/src/Test.ts
+++ b/packages/test/src/Test.ts
@@ -122,9 +122,7 @@ export const Test = {
 
     const accounts = await this.getAccounts(interfaceAdapter);
 
-    const testResolver = new Resolver(config, {
-      includeTruffleSources: true
-    });
+    const testResolver = new Resolver(config);
 
     const { compilations } = await this.compileContractsWithTestFilesIfNeeded(
       solTests,

--- a/packages/test/src/TestRunner.ts
+++ b/packages/test/src/TestRunner.ts
@@ -66,9 +66,7 @@ export class TestRunner {
 
   async initialize() {
     debug("initializing");
-    this.config.resolver = new Resolver(this.config, {
-      includeTruffleSources: true
-    });
+    this.config.resolver = new Resolver(this.config);
 
     if (this.firstSnapshot) {
       debug("taking first snapshot");

--- a/packages/truffle/package.json
+++ b/packages/truffle/package.json
@@ -42,6 +42,7 @@
     "original-require": "^1.0.1"
   },
   "devDependencies": {
+    "@ganache/console.log": "^0.2.0",
     "@truffle/box": "^2.1.65",
     "@truffle/config": "^1.3.45",
     "@truffle/contract": "^4.6.9",

--- a/packages/truffle/test/scenarios/sandbox.js
+++ b/packages/truffle/test/scenarios/sandbox.js
@@ -17,7 +17,8 @@ module.exports = {
     );
     return {
       config,
-      cleanupSandboxDir: tempDir.removeCallback
+      cleanupSandboxDir: tempDir.removeCallback,
+      tempDirPath: path.join(tempDir.name, subPath)
     };
   },
 

--- a/packages/truffle/test/scenarios/solidity_console/Printf.sol
+++ b/packages/truffle/test/scenarios/solidity_console/Printf.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.4.22 <0.9.0;
 
-import "./console.sol";
+import "truffle/Console.sol";
 
 contract Printf {
   address public owner = msg.sender;

--- a/packages/truffle/test/scenarios/solidity_console/Printf.sol
+++ b/packages/truffle/test/scenarios/solidity_console/Printf.sol
@@ -4,8 +4,6 @@ pragma solidity >=0.4.22 <0.9.0;
 import "truffle/Console.sol";
 
 contract Printf {
-  address public owner = msg.sender;
-
   constructor() payable { }
 
   function log_string() view public {

--- a/packages/truffle/test/scenarios/solidity_console/Printf.sol
+++ b/packages/truffle/test/scenarios/solidity_console/Printf.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.4.22 <0.9.0;
+
+import "./console.sol";
+
+contract Printf {
+  address public owner = msg.sender;
+
+  constructor() payable { }
+
+  function log_string() view public {
+    console.log("String! I am not a twine!");
+  }
+
+  function log_unicode() view public {
+    console.log(unicode"This is unicode: ☮");
+  }
+
+  function log_address_o() view public {
+    console.log("The address is: %o", address(this));
+  }
+
+  function log_address_s() view public {
+    console.log("The address is: %s", address(this));
+  }
+
+  function log_multiline_carriageReturn() view public {
+    console.log("The cr: line 1\r       line 2\rline 3");
+  }
+
+  function log_multiline_lineFeed() view public {
+    console.log("The lf: line 1\nline 2\nline 3");
+  }
+
+  function log_uint256() view public returns (uint256) {
+    console.log("The uint256: %d", address(this).balance);
+    return address(this).balance;
+  }
+}

--- a/packages/truffle/test/scenarios/solidity_console/printf.js
+++ b/packages/truffle/test/scenarios/solidity_console/printf.js
@@ -16,18 +16,6 @@ const formatLines = lines =>
     .join("\n");
 
 const copyFixtures = config => {
-  const ganacheConsoleSol = path.resolve(
-    path.join(
-      __dirname,
-      "../../../../..",
-      "node_modules/@ganache/console.log/console.sol"
-    )
-  );
-  fs.copySync(
-    ganacheConsoleSol,
-    path.join(config.contracts_directory, "console.sol")
-  );
-
   fs.copySync(
     path.join(__dirname, "Printf.sol"),
     path.join(config.contracts_directory, "Printf.sol")

--- a/packages/truffle/test/scenarios/solidity_console/printf.js
+++ b/packages/truffle/test/scenarios/solidity_console/printf.js
@@ -157,7 +157,7 @@ describe("Solidity console log [ @standalone ]", function () {
       await server.close();
     });
 
-    it("MAINNET disableMigrate: false", async function () {
+    it("MAINNET preventConsoleLogMigration: false", async function () {
       try {
         logger = new MemoryLogger();
         config.logger = logger;
@@ -174,7 +174,7 @@ describe("Solidity console log [ @standalone ]", function () {
       }
     });
 
-    it("MAINNET disableMigrate: true", async function () {
+    it("MAINNET preventConsoleLogMigration: true", async function () {
       try {
         logger = new MemoryLogger();
         config.logger = logger;
@@ -193,7 +193,7 @@ describe("Solidity console log [ @standalone ]", function () {
         const exceptionMessage =
           "You are trying to deploy contracts that use console.log." +
           os.EOL +
-          "Please fix, or disable this check by setting solidityLog.disableMigrate to false" +
+          "Please fix, or disable this check by setting solidityLog.preventConsoleLogMigration to false" +
           os.EOL;
         assert(
           logger.includes(exceptionMessage),

--- a/packages/truffle/test/scenarios/solidity_console/printf.js
+++ b/packages/truffle/test/scenarios/solidity_console/printf.js
@@ -38,7 +38,7 @@ describe("Solidity console log [ @standalone ]", function () {
   let config, logger, output, provider;
   let cleanupSandboxDir;
 
-  this.timeout(10000);
+  this.timeout(30000);
 
   before("set up sandbox", async () => {
     ({ config, cleanupSandboxDir } = await sandbox.create(
@@ -148,7 +148,7 @@ describe("Solidity console log [ @standalone ]", function () {
   });
 
   describe("Migration", async function () {
-    this.timeout(100000);
+    this.timeout(30000);
     let server;
     before("setup: interact with contract", async function () {
       server = Ganache.server({

--- a/packages/truffle/test/scenarios/solidity_console/printf.js
+++ b/packages/truffle/test/scenarios/solidity_console/printf.js
@@ -151,6 +151,7 @@ describe("Solidity console log [ @standalone ]", function () {
   describe("Migration", async function () {
     this.timeout(30000);
     let server;
+    let debugEnv = "";
 
     before("setup: interact with contract", async function () {
       server = Ganache.server({
@@ -177,11 +178,7 @@ describe("Solidity console log [ @standalone ]", function () {
           path.join(tempDirPath, "config-disable-migrate-false.js"),
           path.join(tempDirPath, "truffle-config.js")
         );
-        await CommandRunner.run(
-          "migrate --network mainnet",
-          config,
-          "migrate:run"
-        );
+        await CommandRunner.run("migrate --network mainnet", config, debugEnv);
         assert(logger.includes("Total deployments:   1"));
       } catch (error) {
         console.log("ERROR: %o", error);
@@ -201,7 +198,7 @@ describe("Solidity console log [ @standalone ]", function () {
         await CommandRunner.run(
           "migrate --network mainnet --reset --skip-dry-run",
           config,
-          "migrate:run:*"
+          debugEnv
         );
         assert.fail("Migration should have failed");
       } catch (error) {

--- a/packages/truffle/test/scenarios/solidity_console/printf.js
+++ b/packages/truffle/test/scenarios/solidity_console/printf.js
@@ -169,7 +169,7 @@ describe("Solidity console log [ @standalone ]", function () {
       await server.close();
     });
 
-    it("MAINNET disableMigration: false", async function () {
+    it("MAINNET disableMigrate: false", async function () {
       try {
         logger = new MemoryLogger();
         config.logger = logger;
@@ -186,7 +186,7 @@ describe("Solidity console log [ @standalone ]", function () {
       }
     });
 
-    it("MAINNET disableMigration: true", async function () {
+    it("MAINNET disableMigrate: true", async function () {
       try {
         logger = new MemoryLogger();
         config.logger = logger;

--- a/packages/truffle/test/scenarios/solidity_console/printf.js
+++ b/packages/truffle/test/scenarios/solidity_console/printf.js
@@ -1,0 +1,198 @@
+const MemoryLogger = require("../MemoryLogger");
+const CommandRunner = require("../commandRunner");
+const fs = require("fs-extra");
+const path = require("path");
+const assert = require("assert");
+const Ganache = require("ganache");
+const sandbox = require("../sandbox");
+const MemDown = require("memdown");
+const os = require("os");
+
+//prepare a helpful message to standout in CI log noise
+const formatLines = lines =>
+  lines
+    .split("\n")
+    .map(line => `\t---truffle develop log---\t${line}`)
+    .join("\n");
+
+const copyFixtures = config => {
+  const ganacheConsoleSol = path.resolve(
+    path.join(
+      __dirname,
+      "../../../../..",
+      "node_modules/@ganache/console.log/console.sol"
+    )
+  );
+  fs.copySync(
+    ganacheConsoleSol,
+    path.join(config.contracts_directory, "console.sol")
+  );
+
+  fs.copySync(
+    path.join(__dirname, "Printf.sol"),
+    path.join(config.contracts_directory, "Printf.sol")
+  );
+};
+
+describe("Solidity console log [ @standalone ]", function () {
+  let config, logger, output, provider;
+  let cleanupSandboxDir;
+
+  this.timeout(10000);
+
+  before("set up sandbox", async () => {
+    ({ config, cleanupSandboxDir } = await sandbox.create(
+      path.join(__dirname, "../../sources/init")
+    ));
+
+    provider = Ganache.provider({
+      miner: { instamine: "eager" },
+      gasLimit: config.gasLimit,
+      database: { db: new MemDown() }
+    });
+
+    logger = new MemoryLogger();
+    config.logger = logger;
+    config.networks = { development: { provider } };
+
+    copyFixtures(config);
+  });
+
+  after(async () => {
+    await cleanupSandboxDir();
+  });
+
+  describe("Logging", async function () {
+    before("setup: interact with contract", async function () {
+      const input = [
+        "compile",
+        "p = await Printf.new({value: 0x11235})",
+        "`Contract address is: ${p.address}`",
+
+        "await p.log_string()",
+        "await p.log_unicode()",
+        "await p.log_address_s()",
+        "await p.log_address_o()",
+        "await p.log_multiline_carriageReturn()",
+        "await p.log_multiline_lineFeed()"
+      ];
+
+      await CommandRunner.runInREPL({
+        inputCommands: input,
+        config,
+        executableCommand: "develop",
+        displayHost: "develop"
+      });
+
+      output = logger.contents().replace(/\x1b\[[0-9;]*m/g, ""); // strip terminal control codes
+    });
+
+    after(async () => {
+      provider && (await provider.disconnect());
+    });
+
+    it("logs string", function () {
+      let expectedValue = ":  String! I am not a twine!";
+
+      assert(
+        output.includes(expectedValue),
+        `Expected: "${expectedValue}" in output:\n${formatLines(output)}`
+      );
+    });
+
+    it("logs unicode", () => {
+      let expectedValue = ":  This is unicode: ☮";
+      assert(
+        output.includes(expectedValue),
+        `Expected: "${expectedValue}" in output:\n${formatLines(output)}`
+      );
+    });
+
+    it("logs address as %o", () => {
+      let expectedValue = ":  The address is: 0x...";
+      let rex = /:  The address is: '0x[\da-f]{40}'/;
+      assert(
+        rex.test(output),
+        `Expected: "${expectedValue}" in output:\n${formatLines(output)}`
+      );
+    });
+
+    it("Logs address as %s", () => {
+      let expectedValue = ":  The address is: 0x...";
+      let rex = /:  The address is: 0x[\da-f]{40}/;
+      assert(
+        rex.test(output),
+        `Expected: "${expectedValue}" in output:\n${formatLines(output)}`
+      );
+    });
+
+    it("Logs multiline strings with carriage-return", () => {
+      let rex = /:  The cr: line 1.       line 2.line 3/is;
+      assert(
+        rex.test(output),
+        `Expected: a string with carriage return in output:\n${formatLines(
+          output
+        )}`
+      );
+    });
+
+    it("Logs multiline strings with linefeed", () => {
+      let rex1 = /:  The lf: line 1/;
+      let rex2 = /:  line 2/;
+      let rex3 = /:  line 3/;
+      assert(
+        rex1.test(output) && rex2.test(output) && rex3.test(output),
+        `Expected: a string with linefeeds in output:\n${formatLines(output)}`
+      );
+    });
+  });
+
+  describe("Migration", async function () {
+    this.timeout(100000);
+    let server;
+    before("setup: interact with contract", async function () {
+      server = Ganache.server({
+        chain: { chainId: 1, networkId: 1 },
+        miner: { instamine: "eager" },
+        database: { db: new MemDown() },
+        logging: { quiet: true }
+      });
+      await server.listen(7545);
+
+      copyFixtures(config);
+    });
+
+    after(async () => {
+      await server.close();
+    });
+
+    it("MAINNET disableMigration: false", async function () {
+      try {
+        logger = new MemoryLogger();
+        config.logger = logger;
+        config.solidityLog = { disableMigration: false };
+        await CommandRunner.run("migrate --network mainnet", config);
+        assert(logger.includes("Total deployments:   1"));
+      } catch (error) {
+        console.log("ERROR: %o", error);
+        assert.fail(); // flow should not get here
+      }
+    });
+
+    it("MAINNET disableMigration: true", async function () {
+      try {
+        logger = new MemoryLogger();
+        config.logger = logger;
+        config.solidityLog = { disableMigration: true };
+        await CommandRunner.run("migrate --network mainnet", config);
+        assert.fail(); // flow should not get here
+      } catch (error) {
+        const exceptionMessage =
+          "You are trying to deploy contracts that use console.log." +
+          os.EOL +
+          "Please fix, or disable this check by setting solidityLog.disableMigration to false";
+        assert(logger.includes(exceptionMessage), "Expected Migration to fail"); //TODO: get warning verbiage correct
+      }
+    });
+  });
+});

--- a/packages/truffle/test/scenarios/solidity_console/printf.js
+++ b/packages/truffle/test/scenarios/solidity_console/printf.js
@@ -6,7 +6,6 @@ const assert = require("assert");
 const Ganache = require("ganache");
 const sandbox = require("../sandbox");
 const MemDown = require("memdown");
-const os = require("os");
 
 //prepare a helpful message to standout in CI log noise
 const formatLines = lines =>
@@ -190,15 +189,21 @@ describe("Solidity console log [ @standalone ]", function () {
         );
         assert.fail("Migration should have failed");
       } catch (error) {
-        const exceptionMessage =
-          "You are trying to deploy contracts that use console.log." +
-          os.EOL +
-          "Please fix, or disable this check by setting solidityLog.preventConsoleLogMigration to false" +
-          os.EOL;
+        const output = logger.contents();
+        const summary =
+          /Solidity console.log detected in the following assets:.+Printf.json/ms;
         assert(
-          logger.includes(exceptionMessage),
-          "Migration should have failed"
+          summary.test(output),
+          "Should list the contract using console.log"
         );
+        const action1 =
+          /You are trying to deploy contracts that use console.log./;
+
+        assert(action1.test(output), "Should suggest action");
+
+        const action2 =
+          /Please fix, or disable this check by setting.+preventConsoleLogMigration to false/;
+        assert(action2.test(output), "Should suggest action");
       }
     });
   });

--- a/packages/truffle/test/sources/init/config-disable-migrate-false.js
+++ b/packages/truffle/test/sources/init/config-disable-migrate-false.js
@@ -1,6 +1,7 @@
 module.exports = {
   solidityLog: {
-    displayPrefix: ": "
+    displayPrefix: ": ",
+    disableMigrate: false
   },
 
   networks: {

--- a/packages/truffle/test/sources/init/config-disable-migrate-false.js
+++ b/packages/truffle/test/sources/init/config-disable-migrate-false.js
@@ -1,7 +1,7 @@
 module.exports = {
   solidityLog: {
     displayPrefix: ": ",
-    disableMigrate: false
+    preventConsoleLogMigration: false
   },
 
   networks: {

--- a/packages/truffle/test/sources/init/config-disable-migrate-true.js
+++ b/packages/truffle/test/sources/init/config-disable-migrate-true.js
@@ -1,7 +1,7 @@
 module.exports = {
   solidityLog: {
     displayPrefix: ": ",
-    disableMigrate: true
+    preventConsoleLogMigration: true
   },
 
   networks: {

--- a/packages/truffle/test/sources/init/config-disable-migrate-true.js
+++ b/packages/truffle/test/sources/init/config-disable-migrate-true.js
@@ -1,6 +1,7 @@
 module.exports = {
   solidityLog: {
-    displayPrefix: ": "
+    displayPrefix: ": ",
+    disableMigrate: true
   },
 
   networks: {

--- a/packages/truffle/test/sources/init/truffle-config.js
+++ b/packages/truffle/test/sources/init/truffle-config.js
@@ -1,4 +1,17 @@
 module.exports = {
+  solidityLog: {
+    displayPrefix: ": ",
+    disableMigration: true
+  },
+
+  networks: {
+    mainnet: {
+      network_id: 1,
+      host: "127.0.0.1",
+      port: 7545
+    }
+  },
+
   compilers: {
     solc: {
       version: "0.8.13" // Fetch exact version from solc-bin (default: truffle's version)

--- a/packages/truffle/webpack.config.js
+++ b/packages/truffle/webpack.config.js
@@ -25,9 +25,7 @@ const truffleRequireDistDirectory = path.join(
   "dist"
 );
 
-const ganacheConsoleSol = path.resolve(
-  path.join(require.resolve("@ganache/console.log"), "..", "..", "console.sol")
-);
+const ganacheConsoleSol = require.resolve("@ganache/console.log/console.sol");
 
 const commandsEntries = commands.reduce((a, command) => {
   a[command] = path.join(

--- a/packages/truffle/webpack.config.js
+++ b/packages/truffle/webpack.config.js
@@ -25,6 +25,10 @@ const truffleRequireDistDirectory = path.join(
   "dist"
 );
 
+const ganacheConsoleSol = path.resolve(
+  path.join(require.resolve("@ganache/console.log"), "..", "..", "console.sol")
+);
+
 const commandsEntries = commands.reduce((a, command) => {
   a[command] = path.join(
     __dirname,
@@ -175,7 +179,7 @@ module.exports = {
         "bn.js"
       ),
       "original-fs": path.join(__dirname, "./nil.js"),
-      scrypt: "js-scrypt"
+      "scrypt": "js-scrypt"
     }
   },
 
@@ -212,6 +216,9 @@ module.exports = {
             "initSource"
           ),
           to: "initSource"
+        },
+        {
+          from: ganacheConsoleSol
         },
         {
           from: path.join(truffleLibraryDirectory, "Assert.sol")

--- a/yarn.lock
+++ b/yarn.lock
@@ -3706,7 +3706,7 @@
     "@floating-ui/dom" "^0.5.3"
     use-isomorphic-layout-effect "^1.1.1"
 
-"@ganache/console.log@^0.2.0":
+"@ganache/console.log@0.2.0", "@ganache/console.log@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@ganache/console.log/-/console.log-0.2.0.tgz#32ea0df806ed735d61bd0537d7b7fc350e511479"
   integrity sha512-+SNBUZzrbe4DE4F0jdl9SU8w3ek5k4cUE73ttUFweo8FaKEDQsMbFjZ3ZU0LM6QM/zCMqE7euSq0s/IlsYxf7A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3706,6 +3706,14 @@
     "@floating-ui/dom" "^0.5.3"
     use-isomorphic-layout-effect "^1.1.1"
 
+"@ganache/console.log@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@ganache/console.log/-/console.log-0.2.0.tgz#32ea0df806ed735d61bd0537d7b7fc350e511479"
+  integrity sha512-+SNBUZzrbe4DE4F0jdl9SU8w3ek5k4cUE73ttUFweo8FaKEDQsMbFjZ3ZU0LM6QM/zCMqE7euSq0s/IlsYxf7A==
+  dependencies:
+    "@ganache/utils" "0.3.0"
+    ethereumjs-util "7.1.5"
+
 "@ganache/ethereum-address@0.1.5":
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/@ganache/ethereum-address/-/ethereum-address-0.1.5.tgz#4b4994cf3b49b2f79bcd9fa9923f8217e956b99c"
@@ -3847,6 +3855,17 @@
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/@ganache/utils/-/utils-0.1.5.tgz#45687a42adc37cefee3c4557837df2f9bbfab96e"
   integrity sha512-1lpNtRVsGLb2rHwNnbVQj4lTehrw4j3iLgXF5a5GNRKCx7ccqZRrPaMKmSgo0XjFME4YsFMO+de7ZBRzfmiqcQ==
+  dependencies:
+    emittery "0.10.0"
+    keccak "3.0.1"
+    seedrandom "3.0.5"
+  optionalDependencies:
+    "@trufflesuite/bigint-buffer" "1.1.9"
+
+"@ganache/utils@0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@ganache/utils/-/utils-0.3.0.tgz#f95d7a4746d4e062febf3ce59f65f6ca1336be8a"
+  integrity sha512-cxoG8KQxkYPl71BPdKZihjVKqN2AE7WLXjU65BVOQ5jEYrUH3CWSxA9v7CCUJj4e0HoXFpVFIZ+1HRkiBKKiKg==
   dependencies:
     emittery "0.10.0"
     keccak "3.0.1"
@@ -13086,6 +13105,17 @@ ethereumjs-util@7.1.3:
     ethereum-cryptography "^0.1.3"
     rlp "^2.2.4"
 
+ethereumjs-util@7.1.5, ethereumjs-util@^7.1.5:
+  version "7.1.5"
+  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz#9ecf04861e4fbbeed7465ece5f23317ad1129181"
+  integrity sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==
+  dependencies:
+    "@types/bn.js" "^5.1.0"
+    bn.js "^5.1.2"
+    create-hash "^1.1.2"
+    ethereum-cryptography "^0.1.3"
+    rlp "^2.2.4"
+
 ethereumjs-util@^4.3.0:
   version "4.5.1"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-4.5.1.tgz#f4bf9b3b515a484e3cc8781d61d9d980f7c83bd0"
@@ -13164,17 +13194,6 @@ ethereumjs-util@^7.1.1, ethereumjs-util@^7.1.3, ethereumjs-util@^7.1.4:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz#a6885bcdd92045b06f596c7626c3e89ab3312458"
   integrity sha512-p6KmuPCX4mZIqsQzXfmSx9Y0l2hqf+VkAiwSisW3UKUFdk8ZkAt+AYaor83z2nSi6CU2zSsXMlD80hAbNEGM0A==
-  dependencies:
-    "@types/bn.js" "^5.1.0"
-    bn.js "^5.1.2"
-    create-hash "^1.1.2"
-    ethereum-cryptography "^0.1.3"
-    rlp "^2.2.4"
-
-ethereumjs-util@^7.1.5:
-  version "7.1.5"
-  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz#9ecf04861e4fbbeed7465ece5f23317ad1129181"
-  integrity sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==
   dependencies:
     "@types/bn.js" "^5.1.0"
     bn.js "^5.1.2"


### PR DESCRIPTION
## PR description

Integrates [`@ganache/console.sol`](https://github.com/trufflesuite/ganache/tree/develop/src/chains/ethereum/console.log) Smart contract logging into Truffle's test and develop workflow. 

Note: Ganache already provides console logging, but it isn't integrated into Truffle (if you start a ganache instance and use truffle to interact with your smart contract on the ganache instance, logging output will be in the Ganache's TTY)

This is part of the effort outlined in #5282 and should address: #5193 and #5195

<details><summary>Click to see sample output using truffle test</summary>

Note every line prefixed with a `:` is a console.log output.

```console
$ truffle test
Using network 'test'.


Compiling your contracts...
===========================
> Everything is up to date, there is nothing to compile.
  : CSTR::Simple
  :     secret: 13n


  Contract: Simple
    Works with migrations deployment
      ✔ Should have a deployed contract
      ✔ has the secret
  : The passphrase is: 13n
  : Leak it a hundred times, plus one more: 1313n
      ✔ has the derived Secret


    Works with new deployment
  : CSTR::Simple
  :     secret: 551n
      ✔ Should have a deployed contract
      ✔ has the secret
  : The passphrase is: 551n
  : Leak it a hundred times, plus one more: 55651n
      ✔ has the derived Secret


  6 passing (139ms)

```

</details>


### How to use in a project

- Import `truffle/Console.sol` in your contract and use its interface. See [Ganache docs for usage details](https://github.com/trufflesuite/ganache/tree/develop/src/chains/ethereum/console.log)
  ```solidity
   pragma solidity >=0.4.25 <0.9.0;
   import "truffle/Console.sol";
   
   ...
   // in some function...
   console.log("hello msg.sender: %o", msg.sender);
   ```
- Configuration: There are 2 options for configuration, both set in `truffle-config.js`. 
  1. `solidityLog.displayPrefix` sets the prefix for every console.log line. The
     default is `""`; however, it is a nice option when you want to differentiate
     console.log output from extra verbose text output.
  2. `solidityLog.preventConsoleLogMigration` a safety measure to disable accidentally
     migrating contracts that use console.log to MAINNET. The default is `false`,
     you would have to opt in, setting to `true`, should you need it. 

## Testing instructions

This is more of a smoke test scenario. Try adding console.log in a contract, or if you prefer, [try one of these](https://github.com/cds-amal/console-log-tests). Does logging work? Is it intuitive? Do reverts log how you expect? Please try to break it. This feature only works when using `truffle develop` or `truffle test`. 


- To test `preventConsoleLogMigration` you will need to run the project against a network that simulates Mainnet. This can be done by starting ganache w/ `ganache  --chain.networkId 1`

  The linked projects define a `mainfork` network in their `truffle-config.js`,
  so specify it in the migrate command (`truffle migrate --network mainfork`).

  |mainnet | preventConsoleLogMigration| expectation|
  |---|---|---|
  |false |false| it should deploy|
  |false |true| it should deploy |
  |true |false| it should deploy|
  |true |true| it should NOT deploy, and print a helpful, actionable message.|
  
  1. Start ganache w/ `ganache --chain.networkId 1` (simulate mainnet)
  2. Set `preventConsoleLogMigration` appropriately. test true/false on mainnet and not mainnet
  2. `truffle migrate --network mainfork` for testing on mainnet, if using one the linked projects.


## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.

## Breaking changes and new features

- [x] I have added any needed `breaking-change` and `new-feature` labels for the appropriate packages.
