### PR TITLE
Have Dashboard politely ask users occasionally if they'll share telemetry 

### DIFF
--- a/packages/dashboard/lib/DashboardServer.ts
+++ b/packages/dashboard/lib/DashboardServer.ts
@@ -2,12 +2,13 @@ import express, { Application, NextFunction, Request, Response } from "express";
 import path from "path";
 import getPort from "get-port";
 import open from "open";
+import { v4 as uuid } from "uuid";
+import Config from "@truffle/config";
 import {
   dashboardProviderMessageType,
   LogMessage,
   logMessageType
 } from "@truffle/dashboard-message-bus-common";
-
 import { DashboardMessageBus } from "@truffle/dashboard-message-bus";
 import { DashboardMessageBusClient } from "@truffle/dashboard-message-bus-client";
 import cors from "cors";
@@ -93,6 +94,30 @@ export class DashboardServer {
       await this.connectToMessageBus();
       this.expressApp.post("/rpc", this.postRpc.bind(this));
     }
+
+    this.expressApp.get("/analytics", (_req, res) => {
+      const userConfig = Config.getUserConfig();
+      res.json({
+        enableAnalytics: userConfig.get("enableAnalytics"),
+        analyticsSet: userConfig.get("analyticsSet"),
+        analyticsMessageDateTime: userConfig.get("analyticsMessageDateTime")
+      });
+    });
+
+    this.expressApp.put("/analytics", (req, _res) => {
+      const { enable } = req.body as { enable: boolean };
+
+      const userConfig = Config.getUserConfig();
+
+      const uid = userConfig.get("uniqueId");
+      if (!uid) userConfig.set("uniqueId", uuid());
+
+      userConfig.set({
+        enableAnalytics: !!enable,
+        analyticsSet: true,
+        analyticsMessageDateTime: Date.now()
+      });
+    });
 
     this.expressApp.use(express.static(this.frontendPath));
     this.expressApp.get("*", (_req, res) => {

--- a/packages/dashboard/lib/DashboardServer.ts
+++ b/packages/dashboard/lib/DashboardServer.ts
@@ -105,7 +105,7 @@ export class DashboardServer {
     });
 
     this.expressApp.put("/analytics", (req, _res) => {
-      const { enable } = req.body as { enable: boolean };
+      const { value } = req.body as { value: boolean };
 
       const userConfig = Config.getUserConfig();
 
@@ -113,7 +113,7 @@ export class DashboardServer {
       if (!uid) userConfig.set("uniqueId", uuid());
 
       userConfig.set({
-        enableAnalytics: !!enable,
+        enableAnalytics: !!value,
         analyticsSet: true,
         analyticsMessageDateTime: Date.now()
       });

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -38,6 +38,7 @@
     "@mantine/notifications": "^5.0.0",
     "@mantine/prism": "^5.0.0",
     "@truffle/codec": "^0.14.12",
+    "@truffle/config": "^1.3.48",
     "@truffle/dashboard-message-bus": "^0.1.10",
     "@truffle/dashboard-message-bus-client": "^0.1.9",
     "@truffle/dashboard-message-bus-common": "^0.1.5",
@@ -56,6 +57,7 @@
     "react-dom": "^18.2.0",
     "react-feather": "^2.0.10",
     "react-router-dom": "^6.3.0",
+    "uuid": "^9.0.0",
     "wagmi": "^0.6.3",
     "ws": "^7.2.0"
   },

--- a/packages/dashboard/src/components/composed/Layout.tsx
+++ b/packages/dashboard/src/components/composed/Layout.tsx
@@ -14,7 +14,7 @@ import {
   analyticsNotificationId
 } from "src/utils/notifications";
 
-const ARBITRARY_ANALYTICS_NEXT_ASK_THRESHOLD = 31544444444; // 365 days
+const ARBITRARY_ANALYTICS_NEXT_ASK_THRESHOLD_IN_DAYS = 365;
 
 const useStyles = createStyles((_theme, _params, _getRef) => ({
   main: {
@@ -30,15 +30,26 @@ function Layout(): JSX.Element {
   } = useDash()!;
   const { classes } = useStyles();
 
+  // Analytics notifications
   useEffect(() => {
-    if (notice.show || analyticsConfig.analyticsSet === null) return;
+    // Don't ask if...
+    if (
+      // There's currently a fullscreen notice
+      notice.show ||
+      // Analytics is already enabled
+      analyticsConfig.enableAnalytics ||
+      // Analytics config info is not in state yet
+      analyticsConfig.analyticsMessageDateTime === null
+    )
+      return;
 
-    const shouldAsk =
-      !analyticsConfig.enableAnalytics && !analyticsConfig.analyticsSet;
-    const shouldAskAgain =
-      !analyticsConfig.enableAnalytics &&
-      Date.now() - analyticsConfig.analyticsMessageDateTime! >
-        ARBITRARY_ANALYTICS_NEXT_ASK_THRESHOLD;
+    const askAfter = new Date(analyticsConfig.analyticsMessageDateTime);
+    askAfter.setDate(
+      askAfter.getDate() + ARBITRARY_ANALYTICS_NEXT_ASK_THRESHOLD_IN_DAYS
+    );
+
+    const shouldAsk = !analyticsConfig.analyticsSet;
+    const shouldAskAgain = new Date() > askAfter;
 
     const analyticsNotificationArgs = [
       () => {

--- a/packages/dashboard/src/components/composed/Layout.tsx
+++ b/packages/dashboard/src/components/composed/Layout.tsx
@@ -1,8 +1,20 @@
+import { useEffect } from "react";
 import { AppShell, createStyles } from "@mantine/core";
+import {
+  showNotification,
+  updateNotification,
+  hideNotification
+} from "@mantine/notifications";
 import { Outlet } from "react-router-dom";
 import { useDash } from "src/hooks";
 import Sidebar from "src/components/composed/Sidebar";
 import Notice from "src/components/composed/Notice";
+import {
+  analyticsNotifications,
+  analyticsNotificationId
+} from "src/utils/notifications";
+
+const ARBITRARY_ANALYTICS_NEXT_ASK_THRESHOLD = 31544444444; // 365 days
 
 const useStyles = createStyles((_theme, _params, _getRef) => ({
   main: {
@@ -13,9 +25,42 @@ const useStyles = createStyles((_theme, _params, _getRef) => ({
 
 function Layout(): JSX.Element {
   const {
-    state: { notice }
+    state: { notice, analyticsConfig },
+    operations: { updateAnalyticsConfig }
   } = useDash()!;
   const { classes } = useStyles();
+
+  useEffect(() => {
+    if (notice.show || analyticsConfig.analyticsSet === null) return;
+
+    const shouldAsk =
+      !analyticsConfig.enableAnalytics && !analyticsConfig.analyticsSet;
+    const shouldAskAgain =
+      !analyticsConfig.enableAnalytics &&
+      Date.now() - analyticsConfig.analyticsMessageDateTime! >
+        ARBITRARY_ANALYTICS_NEXT_ASK_THRESHOLD;
+
+    const analyticsNotificationArgs = [
+      () => {
+        updateAnalyticsConfig(true);
+        updateNotification(analyticsNotifications["thank"]());
+      },
+      () => {
+        updateAnalyticsConfig(false);
+        hideNotification(analyticsNotificationId);
+      }
+    ];
+
+    if (shouldAsk) {
+      showNotification(
+        analyticsNotifications["ask"](...analyticsNotificationArgs)
+      );
+    } else if (shouldAskAgain) {
+      showNotification(
+        analyticsNotifications["ask-again"](...analyticsNotificationArgs)
+      );
+    }
+  }, [notice, analyticsConfig, updateAnalyticsConfig]);
 
   return (
     <AppShell

--- a/packages/dashboard/src/contexts/DashContext/DashContext.ts
+++ b/packages/dashboard/src/contexts/DashContext/DashContext.ts
@@ -13,6 +13,7 @@ export interface ContextValue {
       lifecycle: ReceivedMessageLifecycle<DashboardProviderMessage>
     ) => any;
     toggleNotice: () => void;
+    updateAnalyticsConfig: (value: boolean) => void;
   };
   dispatch?: React.Dispatch<Action>;
 }

--- a/packages/dashboard/src/contexts/DashContext/DashProvider.tsx
+++ b/packages/dashboard/src/contexts/DashContext/DashProvider.tsx
@@ -283,7 +283,7 @@ function DashProvider({ children }: DashProviderProps): JSX.Element {
       await fetch(`http://${host}:${port}/analytics`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ enable: value })
+        body: JSON.stringify({ value })
       });
       // No need to update state afterwards
     }

--- a/packages/dashboard/src/contexts/DashContext/state.ts
+++ b/packages/dashboard/src/contexts/DashContext/state.ts
@@ -46,6 +46,11 @@ export const initialState: State = {
   notice: {
     show: false,
     type: "LOADING"
+  },
+  analyticsConfig: {
+    enableAnalytics: null,
+    analyticsSet: null,
+    analyticsMessageDateTime: null
   }
 };
 
@@ -58,6 +63,8 @@ export const reducer = (state: State, action: Action): State => {
       return { ...state, chainInfo: data };
     case "set-notice":
       return { ...state, notice: { ...state.notice, ...data } };
+    case "set-analytics-config":
+      return { ...state, analyticsConfig: data };
     case "handle-message":
       // Copy state,
       // modify it depending on message type,

--- a/packages/dashboard/src/contexts/DashContext/types/Action.ts
+++ b/packages/dashboard/src/contexts/DashContext/types/Action.ts
@@ -6,6 +6,7 @@ export type ActionType =
   | "set-decoder"
   | "set-chain-info"
   | "set-notice"
+  | "set-analytics-config"
   | "handle-message";
 
 export interface BaseAction {
@@ -30,6 +31,11 @@ export interface SetNoticeAction extends BaseAction {
   data: Partial<State["notice"]>;
 }
 
+export interface SetAnalyticsConfigAction extends BaseAction {
+  type: "set-analytics-config";
+  data: State["analyticsConfig"];
+}
+
 export interface HandleMessageAction extends BaseAction {
   type: "handle-message";
   data: ReceivedMessageLifecycle<Message>;
@@ -39,4 +45,5 @@ export type Action =
   | SetDecoderAction
   | SetChainInfoAction
   | SetNoticeAction
+  | SetAnalyticsConfigAction
   | HandleMessageAction;

--- a/packages/dashboard/src/contexts/DashContext/types/State.ts
+++ b/packages/dashboard/src/contexts/DashContext/types/State.ts
@@ -28,4 +28,9 @@ export interface State {
     show: boolean;
     type: NoticeContent | null;
   };
+  analyticsConfig: {
+    enableAnalytics: boolean | null;
+    analyticsSet: boolean | null;
+    analyticsMessageDateTime: number | null;
+  };
 }

--- a/packages/dashboard/src/utils/notifications/analytics.tsx
+++ b/packages/dashboard/src/utils/notifications/analytics.tsx
@@ -22,7 +22,7 @@ export const analyticsNotifications: Record<
       <Stack>
         <Text>
           You can help us improve Truffle by allowing us to track how you use
-          our tools. Would you like to share anonymous telemetry data? View the
+          our tools. Would you like to share anonymous telemetry? View the
           Truffle Analytics policy&nbsp;
           <Anchor href="https://trufflesuite.com/analytics" target="_blank">
             here

--- a/packages/dashboard/src/utils/notifications/analytics.tsx
+++ b/packages/dashboard/src/utils/notifications/analytics.tsx
@@ -1,0 +1,71 @@
+import { Stack, Group, Button, Text, Anchor } from "@mantine/core";
+import type { NotificationProps } from "@mantine/notifications";
+
+type NotificationPropsWithId = NotificationProps & { id: string };
+
+export const analyticsNotificationId = "analytics";
+
+const baseNotification = {
+  autoClose: false,
+  disallowClose: true,
+  id: analyticsNotificationId
+};
+
+export const analyticsNotifications: Record<
+  "ask" | "ask-again" | "thank",
+  (enable?: () => void, disable?: () => void) => NotificationPropsWithId
+> = {
+  "ask": (enable, disable) => ({
+    ...baseNotification,
+    title: "Help improve Truffle",
+    message: (
+      <Stack>
+        <Text>
+          You can help us improve Truffle by allowing us to track how you use
+          our tools. Would you like to share anonymous telemetry data? View the
+          Truffle Analytics policy&nbsp;
+          <Anchor href="https://trufflesuite.com/analytics" target="_blank">
+            here
+          </Anchor>
+          .
+        </Text>
+        <Group grow>
+          <Button onClick={disable} color="gray" variant="light">
+            Dismiss
+          </Button>
+          <Button onClick={enable} variant="outline">
+            Enable
+          </Button>
+        </Group>
+      </Stack>
+    ),
+    color: "yellow"
+  }),
+  "ask-again": (enable, disable) => ({
+    ...baseNotification,
+    title: "Telemetry is currently disabled",
+    message: (
+      <Stack>
+        <Text>
+          Would you consider enabling it? It helps us make Truffle a better
+          experience for you.
+        </Text>
+        <Group grow>
+          <Button onClick={disable} color="gray" variant="light">
+            No
+          </Button>
+          <Button onClick={enable} variant="outline">
+            Enable
+          </Button>
+        </Group>
+      </Stack>
+    ),
+    color: "yellow"
+  }),
+  "thank": () => ({
+    ...baseNotification,
+    title: "Telemetry is now enabled",
+    message: "Thank you!",
+    autoClose: 1500
+  })
+};

--- a/packages/dashboard/src/utils/notifications/analytics.tsx
+++ b/packages/dashboard/src/utils/notifications/analytics.tsx
@@ -48,7 +48,11 @@ export const analyticsNotifications: Record<
       <Stack>
         <Text>
           Would you consider enabling it? It helps us make Truffle a better
-          experience for you.
+          experience for you. View the Truffle Analytics policy&nbsp;
+          <Anchor href="https://trufflesuite.com/analytics" target="_blank">
+            here
+          </Anchor>
+          .
         </Text>
         <Group grow>
           <Button onClick={disable} color="gray" variant="light">

--- a/packages/dashboard/src/utils/notifications/index.ts
+++ b/packages/dashboard/src/utils/notifications/index.ts
@@ -1,1 +1,2 @@
 export * from "src/utils/notifications/decode";
+export * from "src/utils/notifications/analytics";


### PR DESCRIPTION
Addresses: #4828

Use dashboard to prompt our users to graciously enable analytics.

### Behavior on load:
```mermaid
flowchart TD
  A{"Has the user explicitly<br/>opted in/out before?<br />(via the config command,<br />or much less likely, editing<br />the user config manually)"} -->|no| B([Ask to enable analytics])
  A -->|yes| C{Is analytics enabled?}
  C -->|no| D{Has it been a year since<br/>user last said no?}
  C -->|yes| E([OK])
  D -->|no| E
  D -->|yes, ask again| B
```

### How?
`DashboardServer`'s express server has two new endpoints: `POST` and `GET` at `/analytics`. Their corresponding handlers read and write to the user config object, which in turn modifies the config file on disk. Frontend just interacts with `/analytics` and manages notifications as needed.

### Wording
The prompt content (located at `src/utils/notifications/analytics.tsx`) mostly follows that of the previous PR (#5290).

### Testing instructions
0. Locate your Truffle user config file (likely at `~/.config/truffle-nodejs/config.json`)
1. Inside this user config file, remove `enableAnalytics`, `analyticsSet`, `analyticsMessageDateTime` for a clean slate, maybe `uniqueId` also. Continue if these fields are not present.
2. Start and open dashboard. You will be prompted to enable analytics, click `Enable`.
3. Verify that the config file is updated with analytics enabled. Repeat step 1 for clean slate.
4. Refresh dashboard. This time when you're prompted click `Dismiss`.
5. Verify that the config file is updated with analytics disabled. Edit `analyticsMessageDateTime` to `1` (no quotes!).
6. Refresh dashboard. You will be prompted to enable analytics, but with slightly different text.


### Related:
- Our [analytics policy](https://trufflesuite.com/analytics)
- Our [analytics code](https://github.com/trufflesuite/truffle/blob/v5.7.2/packages/core/lib/services/analytics/google.js)