### PR TITLE
Link to Debugger reference docs

### DIFF
--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -369,7 +369,11 @@ var DebugUtils = {
       return shortcuts.map(DebugUtils.formatCommandDescription).join(", ");
     });
 
-    var suffix = [""];
+    var suffix = [
+      "",
+      "Docs: https://trufflesuite.com/docs/truffle/how-to/debug-test/use-the-truffle-debugger/",
+      ""
+    ];
 
     var lines = prefix.concat(commandSections).concat(suffix);
 


### PR DESCRIPTION
## PR description

This PR adds a link to the debugger docs to help users quickly navigate to extended help. 

### Help with link

```
MetaCoin.sol:

 9: // coin/token contracts.
10:
11: contract MetaCoin {
    ^^^^^^^^^^^^^^^^^^^

debug(development:0xad5d9050...)> h

Commands:
(enter) last command entered (step next)
(o) step over, (i) step line / step into, (u) step out, (n) step next
(c) continue until breakpoint, (Y) reset & continue to previous error
(y) (if at end) reset & continue to final error
(;) step instruction (include number to step multiple)
(g) turn on generated sources, (G) turn off generated sources except via `;`
(p) print instruction & state (`p [mem|cal|sto]*`; see docs for more)
(l) print additional source context (`l [+<lines-ahead>] [-<lines-back>]`)
(s) print stacktrace, (e) Print recent events (`e [<number>|all]`)
(q) quit, (r) reset, (t) load new transaction, (T) unload transaction
(b) add breakpoint (`b [[<source-file>:]<line-number>]`; see docs for more)
(B) remove breakpoint (similar to adding, or `B all` to remove all)
(+) add watch expression (`+:<expr>`), (-) remove watch expression (-:<expr>)
(?) list existing watch expressions and breakpoints
(v) print variables and values (`v [bui|glo|con|loc]*`)
(:) evaluate expression - see `v`, (h) print this help

Docs: https://trufflesuite.com/docs/truffle/how-to/debug-test/use-the-truffle-debugger/

debug(development:0xad5d9050...)>
```

## Testing instructions

Start a debug session and verify `h` shows the reference link.

## Documentation

- [x] no doc change required.

## Breaking changes and new features

- [x] no breaking change or new feature
