### PR TITLE
Prevent spawned Hardhat console from triggering a compile

### DIFF
--- a/packages/from-hardhat/src/ask-hardhat.ts
+++ b/packages/from-hardhat/src/ask-hardhat.ts
@@ -73,7 +73,7 @@ export const askHardhatConsole = async (
     const prefix = `${sos}truffle-start${st}`;
     const suffix = `${sos}truffle-end${st}`;
 
-    const hardhat = spawn(`npx`, ["hardhat", "console"], {
+    const hardhat = spawn(`npx`, ["hardhat", "console", "--no-compile"], {
       stdio: ["pipe", "pipe", "inherit"],
       cwd: workingDirectory
     });

--- a/packages/from-hardhat/src/ask-hardhat.ts
+++ b/packages/from-hardhat/src/ask-hardhat.ts
@@ -73,6 +73,7 @@ export const askHardhatConsole = async (
     const prefix = `${sos}truffle-start${st}`;
     const suffix = `${sos}truffle-end${st}`;
 
+    // note the hardhat console instance is spawned with --no-compile which causes it to skip the initial (default) compilation step
     const hardhat = spawn(`npx`, ["hardhat", "console", "--no-compile"], {
       stdio: ["pipe", "pipe", "inherit"],
       cwd: workingDirectory


### PR DESCRIPTION
## PR description

This PR prevents the [spawned Hardhat console](https://github.com/trufflesuite/truffle/blob/develop/packages/from-hardhat/src/ask-hardhat.ts#L76-L79) in `from-hardhat` from triggering a compile (via `--no-compile`). This is being added to mitigate a circular reference in an upcoming Hardhat plugin that provides support for Truffle Dashboard decoding/debugging.

## Testing instructions

One testing approach...

- Create a local Hardhat project (via `git clone https://github.com/amanusk/hardhat-template` or equivalent)
- `yarn link` to the `from-hardhat` package from the above
- Run the following from the `node` REPL:
  - `const FromHardhat = require("@truffle/from-hardhat");`
  - `await FromHardhat.prepareCompilations()`

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.

## Breaking changes and new features

- [ ] I have added any needed `breaking-change` and `new-feature` labels for the appropriate packages.
