### PR TITLE
Set yargs help to always use truffle instead of script name

### DIFF
--- a/packages/core/lib/command-utils.js
+++ b/packages/core/lib/command-utils.js
@@ -304,6 +304,7 @@ const displayGeneralHelp = () => {
     }
   });
   yargs
+    .scriptName("truffle")
     .usage(
       "Truffle v" +
         (bundled || core) +


### PR DESCRIPTION
This PR sets the script name to always use `truffle` instead of the default, `process.argv[0]`.  This is related to #2041 

Test this by running help in `truffle develop`, it should display commands as `truffle <cmd>` instead of `console-child.js <cmd>`
