### PR TITLE
Remove clover support from etherscan fetcher

### DIFF
--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -87,7 +87,6 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
       "donau-bttc": "api-testnet.bttcscan.com",
       "celo": "api.celoscan.io",
       "alfajores-celo": "api-alfajores.celoscan.io",
-      "clover": "api.clvscan.com",
       "boba": "api.bobascan.com",
       "goerli-boba": "api-testnet.bobascan.com",
       "gnosis": "api.gnosisscan.io",

--- a/packages/source-fetcher/lib/networks.ts
+++ b/packages/source-fetcher/lib/networks.ts
@@ -66,7 +66,7 @@ export const networkNamesById: { [id: number]: string } = {
   338: "testnet-cronos",
   199: "bttc",
   1029: "donau-bttc",
-  1024: "clover",
+  1024: "clover", //not presently supported by either fetcher, but formerly by etherscan
   44: "crab-darwinia",
   43: "pangolin-darwinia",
   9001: "evmos",


### PR DESCRIPTION
Etherscan has removed support for CLV.  The website https://clvscan.com/ still exists, but it's been converted to Blockscout.  Hopefully we'll have a Blockscout fetcher soon, but for now, I've just removed support from the Etherscan fetcher.