### PR TITLE
Remove babel from debugger

### DIFF
--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -38,17 +38,12 @@
     "web3-eth-abi": "1.7.4"
   },
   "devDependencies": {
-    "@babel/core": "^7.16.0",
-    "@babel/plugin-transform-runtime": "^7.16.4",
-    "@babel/preset-env": "^7.16.4",
     "@jsdevtools/coverage-istanbul-loader": "^3.0.5",
     "@truffle/artifactor": "^4.0.174",
     "@truffle/config": "^1.3.43",
     "@truffle/migrate": "^3.3.17",
     "@truffle/resolver": "^9.0.22",
     "@truffle/workflow-compile": "^4.0.40",
-    "babel-loader": "^9.1.0",
-    "babel-runtime": "^6.26.0",
     "chai": "^4.2.0",
     "change-case": "3.0.2",
     "faker": "5.5.3",

--- a/packages/debugger/webpack/webpack.config-common.js
+++ b/packages/debugger/webpack/webpack.config-common.js
@@ -6,28 +6,6 @@ module.exports = {
   devtool: "source-map",
   target: "node",
 
-  module: {
-    rules: [
-      {
-        test: /\.js$/,
-        use: {
-          loader: "babel-loader",
-          options: {
-            presets: [
-              [
-                "@babel/preset-env",
-                { targets: { node: "12.0" }, modules: false }
-              ]
-            ],
-            plugins: ["@babel/plugin-transform-runtime"]
-          }
-        },
-        exclude: [path.resolve(__dirname, "..", "node_modules")],
-        include: [path.resolve(__dirname, "..", "lib")]
-      }
-    ]
-  },
-
   output: {
     clean: true,
     library: "Debugger",

--- a/packages/debugger/webpack/webpack.config-test.js
+++ b/packages/debugger/webpack/webpack.config-test.js
@@ -13,26 +13,6 @@ module.exports = merge(commonConfig, {
         include: path.resolve(__dirname, "..", "lib"),
         exclude: path.resolve(__dirname, "..", "node_modules"),
         use: "@jsdevtools/coverage-istanbul-loader"
-      },
-      {
-        test: /\.js$/,
-        use: {
-          loader: "babel-loader",
-          options: {
-            presets: [
-              [
-                "@babel/preset-env",
-                { targets: { node: "12.0" }, modules: false }
-              ]
-            ],
-            plugins: ["@babel/plugin-transform-runtime"]
-          }
-        },
-        exclude: [path.resolve(__dirname, "..", "node_modules")],
-        include: [
-          path.resolve(__dirname, "..", "lib"),
-          path.resolve(__dirname, "..", "test")
-        ]
       }
     ]
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9875,14 +9875,6 @@ babel-loader@^8.2.3:
     make-dir "^3.1.0"
     schema-utils "^2.6.5"
 
-babel-loader@^9.1.0:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-9.1.0.tgz#839e9ae88aea930864ef9ec0f356dfca96ecf238"
-  integrity sha512-Antt61KJPinUMwHwIIz9T5zfMgevnfZkEVWYDWlG888fgdvRRGD0JTuf/fFozQnfT+uq64sk1bmdHDy/mOEWnA==
-  dependencies:
-    find-cache-dir "^3.3.2"
-    schema-utils "^4.0.0"
-
 babel-messages@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
@@ -15646,7 +15638,7 @@ find-cache-dir@^2.0.0:
     make-dir "^2.0.0"
     pkg-dir "^3.0.0"
 
-find-cache-dir@^3.2.0, find-cache-dir@^3.3.1, find-cache-dir@^3.3.2:
+find-cache-dir@^3.2.0, find-cache-dir@^3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.3.2.tgz#b30c5b6eff0730731aea9bbd9dbecbd80256d64b"
   integrity sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==


### PR DESCRIPTION
Since we no longer support Node versions older than Node 14, there's not really any more need for Babel in the debugger, so I removed it.

There was some worry that we still used Babel for certain things, but the tests passed, and I also did a manual run of the debugger to be sure.  Everything seems to work fine!