### PR TITLE
don't load Truffle's console contract into the console environment

### DIFF
--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -263,16 +263,17 @@ class Console extends EventEmitter {
           "utf8"
         );
         const json = JSON.parse(body);
-        // hack to prevent a warning about the console.sol contract which we
-        // don't load into the environment - we only want to do this when it is
-        // Truffle's console.sol, that is why we check the sources keys
+        const metadata = JSON.parse(json.metadata);
+        // filter out Truffle's console.log. We don't want users to interact with in the REPL.
+        // user contracts named console.log will be imported, and a warning will be issued.
         if (
-          !Object.keys(JSON.parse(json.metadata).sources).some(source => {
+          !Object.keys(metadata.sources).some(source => {
             return (
               source === "truffle/console.sol" ||
               source === "truffle/Console.sol"
             );
-          })
+          }) &&
+          Object.keys(metadata.sources).length === 1
         ) {
           jsonBlobs.push(json);
         }

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -262,7 +262,20 @@ class Console extends EventEmitter {
           path.join(this.options.contracts_build_directory, file),
           "utf8"
         );
-        jsonBlobs.push(JSON.parse(body));
+        const json = JSON.parse(body);
+        // hack to prevent a warning about the console.sol contract which we
+        // don't load into the environment - we only want to do this when it is
+        // Truffle's console.sol, that is why we check the sources keys
+        if (
+          !Object.keys(JSON.parse(json.metadata).sources).some(source => {
+            return (
+              source === "truffle/console.sol" ||
+              source === "truffle/Console.sol"
+            );
+          })
+        ) {
+          jsonBlobs.push(json);
+        }
       } catch (error) {
         throw new Error(`Error parsing or reading ${file}: ${error.message}`);
       }

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -264,16 +264,18 @@ class Console extends EventEmitter {
         );
         const json = JSON.parse(body);
         const metadata = JSON.parse(json.metadata);
+        const sources = Object.keys(metadata.sources);
         // filter out Truffle's console.log. We don't want users to interact with in the REPL.
         // user contracts named console.log will be imported, and a warning will be issued.
         if (
-          !Object.keys(metadata.sources).some(source => {
-            return (
-              source === "truffle/console.sol" ||
-              source === "truffle/Console.sol"
-            );
-          }) &&
-          Object.keys(metadata.sources).length === 1
+          sources.length > 1 ||
+          (sources.length === 1 &&
+            !sources.some(source => {
+              return (
+                source === "truffle/console.sol" ||
+                source === "truffle/Console.sol"
+              );
+            }))
         ) {
           jsonBlobs.push(json);
         }


### PR DESCRIPTION
This PR stops Truffle from loading its console contract into the console environment. Previously Truffle would load it into the console context (which users will not need to directly interact with in the repl) which would also cause the namespace error to be printed. 