### PR TITLE
Change display name of @truffle/error and remove its stack property

### DIFF
--- a/packages/error/src/index.ts
+++ b/packages/error/src/index.ts
@@ -1,11 +1,9 @@
-//Note: This class only exists for compatibility with some old Javascript
-//stuff that avoided using Error directly for whatever reason.  Eventually
-//it should be eliminated.
-class ExtendableError extends Error {
+class TruffleError extends Error {
   constructor(message: string) {
     super(message);
     this.name = this.constructor.name;
+    this.stack = "";
   }
 }
 
-export = ExtendableError;
+export = TruffleError;


### PR DESCRIPTION
When using the bundle, I noticed `@truffle/error` includes a stack trace, unlike the unbundled behavior. @truffle/error's intent is to give the user an action and does not need a stack trace.

## Error with stack trace
```console
Solidity console.log detected in the following assets:
Telephone.json

ExtendableError: You are trying to deploy contracts that use console.log.
Please fix, or disable this check by setting solidityLog.preventConsoleLogMigration to false

    at module.exports (/home/amal/work/trees/truffle/console.log/packages/truffle/build/webpack:/packages/core/lib/commands/migrate/runMigrations.js:87:1)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at module.exports (/home/amal/work/trees/truffle/console.log/packages/truffle/build/webpack:/packages/core/lib/commands/migrate/setUpDryRunEnvironmentThenRunMigrations.js:37:1)
    at Object.module.exports [as run] (/home/amal/work/trees/truffle/console.log/packages/truffle/build/webpack:/packages/core/lib/commands/migrate/run.js:33:1)
    at runCommand (/home/amal/work/trees/truffle/console.log/packages/truffle/build/webpack:/packages/core/lib/command-utils.js:201:1)
Truffle v5.6.9 (core: 5.6.9)
Node v18.12.1
```

## How to test
1. bootstrap the repo
2. unbox metacoin, config and run migrate with mutually exclusive `--url` and `--network` options with truffle bundle.
   ```console
   reprod
   use-truffle-bundle # if you have the truffle dotfiles setup!
   truffle unbox metacoin
   truffle console --url http://127.0.0.1 --network development
   ```
3. There should be no stack trace! (Make sure you use the bundle)



