### PR TITLE
Fix incorrect check for panic

### DIFF
--- a/packages/core/lib/debug/printer.js
+++ b/packages/core/lib/debug/printer.js
@@ -420,7 +420,7 @@ class DebugPrinter {
                     break;
                 }
                 break;
-              case "Panic(uint)":
+              case "Panic(uint256)":
                 const panicCode = revertDecoding.arguments[0].value.value.asBN;
                 const panicString = DebugUtils.panicString(panicCode, true); //get verbose panic string :)
                 this.config.logger.log(


### PR DESCRIPTION
Panics weren't displaying correctly in the debugger CLI because I screwed up the check for them!  Fixed now.