### PR TITLE
Make @truffle/dashboard-hardhat-plugin automatically manage the Dashboard Hardhat network configuration (while still allowing customization)

### DIFF
--- a/packages/dashboard-hardhat-plugin/README.md
+++ b/packages/dashboard-hardhat-plugin/README.md
@@ -1,10 +1,18 @@
 # @truffle/dashboard-hardhat-plugin
 
-Enable decoded results when using
-[Truffle Dashboard](https://trufflesuite.com/docs/truffle/how-to/use-the-truffle-dashboard/)
-with your Hardhat projects.
+> No more private keys inside `.env` files! Truffle Dashboard lets you sign
+> messages with MetaMask and provides insights for better dapp development.
+> :lock:
 
-## What
+This plugin makes it easy to access all the features of
+[Truffle Dashboard](https://trufflesuite.com/docs/truffle/how-to/use-the-truffle-dashboard/),
+including better security and high-quality transaction decoding.
+
+## Summary
+
+This plugin automatically adds a `--network truffleDashboard` to your Hardhat
+project and tells Truffle Dashboard all the information it needs about your
+smart contracts.
 
 This plugin enables you to see decoded transaction information (both the
 function signature and the values of any arguments passed) when using
@@ -23,35 +31,39 @@ transactions with your browser-based wallet.
 
 You can install this plugin with `npm` (or `yarn`) by running:
 
-```bash
-npm i @truffle/dashboard-hardhat-plugin -D
+```console
+npm install --save-dev @truffle/dashboard-hardhat-plugin
 ```
 
-Beyond that, simply import the plugin in your `hardhat.config.js`:
+Then simply import the plugin in your `hardhat.config.ts`:
 
-```ts
+```typescript
 import "@truffle/dashboard-hardhat-plugin";
 ```
 
 ## Setup
 
-This extension assumes you have `truffle` installed (either globally or in a
-local project context). If not, you can install it with `npm i -g truffle`.
-Beyond this you'll be able to start Truffle Dashboard with `truffle dashboard`.
-For reference, more information on using the Truffle Dashboard can be found
+This extension assumes you have Truffle installed (either globally or in a local
+project context). If not, you can install it with `npm i -g truffle`. Beyond
+this you'll be able to start Truffle Dashboard with `truffle dashboard`. For
+reference, more information on using the Truffle Dashboard can be found
 [here](https://trufflesuite.com/docs/truffle/how-to/use-the-truffle-dashboard/).
 
 Alternatively, you can skip the installation and fetch (and run) it remotely
 with `npx truffle dashboard`.
 
-This plugin automatically tells Hardhat about the `"truffle-dashboard"` network,
-so you don't need to modify your `hardhat.config.ts` to get started! Just
-specify `--network truffle-dashboard` when running your usual Hardhat commands
-(e.g.
-`npx hardhat run ./scripts/deploy-contracts.ts --network truffle-dashboard`).
+This plugin automatically tells Hardhat about the `truffleDashboard` network, so
+you don't need to modify your `hardhat.config.ts` to get started. Just specify
+`--network truffleDashboard` when running your usual Hardhat commands (e.g.
+`npx hardhat run ./scripts/deploy-contracts.ts --network truffleDashboard`).
 This managed network will include the `url` property (default
 `"http://localhost:24012/rpc"`) and a few other sensible defaults for this
 workflow.
+
+**Note on request timeouts**: Signing transactions with MetaMask is slower than
+Hardhat computing signatures automatically. For this reason,
+@truffle/dashboard-hardhat-plugin disables request timeouts for the
+`truffleDashboard` network. See below if you'd like to change this behavior.
 
 ### Configuration
 
@@ -62,24 +74,25 @@ workflow.
 > reference documentation to learn more about this; this section pertains only
 > to configuring @truffle/dashboard-hardhat-plugin itself.
 
-To configure this plugin, add a `truffleDashboard` section to your Hardhat
-config. This namespace can contain the following fields (all are optional):
+To configure this plugin, add a `truffle` section to your Hardhat config. This
+namespace can contain the following fields (all are optional):
 
-- **`networkName`** _(default: `"truffle-dashboard"`)_: Specify the name of the
-  Truffle Dashboard network, e.g. via the `--network <...>` command-line option.
+- **`dashboardNetworkName`** _(default: `"truffleDashboard"`)_: Specify the name
+  of the Truffle Dashboard network, e.g. via the `--network <...>` command-line
+  option.
 
-- **`networkConfig`**: A subset of the usual Hardhat network configuration
-  settings.
+- **`dashboardNetworkConfig`**: A subset of the usual Hardhat network
+  configuration settings.
 
   You can use this to override managed network behavior for any fields
   documented by Hardhat's
   [JSON-RPC based networks](https://hardhat.org/hardhat-runner/docs/config#json-rpc-based-networks)
   reference **except** `chainId`, `from`, `accounts`, and `url`. (This plugin
-  supplies `url`, and the other three fields are meaningless in the Truffle
+  supplies `url`; the other three fields are meaningless in the Truffle
   Dashboard signing workflow.)
 
-  All `networkConfig` properties are optional. The following field has a
-  different default than what Hardhat normally provides:
+  All `dashboardNetworkConfig` properties are optional. The following field has
+  a different default than what Hardhat normally provides:
 
   - **`timeout`** _(default: `0`; i.e., no timeout)_: Hardhat's normal default
     value for this is `40000` (40 seconds)
@@ -89,8 +102,8 @@ config. This namespace can contain the following fields (all are optional):
 Assuming the above is all looking good, any subsequent compilations via
 `npx hardhat compile` will send the compiled artifacts to Truffle Dashboard.
 Subsequently, any deployments (or transactions via scripts) that target the
-`"truffle-dashboard"` network will now send them to Truffle Dashboard for
-signing via your browser-based wallet.
+`truffleDashboard` network will now send them to Truffle Dashboard for signing
+via your browser-based wallet.
 
 > Note you'll need to ensure your browser-based wallet is unlocked for
 > transactions to be received (otherwise you might see a
@@ -98,7 +111,7 @@ signing via your browser-based wallet.
 > command below).
 
 ```console
-npx hardhat run scripts/deploy.ts --network truffle-dashboard
+npx hardhat run scripts/deploy.ts --network truffleDashboard
 ```
 
 ![Truffle Dashboard](./assets/truffle-dashboard-screenshot.jpg)

--- a/packages/dashboard-hardhat-plugin/README.md
+++ b/packages/dashboard-hardhat-plugin/README.md
@@ -49,34 +49,27 @@ so you don't need to anything to your `hardhat.config.ts` to get started! Just
 specify `--network truffle-dashboard` when running your usual Hardhat commands
 (e.g.
 `npx hardhat run ./scripts/deploy-contracts.ts --network truffle-dashboard`).
+This managed network will include the `url` property (default
+`"http://localhost:24012/rpc"`) and a few other sensible defaults for this
+workflow.
 
 ### Configuration
 
-This plugin's defaults to injecting `url` and other network properties into your
-project's `networks` configuration automatically.
+> ℹ️ If you want to run Truffle Dashboard on a custom host or port, please
+> configure that inside a `truffle-config.js` file in your Hardhat project
+> directory. See the
+> [truffle-config.js#dashboard](https://trufflesuite.com/docs/truffle/reference/configuration/#dashboard)
+> reference documentation to learn more about this; this section pertains only
+> to configuring @truffle/dashboard-hardhat-plugin itself.
 
-This `url` property respects any local `truffle-config.js`, so if you'd like to
-run Truffle Dashboard on a custom `host` or `port`, please make that file inside
-your Hardhat project directory and see the
-[truffle-config.js#dashboard](https://trufflesuite.com/docs/truffle/reference/configuration/#dashboard)
-reference documentation to learn how to configure this. The rest of this section
-of this README covers how to configure @truffle/dashboard-hardhat-plugin itself.
-
-#### Configure managed network
-
-This plugin defines the `truffleDashboard` namespace within the Hardhat config.
-
-Please see the following configuration settings (all of these are optional):
-
-- **`disableManagedNetwork`** _(default: `false`)_: Ignore `networkConfig` and
-  don't add anything to `config.networks`. See below to learn how to
-  [turn off automatic network management](#turn-off-automatic-network-management).
+To configure this plugin, add a `truffleDashboard` section to your Hardhat
+config. This namespace can contain the following fields (all are optional):
 
 - **`networkName`** _(default: `"truffle-dashboard"`)_: Specify the name of the
   Truffle Dashboard network, e.g. via the `--network <...>` command-line option.
 
 - **`networkConfig`**: A subset of the usual Hardhat network configuration
-  settings. This field is ignored if `disableManagedNetwork` is set to `true`.
+  settings.
 
   You can use this to override managed network behavior for any fields
   documented by Hardhat's
@@ -90,42 +83,6 @@ Please see the following configuration settings (all of these are optional):
 
   - **`timeout`** _(default: `0`; i.e., no timeout)_: Hardhat's normal default
     value for this is `40000` (40 seconds)
-
-<h4 id="turn-off-automatic-network-management">Turn off automatic network management</h4>
-
-If you'd rather this plugin not get fancy, you might want to just define the
-network yourself.
-
-To do this, make sure you specify `disableManagedNetwork: true`. This plugin
-will need to read from your configuration, so if you give your network a name
-different than the default `"truffle-dashboard"`, you'll also need to specify
-`networkName`.
-
-See this example `hardhat.config.ts`:
-
-```typescript
-import { HardhatUserConfig } from "hardhat/config";
-import "@nomicfoundation/hardhat-toolbox";
-import "@truffle/dashboard-hardhat-plugin";
-
-const config: HardhatUserConfig = {
-  networks: {
-    // ... other networks ...
-
-    dashboard: {
-      url: "http://localhost:24012/rpc",
-      timeout: 0 // disable timeout to have enough time for MetaMask pop-ups
-    }
-  },
-
-  // ... rest of config ...
-
-  truffleDashboard: {
-    networkName: "dashboard",
-    disableManagedNetwork: true
-  }
-};
-```
 
 ## Usage
 

--- a/packages/dashboard-hardhat-plugin/README.md
+++ b/packages/dashboard-hardhat-plugin/README.md
@@ -76,7 +76,7 @@ If you don't like this plugin's default network configuration (is
 information on how to modify this.
 
 **Note on request timeouts**: Signing transactions with MetaMask is slower than
-Hardhat computing signatures automatically. For this reason,
+Hardhat at computing signatures automatically. For this reason,
 @truffle/dashboard-hardhat-plugin disables request timeouts for the
 `truffleDashboard` network. You can override this if you want the timeout anyway
 (see below!).

--- a/packages/dashboard-hardhat-plugin/README.md
+++ b/packages/dashboard-hardhat-plugin/README.md
@@ -1,12 +1,21 @@
 # @truffle/dashboard-hardhat-plugin
 
-Enable decoded results when using [Truffle Dashboard](https://trufflesuite.com/docs/truffle/how-to/use-the-truffle-dashboard/) with your Hardhat projects.
+Enable decoded results when using
+[Truffle Dashboard](https://trufflesuite.com/docs/truffle/how-to/use-the-truffle-dashboard/)
+with your Hardhat projects.
 
 ## What
 
-This plugin enables you to see decoded transaction information (both the function signature and the values of any arguments passed) when using [Truffle Dashboard](https://trufflesuite.com/docs/truffle/how-to/use-the-truffle-dashboard/) with your Hardhat projects.
+This plugin enables you to see decoded transaction information (both the
+function signature and the values of any arguments passed) when using
+[Truffle Dashboard](https://trufflesuite.com/docs/truffle/how-to/use-the-truffle-dashboard/)
+with your Hardhat projects.
 
-It extends `npx hardhat compile` by sending the compiled artifacts to Truffle Dashboard, which in turn uses [@truffle/decoder](https://trufflesuite.com/docs/truffle/codec/modules/_truffle_decoder.html) for decoding, giving you that extra degree of visibility before signing the transactions with your browser-based wallet.
+It extends `npx hardhat compile` by sending the compiled artifacts to Truffle
+Dashboard, which in turn uses
+[@truffle/decoder](https://trufflesuite.com/docs/truffle/codec/modules/_truffle_decoder.html)
+for decoding, giving you that extra degree of visibility before signing the
+transactions with your browser-based wallet.
 
 ![Before and after using the Truffle Dashboard Hardhat plugin](./assets/truffle-dashboard-before-after.jpg)
 
@@ -26,37 +35,120 @@ import "@truffle/dashboard-hardhat-plugin";
 
 ## Setup
 
-This extension assumes you have `truffle` installed (either globally or in a local project context). If not, you can install it with `npm i -g truffle`. Beyond this you'll be able to start Truffle Dashboard with `truffle dashboard`. For reference, more information on using the Truffle Dashboard can be found [here](https://trufflesuite.com/docs/truffle/how-to/use-the-truffle-dashboard/).
+This extension assumes you have `truffle` installed (either globally or in a
+local project context). If not, you can install it with `npm i -g truffle`.
+Beyond this you'll be able to start Truffle Dashboard with `truffle dashboard`.
+For reference, more information on using the Truffle Dashboard can be found
+[here](https://trufflesuite.com/docs/truffle/how-to/use-the-truffle-dashboard/).
 
-Alternatively, you can skip the installation and fetch (and run) it remotely with `npx truffle dashboard`.
+Alternatively, you can skip the installation and fetch (and run) it remotely
+with `npx truffle dashboard`.
+
+This plugin automatically tells Hardhat about the `"truffle-dashboard"` network,
+so you don't need to anything to your `hardhat.config.ts` to get started! Just
+specify `--network truffle-dashboard` when running your usual Hardhat commands
+(e.g.
+`npx hardhat run ./scripts/deploy-contracts.ts --network truffle-dashboard`).
 
 ### Configuration
 
-To make sure the plugin knows where to send the compiled artifacts (and subsequent transactions), you'll need to add a `dashboard` network (or whatever name you like) to your `hardhat.config.js`:
+This plugin's defaults to injecting `url` and other network properties into your
+project's `networks` configuration automatically.
 
-```ts
+This `url` property respects any local `truffle-config.js`, so if you'd like to
+run Truffle Dashboard on a custom `host` or `port`, please make that file inside
+your Hardhat project directory and see the
+[truffle-config.js#dashboard](https://trufflesuite.com/docs/truffle/reference/configuration/#dashboard)
+reference documentation to learn how to configure this. The rest of this section
+of this README covers how to configure @truffle/dashboard-hardhat-plugin itself.
+
+#### Configure managed network
+
+This plugin defines the `truffleDashboard` namespace within the Hardhat config.
+
+Please see the following configuration settings (all of these are optional):
+
+- **`disableManagedNetwork`** _(default: `false`)_: Ignore `networkConfig` and
+  don't add anything to `config.networks`. See below to learn how to
+  [turn off automatic network management](#turn-off-automatic-network-management).
+
+- **`networkName`** _(default: `"truffle-dashboard"`)_: Specify the name of the
+  Truffle Dashboard network, e.g. via the `--network <...>` command-line option.
+
+- **`networkConfig`**: A subset of the usual Hardhat network configuration
+  settings. This field is ignored if `disableManagedNetwork` is set to `true`.
+
+  You can use this to override managed network behavior for any fields
+  documented by Hardhat's
+  [JSON-RPC based networks](https://hardhat.org/hardhat-runner/docs/config#json-rpc-based-networks)
+  reference **except** `chainId`, `from`, `accounts`, and `url`. (This plugin
+  supplies `url`, and the other three fields are meaningless in the Truffle
+  Dashboard signing workflow.)
+
+  All `networkConfig` properties are optional. The following field has a
+  different default than what Hardhat normally provides:
+
+  - **`timeout`** _(default: `0`; i.e., no timeout)_: Hardhat's normal default
+    value for this is `40000` (40 seconds)
+
+<h4 id="turn-off-automatic-network-management">Turn off automatic network management</h4>
+
+If you'd rather this plugin not get fancy, you might want to just define the
+network yourself.
+
+To do this, make sure you specify `disableManagedNetwork: true`. This plugin
+will need to read from your configuration, so if you give your network a name
+different than the default `"truffle-dashboard"`, you'll also need to specify
+`networkName`.
+
+See this example `hardhat.config.ts`:
+
+```typescript
+import { HardhatUserConfig } from "hardhat/config";
+import "@nomicfoundation/hardhat-toolbox";
+import "@truffle/dashboard-hardhat-plugin";
+
 const config: HardhatUserConfig = {
   networks: {
+    // ... other networks ...
+
     dashboard: {
-      url: "http://localhost:24012/rpc"
+      url: "http://localhost:24012/rpc",
+      timeout: 0 // disable timeout to have enough time for MetaMask pop-ups
     }
   },
-  ...
-}
+
+  // ... rest of config ...
+
+  truffleDashboard: {
+    networkName: "dashboard",
+    disableManagedNetwork: true
+  }
+};
 ```
 
 ## Usage
 
-Assuming the above is all looking good, any subsequent compilations via `npx hardhat compile` will send the compiled artifacts to Truffle Dashboard. Subsequently, any deployments (or transactions via scripts) that target the `dashboard` network will now send them to Truffle Dashboard for signing via your browser-based wallet.
+Assuming the above is all looking good, any subsequent compilations via
+`npx hardhat compile` will send the compiled artifacts to Truffle Dashboard.
+Subsequently, any deployments (or transactions via scripts) that target the
+`"truffle-dashboard"` network will now send them to Truffle Dashboard for
+signing via your browser-based wallet.
 
-> Note you'll need to ensure your browser-based wallet is unlocked for transactions to be received (otherwise you might see a `Cannot read properties of null (reading 'sendTransaction')` when running the command below).
+> Note you'll need to ensure your browser-based wallet is unlocked for
+> transactions to be received (otherwise you might see a
+> `Cannot read properties of null (reading 'sendTransaction')` when running the
+> command below).
 
-```bash
-npx hardhat run scripts/deploy.ts --network dashboard
+```console
+npx hardhat run scripts/deploy.ts --network truffle-dashboard
 ```
 
 ![Truffle Dashboard](./assets/truffle-dashboard-screenshot.jpg)
 
 ## Support
 
-As always, if you have any questions or run into any issues, please reach out to us on our [Github Discussion board](https://github.com/orgs/trufflesuite/discussions) or on [Twitter](https://twitter.com/trufflesuite).
+As always, if you have any questions or run into any issues, please reach out to
+us on our
+[Github Discussion board](https://github.com/orgs/trufflesuite/discussions) or
+on [Twitter](https://twitter.com/trufflesuite).

--- a/packages/dashboard-hardhat-plugin/README.md
+++ b/packages/dashboard-hardhat-plugin/README.md
@@ -45,7 +45,7 @@ Alternatively, you can skip the installation and fetch (and run) it remotely
 with `npx truffle dashboard`.
 
 This plugin automatically tells Hardhat about the `"truffle-dashboard"` network,
-so you don't need to anything to your `hardhat.config.ts` to get started! Just
+so you don't need to modify your `hardhat.config.ts` to get started! Just
 specify `--network truffle-dashboard` when running your usual Hardhat commands
 (e.g.
 `npx hardhat run ./scripts/deploy-contracts.ts --network truffle-dashboard`).

--- a/packages/dashboard-hardhat-plugin/README.md
+++ b/packages/dashboard-hardhat-plugin/README.md
@@ -76,7 +76,7 @@ If you don't like this plugin's default network configuration (is
 information on how to modify this.
 
 **Note on request timeouts**: Signing transactions with MetaMask is slower than
-Hardhat at computing signatures automatically. For this reason,
+Hardhat's computing signatures automatically. For this reason,
 @truffle/dashboard-hardhat-plugin disables request timeouts for the
 `truffleDashboard` network. You can override this if you want the timeout anyway
 (see below!).

--- a/packages/dashboard-hardhat-plugin/README.md
+++ b/packages/dashboard-hardhat-plugin/README.md
@@ -14,18 +14,28 @@ This plugin automatically adds a `--network truffleDashboard` to your Hardhat
 project and tells Truffle Dashboard all the information it needs about your
 smart contracts.
 
-This plugin enables you to see decoded transaction information (both the
-function signature and the values of any arguments passed) when using
-[Truffle Dashboard](https://trufflesuite.com/docs/truffle/how-to/use-the-truffle-dashboard/)
-with your Hardhat projects.
-
-It extends `npx hardhat compile` by sending the compiled artifacts to Truffle
-Dashboard, which in turn uses
-[@truffle/decoder](https://trufflesuite.com/docs/truffle/codec/modules/_truffle_decoder.html)
-for decoding, giving you that extra degree of visibility before signing the
-transactions with your browser-based wallet.
+If you're used to Truffle Dashboard without this plugin, you'll notice that this
+plugin enables you to see decoded transactions (i.e., function name and all
+argument values). Compare before vs. after installing this plugin:
 
 ![Before and after using the Truffle Dashboard Hardhat plugin](./assets/truffle-dashboard-before-after.jpg)
+
+@truffle/dashboard-hardhat-plugin works by hooking into `npx hardhat compile`;
+every time you compile your project, this plugin takes the resulting build-info
+and sends it to Truffle Dashboard. Under the hood, Truffle Dashboard uses the
+advanced
+[@truffle/decoder](https://trufflesuite.com/docs/truffle/codec/modules/_truffle_decoder.html)
+library to decode your smart contract operations, giving you improved visibility
+before you issue a signature with your browser-based wallet.
+
+Besides just relaying project info to Truffle Dashboard, this plugin also
+eliminates the need to add a custom network to your config. Instead, it
+automatically adds the `truffleDashboard` network for you, so you don't need to
+note the JSON-RPC `url`, etc.
+
+Please see below if you're looking to customize network settings (like `timeout`
+or `httpHeaders`, if these are things you need). Otherwise, keep reading to
+learn how to get started. Enjoy!
 
 ## Installation
 
@@ -43,7 +53,7 @@ import "@truffle/dashboard-hardhat-plugin";
 
 ## Setup
 
-This extension assumes you have Truffle installed (either globally or in a local
+This plugin assumes you have Truffle installed (either globally or in a local
 project context). If not, you can install it with `npm i -g truffle`. Beyond
 this you'll be able to start Truffle Dashboard with `truffle dashboard`. For
 reference, more information on using the Truffle Dashboard can be found
@@ -53,29 +63,36 @@ Alternatively, you can skip the installation and fetch (and run) it remotely
 with `npx truffle dashboard`.
 
 This plugin automatically tells Hardhat about the `truffleDashboard` network, so
-you don't need to modify your `hardhat.config.ts` to get started. Just specify
+you don't need to add this network to your `hardhat.config.ts` yourself. This
+means you can get started quickly by just specifying
 `--network truffleDashboard` when running your usual Hardhat commands (e.g.
 `npx hardhat run ./scripts/deploy-contracts.ts --network truffleDashboard`).
-This managed network will include the `url` property (default
+This managed network includes the `url` property (default
 `"http://localhost:24012/rpc"`) and a few other sensible defaults for this
 workflow.
+
+If you don't like this plugin's default network configuration (is
+`--network truffleDashboard` too long?), then please see the next section for
+information on how to modify this.
 
 **Note on request timeouts**: Signing transactions with MetaMask is slower than
 Hardhat computing signatures automatically. For this reason,
 @truffle/dashboard-hardhat-plugin disables request timeouts for the
-`truffleDashboard` network. See below if you'd like to change this behavior.
+`truffleDashboard` network. You can override this if you want the timeout anyway
+(see below!).
 
 ### Configuration
 
-> ℹ️ If you want to run Truffle Dashboard on a custom host or port, please
-> configure that inside a `truffle-config.js` file in your Hardhat project
-> directory. See the
+> ℹ️ **This section is only about configuring this plugin.** If you want to
+> customize Truffle Dashboard itself (e.g., custom host or port), then please
+> ensure you have a `truffle-config.js` file with your preferred settings in
+> your Hardhat project directory. See the
 > [truffle-config.js#dashboard](https://trufflesuite.com/docs/truffle/reference/configuration/#dashboard)
-> reference documentation to learn more about this; this section pertains only
-> to configuring @truffle/dashboard-hardhat-plugin itself.
+> reference docs to learn more.
 
-To configure this plugin, add a `truffle` section to your Hardhat config. This
-namespace can contain the following fields (all are optional):
+To customize @truffle/dashboard-hardhat-plugin, add a `truffle` section to your
+Hardhat config. This namespace can contain the following fields (both are
+optional):
 
 - **`dashboardNetworkName`** _(default: `"truffleDashboard"`)_: Specify the name
   of the Truffle Dashboard network, e.g. via the `--network <...>` command-line
@@ -105,10 +122,10 @@ Subsequently, any deployments (or transactions via scripts) that target the
 `truffleDashboard` network will now send them to Truffle Dashboard for signing
 via your browser-based wallet.
 
-> Note you'll need to ensure your browser-based wallet is unlocked for
-> transactions to be received (otherwise you might see a
-> `Cannot read properties of null (reading 'sendTransaction')` when running the
-> command below).
+> :warning: **Please ensure your browser-based wallet is unlocked** for
+> transactions to be received. Otherwise, you might notice the error
+> `Cannot read properties of null (reading 'sendTransaction')` when running
+> Hardhat commands.
 
 ```console
 npx hardhat run scripts/deploy.ts --network truffleDashboard

--- a/packages/dashboard-hardhat-plugin/package.json
+++ b/packages/dashboard-hardhat-plugin/package.json
@@ -31,6 +31,7 @@
   },
   "files": [
     "dist/src/",
+    "dist/package.json",
     "src/",
     "assets/",
     "LICENSE",

--- a/packages/dashboard-hardhat-plugin/package.json
+++ b/packages/dashboard-hardhat-plugin/package.json
@@ -57,6 +57,7 @@
     "hardhat": "^2.0.0"
   },
   "dependencies": {
+    "@truffle/config": "^1.3.54",
     "@truffle/dashboard-message-bus-client": "^0.1.10",
     "@truffle/from-hardhat": "^0.2.5"
   },

--- a/packages/dashboard-hardhat-plugin/src/index.ts
+++ b/packages/dashboard-hardhat-plugin/src/index.ts
@@ -159,26 +159,8 @@ function getTruffleDashboardUserConfig(
       pluginName,
       `Manual network config disallowed.\n\n` +
         `This plugin manages your Truffle Dashboard network config for you,\n` +
-        `but your Hardhat config contains \`config.networks["${dashboardNetworkName}"]\`.\n\n` +
-        `Please remove this network and use \`config.truffle.dashboardNetworkConfig\`\n` +
-        `to override any particular network settings.\n\n` +
-        `For example, here's how your config might look with populated default values:\n` +
-        `    module.exports = {\n` +
-        `      networks: {\n` +
-        `        // ... networks config ...\n` +
-        `        // MUST NOT INCLUDE "${dashboardNetworkName}"\n` +
-        `      },\n` +
-        `\n` +
-        `      truffle: {\n` +
-        `        dashboardNetworkName: "${dashboardNetworkName}",\n` +
-        `        dashboardNetworkConfig: {\n` +
-        Object.entries(dashboardNetworkConfig)
-          .map(([name, value]) => `          ${name}: ${util.inspect(value)}`)
-          .join(",\n") +
-        `\n` +
-        `        }\n` +
-        `      }\n` +
-        `    }\n\n` +
+        `but your Hardhat config also contains \`config.networks["${dashboardNetworkName}"]\`.\n\n` +
+        `You can fix this error by removing \`config.networks["${dashboardNetworkName}"]\`.\n\n`  +
         `Please see the README for more details about how to configure this plugin:\n` +
         `  https://www.npmjs.com/package/@truffle/dashboard-hardhat-plugin`
     );

--- a/packages/dashboard-hardhat-plugin/src/index.ts
+++ b/packages/dashboard-hardhat-plugin/src/index.ts
@@ -17,7 +17,7 @@ import TruffleConfig from "@truffle/config";
 import "./type-extensions";
 
 const defaults = {
-  networkName: "truffle-dashboard",
+  networkName: "truffleDashboard",
   host: "localhost",
   port: 24012,
   gas: "auto",

--- a/packages/dashboard-hardhat-plugin/src/index.ts
+++ b/packages/dashboard-hardhat-plugin/src/index.ts
@@ -73,7 +73,7 @@ task("compile", "Compile with Truffle Dashboard support").setAction(
       await FromHardhat.expectHardhat();
 
       // Extract Truffle Dashboard host and port from complete Hardhat config
-      const { host, port } = new URL(
+      const { hostname: host, port } = new URL(
         env.config.truffleDashboard.networkConfig.url
       );
 

--- a/packages/dashboard-hardhat-plugin/src/index.ts
+++ b/packages/dashboard-hardhat-plugin/src/index.ts
@@ -1,61 +1,198 @@
-import { task } from "hardhat/config";
-import { ActionType } from "hardhat/types";
+import { name as pluginName } from "../package.json";
+import { URL } from "url";
+import { extendConfig, task } from "hardhat/config";
+import { HardhatPluginError } from "hardhat/plugins";
+import type {
+  HardhatConfig,
+  HardhatUserConfig,
+  HttpNetworkConfig,
+  TruffleDashboardNetworkConfigurableKeys
+} from "hardhat/types";
 
-const FromHardhat = require("@truffle/from-hardhat");
+import { DashboardMessageBusClient } from "@truffle/dashboard-message-bus-client";
+import * as FromHardhat from "@truffle/from-hardhat";
+import TruffleConfig from "@truffle/config";
 
-const {
-  DashboardMessageBusClient
-} = require("@truffle/dashboard-message-bus-client");
+import "./type-extensions";
 
-interface CompilationArgs {}
+const defaults = {
+  networkName: "truffle-dashboard",
+  disableManagedNetwork: false,
+  host: "localhost",
+  port: 24012,
+  gas: "auto",
+  gasPrice: "auto",
+  gasMultiplier: 1,
+  timeout: 0,
+  httpHeaders: {}
+} as const;
 
-const processCompilation: ActionType<CompilationArgs> = async (
-  taskArgs,
-  env,
-  runSuper
-) => {
-  // Run Hardhat compilation
-  const result = await runSuper();
+extendConfig((config: HardhatConfig, userConfig: HardhatUserConfig) => {
+  // Validate configuration and fill in defaults for missing user config fields
+  const {
+    networkName,
+    disableManagedNetwork,
+    networkConfig: networkUserConfig
+  } = getTruffleDashboardUserConfig(config, userConfig);
 
+  // Look for custom Truffle Dashboard configuration inside truffle-config.js
+  // (if it exists)
+  const { host, port } = detectDashboardSettings();
+
+  // Generate URL and supply other plugin invariants
+  // (e.g., accounts should always be "remote" for Truffle Dashboard)
+  //
+  // Note that if `disableManagedNetwork` is set to `true`, then the user's
+  // custom Truffle Dashboard network configuration will be used here instead
+  // of any plugin-supplied defaults or computed values.
+  const networkConfig: HttpNetworkConfig = {
+    url: `http://${host}:${port}/rpc`,
+    accounts: "remote",
+    ...networkUserConfig
+  };
+
+  // Capture completed configuration
+  config.truffleDashboard = {
+    networkName,
+    disableManagedNetwork,
+    networkConfig
+  };
+
+  // Add managed network unless disabled
+  if (!disableManagedNetwork) {
+    config.networks[networkName] = networkConfig;
+  }
+});
+
+task("compile", "Compile with Truffle Dashboard support").setAction(
+  async (taskArgs, env, runSuper) => {
+    // Run Hardhat compilation
+    const result = await runSuper();
+
+    try {
+      await FromHardhat.expectHardhat();
+
+      // Extract Truffle Dashboard host and port from complete Hardhat config
+      const { host, port } = new URL(
+        env.config.truffleDashboard.networkConfig.url
+      );
+
+      console.log("Preparing Truffle compilation");
+
+      // Prepare Truffle compilations
+      let compilations = await FromHardhat.prepareCompilations();
+
+      // Create Message Bus client
+      let messageBusClient = new DashboardMessageBusClient({
+        host,
+        port: parseInt(port)
+      });
+
+      console.log("Sending Truffle compilation to dashboard");
+
+      // Send Truffle compilations to dashboard
+      const publishLifecycle = await messageBusClient.publish({
+        type: "cli-event",
+        payload: {
+          label: "workflow-compile-result",
+          data: { compilations }
+        }
+      });
+      publishLifecycle.abandon();
+
+      console.log("Compilation successfully sent!");
+    } catch (hardhatError) {
+      console.warn(
+        "The Truffle Dashboard plugin failed to compile: ",
+        hardhatError
+      );
+    }
+
+    return result;
+  }
+);
+
+function detectDashboardSettings() {
+  let truffleConfig;
   try {
-    await FromHardhat.expectHardhat();
-
-    const dashboardConfig = {
-      host: "localhost",
-      port: 24012
+    truffleConfig = TruffleConfig.detect();
+  } catch {
+    truffleConfig = {
+      dashboard: {}
     };
+  }
 
-    console.log("Preparing Truffle compilation");
+  const { host = defaults.host, port = defaults.port } =
+    truffleConfig.dashboard;
 
-    // Prepare Truffle compilations
-    let compilations = await FromHardhat.prepareCompilations();
+  return {
+    host,
+    port
+  };
+}
 
-    // Create Message Bus client
-    let messageBusClient = new DashboardMessageBusClient(dashboardConfig);
+function getTruffleDashboardUserConfig(
+  config: HardhatConfig,
+  userConfig: HardhatUserConfig
+) {
+  const {
+    networkName = defaults.networkName,
+    disableManagedNetwork = defaults.disableManagedNetwork,
+    networkConfig: networkUserConfig = {}
+  } = userConfig.truffleDashboard || {};
 
-    console.log("Sending Truffle compilation to dashboard");
+  const networkIsDefinedExplicitly =
+    userConfig.networks && networkName in userConfig.networks;
 
-    // Send Truffle compilations to dashboard
-    const publishLifecycle = await messageBusClient.publish({
-      type: "cli-event",
-      payload: {
-        label: "workflow-compile-result",
-        data: { compilations }
-      }
-    });
-    publishLifecycle.abandon();
-
-    console.log("Compilation successfully sent!");
-  } catch (hardhatError) {
-    console.warn(
-      "The Truffle Dashboard plugin failed to compile: ",
-      hardhatError
+  if (!disableManagedNetwork && networkIsDefinedExplicitly) {
+    throw new HardhatPluginError(
+      pluginName,
+      `Duplicate network config.\n\n` +
+        `This plugin is configured to manage the Truffle Dashboard network\n` +
+        `inside \`config.networks["${networkName}"]\`, but a conflicting user\n` +
+        `configuration was found.\n\n` +
+        `Remove this network or set \`config.truffleDashboard.disableManagedNetwork\`\n` +
+        `to \`true\` if you'd like to configure the Truffle Dashboard network yourself.`
     );
   }
 
-  return result;
-};
+  if (disableManagedNetwork && !networkIsDefinedExplicitly) {
+    throw new HardhatPluginError(
+      pluginName,
+      `Missing network config.\n\n` +
+        `This plugin is configured to require a Truffle Dashboard network\n` +
+        `inside \`config.networks["${networkName}"]\`, but no such network was found.\n\n` +
+        `Please define this network or set \`config.truffleDashboard.disableManagedNetwork\`\n` +
+        `to \`false\` if you'd like this plugin to manage the network for you.\n\n` +
+        `If you configured the Truffle Dashboard network with a different name,\n` +
+        `then please specify \`config.truffleDashboard.networkName\` to match.`
+    );
+  }
 
-task("compile", "Compile with Truffle Dashboard support").setAction(
-  processCompilation
-);
+  const {
+    gas = defaults.gas,
+    gasPrice = defaults.gasPrice,
+    gasMultiplier = defaults.gasMultiplier,
+    timeout = defaults.timeout,
+    httpHeaders = defaults.httpHeaders
+  } = networkUserConfig;
+
+  // Populate config from either config.networks[networkName] or
+  // config.truffleDashboard.networkConfig based on whether this plugin is set
+  // to manage the network itself.
+  //
+  // (The above checks guarantee the presence of config.networks[networkName]
+  // if and only if disableManagedNetwork is true)
+  const networkConfig: Pick<
+    HttpNetworkConfig,
+    TruffleDashboardNetworkConfigurableKeys
+  > = disableManagedNetwork
+    ? (config.networks[networkName] as HttpNetworkConfig)
+    : { gas, gasPrice, gasMultiplier, timeout, httpHeaders };
+
+  return {
+    networkName,
+    disableManagedNetwork,
+    networkConfig
+  };
+}

--- a/packages/dashboard-hardhat-plugin/src/type-extensions.ts
+++ b/packages/dashboard-hardhat-plugin/src/type-extensions.ts
@@ -10,7 +10,6 @@ declare module "hardhat/types/config" {
 
   export interface HardhatUserConfig {
     truffleDashboard?: {
-      disableManagedNetwork?: boolean;
       networkName?: string;
       networkConfig?: Pick<
         HttpNetworkUserConfig,
@@ -21,7 +20,6 @@ declare module "hardhat/types/config" {
 
   export interface HardhatConfig {
     truffleDashboard: {
-      disableManagedNetwork: boolean;
       networkName: string;
       networkConfig: HttpNetworkConfig;
     };

--- a/packages/dashboard-hardhat-plugin/src/type-extensions.ts
+++ b/packages/dashboard-hardhat-plugin/src/type-extensions.ts
@@ -1,0 +1,29 @@
+import type { HttpNetworkConfig, HttpNetworkUserConfig } from "hardhat/types";
+import "hardhat/types/config";
+import "hardhat/types/runtime";
+
+declare module "hardhat/types/config" {
+  export type TruffleDashboardNetworkConfigurableKeys = Exclude<
+    keyof HttpNetworkUserConfig,
+    "chainId" | "from" | "url" | "accounts"
+  >;
+
+  export interface HardhatUserConfig {
+    truffleDashboard?: {
+      disableManagedNetwork?: boolean;
+      networkName?: string;
+      networkConfig?: Pick<
+        HttpNetworkUserConfig,
+        TruffleDashboardNetworkConfigurableKeys
+      >;
+    };
+  }
+
+  export interface HardhatConfig {
+    truffleDashboard: {
+      disableManagedNetwork: boolean;
+      networkName: string;
+      networkConfig: HttpNetworkConfig;
+    };
+  }
+}

--- a/packages/dashboard-hardhat-plugin/src/type-extensions.ts
+++ b/packages/dashboard-hardhat-plugin/src/type-extensions.ts
@@ -9,9 +9,9 @@ declare module "hardhat/types/config" {
   >;
 
   export interface HardhatUserConfig {
-    truffleDashboard?: {
-      networkName?: string;
-      networkConfig?: Pick<
+    truffle?: {
+      dashboardNetworkName?: string;
+      dashboardNetworkConfig?: Pick<
         HttpNetworkUserConfig,
         TruffleDashboardNetworkConfigurableKeys
       >;
@@ -19,9 +19,9 @@ declare module "hardhat/types/config" {
   }
 
   export interface HardhatConfig {
-    truffleDashboard: {
-      networkName: string;
-      networkConfig: HttpNetworkConfig;
+    truffle: {
+      dashboardNetworkName: string;
+      dashboardNetworkConfig: HttpNetworkConfig;
     };
   }
 }

--- a/packages/dashboard-hardhat-plugin/tsconfig.json
+++ b/packages/dashboard-hardhat-plugin/tsconfig.json
@@ -8,6 +8,7 @@
     "outDir": "./dist",
     "strict": true,
     "rootDirs": ["./src", "./test"],
+    "resolveJsonModule": true,
     "esModuleInterop": true,
     "skipLibCheck": true
   },


### PR DESCRIPTION
## PR description

Addresses #5958 

This PR modifies the @truffle/dashboard-hardhat-plugin to respect custom Dashboard configuration inside truffle-config.js.

At a high-level, this does a couple things:
- Automatically add the `truffleDashboard` network to the Hardhat networks configuration based on the Dashboard host/port configuration found via `TruffleConfig.detect()`
- Allow users to disable this network management if they want to configure this network themselves.
- Whichever way the network is configured, connect to the dashboard-message-bus with the configured host/port.

This adds a new `truffle` section to `hardhat.config.ts` with a few settings:
- `dashboardNetworkName` (default `"truffleDashboard"`), to specify the name of the Truffle Dashboard network
- `dashboardNetworkConfig` (default `{}`), to override network settings (such as `timeout`, etc.)

(This last field (`dashboardNetworkConfig`) is necessary because of reasons stated [here](https://github.com/trufflesuite/truffle/issues/5958#issuecomment-1474552333).)

## Testing instructions

### plugin setup

`yarn link`, for some reason, breaks the LSP with the new hardhat project. To get around this:
  1. `cd TRUFFLE_REPO/projects/dashboard-hardhat-plugin`
  1. `yarn pack`
  1. From inside Hardhat project, `yarn add full_path_to_generated_truffle-dashboard-hardhat-plugin-v0.1.1.tgz`
  
### test scenarios
~Set up this plugin via `yarn link` inside a Hardhat project and test the following cases:~
- `config.networks[dashboardNetworkName]` should throw an error if it exists
- `config.networks[dashboardNetworkName]` should connect to Dashboard with the settings obtained via truffle-config.js and via `config.truffle.dashboardNetworkConfig`

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.

## Breaking changes and new features

- [x] I have added any needed `breaking-change` and `new-feature` labels for the appropriate packages.
