### PR TITLE
Allow to override chai from the config

### DIFF
--- a/packages/test/src/Test.ts
+++ b/packages/test/src/Test.ts
@@ -320,7 +320,7 @@ export const Test = {
     global.interfaceAdapter = interfaceAdapter;
     // @ts-ignore
     global.web3 = web3;
-    const resolvedChai = config.chaiOverride ? config.chaiOverride : chai;
+    const resolvedChai = config.chai?.package ?? chai;
     // @ts-ignore
     global.assert = resolvedChai.assert;
     // @ts-ignore

--- a/packages/test/src/Test.ts
+++ b/packages/test/src/Test.ts
@@ -320,10 +320,11 @@ export const Test = {
     global.interfaceAdapter = interfaceAdapter;
     // @ts-ignore
     global.web3 = web3;
+    const resolvedChai = config.chaiOverride ? config.chaiOverride : chai;
     // @ts-ignore
-    global.assert = chai.assert;
+    global.assert = resolvedChai.assert;
     // @ts-ignore
-    global.expect = chai.expect;
+    global.expect = resolvedChai.expect;
     // @ts-ignore
     global.artifacts = {
       require: (importPath: string) => {


### PR DESCRIPTION
## PR description

Allow to override the chai instance from the config. This allows one to reduce the test boilerplate when chai plugins are used, e.g. this snippet could move to the config, instead of being repeated in every test:

```js
import chai from 'chai';
import chaiAsPromised from 'chai-as-promised';

chai.use(chaiAsPromised);

const { assert } = chai;
```

## Testing instructions

require chai from the config and point config's `chaiOverride` to it. No default value is offered as the default is undefined.

## Documentation

Trivial change, no docs required.

- [x] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.

## Breaking changes and new features

Non-breaking.

- [x] I have added any needed `breaking-change` and `new-feature` labels for the appropriate packages.
