### PR TITLE
Remove Aurora support from Etherscan fetcher

### DIFF
--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -83,8 +83,6 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
       "testnet-cronos": "api-testnet.cronoscan.com",
       "bttc": "api.bttcscan.com",
       "donau-bttc": "api-testnet.bttcscan.com",
-      "aurora": "api.aurorascan.dev",
-      "testnet-aurora": "api-testnet.aurorascan.dev",
       "celo": "api.celoscan.io",
       "alfajores-celo": "api-alfajores.celoscan.io",
       "clover": "api.clvscan.com",


### PR DESCRIPTION
Etherscan no longer supports Aurora; their Aurora site has been taken over by a Blockscout site, as happened earlier to their HOO site.  Oh well.  This PR removes support for it from the Etherscan fetcher.