### PR TITLE
Invalidate `require` cache when loading config files

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -190,7 +190,7 @@ class TruffleConfig {
     // The require-nocache module used to do this for us, but
     // it doesn't bundle very well. So we've pulled it out ourselves.
     //@ts-ignore
-    delete require.cache[Module._resolveFilename(file, module)];
+    delete originalRequire.cache[Module._resolveFilename(file, module)];
     const staticConfig = originalRequire(file);
 
     config.merge(staticConfig);

--- a/packages/config/test/methods.test.ts
+++ b/packages/config/test/methods.test.ts
@@ -38,6 +38,58 @@ describe("TruffleConfig.detect", () => {
   });
 });
 
+describe("TruffleConfig.load", () => {
+  it("re-loads a config file after being modified", () => {
+    const options = {
+      workingDirectory: `${process.cwd()}/test`
+    };
+
+    fs.writeFileSync(
+      "./test/truffle-config.js",
+      `
+    module.exports = {
+        networks: {
+            development: {
+                url: "http://127.0.0.1:8545"
+            },
+        },
+    };
+    `
+    );
+    {
+      const config = TruffleConfig.detect(options);
+      delete config.networks["dashboard"];
+      assert.deepStrictEqual(config.networks, {
+        development: { url: "http://127.0.0.1:8545" }
+      });
+    }
+
+    fs.writeFileSync(
+      "./test/truffle-config.js",
+      `
+    module.exports = {
+        networks: {
+            development: {
+                url: "http://127.0.0.1:8545"
+            },
+            development2: {
+                url: "http://127.0.0.1:8546"
+            },
+        },
+    };
+    `
+    );
+    {
+      const config = TruffleConfig.detect(options);
+      delete config.networks["dashboard"];
+      assert.deepStrictEqual(config.networks, {
+        development: { url: "http://127.0.0.1:8545" },
+        development2: { url: "http://127.0.0.1:8546" }
+      });
+    }
+  });
+});
+
 describe("when it can't find a config file", () => {
   beforeEach(() => {
     sinon.stub(TruffleConfig, "search").returns(null);

--- a/packages/config/test/methods.test.ts
+++ b/packages/config/test/methods.test.ts
@@ -48,11 +48,11 @@ describe("TruffleConfig.load", () => {
       "./test/truffle-config.js",
       `
     module.exports = {
-        networks: {
-            development: {
-                url: "http://127.0.0.1:8545"
-            },
+      networks: {
+        development: {
+          url: "http://127.0.0.1:8545"
         },
+      },
     };
     `
     );
@@ -68,14 +68,14 @@ describe("TruffleConfig.load", () => {
       "./test/truffle-config.js",
       `
     module.exports = {
-        networks: {
-            development: {
-                url: "http://127.0.0.1:8545"
-            },
-            development2: {
-                url: "http://127.0.0.1:8546"
-            },
+      networks: {
+        development: {
+          url: "http://127.0.0.1:8545"
         },
+        development2: {
+          url: "http://127.0.0.1:8546"
+        },
+      },
     };
     `
     );


### PR DESCRIPTION
## PR description

This PR solves an issue related with `TruffleConfig.load` when `@truffle/config` is used as a package. The issue happens when _re-requiring_ Truffle config files in webpacked versions. More specifically, when trying to `require` the same config file more than once, the second time does not reflect any changes made since first the `require`.

The solution involves using the same `original-require` to both invalidate the `require` cache and re-load the Truffle config file. The problem was that `original-require` was only used to load the Truffle config file, but not to invalidate its cache.

### Background

The `delete` cache was in from the very beginning, see this blame https://github.com/trufflesuite/truffle/blame/15e7eb87d4659f7b520ea1658e9a833f132567d4/packages/truffle-config/index.js#L244.

And in this commit https://github.com/trufflesuite/truffle/commit/fc455d9b984500c86cc4ddb58f5349c921e2e2c0, the `require("require-nocache")` was removed and replaced with the current code.

## Testing instructions

The issue with testing this PR end-to-end is that it only manifest in the bundled version, but not using the CLI.. For this reason I've created a gist containing a sample repo

https://gist.github.com/acuarica/c9c1ae1e4da22ef78d56b48e9757a67c

The unbundled and bundle versions return different results. The unbundled version works as expected, _i.e._, reflects changes made to Truffle config, however the bundled version does not. You can check this by running the following in the above repo

```sh
yarn bundle
```

and then

```
node main.js
node main-bundle.js
```

should have the same output, but displays different networks.

For completion, a unit test is included to check for re-loading config files.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.

## Breaking changes and new features

- [ ] I have added any needed `breaking-change` and `new-feature` labels for the appropriate packages.
