### PR TITLE
Dep update: bump axios to 1.2.4

### DIFF
--- a/packages/box/package.json
+++ b/packages/box/package.json
@@ -22,7 +22,7 @@
   "types": "./typings/index.d.ts",
   "dependencies": {
     "@truffle/config": "^1.3.49",
-    "axios": "0.27.2",
+    "axios": "1.2.4",
     "debug": "^4.3.1",
     "download-git-repo": "^3.0.2",
     "fs-extra": "^9.1.0",

--- a/packages/compile-solidity/package.json
+++ b/packages/compile-solidity/package.json
@@ -24,7 +24,7 @@
     "@truffle/contract-sources": "^0.2.0",
     "@truffle/expect": "^0.1.4",
     "@truffle/profiler": "^0.1.41",
-    "axios": "0.27.2",
+    "axios": "1.2.4",
     "axios-retry": "^3.1.9",
     "debug": "^4.3.1",
     "fs-extra": "^9.1.0",

--- a/packages/dashboard-message-bus-client/package.json
+++ b/packages/dashboard-message-bus-client/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@truffle/dashboard-message-bus-common": "^0.1.5",
     "@truffle/promise-tracker": "^0.1.5",
-    "axios": "0.27.2",
+    "axios": "1.2.4",
     "debug": "^4.3.1",
     "delay": "^5.0.0",
     "isomorphic-ws": "^4.0.1",

--- a/packages/source-fetcher/package.json
+++ b/packages/source-fetcher/package.json
@@ -27,7 +27,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "async-retry": "^1.3.1",
-    "axios": "0.27.2",
+    "axios": "1.2.4",
     "debug": "^4.3.1",
     "node-abort-controller": "^3.0.1",
     "web3-utils": "1.8.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8561,13 +8561,14 @@ axios@0.21.1:
   dependencies:
     follow-redirects "^1.10.0"
 
-axios@0.27.2:
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
-  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
+axios@1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.2.4.tgz#6555dd955d2efa9b8f4cb4cb0b3371b7b243537a"
+  integrity sha512-lIQuCfBJvZB/Bv7+RWUqEJqNShGOVpk9v7P0ZWx5Ip0qY6u7JBAU6dzQPMLasU9vHL2uD8av/1FDJXj7n6c39w==
   dependencies:
-    follow-redirects "^1.14.9"
+    follow-redirects "^1.15.0"
     form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 axios@^0.21.0:
   version "0.21.4"
@@ -14109,7 +14110,7 @@ flatten@^1.0.2:
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.3.tgz#c1283ac9f27b368abc1e36d1ff7b04501a30356b"
   integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
 
-follow-redirects@^1.0.0, follow-redirects@^1.10.0:
+follow-redirects@^1.0.0, follow-redirects@^1.10.0, follow-redirects@^1.15.0:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
@@ -14119,7 +14120,7 @@ follow-redirects@^1.12.1:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.8.tgz#016996fb9a11a100566398b1c6839337d7bfa8fc"
   integrity sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==
 
-follow-redirects@^1.14.0, follow-redirects@^1.14.9:
+follow-redirects@^1.14.0:
   version "1.15.1"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
   integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
@@ -21420,6 +21421,11 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 prr@~1.0.1:
   version "1.0.1"


### PR DESCRIPTION
While reviewing https://github.com/trufflesuite/truffle/pull/5847, I noticed that we are quite behind on the version of axios that Truffle is using. This PR bumps axios to the latest version.