### PR TITLE
Add compatibility flag to ResultInspector for when Maps can't be inspected

### DIFF
--- a/packages/codec/lib/export.ts
+++ b/packages/codec/lib/export.ts
@@ -18,10 +18,12 @@ import {
   unsafeNativize,
   unsafeNativizeVariables,
   InspectOptions,
+  ResultInspectorOptions,
   nativizeAccessList
 } from "@truffle/codec/format/utils/inspect";
 export {
   ResultInspector,
+  ResultInspectorOptions,
   unsafeNativize,
   unsafeNativizeVariables,
   nativizeAccessList
@@ -297,9 +299,11 @@ function ethersCompatibleNativizeEventArgs(
  */
 export class CalldataDecodingInspector {
   decoding: CalldataDecoding;
+  options: ResultInspectorOptions;
 
-  constructor(decoding: CalldataDecoding) {
+  constructor(decoding: CalldataDecoding, options?: ResultInspectorOptions) {
     this.decoding = decoding;
+    this.options = options || {};
   }
   /**
    * @dev non-standard alternative interface name used by browser-util-inspect
@@ -385,7 +389,10 @@ export class CalldataDecodingInspector {
         } else {
           return `Sent raw data to ${
             this.decoding.class.typeName
-          }: ${util.inspect(new ResultInspector(codecValue), options)}`;
+          }: ${util.inspect(
+            new ResultInspector(codecValue, this.options),
+            options
+          )}`;
         }
       case "unknown":
         return "Receiving contract could not be identified.";
@@ -435,8 +442,10 @@ export function containsDeliberateReadError(
  */
 export class LogDecodingInspector {
   decoding: LogDecoding;
-  constructor(decoding: LogDecoding) {
+  options: ResultInspectorOptions;
+  constructor(decoding: LogDecoding, options?: ResultInspectorOptions) {
     this.decoding = decoding;
+    this.options = options || {};
   }
   /**
    * @dev non-standard alternative interface name used by browser-util-inspect
@@ -470,8 +479,10 @@ export class LogDecodingInspector {
  */
 export class ReturndataDecodingInspector {
   decoding: ReturndataDecoding;
-  constructor(decoding: ReturndataDecoding) {
+  options: ResultInspectorOptions;
+  constructor(decoding: ReturndataDecoding, options?: ResultInspectorOptions) {
     this.decoding = decoding;
+    this.options = options || {};
   }
   /**
    * @dev non-standard alternative interface name used by browser-util-inspect
@@ -502,7 +513,7 @@ export class ReturndataDecodingInspector {
           }
         };
         const dataString = util.inspect(
-          new ResultInspector(codecValue),
+          new ResultInspector(codecValue, this.options),
           options
         );
         return `Returned raw data: ${dataString}`;
@@ -538,7 +549,10 @@ export class ReturndataDecodingInspector {
             (value, index) => {
               const prefix = paddedPrefixes[index];
               const formatted = indentExcludingFirstLine(
-                util.inspect(new ResultInspector(value.value), options),
+                util.inspect(
+                  new ResultInspector(value.value, this.options),
+                  options
+                ),
                 maxLength
               );
               return prefix + formatted;
@@ -588,7 +602,8 @@ export function formatFunctionLike(
   values: AbiArgument[],
   options: InspectOptions,
   suppressType: boolean = false,
-  indent: number = 2 //for use by debug-utils
+  indent: number = 2, //for use by debug-utils
+  inspectorOptions?: ResultInspectorOptions
 ): string {
   if (values.length === 0) {
     return `${header}()`;
@@ -597,7 +612,10 @@ export function formatFunctionLike(
     const namePrefix = name ? `${name}: ` : "";
     const indexedPrefix = indexed ? "<indexed> " : "";
     const prefix = namePrefix + indexedPrefix;
-    const displayValue = util.inspect(new ResultInspector(value), options);
+    const displayValue = util.inspect(
+      new ResultInspector(value, inspectorOptions),
+      options
+    );
     const typeString = suppressType
       ? ""
       : ` (type: ${Format.Types.typeStringWithoutLocation(value.type)})`;
@@ -620,7 +638,8 @@ function formatMulticall(
   decodings: (CalldataDecoding | null)[],
   options: InspectOptions,
   additionalParameterName?: string,
-  additionalParameterValue?: string
+  additionalParameterValue?: string,
+  inspectorOptions?: ResultInspectorOptions
 ): string {
   if (decodings.length === 0) {
     return `${fullName}()`;
@@ -630,7 +649,10 @@ function formatMulticall(
     const formattedDecoding =
       decoding === null
         ? "<decoding error>"
-        : util.inspect(new CalldataDecodingInspector(decoding), options);
+        : util.inspect(
+            new CalldataDecodingInspector(decoding, inspectorOptions),
+            options
+          );
     return formattedDecoding + (index < decodings.length - 1 ? "," : "");
   });
   if (additionalParameterName) {
@@ -649,7 +671,8 @@ function formatAggregate(
   calls: CallInterpretationInfo[],
   options: InspectOptions,
   additionalParameterName?: string,
-  additionalParameterValue?: string
+  additionalParameterValue?: string,
+  inspectorOptions?: ResultInspectorOptions
 ): string {
   if (calls.length === 0) {
     return `${fullName}()`;
@@ -660,7 +683,10 @@ function formatAggregate(
       decoding === null
         ? "<decoding error>"
         : util
-            .inspect(new CalldataDecodingInspector(decoding), options)
+            .inspect(
+              new CalldataDecodingInspector(decoding, inspectorOptions),
+              options
+            )
             .replace(".", `(${options.stylize(address, "number")}).`); //HACK: splice in the address
     return formattedCall + (index < calls.length - 1 ? "," : "");
   });

--- a/packages/codec/lib/format/utils/inspect.ts
+++ b/packages/codec/lib/format/utils/inspect.ts
@@ -160,15 +160,16 @@ export class ResultInspector {
             } else {
               //compatibility case
               return util.inspect(
-                Object.fromEntries(
-                  (<Format.Values.MappingValue>this.result).value.map(
-                    ({ key, value }) => [
-                      util.inspect(
+                Object.assign(
+                  {},
+                  ...(<Format.Values.MappingValue>this.result).value.map(
+                    ({ key, value }) => ({
+                      //need to stringify key
+                      [util.inspect(
                         new ResultInspector(key, this.options),
                         options
-                      ), //need to stringify key
-                      new ResultInspector(value, this.options)
-                    ]
+                      )]: new ResultInspector(value, this.options)
+                    })
                   )
                 ),
                 options

--- a/packages/codec/lib/format/utils/inspect.ts
+++ b/packages/codec/lib/format/utils/inspect.ts
@@ -23,6 +23,15 @@ function cleanStylize(options: InspectOptions): InspectOptions {
   return clonedOptions;
 }
 
+export interface ResultInspectorOptions {
+  /**
+   * This flag, if set, causes mappings to be rendered via objects
+   * rather than Maps.  This is intended for compatibility and not
+   * recommended for normal use.
+   */
+  renderMappingsViaObjects?: boolean;
+}
+
 /**
  * This class is meant to be used with Node's
  * [util.inspect()](https://nodejs.org/api/util.html#util_util_inspect_object_options)
@@ -54,8 +63,10 @@ function cleanStylize(options: InspectOptions): InspectOptions {
  */
 export class ResultInspector {
   result: Format.Values.Result;
-  constructor(result: Format.Values.Result) {
+  options: ResultInspectorOptions;
+  constructor(result: Format.Values.Result, options?: ResultInspectorOptions) {
     this.result = result;
+    this.options = options || {};
   }
   /**
    * @dev non-standard alternative interface name used by browser-util-inspect
@@ -126,22 +137,43 @@ export class ResultInspector {
               return formatCircular(coercedResult.reference, options);
             }
             return util.inspect(
-              coercedResult.value.map(element => new ResultInspector(element)),
+              coercedResult.value.map(
+                element => new ResultInspector(element, this.options)
+              ),
               options
             );
           }
           case "mapping":
-            return util.inspect(
-              new Map(
-                (<Format.Values.MappingValue>this.result).value.map(
-                  ({ key, value }) => [
-                    new ResultInspector(key),
-                    new ResultInspector(value)
-                  ]
-                )
-              ),
-              options
-            );
+            if (!this.options.renderMappingsViaObjects) {
+              //normal case
+              return util.inspect(
+                new Map(
+                  (<Format.Values.MappingValue>this.result).value.map(
+                    ({ key, value }) => [
+                      new ResultInspector(key, this.options),
+                      new ResultInspector(value, this.options)
+                    ]
+                  )
+                ),
+                options
+              );
+            } else {
+              //compatibility case
+              return util.inspect(
+                Object.fromEntries(
+                  (<Format.Values.MappingValue>this.result).value.map(
+                    ({ key, value }) => [
+                      util.inspect(
+                        new ResultInspector(key, this.options),
+                        options
+                      ), //need to stringify key
+                      new ResultInspector(value, this.options)
+                    ]
+                  )
+                ),
+                options
+              );
+            }
           case "struct": {
             let coercedResult = <Format.Values.StructValue>this.result;
             if (coercedResult.reference !== undefined) {
@@ -151,7 +183,7 @@ export class ResultInspector {
               Object.assign(
                 {},
                 ...coercedResult.value.map(({ name, value }) => ({
-                  [name]: new ResultInspector(value)
+                  [name]: new ResultInspector(value, this.options)
                 }))
               ),
               options
@@ -165,7 +197,7 @@ export class ResultInspector {
               this.result
             );
             const inspectOfUnderlying = util.inspect(
-              new ResultInspector(coercedResult.value),
+              new ResultInspector(coercedResult.value, this.options),
               options
             );
             return `${typeName}.wrap(${inspectOfUnderlying})`; //note only the underlying part is stylized
@@ -180,7 +212,7 @@ export class ResultInspector {
                 Object.assign(
                   {},
                   ...coercedResult.value.map(({ name, value }) => ({
-                    [name]: new ResultInspector(value)
+                    [name]: new ResultInspector(value, this.options)
                   }))
                 ),
                 options
@@ -188,7 +220,7 @@ export class ResultInspector {
             } else {
               return util.inspect(
                 coercedResult.value.map(
-                  ({ value }) => new ResultInspector(value)
+                  ({ value }) => new ResultInspector(value, this.options)
                 ),
                 options
               );
@@ -203,7 +235,7 @@ export class ResultInspector {
                     {},
                     ...(<Format.Values.TypeValueContract>this.result).value.map(
                       ({ name, value }) => ({
-                        [name]: new ResultInspector(value)
+                        [name]: new ResultInspector(value, this.options)
                       })
                     )
                   ),
@@ -220,7 +252,9 @@ export class ResultInspector {
                 {},
                 ...Object.entries(
                   (<Format.Values.MagicValue>this.result).value
-                ).map(([key, value]) => ({ [key]: new ResultInspector(value) }))
+                ).map(([key, value]) => ({
+                  [key]: new ResultInspector(value, this.options)
+                }))
               ),
               options
             );
@@ -313,7 +347,7 @@ export class ResultInspector {
         switch (errorResult.error.kind) {
           case "WrappedError":
             return util.inspect(
-              new ResultInspector(errorResult.error.error),
+              new ResultInspector(errorResult.error.error, this.options),
               options
             );
           case "UintPaddingError":

--- a/packages/dashboard/src/components/composed/Debugger/Variables.tsx
+++ b/packages/dashboard/src/components/composed/Debugger/Variables.tsx
@@ -79,7 +79,10 @@ function Variables({
                   <dt>{"  " + variableName}</dt>
                   <dd>
                     {inspect(
-                      new Codec.Export.ResultInspector(variables[variableName])
+                      new Codec.Export.ResultInspector(
+                        variables[variableName],
+                        { renderMappingsViaObjects: true }
+                      )
                     )}
                   </dd>
                 </>


### PR DESCRIPTION
I have not tested this.

Usage: `util.inspect(new ResultInspector(result, { renderMappingsViaObjects: true }), inspectionOptions)` or just `util.inspect(new ResultInspector(result, { renderMappingsViaObjects: true }))`

This'll have some nasty merge conflicts with #5895!  I made this by cherry-picking a commit from there and then modifying it...