### PR TITLE
Build codec and preserve docs as part of bootstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "private": true,
   "scripts": {
     "bootstrap": "yarn exec lerna bootstrap",
-    "prepare": "lerna run prepare --stream --concurrency=1 && husky install",
+    "docs": "lerna run docs --stream --concurrency=1",
+    "prepare": "lerna run prepare --stream --concurrency=1 && husky install && yarn docs",
     "publish-release": "./scripts/publish-release.sh",
     "publish-dist-tag": "./scripts/publish-dist-tag.sh",
     "prepare-release": "./scripts/prepare-release.sh",


### PR DESCRIPTION
## PR description

This PR extends the build process to generate documentation for both codec and preserve. If either fails, we will be alerted and can correct at the time of failure. 

First call `yarn prepare` and allow each package to build, then call `yarn build docs` to generate typedocs for built packagers, avoiding dependency build issues.

Motivation: #5821 

## Testing instructions

Build and verify codec and preserve docs are created.

## Documentation

- No label `doc-change-required`

## Breaking changes and new features

-  No breaking changes
