### PR TITLE
Fix (most) incorrect reports of custom errors

### DIFF
--- a/packages/contract-tests/test/errors.js
+++ b/packages/contract-tests/test/errors.js
@@ -327,6 +327,30 @@ describe("Client appends errors (vmErrorsOnRPCResponse)", function () {
       }
     });
 
+    it("Reports that a custom error occurred when one did", async function () {
+      const example = await Example.new(1);
+      try {
+        await example.triggerCustomError();
+        assert.fail();
+      } catch (e) {
+        assert.include(e.reason, "Custom error");
+        assert.include(e.message, "Custom error");
+      }
+    });
+
+    it("Does not report a custom error when there is none", async function () {
+      const example = await Example.new(1);
+      //there was a bug where custom errors were incorrectly reported when
+      //a function that returns a value failed due to OOG or due to not occurring
+      //(e.g. refused in MetaMask).  This test is meant to check that case.
+      try {
+        await example.returnsInt.sendTransaction({ gas: 5 }); //deliberately too little gas
+        assert.fail();
+      } catch (e) {
+        assert.notInclude(e.message, "Custom error");
+      }
+    });
+
     it("appends original stacktrace for .calls", async function () {
       const example = await Example.new(1);
       try {

--- a/packages/contract-tests/test/sources/Example.sol
+++ b/packages/contract-tests/test/sources/Example.sol
@@ -15,6 +15,8 @@ contract Example {
 
   enum ExampleEnum { ExampleZero, ExampleOne, ExampleTwo }
 
+  error ExampleError(uint, uint);
+
   constructor(uint val) {
     // Constructor revert
     require(val != 13);
@@ -108,6 +110,10 @@ contract Example {
 
   function triggerAssertError() public {
     assert(false);
+  }
+
+  function triggerCustomError() public {
+    revert ExampleError(2, 3);
   }
 
   function triggerInvalidOpcode() public {

--- a/packages/contract/lib/reason.js
+++ b/packages/contract/lib/reason.js
@@ -81,9 +81,22 @@ const reason = {
         return undefined;
       }
     } else {
-      //we can't reasonably handle custom errors here
-      //(but we can probably assume it is one?)
-      return "Custom error (could not decode)";
+      const bytesLength = (rawData.length - 2) / 2; //length of raw data in bytes
+      if (bytesLength % 32 === 4) {
+        //we can't reasonably handle custom errors here at present, sorry
+        return "Custom error (could not decode)";
+      } else {
+        //if the length isn't 4 mod 32, just give up and return undefined.
+        //the reason for this is that sometimes this function can accidentally get
+        //called on a return value rather than an error (because the tx ran out of
+        //gas or failed for a reason other than a revert, e.g., getting refused by
+        //the user in MetaMask), meaning the eth_call rerun will *succeed*, potentially
+        //resulting in a return value.  We don't want to attach an additional
+        //error message in that case, so we return undefined.
+        //(What if e.g. the tx is refused by the user in MetaMask, but the rerun yields
+        //a revert string...?  Well, that's a problem for another time...)
+        return undefined;
+      }
     }
   },
 


### PR DESCRIPTION
Partially addresses #5881.  This is not a total fix, but it fixes the bulk of the problem.

Let's suppose you send a transaction, and it fails due to OOG, or, say, never even happens in the first place (like, intrinsic gas too low, or refused by the user in MetaMask).  In this case, the eth_call to determine the revert reason can *succeed* and get a return value instead of the intended error.  Since we can't decode it as an error, we treat it as a custom error.  Oops!

This PR fixes this by checking the length; if it's 4 mod 32, we treat it as an error, if it's not, we don't.  Assuming the Solidity ABI is being used, then error responses will have length 4 mod 32 (unless they're empty), while return value responses will have length 0 mod 32.

(Well, except for when we're dealing with contract creations, in which case successful responses can have any length, but, uh, I'm just going to not worry about that...)

This is arguably not a total fix for two reasons.  Firstly, there's the case of contract creations as mentioned above; in that case we could still hit the bug if the length of the returned contract just happends to be 4 mod 32.  Secondly, what if the transaction never happens -- e.g. it was refused by the user in MetaMask -- but the subsequent `eth_call` reverts with a valid error?  In this case, we'll append a revert string where it doesn't make sense, and it will be confusing for the user.

In order to address these cases, we should probably go, like, actually checking error codes and such.  However, that would take some actual research, and I thought I should at least start by putting up this quick fix that handles the most frequent cases.  We can do a more comprehensive fix later.

## Testing instructions

I added two tests in `contract-tests` to test this PR.  You might also want to see the original issue if you want to test it manually.