### PR TITLE
remove `require` cache invalidation

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -25,6 +25,7 @@
     "@truffle/events": "^0.1.19",
     "@truffle/provider": "^0.2.64",
     "conf": "^10.1.2",
+    "debug": "^4.3.1",
     "find-up": "^2.1.0",
     "lodash": "^4.17.21",
     "original-require": "^1.0.1"

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,6 +1,5 @@
 import path from "path";
 import merge from "lodash/merge";
-import Module from "module";
 import findUp from "find-up";
 import Conf from "conf";
 import TruffleError from "@truffle/error";
@@ -187,10 +186,6 @@ class TruffleConfig {
 
     const config = new TruffleConfig(undefined, workingDirectory, undefined);
 
-    // The require-nocache module used to do this for us, but
-    // it doesn't bundle very well. So we've pulled it out ourselves.
-    //@ts-ignore
-    delete require.cache[Module._resolveFilename(file, module)];
     const staticConfig = originalRequire(file);
 
     config.merge(staticConfig);

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -6,6 +6,8 @@ import TruffleError from "@truffle/error";
 import originalRequire from "original-require";
 import { getInitialConfig, configProps } from "./configDefaults";
 import { EventManager } from "@truffle/events";
+import debugModule from "debug";
+const debug = debugModule("config");
 
 const DEFAULT_CONFIG_FILENAME = "truffle-config.js";
 const BACKUP_CONFIG_FILENAME = "truffle.js"; // old config filename
@@ -116,6 +118,7 @@ class TruffleConfig {
         if (typeof clone[key] === "object" && this._deepCopy.includes(key)) {
           this[key] = merge(this[key], clone[key]);
         } else {
+          debug("setting key -- %o -- to -- %o", key, clone[key]);
           this[key] = clone[key];
         }
       } catch (e) {
@@ -161,6 +164,7 @@ class TruffleConfig {
   }
 
   public static detect(options: any = {}, filename?: string): TruffleConfig {
+    debug("callling Config.detect with filename -- %o", filename);
     let configFile;
     const configPath = options.config;
 
@@ -180,6 +184,7 @@ class TruffleConfig {
   }
 
   public static load(file: string, options: any = {}): TruffleConfig {
+    debug("calling Config.load with file -- %o", file);
     const workingDirectory = options.config
       ? process.cwd()
       : path.dirname(path.resolve(file));
@@ -187,6 +192,7 @@ class TruffleConfig {
     const config = new TruffleConfig(undefined, workingDirectory, undefined);
 
     const staticConfig = originalRequire(file);
+    debug("the static config is -- %o", staticConfig);
 
     config.merge(staticConfig);
     config.merge(options);

--- a/packages/core/test/lib/commands/config.js
+++ b/packages/core/test/lib/commands/config.js
@@ -11,12 +11,9 @@ describe("config", function () {
   let output = "";
   let memStream;
 
-  before(function () {
+  beforeEach(function () {
     config = createTestProject(path.join(__dirname, "../../sources/metacoin"));
     config.logger = { log: val => val && memStream.write(val) };
-  });
-
-  beforeEach(function () {
     memStream = new MemoryStream();
     memStream.on("data", data => {
       output += data.toString();


### PR DESCRIPTION
THIS IS A BREAKING CHANGE FOR @truffle/config.

So https://github.com/trufflesuite/truffle/pull/5728 brought to our attention the fact that this cache invalidation does not work in the bundle (since `require` in this case is webpack's and not Node's). This PR deletes this line of code until we decide that we actually need to invalidate Node's cache.