### PR TITLE
Increase timeout on migration out of gas test

### DIFF
--- a/packages/truffle/test/scenarios/migrations/errors.js
+++ b/packages/truffle/test/scenarios/migrations/errors.js
@@ -69,7 +69,7 @@ describe("migration errors", function () {
   });
 
   it("runs out of gas correctly", async function () {
-    this.timeout(70000);
+    this.timeout(90000);
 
     try {
       await CommandRunner.run("migrate -f 4", config);


### PR DESCRIPTION
I believe this test has been timing out a bunch recently, upping it.  (It's not the only one, but one at a time...)