### PR TITLE
Fix error message on hitting `v` in debugger with no tx loaded

### DIFF
--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -740,7 +740,7 @@ class DebugPrinter {
   }
 
   async printVariables(sectionOuts = this.sectionPrintouts) {
-    const values = await this.session.variables({ indicateUnknown: true });
+    const values = await this.session.variables();
     const sections = this.session.view(data.current.identifiers.sections);
 
     const sectionNames = {


### PR DESCRIPTION
Once again, the CLI debugger was erroring if you hit `v` with no transaction loaded.  The problem comes from the `data.current.identifiers.sections` selector; this would error if no transaction was loaded.  So basically I added the appropriate guards to allow it to return something in this case; I'll skip going into detail because frankly it's nothing interesting.

Don't be scared by what looks like a gigantic change to complicated code on lines 684 to 767; the only difference is that the whole thing is now within a big `scopes && inlined ? oldStuff : null`.  None of the complicated parts were altered at all!  Most of those lines just had their indentation changed!  I guess you can turn off whitespace changes to make this more evident.

I didn't add any tests, but this is easy enough to test manually; go into a Truffle project, start up ganache, and do `truffle debug` and then `v`.  Hopefully you didn't see an error message!

Alternative I could have just fixed this on the CLI side by not asking for that selector in this case, but, IDK, I liked this approach.  :shrug:

Also, while I was at it, I removed a use of the obsolete `indicateUnknown` option.