### PR TITLE
Bug fix: create utility for dealing with help input

### DIFF
--- a/packages/core/cli.js
+++ b/packages/core/cli.js
@@ -39,8 +39,6 @@ if (!semver.gte(process.version, minimumNodeVersion)) {
 const listeners = process.listeners("warning");
 listeners.forEach(listener => process.removeListener("warning", listener));
 
-const inputStrings = process.argv.slice(2);
-
 const { handleHelpInput } = require("./lib/cliHelp");
 const {
   getCommand,
@@ -49,8 +47,9 @@ const {
   displayGeneralHelp
 } = require("./lib/command-utils");
 
+const inputArguments = process.argv.slice(2);
 // handle cases where input indicates the user wants to access Truffle's help
-const { displayHelp } = handleHelpInput({ inputStrings });
+const { displayHelp, inputStrings } = handleHelpInput({ inputArguments });
 if (displayHelp) {
   displayGeneralHelp();
   process.exit();

--- a/packages/core/cli.js
+++ b/packages/core/cli.js
@@ -41,6 +41,7 @@ listeners.forEach(listener => process.removeListener("warning", listener));
 
 const inputStrings = process.argv.slice(2);
 
+const { handleHelpInput } = require("./lib/cliHelp");
 const {
   getCommand,
   prepareOptions,
@@ -48,31 +49,11 @@ const {
   displayGeneralHelp
 } = require("./lib/command-utils");
 
-//User only enter truffle with no commands, let's show them what's available.
-if (inputStrings.length === 0) {
+// handle cases where input indicates the user wants to access Truffle's help
+const { displayHelp } = handleHelpInput({ inputStrings });
+if (displayHelp) {
   displayGeneralHelp();
   process.exit();
-}
-
-//if `help` or `--help` is in the command, validate and transform the input argument for help
-if (
-  inputStrings.some(inputString => ["help", "--help"].includes(inputString))
-) {
-  //when user wants general help
-  if (inputStrings.length === 1) {
-    displayGeneralHelp();
-    process.exit();
-  }
-
-  //check where is --help used, mutate argument into a proper help command
-  const helpIndex = inputStrings.indexOf("--help");
-
-  if (helpIndex !== -1) {
-    //remove `--help` from array
-    inputStrings.splice(helpIndex, 1);
-    //insert `help` in first position
-    inputStrings.unshift("help");
-  }
 }
 
 const command = getCommand({

--- a/packages/core/lib/cliHelp.js
+++ b/packages/core/lib/cliHelp.js
@@ -1,29 +1,37 @@
-const handleHelpInput = function ({ inputStrings }) {
+const handleHelpInput = function ({ inputArguments }) {
+  // we call slice to make a copy of the array so as not to mutate it
+  const args = inputArguments.slice();
   // if no command was provided, display all available commands
-  if (inputStrings.length === 0) {
-    return { displayHelp: true };
+  if (args.length === 0) {
+    return {
+      displayHelp: true,
+      inputStrings: args
+    };
   }
   // if only 'help' or '--help' was entered, display all available commands
-  if (
-    inputStrings.length === 1 &&
-    (inputStrings[0] === "help" || inputStrings[0] === "--help")
-  ) {
-    return { displayHelp: true };
+  if (args.length === 1 && (args[0] === "help" || args[0] === "--help")) {
+    return {
+      displayHelp: true,
+      inputStrings: args
+    };
   }
 
   // if `--help` is in the input, assume the user wants help for the command
   // provided and transform the input into something the rest
   // of Truffle can handle
-  const helpIndex = inputStrings.indexOf("--help");
+  const helpIndex = args.indexOf("--help");
 
   if (helpIndex !== -1) {
     //remove `--help` from array
-    inputStrings.splice(helpIndex, 1);
+    args.splice(helpIndex, 1);
     //insert `help` in first position
-    inputStrings.unshift("help");
+    args.unshift("help");
   }
   // let Truffle know whether to display the general help
-  return { displayHelp: false };
+  return {
+    displayHelp: false,
+    inputStrings: args
+  };
 };
 
 module.exports = { handleHelpInput };

--- a/packages/core/lib/cliHelp.js
+++ b/packages/core/lib/cliHelp.js
@@ -1,9 +1,9 @@
 const handleHelpInput = function ({ inputStrings }) {
-  //User only enter truffle with no commands, let's show them what's available.
+  // if no command was provided, display all available commands
   if (inputStrings.length === 0) {
     return { displayHelp: true };
   }
-  // handle 'truffle help' and 'truffle --help'
+  // if only 'help' or '--help' was entered, display all available commands
   if (
     inputStrings.length === 1 &&
     (inputStrings[0] === "help" || inputStrings[0] === "--help")
@@ -11,19 +11,16 @@ const handleHelpInput = function ({ inputStrings }) {
     return { displayHelp: true };
   }
 
-  //if `--help` is in the input, validate and transform the input
-  //in order to give the user help
-  if (inputStrings.some(inputString => ["--help"].includes(inputString))) {
-    //check where --help is used, mutate argument into something the rest
-    //of Truffle can deal with
-    const helpIndex = inputStrings.indexOf("--help");
+  // if `--help` is in the input, assume the user wants help for the command
+  // provided and transform the input into something the rest
+  // of Truffle can handle
+  const helpIndex = inputStrings.indexOf("--help");
 
-    if (helpIndex !== -1) {
-      //remove `--help` from array
-      inputStrings.splice(helpIndex, 1);
-      //insert `help` in first position
-      inputStrings.unshift("help");
-    }
+  if (helpIndex !== -1) {
+    //remove `--help` from array
+    inputStrings.splice(helpIndex, 1);
+    //insert `help` in first position
+    inputStrings.unshift("help");
   }
   // let Truffle know whether to display the general help
   return { displayHelp: false };

--- a/packages/core/lib/cliHelp.js
+++ b/packages/core/lib/cliHelp.js
@@ -1,15 +1,14 @@
 const handleHelpInput = function ({ inputStrings }) {
-  let displayHelp = false;
   //User only enter truffle with no commands, let's show them what's available.
   if (inputStrings.length === 0) {
-    displayHelp = true;
+    return { displayHelp: true };
   }
   // handle 'truffle help' and 'truffle --help'
   if (
     inputStrings.length === 1 &&
     (inputStrings[0] === "help" || inputStrings[0] === "--help")
   ) {
-    displayHelp = true;
+    return { displayHelp: true };
   }
 
   //if `--help` is in the input, validate and transform the input
@@ -27,7 +26,7 @@ const handleHelpInput = function ({ inputStrings }) {
     }
   }
   // let Truffle know whether to display the general help
-  return { displayHelp };
+  return { displayHelp: false };
 };
 
 module.exports = { handleHelpInput };

--- a/packages/core/lib/cliHelp.js
+++ b/packages/core/lib/cliHelp.js
@@ -1,0 +1,33 @@
+const handleHelpInput = function ({ inputStrings }) {
+  let displayHelp = false;
+  //User only enter truffle with no commands, let's show them what's available.
+  if (inputStrings.length === 0) {
+    displayHelp = true;
+  }
+  // handle 'truffle help' and 'truffle --help'
+  if (
+    inputStrings.length === 1 &&
+    (inputStrings[0] === "help" || inputStrings[0] === "--help")
+  ) {
+    displayHelp = true;
+  }
+
+  //if `--help` is in the input, validate and transform the input
+  //in order to give the user help
+  if (inputStrings.some(inputString => ["--help"].includes(inputString))) {
+    //check where --help is used, mutate argument into something the rest
+    //of Truffle can deal with
+    const helpIndex = inputStrings.indexOf("--help");
+
+    if (helpIndex !== -1) {
+      //remove `--help` from array
+      inputStrings.splice(helpIndex, 1);
+      //insert `help` in first position
+      inputStrings.unshift("help");
+    }
+  }
+  // let Truffle know whether to display the general help
+  return { displayHelp };
+};
+
+module.exports = { handleHelpInput };

--- a/packages/core/lib/command-utils.js
+++ b/packages/core/lib/command-utils.js
@@ -300,7 +300,8 @@ const displayGeneralHelp = () => {
     // Exclude "install" and "publish" commands from the generated help list
     // because they have been deprecated/removed.
     if (command !== "install" && command !== "publish") {
-      yargs.command(require(`./commands/${command}/meta`));
+      const thing = require(`./commands/${command}/meta`);
+      yargs.command(thing);
     }
   });
   yargs
@@ -313,7 +314,9 @@ const displayGeneralHelp = () => {
         "Usage: truffle <command> [options]"
     )
     .epilog("See more at http://trufflesuite.com/docs")
-    .showHelp();
+    // showHelp prints using console.error, this won't log in a
+    // child process - "log" forces it to use console.log instead
+    .showHelp("log");
 };
 
 /**

--- a/packages/core/lib/command-utils.js
+++ b/packages/core/lib/command-utils.js
@@ -300,8 +300,7 @@ const displayGeneralHelp = () => {
     // Exclude "install" and "publish" commands from the generated help list
     // because they have been deprecated/removed.
     if (command !== "install" && command !== "publish") {
-      const thing = require(`./commands/${command}/meta`);
-      yargs.command(thing);
+      yargs.command(require(`./commands/${command}/meta`));
     }
   });
   yargs

--- a/packages/core/lib/console-child.js
+++ b/packages/core/lib/console-child.js
@@ -4,14 +4,23 @@ const yargs = require("yargs");
 const path = require("path");
 const {
   deriveConfigEnvironment,
-  parseQuotesAndEscapes
+  parseQuotesAndEscapes,
+  displayGeneralHelp
 } = require("./command-utils");
+const { handleHelpInput } = require("./cliHelp");
 
 // we split off the part Truffle cares about and need to convert to an array
 const input = process.argv[2].split(" -- ");
 const escapeCharacters = path.sep === "\\" ? "^`" : "\\"; //set escape character
 //based on current OS; backslash for Unix, caret or grave for Windows
 const inputStrings = parseQuotesAndEscapes(input[1], escapeCharacters); //note this shouldn't error since it's a recomputation
+
+// handle cases where input indicates the user wants to access Truffle's help
+const { displayHelp } = handleHelpInput({ inputStrings });
+if (displayHelp) {
+  displayGeneralHelp();
+  process.exit();
+}
 
 // we need to make sure this function exists so ensjs doesn't complain as it requires
 // getRandomValues for some functionalities - webpack strips out the crypto lib

--- a/packages/core/lib/console-child.js
+++ b/packages/core/lib/console-child.js
@@ -13,10 +13,10 @@ const { handleHelpInput } = require("./cliHelp");
 const input = process.argv[2].split(" -- ");
 const escapeCharacters = path.sep === "\\" ? "^`" : "\\"; //set escape character
 //based on current OS; backslash for Unix, caret or grave for Windows
-const inputStrings = parseQuotesAndEscapes(input[1], escapeCharacters); //note this shouldn't error since it's a recomputation
+const inputArguments = parseQuotesAndEscapes(input[1], escapeCharacters); //note this shouldn't error since it's a recomputation
 
 // handle cases where input indicates the user wants to access Truffle's help
-const { displayHelp } = handleHelpInput({ inputStrings });
+const { displayHelp, inputStrings } = handleHelpInput({ inputArguments });
 if (displayHelp) {
   displayGeneralHelp();
   process.exit();


### PR DESCRIPTION
## PR description

addresses https://github.com/trufflesuite/truffle/issues/2041

This PR creates a utility method for parsing help input. It then uses that same logic in console-child.js. This is so that we use the same logic for parsing help input from both the command line and the development console (repl).

I also found out that yargs uses `console.error` for the `showHelp` method which we use to display general help in Truffle. This was causing a bug where general help would not print in the development console as the stderr was not "hooked up". So this PR also passes the "log" argument to this method to force it to use `console.log`.

## Testing instructions

To test this, checkout this branch and run the development console. Enter "help" and you can see that the general help is printed to the screen.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.

## Breaking changes and new features

- [x] I have added any needed `breaking-change` and `new-feature` labels for the appropriate packages.
