### PR TITLE
Update Sourcify chains for February 2023

### DIFF
--- a/packages/source-fetcher/lib/networks.ts
+++ b/packages/source-fetcher/lib/networks.ts
@@ -90,7 +90,11 @@ export const networkNamesById: { [id: number]: string } = {
   42262: "emerald-oasis",
   42261: "testnet-emerald-oasis",
   23294: "sapphire-oasis", //not presently supported by either fetcher, but...
-  23295: "testnet-sapphire-oasis"
+  23295: "testnet-sapphire-oasis",
+  14: "flare",
+  19: "songbird-flare",
+  2048: "stratos", //not presently supported by either fetcher, but...
+  2047: "testnet-stratos"
   //I'm not including crystaleum as it has network ID different from chain ID
   //not including kekchain for the same reason
 };

--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -117,7 +117,11 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "emerald-oasis",
     "testnet-emerald-oasis",
     //sourcify does *not* support oasis sapphire mainnet?
-    "testnet-sapphire-oasis"
+    "testnet-sapphire-oasis",
+    "flare",
+    "songbird-flare",
+    //sourcify does *not* support stratos mainnet?
+    "testnet-stratos"
     //I'm excluding crystaleum as it has network ID different from chain ID
     //excluding kekchain for the same reason
   ]);


### PR DESCRIPTION
New sourcify update, added new chains.

As usual I didn't really bother testing this, but if you want to, you could try testing it with:

On chain 14: 0xbBc2EdeDc9d2d97970eE20d0Dc7216216a27e635
On chain 19: 0x024829b4A91fB78437A854380c89A3fFc966c2D1
On chain 2047: 0x9082db5F71534984DEAC8E4ed66cFe364d77dd36