### PR TITLE
fix `truffle help db <subCommand>`

### DIFF
--- a/packages/core/lib/commands/db/meta.js
+++ b/packages/core/lib/commands/db/meta.js
@@ -7,7 +7,9 @@ const usage =
   OS.EOL +
   "  Available sub-commands: " +
   OS.EOL +
-  "                serve \tStart the GraphQL server";
+  "                serve \tStart the GraphQL server" +
+  OS.EOL +
+  "                query \tQuery @truffle/db";
 
 module.exports = {
   command: "db",
@@ -18,18 +20,16 @@ module.exports = {
         ...serveCommand.run,
         ...serveCommand.meta
       })
+      .command({
+        ...queryCommand.run,
+        ...queryCommand.meta
+      })
       .demandCommand();
   },
 
   subCommands: {
-    serve: {
-      help: serveCommand.help,
-      description: serveCommand.meta
-    },
-    query: {
-      help: queryCommand.help,
-      description: queryCommand.meta
-    }
+    serve: serveCommand.meta,
+    query: queryCommand.meta
   },
 
   help: {

--- a/packages/core/lib/commands/help/displayCommandHelp.js
+++ b/packages/core/lib/commands/help/displayCommandHelp.js
@@ -4,14 +4,14 @@ module.exports = async function (selectedCommand, subCommand, options) {
 
   let commandHelp, commandDescription;
 
-  const chosenCommand = commands[selectedCommand];
+  const chosenCommand = commands[selectedCommand].meta;
 
   if (subCommand && chosenCommand.subCommands[subCommand]) {
-    commandHelp = chosenCommand.subCommands[subCommand].meta.help;
-    commandDescription = chosenCommand.subCommands[subCommand].meta.description;
+    commandHelp = chosenCommand.subCommands[subCommand].help;
+    commandDescription = chosenCommand.subCommands[subCommand].description;
   } else {
-    commandHelp = chosenCommand.meta.help;
-    commandDescription = chosenCommand.meta.description;
+    commandHelp = chosenCommand.help;
+    commandDescription = chosenCommand.description;
   }
 
   if (typeof commandHelp === "function") {


### PR DESCRIPTION


## Testing instructions

`truffle help db serve` & `truffle help db query` should work now. 
`truffle help db` should include both subCommands `serve` & `query`

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.

## Breaking changes and new features

- [ ] I have added any needed `breaking-change` and `new-feature` labels for the appropriate packages.
