### PR TITLE
dashboard: Fix decoding text overflow

### DIFF
--- a/packages/dashboard/src/components/composed/RPCs/RPC/Overview.tsx
+++ b/packages/dashboard/src/components/composed/RPCs/RPC/Overview.tsx
@@ -7,7 +7,17 @@ import type { Decoding } from "src/utils/dash";
 import ChainIcon from "src/components/common/ChainIcon";
 
 const useStyles = createStyles((theme, _params, getRef) => {
-  const { colors, colorScheme, white, radius, fontFamilyMonospace, fn } = theme;
+  const {
+    colors,
+    colorScheme,
+    white,
+    radius,
+    spacing,
+    fontFamilyMonospace,
+    fn
+  } = theme;
+  const buttonsWidth = 234;
+
   return {
     container: {
       flexWrap: "nowrap",
@@ -40,6 +50,9 @@ const useStyles = createStyles((theme, _params, getRef) => {
         }
       }
     },
+    info: {
+      width: `calc(100% - ${buttonsWidth + spacing.xl}px)`
+    },
     methodBadge: {
       textTransform: "initial",
       cursor: "pointer",
@@ -52,6 +65,8 @@ const useStyles = createStyles((theme, _params, getRef) => {
           : colors["yellow"][1]
     },
     decoding: {
+      display: "inline-block",
+      maxWidth: "90%",
       fontFamily: fontFamilyMonospace,
       fontWeight: 700,
       color:
@@ -60,7 +75,7 @@ const useStyles = createStyles((theme, _params, getRef) => {
           : colors["truffle-beige"][8]
     },
     buttons: {
-      minWidth: 234
+      minWidth: buttonsWidth
     },
     button: {
       ref: getRef("button"),
@@ -125,7 +140,6 @@ function Overview({
       onMouseEnter={onBackEnter}
       onMouseLeave={onBackLeave}
       position="apart"
-      spacing={50}
       pl={42}
       pr={35}
       py="lg"
@@ -134,7 +148,7 @@ function Overview({
       }`}
       tabIndex={0}
     >
-      <Stack align="flex-start" spacing="xs">
+      <Stack className={classes.info} align="flex-start" spacing="xs">
         <Badge
           size="lg"
           variant="outline"


### PR DESCRIPTION
So say your decoding is `"AAAAAAAAAA AAAAAAAAAA AAAAAAAAAA AAAAAAAAAA"`, the display is ok:
<img src="https://user-images.githubusercontent.com/41348973/204595866-9a797610-9088-48e9-8de3-1c09252d6c11.png" width="300px" />
But if we remove the whitespaces it pushes the buttons away:
<img src="https://user-images.githubusercontent.com/41348973/204596498-f3a1c392-2f7d-411e-9b58-d604dc1da8aa.png" width="300px" />
This PR is fix:
<img src="https://user-images.githubusercontent.com/41348973/204596744-dc4dc2b9-d92d-45b1-9d07-159599377372.png" width="300px" />
