### PR TITLE
[internal improvement] Simplify `Develop.connectOrStart()`'s signature

### DIFF
--- a/packages/core/lib/commands/develop/run.js
+++ b/packages/core/lib/commands/develop/run.js
@@ -60,7 +60,7 @@ module.exports = async options => {
   const { started } = await Develop.connectOrStart(
     ipcOptions,
     ganacheOptions,
-    config
+    config?.solidityLog?.displayPrefix ?? ""
   );
   const url = `http://${ganacheOptions.host}:${ganacheOptions.port}/`;
 

--- a/packages/core/lib/commands/test/run.js
+++ b/packages/core/lib/commands/test/run.js
@@ -46,7 +46,7 @@ module.exports = async function (options) {
     const { disconnect } = await Develop.connectOrStart(
       ipcOptions,
       ganacheOptions,
-      truffleConfig
+      truffleConfig?.solidityLog?.displayPrefix ?? ""
     );
     const ipcDisconnect = disconnect;
     await Environment.develop(truffleConfig, ganacheOptions);

--- a/packages/environment/develop.js
+++ b/packages/environment/develop.js
@@ -153,7 +153,10 @@ const Develop = {
    * @param {string} ipcOptions.network - the network name.
    * @param {Object} ganacheOptions - Ganache options if service is necessary.
    * @param {string} solidityLogDisplayPrefix - solidity log messages prefix.
-   * @returns void
+   * @returns {Promise<Object>} - object with `disconnect` function and
+   *     `started` boolean. The `disconnect` function is used to disconnect
+   *     from the Ganache service. The `started` boolean is true if a new
+   *     Ganache service was started, false otherwise.
    */
   connectOrStart: async function (
     ipcOptions,

--- a/packages/environment/develop.js
+++ b/packages/environment/develop.js
@@ -41,7 +41,17 @@ const Develop = {
     });
   },
 
-  connect: function (ipcOptions, truffleConfig) {
+  /**
+   * Connect to an existing Ganache server or start a new one.
+   * @param {object} options
+   * @param {object} options.ipcOptions - options for IPC connection
+   * @param {boolean} options.ipcOptions.log - whether to log IPC messages. Defaults to false.
+   * @param {string} options.ipcOptions.network - network name. Defaults to "develop".
+   * @param {boolean} options.ipcOptions.retry - whether to retry connection. Defaults to false.
+   * @param {string} options.solidityLogDisplayPrefix - prefix to display before solidity log messages. Defaults to "".
+   * @returns {Promise<(): void>} - IPC disconnection function.
+   */
+  connect: function ({ ipcOptions, solidityLogDisplayPrefix }) {
     const debugServer = debug("develop:ipc:server");
     const debugClient = debug("develop:ipc:client");
     const debugRPC = debug("develop:ganache");
@@ -54,6 +64,7 @@ const Develop = {
     ipcOptions.retry = ipcOptions.retry || false;
     ipcOptions.log = ipcOptions.log || false;
     ipcOptions.network = ipcOptions.network || "develop";
+    solidityLogDisplayPrefix = solidityLogDisplayPrefix || "";
     var ipcNetwork = ipcOptions.network;
 
     var ipc = new IPC();
@@ -88,10 +99,6 @@ const Develop = {
 
     // create a logger to present Ganache's console log messages
     const createSolidityLogger = prefix => {
-      if (prefix == null || typeof prefix !== "string") {
-        prefix = "";
-      }
-
       return maybeMultipleLines =>
         maybeMultipleLines.split("\n").forEach(
           // decorate each line's prefix.
@@ -101,9 +108,7 @@ const Develop = {
 
     // enable output/logger for solidity console.log
     loggers.solidity = sanitizeAndCallFn(
-      createSolidityLogger(
-        truffleConfig.solidityLog && truffleConfig.solidityLog.displayPrefix
-      )
+      createSolidityLogger(solidityLogDisplayPrefix)
     );
 
     if (ipcOptions.log) {
@@ -144,14 +149,17 @@ const Develop = {
    * Connect to a managed Ganache service. This will connect to an existing
    * Ganache service if one exists, or, create a new one to connect to.
    *
-   * @param {Object} ipcOptions
-   * @param {string} ipcOptions.network the network name.
-   * @param {Object} ganacheOptions to be used if starting a Ganache service is
-   *        necessary.
-   * @param {TruffleConfig} truffleConfig the truffle config.
+   * @param {Object} ipcOptions - IPC connection options.
+   * @param {string} ipcOptions.network - the network name.
+   * @param {Object} ganacheOptions - Ganache options if service is necessary.
+   * @param {string} solidityLogDisplayPrefix - solidity log messages prefix.
    * @returns void
    */
-  connectOrStart: async function (ipcOptions, ganacheOptions, truffleConfig) {
+  connectOrStart: async function (
+    ipcOptions,
+    ganacheOptions,
+    solidityLogDisplayPrefix = ""
+  ) {
     ipcOptions.retry = false;
 
     const ipcNetwork = ipcOptions.network || "develop";
@@ -160,11 +168,11 @@ const Develop = {
     let disconnect;
 
     try {
-      disconnect = await this.connect(ipcOptions, truffleConfig);
+      disconnect = await this.connect({ ipcOptions, solidityLogDisplayPrefix });
     } catch (_error) {
       await this.start(ipcNetwork, ganacheOptions);
       ipcOptions.retry = true;
-      disconnect = await this.connect(ipcOptions, truffleConfig);
+      disconnect = await this.connect({ ipcOptions, solidityLogDisplayPrefix });
       started = true;
     } finally {
       return {

--- a/packages/environment/test/connectOrStartTest.js
+++ b/packages/environment/test/connectOrStartTest.js
@@ -1,6 +1,5 @@
 const assert = require("chai").assert;
 const Develop = require("../develop");
-const TruffleConfig = require("@truffle/config");
 
 describe("connectOrStart test network", async function () {
   const ipcOptions = { network: "test" };
@@ -9,6 +8,7 @@ describe("connectOrStart test network", async function () {
     network_id: 666,
     port: 6969
   };
+  const defaultSolidityLogDisplayPrefix = "";
 
   it("starts Ganache when no Ganache instance is running", async function () {
     let connection;
@@ -16,7 +16,7 @@ describe("connectOrStart test network", async function () {
       connection = await Develop.connectOrStart(
         ipcOptions,
         ganacheOptions,
-        TruffleConfig.default()
+        defaultSolidityLogDisplayPrefix
       );
       assert.isTrue(connection.started, "A new Ganache server did not spin up");
       assert.isFunction(connection.disconnect, "disconnect is not a function");
@@ -34,19 +34,19 @@ describe("connectOrStart test network", async function () {
     try {
       //Establish IPC Ganache service
       spawnedGanache = await Develop.start(ipcOptions.network, ganacheOptions);
-      connectionOneDisconnect = await Develop.connect(
-        {
+      connectionOneDisconnect = await Develop.connect({
+        ipcOptions: {
           ...ipcOptions,
           retry: true
         },
-        TruffleConfig.default()
-      );
+        defaultSolidityLogDisplayPrefix
+      });
 
       //Test
       connectionTwo = await Develop.connectOrStart(
         ipcOptions,
         ganacheOptions,
-        TruffleConfig.default()
+        defaultSolidityLogDisplayPrefix
       );
 
       //Validate


### PR DESCRIPTION
## PR description

This pull request updates the signatures of `connect` and `connectOrStart` functions to avoid passing a large truffle-config object when connecting to the ganache service. See: #5784.

## Testing instructions

No test, just code review

## Documentation

- [x] No `doc-change-required` label required for this PR

## Breaking changes and new features

- [x] No `breaking-change` or `new-feature` labels apply
