### PR TITLE
Add `block.prevrandao` as globally available variable in debugger

### DIFF
--- a/packages/codec/lib/compiler/types.ts
+++ b/packages/codec/lib/compiler/types.ts
@@ -14,7 +14,8 @@ export type SolidityFamily =
   | "0.5.x"
   | "0.8.x"
   | "0.8.7+"
-  | "0.8.9+";
+  | "0.8.9+"
+  | "0.8.18+";
 
 export interface Settings {
   //this type is deliberately incomplete,

--- a/packages/codec/lib/compiler/utils.ts
+++ b/packages/codec/lib/compiler/utils.ts
@@ -9,6 +9,12 @@ export function solidityFamily(compiler: CompilerVersion): SolidityFamily {
     return "unknown";
   }
   if (
+    semver.satisfies(compiler.version, ">=0.8.18", {
+      includePrerelease: true
+    })
+  ) {
+    return "0.8.18+";
+  } else if (
     semver.satisfies(compiler.version, ">=0.8.9", {
       includePrerelease: true
     })

--- a/packages/debugger/test/data/global.js
+++ b/packages/debugger/test/data/global.js
@@ -34,6 +34,7 @@ contract GlobalTest {
   struct Block {
     address payable coinbase;
     uint difficulty;
+    uint prevrandao;
     uint gaslimit;
     uint number;
     uint timestamp;
@@ -50,7 +51,7 @@ contract GlobalTest {
     _this = this;
     _msg = Msg(msg.data, msg.sender, msg.sig, msg.value);
     _tx = Tx(tx.origin, tx.gasprice);
-    _block = Block(block.coinbase, block.difficulty,
+    _block = Block(block.coinbase, block.difficulty, block.prevrandao,
       block.gaslimit, block.number, block.timestamp, block.chainid,
       block.basefee);
     emit Done(x); //BREAK SIMPLE
@@ -68,7 +69,7 @@ contract GlobalTest {
     __this = this;
     __msg = Msg(msg.data, msg.sender, msg.sig, 0);
     __tx = Tx(tx.origin, tx.gasprice);
-    __block = Block(block.coinbase, block.difficulty,
+    __block = Block(block.coinbase, block.difficulty, block.prevrandao,
       block.gaslimit, block.number, block.timestamp, block.chainid,
       block.basefee);
     return x + uint160(address(__this)) //BREAK STATIC
@@ -109,7 +110,7 @@ contract CreationTest {
     _this = this;
     _msg = GlobalTest.Msg(msg.data, msg.sender, msg.sig, msg.value);
     _tx = GlobalTest.Tx(tx.origin, tx.gasprice);
-    _block = GlobalTest.Block(block.coinbase, block.difficulty,
+    _block = GlobalTest.Block(block.coinbase, block.difficulty, block.prevrandao,
       block.gaslimit, block.number, block.timestamp, block.chainid,
       block.basefee);
     require(succeed); //BREAK CREATE
@@ -127,7 +128,7 @@ library GlobalTestLib {
     GlobalTest.Block memory __block;
     __msg = GlobalTest.Msg(msg.data, msg.sender, msg.sig, msg.value);
     __tx = GlobalTest.Tx(tx.origin, tx.gasprice);
-    __block = GlobalTest.Block(block.coinbase, block.difficulty,
+    __block = GlobalTest.Block(block.coinbase, block.difficulty, block.prevrandao,
       block.gaslimit, block.number, block.timestamp, block.chainid, block.basefee);
     emit Done(x + __msg.value + __tx.gasprice + __block.number); //BREAK LIBRARY
   }

--- a/packages/debugger/test/helpers.js
+++ b/packages/debugger/test/helpers.js
@@ -29,10 +29,10 @@ export async function prepareContracts(provider, sources = {}, migrations) {
 
   config.compilers = {
     solc: {
-      version: "0.8.12",
+      version: "0.8.18",
       settings: {
         optimizer: { enabled: false, runs: 200 },
-        evmVersion: "london"
+        evmVersion: "paris"
       }
     },
     vyper: {


### PR DESCRIPTION
Solidity 0.8.18 introduces `block.prevrandao` as an alias for `block.difficulty`, so this PR adds support for that in the debugger.  Or rather in codec, because that's actually where this is handled.

Note that we do a version check, so `block.prevrandao` will only be present on versions 0.8.18 and later; that means that 0.8.18 is another one of those versions we care about.  Strictly speaking, we arguably should also check the version of the EVM that's being targeted, but that potentially opens some cans of worms I didn't want to deal with, so I left that out for now; I figure it can be added in if people really think it's necessary or we decide the resulting worms aren't a big deal.

I also updated the globally-available variable tests in the debugger to include it.

## Testing instructions

I updated the debugger tests, but you might also want to test this manually.  I tested this manually with the `solc8-magic-square` project in the Solidity test examples repo.   I compiled it both with Solidity 0.8.0, ran a transaction, debugged it, verified that `block.prevrandao` is not there.  Then I recompiled with Solidity 0.8.18, did the same thing, and verified that it is there and equal to `block.difficulty`.