### PR TITLE
Bug fix: add debugGlobal default to config

### DIFF
--- a/packages/config/src/configDefaults.ts
+++ b/packages/config/src/configDefaults.ts
@@ -32,6 +32,7 @@ export const getInitialConfig = ({
       displayPrefix: "",
       preventConsoleLogMigration: false
     },
+    debugGlobal: "debug",
     gas: null,
     gasPrice: null,
     maxFeePerGas: null,
@@ -108,6 +109,7 @@ export const configProps = ({
     console() {},
     mocha() {},
     quiet() {},
+    debugGlobal() {},
 
     build_directory: {
       default: () => path.join(configObject.working_directory, "build"),


### PR DESCRIPTION
Addresses #5828

## PR description

There is a property that gets set on config (during testing) named `debugGlobal`. Currently Truffle relies on the yargs `builder` object to set this property which is jank. It is also causing problems where it doesn't get set when you miskey `truffle test`. There is an issue for this bug [here](https://github.com/trufflesuite/truffle/issues/5828). This PR adds a proper default for this value in @truffle/config.

## Testing instructions

Run `truffle tes` on the command line. Verify that Truffle correctly runs the tests. If you currently try this on published Truffle, it will fail.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.

## Breaking changes and new features

- [x] I have added any needed `breaking-change` and `new-feature` labels for the appropriate packages.
