### PR TITLE
Add support for PUSH0 instruction to debugger & disassembler

### DIFF
--- a/packages/code-utils/src/index.ts
+++ b/packages/code-utils/src/index.ts
@@ -75,7 +75,7 @@ export function parseCode(
       name: parseOpcode(code[pc])
     };
     if (opcode.name.slice(0, 4) === "PUSH") {
-      const length = code[pc] - 0x60 + 1; //0x60 is code for PUSH1
+      const length = code[pc] - 0x5f; //0x5f is code for PUSH0
       let pushData = code.subarray(pc + 1, pc + length + 1);
       if (pushData.length < length) {
         //if we run out of bytes for our pushdata, fill the rest

--- a/packages/code-utils/src/opcodes.ts
+++ b/packages/code-utils/src/opcodes.ts
@@ -75,6 +75,7 @@ const codes = {
   0x5b: "JUMPDEST",
 
   // 0x60 & 0x70 range - pushes
+  0x5f: "PUSH0",
   0x60: "PUSH1",
   0x61: "PUSH2",
   0x62: "PUSH3",

--- a/packages/codec/lib/abi-data/allocate/index.ts
+++ b/packages/codec/lib/abi-data/allocate/index.ts
@@ -1014,9 +1014,7 @@ function constructorOutputAllocation(
   if (contractKind === "library") {
     //note: I am relying on this being present!
     //(also this part is a bit HACKy)
-    const pushAddressInstruction = (0x60 + Evm.Utils.ADDRESS_SIZE - 1).toString(
-      16
-    ); //"73"
+    const pushAddressInstruction = (0x5f + Evm.Utils.ADDRESS_SIZE).toString(16); //"73"
     const delegateCallGuardString =
       "0x" + pushAddressInstruction + "..".repeat(Evm.Utils.ADDRESS_SIZE);
     if (binary.startsWith(delegateCallGuardString)) {

--- a/packages/codec/lib/contexts/utils.ts
+++ b/packages/codec/lib/contexts/utils.ts
@@ -141,9 +141,7 @@ export function normalizeContexts(contexts: Contexts): Contexts {
   //now we must handle the delegatecall guard -- libraries' deployedBytecode will include
   //0s in place of their own address instead of a link reference at the
   //beginning, so we need to account for that too
-  const pushAddressInstruction = (0x60 + Evm.Utils.ADDRESS_SIZE - 1).toString(
-    16
-  ); //"73"
+  const pushAddressInstruction = (0x5f + Evm.Utils.ADDRESS_SIZE).toString(16); //"73"
   for (let context of Object.values(newContexts)) {
     if (context.contractKind === "library" && !context.isConstructor) {
       context.binary = context.binary.replace(
@@ -401,9 +399,7 @@ function contractKind(
     const deployedBytecode = Shims.NewToLegacy.forBytecode(
       contract.deployedBytecode
     );
-    const pushAddressInstruction = (0x60 + Evm.Utils.ADDRESS_SIZE - 1).toString(
-      16
-    ); //"73"
+    const pushAddressInstruction = (0x5f + Evm.Utils.ADDRESS_SIZE).toString(16); //"73"
     const libraryString =
       "0x" + pushAddressInstruction + "00".repeat(Evm.Utils.ADDRESS_SIZE);
     return deployedBytecode.startsWith(libraryString) ? "library" : "contract";

--- a/packages/core/lib/commands/opcode/run.js
+++ b/packages/core/lib/commands/opcode/run.js
@@ -53,7 +53,9 @@ module.exports = async function (options) {
     console.log(
       Conversion.toHexString(opcode.pc, lastPCByteLength) + ":",
       opcode.name,
-      opcode.pushData || ""
+      opcode.pushData !== undefined && opcode.pushData !== "0x"
+        ? opcode.pushData
+        : "" //display just "PUSH0", not "PUSH0 0x"
     );
   });
 };

--- a/packages/debug-utils/index.js
+++ b/packages/debug-utils/index.js
@@ -551,7 +551,11 @@ var DebugUtils = {
 
   formatInstruction: function (instruction) {
     return truffleColors.mint(
-      instruction.name + " " + (instruction.pushData || "")
+      instruction.name +
+        " " +
+        (instruction.pushData !== undefined && instruction.pushData !== "0x"
+          ? instruction.pushData
+          : "") //display just "PUSH0", not "PUSH0 0x"
     );
   },
 


### PR DESCRIPTION
This PR adds support for the upcoming PUSH0 instruction to Truffle's debugger and disassembler.  I'm doing this now because I'm going to be gone in March and this sort of thing usually falls to me, so, why not get it done before I leave.

This PR has 3 commits.  The first commit adds support for the opcode.  Note I grouped it with the other PUSHes rather than with the rest of the 0x50's.

The second commit makes it so that, when printing out PUSH0 in the debugger or disassembler, we just print out `PUSH0`, not `PUSH0 0x`, because the latter would look ugly.

The third commit is purely a code style matter -- I rewrote some calculations that previously used 0x60 (`PUSH1`) as a base to now use 0x5f (`PUSH0`) as a base.

NOTE: I didn't really test this (beyond existing CI) because Shanghai's not out yet...