### PR TITLE
add a warning when unable to save the solidity compiler to disk instead of throwing

### DIFF
--- a/packages/compile-solidity/src/compilerSupplier/loadingStrategies/VersionRange.ts
+++ b/packages/compile-solidity/src/compilerSupplier/loadingStrategies/VersionRange.ts
@@ -189,7 +189,7 @@ export class VersionRange {
           "The current user likely does not have sufficient permissions to " +
           "write to disk in Truffle's compiler cache directory. See the error" +
           `printed below for more information about this directory.\n${error}`;
-        console.log(warningMessage);
+        console.warn(warningMessage);
       }
     }
     return this.compilerFromString(response.data);

--- a/packages/compile-solidity/src/compilerSupplier/loadingStrategies/VersionRange.ts
+++ b/packages/compile-solidity/src/compilerSupplier/loadingStrategies/VersionRange.ts
@@ -180,7 +180,18 @@ export class VersionRange {
       throw error;
     }
     events.emit("downloadCompiler:succeed");
-    await this.cache.add(response.data, fileName);
+    try {
+      await this.cache.add(response.data, fileName);
+    } catch (error) {
+      if (error.message.includes("EACCES: permission denied")) {
+        const warningMessage =
+          "There was an error attempting to save the compiler to disk. " +
+          "The current user likely does not have sufficient permissions to " +
+          "write to disk in Truffle's compiler cache directory. See the error" +
+          `printed below for more information about this directory.\n${error}`;
+        console.log(warningMessage);
+      }
+    }
     return this.compilerFromString(response.data);
   }
 
@@ -222,14 +233,6 @@ export class VersionRange {
       }
       return await this.getAndCacheSolcByUrl(fileName, index);
     } catch (error) {
-      if (error.message.includes("EACCES: permission denied")) {
-        throw new Error(
-          "There was an error attempting to save the compiler to the cache." +
-            "The current user likely does not have sufficient permissions to " +
-            "write to disk in Truffle's compiler cache directory. See the full" +
-            `error below: \n${error}`
-        );
-      }
       const attemptNumber = index + 1;
       return await this.getSolcFromCacheOrUrl(versionConstraint, attemptNumber);
     }


### PR DESCRIPTION
Currently when Truffle fails to save the Solidity compiler to the cache directory, it will throw an error. This PR changes this behavior so that it displays a warning to the user and continues on with the rest of the compilation flow. 