### PR TITLE
Early return dashboard event handlers if network isn't dashboard

### DIFF
--- a/packages/events/defaultSubscribers/dashboard.js
+++ b/packages/events/defaultSubscribers/dashboard.js
@@ -26,6 +26,8 @@ module.exports = {
   handlers: {
     "compile:start": [
       async function () {
+        if (!isDashboardNetwork(this.config)) return;
+
         try {
           const publishLifecycle = await this.messageBus.publish({
             type: "debug",
@@ -41,9 +43,7 @@ module.exports = {
     ],
     "rpc:request": [
       function (event) {
-        if (!isDashboardNetwork(this.config)) {
-          return;
-        }
+        if (!isDashboardNetwork(this.config)) return;
 
         const { payload } = event;
         if (payload.method === "eth_sendTransaction") {
@@ -57,9 +57,7 @@ module.exports = {
     ],
     "rpc:result": [
       function (event) {
-        if (!isDashboardNetwork(this.config)) {
-          return;
-        }
+        if (!isDashboardNetwork(this.config)) return;
 
         let { error } = event;
         const { payload, result } = event;


### PR DESCRIPTION
So @cds-amal discovered that sometimes event handlers for dashboard are run even if dashboard isn't the targeted network, causing a failed request to the message bus on every such occasion. The fix is to check that the current network is in fact dashboard, then proceed with the event handler logic. 