### PR TITLE
Add --url option to the `truffle deploy` command

### DIFF
--- a/packages/core/lib/commands/deploy/meta.js
+++ b/packages/core/lib/commands/deploy/meta.js
@@ -6,8 +6,10 @@ module.exports = {
   builder: migrate.builder,
   help: {
     usage:
-      "truffle deploy [--reset] [-f <number>] [--compile-all] [--verbose-rpc]",
+      "truffle deploy [--reset] [-f <number>] [--compile-all] [--verbose-rpc] \n" +
+      "                               " + // spacing to align with previous line
+      "[--network <network>|--url <provider_url>]",
     options: migrate.meta.help.options,
-    allowedGlobalOptions: ["network", "config"]
+    allowedGlobalOptions: ["config"]
   }
 };

--- a/packages/truffle/test/scenarios/commands/deploy.js
+++ b/packages/truffle/test/scenarios/commands/deploy.js
@@ -2,6 +2,7 @@ const CommandRunner = require("../commandRunner");
 const sandbox = require("../sandbox");
 const Server = require("../server");
 const path = require("path");
+const { assert } = require("chai");
 
 describe("truffle deploy (alias for migrate)", () => {
   let config, projectPath, cleanupSandboxDir;
@@ -21,6 +22,16 @@ describe("truffle deploy (alias for migrate)", () => {
   describe("when run on the most basic truffle project", () => {
     it("doesn't throw", async () => {
       await CommandRunner.run("deploy", config);
+    }).timeout(20000);
+
+    it("doesn't throw when --url option is passed", async () => {
+      try {
+        await CommandRunner.run("deploy --url http://127.0.0.1:8545", config);
+      } catch (error) {
+        console.log("the logger contents -- %o", config.logger.loggedStuff);
+        console.log("the following error occurred -- %o", error.message);
+        assert.fail();
+      }
     }).timeout(20000);
   });
 });


### PR DESCRIPTION
## PR description

This PR adds `--url` option to the `truffle deploy` command (alias for `truffle migrate`)that connects to a specified url. See #5701.

## Testing instructions

To test this option -
1. Run a ganache instance in a terminal.
2. Run `truffle deploy --url http://127.0.0.1:8545` inside a truffle project. The contracts inside the truffle project will be deployed in Ganache. 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.