### PR TITLE
Add --url option to the `truffle exec` command 

### DIFF
--- a/packages/core/lib/commands/exec/meta.js
+++ b/packages/core/lib/commands/exec/meta.js
@@ -12,10 +12,15 @@ module.exports = {
     compile: {
       type: "boolean",
       default: false
+    },
+    url: {
+      describe: "Connect to a specified provider given via URL",
+      type: "string"
     }
   },
   help: {
-    usage: "truffle exec <script.js> [--compile]",
+    usage:
+      "truffle exec <script.js> [--compile] [--network <network>|--url <provider_url>]",
     options: [
       {
         option: "<script.js>",
@@ -26,8 +31,18 @@ module.exports = {
       {
         option: "--compile",
         description: "Compile contracts before executing the script."
+      },
+      {
+        option: "--url",
+        description:
+          "Connects to a specified provider given via URL, ignoring networks in config."
+      },
+      {
+        option: "--network",
+        description:
+          "The network to connect to, as specified in the Truffle config."
       }
     ],
-    allowedGlobalOptions: ["network", "config"]
+    allowedGlobalOptions: ["config"]
   }
 };

--- a/packages/core/lib/commands/exec/run.js
+++ b/packages/core/lib/commands/exec/run.js
@@ -1,5 +1,4 @@
 module.exports = async function (options) {
-  const Config = require("@truffle/config");
   const WorkflowCompile = require("@truffle/workflow-compile").default;
   const ConfigurationError = require("../../errors/configurationerror");
   const exec = require("@truffle/require").exec;
@@ -7,8 +6,22 @@ module.exports = async function (options) {
   const path = require("path");
   const OS = require("os");
   const { promisify } = require("util");
+  const loadConfig = require("../../loadConfig");
+  const TruffleError = require("@truffle/error");
 
-  const config = Config.detect(options);
+  if (options.url && options.network) {
+    const message =
+      "" +
+      "Mutually exclusive options, --url and --network detected!" +
+      OS.EOL +
+      "Please use either --url or --network and try again." +
+      OS.EOL +
+      "See: https://trufflesuite.com/docs/truffle/reference/truffle-commands/#exec" +
+      OS.EOL;
+    throw new TruffleError(message);
+  }
+
+  const config = loadConfig(options);
 
   let file = options.file;
 

--- a/packages/truffle/test/scenarios/commands/exec.js
+++ b/packages/truffle/test/scenarios/commands/exec.js
@@ -6,7 +6,7 @@ const assert = require("assert");
 const Server = require("../server");
 const sandbox = require("../sandbox");
 
-describe.only("truffle exec [ @standalone ]", function () {
+describe("truffle exec [ @standalone ]", function () {
   let config, cleanupSandboxDir;
   const project = path.join(__dirname, "../../sources/exec");
   const logger = new MemoryLogger();

--- a/packages/truffle/test/scenarios/commands/exec.js
+++ b/packages/truffle/test/scenarios/commands/exec.js
@@ -6,7 +6,7 @@ const assert = require("assert");
 const Server = require("../server");
 const sandbox = require("../sandbox");
 
-describe("truffle exec [ @standalone ]", function () {
+describe.only("truffle exec [ @standalone ]", function () {
   let config, cleanupSandboxDir;
   const project = path.join(__dirname, "../../sources/exec");
   const logger = new MemoryLogger();
@@ -55,6 +55,23 @@ describe("truffle exec [ @standalone ]", function () {
   it("succeeds when -c flag is set", async function () {
     this.timeout(30000);
     await CommandRunner.run("exec -c script.js", config);
+    const output = logger.contents();
+    assert(output.includes("5"));
+  });
+
+  it("runs script when --url option is passed", async function () {
+    this.timeout(30000);
+    await CommandRunner.run("compile", config);
+    assert(
+      fs.existsSync(
+        path.join(config.contracts_build_directory, "Executable.json")
+      )
+    );
+
+    await CommandRunner.run(
+      "exec script.js --url http://127.0.0.1:8545",
+      config
+    );
     const output = logger.contents();
     assert(output.includes("5"));
   });


### PR DESCRIPTION
## PR description

This PR adds `--url` option to the `truffle exec` command that connects to a specified url. See #5701.

## Testing instructions

To test this option, you can clone this [Test Project with a simple storage contract and a test script](https://github.com/sukanyaparashar/truffle-test-project).

1. Run a ganache instance in a terminal.
2. Run `truffle compile` inside a truffle project in a separate terminal.
3. Run `truffle exec test-script.js --url http://127.0.0.1:8545`. It should execute the script and deploys a new instance of the contract and returns the value of the state variable that is set with a constructor.

<img width="788" alt="Screenshot 2023-01-17 at 8 36 48 PM" src="https://user-images.githubusercontent.com/25079663/213083055-7cde1d2f-fe0f-4556-a9d8-7c749fb9e2d2.png">

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.