### PR TITLE
Fix missing mocha runner during in-test debugging setup

### DIFF
--- a/packages/core/lib/debug/mocha.js
+++ b/packages/core/lib/debug/mocha.js
@@ -18,7 +18,7 @@ class CLIDebugHook {
     // turn off timeouts for the current runnable
     // HACK we don't turn it back on because it doesn't work...
     // tests that take a long time _after_ debug break just won't timeout
-    this.disableTimeout();
+    await this.disableTimeout();
 
     const { txHash, result, method } = await this.invoke(operation);
     debug("txHash: %o", txHash);
@@ -38,8 +38,8 @@ class CLIDebugHook {
 
   async start() {}
 
-  disableTimeout() {
-    this.runner.currentRunnable.timeout(0);
+  async disableTimeout() {
+    (await this.runner).currentRunnable.timeout(0);
   }
 
   async invoke(operation) {

--- a/packages/test/src/Test.ts
+++ b/packages/test/src/Test.ts
@@ -90,6 +90,17 @@ export const Test = {
 
     const mocha = this.createMocha(config);
 
+    // set up a promise on this instance to resolve to
+    // Mocha's "runner" returned by `mocha.run(...)`.
+    //
+    // do this upfront so that the promise is available
+    // immediately, even though mocha.run happens at the very
+    // end of this setup.
+    let setMochaRunner: (mochaRunner: any) => void;
+    this.mochaRunner = new Promise(resolve => {
+      setMochaRunner = resolve;
+    });
+
     const jsTests = config.test_files.filter((file: string) => {
       return path.extname(file) !== ".sol";
     });
@@ -177,10 +188,14 @@ export const Test = {
     });
 
     return new Promise(resolve => {
-      this.mochaRunner = mocha.run((failures: number) => {
+      const mochaRunner = mocha.run((failures: number) => {
         config.logger.warn = warn;
         resolve(failures);
       });
+
+      // finish setting up the mocha runner so that the
+      // previously-made promise resolves.
+      setMochaRunner(mochaRunner);
     });
   },
 

--- a/packages/test/src/Test.ts
+++ b/packages/test/src/Test.ts
@@ -24,7 +24,7 @@ let Mocha: any; // Late init with "mocha" or "mocha-parallel-tests"
 chai.use(require("./assertions").default);
 
 type CreateInTestDebugFunction = (options: {
-  mochaRunner: any;
+  mochaRunner: Promise<unknown>;
   config: Config;
   compilations: Compilation[];
 }) => (operation: any) => any;
@@ -96,7 +96,7 @@ export const Test = {
     // do this upfront so that the promise is available
     // immediately, even though mocha.run happens at the very
     // end of this setup.
-    let setMochaRunner: (mochaRunner: any) => void;
+    let setMochaRunner: (mochaRunner: unknown) => void;
     this.mochaRunner = new Promise(resolve => {
       setMochaRunner = resolve;
     });


### PR DESCRIPTION
 ## PR description

Addresses #5783 

Somehow this must've gotten broken as part of a refactor... in-test debugging uses the `CLIDebugHook`, which expects the availability of the Mocha runner _during setup_. Since this runner gets returned by `mocha.run()`, and since `mocha.run()` happens at the end of setup, the CLIDebugHook has been getting a value of `undefined` for this property.

This PR converts `Test.mochaRunner` to a Promise so that it can be `await`-ed during setup, instead of being statefully `undefined` until after it's needed.

## Testing instructions

Follow the instructions on [in-test debugging](https://trufflesuite.com/docs/truffle/how-to/debug-test/use-the-truffle-debugger/#in-test-debugging). Debug a successful transaction. Observe that the debugger starts.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.

## Breaking changes and new features

- [x] I have added any needed `breaking-change` and `new-feature` labels for the appropriate packages.