### PR TITLE
Update Sourcify networks for January 2023

### DIFF
--- a/packages/source-fetcher/lib/networks.ts
+++ b/packages/source-fetcher/lib/networks.ts
@@ -31,8 +31,9 @@ export const networkNamesById: { [id: number]: string } = {
   43113: "fuji-avalanche",
   11111: "wagmi-avalanche",
   53935: "dfk-avalanche",
-  432201: "dexalot-avalanche",
   335: "testnet-dfk-avalance",
+  432204: "dexalot-avalanche",
+  432201: "testnet-dexalot-avalanche",
   40: "telos",
   41: "testnet-telos",
   8: "ubiq",
@@ -83,7 +84,13 @@ export const networkNamesById: { [id: number]: string } = {
   592: "astar",
   336: "shiden-astar",
   8217: "cypress-klaytn",
-  1001: "baobab-klaytn"
+  1001: "baobab-klaytn",
+  7000: "zetachain", //not presently supported by either fetcher, but...
+  7001: "athens-zetachain",
+  42262: "emerald-oasis",
+  42261: "testnet-emerald-oasis",
+  23294: "sapphire-oasis", //not presently supported by either fetcher, but...
+  23295: "testnet-sapphire-oasis"
   //I'm not including crystaleum as it has network ID different from chain ID
   //not including kekchain for the same reason
 };

--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -71,6 +71,7 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "dfk-avalanche",
     "testnet-dfk-avalanche",
     "dexalot-avalanche",
+    "testnet-dexalot-avalanche",
     "telos",
     "testnet-telos",
     "ubiq",
@@ -110,7 +111,13 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "astar",
     "shiden-astar",
     "cypress-klaytn",
-    "baobab-klaytn"
+    "baobab-klaytn",
+    //sourcify does *not* support zetachain mainnet?
+    "athens-zetachain",
+    "emerald-oasis",
+    "testnet-emerald-oasis",
+    //sourcify does *not* support oasis sapphire mainnet?
+    "testnet-sapphire-oasis"
     //I'm excluding crystaleum as it has network ID different from chain ID
     //excluding kekchain for the same reason
   ]);


### PR DESCRIPTION
Sourcify has added more networks, so this PR adds support for them.

Also, it turns out I'd mislabeled one network -- what I thought was Dexalot was actually just the *testnet* for Dexalot.  Oops!  Well, fixed that labelling error, and also now the actual Dexalot is added because Sourcify supports it now.

(So it *looks* like I'm adding support for the Dexalot testnet, when actually I'm adding support for the Dexalot *mainnet* and fixing my incorrect labelling of the former.)

I don't normally bother testing these sorts of network updates, but if you want to try, some addresses you might try are:

* For chain 432204 (Dexalot on Avalanche), address 0x1c799C32a6cF228D0656f3B87D60224afaB45903
* For chain 7001 (the Athens testnet for Zetachain), address 0x1f42652a86918fd84E74e066db94E3078d25Dd8D
* For chain 42262 (Oasis Emerald), address 0x7228Ab1F57e6fFd9F85930b9a9C2E9DD2307E4D0
* For chain 42261 (Oasis Emerald Testnet), address 0x70D7603cAc831A9f23Fc7cAc301db300D55EA921
* For chain 23295 (Oasis Sapphire Testnet), address 0xFBcb580DD6D64fbF7caF57FB0439502412324179