### PR TITLE
Ensure resolver.resolve()'s type only needs 1 arg.

### DIFF
--- a/packages/resolver/lib/resolver.ts
+++ b/packages/resolver/lib/resolver.ts
@@ -70,7 +70,7 @@ export class Resolver {
 
   async resolve(
     importPath: string,
-    importedFrom: string,
+    importedFrom?: string,
     options: {
       compiler?: {
         name: string;


### PR DESCRIPTION
... since only the first argument is required and the others are optional, but the type incorrectly specifies that 2 arguments are required

This was raised [here](https://github.com/rkalis/truffle-plugin-verify/pull/196#discussion_r1123032692)