### PR TITLE
Fix deployer tests from hanging

### DIFF
--- a/packages/contract/lib/handlers.js
+++ b/packages/contract/lib/handlers.js
@@ -41,13 +41,38 @@ const handlers = {
    * @param {Object}       context  execution state
    * @param {PromiEvent}   emitter  promiEvent returned by a web3 method call
    */
-  setup: function(emitter, context) {
+  setup: function (emitter, context) {
     emitter.on("error", handlers.error.bind(emitter, context));
     emitter.on("transactionHash", handlers.hash.bind(emitter, context));
+
     // web3 block polls if the confirmation listener is enabled so we want to
     // give users a way of opting out of this behavior - it causes problems in testing
     if (!context.contract.disableConfirmationListener) {
-      emitter.on("confirmation", handlers.confirmation.bind(emitter, context));
+      // maintain a count of confirmation listeners
+      let confirmationListenersCount = 0;
+
+      // a new promievent listener...
+      context.promiEvent.eventEmitter.on("newListener", event => {
+        if (event === "confirmation") {
+          //connect listener to confirmation messages one time
+          if (++confirmationListenersCount === 1) {
+            emitter.on(
+              "confirmation",
+              handlers.confirmation.bind(emitter, context)
+            );
+          }
+        }
+      });
+
+      // a listener de-registers...
+      context.promiEvent.eventEmitter.on("removerListener", event => {
+        // clean up if its the confirmation listener
+        if (event === "confirmation") {
+          if (--confirmationListenersCount === 0) {
+            emitter.removeListener("confirmation", handlers.confirmation);
+          }
+        }
+      });
     }
     emitter.on("receipt", handlers.receipt.bind(emitter, context));
   },
@@ -59,7 +84,7 @@ const handlers = {
    * @param  {Object} context   execution state
    * @param  {Object} error     error
    */
-  error: function(context, error) {
+  error: function (context, error) {
     if (!handlers.ignoreTimeoutError(context, error)) {
       context.promiEvent.eventEmitter.emit("error", error);
       this.removeListener("error", handlers.error);
@@ -72,13 +97,13 @@ const handlers = {
    * @param  {Object} context   execution state
    * @param  {String} hash      transaction hash
    */
-  hash: function(context, hash) {
+  hash: function (context, hash) {
     context.transactionHash = hash;
     context.promiEvent.eventEmitter.emit("transactionHash", hash);
     this.removeListener("transactionHash", handlers.hash);
   },
 
-  confirmation: function(context, number, receipt) {
+  confirmation: function (context, number, receipt) {
     context.promiEvent.eventEmitter.emit("confirmation", number, receipt);
 
     // Per web3: initial confirmation index is 0
@@ -93,7 +118,7 @@ const handlers = {
    * @param  {Object} context   execution state
    * @param  {Object} receipt   transaction receipt
    */
-  receipt: async function(context, receipt) {
+  receipt: async function (context, receipt) {
     // keep around the raw (not decoded) logs in the raw logs field as a
     // stopgap until we can get the ABI for all events, not just the current
     // contract

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -16,7 +16,7 @@
   "main": "index.js",
   "scripts": {
     "prepare": "exit 0",
-    "test": "mocha --no-warnings --timeout 10000 --exit"
+    "test": "mocha --no-warnings --timeout 10000"
   },
   "dependencies": {
     "@ensdomains/ensjs": "^2.1.0",

--- a/packages/deployer/test/deployer.js
+++ b/packages/deployer/test/deployer.js
@@ -23,15 +23,27 @@ describe("Deployer (sync)", function () {
   let UsesExample;
   let IsLibrary;
   let UsesLibrary;
+  let web3;
+  let provider;
 
-  const provider = ganache.provider({
-    miner: {
-      instamine: "strict"
-    },
-    logging: { quiet: true }
+  before(async function () {
+    provider = ganache.provider({
+      miner: {
+        instamine: "eager"
+      },
+      logging: { quiet: true }
+    });
+
+    web3 = new Web3(provider);
+    // web3.eth.transactionPollingTimeout = 5;
   });
 
-  const web3 = new Web3(provider);
+  after(async function () {
+    if (provider) {
+      await provider.disconnect();
+    }
+    web3 = null;
+  });
 
   beforeEach(async function () {
     networkId = await web3.eth.net.getId();
@@ -322,7 +334,7 @@ describe("Deployer (sync)", function () {
         deployer.then(async function () {
           await deployer._startBlockPolling(interfaceAdapter);
           await utils.waitMS(9000);
-          await deployer._startBlockPolling(interfaceAdapter);
+          await deployer._stopBlockPolling(interfaceAdapter);
         });
       };
 

--- a/packages/deployer/test/deployer.js
+++ b/packages/deployer/test/deployer.js
@@ -35,7 +35,6 @@ describe("Deployer (sync)", function () {
     });
 
     web3 = new Web3(provider);
-    // web3.eth.transactionPollingTimeout = 5;
   });
 
   after(async function () {

--- a/packages/deployer/test/ens.js
+++ b/packages/deployer/test/ens.js
@@ -19,8 +19,7 @@ let providerOptions,
 describe("ENS class", () => {
   before(() => {
     providerOptions = {
-      // note that when vmErrorsOnRPCResponse is true, `"eager"` instamine must be enabled (default)
-      vmErrorsOnRPCResponse: true,
+      miner: { instamine: "eager" },
       mnemonic:
         "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat",
       total_accounts: 1,


### PR DESCRIPTION
## PR description

Remove `mocha --exit` crutch for deployer tests.

Truffle defaults to listening for confirmations, which isn't configurable for tests sans truffle-config (like ones solely relying on truffle-contract). When ganache shutdowns, web3 still tries to get newHeads for confirmations, but ganache will keep responding with an error, and then the endless cycle begins. (test process hangs)

**TODO**
- [x] works when using truffle contract indirectly, as in test/ens.js
- [ ] works when [using a contract directly](https://github.com/trufflesuite/truffle/blob/coy-confirmations/packages/contract-tests/test/deploy.js#L70). NOTE: This confirmation test looks suspicious:
  - contract-tests uses [--exit which would mask any confirmation handler failure](https://github.com/trufflesuite/truffle/blob/coy-confirmations/packages/contract-tests/scripts/test.sh#L9-L11)
  - the test [invokes `done()` and has extra work in subsequent `thenable`](https://github.com/trufflesuite/truffle/blob/coy-confirmations/packages/contract-tests/test/deploy.js#L76-L83)
  -[ Is this test even set up correctly](https://github.com/trufflesuite/truffle/blob/coy-confirmations/packages/contract-tests/test/deploy.js#L71-L72)? If contract instance is an eventListener, verify it automatically enables confirmation-listening on its transactions. What is the `.on("confirmation",...)` registering to? Shouldn't it be a transaction? 🤔 
- [ ] Should tests that require confirmation counts and using ganache, be responsible to keep ganache mining?
## Testing instructions

<!-- Don't forget instructions about how to test the PR! -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.

## Breaking changes and new features

- [ ] I have added any needed `breaking-change` and `new-feature` labels for the appropriate packages.
