### PR TITLE
Internal improvement: add memoization to `Cache` utility and switch to using `async` fs methods

### DIFF
--- a/packages/compile-solidity-tests/test/compilerSupplier/Cache.ts
+++ b/packages/compile-solidity-tests/test/compilerSupplier/Cache.ts
@@ -1,0 +1,62 @@
+// @ts-ignore
+import fs from "fs/promises";
+import * as sinon from "sinon";
+import { assert } from "chai";
+import { describe, it, beforeEach, afterEach } from "mocha";
+import { Cache } from "@truffle/compile-solidity";
+let cache;
+
+describe("Cache", function () {
+  describe(".loadFile", function () {
+    describe("when the file content is memoized", function () {
+      beforeEach(function () {
+        cache = new Cache();
+        // invoking add memoizes the file contents
+        cache.add("these are the file contents", "myFileName.json");
+        sinon.stub(fs, "readFile");
+        sinon.stub(cache.memoizedCompilers, "set");
+      });
+      afterEach(async function () {
+        // @ts-ignore - what the hell are ya doin TS?
+        await fs.rm(cache.resolve("myFileName.json"), { force: true });
+        // @ts-ignore
+        fs.readFile.restore();
+        cache.memoizedCompilers.set.restore();
+      });
+
+      it("returns the memoized file contents as a string", function () {
+        const result = cache.loadFile("myFileName.json");
+        assert.equal(result, "these are the file contents");
+      });
+      it("doesn't read the file from disk", function () {
+        cache.loadFile("myFileName.json");
+        // @ts-ignore
+        assert(!fs.readFile.called);
+      });
+      it("doesn't memoize the contents", function () {
+        cache.loadFile("myFileName.json");
+        assert(!cache.memoizedCompilers.called);
+      });
+    });
+
+    describe("when the file content is not memoized", function () {
+      beforeEach(async function () {
+        // create new cache to ensure nothing is memoized
+        cache = new Cache();
+        // create file to load contents from
+        await fs.writeFile(cache.resolve("myFileName.json"), "file contents");
+        sinon.stub(cache.memoizedCompilers, "get");
+      });
+      afterEach(function () {
+        cache.memoizedCompilers.get.restore();
+      });
+
+      it("loads the file from disk", function () {
+        const result = cache.loadFile("myFileName.json");
+        // the get method for the map should not have been called
+        assert(!cache.memoizedCompilers.get.called);
+        assert.equal(result, "file contents");
+      });
+    });
+  });
+});

--- a/packages/compile-solidity-tests/test/compilerSupplier/Cache.ts
+++ b/packages/compile-solidity-tests/test/compilerSupplier/Cache.ts
@@ -9,10 +9,10 @@ let cache;
 describe("Cache", function () {
   describe(".loadFile", function () {
     describe("when the file content is memoized", function () {
-      beforeEach(function () {
+      beforeEach(async function () {
         cache = new Cache();
         // invoking add memoizes the file contents
-        cache.add("these are the file contents", "myFileName.json");
+        await cache.add("these are the file contents", "myFileName.json");
         sinon.stub(fs, "readFile");
         sinon.stub(cache.memoizedCompilers, "set");
       });
@@ -24,17 +24,17 @@ describe("Cache", function () {
         cache.memoizedCompilers.set.restore();
       });
 
-      it("returns the memoized file contents as a string", function () {
-        const result = cache.loadFile("myFileName.json");
+      it("returns the memoized file contents as a string", async function () {
+        const result = await cache.loadFile("myFileName.json");
         assert.equal(result, "these are the file contents");
       });
-      it("doesn't read the file from disk", function () {
-        cache.loadFile("myFileName.json");
+      it("doesn't read the file from disk", async function () {
+        await cache.loadFile("myFileName.json");
         // @ts-ignore
         assert(!fs.readFile.called);
       });
-      it("doesn't memoize the contents", function () {
-        cache.loadFile("myFileName.json");
+      it("doesn't memoize the contents", async function () {
+        await cache.loadFile("myFileName.json");
         assert(!cache.memoizedCompilers.called);
       });
     });
@@ -51,8 +51,8 @@ describe("Cache", function () {
         cache.memoizedCompilers.get.restore();
       });
 
-      it("loads the file from disk", function () {
-        const result = cache.loadFile("myFileName.json");
+      it("loads the file from disk", async function () {
+        const result = await cache.loadFile("myFileName.json");
         // the get method for the map should not have been called
         assert(!cache.memoizedCompilers.get.called);
         assert.equal(result, "file contents");

--- a/packages/compile-solidity-tests/test/compilerSupplier/index.ts
+++ b/packages/compile-solidity-tests/test/compilerSupplier/index.ts
@@ -151,13 +151,13 @@ describe("CompilerSupplier", () => {
     describe("when a user specifies the compiler url root", () => {
       beforeEach(() => {
         sinon.stub(Cache.prototype, "add");
-        sinon.stub(Cache.prototype, "has").returns(false);
+        sinon.stub(Cache.prototype, "has").returns(Promise.resolve(false));
         sinon
           .stub(VersionRange.prototype, "getSolcVersionsForSource")
           .returns(Promise.resolve(allVersions));
         sinon
           .stub(VersionRange.prototype, "versionIsCached")
-          .returns(undefined);
+          .returns(Promise.resolve(undefined));
         sinon.stub(VersionRange.prototype, "compilerFromString");
         sinon
           .stub(axios, "get")

--- a/packages/compile-solidity-tests/test/compilerSupplier/loadingStrategies/VersionRange.ts
+++ b/packages/compile-solidity-tests/test/compilerSupplier/loadingStrategies/VersionRange.ts
@@ -231,8 +231,8 @@ describe("VersionRange loading strategy", () => {
         expectedResult = "v0.4.11+commit.124234rd.js";
       });
 
-      it("returns the file name with the prefix removed", () => {
-        assert.equal(instance.versionIsCached("0.4.11"), expectedResult);
+      it("returns the file name with the prefix removed", async () => {
+        assert.equal(await instance.versionIsCached("0.4.11"), expectedResult);
       });
     });
 
@@ -241,8 +241,8 @@ describe("VersionRange loading strategy", () => {
         expectedResult = undefined;
       });
 
-      it("returns undefined", () => {
-        assert.equal(instance.versionIsCached("0.4.29"), expectedResult);
+      it("returns undefined", async () => {
+        assert.equal(await instance.versionIsCached("0.4.29"), expectedResult);
       });
     });
   });
@@ -260,15 +260,15 @@ describe("VersionRange loading strategy", () => {
       unStub(instance, "getCachedSolcByFileName");
     });
 
-    it("returns the compiler when a single version is specified", () => {
-      instance.getCachedSolcByVersionRange("0.4.23");
+    it("returns the compiler when a single version is specified", async () => {
+      await instance.getCachedSolcByVersionRange("0.4.23");
       assert.isTrue(
         // @ts-ignore
         instance.getCachedSolcByFileName.calledWith(expectedResult)
       );
     });
-    it("returns the newest compiler when there are multiple valid ones", () => {
-      instance.getCachedSolcByVersionRange("^0.4.1");
+    it("returns the newest compiler when there are multiple valid ones", async () => {
+      await instance.getCachedSolcByVersionRange("^0.4.1");
       assert.isTrue(
         // @ts-ignore
         instance.getCachedSolcByFileName.calledWith(expectedResult)

--- a/packages/compile-solidity-tests/test/compilerSupplier/loadingStrategies/VersionRange.ts
+++ b/packages/compile-solidity-tests/test/compilerSupplier/loadingStrategies/VersionRange.ts
@@ -75,7 +75,9 @@ describe("VersionRange loading strategy", () => {
     beforeEach(() => {
       sinon.stub(instance, "getCachedSolcByVersionRange");
       sinon.stub(instance, "getSolcFromCacheOrUrl");
-      sinon.stub(instance, "versionIsCached").returns("compilerFilename.js");
+      sinon
+        .stub(instance, "versionIsCached")
+        .returns(Promise.resolve("compilerFilename.js"));
     });
     afterEach(() => {
       unStub(instance, "getCachedSolcByVersionRange");
@@ -106,7 +108,7 @@ describe("VersionRange loading strategy", () => {
     describe("when a version constraint is specified", () => {
       beforeEach(() => {
         sinon.stub(instance, "getAndCacheSolcByUrl");
-        sinon.stub(instance.cache, "has").returns(false);
+        sinon.stub(instance.cache, "has").returns(Promise.resolve(false));
       });
       afterEach(() => {
         unStub(instance, "getAndCacheSolcByUrl");
@@ -127,7 +129,7 @@ describe("VersionRange loading strategy", () => {
 
     describe("when the version is cached", () => {
       beforeEach(() => {
-        sinon.stub(instance.cache, "has").returns(true);
+        sinon.stub(instance.cache, "has").returns(Promise.resolve(true));
       });
       afterEach(() => {
         unStub(instance.cache, "has");
@@ -146,7 +148,7 @@ describe("VersionRange loading strategy", () => {
 
     describe("when the version is not cached", () => {
       beforeEach(() => {
-        sinon.stub(instance.cache, "has").returns(false);
+        sinon.stub(instance.cache, "has").returns(Promise.resolve(false));
         sinon.stub(instance.cache, "add");
         sinon.stub(instance, "compilerFromString").returns("compiler");
       });
@@ -216,7 +218,9 @@ describe("VersionRange loading strategy", () => {
 
   describe("versionIsCached(version)", () => {
     beforeEach(() => {
-      sinon.stub(instance.cache, "list").returns(compilerFileNames);
+      sinon
+        .stub(instance.cache, "list")
+        .returns(Promise.resolve(compilerFileNames));
     });
     afterEach(() => {
       unStub(instance.cache, "list");
@@ -246,7 +250,9 @@ describe("VersionRange loading strategy", () => {
   describe("getCachedSolcByVersionRange(version)", () => {
     beforeEach(() => {
       expectedResult = "soljson-v0.4.23+commit.1534a40d.js";
-      sinon.stub(instance.cache, "list").returns(compilerFileNames);
+      sinon
+        .stub(instance.cache, "list")
+        .returns(Promise.resolve(compilerFileNames));
       sinon.stub(instance, "getCachedSolcByFileName");
     });
     afterEach(() => {

--- a/packages/compile-solidity/src/compilerSupplier/Cache.ts
+++ b/packages/compile-solidity/src/compilerSupplier/Cache.ts
@@ -4,6 +4,7 @@ import fs from "fs";
 
 export class Cache {
   private compilerCachePath: string;
+  private memoizedCompilers: Map<string, string>;
 
   constructor() {
     const compilersDir = path.resolve(
@@ -15,6 +16,7 @@ export class Cache {
     if (!fs.existsSync(compilerCachePath)) fs.mkdirSync(compilerCachePath); // for 5.0.8 users
 
     this.compilerCachePath = compilerCachePath;
+    this.memoizedCompilers = new Map();
   }
 
   list() {
@@ -24,11 +26,29 @@ export class Cache {
   add(code: string, fileName: string) {
     const filePath = this.resolve(fileName);
     fs.writeFileSync(filePath, code);
+    this.memoizedCompilers[fileName] = code;
   }
 
   has(fileName: string) {
     const file = this.resolve(fileName);
     return fs.existsSync(file);
+  }
+
+  loadFile(fileName: string): string {
+    if (this.memoizedCompilers.has(fileName)) {
+      return this.memoizedCompilers[fileName];
+    }
+    try {
+      const compiler = fs.readFileSync(fileName).toString();
+      this.memoizedCompilers[fileName] = compiler;
+      return compiler;
+    } catch (error) {
+      if (!error.message.includes("ENOENT: no such file")) {
+        throw error;
+      } else {
+        throw new Error("The file specified could not be found.");
+      }
+    }
   }
 
   resolve(fileName: string) {

--- a/packages/compile-solidity/src/compilerSupplier/Cache.ts
+++ b/packages/compile-solidity/src/compilerSupplier/Cache.ts
@@ -1,6 +1,8 @@
 import Config from "@truffle/config";
 import path from "path";
 import fs from "fs";
+// @ts-ignore
+import * as fsPromises from "fs/promises";
 
 export class Cache {
   private compilerCachePath: string;
@@ -19,28 +21,28 @@ export class Cache {
     this.memoizedCompilers = new Map();
   }
 
-  list() {
-    return fs.readdirSync(this.compilerCachePath);
+  async list() {
+    return await fsPromises.readdir(this.compilerCachePath);
   }
 
-  add(code: string, fileName: string) {
+  async add(code: string, fileName: string) {
     const filePath = this.resolve(fileName);
-    fs.writeFileSync(filePath, code);
+    await fsPromises.writeFile(filePath, code);
     this.memoizedCompilers.set(filePath, code);
   }
 
-  has(fileName: string) {
+  async has(fileName: string) {
     const filePath = this.resolve(fileName);
-    return fs.existsSync(filePath);
+    return await fsPromises.exists(filePath);
   }
 
-  loadFile(fileName: string): string {
+  async loadFile(fileName: string): Promise<string> {
     const filePath = this.resolve(fileName);
     if (this.memoizedCompilers.has(filePath)) {
       return this.memoizedCompilers.get(filePath)!;
     }
     try {
-      const compiler = fs.readFileSync(filePath).toString();
+      const compiler = (await fsPromises.readFile(filePath)).toString();
       this.memoizedCompilers.set(filePath, compiler);
       return compiler;
     } catch (error) {

--- a/packages/compile-solidity/src/compilerSupplier/Cache.ts
+++ b/packages/compile-solidity/src/compilerSupplier/Cache.ts
@@ -4,7 +4,7 @@ import fs from "fs";
 
 export class Cache {
   private compilerCachePath: string;
-  private memoizedCompilers: Map<string, string>;
+  public memoizedCompilers: Map<string, string>;
 
   constructor() {
     const compilersDir = path.resolve(

--- a/packages/compile-solidity/src/compilerSupplier/Cache.ts
+++ b/packages/compile-solidity/src/compilerSupplier/Cache.ts
@@ -31,9 +31,18 @@ export class Cache {
     this.memoizedCompilers.set(filePath, code);
   }
 
-  async has(fileName: string) {
+  async has(fileName: string): Promise<boolean> {
     const filePath = this.resolve(fileName);
-    return await fsPromises.exists(filePath);
+    try {
+      await fsPromises.stat(filePath);
+      return true;
+    } catch (error) {
+      // only throw if the error is due to something other than it not existing
+      if (!error.message.includes("no such file or directory")) {
+        throw error;
+      }
+      return false;
+    }
   }
 
   async loadFile(fileName: string): Promise<string> {

--- a/packages/compile-solidity/src/compilerSupplier/Cache.ts
+++ b/packages/compile-solidity/src/compilerSupplier/Cache.ts
@@ -58,7 +58,7 @@ export class Cache {
       if (!error.message.includes("ENOENT: no such file")) {
         throw error;
       } else {
-        throw new Error("The file specified could not be found.");
+        throw new Error("The specified file could not be found.");
       }
     }
   }

--- a/packages/compile-solidity/src/compilerSupplier/Cache.ts
+++ b/packages/compile-solidity/src/compilerSupplier/Cache.ts
@@ -4,6 +4,8 @@ import fs from "fs";
 // @ts-ignore
 import * as fsPromises from "fs/promises";
 
+const fileNotFoundMessage = "no such file or directory";
+
 export class Cache {
   private compilerCachePath: string;
   public memoizedCompilers: Map<string, string>;
@@ -38,7 +40,7 @@ export class Cache {
       return true;
     } catch (error) {
       // only throw if the error is due to something other than it not existing
-      if (!error.message.includes("no such file or directory")) {
+      if (!error.message.includes(fileNotFoundMessage)) {
         throw error;
       }
       return false;
@@ -55,7 +57,7 @@ export class Cache {
       this.memoizedCompilers.set(filePath, compiler);
       return compiler;
     } catch (error) {
-      if (!error.message.includes("ENOENT: no such file")) {
+      if (!error.message.includes(fileNotFoundMessage)) {
         throw error;
       } else {
         throw new Error("The specified file could not be found.");

--- a/packages/compile-solidity/src/compilerSupplier/Cache.ts
+++ b/packages/compile-solidity/src/compilerSupplier/Cache.ts
@@ -26,7 +26,7 @@ export class Cache {
   add(code: string, fileName: string) {
     const filePath = this.resolve(fileName);
     fs.writeFileSync(filePath, code);
-    this.memoizedCompilers[filePath] = code;
+    this.memoizedCompilers.set(filePath, code);
   }
 
   has(fileName: string) {
@@ -37,11 +37,11 @@ export class Cache {
   loadFile(fileName: string): string {
     const filePath = this.resolve(fileName);
     if (this.memoizedCompilers.has(filePath)) {
-      return this.memoizedCompilers[filePath];
+      return this.memoizedCompilers.get(filePath)!;
     }
     try {
       const compiler = fs.readFileSync(filePath).toString();
-      this.memoizedCompilers[filePath] = compiler;
+      this.memoizedCompilers.set(filePath, compiler);
       return compiler;
     } catch (error) {
       if (!error.message.includes("ENOENT: no such file")) {

--- a/packages/compile-solidity/src/compilerSupplier/Cache.ts
+++ b/packages/compile-solidity/src/compilerSupplier/Cache.ts
@@ -26,21 +26,22 @@ export class Cache {
   add(code: string, fileName: string) {
     const filePath = this.resolve(fileName);
     fs.writeFileSync(filePath, code);
-    this.memoizedCompilers[fileName] = code;
+    this.memoizedCompilers[filePath] = code;
   }
 
   has(fileName: string) {
-    const file = this.resolve(fileName);
-    return fs.existsSync(file);
+    const filePath = this.resolve(fileName);
+    return fs.existsSync(filePath);
   }
 
   loadFile(fileName: string): string {
-    if (this.memoizedCompilers.has(fileName)) {
-      return this.memoizedCompilers[fileName];
+    const filePath = this.resolve(fileName);
+    if (this.memoizedCompilers.has(filePath)) {
+      return this.memoizedCompilers[filePath];
     }
     try {
-      const compiler = fs.readFileSync(fileName).toString();
-      this.memoizedCompilers[fileName] = compiler;
+      const compiler = fs.readFileSync(filePath).toString();
+      this.memoizedCompilers[filePath] = compiler;
       return compiler;
     } catch (error) {
       if (!error.message.includes("ENOENT: no such file")) {

--- a/packages/compile-solidity/src/compilerSupplier/loadingStrategies/Docker.ts
+++ b/packages/compile-solidity/src/compilerSupplier/loadingStrategies/Docker.ts
@@ -3,6 +3,7 @@ import "../../polyfill";
 import axios from "axios";
 
 import axiosRetry from "axios-retry";
+// @ts-ignore
 import fs from "fs";
 import { execSync } from "child_process";
 import semver from "semver";
@@ -118,7 +119,7 @@ export class Docker {
     const fileName = image + ".version";
 
     // Skip validation if they've validated for this image before.
-    if (this.cache.has(fileName)) {
+    if (await this.cache.has(fileName)) {
       const cachePath = this.cache.resolve(fileName);
       return fs.readFileSync(cachePath, "utf-8");
     }
@@ -145,7 +146,7 @@ export class Docker {
       "docker run --platform=linux/amd64 ethereum/solc:" + image + " --version"
     );
     const normalized = normalizeSolcVersion(version);
-    this.cache.add(normalized, fileName);
+    await this.cache.add(normalized, fileName);
     return normalized;
   }
 

--- a/packages/compile-solidity/src/compilerSupplier/loadingStrategies/VersionRange.ts
+++ b/packages/compile-solidity/src/compilerSupplier/loadingStrategies/VersionRange.ts
@@ -118,8 +118,7 @@ export class VersionRange {
   getCachedSolcByFileName(fileName: string) {
     const listeners = observeListeners();
     try {
-      const filePath = this.cache.resolve(fileName);
-      const soljson = this.cache.loadFile(filePath);
+      const soljson = this.cache.loadFile(fileName);
       debug("soljson %o", soljson);
       return this.compilerFromString(soljson);
     } finally {

--- a/packages/compile-solidity/src/compilerSupplier/loadingStrategies/VersionRange.ts
+++ b/packages/compile-solidity/src/compilerSupplier/loadingStrategies/VersionRange.ts
@@ -2,7 +2,6 @@ import debugModule from "debug";
 const debug = debugModule("compile:compilerSupplier");
 
 import requireFromString from "require-from-string";
-import fs from "fs";
 
 // must polyfill AbortController to use axios >=0.20.0, <=0.27.2 on node <= v14.x
 import "../../polyfill";
@@ -120,7 +119,7 @@ export class VersionRange {
     const listeners = observeListeners();
     try {
       const filePath = this.cache.resolve(fileName);
-      const soljson = fs.readFileSync(filePath).toString();
+      const soljson = this.cache.loadFile(filePath);
       debug("soljson %o", soljson);
       return this.compilerFromString(soljson);
     } finally {

--- a/packages/compile-solidity/src/compilerSupplier/loadingStrategies/VersionRange.ts
+++ b/packages/compile-solidity/src/compilerSupplier/loadingStrategies/VersionRange.ts
@@ -180,7 +180,7 @@ export class VersionRange {
       throw error;
     }
     events.emit("downloadCompiler:succeed");
-    this.cache.add(response.data, fileName);
+    await this.cache.add(response.data, fileName);
     return this.compilerFromString(response.data);
   }
 

--- a/packages/compile-solidity/src/compilerSupplier/loadingStrategies/VersionRange.ts
+++ b/packages/compile-solidity/src/compilerSupplier/loadingStrategies/VersionRange.ts
@@ -2,7 +2,7 @@ import debugModule from "debug";
 const debug = debugModule("compile:compilerSupplier");
 
 import requireFromString from "require-from-string";
-import originalRequire from "original-require";
+import fs from "fs";
 
 // must polyfill AbortController to use axios >=0.20.0, <=0.27.2 on node <= v14.x
 import "../../polyfill";
@@ -120,9 +120,9 @@ export class VersionRange {
     const listeners = observeListeners();
     try {
       const filePath = this.cache.resolve(fileName);
-      const soljson = originalRequire(filePath);
+      const soljson = fs.readFileSync(filePath).toString();
       debug("soljson %o", soljson);
-      return solcWrap(soljson);
+      return this.compilerFromString(soljson);
     } finally {
       listeners.cleanup();
     }


### PR DESCRIPTION
## PR description

This PR removes one instance of usage of `originalRequire` in favor of reading a cached compiler file directly from disk. This also makes it a bit more consistent with how compilers are loaded when fetching them remotely as it will now use the method [`compilerFromString`](https://github.com/trufflesuite/truffle/blob/develop/packages/compile-solidity/src/compilerSupplier/loadingStrategies/VersionRange.ts#L99-L107)

## Testing instructions

You can test this by running `truffle compile` on a project where you have a compiler cached and verify that it compiles correctly.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.

## Breaking changes and new features

- [x] I have added any needed `breaking-change` and `new-feature` labels for the appropriate packages.
