### PR TITLE
Add notice for @truffle/config and @truffle/db-loader

### DIFF
--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -1,23 +1,37 @@
 # @truffle/config
-Utility for interacting with truffle-config.js files
+
+Utility for interacting with truffle-config.js files.
+
+## Semver notice
+
+:warning: This package does not follow semver recommendations as it is a
+Truffle internal module.
 
 ### Usage
- ```javascript
+
+```javascript
 const TruffleConfig = require("@truffle/config");
 ```
 
 #### Instantiate default TruffleConfig object
- ```javascript
+
+```javascript
 const newConfig = TruffleConfig.default();
 ```
 
 #### Instantiate custom TruffleConfig object
- ```javascript
-const customConfig = new TruffleConfig("/truffleDirPath", "/currentWorkingDirPath", networkObj);
+
+```javascript
+const customConfig = new TruffleConfig(
+  "/truffleDirPath",
+  "/currentWorkingDirPath",
+  networkObj
+);
 ```
 
 #### Config.detect()
- ```javascript
+
+```javascript
 // find config file & return new TruffleConfig object with config file settings (cwd)
 const truffleConfig = TruffleConfig.detect();
 
@@ -26,4 +40,5 @@ const truffleConfig = TruffleConfig.detect({ workingDirectory: "./some/Path" });
 
 // find & return new TruffleConfig object from custom named config
 const customTruffleConfig = TruffleConfig.detect({}, "./customConfig.js");
- ```
+`` `
+```

--- a/packages/db-loader/README.md
+++ b/packages/db-loader/README.md
@@ -1,6 +1,12 @@
 # `@truffle/db-loader`
 
-A loader for importing Truffle Db that does not throw an error when it is not installed.
+A loader for importing Truffle Db that does not throw an error when it is not
+installed.
+
+## Semver notice
+
+:warning: This package does not follow semver recommendations as it is a
+Truffle internal module.
 
 ## Contents
 


### PR DESCRIPTION
Truffle's monorepo contains several packages that are strictly for internal consumption. We should declare they won't follow semver. This came up when we made a breaking change to `@truffle/config` that doesn't impact production because of webpack + original-require.

Work in progress.