### PR TITLE
Upgrade solc version to latest 0.8.20 in truffle init

### DIFF
--- a/packages/core/lib/commands/init/initSource/truffle-config.js
+++ b/packages/core/lib/commands/init/initSource/truffle-config.js
@@ -106,7 +106,7 @@ module.exports = {
   // Configure your compilers
   compilers: {
     solc: {
-      version: "0.8.19",      // Fetch exact version from solc-bin (default: truffle's version)
+      version: "0.8.20",      // Fetch exact version from solc-bin (default: truffle's version)
       // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
       // settings: {          // See the solidity docs for advice about optimization and evmVersion
       //  optimizer: {


### PR DESCRIPTION
## PR description

This PR upgrades the `solc` version to latest **v0.8.20** in `truffle-config.js` when `truffle init` command is run.
