### PR TITLE
Add the link to the License in README.md

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -59,4 +59,4 @@ A project by Consensys and [@tcoulter](https://github.com/tcoulter), and many co
 
 ### License
 
-MIT
+[MIT](./LICENSE)


### PR DESCRIPTION
## PR description

<!-- Enter PR description here -->

I add the link to the License in README.md: `[MIT](./LICENSE)`
It would be more convenient for users.