### PR TITLE
Fix console.log when presenting BigInts

### DIFF
--- a/packages/environment/chain.js
+++ b/packages/environment/chain.js
@@ -74,18 +74,20 @@ class Logger {
 
   // log a message to be sent to all active subscribers
   // buffers if there are no active subscribers (to send on first subscribe)
-  log(message) {
+  log(...messages) {
     const subscriberIDs = Object.keys(this.subscribers);
+    const formattedMessages = util.formatWithOptions(
+      { colors: true },
+      ...messages
+    );
     if (subscriberIDs.length === 0) {
-      this.messages.push(message);
-
+      this.messages.push(formattedMessages);
       return;
     }
 
     subscriberIDs.forEach(subscriberID => {
       const callback = this.subscribers[subscriberID];
-
-      callback(message);
+      callback(formattedMessages);
     });
   }
 }


### PR DESCRIPTION
This is necessary because JSON.stringify cannot serialize BigInt, which is a possible type from ganache and solidity logs. Special thanks to @MicaiahReid for the Rubber duck support! :bow: 

## PR description

This PR fixes an error @emilyJLin95 discovered. If you have a contract that logs a UINT* as the only argument (`console.log(100)`), then `truffle develop` would crash when the log is presented.

## Testing instructions
Write a contract that with `console.log(some-int)` and invoke the method to present the log. Truffle develop should not crash, and present the log.

## Documentation

- [x] No docs required
## Breaking changes and new features

- [x] No breaking changes
