### PR TITLE
Upgrade solc version to latest 0.8.18 in truffle init

### DIFF
--- a/packages/core/lib/commands/init/initSource/truffle-config.js
+++ b/packages/core/lib/commands/init/initSource/truffle-config.js
@@ -106,7 +106,7 @@ module.exports = {
   // Configure your compilers
   compilers: {
     solc: {
-      version: "0.8.17" // Fetch exact version from solc-bin (default: truffle's version)
+      version: "0.8.18",      // Fetch exact version from solc-bin (default: truffle's version)
       // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
       // settings: {          // See the solidity docs for advice about optimization and evmVersion
       //  optimizer: {
@@ -116,7 +116,7 @@ module.exports = {
       //  evmVersion: "byzantium"
       // }
     }
-  }
+  },
 
   // Truffle DB is currently disabled by default; to enable it, change enabled:
   // false to enabled: true. The default storage location can also be


### PR DESCRIPTION
## PR description

This PR upgrades the `solc` version to latest **v0.8.18** in `truffle-config.js` when `truffle init` command is run.
