### PR TITLE
Bug fix: ensure yargs receives the correct command name when it has a typo

### DIFF
--- a/packages/core/lib/command-utils.js
+++ b/packages/core/lib/command-utils.js
@@ -49,6 +49,10 @@ const getCommand = ({ inputStrings, options, noAliases }) => {
       // Did we find only one command that matches? If so, use that one.
       if (possibleCommands.length === 1) {
         chosenCommand = possibleCommands[0];
+        // if they miskey a command we need to make sure it is correct so that
+        // yargs can parse it correctly later
+        inputStrings.shift();
+        inputStrings.unshift(chosenCommand);
         break;
       }
       currentLength += 1;


### PR DESCRIPTION
## PR description

There is currently a bug related to when a user types in a command name incorrectly but Truffle infers it. In the case where Truffle infers a command with a typo, the input strings (which includes the name of the command with a typo like `truffle migr --network myNetwork`) get passed to yargs with the typo. Yargs then is unable to pull up all the option defaults it knows about since the name of the command has a typo and won't match what it knows about.

This PR fixes this by mutating the input strings, replacing the typo'ed command name with the accurate name of the command. 

## Testing instructions

In currently released Truffle (v5.7.2), you can confirm this bug by executing `truffle tes`. Truffle will execute the test command. In the `prepareOptions` method in `packages/core/lib/command-utils.js` you can inspect the value of `commandOptions` to see what yargs has parsed out from what was entered on the command line. With what is currently on the `develop` branch you can see that no defaults get set. With this branch checked out you can do the same test and verify that all of the defaults set in the `builder` object in its `meta.js` file get set.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.

## Breaking changes and new features

- [x] I have added any needed `breaking-change` and `new-feature` labels for the appropriate packages.
