### PR TITLE
Support switching accounts between signature requests in dashboard

### DIFF
--- a/packages/dashboard/src/contexts/DashContext/DashProvider.tsx
+++ b/packages/dashboard/src/contexts/DashContext/DashProvider.tsx
@@ -33,7 +33,7 @@ type DashProviderProps = {
 };
 
 function DashProvider({ children }: DashProviderProps): JSX.Element {
-  const { isConnected } = useAccount();
+  const { isConnected, address } = useAccount();
   const { chain } = useNetwork();
   const [state, dispatch] = useReducer(reducer, initialState);
   const initCalled = useRef(false);
@@ -261,6 +261,16 @@ function DashProvider({ children }: DashProviderProps): JSX.Element {
 
     updateChainInfo();
   }, [chain]);
+
+  useEffect(() => {
+    const updateProviderMessages = () => {
+      if (address) {
+        dispatch({ type: "update-provider-message-sender", data: address });
+      }
+    };
+
+    updateProviderMessages();
+  }, [address]);
 
   useEffect(() => {
     dispatch({

--- a/packages/dashboard/src/contexts/DashContext/state.ts
+++ b/packages/dashboard/src/contexts/DashContext/state.ts
@@ -12,6 +12,7 @@ import {
   rejectMessage,
   confirmMessage
 } from "src/utils/dash";
+import type { InteractiveRpcMethod } from "src/utils/constants";
 import type { State, Action, Schema } from "src/contexts/DashContext";
 
 const DB_NAME = "TruffleDashboard";
@@ -99,6 +100,32 @@ export const reducer = (state: State, action: Action): State => {
       }
 
       return newState;
+    case "update-provider-message-sender":
+      const newProviderMessages = new Map(state.providerMessages);
+      const newSender = data;
+
+      for (const [id, lifecycle] of newProviderMessages) {
+        const { message } = lifecycle;
+        const newParams = message.payload.params;
+
+        switch (message.payload.method as InteractiveRpcMethod) {
+          case "eth_sendTransaction":
+            newParams[0].from = newSender;
+            break;
+          case "personal_sign":
+            newParams[1] = newSender;
+            break;
+          case "eth_signTypedData_v3":
+          case "eth_signTypedData_v4":
+            newParams[0] = newSender;
+            break;
+        }
+
+        lifecycle.message.payload.params = newParams;
+        newProviderMessages.set(id, lifecycle);
+      }
+
+      return { ...state, providerMessages: newProviderMessages };
     default:
       throw new Error("Undefined reducer action type");
   }

--- a/packages/dashboard/src/contexts/DashContext/types/Action.ts
+++ b/packages/dashboard/src/contexts/DashContext/types/Action.ts
@@ -7,7 +7,8 @@ export type ActionType =
   | "set-chain-info"
   | "set-notice"
   | "set-analytics-config"
-  | "handle-message";
+  | "handle-message"
+  | "update-provider-message-sender";
 
 export interface BaseAction {
   type: ActionType;
@@ -41,9 +42,15 @@ export interface HandleMessageAction extends BaseAction {
   data: ReceivedMessageLifecycle<Message>;
 }
 
+export interface UpdateProviderMessageSender extends BaseAction {
+  type: "update-provider-message-sender";
+  data: string;
+}
+
 export type Action =
   | SetDecoderAction
   | SetChainInfoAction
   | SetNoticeAction
   | SetAnalyticsConfigAction
-  | HandleMessageAction;
+  | HandleMessageAction
+  | UpdateProviderMessageSender;

--- a/packages/dashboard/src/contexts/DashContext/types/Action.ts
+++ b/packages/dashboard/src/contexts/DashContext/types/Action.ts
@@ -42,7 +42,7 @@ export interface HandleMessageAction extends BaseAction {
   data: ReceivedMessageLifecycle<Message>;
 }
 
-export interface UpdateProviderMessageSender extends BaseAction {
+export interface UpdateProviderMessageSenderAction extends BaseAction {
   type: "update-provider-message-sender";
   data: string;
 }
@@ -53,4 +53,4 @@ export type Action =
   | SetNoticeAction
   | SetAnalyticsConfigAction
   | HandleMessageAction
-  | UpdateProviderMessageSender;
+  | UpdateProviderMessageSenderAction;


### PR DESCRIPTION
Addresses: #5837

#### Testing instructions

- Run `truffle migrate --network dashboard` inside a Truffle project that requires >1 transactions to complete a migration.
- Confirm transactions with different accounts:
  - It should work!
  - The params display should reflect the account change.
- The console where the migration is run should reflect the correct account address in the receipts.
