### PR TITLE
Increase maxBuffer to 50MB when compiling using native compiler

### DIFF
--- a/packages/compile-solidity/src/compilerSupplier/loadingStrategies/Native.ts
+++ b/packages/compile-solidity/src/compilerSupplier/loadingStrategies/Native.ts
@@ -6,7 +6,7 @@ export class Native {
   load() {
     const versionString = this.validateAndGetSolcVersion();
     const command = "solc --standard-json";
-    const maxBuffer = 1024 * 1024 * 10;
+    const maxBuffer = 1024 * 1024 * 50;
 
     try {
       return {


### PR DESCRIPTION
## PR description

Same issue as already tackled in https://github.com/trufflesuite/truffle/pull/3002, but which keeps getting up for more complex projects. Also see https://github.com/trufflesuite/truffle/issues/4499

## Testing instructions

I only can tell how to reproduce the issue before the change:
```
git clone https://github.com/superfluid-finance/protocol-monorepo
cd protocol-monorepo
yarn install
cd packages/ethereum-contracts
sed -i 's/version: "0.8.19",/version: "native",/g' truffle-config.js
npx truffle compile
```

You need to have solc version 0.8.19 in PATH.
