### PR TITLE
Consistify location of user ENS registry address setting

### DIFF
--- a/packages/config/src/configDefaults.ts
+++ b/packages/config/src/configDefaults.ts
@@ -336,6 +336,31 @@ export const configProps = ({
           "Don't set config.timeoutBlocks directly. Instead, set config.networks and then config.networks[<network name>].timeoutBlocks"
         );
       }
+    },
+    ensRegistry: {
+      get() {
+        let networkConfig;
+        try {
+          networkConfig = configObject.network_config;
+        } catch {
+          //if this throws, then there's no network config, whatever
+        }
+        //NOTE: in what follows I'm not just using || or ?? because I want
+        //null to be respected but undefined not to be
+        const address = [
+          //note that network-specific locations go first
+          networkConfig?.registry?.address,
+          networkConfig?.registryAddress,
+          configObject.ens?.registry?.address,
+          configObject.ens?.registryAddress
+        ].find(x => x !== undefined);
+        return { address };
+      },
+      set() {
+        throw new Error(
+          "Don't set config.ensRegistry directly. Instead, set config.ens.registry, or config.ens.registryAddress, or config.networks[<network name>].registry, or config.networks[<network name>].registryAddress."
+        );
+      }
     }
   };
 };

--- a/packages/config/src/configDefaults.ts
+++ b/packages/config/src/configDefaults.ts
@@ -358,7 +358,7 @@ export const configProps = ({
       },
       set() {
         throw new Error(
-          "Don't set config.ensRegistry directly. Instead, set config.ens.registry, or config.ens.registryAddress, or config.networks[<network name>].registry, or config.networks[<network name>].registryAddress."
+          "Don't set config.ensRegistry directly. Instead, set config.networks[<network name>].registry, or config.networks[<network name>].registryAddress, or config.ens.registry, or config.ens.registryAddress."
         );
       }
     }

--- a/packages/contract/lib/utils/ens.js
+++ b/packages/contract/lib/utils/ens.js
@@ -1,3 +1,4 @@
+const debug = require("debug")("contract:utils:ens");
 const { default: ENSJS, getEnsAddress } = require("@ensdomains/ensjs");
 const { isAddress } = require("web3-utils");
 
@@ -10,6 +11,8 @@ module.exports = {
     web3,
     networkId
   }) {
+    //note that registryAddress here is for a user-supplied registry address
+    //if none is supplied this will be undefined, and we'll apply a default later
     const { registryAddress } = ens;
     let args;
     if (inputArgs.length && methodABI) {
@@ -38,7 +41,7 @@ module.exports = {
   getNewENSJS: function ({ provider, registryAddress, networkId }) {
     return new ENSJS({
       provider,
-      ensAddress: registryAddress || getEnsAddress(networkId)
+      ensAddress: registryAddress ?? getEnsAddress(networkId)
     });
   },
 
@@ -115,7 +118,7 @@ module.exports = {
     }
     if (inputParams.accessList && Array.isArray(inputParams.accessList)) {
       const newAccessList = await Promise.all(
-        inputParams.accessList.map(async (entry) => {
+        inputParams.accessList.map(async entry => {
           if (entry && entry.address && !isAddress(entry.address)) {
             const newAddress = await this.resolveNameToAddress({
               name: entry.address,

--- a/packages/deployer/index.js
+++ b/packages/deployer/index.js
@@ -18,11 +18,8 @@ class Deployer extends Deployment {
     this.provider = options.provider;
     this.known_contracts = {};
     if (options.ens && options.ens.enabled) {
-      options.ens.registryAddress =
-        this.networks[this.network].registryAddress ??
-        this.networks[this.network].registry?.address ??
-        options.ens.registryAddress ??
-        options.ens.registry?.address;
+      //HACK: use getter to get what we want and put it where we want
+      options.ens.registryAddress = options.ensRegistry.address;
       this.ens = new ENS({
         provider: options.provider,
         networkId: options.network_id,

--- a/packages/deployer/index.js
+++ b/packages/deployer/index.js
@@ -18,9 +18,11 @@ class Deployer extends Deployment {
     this.provider = options.provider;
     this.known_contracts = {};
     if (options.ens && options.ens.enabled) {
-      options.ens.registryAddress = this.networks[this.network].registry
-        ? this.networks[this.network].registry.address
-        : null;
+      options.ens.registryAddress =
+        this.networks[this.network].registryAddress ??
+        this.networks[this.network].registry?.address ??
+        options.ens.registryAddress ??
+        options.ens.registry?.address;
       this.ens = new ENS({
         provider: options.provider,
         networkId: options.network_id,

--- a/packages/deployer/test/ens.js
+++ b/packages/deployer/test/ens.js
@@ -3,6 +3,8 @@ const { sha3 } = Web3.utils;
 const assert = require("assert");
 const Ganache = require("ganache");
 const ENS = require("../ens");
+const Deployer = require("..");
+const Config = require("@truffle/config");
 const sinon = require("sinon");
 const ENSJS = require("@ensdomains/ensjs").default;
 
@@ -166,6 +168,102 @@ describe("ENS class", () => {
       const owner1 = await ensjs.name("name").getOwner();
       const owner2 = await ensjs.name("test.name").getOwner();
       assert(owner1 === fromAddress && owner1 === owner2);
+    });
+  });
+
+  describe("User-specified registries", function () {
+    it("Allows user-set registry address in any of the valid places", function () {
+      const registryAddress = "0x0123456789012345678901234567890123456789";
+      let config = Config.default().merge({
+        ens: {
+          enabled: true,
+          registryAddress
+        },
+        networks: {
+          myNetwork: {
+            host: "127.0.0.1",
+            port: 7545,
+            network_id: "*"
+          }
+        },
+        network: "myNetwork"
+      });
+      let deployer = new Deployer(config);
+      assert.equal(deployer.ens.ens.registryAddress, registryAddress);
+      config = Config.default().merge({
+        ens: {
+          enabled: true,
+          registry: {
+            address: registryAddress
+          }
+        },
+        networks: {
+          myNetwork: {
+            host: "127.0.0.1",
+            port: 7545,
+            network_id: "*"
+          }
+        },
+        network: "myNetwork"
+      });
+      deployer = new Deployer(config);
+      assert.equal(deployer.ens.ens.registryAddress, registryAddress);
+      config = Config.default().merge({
+        ens: {
+          enabled: true
+        },
+        networks: {
+          myNetwork: {
+            host: "127.0.0.1",
+            port: 7545,
+            network_id: "*",
+            registryAddress
+          }
+        },
+        network: "myNetwork"
+      });
+      deployer = new Deployer(config);
+      assert.equal(deployer.ens.ens.registryAddress, registryAddress);
+      config = Config.default().merge({
+        ens: {
+          enabled: true
+        },
+        networks: {
+          myNetwork: {
+            host: "127.0.0.1",
+            port: 7545,
+            network_id: "*",
+            registry: {
+              address: registryAddress
+            }
+          }
+        },
+        network: "myNetwork"
+      });
+      deployer = new Deployer(config);
+      assert.equal(deployer.ens.ens.registryAddress, registryAddress);
+    });
+
+    it("Prefers network-specific registries", function () {
+      const registryAddress = "0x0123456789012345678901234567890123456789";
+      const fakeRegistryAddress = "0x9876543210987654321098765432109876543210";
+      const config = Config.default().merge({
+        ens: {
+          enabled: true,
+          registryAddress: fakeRegistryAddress
+        },
+        networks: {
+          myNetwork: {
+            host: "127.0.0.1",
+            port: 7545,
+            network_id: "*",
+            registryAddress
+          }
+        },
+        network: "myNetwork"
+      });
+      const deployer = new Deployer(config);
+      assert.equal(deployer.ens.ens.registryAddress, registryAddress);
     });
   });
 });

--- a/packages/provisioner/src/index.ts
+++ b/packages/provisioner/src/index.ts
@@ -24,12 +24,8 @@ const provision = (contractAbstraction: any, truffleConfig: TruffleConfig) => {
   }
 
   contractAbstraction.ens = truffleConfig.ens;
-  //HACK
-  contractAbstraction.ens.registryAddress =
-    truffleConfig.networks[truffleConfig.network]?.registryAddress ??
-    truffleConfig.networks[truffleConfig.network]?.registry?.address ??
-    truffleConfig.ens.registryAddress ??
-    truffleConfig.ens.registry?.address;
+  //HACK: use getter to get what we want and put it where we want
+  contractAbstraction.ens.registryAddress = truffleConfig.ensRegistry.address;
 
   [
     "from",

--- a/packages/provisioner/src/index.ts
+++ b/packages/provisioner/src/index.ts
@@ -26,8 +26,8 @@ const provision = (contractAbstraction: any, truffleConfig: TruffleConfig) => {
   contractAbstraction.ens = truffleConfig.ens;
   //HACK
   contractAbstraction.ens.registryAddress =
-    truffleConfig.network_config.registryAddress ??
-    truffleConfig.network_config.registry?.address ??
+    truffleConfig.networks[truffleConfig.network]?.registryAddress ??
+    truffleConfig.networks[truffleConfig.network]?.registry?.address ??
     truffleConfig.ens.registryAddress ??
     truffleConfig.ens.registry?.address;
 

--- a/packages/provisioner/src/index.ts
+++ b/packages/provisioner/src/index.ts
@@ -16,12 +16,20 @@ const provision = (contractAbstraction: any, truffleConfig: TruffleConfig) => {
     // this is a workaround to allow users to opt out of the block polling that
     // web3 performs when we listen for confirmations which causes problems in testing
     if (truffleConfig.networks[truffleConfig.network]) {
-      const {disableConfirmationListener} = truffleConfig.networks[truffleConfig.network];
-      contractAbstraction.disableConfirmationListener = disableConfirmationListener;
+      const { disableConfirmationListener } =
+        truffleConfig.networks[truffleConfig.network];
+      contractAbstraction.disableConfirmationListener =
+        disableConfirmationListener;
     }
   }
 
   contractAbstraction.ens = truffleConfig.ens;
+  //HACK
+  contractAbstraction.ens.registryAddress =
+    truffleConfig.network_config.registryAddress ??
+    truffleConfig.network_config.registry?.address ??
+    truffleConfig.ens.registryAddress ??
+    truffleConfig.ens.registry?.address;
 
   [
     "from",


### PR DESCRIPTION
## PR description

This PR addresses #5997. I'm not entirely happy with this one, but, well, I figured I ought to put it up as it is and we can iron out the problems in review.

Basically, I altered both Truffle Contract and Truffle Deployer to check 4 places for the ens registry address:
1. `config.network_config.registryAddress`
2. `config.network_config.registry.address`
3. `config.ens.registryAddress`
4. `config.ens.registry.address`

Note that specific network configs are checked before the overall ENS config, so that a specific network config can override the overall ENS config.

Now I say I altered Truffle Contract, but actually I didn't -- the easiest place to make these changes was actually the provisioner, rather than Contract itself.  Not sure if that's appropriate, but I didn't want to deal with the complication of doing it a different way.

I say I'm not entirely happy with this one, and there are two reasons for that:

1. Right now, since values are just combined with `??`, if you set `config.ens.registryAddress`, it's not possible to, say, set an explicit `null` in a network config to say that you shouldn't use the global registry for that specific network.  I can imagine people might want this in `deployer`.  So likely only `undefined` should defer to the next one, rather than `null`.
2. This PR is repeating the same code twice -- and if we add similar code to #5895 as @gnidan has suggested, that'll make 3 copies.  Moreover, if we account for point (1) just above, the code will get more complicated in all these locations.  That suggests it should be factored.  The question then is, where should such the factored version live?  One possibility would be to add a getter for this in `config` like we have for various other properties of the config; it could be called `config.ensRegistryAddress` or something (`config.networkRegistryAddress`? IDK).  The naming's a little ugly, but it seems probably better than the alternative?

Anyway, let me know what you think and what changes should be made to this.

## Testing instructions

I added tests to `deployer` to test the code changes there.  I didn't really directly test the `provisioner` changes, hm, maybe I should go back and do that... (adding tests there seemed pretty messy)