### PR TITLE
Hack config and provider - what will break?

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -190,7 +190,7 @@ class TruffleConfig {
     // The require-nocache module used to do this for us, but
     // it doesn't bundle very well. So we've pulled it out ourselves.
     //@ts-ignore
-    delete require.cache[Module._resolveFilename(file, module)];
+    delete originalRequire.cache[Module._resolveFilename(file, module)];
     const staticConfig = originalRequire(file);
 
     config.merge(staticConfig);

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -190,7 +190,9 @@ class TruffleConfig {
     // The require-nocache module used to do this for us, but
     // it doesn't bundle very well. So we've pulled it out ourselves.
     //@ts-ignore
-    delete originalRequire.cache[Module._resolveFilename(file, module)];
+    //this doesn't do anything in the webpack build
+    //BUT may have an impact in non-webpack scenarios, ie, unit tests
+    delete require.cache[Module._resolveFilename(file, module)];
     const staticConfig = originalRequire(file);
 
     config.merge(staticConfig);

--- a/packages/provider/index.js
+++ b/packages/provider/index.js
@@ -3,7 +3,7 @@ const Web3 = require("web3");
 const { createInterfaceAdapter } = require("@truffle/interface-adapter");
 const wrapper = require("./wrapper");
 const DEFAULT_NETWORK_CHECK_TIMEOUT = 5000;
-
+let count = 0;
 module.exports = {
   wrap: function (provider, options) {
     return wrapper.wrap(provider, options);
@@ -17,7 +17,9 @@ module.exports = {
   getProvider: function (options) {
     let provider;
     if (options.provider && typeof options.provider === "function") {
+      console.log("Unthunking provider:", ++count);
       provider = options.provider();
+      options.provider = provider;
     } else if (options.provider) {
       provider = options.provider;
     } else if (options.websockets || /^wss?:\/\//.test(options.url)) {
@@ -49,17 +51,18 @@ module.exports = {
     return new Promise((resolve, reject) => {
       const noResponseFromNetworkCall = setTimeout(() => {
         let errorMessage =
-          "There was a timeout while attempting to connect to the network at " + host +
+          "There was a timeout while attempting to connect to the network at " +
+          host +
           ".\n       Check to see that your provider is valid." +
           "\n       If you have a slow internet connection, try configuring a longer " +
           "timeout in your Truffle config. Use the " +
           "networks[networkName].networkCheckTimeout property to do this.";
 
-          if (network === "dashboard") {
-            errorMessage +=
-              "\n       Also make sure that your Truffle Dashboard browser " +
-              "tab is open and connected to MetaMask.";
-          }
+        if (network === "dashboard") {
+          errorMessage +=
+            "\n       Also make sure that your Truffle Dashboard browser " +
+            "tab is open and connected to MetaMask.";
+        }
 
         throw new Error(errorMessage);
       }, networkCheckTimeout);
@@ -75,7 +78,9 @@ module.exports = {
           } catch (error) {
             console.log(
               "> Something went wrong while attempting to connect to the " +
-                "network at " + host + ". Check your network configuration."
+                "network at " +
+                host +
+                ". Check your network configuration."
             );
             clearTimeout(noResponseFromNetworkCall);
             clearTimeout(networkCheck);
@@ -86,5 +91,5 @@ module.exports = {
         }, networkCheckDelay);
       })();
     });
-  },
+  }
 };


### PR DESCRIPTION
We learned @truffle/config (`delete require.cache[...]`) doesn't invalidate the cache because webpack redefines require.  This means production usage of `@truffle/config` utilizes node require caching, and only loads 
`@truffle/config` once per process invocation.

This suggests we can modify config to cache its provider. `config.provider`  can be a thunk (`provider: () => ...`) which results in a new provider instance every time the thunk is invoked (many times!). Now, when we evaluate it the first time, we store the instance instead of the thunk.

This *Draft* PR will try to ferret out issues in our understanding. Currently, we think:
- there may be some nonce issue with hdwallet-provider, or its use in one of its sub-providers (per @davidmurdoch)
- tests that rely on the old behavior may need to be updated. 



## PR description

<!-- Enter PR description here -->

## Testing instructions

<!-- Don't forget instructions about how to test the PR! -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.

## Breaking changes and new features

- [x] I have added any needed `breaking-change` and `new-feature` labels for the appropriate packages.
