### PR TITLE
Fix @truffle/dashboard-hardhat-plugin's `package.json`

### DIFF
--- a/packages/dashboard-hardhat-plugin/package.json
+++ b/packages/dashboard-hardhat-plugin/package.json
@@ -2,7 +2,14 @@
   "name": "@truffle/dashboard-hardhat-plugin",
   "version": "0.1.0",
   "description": "Truffle Dashboard for Hardhat plugin",
-  "repository": "github:trufflesuite/dashboard-hardhat-plugin",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/truffle.git",
+    "directory": "packages/dashboard-hardhat-plugin"
+  },
+  "bugs": {
+    "url": "https://github.com/trufflesuite/truffle/issues"
+  },
   "author": "ConsenSys Software Inc",
   "license": "MIT",
   "main": "dist/src/index.js",

--- a/packages/dashboard-hardhat-plugin/package.json
+++ b/packages/dashboard-hardhat-plugin/package.json
@@ -32,6 +32,7 @@
   "files": [
     "dist/src/",
     "src/",
+    "assets/",
     "LICENSE",
     "README.md"
   ],


### PR DESCRIPTION
## PR description

- Ensure we specify `repository` and `bugs` the same way we do in our other packages
- Ensure we include the two README images in the `files`, so NPM has them to display on npmjs.com