### PR TITLE
Add appendCBOR field in metadata settings type in source fetcher

### DIFF
--- a/packages/source-fetcher/lib/types.ts
+++ b/packages/source-fetcher/lib/types.ts
@@ -128,6 +128,7 @@ export interface Libraries {
 export interface MetadataSettings {
   useLiteralContent?: boolean;
   bytecodeHash?: "none" | "ipfs" | "bzzr1";
+  appendCBOR?: boolean;
 }
 
 export interface DebugSettings {


### PR DESCRIPTION
Just keeping this type up to date with the latest Solidity compiler options.  This change has no actual effect at the moment.