### PR TITLE
Update Sourcify and Etherscan fetchers w/Base Goerli & more

### DIFF
--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -88,7 +88,9 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
       "clover": "api.clvscan.com",
       "boba": "api.bobascan.com",
       "goerli-boba": "api-testnet.bobascan.com",
-      "gnosis": "api.gnosisscan.io"
+      "gnosis": "api.gnosisscan.io",
+      //etherscan does *not* support base mainnet?
+      "goerli-base": "api-goerli.basescan.org"
     };
 
   constructor(networkId: number, apiKey: string = "") {

--- a/packages/source-fetcher/lib/networks.ts
+++ b/packages/source-fetcher/lib/networks.ts
@@ -94,7 +94,10 @@ export const networkNamesById: { [id: number]: string } = {
   14: "flare",
   19: "songbird-flare",
   2048: "stratos", //not presently supported by either fetcher, but...
-  2047: "testnet-stratos"
+  2047: "testnet-stratos",
+  8453: "base", //not presently supported by either fetcher, but...
+  84531: "goerli-base",
+  641230: "bear"
   //I'm not including crystaleum as it has network ID different from chain ID
   //not including kekchain for the same reason
 };

--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -121,7 +121,10 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "flare",
     "songbird-flare",
     //sourcify does *not* support stratos mainnet?
-    "testnet-stratos"
+    "testnet-stratos",
+    //sourcify does *not* support base mainnet?
+    "goerli-base",
+    "bear"
     //I'm excluding crystaleum as it has network ID different from chain ID
     //excluding kekchain for the same reason
   ]);


### PR DESCRIPTION
A quick update to the fetchers while I'm away!

Etherscan added support for base Base Goerli (but *not* Base Mainnet), and Sourcify added support for the same and for Bear.  This PR adds those.

Contracts you can use for testing if you like:
1. Bear on Sourcify: 0x0f103813fa15CA19b6C4B46a0Afe99440b81d7C3
2. Base Goerli on Sourcify: 0x8F78b9c92a68DdF719849a40702cFBfa4EB60dD0
3. Base Goerli on Etherscan: 0xB7eD95bbE808A72C1175fb3845581616e29642B0

(Feel free to merge this one without me, obviously!)