### PR TITLE
Update Sourcify networks for late November 2022

### DIFF
--- a/packages/source-fetcher/lib/networks.ts
+++ b/packages/source-fetcher/lib/networks.ts
@@ -10,6 +10,7 @@ export const networkNamesById: { [id: number]: string } = {
   10: "optimistic",
   69: "kovan-optimistic",
   420: "goerli-optimistic",
+  28528: "goerli-bedrock-optimistic",
   42161: "arbitrum",
   42170: "nova-arbitrum",
   421611: "rinkeby-arbitrum",
@@ -17,6 +18,7 @@ export const networkNamesById: { [id: number]: string } = {
   137: "polygon",
   80001: "mumbai-polygon",
   100: "gnosis", //formerly known as xdai
+  10200: "chiado-gnosis",
   300: "optimism-gnosis", //optimism on gnosis, not vice versa
   99: "core-poa",
   77: "sokol-poa",
@@ -78,6 +80,7 @@ export const networkNamesById: { [id: number]: string } = {
   51: "apothem-xinfin",
   7700: "canto",
   592: "astar",
+  336: "shiden-astar",
   8217: "cypress-klaytn", //not presently supported by either fetcher, but...
   1001: "baobab-klaytn"
   //I'm not including crystaleum as it has network ID different from chain ID

--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -49,12 +49,14 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "optimistic",
     "kovan-optimistic", //can no longer verify but can still fetch existing
     "goerli-optimistic",
+    "goerli-bedrock-optimistic",
     "arbitrum",
     "rinkeby-arbitrum", //can no longer verify but can still fetch existing
     "goerli-arbitrum",
     "polygon",
     "mumbai-polygon",
     "gnosis",
+    "chiado-gnosis",
     "optimism-gnosis",
     "core-poa",
     "sokol-poa",
@@ -106,9 +108,11 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "apothem-xinfin",
     "canto",
     "astar",
-    //sourcify does *not* support klaytn mainnet cypress...?
+    "shiden-astar",
+    "cypress-klaytn",
     "baobab-klaytn"
     //I'm excluding crystaleum as it has network ID different from chain ID
+    //excluding kekchain for the same reason
   ]);
 
   constructor(networkId: number) {


### PR DESCRIPTION
Sourcify has updated its networks again, I've udpated the fetcher to match.

I don't typically bother testing these sorts of PRs, but if you want to test it, you could try testing it with the following contracts:

Network 28528: 0xA7e70Be8A6563DCe75299c30D1566A83fC63BC37
Network 10200: 0x78f71adAf9601034faC12C80F316ce4c2E95D1ab
Network 336: 0x3b2e3383AeE77A58f252aFB3635bCBd842BaeCB3
Network 8217: 0x3b2e3383AeE77A58f252aFB3635bCBd842BaeCB3