### PR TITLE
Fix codec typedoc build script

### DIFF
--- a/packages/codec/docs/typedoc.json
+++ b/packages/codec/docs/typedoc.json
@@ -1,8 +1,6 @@
 {
   "name": "Truffle Decoding and Encoding",
-  "theme": "../../node_modules/@trufflesuite/typedoc-default-themes/bin/default/",
   "excludeExternals": true,
-  "plugin": ["typedoc-plugin-remove-references"],
   "categoryOrder": [
     "Data",
     "ABI data location",

--- a/packages/codec/package.json
+++ b/packages/codec/package.json
@@ -49,7 +49,6 @@
     "ts-node": "10.7.0",
     "ttypescript": "1.5.13",
     "typedoc": "0.22.18",
-    "typedoc-plugin-remove-references": "^0.0.5",
     "typescript": "^4.7.4",
     "typescript-transform-paths": "3.3.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -24548,11 +24548,6 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typedoc-plugin-remove-references@^0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/typedoc-plugin-remove-references/-/typedoc-plugin-remove-references-0.0.5.tgz#08b129d2697e50208c807e06c3662fd2fc86a925"
-  integrity sha512-DSZ7kM/Y90CgZUKt8MiDsoi4fvrJyleHydj3ncGyqDqMdhuMes2E/4I6mSmXBrVdTjYhVH6BeoOFSbj2pQ821g==
-
 typedoc@0.22.18:
   version "0.22.18"
   resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.22.18.tgz#1d000c33b66b88fd8cdfea14a26113a83b7e6591"


### PR DESCRIPTION
## PR description

This PR makes minimal changes to get the codec docs to build. It now uses the default `typedoc` theme instead of our [fork](https://github.com/trufflesuite/typedoc-default-themes) which should probably incorporate [upstream](https://github.com/TypeStrong/typedoc-default-themes) changes. Upstream has been deprecated and is no longer compatible with `typedoc` v0.22. Truffle is currently using pinned `typedoc` version v0.22.18. 

Issue: #5793

Remove:
  - theme @trufflesuite/typedoc-default-themes
  - typedoc-plugin-remove-references


NOTE: can probably bump `typedoc` to latest, and if we want to keep our customized theme, will have to rework the changes against upstream as `typedoc@0.22.0` broke all hbs custom themes. See: https://github.com/TypeStrong/typedoc/blob/master/internal-docs/custom-themes.md

## Testing instructions

Build the codec docs and view them? 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.

## Breaking changes and new features

- [x] I have added any needed `breaking-change` and `new-feature` labels for the appropriate packages.
