### PR TITLE
Add --url option to the `truffle migrate` command

### DIFF
--- a/packages/core/lib/commands/migrate/meta.js
+++ b/packages/core/lib/commands/migrate/meta.js
@@ -54,6 +54,10 @@ module.exports = {
       type: "boolean",
       default: true,
       hidden: true
+    },
+    "url": {
+      describe: "Use specified URL for provider",
+      type: "string"
     }
   },
   help: {
@@ -62,7 +66,7 @@ module.exports = {
       "                                " + // spacing to align with previous line
       "[--compile-all] [--compile-none] [--verbose-rpc] [--interactive]\n" +
       "                                " + // spacing to align with previous line
-      "[--skip-dry-run] [--describe-json] [--dry-run]",
+      "[--skip-dry-run] [--describe-json] [--dry-run] [--network <network>|--url <provider_url>]",
     options: [
       {
         option: "--reset",
@@ -118,8 +122,18 @@ module.exports = {
         option: "--save",
         description: "Specify whether the migration will save on chain",
         hidden: true
+      },
+      {
+        option: "--url",
+        description:
+          "Creates a provider using the given url and connects to the network."
+      },
+      {
+        option: "--network",
+        description:
+          "The network to connect to, as specified in the Truffle config."
       }
     ],
-    allowedGlobalOptions: ["network", "config", "quiet"]
+    allowedGlobalOptions: ["config", "quiet"]
   }
 };

--- a/packages/core/lib/commands/migrate/run.js
+++ b/packages/core/lib/commands/migrate/run.js
@@ -1,15 +1,29 @@
 module.exports = async function (options) {
   const WorkflowCompile = require("@truffle/workflow-compile").default;
   const { Environment } = require("@truffle/environment");
-  const Config = require("@truffle/config");
   const determineDryRunSettings = require("./determineDryRunSettings");
   const prepareConfigForRealMigrations = require("./prepareConfigForRealMigrations");
   const runMigrations = require("./runMigrations");
   const setUpDryRunEnvironmentThenRunMigrations = require("./setUpDryRunEnvironmentThenRunMigrations");
+  const loadConfig = require("../../loadConfig");
+  const OS = require("os");
+  const TruffleError = require("@truffle/error");
   const tmp = require("tmp");
   tmp.setGracefulCleanup();
 
-  const config = Config.detect(options);
+  if (options.url && options.network) {
+    const message =
+      "" +
+      "Mutually exclusive options, --url and --network detected!" +
+      OS.EOL +
+      "Please use either --url or --network and try again." +
+      OS.EOL +
+      "See: https://trufflesuite.com/docs/truffle/reference/truffle-commands/#migrate" +
+      OS.EOL;
+    throw new TruffleError(message);
+  }
+
+  let config = loadConfig(options);
   if (config.compileNone || config["compile-none"]) {
     config.compiler = "none";
   }

--- a/packages/truffle/test/scenarios/commands/migrate.js
+++ b/packages/truffle/test/scenarios/commands/migrate.js
@@ -34,5 +34,15 @@ describe("truffle migrate", () => {
         assert.fail();
       }
     }).timeout(20000);
+
+    it("doesn't throw when --url option is passed", async () => {
+      try {
+        await CommandRunner.run("migrate --url http://127.0.0.1:8545", config);
+      } catch (error) {
+        console.log("the logger contents -- %o", config.logger.loggedStuff);
+        console.log("the following error occurred -- %o", error.message);
+        assert.fail();
+      }
+    }).timeout(20000);
   });
 });


### PR DESCRIPTION
## PR description

This PR adds `--url` option to the `truffle migrate` command that connects to a specified url.

## Testing instructions

To test this option -
1. Run a ganache instance in a terminal.
2. Run `truffle migrate --url http://127.0.0.1:8545` inside a truffle project. The contracts inside the truffle project will be deployed in Ganache. 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.