### PR TITLE
Add `encodeCreation()` method to Encoder

### DIFF
--- a/packages/encoder/lib/encoders.ts
+++ b/packages/encoder/lib/encoders.ts
@@ -1597,4 +1597,17 @@ export class ContractInstanceEncoder {
     encoded.tx.to = this.toAddress;
     return encoded;
   }
+
+  /**
+   * **This method is asynchronous.**
+   *
+   * This method functions identically to [[ContractEncoder.encodeCreation]].
+   * The particular contract instance is ignored, only its class is used.
+   */
+  public async encodeCreation(
+    inputs: unknown[],
+    options: Types.ResolveOptions = {}
+  ): Promise<Codec.Options> {
+    return await this.contractEncoder.encodeCreation(inputs, options);
+  }
 }

--- a/packages/encoder/lib/encoders.ts
+++ b/packages/encoder/lib/encoders.ts
@@ -1298,6 +1298,40 @@ export class ContractEncoder {
   /**
    * **This method is asynchronous.**
    *
+   * This method is similar to [[encodeTransaction]], except that instead of
+   * encoding a function transaction, it encodes a creation transaction.
+   *
+   * Because this method does not perform overload resolution, it only returns
+   * the resulting transaction options (including the encoded `data`), and does
+   * not bother returning the ABI used (as this was user-supplied.)
+   *
+   * If the `allowOptions` flag is set in the `options` argument, the input may
+   * contain an additional transaction options argument after the other
+   * arguments.  Any non-`data` options not specified in such a transaction
+   * options argument will be simply omitted; it you want some options to have
+   * defaults, it is up to the you to set these options as appropriate
+   * afterwards.
+   *
+   * If the transaction options parameter has a `data` or a `to` option,
+   * these option will be recognized but ignored.
+   *
+   * See [[encodeTransaction]] for documentation of the inputs.
+   */
+  public async encodeCreation(
+    inputs: unknown[],
+    options: Types.ResolveOptions = {}
+  ): Promise<Codec.Options> {
+    const method = this.getConstructorMethod();
+    return await this.projectEncoder.encodeTxNoResolution(
+      method,
+      inputs,
+      options
+    );
+  }
+
+  /**
+   * **This method is asynchronous.**
+   *
    * Constructs a contract instance encoder for a given instance of the
    * contract this encoder is for.
    * @param address The address of the contract instance.

--- a/packages/encoder/lib/encoders.ts
+++ b/packages/encoder/lib/encoders.ts
@@ -1350,36 +1350,12 @@ export class ContractEncoder {
     abi: Abi.FunctionEntry | Abi.ConstructorEntry
   ): Codec.Wrap.Method {
     abi = <Abi.FunctionEntry | Abi.ConstructorEntry>Abi.normalizeEntry(abi); //just to be absolutely certain!
-    const allocations = this.projectEncoder.getAllocations();
     debug("got allocations");
     switch (abi.type) {
-      case "constructor": {
-        debug("constructor binary: %s", this.constructorBinary);
-        //first check that we have constructor binary, and that it's all linked
-        if (!this.constructorBinary || this.constructorBinary === "0x") {
-          throw new NoBytecodeError(this.contract.contractName);
-        } else if (!this.constructorBinary.match(/^0x([0-9a-fA-F]{2})+$/)) {
-          throw new UnlinkedContractError(
-            this.contract.contractName,
-            this.artifact ? this.artifact.bytecode : undefined
-          );
-        }
-        //otherwise, we're good to go!
-        const allocation =
-          //@ts-ignore: We set this up and checked this earlier
-          allocations.calldata.constructorAllocations[
-            <string>this.constructorContextHash
-          ].input;
-        const inputs = allocation.arguments.map(
-          input => ({ type: input.type, name: input.name || undefined }) //convert "" to undefined
-        );
-        return {
-          selector: this.constructorBinary,
-          inputs,
-          abi
-        };
-      }
-      case "function": {
+      case "constructor":
+        return this.getConstructorMethod(abi);
+      case "function":
+        const allocations = this.projectEncoder.getAllocations();
         const selector: string = Codec.AbiData.Utils.abiSelector(abi);
         const allocation: Codec.AbiData.Allocate.CalldataAllocation = this
           .deployedContextHash
@@ -1397,8 +1373,49 @@ export class ContractEncoder {
           inputs,
           abi
         };
-      }
     }
+  }
+
+  //if you already know the ABI, you can pass it in for convenience.
+  //if you don't, we'll find it for you.
+  private getConstructorMethod(abi?: Abi.ConstructorEntry): Codec.Wrap.Method {
+    if (!abi) {
+      abi = this.getConstructorAbi();
+    }
+    const allocations = this.projectEncoder.getAllocations();
+    debug("constructor binary: %s", this.constructorBinary);
+    //first check that we have constructor binary, and that it's all linked
+    if (!this.constructorBinary || this.constructorBinary === "0x") {
+      throw new NoBytecodeError(this.contract.contractName);
+    } else if (!this.constructorBinary.match(/^0x([0-9a-fA-F]{2})+$/)) {
+      throw new UnlinkedContractError(
+        this.contract.contractName,
+        this.artifact ? this.artifact.bytecode : undefined
+      );
+    }
+    //otherwise, we're good to go!
+    const allocation =
+      //@ts-ignore: We set this up and checked this earlier
+      allocations.calldata.constructorAllocations[
+        <string>this.constructorContextHash
+      ].input;
+    const inputs = allocation.arguments.map(
+      input => ({ type: input.type, name: input.name || undefined }) //convert "" to undefined
+    );
+    return {
+      selector: this.constructorBinary,
+      inputs,
+      abi
+    };
+  }
+
+  private getConstructorAbi(): Abi.ConstructorEntry {
+    return (
+      this.abi.find(
+        (abi: Abi.Entry): abi is Abi.ConstructorEntry =>
+          abi.type === "constructor"
+      ) || Codec.AbiData.Utils.DEFAULT_CONSTRUCTOR_ABI
+    );
   }
 }
 

--- a/packages/encoder/test/constructor.test.ts
+++ b/packages/encoder/test/constructor.test.ts
@@ -9,7 +9,6 @@ import * as Encoder from "..";
 import * as Codec from "@truffle/codec";
 import { Shims } from "@truffle/compile-common";
 import type { ContractObject as Artifact } from "@truffle/contract-schema/spec";
-import * as Abi from "@truffle/abi-utils";
 import Ganache from "ganache";
 import type { Provider } from "web3/providers";
 
@@ -61,23 +60,17 @@ beforeAll(async () => {
 describe("Encoding", () => {
   describe("Constructors", () => {
     let encoder: Encoder.ContractEncoder;
-    let abi: Abi.ConstructorEntry;
     let bytecode: string;
 
     beforeAll(async () => {
       encoder = await Encoder.forArtifact(artifacts.TestContract, {
         projectInfo: { compilations }
       });
-      abi = <Abi.ConstructorEntry>(
-        Abi.normalize(artifacts.TestContract.abi).find(
-          entry => entry.type === "constructor"
-        )
-      );
       bytecode = Shims.NewToLegacy.forBytecode(artifacts.TestContract.bytecode);
     });
 
     it("Encodes constructors", async () => {
-      const { data } = await encoder.encodeTxNoResolution(abi, [1]);
+      const { data } = await encoder.encodeCreation([1]);
       assert.strictEqual(
         data,
         bytecode +

--- a/packages/encoder/test/constructor.test.ts
+++ b/packages/encoder/test/constructor.test.ts
@@ -59,23 +59,30 @@ beforeAll(async () => {
 
 describe("Encoding", () => {
   describe("Constructors", () => {
-    let encoder: Encoder.ContractEncoder;
-    let bytecode: string;
-
-    beforeAll(async () => {
-      encoder = await Encoder.forArtifact(artifacts.TestContract, {
+    it("Encodes constructors", async () => {
+      const artifact = artifacts.TestContract;
+      const encoder = await Encoder.forArtifact(artifact, {
         projectInfo: { compilations }
       });
-      bytecode = Shims.NewToLegacy.forBytecode(artifacts.TestContract.bytecode);
-    });
-
-    it("Encodes constructors", async () => {
+      const bytecode = Shims.NewToLegacy.forBytecode(artifact.bytecode);
       const { data } = await encoder.encodeCreation([1]);
       assert.strictEqual(
         data,
         bytecode +
           "0000000000000000000000000000000000000000000000000000000000000001"
       );
+    });
+
+    it("Encodes implicit default constructors", async () => {
+      const artifact = artifacts.AuxContract;
+      //check that it really is implicit, that it's not in the ABI
+      assert(!artifact.abi.some(abi => abi.type === "constructor"));
+      const encoder = await Encoder.forArtifact(artifact, {
+        projectInfo: { compilations }
+      });
+      const bytecode = Shims.NewToLegacy.forBytecode(artifact.bytecode);
+      const { data } = await encoder.encodeCreation([]);
+      assert.strictEqual(data, bytecode);
     });
   });
 });


### PR DESCRIPTION
Addresses #5749.

This PR adds an `encodeCreation()` method to the `ContractEncoder` and `ContractInstanceEncoder` classes.  (Using it from the latter ignores the particular instance; it's included for consistency.)

The encoder already had the functionality of encoding contract creations, but accessing it wasn't convenient; you had to pass in the ABI for the constructor, and make one up if none existed.  This PR just factors out the relevant functionality to make it accessible.  It adds an `encodeCreation()` method to the contract encoder (and also contract instance encoder); it doesn't take an `abi` argument because none is necessary.

The existing functionality for getting constructor information, which used to just live in the constructor case of `getMethod()`, has been factored out into `getConstructorMethod()`.  Note that this method accepts an optional ABI argument with the constructor ABI; this is just to avoid re-finding it in cases where it's already known.  The new `encodeCreation()` method doesn't pass this in, but when it's being called from `getMethod(abi)`, it will pass in this argument to avoid recomputation.  In the case where `abi` is not passed in, `getConstructorMethod()` will call `getConstructorAbi()`, which will find the relevant ABI entry if it exists and use a default one if it doesn't.

I modified the existing test of constructor encoding to use this new method.  I also added one more, which tests the case of a default constructor; we didn't have a test for that case before.

Testing instructions: The tests I added to CI should be sufficient, I think, but let me know if you think they're not...