### PR TITLE
Add support for Polygon ZkEVM to Etherscan fetcher

### DIFF
--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -68,6 +68,8 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
       "goerli-arbitrum": "api-goerli.arbiscan.io",
       "polygon": "api.polygonscan.com",
       "mumbai-polygon": "api-mumbai.polygonscan.com",
+      "zkevm-polygon": "api-zkevm.polygonscan.com",
+      "testnet-zkevm-polygon": "api-testnet-zkevm.polygonscan.com",
       "binance": "api.bscscan.com",
       "testnet-binance": "api-testnet.bscscan.com",
       "fantom": "api.ftmscan.com",

--- a/packages/source-fetcher/lib/networks.ts
+++ b/packages/source-fetcher/lib/networks.ts
@@ -17,6 +17,8 @@ export const networkNamesById: { [id: number]: string } = {
   421613: "goerli-arbitrum",
   137: "polygon",
   80001: "mumbai-polygon",
+  1101: "zkevm-polygon",
+  1442: "testnet-zkevm-polygon",
   100: "gnosis", //formerly known as xdai
   10200: "chiado-gnosis",
   300: "optimism-gnosis", //optimism on gnosis, not vice versa


### PR DESCRIPTION
Etherscan has added support for Polygon ZKEVM!  Both mainnet and testnet.  I've added support to the Etherscan fetcher for these.

As usual, I didn't actually bother testing this PR, but if you want to, you could try it with the following addresses:

* Polygon ZKEVM mainnet (network ID 1101): 0xee1727f5074E747716637e1776B7F7C7133f16b
* Polygon ZKEVM testnet (network ID 1442): 0x1dAC955a58f292b8d95c6EBc79d14D3E618971b2