### PR TITLE
Native loading strategy to support TRUFFLE_NATIVE_SOLC_PATH

### DIFF
--- a/packages/compile-solidity/src/compilerSupplier/loadingStrategies/Native.ts
+++ b/packages/compile-solidity/src/compilerSupplier/loadingStrategies/Native.ts
@@ -5,7 +5,7 @@ const { NoVersionError } = require("../errors");
 export class Native {
   load() {
     const versionString = this.validateAndGetSolcVersion();
-    const command = "solc --standard-json";
+    const command = (process.env.TRUFFLE_NATIVE_SOLC_PATH || "solc") + " --standard-json";
     const maxBuffer = 1024 * 1024 * 10;
 
     try {


### PR DESCRIPTION
## PR description

Related to https://github.com/trufflesuite/truffle/issues/4490

## Testing instructions

Truffle compile to support the usage of process environment `TRUFFLE_NATIVE_SOLC_PATH` when `compilers.solc.version` is "native".

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.

## Breaking changes and new features

- [ ] I have added any needed `breaking-change` and `new-feature` labels for the appropriate packages.
