### PR TITLE
Restrict general help content in REPL context

### DIFF
--- a/packages/core/cli.js
+++ b/packages/core/cli.js
@@ -51,7 +51,7 @@ const inputArguments = process.argv.slice(2);
 // handle cases where input indicates the user wants to access Truffle's help
 const { displayHelp, inputStrings } = handleHelpInput({ inputArguments });
 if (displayHelp) {
-  displayGeneralHelp();
+  displayGeneralHelp({});
   process.exit();
 }
 

--- a/packages/core/cli.js
+++ b/packages/core/cli.js
@@ -51,7 +51,7 @@ const inputArguments = process.argv.slice(2);
 // handle cases where input indicates the user wants to access Truffle's help
 const { displayHelp, inputStrings } = handleHelpInput({ inputArguments });
 if (displayHelp) {
-  displayGeneralHelp({});
+  displayGeneralHelp();
   process.exit();
 }
 

--- a/packages/core/lib/command-utils.js
+++ b/packages/core/lib/command-utils.js
@@ -5,7 +5,10 @@ const { extractFlags } = require("./utils/utils"); // contains utility methods
 const globalCommandOptions = require("./global-command-options");
 const debugModule = require("debug");
 const debug = debugModule("core:command:run");
-const { validTruffleCommands } = require("./commands/commands");
+const {
+  validTruffleCommands,
+  validTruffleConsoleCommands
+} = require("./commands/commands");
 const Web3 = require("web3");
 const TruffleError = require("@truffle/error");
 
@@ -294,8 +297,16 @@ const runCommand = async function (command, options) {
   return await command.run(options);
 };
 
-const displayGeneralHelp = ({ commands = validTruffleCommands }) => {
+/**
+ * Display general help for Truffle commands
+ * @param {Object} options - options object
+ * @param {Boolean} options.isREPL - whether or not the help is being displayed in a REPL
+ * @returns {void}
+ */
+const displayGeneralHelp = options => {
   const yargs = require("yargs/yargs")();
+  const isREPL = options?.isREPL ?? false; //default to not displaying REPL commands
+  const commands = isREPL ? validTruffleConsoleCommands : validTruffleCommands;
   commands.forEach(command => {
     // Exclude "install" and "publish" commands from the generated help list
     // because they have been deprecated/removed.

--- a/packages/core/lib/command-utils.js
+++ b/packages/core/lib/command-utils.js
@@ -5,7 +5,7 @@ const { extractFlags } = require("./utils/utils"); // contains utility methods
 const globalCommandOptions = require("./global-command-options");
 const debugModule = require("debug");
 const debug = debugModule("core:command:run");
-const commands = require("./commands/commands");
+const { validTruffleCommands } = require("./commands/commands");
 const Web3 = require("web3");
 const TruffleError = require("@truffle/error");
 
@@ -116,11 +116,11 @@ const getCommand = ({ inputStrings, options, noAliases }) => {
   // for inferring the command.
   if (firstInputString === "-v" || firstInputString === "--version") {
     chosenCommand = "version";
-  } else if (commands.includes(firstInputString)) {
+  } else if (validTruffleCommands.includes(firstInputString)) {
     chosenCommand = firstInputString;
   } else if (noAliases !== true) {
     let currentLength = 1;
-    const availableCommandNames = commands;
+    const availableCommandNames = validTruffleCommands;
 
     // Loop through each letter of the input until we find a command
     // that uniquely matches.
@@ -294,7 +294,7 @@ const runCommand = async function (command, options) {
   return await command.run(options);
 };
 
-const displayGeneralHelp = () => {
+const displayGeneralHelp = ({ commands = validTruffleCommands }) => {
   const yargs = require("yargs/yargs")();
   commands.forEach(command => {
     // Exclude "install" and "publish" commands from the generated help list

--- a/packages/core/lib/commands/commands.js
+++ b/packages/core/lib/commands/commands.js
@@ -26,30 +26,22 @@ const validTruffleCommands = [
   "watch"
 ];
 
-//Subset of truffle commands that are allowed to run in console REPLS.
-//Excluded commands are:
-//  console, dashboard, db, develop, init and watch
-const validTruffleConsoleCommands = [
-  "build",
-  "compile",
-  "config",
-  "create",
-  "debug",
-  "deploy",
-  "exec",
-  "help",
-  "migrate",
-  "networks",
-  "obtain",
-  "opcode",
-  "preserve",
-  "run",
-  "test",
-  "unbox",
-  "version"
+//List of truffle commands that are excluded from the console REPLS.
+const excludedTruffleConsoleCommands = [
+  "console",
+  "dashboard",
+  "db",
+  "develop",
+  "init",
+  "watch"
 ];
 
+const validTruffleConsoleCommands = validTruffleCommands.filter(
+  command => !excludedTruffleConsoleCommands.includes(command)
+);
+
 module.exports = {
+  excludedTruffleConsoleCommands,
   validTruffleCommands,
   validTruffleConsoleCommands
 };

--- a/packages/core/lib/commands/commands.js
+++ b/packages/core/lib/commands/commands.js
@@ -1,5 +1,4 @@
-// The list of commands that Truffle supports
-module.exports = [
+const validTruffleCommands = [
   "build",
   "compile",
   "config",
@@ -26,3 +25,31 @@ module.exports = [
   "version",
   "watch"
 ];
+
+//Subset of truffle commands that are allowed to run in console REPLS.
+//Excluded commands are:
+//  console, dashboard, db, develop, init and watch
+const validTruffleConsoleCommands = [
+  "build",
+  "compile",
+  "config",
+  "create",
+  "debug",
+  "deploy",
+  "exec",
+  "help",
+  "migrate",
+  "networks",
+  "obtain",
+  "opcode",
+  "preserve",
+  "run",
+  "test",
+  "unbox",
+  "version"
+];
+
+module.exports = {
+  validTruffleCommands,
+  validTruffleConsoleCommands
+};

--- a/packages/core/lib/commands/console/run.js
+++ b/packages/core/lib/commands/console/run.js
@@ -1,7 +1,6 @@
 module.exports = async function (options) {
   const OS = require("os");
   const { Console } = require("../../console");
-  const { validTruffleConsoleCommands } = require("../commands");
   const { Environment } = require("@truffle/environment");
   const TruffleError = require("@truffle/error");
   const loadConfig = require("../../loadConfig");
@@ -20,9 +19,6 @@ module.exports = async function (options) {
 
   let config = loadConfig(options);
   await Environment.detect(config);
-  const c = new Console(
-    validTruffleConsoleCommands,
-    config.with({ noAliases: true })
-  );
+  const c = new Console(config.with({ noAliases: true }));
   return await c.start();
 };

--- a/packages/core/lib/commands/console/run.js
+++ b/packages/core/lib/commands/console/run.js
@@ -1,9 +1,9 @@
 module.exports = async function (options) {
   const OS = require("os");
-  const { Console, excludedCommands } = require("../../console");
+  const { Console } = require("../../console");
+  const { validTruffleConsoleCommands } = require("../commands");
   const { Environment } = require("@truffle/environment");
   const TruffleError = require("@truffle/error");
-  const commands = require("../commands");
   const loadConfig = require("../../loadConfig");
 
   if (options.url && options.network) {
@@ -19,14 +19,9 @@ module.exports = async function (options) {
   }
 
   let config = loadConfig(options);
-
-  const allowedConsoleCommands = commands.filter(
-    cmd => !excludedCommands.has(cmd)
-  );
-
   await Environment.detect(config);
   const c = new Console(
-    allowedConsoleCommands,
+    validTruffleConsoleCommands,
     config.with({ noAliases: true })
   );
   return await c.start();

--- a/packages/core/lib/commands/develop/run.js
+++ b/packages/core/lib/commands/develop/run.js
@@ -6,14 +6,11 @@ const {
 } = require("../../configAdapter");
 
 const runConsole = async (config, ganacheOptions) => {
-  const { Console, validTruffleConsoleCommands } = require("../../console");
+  const { Console } = require("../../console");
   const { Environment } = require("@truffle/environment");
 
   await Environment.develop(config, ganacheOptions);
-  const c = new Console(
-    validTruffleConsoleCommands,
-    config.with({ noAliases: true })
-  );
+  const c = new Console(config.with({ noAliases: true }));
   c.on("exit", () => process.exit());
   return await c.start();
 };

--- a/packages/core/lib/commands/develop/run.js
+++ b/packages/core/lib/commands/develop/run.js
@@ -6,17 +6,12 @@ const {
 } = require("../../configAdapter");
 
 const runConsole = async (config, ganacheOptions) => {
-  const { Console, excludedCommands } = require("../../console");
+  const { Console, validTruffleConsoleCommands } = require("../../console");
   const { Environment } = require("@truffle/environment");
-
-  const commands = require("../commands");
-  const allowedConsoleCommands = commands.filter(
-    cmd => !excludedCommands.has(cmd)
-  );
 
   await Environment.develop(config, ganacheOptions);
   const c = new Console(
-    allowedConsoleCommands,
+    validTruffleConsoleCommands,
     config.with({ noAliases: true })
   );
   c.on("exit", () => process.exit());

--- a/packages/core/lib/console-child.js
+++ b/packages/core/lib/console-child.js
@@ -8,6 +8,7 @@ const {
   displayGeneralHelp
 } = require("./command-utils");
 const { handleHelpInput } = require("./cliHelp");
+const { validTruffleConsoleCommands } = require("./console");
 
 // we split off the part Truffle cares about and need to convert to an array
 const input = process.argv[2].split(" -- ");
@@ -18,7 +19,7 @@ const inputArguments = parseQuotesAndEscapes(input[1], escapeCharacters); //note
 // handle cases where input indicates the user wants to access Truffle's help
 const { displayHelp, inputStrings } = handleHelpInput({ inputArguments });
 if (displayHelp) {
-  displayGeneralHelp();
+  displayGeneralHelp({ commands: validTruffleConsoleCommands });
   process.exit();
 }
 

--- a/packages/core/lib/console-child.js
+++ b/packages/core/lib/console-child.js
@@ -8,7 +8,7 @@ const {
   displayGeneralHelp
 } = require("./command-utils");
 const { handleHelpInput } = require("./cliHelp");
-const { validTruffleConsoleCommands } = require("./console");
+const { validTruffleConsoleCommands } = require("./commands/commands");
 
 // we split off the part Truffle cares about and need to convert to an array
 const input = process.argv[2].split(" -- ");

--- a/packages/core/lib/console-child.js
+++ b/packages/core/lib/console-child.js
@@ -8,7 +8,6 @@ const {
   displayGeneralHelp
 } = require("./command-utils");
 const { handleHelpInput } = require("./cliHelp");
-const { validTruffleConsoleCommands } = require("./commands/commands");
 
 // we split off the part Truffle cares about and need to convert to an array
 const input = process.argv[2].split(" -- ");
@@ -19,7 +18,7 @@ const inputArguments = parseQuotesAndEscapes(input[1], escapeCharacters); //note
 // handle cases where input indicates the user wants to access Truffle's help
 const { displayHelp, inputStrings } = handleHelpInput({ inputArguments });
 if (displayHelp) {
-  displayGeneralHelp({ commands: validTruffleConsoleCommands });
+  displayGeneralHelp({ isREPL: true });
   process.exit();
 }
 

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -15,7 +15,7 @@ const EventEmitter = require("events");
 const { spawn } = require("child_process");
 const Require = require("@truffle/require");
 const debug = require("debug")("console");
-const { getCommand, parseQuotesAndEscapes } = require("./command-utils");
+const { parseQuotesAndEscapes } = require("./command-utils");
 const { validTruffleConsoleCommands } = require("./commands/commands");
 
 // Create an expression that returns a string when evaluated
@@ -397,14 +397,7 @@ class Console extends EventEmitter {
 
   async interpret(input, context, filename, callback) {
     const processedInput = processInput(input);
-    if (
-      validTruffleConsoleCommands.includes(processedInput.split(/\s+/)[0]) &&
-      getCommand({
-        inputStrings: processedInput.split(/\s+/),
-        options: {},
-        noAliases: this.options.noAliases
-      }) !== null
-    ) {
+    if (validTruffleConsoleCommands.includes(processedInput.split(/\s+/)[0])) {
       try {
         parseQuotesAndEscapes(processedInput); //we're just doing this to see
         //if it errors. unfortunately we need to throw out the result and recompute

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -16,7 +16,10 @@ const { spawn } = require("child_process");
 const Require = require("@truffle/require");
 const debug = require("debug")("console");
 const { parseQuotesAndEscapes } = require("./command-utils");
-const { validTruffleConsoleCommands } = require("./commands/commands");
+const {
+  excludedTruffleConsoleCommands,
+  validTruffleConsoleCommands
+} = require("./commands/commands");
 
 // Create an expression that returns a string when evaluated
 // by the REPL
@@ -39,11 +42,22 @@ const processInput = input => {
     }
 
     const normalizedCommand = cmd.toLowerCase();
-    return validTruffleConsoleCommands.includes(normalizedCommand)
-      ? words.slice(1).join(" ")
-      : makeIIFE(
-          `ℹ️ : '${words[0]} ${cmd}' is not valid in Console environment.`
-        );
+    const isExcludedInREPL =
+      excludedTruffleConsoleCommands.includes(normalizedCommand);
+
+    if (isExcludedInREPL) {
+      return makeIIFE(
+        `ℹ️ : '${words[0]} ${cmd}' is not allowed in Console environment.`
+      );
+    }
+
+    if (!validTruffleConsoleCommands.includes(normalizedCommand)) {
+      return makeIIFE(
+        `ℹ️ : '${words[0]} ${cmd}' is not a valid truffle command.`
+      );
+    }
+
+    return words.slice(1).join(" ");
   }
 
   // an expression

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -16,7 +16,10 @@ const { spawn } = require("child_process");
 const Require = require("@truffle/require");
 const debug = require("debug")("console");
 const { getCommand, parseQuotesAndEscapes } = require("./command-utils");
-const validTruffleCommands = require("./commands/commands");
+const {
+  validTruffleCommands,
+  validTruffleConsoleCommands
+} = require("./commands/commands");
 
 // Create an expression that returns a string when evaluated
 // by the REPL
@@ -526,9 +529,7 @@ class Console extends EventEmitter {
   }
 }
 
-const excludedCommands = new Set(["console", "db", "init", "watch", "develop"]);
-
 module.exports = {
-  excludedCommands,
+  validTruffleConsoleCommands,
   Console
 };

--- a/packages/core/test/commands.js
+++ b/packages/core/test/commands.js
@@ -3,7 +3,7 @@ const {
   prepareOptions,
   runCommand
 } = require("../lib/command-utils");
-const commandsArray = require("../lib/commands/commands");
+const { validTruffleCommands } = require("../lib/commands/commands");
 const allCommands = require("../lib/commands");
 const { assert } = require("chai");
 
@@ -14,13 +14,13 @@ describe("commands", function () {
     it("contains an array item for each command", function () {
       assert(
         Object.keys(allCommands).every(command =>
-          commandsArray.includes(command)
+          validTruffleCommands.includes(command)
         )
       );
     });
     it("contains a command for every array item", function () {
       assert(
-        commandsArray.every(command =>
+        validTruffleCommands.every(command =>
           Object.keys(allCommands).includes(command)
         )
       );

--- a/packages/core/test/lib/console.js
+++ b/packages/core/test/lib/console.js
@@ -1,16 +1,13 @@
 const assert = require("chai").assert;
 const path = require("path");
-const { Console, excludedCommands } = require("../../lib/console");
-const commands = require("../../lib/commands");
+const { Console } = require("../../lib/console");
+const { validTruffleConsoleCommands } = require("../../lib/commands/commands");
 const sinon = require("sinon");
 const Config = require("@truffle/config");
 const Web3 = require("web3");
 const { Resolver } = require("@truffle/resolver");
 const config = new Config();
 
-const allowedConsoleCommands = Object.keys(commands).filter(
-  cmd => !excludedCommands.has(cmd)
-);
 let truffleConsole, consoleOptions;
 
 describe("Console", function () {
@@ -40,7 +37,7 @@ describe("Console", function () {
         { path: pathToMoreUserJs },
         { path: pathToUserJs, as: "namespace" }
       ];
-      truffleConsole = new Console(allowedConsoleCommands, consoleOptions);
+      truffleConsole = new Console(validTruffleConsoleCommands, consoleOptions);
       sinon
         .stub(truffleConsole.interfaceAdapter, "getAccounts")
         .returns(["0x0"]);
@@ -87,7 +84,7 @@ describe("Console", function () {
         );
         otherConsoleOptions["require-none"] = true;
         otherTruffleConsole = new Console(
-          allowedConsoleCommands,
+          validTruffleConsoleCommands,
           otherConsoleOptions
         );
       });
@@ -119,7 +116,7 @@ describe("Console", function () {
           "test/sources/nameConflicts.js"
         );
         otherTruffleConsole = new Console(
-          allowedConsoleCommands,
+          validTruffleConsoleCommands,
           otherConsoleOptions
         );
       });
@@ -148,7 +145,7 @@ describe("Console", function () {
           resolver: new Resolver(config)
         });
         otherTruffleConsole = new Console(
-          allowedConsoleCommands,
+          validTruffleConsoleCommands,
           otherConsoleOptions
         );
       });

--- a/packages/core/test/lib/console.js
+++ b/packages/core/test/lib/console.js
@@ -1,7 +1,6 @@
 const assert = require("chai").assert;
 const path = require("path");
 const { Console } = require("../../lib/console");
-const { validTruffleConsoleCommands } = require("../../lib/commands/commands");
 const sinon = require("sinon");
 const Config = require("@truffle/config");
 const Web3 = require("web3");
@@ -37,7 +36,7 @@ describe("Console", function () {
         { path: pathToMoreUserJs },
         { path: pathToUserJs, as: "namespace" }
       ];
-      truffleConsole = new Console(validTruffleConsoleCommands, consoleOptions);
+      truffleConsole = new Console(consoleOptions);
       sinon
         .stub(truffleConsole.interfaceAdapter, "getAccounts")
         .returns(["0x0"]);
@@ -83,10 +82,7 @@ describe("Console", function () {
           "test/sources/moreUserVariables.js"
         );
         otherConsoleOptions["require-none"] = true;
-        otherTruffleConsole = new Console(
-          validTruffleConsoleCommands,
-          otherConsoleOptions
-        );
+        otherTruffleConsole = new Console(otherConsoleOptions);
       });
 
       it("won't load any user-defined JS", async function () {
@@ -115,10 +111,7 @@ describe("Console", function () {
           config.working_directory,
           "test/sources/nameConflicts.js"
         );
-        otherTruffleConsole = new Console(
-          validTruffleConsoleCommands,
-          otherConsoleOptions
-        );
+        otherTruffleConsole = new Console(otherConsoleOptions);
       });
 
       it("won't let users clobber Truffle variables", async function () {
@@ -144,10 +137,7 @@ describe("Console", function () {
           provider: new Web3.providers.WebsocketProvider("ws://localhost:666"),
           resolver: new Resolver(config)
         });
-        otherTruffleConsole = new Console(
-          validTruffleConsoleCommands,
-          otherConsoleOptions
-        );
+        otherTruffleConsole = new Console(otherConsoleOptions);
       });
 
       it("accepts options.r", async function () {

--- a/packages/truffle/test/scenarios/commands/develop.js
+++ b/packages/truffle/test/scenarios/commands/develop.js
@@ -78,19 +78,19 @@ describe("truffle develop", function () {
     [
       {
         cmd: "console",
-        expectedError: `ℹ️ : 'console' is not allowed within Truffle REPL`
+        expectedError: `ℹ️ : 'truffle console' is not valid in Console environment.`
       },
       {
         cmd: "CONSOLE",
-        expectedError: `ℹ️ : 'CONSOLE' is not allowed within Truffle REPL`
+        expectedError: `ℹ️ : 'truffle CONSOLE' is not valid in Console environment.`
       },
       {
         cmd: "develop",
-        expectedError: `ℹ️ : 'develop' is not allowed within Truffle REPL`
+        expectedError: `ℹ️ : 'truffle develop' is not valid in Console environment.`
       },
       {
         cmd: "alakazam",
-        expectedError: `ℹ️ : 'alakazam' is not a valid Truffle command`
+        expectedError: `ℹ️ : 'truffle alakazam' is not valid in Console environment`
       },
       {
         cmd: "",

--- a/packages/truffle/test/scenarios/commands/develop.js
+++ b/packages/truffle/test/scenarios/commands/develop.js
@@ -78,19 +78,19 @@ describe("truffle develop", function () {
     [
       {
         cmd: "console",
-        expectedError: `ℹ️ : 'truffle console' is not valid in Console environment.`
+        expectedError: `ℹ️ : 'truffle console' is not allowed in Console environment.`
       },
       {
         cmd: "CONSOLE",
-        expectedError: `ℹ️ : 'truffle CONSOLE' is not valid in Console environment.`
+        expectedError: `ℹ️ : 'truffle CONSOLE' is not allowed in Console environment.`
       },
       {
         cmd: "develop",
-        expectedError: `ℹ️ : 'truffle develop' is not valid in Console environment.`
+        expectedError: `ℹ️ : 'truffle develop' is not allowed in Console environment.`
       },
       {
         cmd: "alakazam",
-        expectedError: `ℹ️ : 'truffle alakazam' is not valid in Console environment`
+        expectedError: `ℹ️ : 'truffle alakazam' is not a valid truffle command.`
       },
       {
         cmd: "",

--- a/packages/truffle/webpack.config.js
+++ b/packages/truffle/webpack.config.js
@@ -5,7 +5,7 @@ const webpack = require("webpack");
 const pkg = require("./package.json");
 const rootDir = path.join(__dirname, "../..");
 const outputDir = path.join(__dirname, "build");
-const commands = require("../core/lib/commands/commands");
+const { validTruffleCommands } = require("../core/lib/commands/commands");
 const truffleLibraryDirectory = path.join(
   __dirname,
   "../..",
@@ -27,7 +27,7 @@ const truffleRequireDistDirectory = path.join(
 
 const ganacheConsoleSol = require.resolve("@ganache/console.log/console.sol");
 
-const commandsEntries = commands.reduce((a, command) => {
+const commandsEntries = validTruffleCommands.reduce((a, command) => {
   a[command] = path.join(
     __dirname,
     "../..",


### PR DESCRIPTION
## PR description

This PR limits the general help output for `truffle console` and `truffle develop` so help for `console`, `dashboard`, `db`, `develop`, `init` and `watch` won't be shown. It achieves this by defining a single source of truth for valid CLI and Console commands. The `commands/commands.js` module defines this state, and other parts of the codebase have been refactored to import and rely on this information. The Console class no longer needs to be passed `allowedCommands` and has removed the maintenance of `excludedCommands`. Instead, the signature for the help function has changed to indicate whether it is displaying help for the CLI or the REPL.  Tests and webpack concerns have been updated to reflect these changes, and the source of truth for valid Truffle commands has been updated in various files. 

Contributes to: #5312


## Testing instructions

- Try `help` in truffle develop, and confirm it doesn't show help for `console`, `dashboard`, `db`, `develop`, `init` and `watch`
- Verify help isn't broken :/

## Documentation & breaking changes concerns
- No docs required.
- Error text changed in REPL output, so it's arguable this might be a breaking change. Thoughts?
