### PR TITLE
Add new chains for Sourcify for May 2023

### DIFF
--- a/packages/source-fetcher/lib/networks.ts
+++ b/packages/source-fetcher/lib/networks.ts
@@ -83,6 +83,7 @@ export const networkNamesById: { [id: number]: string } = {
   50: "xinfin", //not presently supported by either fetcher, but...
   51: "apothem-xinfin",
   7700: "canto",
+  7701: "testnet-canto",
   592: "astar",
   336: "shiden-astar",
   8217: "cypress-klaytn",
@@ -99,7 +100,12 @@ export const networkNamesById: { [id: number]: string } = {
   2047: "testnet-stratos",
   8453: "base", //not presently supported by either fetcher, but...
   84531: "goerli-base",
-  641230: "bear"
+  641230: "bear",
+  888: "wanchain",
+  999: "testnet-wanchain",
+  7668: "root",
+  7672: "porcini-root",
+  295: "hedera"
   //I'm not including crystaleum as it has network ID different from chain ID
   //not including kekchain for the same reason
 };

--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -108,6 +108,7 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     //sourcify does *not* support xinfin mainnet...?
     "apothem-xinfin",
     "canto",
+    "testnet-canto",
     "astar",
     "shiden-astar",
     "cypress-klaytn",
@@ -124,7 +125,12 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "testnet-stratos",
     //sourcify does *not* support base mainnet?
     "goerli-base",
-    "bear"
+    "bear",
+    "wanchain",
+    "testnet-wanchain",
+    "root",
+    "porcini-root",
+    "hedera"
     //I'm excluding crystaleum as it has network ID different from chain ID
     //excluding kekchain for the same reason
   ]);


### PR DESCRIPTION
Sourcify has added more chains, updating!

Addresses you can test with if you want:

7701: 0x37e12c98b4663DcE9ab1460073D9Fe82A7bFD0d8

888: 0xC3649123BCa36c0c38A71bDbd2F508AB4f939f47

999: 0x500E12a948E9Fc594bC6Fe86B3B270B5a67332D8

7668: 0x6C0cE8d62F1D81464F6F4DecB62f97aa83B8Df89

7672: 0x225F2cD344c61152F8E7200E62e03dEfD683f2c4

295: 0x00000000000000000000000000000000002265bb