### PR TITLE
fix source map with multibyte characters

### DIFF
--- a/packages/source-map-utils/index.js
+++ b/packages/source-map-utils/index.js
@@ -29,6 +29,9 @@ var SourceMapUtils = {
       }
 
       for (let i = 0; i < Buffer.from(character).length; i++) {
+        //because our character offsets here are in bytes, we need to
+        //pad out the line/column map as per the UTF-8 length of the
+        //characters so we're mapping *bytes* to line/columns
         mapping.push(loc);
       }
       column += 1;

--- a/packages/source-map-utils/index.js
+++ b/packages/source-map-utils/index.js
@@ -17,21 +17,25 @@ var SourceMapUtils = {
     var column = 0;
 
     source.forEach(function (character) {
+      let loc;
       if (character === "\n") {
         line += 1;
         column = -1;
 
-        mapping.push({
+        loc = {
           line: line,
           column: 0
-        });
+        };
       } else {
-        mapping.push({
+        loc = {
           line: line,
           column: column
-        });
+        };
       }
 
+      for (let i = 0; i < Buffer.from(character).length; i++) {
+        mapping.push(loc);
+      }
       column += 1;
     });
 

--- a/packages/source-map-utils/index.js
+++ b/packages/source-map-utils/index.js
@@ -17,7 +17,7 @@ var SourceMapUtils = {
     var column = 0;
 
     source.forEach(function (character) {
-      let loc;
+      let loc = { line, column };
       if (character === "\n") {
         line += 1;
         column = -1;
@@ -25,11 +25,6 @@ var SourceMapUtils = {
         loc = {
           line: line,
           column: 0
-        };
-      } else {
-        loc = {
-          line: line,
-          column: column
         };
       }
 


### PR DESCRIPTION
## PR description

Make `getCharacterOffsetToLineAndColumnMapping()` handle multibyte characters properly. Previously, it counts all characters as 1 byte.

Addresses https://github.com/trufflesuite/truffle/issues/5914

## Testing instructions

Run `truffle debug 0xfb6027725ccff056d8fe4065227fecd335fe123e8ab4da3a85a71377f7e9c6f9 --fetch-external`. With this bugfix, source mapping seems correct

### Steps
1. Start ganache in terminal 1
  ```console
   ganache --fork
  ```
2. In terminal 2 
  ```console
  truffle debug 0xfb6027725ccff056d8fe4065227fecd335fe123e8ab4da3a85a71377f7e9c6f9 --fetch-external --url http://localhost:8545
  ```
3.  In Truffle debugger
  ```console 
  debug(localhost:8545:0xfb602772...)> b AggregationRouterV5.sol:2849
  debug(localhost:8545:0xfb602772...)>  c
  ```
4. observe source misalignment w/ highlight
