### PR TITLE
Remove Arbitrum Rinkeby and Optimistic Kovan from Etherscan fetcher

### DIFF
--- a/packages/fetch-and-compile/test/fetch.test.ts
+++ b/packages/fetch-and-compile/test/fetch.test.ts
@@ -167,15 +167,6 @@ describe("Etherscan single-source Solidity case", function () {
     );
   });
 
-  it("verifies contract from optimism kovan", async function () {
-    await runTestBody(
-      69,
-      "0x5bb6699ef885ca997d1467380ff9e51c606a07e1",
-      "etherscan",
-      "Wormhole"
-    );
-  });
-
   it("verifies contract from moonbeam", async function () {
     await runTestBody(
       1284,

--- a/packages/fetch-and-compile/test/fetch.test.ts
+++ b/packages/fetch-and-compile/test/fetch.test.ts
@@ -140,15 +140,6 @@ describe("Etherscan single-source Solidity case", function () {
     );
   });
 
-  it("verifies contract from arbitrum rinkeby", async function () {
-    await runTestBody(
-      421611,
-      "0x1167d145919642dac82e03a6cfe2848db7a94995",
-      "etherscan",
-      "ProxyRegistry"
-    );
-  });
-
   it("verifies contract from polygon", async function () {
     await runTestBody(
       137,

--- a/packages/fetch-and-compile/test/fixture.js
+++ b/packages/fetch-and-compile/test/fixture.js
@@ -237,43 +237,6 @@ const etherscanFixture = {
     }
   },
 
-  "https://api-kovan-optimistic.etherscan.io/api": {
-    "0x5bb6699ef885ca997d1467380ff9e51c606a07e1": {
-      status: "1",
-      message: "OK",
-      result: [
-        {
-          SourceCode: fs.readFileSync(
-            path.resolve(
-              __dirname,
-              "./sources/etherscan/kovan-optimistic/0x5bb6699ef885ca997d1467380ff9e51c606a07e1/Wormhole.sol"
-            ),
-            "utf8"
-          ),
-          ABI: fs.readFileSync(
-            path.resolve(
-              __dirname,
-              "./sources/etherscan/kovan-optimistic/0x5bb6699ef885ca997d1467380ff9e51c606a07e1/Wormhole.abi.json"
-            ),
-            "utf8"
-          ),
-          ContractName: "Wormhole",
-          CompilerVersion: "v0.8.6+commit.11564f7e",
-          OptimizationUsed: "0",
-          Runs: "200",
-          ConstructorArguments: "",
-          EVMVersion: "Default",
-          Library: "",
-          LicenseType: "None",
-          Proxy: "0",
-          Implementation: "",
-          SwarmSource:
-            "ipfs://10357a4f7b671c8a5b0c870cd2bda25dd017773e274f0cfa416461963ac82b5b"
-        }
-      ]
-    }
-  },
-
   "https://api.arbiscan.io/api": {
     "0x2B52D1B2b359eA39536069D8c6f2a3CFE3a09c31": {
       status: "1",

--- a/packages/fetch-and-compile/test/fixture.js
+++ b/packages/fetch-and-compile/test/fixture.js
@@ -311,44 +311,6 @@ const etherscanFixture = {
     }
   },
 
-  "https://api-testnet.arbiscan.io/api": {
-    "0x1167d145919642dac82e03a6cfe2848db7a94995": {
-      status: "1",
-      message: "OK",
-      result: [
-        {
-          SourceCode: fs.readFileSync(
-            path.resolve(
-              __dirname,
-              "./sources/etherscan/rinkeby-arbitrum/0x1167d145919642dac82e03a6cfe2848db7a94995/ProxyRegistry.sol"
-            ),
-            "utf8"
-          ),
-          ABI: fs.readFileSync(
-            path.resolve(
-              __dirname,
-              "./sources/etherscan/rinkeby-arbitrum/0x1167d145919642dac82e03a6cfe2848db7a94995/ProxyRegistry.abi.json"
-            ),
-            "utf8"
-          ),
-          ContractName: "ProxyRegistry",
-          CompilerVersion: "v0.4.26+commit.4563c3fc",
-          OptimizationUsed: "1",
-          Runs: "200",
-          ConstructorArguments:
-            "0000000000000000000000006401e31976887d39a35a558891b4f6d476388181",
-          EVMVersion: "Default",
-          Library: "",
-          LicenseType: "GNU GPLv3",
-          Proxy: "0",
-          Implementation: "",
-          SwarmSource:
-            "bzzr://e7e9638fe071622556b31cfd1452cbcc9526ed4db6a7845a2984c071bc55326f"
-        }
-      ]
-    }
-  },
-
   "https://api.polygonscan.com/api": {
     "0xCF79C5417934ECde6BA055C0119A03380CE28DEC": {
       status: "1",

--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -66,7 +66,6 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
       "goerli-optimistic": "api-goerli-optimism.etherscan.io", //yes this one is different!
       "arbitrum": "api.arbiscan.io",
       "nova-arbitrum": "api-nova.arbiscan.io",
-      "rinkeby-arbitrum": "api-testnet.arbiscan.io", //hidden now, but it still works!
       "goerli-arbitrum": "api-goerli.arbiscan.io",
       "polygon": "api.polygonscan.com",
       "mumbai-polygon": "api-mumbai.polygonscan.com",

--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -62,7 +62,6 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
       "goerli": "api-goerli.etherscan.io",
       "sepolia": "api-sepolia.etherscan.io",
       "optimistic": "api-optimistic.etherscan.io",
-      "kovan-optimistic": "api-kovan-optimistic.etherscan.io",
       "goerli-optimistic": "api-goerli-optimism.etherscan.io", //yes this one is different!
       "arbitrum": "api.arbiscan.io",
       "nova-arbitrum": "api-nova.arbiscan.io",


### PR DESCRIPTION
It looks like Etherscan has removed support for Arbitrum Rinkeby; the old URL `testnet.arbiscan.io` is still there, sure, but now it's just a duplicate of `goerli.arbiscan.io`.  So, I'm removing support from this network from the Etherscan fetcher.  (Note that it's still supported by the Sourcify fetcher, since while Sourcify will disable new networks and stop letting you verify on them, it doesn't remove access to the already-verified contracts.)

Edit: Looks like Optimistic Kovan is gone too, removed that too.  (Along with the appropriate tests.)

Boba Rinkeby is also gone and replaced by Boba Goerli, but I'm going to save handling that for a separate PR as I need more information there.