### PR TITLE
Update Sourcify networks for Sourcify 1.2.2

### DIFF
--- a/packages/source-fetcher/lib/networks.ts
+++ b/packages/source-fetcher/lib/networks.ts
@@ -89,7 +89,7 @@ export const networkNamesById: { [id: number]: string } = {
   7001: "athens-zetachain",
   42262: "emerald-oasis",
   42261: "testnet-emerald-oasis",
-  23294: "sapphire-oasis", //not presently supported by either fetcher, but...
+  23294: "sapphire-oasis",
   23295: "testnet-sapphire-oasis",
   14: "flare",
   19: "songbird-flare",

--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -116,7 +116,7 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "athens-zetachain",
     "emerald-oasis",
     "testnet-emerald-oasis",
-    //sourcify does *not* support oasis sapphire mainnet?
+    "sapphire-oasis",
     "testnet-sapphire-oasis",
     "flare",
     "songbird-flare",


### PR DESCRIPTION
Unusually, Sourcify has made two network updates in rapid succession.  So, here's a second PR to update source-fetcher correspondingly!  This update adds only one network, Oasis Sapphire Mainnet.  (I already had this in networks.ts, but of course not in sourcify.ts).

If you want to test it, you can use address 0xFBcb580DD6D64fbF7caF57FB0439502412324179.