### PR TITLE
Upgrade solc dependencies to v0.8.18 in `contract-schema` and `compile-solidity` packages

### DIFF
--- a/packages/compile-solidity/package.json
+++ b/packages/compile-solidity/package.json
@@ -34,7 +34,7 @@
     "original-require": "^1.0.1",
     "require-from-string": "^2.0.2",
     "semver": "7.3.7",
-    "solc": "0.8.17"
+    "solc": "0.8.18"
   },
   "devDependencies": {
     "@truffle/artifactor": "^4.0.182",

--- a/packages/contract-schema/package.json
+++ b/packages/contract-schema/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "json-schema-to-typescript": "^5.5.0",
     "mocha": "10.1.0",
-    "solc": "0.8.17"
+    "solc": "0.8.18"
   },
   "keywords": [
     "artifacts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23146,10 +23146,10 @@ solc@0.7.3:
     semver "^5.5.0"
     tmp "0.0.33"
 
-solc@0.8.17:
-  version "0.8.17"
-  resolved "https://registry.yarnpkg.com/solc/-/solc-0.8.17.tgz#c748fec6a64bf029ec406aa9b37e75938d1115ae"
-  integrity sha512-Dtidk2XtTTmkB3IKdyeg6wLYopJnBVxdoykN8oP8VY3PQjN16BScYoUJTXFm2OP7P0hXNAqWiJNmmfuELtLf8g==
+solc@0.8.18:
+  version "0.8.18"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.8.18.tgz#a05ce8918540eda5f10aa91f0f52f239b9645dad"
+  integrity sha512-wVAa2Y3BYd64Aby5LsgS3g6YC2NvZ3bJ+A8TAIAukfVuQb3AjyGrLZpyxQk5YLn14G35uZtSnIgHEpab9klOLQ==
   dependencies:
     command-exists "^1.2.8"
     commander "^8.1.0"


### PR DESCRIPTION
## PR description

This PR upgrades the `solc` version to the latest **v0.8.18** in the `contract-schema` and `compile-solidity` packages.
