### PR TITLE
Switch Etherscan fetcher from Boba Rinkeby to Boba Goerli

### DIFF
--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -89,7 +89,7 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
       "alfajores-celo": "api-alfajores.celoscan.io",
       "clover": "api.clvscan.com",
       "boba": "api.bobascan.com",
-      "rinkeby-boba": "api-testnet.bobascan.com",
+      "goerli-boba": "api-testnet.bobascan.com",
       "gnosis": "api.gnosisscan.io"
     };
 

--- a/packages/source-fetcher/lib/networks.ts
+++ b/packages/source-fetcher/lib/networks.ts
@@ -42,6 +42,7 @@ export const networkNamesById: { [id: number]: string } = {
   5700: "tanenbaum-syscoin",
   288: "boba",
   28: "rinkeby-boba",
+  2888: "goerli-boba",
   106: "velas",
   82: "meter",
   83: "testnet-meter",
@@ -81,7 +82,7 @@ export const networkNamesById: { [id: number]: string } = {
   7700: "canto",
   592: "astar",
   336: "shiden-astar",
-  8217: "cypress-klaytn", //not presently supported by either fetcher, but...
+  8217: "cypress-klaytn",
   1001: "baobab-klaytn"
   //I'm not including crystaleum as it has network ID different from chain ID
   //not including kekchain for the same reason


### PR DESCRIPTION
Etherscan has removed support for Boba Rinkeby and added support for Boba Goerli.  Note that they didn't add any new URL for Boba Goerli -- they just changed `testnet.bobascan.com` from covering Rinkeby to covering Goerli.  So, yeah.

Anyway this PR adds the Boba Goerli network and updates the Etherscan fetcher appropriately.  Note btw that Boba Goerli actually doesn't appear in any of the usual `chains.json`s that I'm aware of, so I had to look up its chain ID elsewhere.  Fortunately, `2888` doesn't collide with any of the IDs in the usual `chains.json`s!  Hopefully they get it added to those lists soon.

(Also while I was at it I removed an outdated comment.)

Testing instructions: I don't normally bother testing these source-fetcher updates, but if you want to test it you could try testing it with, say, address [`0x40Cb6360a3f79cAb1cD3033AbF3b22b579187a10`](https://testnet.bobascan.com/address/0x40Cb6360a3f79cAb1cD3033AbF3b22b579187a10) on Boba Goerli.