### PR TITLE
CI: shorten prefix for debug logging

### DIFF
--- a/packages/truffle/test/scenarios/commandRunner.js
+++ b/packages/truffle/test/scenarios/commandRunner.js
@@ -11,12 +11,10 @@ const path = require("path");
  * @param {boolean} isError - true if error
  */
 const Log = (message, isError) => {
-  const decoratedPrefix = `\t---truffle commandRunner ${
-    isError ? "stderr" : "stdout"
-  }--- |\t`;
+  const prefix = `* ${isError ? "E" : " "} * |\t`;
   const annotatedMessage = message
     .split("\n")
-    .map(l => `${decoratedPrefix}${l}`)
+    .map(l => `${prefix}${l}`)
     .join("\n");
   console.log(annotatedMessage);
 };


### PR DESCRIPTION
## PR description

DEBUG output, when enabled, logs with a shorter prefix:
- `*   * |` prefixes Stdout
- `* E * |` prefexes Stderr

## Sample output
```console

  truffle migrate
    when run on the most basic truffle project
*   * | CommandRunner
*   * | execString: node /home/amal/work/trees/truffle/trim-it/packages/truffle/build/cli.bundled.js migrate
*   * |
*   * | Compiling your contracts...
*   * | ===========================
* E * | 2022-11-14T13:49:03.743Z dashboard-message-bus-client:client publisher sending message { id: 0.5939280616648626, type: 'debug', payload: { message: 'compile:start' } }
* E * | 2022-11-14T13:49:03.744Z dashboard-message-bus-client:connection _getMessageBusPort: publish connection attempting to fetch ports
* E * | 2022-11-14T13:49:03.747Z follow-redirects options {
```

## Testing instructions

Modify a test to [enable debugEnv](https://github.com/trufflesuite/truffle/blob/c0db72f7f1e028616fa6cfb7925799ca4292aa8e/packages/truffle/test/scenarios/commandRunner.js#L45-L45) when invoking `commandRunner.run` and verify the output contains lines prefixed by `*  *` or `* E *` 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.

## Breaking changes and new features

- [x] I have added any needed `breaking-change` and `new-feature` labels for the appropriate packages.
