### PR TITLE
Bump minimum Node version check to 14

### DIFF
--- a/packages/core/cli.js
+++ b/packages/core/cli.js
@@ -17,7 +17,7 @@ global.crypto = {
 };
 
 // pre-flight check: Node version compatibility
-const minimumNodeVersion = "12.0.0";
+const minimumNodeVersion = "14.0.0";
 if (!semver.gte(process.version, minimumNodeVersion)) {
   console.log(
     "Error: Node version not supported. You are currently using version " +


### PR DESCRIPTION
This was missed when truffle dropped support for Node 12. This PR bumps it.