### PR TITLE
Allow disabling Truffle's default solc settings

### DIFF
--- a/packages/compile-solidity-tests/test/fixture/default-box/truffle-config.js
+++ b/packages/compile-solidity-tests/test/fixture/default-box/truffle-config.js
@@ -11,8 +11,7 @@ module.exports = {
     solc: {
       settings: {
         optimizer: {
-          enabled: false, // Default: false
-          runs: 200 // Default: 200
+          enabled: false // Default: false
         }
       }
     }

--- a/packages/compile-solidity-tests/test/fixture/default-box/truffle-config.js
+++ b/packages/compile-solidity-tests/test/fixture/default-box/truffle-config.js
@@ -9,7 +9,6 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: "0.6.9",
       settings: {
         optimizer: {
           enabled: false, // Default: false

--- a/packages/compile-solidity-tests/test/fixture/default-box/truffle-config.js
+++ b/packages/compile-solidity-tests/test/fixture/default-box/truffle-config.js
@@ -9,9 +9,10 @@ module.exports = {
   },
   compilers: {
     solc: {
+      version: "0.6.9",
       settings: {
         optimizer: {
-          enabled: true, // Default: false
+          enabled: false, // Default: false
           runs: 200 // Default: 200
         }
       }

--- a/packages/compile-solidity-tests/test/settings.ts
+++ b/packages/compile-solidity-tests/test/settings.ts
@@ -17,7 +17,7 @@ before("Set up config", () => {
   Environment.detect(config);
 });
 describe("Compile with disableDefaults flag", () => {
-  it("should not add the optimizer when missing if disableDefaults is true", async () => {
+  it("should not add missing optimizer when `disableDefaults` is true", async () => {
     //compile when optimizer is set to false
     const compilationWithOptimizer = await Compile.all(config);
 

--- a/packages/compile-solidity-tests/test/settings.ts
+++ b/packages/compile-solidity-tests/test/settings.ts
@@ -42,7 +42,8 @@ describe("Compile with disableDefaults flag", () => {
     // Verify that the bytecode is different
     assert.notStrictEqual(
       bytecodeWithDefaultsDisabled,
-      bytecodeWithOptimizerSetting
+      bytecodeWithOptimizerSetting,
+      "Bytecode should be different when disableDefaults is true and optimizer is missing"
     );
   });
 
@@ -71,7 +72,8 @@ describe("Compile with disableDefaults flag", () => {
     // Verify that the bytecode is different
     assert.strictEqual(
       bytecodeWithDefaultsEnabled,
-      bytecodeWithOptimizerSetting
+      bytecodeWithOptimizerSetting,
+      "Bytecode should be the same when disableDefaults is false and optimizer is missing"
     );
   });
 });

--- a/packages/compile-solidity-tests/test/settings.ts
+++ b/packages/compile-solidity-tests/test/settings.ts
@@ -1,26 +1,28 @@
 import { assert } from "chai";
 import Config from "@truffle/config";
 import { Compile } from "@truffle/compile-solidity";
-import { describe, it } from "mocha";
+import { describe, it, before } from "mocha";
 import path from "path";
 import { Environment } from "@truffle/environment";
 
+let config;
+before("Set up config", () => {
+  // Load configuration from the fixture file
+  config = Config.detect(
+    { workingDirectory: path.join(__dirname, "fixture/default-box") },
+    "./truffle-config.js"
+  );
+
+  // Environment.detect() so we get all the other config goodies
+  Environment.detect(config);
+});
 describe("Compile with disableDefaults flag", () => {
   it("should not add the optimizer when missing if disableDefaults is true", async () => {
-    // Load configuration from the fixture file
-    const config = Config.detect(
-      { workingDirectory: path.join(__dirname, "fixture/default-box") },
-      "./truffle-config.js"
-    );
-
-    // Environment.detect() so we get all the other config goodies
-    Environment.detect(config);
-
     //compile when optimizer is set to false
     const compilationWithOptimizer = await Compile.all(config);
 
     //get the bytecode for the `optimizer: false` case
-    const bytecodeOptimizer =
+    const bytecodeWithOptimizerSetting =
       compilationWithOptimizer.compilations[0].contracts[0].bytecode.bytes;
 
     //remove the optimizer completely from the settings
@@ -34,10 +36,42 @@ describe("Compile with disableDefaults flag", () => {
     const compilationWithoutOptimizer = await Compile.all(config);
 
     // Get the bytecode for the compiled contract
-    const bytecodeNoOptimizer =
+    const bytecodeWithDefaultsDisabled =
       compilationWithoutOptimizer.compilations[0].contracts[0].bytecode.bytes;
 
     // Verify that the bytecode is different
-    assert.notStrictEqual(bytecodeNoOptimizer, bytecodeOptimizer);
+    assert.notStrictEqual(
+      bytecodeWithDefaultsDisabled,
+      bytecodeWithOptimizerSetting
+    );
+  });
+
+  it("should add the optimizer when missing if disableDefaults is false", async () => {
+    //compile when optimizer is set to false
+    const compilationWithOptimizer = await Compile.all(config);
+
+    //get the bytecode for the `optimizer: false` case
+    const bytecodeWithOptimizerSetting =
+      compilationWithOptimizer.compilations[0].contracts[0].bytecode.bytes;
+
+    //remove the optimizer completely from the settings
+    config.compilers.solc.settings = {};
+
+    // Set disableDefaults flag to true in the configuration
+    // now Truffle should compile without any optimizer settings
+    config.compilers.solc.disableDefaults = false;
+
+    // Compile the contract
+    const compilationWithoutOptimizer = await Compile.all(config);
+
+    // Get the bytecode for the compiled contract
+    const bytecodeWithDefaultsEnabled =
+      compilationWithoutOptimizer.compilations[0].contracts[0].bytecode.bytes;
+
+    // Verify that the bytecode is different
+    assert.strictEqual(
+      bytecodeWithDefaultsEnabled,
+      bytecodeWithOptimizerSetting
+    );
   });
 });

--- a/packages/compile-solidity-tests/test/settings.ts
+++ b/packages/compile-solidity-tests/test/settings.ts
@@ -1,0 +1,43 @@
+import { assert } from "chai";
+import Config from "@truffle/config";
+import { Compile } from "@truffle/compile-solidity";
+import { describe, it } from "mocha";
+import path from "path";
+import { Environment } from "@truffle/environment";
+
+describe("Compile with disableDefaults flag", () => {
+  it("should not add the optimizer when missing if disableDefaults is true", async () => {
+    // Load configuration from the fixture file
+    const config = Config.detect(
+      { workingDirectory: path.join(__dirname, "fixture/default-box") },
+      "./truffle-config.js"
+    );
+
+    // Environment.detect() so we get all the other config goodies
+    Environment.detect(config);
+
+    //compile when optimizer is set to false
+    const compilationWithOptimizer = await Compile.all(config);
+
+    //get the bytecode for the `optimizer: false` case
+    const bytecodeOptimizer =
+      compilationWithOptimizer.compilations[0].contracts[0].bytecode.bytes;
+
+    //remove the optimizer completely from the settings
+    config.compilers.solc.settings = {};
+
+    // Set disableDefaults flag to true in the configuration
+    // now Truffle should compile without any optimizer settings
+    config.compilers.solc.disableDefaults = true;
+
+    // Compile the contract
+    const compilationWithoutOptimizer = await Compile.all(config);
+
+    // Get the bytecode for the compiled contract
+    const bytecodeNoOptimizer =
+      compilationWithoutOptimizer.compilations[0].contracts[0].bytecode.bytes;
+
+    // Verify that the bytecode is different
+    assert.notStrictEqual(bytecodeNoOptimizer, bytecodeOptimizer);
+  });
+});

--- a/packages/compile-solidity/src/index.ts
+++ b/packages/compile-solidity/src/index.ts
@@ -59,8 +59,16 @@ export const Compile = {
   // NOTE: this function does *not* transform the source path prefix to
   // "project:/" before passing to the compiler!
   async sources({ sources, options }: SourcesArgs) {
+    //this inserts optimizer settings
+    // TODO: do we need a deep copy here?
+    let originalSettings = options.compilers.solc.settings;
     options = Config.default().merge(options);
     options = normalizeOptions(options);
+    // if disableDefaults is set, we don't want to insert
+    // the default optimizer settings
+    if (options.compilers.solc.disableDefaults) {
+      options.compilers.solc.settings = originalSettings;
+    }
     //note: "solidity" here includes JSON as well!
     const [yulNames, solidityNames] = partition(Object.keys(sources), name =>
       name.endsWith(".yul")

--- a/packages/compile-solidity/src/index.ts
+++ b/packages/compile-solidity/src/index.ts
@@ -59,14 +59,9 @@ export const Compile = {
   // NOTE: this function does *not* transform the source path prefix to
   // "project:/" before passing to the compiler!
   async sources({ sources, options }: SourcesArgs) {
-    let originalSettings = options.compilers.solc.settings;
     options = Config.default().merge(options);
     options = normalizeOptions(options);
-    // if disableDefaults is set, we don't want to insert
-    // the default optimizer settings
-    if (options.compilers.solc.disableDefaults) {
-      options.compilers.solc.settings = originalSettings;
-    }
+
     //note: "solidity" here includes JSON as well!
     const [yulNames, solidityNames] = partition(Object.keys(sources), name =>
       name.endsWith(".yul")
@@ -146,14 +141,8 @@ export const Compile = {
       "resolver"
     ]);
 
-    let originalSettings = options.compilers.solc.settings;
     options = Config.default().merge(options);
     options = normalizeOptions(options);
-    // if disableDefaults is set, we don't want to insert
-    // the default optimizer settings
-    if (options.compilers.solc.disableDefaults) {
-      options.compilers.solc.settings = originalSettings;
-    }
 
     const supplier = new CompilerSupplier({
       events: options.events,

--- a/packages/compile-solidity/src/index.ts
+++ b/packages/compile-solidity/src/index.ts
@@ -59,8 +59,6 @@ export const Compile = {
   // NOTE: this function does *not* transform the source path prefix to
   // "project:/" before passing to the compiler!
   async sources({ sources, options }: SourcesArgs) {
-    //this inserts optimizer settings
-    // TODO: do we need a deep copy here?
     let originalSettings = options.compilers.solc.settings;
     options = Config.default().merge(options);
     options = normalizeOptions(options);

--- a/packages/compile-solidity/src/index.ts
+++ b/packages/compile-solidity/src/index.ts
@@ -148,8 +148,14 @@ export const Compile = {
       "resolver"
     ]);
 
+    let originalSettings = options.compilers.solc.settings;
     options = Config.default().merge(options);
     options = normalizeOptions(options);
+    // if disableDefaults is set, we don't want to insert
+    // the default optimizer settings
+    if (options.compilers.solc.disableDefaults) {
+      options.compilers.solc.settings = originalSettings;
+    }
 
     const supplier = new CompilerSupplier({
       events: options.events,

--- a/packages/compile-solidity/src/normalizeOptions.ts
+++ b/packages/compile-solidity/src/normalizeOptions.ts
@@ -12,6 +12,7 @@ export const normalizeOptions = (options: Config) => {
     options.compilers.solc.evmVersion;
 
   if (options.compilers.solc.disableDefaults) {
+    // if the user has disabled defaults, we don't want to set optimizer defaults; Solidity versions prior to 0.8.6 will produce different bytecodes if optimizer settings are missing vs. set to false; this matters for how Blockscout does verification
     options.compilers.solc.settings.optimizer =
       options.compilers.solc.settings.optimizer || {};
   } else {

--- a/packages/compile-solidity/src/normalizeOptions.ts
+++ b/packages/compile-solidity/src/normalizeOptions.ts
@@ -12,7 +12,8 @@ export const normalizeOptions = (options: Config) => {
     options.compilers.solc.evmVersion;
 
   if (options.compilers.solc.disableDefaults) {
-    options.compilers.solc.settings = options.compilers.solc.settings || {};
+    options.compilers.solc.settings.optimizer =
+      options.compilers.solc.settings.optimizer || {};
   } else {
     options.compilers.solc.settings.optimizer =
       options.compilers.solc.settings.optimizer ||

--- a/packages/compile-solidity/src/normalizeOptions.ts
+++ b/packages/compile-solidity/src/normalizeOptions.ts
@@ -10,10 +10,15 @@ export const normalizeOptions = (options: Config) => {
   options.compilers.solc.settings.evmVersion =
     options.compilers.solc.settings.evmVersion ||
     options.compilers.solc.evmVersion;
-  options.compilers.solc.settings.optimizer =
-    options.compilers.solc.settings.optimizer ||
-    options.compilers.solc.optimizer ||
-    {};
+
+  if (options.compilers.solc.disableDefaults) {
+    options.compilers.solc.settings = options.compilers.solc.settings || {};
+  } else {
+    options.compilers.solc.settings.optimizer =
+      options.compilers.solc.settings.optimizer ||
+      options.compilers.solc.optimizer ||
+      {};
+  }
 
   // Grandfather in old solc config
   if (options.solc) {

--- a/packages/config/src/configDefaults.ts
+++ b/packages/config/src/configDefaults.ts
@@ -70,7 +70,8 @@ export const getInitialConfig = ({
             runs: 200
           },
           remappings: []
-        }
+        },
+        disableDefaults: false
       },
       vyper: {
         settings: {}

--- a/packages/core/lib/commands/init/initSource/truffle-config.js
+++ b/packages/core/lib/commands/init/initSource/truffle-config.js
@@ -113,7 +113,8 @@ module.exports = {
       //    enabled: false,
       //    runs: 200
       //  },
-      //  evmVersion: "byzantium"
+      //  evmVersion: "byzantium",
+      //  disableDefaults: false, // Disable the default solc optimizations
       // }
     }
   },

--- a/packages/core/lib/commands/init/initSource/truffle-config.js
+++ b/packages/core/lib/commands/init/initSource/truffle-config.js
@@ -115,7 +115,10 @@ module.exports = {
       //  },
       //  evmVersion: "byzantium",
       // },
-      // disableDefaults: false, // Disable the default solc optimizations
+      // disableDefaults: false, // Disable the default solc optimizer settings; if true,
+      //                         // whatever setting is passed in settings.optimizer will be respected;
+      //                         // if false, the default when settings.optimizer is missing is
+      //                         // { enabled: false }.
     }
   },
 

--- a/packages/core/lib/commands/init/initSource/truffle-config.js
+++ b/packages/core/lib/commands/init/initSource/truffle-config.js
@@ -114,8 +114,8 @@ module.exports = {
       //    runs: 200
       //  },
       //  evmVersion: "byzantium",
-      //  disableDefaults: false, // Disable the default solc optimizations
-      // }
+      // },
+      // disableDefaults: false, // Disable the default solc optimizations
     }
   },
 


### PR DESCRIPTION
## PR description

This PR adds a `disableDefaults` field to `config.compilers.solc`. Additionally, it adds a check to the compile functions in `compile-solidity` to refrain from using the default  optimizer settings if `disableDefaults` is true. This is the first step toward Blockscout support in our source-fetcher. See [this issue](https://github.com/trufflesuite/truffle/issues/5441) for more information on why this is necessary.