### PR TITLE
Bug fix: only edit state in txLog when we have an initial state

### DIFF
--- a/packages/debugger/lib/txlog/sagas/index.js
+++ b/packages/debugger/lib/txlog/sagas/index.js
@@ -262,7 +262,9 @@ function callKind(context, calldata, instant) {
 export function* reset() {
   const initialCall = yield select(txlog.transaction.initialCall);
   yield put(actions.reset());
-  yield put(initialCall);
+  if (initialCall) {
+    yield put(initialCall);
+  }
 }
 
 export function* unload() {


### PR DESCRIPTION
Attempting to use [this utility](https://github.com/trufflesuite/truffle/blob/develop/packages/debug-utils/index.js#L882) with the debugger in light mode resulted in a crash. We tracked this down in the debugger, it crashed at [this line](https://github.com/trufflesuite/truffle/blob/develop/packages/debugger/lib/txlog/sagas/index.js#L265). Apparently in light mode, this tx log tracking is not enabled and will make `initialState` `null` which in turn will cause things to crash. This PR fixes this by only updating state when we receive a value for `initialState`.