### PR TITLE
Fix: `truffle console` crash when metadata is missing in JSON artifact

### DIFF
--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -263,7 +263,8 @@ class Console extends EventEmitter {
           "utf8"
         );
         const json = JSON.parse(body);
-        // Vyper contracts may not have metadata field included, just push them to json blobs
+        // Artifacts may not contain metadata. For example, early Solidity versions as well as
+        // Vyper contracts do not include metadata. Just push them to json blobs.
         if (json.metadata === undefined) {
           jsonBlobs.push(json);
         } else {

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -268,10 +268,10 @@ class Console extends EventEmitter {
         if (json.metadata === undefined) {
           jsonBlobs.push(json);
         } else {
-          const metadata = JSON.parse(json.metadata);
-          const sources = Object.keys(metadata.sources);
           // filter out Truffle's console.log. We don't want users to interact with in the REPL.
           // user contracts named console.log will be imported, and a warning will be issued.
+          const metadata = JSON.parse(json.metadata);
+          const sources = Object.keys(metadata.sources);
           if (
             sources.length > 1 ||
             (sources.length === 1 &&

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -263,21 +263,26 @@ class Console extends EventEmitter {
           "utf8"
         );
         const json = JSON.parse(body);
-        const metadata = JSON.parse(json.metadata);
-        const sources = Object.keys(metadata.sources);
-        // filter out Truffle's console.log. We don't want users to interact with in the REPL.
-        // user contracts named console.log will be imported, and a warning will be issued.
-        if (
-          sources.length > 1 ||
-          (sources.length === 1 &&
-            !sources.some(source => {
-              return (
-                source === "truffle/console.sol" ||
-                source === "truffle/Console.sol"
-              );
-            }))
-        ) {
+        // Vyper contracts may not have metadata field included, just push them to json blobs
+        if (json.metadata === undefined) {
           jsonBlobs.push(json);
+        } else {
+          const metadata = JSON.parse(json.metadata);
+          const sources = Object.keys(metadata.sources);
+          // filter out Truffle's console.log. We don't want users to interact with in the REPL.
+          // user contracts named console.log will be imported, and a warning will be issued.
+          if (
+            sources.length > 1 ||
+            (sources.length === 1 &&
+              !sources.some(source => {
+                return (
+                  source === "truffle/console.sol" ||
+                  source === "truffle/Console.sol"
+                );
+              }))
+          ) {
+            jsonBlobs.push(json);
+          }
         }
       } catch (error) {
         throw new Error(`Error parsing or reading ${file}: ${error.message}`);


### PR DESCRIPTION
## PR description

As per the issue [#5812 ](https://github.com/trufflesuite/truffle/issues/5812) , `truffle console` command would throw an error and exit, if the metadata field was not present in all JSON blob files generated in the build process. The metadata field is not present in JSON files derived from Vyper source files.

## Testing instructions

1. Either compile a Vyper smart contract or delete metadata field in one of the generated JSON blobs from Solidity smart contracts.
2. Run `truffle migrate`. IMPORTANT: do not run truffle develop, as some configurations (truffle-config.js) were not affected by this bug (see issue for more details).
3. Run `truffle console`. The command executes without errors.

## Documentation, breaking changes and new features

This PR does not introduce any breaking changes or new features. The documentation does not need to be changed either.

