### PR TITLE
Add sourcify networks for November

### DIFF
--- a/packages/source-fetcher/lib/networks.ts
+++ b/packages/source-fetcher/lib/networks.ts
@@ -76,7 +76,10 @@ export const networkNamesById: { [id: number]: string } = {
   71401: "testnet-godwoken",
   50: "xinfin", //not presently supported by either fetcher, but...
   51: "apothem-xinfin",
-  7700: "canto"
+  7700: "canto",
+  592: "astar",
+  8217: "cypress-klaytn", //not presently supported by either fetcher, but...
+  1001: "baobab-klaytn"
   //I'm not including crystaleum as it has network ID different from chain ID
   //not including kekchain for the same reason
 };

--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -50,7 +50,7 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "kovan-optimistic", //can no longer verify but can still fetch existing
     "goerli-optimistic",
     "arbitrum",
-    "rinkeby-arbitrum",
+    "rinkeby-arbitrum", //can no longer verify but can still fetch existing
     "goerli-arbitrum",
     "polygon",
     "mumbai-polygon",
@@ -104,7 +104,10 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "testnet-godwoken",
     //sourcify does *not* support xinfin mainnet...?
     "apothem-xinfin",
-    "canto"
+    "canto",
+    "astar",
+    //sourcify does *not* support klaytn mainnet cypress...?
+    "baobab-klaytn"
     //I'm excluding crystaleum as it has network ID different from chain ID
   ]);
 


### PR DESCRIPTION
Sourcify has added more networks.  Updated this.

Because this is such a small routine change, I didn't bother testing it.  But, uh, you could try using `fetch-and-compile` with a contract from one of these networks, I guess?

Sourcify's own tests use addresses `0xA7e70Be8A6563DCe75299c30D1566A83fC63BC37` and `0x571bb36009bB26D5313244B30397D2a2341a2A11` for chain 592, and addresses `0x662749a392CeB1b5973a90FB2c388a2C18B8812c` and `0x9FEc9e780c422916E21845748e001E949A5ddD57` for chain 1001, so those seem like ones to use for this purpose!