### PR TITLE
Enhancement: More robustly handle help requests in Truffle

### DIFF
--- a/packages/core/cli.js
+++ b/packages/core/cli.js
@@ -52,6 +52,12 @@ if (userWantsGeneralHelp) {
   process.exit(0);
 }
 
+//if the last word of inputString is `help` or `--help`, re-assign inputString to run as `truffle help <cmd>`
+if (["help", "--help"].includes(inputStrings[inputStrings.length - 1])) {
+  inputStrings.pop();
+  inputStrings.unshift("help");
+}
+
 const {
   getCommand,
   prepareOptions,

--- a/packages/core/cli.js
+++ b/packages/core/cli.js
@@ -46,15 +46,32 @@ const {
   getCommand,
   prepareOptions,
   runCommand,
-  processHelpInput
+  displayGeneralHelp
 } = require("./lib/command-utils");
 
-//if `help` or `--help` is in the command, validate and transform the input
+//User only enter truffle with no commands, let's show them what's available.
+if (inputStrings.length === 0) {
+  displayGeneralHelp();
+  process.exit();
+}
+
+//if `help` or `--help` is in the command, validate and transform the input argument for help
 if (
   inputStrings.some(inputString => ["help", "--help"].includes(inputString))
 ) {
-  //handle general help case and displayCommand Help cases and return the inputStrings to be process further
-  processHelpInput(inputStrings);
+  //when user wants general help
+  if (inputStrings.length === 1) {
+    displayGeneralHelp();
+    process.exit();
+  }
+
+  //check where is --help used, mutate argument into a proper help command
+  const helpIndex = inputStrings.indexOf("--help");
+
+  if (helpIndex !== -1) {
+    inputStrings.splice(helpIndex, 1);
+    inputStrings.unshift("help");
+  }
 }
 
 const command = getCommand({

--- a/packages/core/cli.js
+++ b/packages/core/cli.js
@@ -43,12 +43,16 @@ listeners.forEach(listener => process.removeListener("warning", listener));
 let inputStrings = process.argv.slice(2);
 
 //check if user wants some help
-const helpNeeded = inputStrings.some(r => ["help", "--help"].indexOf(r) >= 0);
-
-if (helpNeeded) {
-  //check what help does user want
+if (inputStrings.length === 0) {
+  const { displayGeneralHelp } = require("./lib/command-utils");
+  displayGeneralHelp();
+  process.exit();
+} else if (
+  inputStrings.some(inputString => ["help", "--help"].includes(inputString))
+) {
+  //check what kind of help the user is looking for
   const { processHelpInput } = require("./lib/command-utils");
-  inputStrings = processHelpInput(inputStrings);
+  processHelpInput(inputStrings);
 }
 
 const {

--- a/packages/core/cli.js
+++ b/packages/core/cli.js
@@ -42,6 +42,16 @@ listeners.forEach(listener => process.removeListener("warning", listener));
 
 const inputStrings = process.argv.slice(2);
 
+if (inputStrings.length > 2 && ["help", "--help"].includes(inputStrings[1])) {
+  const help = require("./lib/commands/help").meta;
+  console.log(
+    "Error: please use below syntax to displaying help information\n",
+    "\n               ",
+    help.help.usage
+  );
+  process.exit();
+}
+
 const userWantsGeneralHelp =
   inputStrings.length === 0 ||
   (inputStrings.length === 1 && ["help", "--help"].includes(inputStrings[0]));

--- a/packages/core/cli.js
+++ b/packages/core/cli.js
@@ -69,7 +69,9 @@ if (
   const helpIndex = inputStrings.indexOf("--help");
 
   if (helpIndex !== -1) {
+    //remove `--help` from array
     inputStrings.splice(helpIndex, 1);
+    //insert `help` in first position
     inputStrings.unshift("help");
   }
 }

--- a/packages/core/cli.js
+++ b/packages/core/cli.js
@@ -42,24 +42,20 @@ listeners.forEach(listener => process.removeListener("warning", listener));
 
 const inputStrings = process.argv.slice(2);
 
-//check if user wants some help
-if (inputStrings.length === 0) {
-  const { displayGeneralHelp } = require("./lib/command-utils");
-  displayGeneralHelp();
-  process.exit();
-} else if (
-  inputStrings.some(inputString => ["help", "--help"].includes(inputString))
-) {
-  //check what kind of help the user is looking for
-  const { processHelpInput } = require("./lib/command-utils");
-  processHelpInput(inputStrings);
-}
-
 const {
   getCommand,
   prepareOptions,
-  runCommand
+  runCommand,
+  processHelpInput
 } = require("./lib/command-utils");
+
+//if `help` or `--help` is in the command, validate and transform the input
+if (
+  inputStrings.some(inputString => ["help", "--help"].includes(inputString))
+) {
+  //handle general help case and displayCommand Help cases and return the inputStrings to be process further
+  processHelpInput(inputStrings);
+}
 
 const command = getCommand({
   inputStrings,

--- a/packages/core/cli.js
+++ b/packages/core/cli.js
@@ -40,7 +40,7 @@ if (!semver.gte(process.version, minimumNodeVersion)) {
 const listeners = process.listeners("warning");
 listeners.forEach(listener => process.removeListener("warning", listener));
 
-let inputStrings = process.argv.slice(2);
+const inputStrings = process.argv.slice(2);
 
 //check if user wants some help
 if (inputStrings.length === 0) {

--- a/packages/core/cli.js
+++ b/packages/core/cli.js
@@ -51,8 +51,10 @@ if (userWantsGeneralHelp) {
   displayGeneralHelp();
   process.exit(0);
 }
-
-//if the last word of inputString is `help` or `--help`, re-assign inputString to run as `truffle help <cmd>`
+//clean up inputString to run as `truffle help <cmd>` if `help`, `--help` is present with a <cmd>
+if (inputStrings.length > 1 && inputStrings[0] === "--help") {
+  inputStrings[inputStrings.indexOf("--help")] = "help";
+}
 if (["help", "--help"].includes(inputStrings[inputStrings.length - 1])) {
   inputStrings.pop();
   inputStrings.unshift("help");
@@ -73,7 +75,9 @@ const command = getCommand({
 //getCommand() will return null if a command not recognized by truffle is used.
 if (command === null) {
   console.log(
-    `\`truffle ${inputStrings}\` is not a valid truffle command. Please see \`truffle help\` for available commands.`
+    `\`truffle ${inputStrings.join(
+      " "
+    )}\` is not a valid truffle command. Please see \`truffle help\` for available commands.`
   );
   process.exit(1);
 }

--- a/packages/core/cli.js
+++ b/packages/core/cli.js
@@ -40,35 +40,15 @@ if (!semver.gte(process.version, minimumNodeVersion)) {
 const listeners = process.listeners("warning");
 listeners.forEach(listener => process.removeListener("warning", listener));
 
-const inputStrings = process.argv.slice(2);
+let inputStrings = process.argv.slice(2);
 
-if (inputStrings.length > 2 && ["help", "--help"].includes(inputStrings[1])) {
-  const help = require("./lib/commands/help").meta;
-  console.log(
-    "Error: please use below syntax to displaying help information\n",
-    "\n               ",
-    help.help.usage
-  );
-  process.exit();
-}
+//check if user wants some help
+const helpNeeded = inputStrings.some(r => ["help", "--help"].indexOf(r) >= 0);
 
-const userWantsGeneralHelp =
-  inputStrings.length === 0 ||
-  (inputStrings.length === 1 && ["help", "--help"].includes(inputStrings[0]));
-
-if (userWantsGeneralHelp) {
-  const { displayGeneralHelp } = require("./lib/command-utils");
-  displayGeneralHelp();
-  process.exit(0);
-}
-// when `truffle --help <cmd>` is used, convert inputStrings to run as `truffle help <cmd>`
-if (inputStrings.length > 1 && inputStrings[0] === "--help") {
-  inputStrings[inputStrings.indexOf("--help")] = "help";
-}
-// when `truffle <cmd> help | --help` is used, convert inputStrings  to run as `truffle help <cmd>`
-if (["help", "--help"].includes(inputStrings[inputStrings.length - 1])) {
-  inputStrings.pop();
-  inputStrings.unshift("help");
+if (helpNeeded) {
+  //check what help does user want
+  const { processHelpInput } = require("./lib/command-utils");
+  inputStrings = processHelpInput(inputStrings);
 }
 
 const {

--- a/packages/core/cli.js
+++ b/packages/core/cli.js
@@ -51,10 +51,11 @@ if (userWantsGeneralHelp) {
   displayGeneralHelp();
   process.exit(0);
 }
-//clean up inputString to run as `truffle help <cmd>` if `help`, `--help` is present with a <cmd>
+// when `truffle --help <cmd>` is used, convert inputStrings to run as `truffle help <cmd>`
 if (inputStrings.length > 1 && inputStrings[0] === "--help") {
   inputStrings[inputStrings.indexOf("--help")] = "help";
 }
+// when `truffle <cmd> help | --help` is used, convert inputStrings  to run as `truffle help <cmd>`
 if (["help", "--help"].includes(inputStrings[inputStrings.length - 1])) {
   inputStrings.pop();
   inputStrings.unshift("help");

--- a/packages/core/lib/command-utils.js
+++ b/packages/core/lib/command-utils.js
@@ -204,14 +204,16 @@ const runCommand = async function (command, options) {
 };
 
 const processHelpInput = inputStrings => {
+  //  handle general help case and displayCommand Help cases
+
   //when user wants general help
-  if (inputStrings.length === 1) {
+  if (inputStrings.length === 0 || inputStrings.length === 1) {
     displayGeneralHelp();
     process.exit();
   }
 
-  //check if --help is used
-  const helpIndex = inputStrings.findIndex(x => x === "--help");
+  //check where is --help used
+  const helpIndex = inputStrings.indexOf("--help");
 
   if (helpIndex !== -1) {
     inputStrings.splice(helpIndex, 1);

--- a/packages/core/lib/command-utils.js
+++ b/packages/core/lib/command-utils.js
@@ -203,6 +203,41 @@ const runCommand = async function (command, options) {
   return await command.run(options);
 };
 
+const processHelpInput = inputStrings => {
+  //is it wrong syntax of help?
+  if (inputStrings.length > 2 && ["help", "--help"].includes(inputStrings[1])) {
+    const help = require("./commands/help").meta;
+    console.log(
+      "Error: please use below syntax to displaying help information\n",
+      "\n               ",
+      help.help.usage
+    );
+    process.exit();
+  }
+
+  // when `truffle --help <cmd>` is used, convert inputStrings to run as `truffle help <cmd>`
+  if (inputStrings.length > 1 && inputStrings[0] === "--help") {
+    inputStrings[inputStrings.indexOf("--help")] = "help";
+  }
+
+  // when `truffle <cmd> help | --help` is used, convert inputStrings  to run as `truffle help <cmd>`
+  if (["help", "--help"].includes(inputStrings[inputStrings.length - 1])) {
+    inputStrings.pop();
+    inputStrings.unshift("help");
+  }
+
+  const userWantsGeneralHelp =
+    inputStrings.length === 0 ||
+    (inputStrings.length === 1 && ["help", "--help"].includes(inputStrings[0]));
+
+  //is it general help?
+  if (userWantsGeneralHelp) {
+    displayGeneralHelp();
+    process.exit(0);
+  }
+  return inputStrings;
+};
+
 const displayGeneralHelp = () => {
   const yargs = require("yargs/yargs")();
   commands.forEach(command => {
@@ -307,6 +342,7 @@ const deriveConfigEnvironment = function (detectedConfig, network, url) {
 };
 
 module.exports = {
+  processHelpInput,
   displayGeneralHelp,
   getCommand,
   prepareOptions,

--- a/packages/core/lib/command-utils.js
+++ b/packages/core/lib/command-utils.js
@@ -93,8 +93,10 @@ const prepareOptions = ({ command, inputStrings, options }) => {
   const yargs = require("yargs/yargs")();
   yargs
     .command(require(`./commands/${command.name}/meta`))
-    //Turn off yargs' default behavior when handling "truffle --version"
-    .version(false);
+    //Turn off yargs' default behavior when handling `truffle --version` & `truffle <cmd> --help`
+    .version(false)
+    .help(false);
+
   const commandOptions = yargs.parse(inputStrings);
 
   // remove the task name itself put there by yargs

--- a/packages/core/lib/command-utils.js
+++ b/packages/core/lib/command-utils.js
@@ -204,11 +204,11 @@ const runCommand = async function (command, options) {
 };
 
 const processHelpInput = inputStrings => {
-  //is it wrong syntax of help?
+  //When we think user is trying to access help incorrectly, provide them with some helpful information.
   if (inputStrings.length > 2 && ["help", "--help"].includes(inputStrings[1])) {
     const help = require("./commands/help").meta;
     console.log(
-      "Error: please use below syntax to displaying help information\n",
+      "Error: please use the following syntax for accessing help information\n",
       "\n               ",
       help.help.usage
     );
@@ -221,19 +221,15 @@ const processHelpInput = inputStrings => {
   }
 
   // when `truffle <cmd> help | --help` is used, convert inputStrings  to run as `truffle help <cmd>`
-  if (["help", "--help"].includes(inputStrings[inputStrings.length - 1])) {
+  if (["help", "--help"].includes(inputStrings[1])) {
     inputStrings.pop();
     inputStrings.unshift("help");
   }
 
-  const userWantsGeneralHelp =
-    inputStrings.length === 0 ||
-    (inputStrings.length === 1 && ["help", "--help"].includes(inputStrings[0]));
-
-  //is it general help?
-  if (userWantsGeneralHelp) {
+  //when user wants general help
+  if (inputStrings.length === 1) {
     displayGeneralHelp();
-    process.exit(0);
+    process.exit();
   }
   return inputStrings;
 };

--- a/packages/core/lib/command-utils.js
+++ b/packages/core/lib/command-utils.js
@@ -203,26 +203,6 @@ const runCommand = async function (command, options) {
   return await command.run(options);
 };
 
-const processHelpInput = inputStrings => {
-  //  handle general help case and displayCommand Help cases
-
-  //when user wants general help
-  if (inputStrings.length === 0 || inputStrings.length === 1) {
-    displayGeneralHelp();
-    process.exit();
-  }
-
-  //check where is --help used
-  const helpIndex = inputStrings.indexOf("--help");
-
-  if (helpIndex !== -1) {
-    inputStrings.splice(helpIndex, 1);
-    inputStrings.unshift("help");
-  }
-
-  return inputStrings;
-};
-
 const displayGeneralHelp = () => {
   const yargs = require("yargs/yargs")();
   commands.forEach(command => {
@@ -327,7 +307,6 @@ const deriveConfigEnvironment = function (detectedConfig, network, url) {
 };
 
 module.exports = {
-  processHelpInput,
   displayGeneralHelp,
   getCommand,
   prepareOptions,

--- a/packages/core/lib/command-utils.js
+++ b/packages/core/lib/command-utils.js
@@ -204,33 +204,20 @@ const runCommand = async function (command, options) {
 };
 
 const processHelpInput = inputStrings => {
-  //When we think user is trying to access help incorrectly, provide them with some helpful information.
-  if (inputStrings.length > 2 && ["help", "--help"].includes(inputStrings[1])) {
-    const help = require("./commands/help").meta;
-    console.log(
-      "Error: please use the following syntax for accessing help information\n",
-      "\n               ",
-      help.help.usage
-    );
-    process.exit();
-  }
-
-  // when `truffle --help <cmd>` is used, convert inputStrings to run as `truffle help <cmd>`
-  if (inputStrings.length > 1 && inputStrings[0] === "--help") {
-    inputStrings[inputStrings.indexOf("--help")] = "help";
-  }
-
-  // when `truffle <cmd> help | --help` is used, convert inputStrings  to run as `truffle help <cmd>`
-  if (["help", "--help"].includes(inputStrings[1])) {
-    inputStrings.pop();
-    inputStrings.unshift("help");
-  }
-
   //when user wants general help
   if (inputStrings.length === 1) {
     displayGeneralHelp();
     process.exit();
   }
+
+  //check if --help is used
+  const helpIndex = inputStrings.findIndex(x => x === "--help");
+
+  if (helpIndex !== -1) {
+    inputStrings.splice(helpIndex, 1);
+    inputStrings.unshift("help");
+  }
+
   return inputStrings;
 };
 

--- a/packages/core/lib/commands/db/run.js
+++ b/packages/core/lib/commands/db/run.js
@@ -13,6 +13,6 @@ module.exports = async function (args) {
       break;
 
     default:
-      console.log(`Unknown command: ${subCommand}`);
+      console.log(`Unknown truffle db command: ${subCommand}`);
   }
 };

--- a/packages/core/lib/commands/help/displayCommandHelp.js
+++ b/packages/core/lib/commands/help/displayCommandHelp.js
@@ -1,24 +1,20 @@
 module.exports = async function (selectedCommand, subCommand, options) {
   const commands = require("../index");
   const globalCommandOptions = require("../../global-command-options");
+  const TruffleError = require("@truffle/error");
 
   let commandHelp, commandDescription;
+
+  const inputStrings = process.argv.slice(2);
 
   const chosenCommand = commands[selectedCommand].meta;
 
   if (subCommand) {
-    if (!chosenCommand.subCommands) {
-      console.log(`WARNING: ${selectedCommand} does not have sub commands.`);
-      process.exit();
-    }
-
-    if (!chosenCommand.subCommands[subCommand]) {
-      console.log(
-        `WARNING: ${subCommand} is an invalid sub command for ${selectedCommand}.`
+    if (!chosenCommand.subCommands || !chosenCommand.subCommands[subCommand]) {
+      throw new TruffleError(
+        `"truffle ${inputStrings.join(" ")}" is an anvalid command`
       );
-      process.exit();
     }
-
     commandHelp = chosenCommand.subCommands[subCommand].help;
     commandDescription = chosenCommand.subCommands[subCommand].description;
   } else {

--- a/packages/core/lib/commands/help/displayCommandHelp.js
+++ b/packages/core/lib/commands/help/displayCommandHelp.js
@@ -12,7 +12,7 @@ module.exports = async function (selectedCommand, subCommand, options) {
   if (subCommand) {
     if (!chosenCommand.subCommands || !chosenCommand.subCommands[subCommand]) {
       throw new TruffleError(
-        `"truffle ${inputStrings.join(" ")}" is an anvalid command`
+        `"truffle ${inputStrings.join(" ")}" is an invalid command`
       );
     }
     commandHelp = chosenCommand.subCommands[subCommand].help;

--- a/packages/core/lib/commands/help/displayCommandHelp.js
+++ b/packages/core/lib/commands/help/displayCommandHelp.js
@@ -6,7 +6,19 @@ module.exports = async function (selectedCommand, subCommand, options) {
 
   const chosenCommand = commands[selectedCommand].meta;
 
-  if (subCommand && chosenCommand.subCommands[subCommand]) {
+  if (subCommand) {
+    if (!chosenCommand.subCommands) {
+      console.log(`WARNING: ${selectedCommand} does not have sub commands.`);
+      process.exit();
+    }
+
+    if (!chosenCommand.subCommands[subCommand]) {
+      console.log(
+        `WARNING: ${subCommand} is an invalid sub command for ${selectedCommand}.`
+      );
+      process.exit();
+    }
+
     commandHelp = chosenCommand.subCommands[subCommand].help;
     commandDescription = chosenCommand.subCommands[subCommand].description;
   } else {

--- a/packages/core/lib/commands/help/meta.js
+++ b/packages/core/lib/commands/help/meta.js
@@ -6,11 +6,11 @@ module.exports = {
     "List all commands or provide information about a specific command",
   help: {
     usage:
-      "truffle help [<command> <subCommand>]" +
+      "truffle help [<command> [<subCommand>]]" +
       OS.EOL +
-      "                truffle --help [<command> <subCommand>]" +
+      "                truffle --help [<command> [<subCommand>]]" +
       OS.EOL +
-      "                truffle [<command> <subCommand>] --help",
+      "                truffle [<command> [<subCommand>]] --help",
     options: [
       {
         option: "<command>",

--- a/packages/core/lib/commands/help/meta.js
+++ b/packages/core/lib/commands/help/meta.js
@@ -1,16 +1,9 @@
-const OS = require("os");
-
 module.exports = {
   command: "help",
   description:
     "List all commands or provide information about a specific command",
   help: {
-    usage:
-      "truffle help [<command> [<subCommand>]]" +
-      OS.EOL +
-      "                truffle --help [<command> [<subCommand>]]" +
-      OS.EOL +
-      "                truffle [<command> [<subCommand>]] --help",
+    usage: "truffle help [<command> [<subCommand>]]",
     options: [
       {
         option: "<command>",

--- a/packages/core/lib/commands/help/meta.js
+++ b/packages/core/lib/commands/help/meta.js
@@ -1,9 +1,16 @@
+const OS = require("os");
+
 module.exports = {
   command: "help",
   description:
     "List all commands or provide information about a specific command",
   help: {
-    usage: "truffle help [<command>]",
+    usage:
+      "truffle help [<command> <subCommand>]" +
+      OS.EOL +
+      "                truffle --help [<command> <subCommand>]" +
+      OS.EOL +
+      "                truffle [<command> <subCommand>] --help",
     options: [
       {
         option: "<command>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,6 +35,7 @@
     "@truffle/debugger": "^11.0.22",
     "@truffle/decoder": "^5.3.5",
     "@truffle/deployer": "^3.3.2",
+    "@truffle/db-loader": "^0.2.10",
     "@truffle/environment": "^0.2.135",
     "@truffle/error": "^0.2.0",
     "@truffle/expect": "^0.1.4",
@@ -69,6 +70,7 @@
     "get-random-values": "^1.2.2",
     "glob": "^7.1.6",
     "inquirer": "8.2.2",
+    "iter-tools": "^7.5.0",
     "js-interpreter": "2.2.0",
     "lodash": "^4.17.21",
     "mocha": "10.1.0",
@@ -82,6 +84,7 @@
     "universal-analytics": "^0.4.17",
     "web3": "1.8.1",
     "web3-utils": "1.8.1",
+    "uuid": "^9.0.0",
     "xregexp": "^4.2.4",
     "yargs": "^13.3.0"
   },

--- a/packages/truffle/test/scenarios/commands/help.js
+++ b/packages/truffle/test/scenarios/commands/help.js
@@ -43,20 +43,8 @@ describe("truffle help [ @standalone ]", function () {
       assert(output.includes("--environment"));
     });
 
-    it("displays help for given command when `--help` is at the end of the command line", async function () {
+    it("displays help for given command when `--help` is in the command line", async function () {
       await CommandRunner.run("compile --help", config);
-      const output = logger.contents();
-      assert(output.includes("Description:  Compile contract source files"));
-    }).timeout(20000);
-
-    it("displays help for given command when `help` is at the end of the command line", async function () {
-      await CommandRunner.run("compile help", config);
-      const output = logger.contents();
-      assert(output.includes("Description:  Compile contract source files"));
-    }).timeout(20000);
-
-    it("displays help for given command when `--help` is right before the truffle command", async function () {
-      await CommandRunner.run("help compile", config);
       const output = logger.contents();
       assert(output.includes("Description:  Compile contract source files"));
     }).timeout(20000);
@@ -71,29 +59,11 @@ describe("truffle help [ @standalone ]", function () {
       );
     }).timeout(20000);
 
-    it("errors when <subCommand> is not valid", async function () {
-      await CommandRunner.run("help compile boo", config);
-      const output = logger.contents();
-      assert(output.includes("WARNING: compile does not have sub commands"));
-    }).timeout(20000);
-
-    it("errors with correct `help` usage info when `truffle <cmd> --help <subCommand>` is used", async function () {
+    it("displays help for `truffle <cmd> --help <subCommand>` is used", async function () {
       await CommandRunner.run("db --help serve", config);
       const output = logger.contents();
       assert(
-        output.includes(
-          "Error: please use the following syntax for accessing help information"
-        )
-      );
-    }).timeout(20000);
-
-    it("errors with correct `help` usage info when `truffle <cmd> help <subCommand>` is used", async function () {
-      await CommandRunner.run("db help serve", config);
-      const output = logger.contents();
-      assert(
-        output.includes(
-          "Error: please use the following syntax for accessing help information"
-        )
+        output.includes("Description:  Start Truffle's GraphQL UI playground")
       );
     }).timeout(20000);
   });

--- a/packages/truffle/test/scenarios/commands/help.js
+++ b/packages/truffle/test/scenarios/commands/help.js
@@ -42,5 +42,59 @@ describe("truffle help [ @standalone ]", function () {
       );
       assert(output.includes("--environment"));
     });
+
+    it("displays help for given command when `--help` is at the end of the command line", async function () {
+      await CommandRunner.run("compile --help", config);
+      const output = logger.contents();
+      assert(output.includes("Description:  Compile contract source files"));
+    }).timeout(20000);
+
+    it("displays help for given command when `help` is at the end of the command line", async function () {
+      await CommandRunner.run("compile help", config);
+      const output = logger.contents();
+      assert(output.includes("Description:  Compile contract source files"));
+    }).timeout(20000);
+
+    it("displays help for given command when `--help` is right before the truffle command", async function () {
+      await CommandRunner.run("help compile", config);
+      const output = logger.contents();
+      assert(output.includes("Description:  Compile contract source files"));
+    }).timeout(20000);
+
+    it("displays help for the `help` command", async function () {
+      await CommandRunner.run("help help", config);
+      const output = logger.contents();
+      assert(
+        output.includes(
+          " Description:  List all commands or provide information about a specific command"
+        )
+      );
+    }).timeout(20000);
+
+    it("errors when <subCommand> is not valid", async function () {
+      await CommandRunner.run("help compile boo", config);
+      const output = logger.contents();
+      assert(output.includes("WARNING: compile does not have sub commands"));
+    }).timeout(20000);
+
+    it("errors with correct `help` usage info when `truffle <cmd> --help <subCommand>` is used", async function () {
+      await CommandRunner.run("db --help serve", config);
+      const output = logger.contents();
+      assert(
+        output.includes(
+          "Error: please use below syntax to displaying help information"
+        )
+      );
+    }).timeout(20000);
+
+    it("errors with correct `help` usage info when `truffle <cmd> help <subCommand>` is used", async function () {
+      await CommandRunner.run("db help serve", config);
+      const output = logger.contents();
+      assert(
+        output.includes(
+          "Error: please use below syntax to displaying help information"
+        )
+      );
+    }).timeout(20000);
   });
 });

--- a/packages/truffle/test/scenarios/commands/help.js
+++ b/packages/truffle/test/scenarios/commands/help.js
@@ -43,12 +43,6 @@ describe("truffle help [ @standalone ]", function () {
       assert(output.includes("--environment"));
     });
 
-    it("displays help for given command when `--help` is in the command line", async function () {
-      await CommandRunner.run("compile --help", config);
-      const output = logger.contents();
-      assert(output.includes("Description:  Compile contract source files"));
-    }).timeout(20000);
-
     it("displays help for the `help` command", async function () {
       await CommandRunner.run("help help", config);
       const output = logger.contents();
@@ -59,7 +53,21 @@ describe("truffle help [ @standalone ]", function () {
       );
     }).timeout(20000);
 
-    it("displays help for `truffle <cmd> --help <subCommand>` is used", async function () {
+    it("displays help for given command when `--help` is at final position of the command line", async function () {
+      await CommandRunner.run("compile --help", config);
+      const output = logger.contents();
+      assert(output.includes("Description:  Compile contract source files"));
+    }).timeout(20000);
+
+    it("displays help for given command when `--help` is at first position of the command line", async function () {
+      await CommandRunner.run("--help db serve", config);
+      const output = logger.contents();
+      assert(
+        output.includes("Description:  Start Truffle's GraphQL UI playground")
+      );
+    }).timeout(20000);
+
+    it("displays help for given command when `--help` is in the middle of the command line", async function () {
       await CommandRunner.run("db --help serve", config);
       const output = logger.contents();
       assert(

--- a/packages/truffle/test/scenarios/commands/help.js
+++ b/packages/truffle/test/scenarios/commands/help.js
@@ -82,7 +82,7 @@ describe("truffle help [ @standalone ]", function () {
       const output = logger.contents();
       assert(
         output.includes(
-          "Error: please use below syntax to displaying help information"
+          "Error: please use the following syntax for accessing help information"
         )
       );
     }).timeout(20000);
@@ -92,7 +92,7 @@ describe("truffle help [ @standalone ]", function () {
       const output = logger.contents();
       assert(
         output.includes(
-          "Error: please use below syntax to displaying help information"
+          "Error: please use the following syntax for accessing help information"
         )
       );
     }).timeout(20000);

--- a/yarn.lock
+++ b/yarn.lock
@@ -16659,6 +16659,13 @@ iter-tools@^7.0.2:
   dependencies:
     "@babel/runtime" "^7.12.1"
 
+iter-tools@^7.5.0:
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/iter-tools/-/iter-tools-7.5.0.tgz#061240dcac13668e66bb787b0fcd407a58ea39ab"
+  integrity sha512-L0p/RG3Hwk1urilryDKqU8pQ1t5AaaMc7CHmiwJD/uh63Lv7VyjNng/esstf+Tct1587IpetpcDFdufz8sG+sQ==
+  dependencies:
+    "@babel/runtime" "^7.12.1"
+
 iterate-iterator@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/iterate-iterator/-/iterate-iterator-1.0.1.tgz#1693a768c1ddd79c969051459453f082fe82e9f6"


### PR DESCRIPTION
## PR description
This addresses #5662.
Currently, We have `help` as a truffle command.  And since our truffle commands were built using Yargs, we also have yargs default help info display via `truffle <cmd> help` or `truffle <cmd> --help`.  
Truffle's help command uses the command's `meta.help` object and Yargs help uses the command's `meta.builder` object. It's often the info in these two objects are miss matching causing the `help` outputs to be different.

Should we update the documentation to let users know about the other syntax for getting help?

For this, I explored two options and decided to go with option 1. 
1) Turn off yargs's default for help. Use our own `displayCommandHelp` when `--help` is used anywhere in the command line.  

Here are the reasons why I chose this option.
At this point, the info in the Help objects is more complete than in the Build object.
The output can be more customized. 


Modify the `inputStrings` if they have  `--help` in the command line before running through the command utils. As well as `truffle --help <cmd>`
I would love to know if there's a better way to handle this. 
Added scenario testing of `Help`. Let me know if I'm missing any cases. 
Do note, I did not include any fixes in this PR for getting help in `truffle console` or `truffle develop`.


2) Keep the current yargs default, and edit our Help command's `run.js` to use yargs's default `showHelp()` for the particular command. 

There are still some limitations to using Yargs for this. 
Need to inject the command's options as well as global options.
Not enough control over how the format of the output will look. 



## Testing instructions

`truffle help <cmd>`  & `truffle <cmd> --help` & `truffle --help <cmd>` should have the same output.
run the help scenario test.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.

## Breaking changes and new features

- [ ] I have added any needed `breaking-change` and `new-feature` labels for the appropriate packages.
