### PR TITLE
Suppress evalmachine error stack in truffle consoles

### DIFF
--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -491,7 +491,7 @@ class Console extends EventEmitter {
 
     const runScript = script => {
       const options = {
-        displayErrors: true,
+        displayErrors: false,
         breakOnSigint: true,
         filename: filename
       };

--- a/packages/core/lib/console.js
+++ b/packages/core/lib/console.js
@@ -502,7 +502,7 @@ class Console extends EventEmitter {
 
     let script;
     try {
-      const options = { displayErrors: true, lineOffset: -1 };
+      const options = { lineOffset: -1 };
       script = vm.createScript(source, options);
     } catch (error) {
       // If syntax error, or similar, bail.


### PR DESCRIPTION
## PR description

Suppress errors in truffle REPL (console & develop). With this change, REPL errors no longer display `evalmachine` vm errors. This is done by setting `options.displayErrors = false` when invoking [vm.runInContext()](https://nodejs.org/dist/latest-v19.x/docs/api/vm.html#scriptrunincontextcontextifiedobject-options).

## current behavior

```console
truffle(develop)> jk
evalmachine.<anonymous>:0
jk
^

Uncaught ReferenceError: jk is not defined
    at evalmachine.<anonymous>
    at sigintHandlersWrap (node:vm:276:12)
    at Script.runInContext (node:vm:139:14)
    at runScript (/Users/amal/work/truffle/packages/core/lib/console.js:500:21)
    at Console.interpret (/Users/amal/work/truffle/packages/core/lib/console.js:515:21)
    at bound (node:domain:433:15)
    at REPLServer.runBound [as eval] (node:domain:444:12)
    at REPLServer.onLine (node:repl:902:10)
    at REPLServer.emit (node:events:513:28)
    at REPLServer.emit (node:domain:489:12)
truffle(develop)> 
```

## with change

```console
truffle(develop)> jk
Uncaught ReferenceError: jk is not defined
truffle(develop)> 
```

## Testing instructions
Use console and develop to verify REPL errors don't show `evalmachine` vm errors.
## Documentation

- [x] No documentation change required

## Breaking changes and new features

- [x] no breaking change
