### PR TITLE
Change default registry in config from null to undefined

### DIFF
--- a/packages/config/src/configDefaults.ts
+++ b/packages/config/src/configDefaults.ts
@@ -54,7 +54,7 @@ export const getInitialConfig = ({
     },
     ens: {
       enabled: false,
-      registryAddress: null
+      registryAddress: undefined
     },
     mocha: {
       bail: false,


### PR DESCRIPTION
This `null` was screwing things up, I was using `null` to mean *no* registry, not *default* registry >_>

I guess likely I should have done things differently but oh well this is a simple fix and shouldn't break anything...