### PR TITLE
Update typescript to ^4.9.5 and and ttypescript to 1.5.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "nyc": "15.1.0",
     "prettier": "^2.5.1",
     "prs-merged-since": "^1.1.0",
-    "typescript": "^4.7.4"
+    "typescript": "^4.9.5"
   },
   "workspaces": {
     "packages": [

--- a/packages/abi-utils/package.json
+++ b/packages/abi-utils/package.json
@@ -39,7 +39,7 @@
     "jest-json-schema": "^2.1.0",
     "ts-jest": "29.0.3",
     "ts-node": "10.7.0",
-    "typescript": "^4.7.4"
+    "typescript": "^4.9.5"
   },
   "keywords": [
     "abi",

--- a/packages/artifactor/package.json
+++ b/packages/artifactor/package.json
@@ -39,7 +39,7 @@
     "sinon": "^9.0.2",
     "tmp": "^0.2.1",
     "ts-node": "10.7.0",
-    "typescript": "^4.7.4",
+    "typescript": "^4.9.5",
     "web3": "1.10.0"
   },
   "publishConfig": {

--- a/packages/blockchain-utils/package.json
+++ b/packages/blockchain-utils/package.json
@@ -27,7 +27,7 @@
     "@types/web3": "1.0.20",
     "mocha": "10.1.0",
     "ts-node": "10.7.0",
-    "typescript": "^4.7.4"
+    "typescript": "^4.9.5"
   },
   "keywords": [
     "blockchain",

--- a/packages/box/package.json
+++ b/packages/box/package.json
@@ -38,7 +38,7 @@
     "mocha": "10.1.0",
     "sinon": "^9.0.2",
     "ts-node": "10.7.0",
-    "typescript": "^4.7.4"
+    "typescript": "^4.9.5"
   },
   "keywords": [
     "boilerplate",

--- a/packages/code-utils/package.json
+++ b/packages/code-utils/package.json
@@ -29,7 +29,7 @@
     "@types/node": "~12.12.0",
     "mocha": "10.1.0",
     "ts-node": "10.7.0",
-    "typescript": "^4.7.4"
+    "typescript": "^4.9.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/codec/package.json
+++ b/packages/codec/package.json
@@ -46,7 +46,7 @@
     "@types/semver": "^6.0.0",
     "@types/utf8": "^2.1.6",
     "ts-node": "10.7.0",
-    "ttypescript": "1.5.13",
+    "ttypescript": "1.5.15",
     "typedoc": "0.22.18",
     "typescript": "^4.7.4",
     "typescript-transform-paths": "3.3.1"

--- a/packages/codec/package.json
+++ b/packages/codec/package.json
@@ -48,7 +48,7 @@
     "ts-node": "10.7.0",
     "ttypescript": "1.5.15",
     "typedoc": "0.22.18",
-    "typescript": "^4.7.4",
+    "typescript": "^4.9.5",
     "typescript-transform-paths": "3.3.1"
   },
   "keywords": [

--- a/packages/compile-common/package.json
+++ b/packages/compile-common/package.json
@@ -30,6 +30,6 @@
     "@types/node": "~12.12.0",
     "mocha": "10.1.0",
     "ts-node": "10.7.0",
-    "typescript": "^4.7.4"
+    "typescript": "^4.9.5"
   }
 }

--- a/packages/compile-solidity-tests/package.json
+++ b/packages/compile-solidity-tests/package.json
@@ -38,7 +38,7 @@
     "solc": "0.8.20",
     "tmp": "^0.2.1",
     "ts-node": "10.7.0",
-    "typescript": "^4.7.4"
+    "typescript": "^4.9.5"
   },
   "keywords": [
     "compile",

--- a/packages/compile-solidity/package.json
+++ b/packages/compile-solidity/package.json
@@ -51,7 +51,7 @@
     "tmp": "^0.2.1",
     "ts-node": "10.7.0",
     "ttypescript": "1.5.15",
-    "typescript": "^4.7.4",
+    "typescript": "^4.9.5",
     "typescript-transform-paths": "3.3.1"
   },
   "keywords": [

--- a/packages/compile-solidity/package.json
+++ b/packages/compile-solidity/package.json
@@ -50,7 +50,7 @@
     "sinon": "^9.0.2",
     "tmp": "^0.2.1",
     "ts-node": "10.7.0",
-    "ttypescript": "1.5.13",
+    "ttypescript": "1.5.15",
     "typescript": "^4.7.4",
     "typescript-transform-paths": "3.3.1"
   },

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -39,7 +39,7 @@
     "mocha": "10.1.0",
     "sinon": "^9.0.2",
     "ts-node": "10.7.0",
-    "typescript": "^4.7.4"
+    "typescript": "^4.9.5"
   },
   "keywords": [
     "config",

--- a/packages/dashboard-hardhat-plugin/package.json
+++ b/packages/dashboard-hardhat-plugin/package.json
@@ -52,7 +52,7 @@
     "tslint": "^5.16.0",
     "tslint-config-prettier": "^1.18.0",
     "tslint-plugin-prettier": "^2.0.1",
-    "typescript": "^4.0.3"
+    "typescript": "^4.9.5"
   },
   "peerDependencies": {
     "hardhat": "^2.0.0"

--- a/packages/dashboard-message-bus-client/package.json
+++ b/packages/dashboard-message-bus-client/package.json
@@ -50,6 +50,6 @@
   "devDependencies": {
     "@types/debug": "^4.1.5",
     "@types/node": "~12.12.0",
-    "typescript": "^4.7.4"
+    "typescript": "^4.9.5"
   }
 }

--- a/packages/dashboard-message-bus-common/package.json
+++ b/packages/dashboard-message-bus-common/package.json
@@ -30,6 +30,6 @@
   },
   "devDependencies": {
     "@types/node": "~12.12.0",
-    "typescript": "^4.7.4"
+    "typescript": "^4.9.5"
   }
 }

--- a/packages/dashboard-message-bus/package.json
+++ b/packages/dashboard-message-bus/package.json
@@ -29,7 +29,7 @@
     "@types/node": "~12.12.0",
     "@types/promise.any": "^2.0.0",
     "@types/web3": "1.0.20",
-    "typescript": "^4.7.4"
+    "typescript": "^4.9.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -90,7 +90,7 @@
     "ts-jest": "29.0.3",
     "ts-loader": "^9.4.1",
     "ts-node": "10.7.0",
-    "typescript": "^4.7.4",
+    "typescript": "^4.9.5",
     "vm-browserify": "^1.1.2",
     "webpack": "^5.74.0",
     "webpack-cli": "^4.10.0",

--- a/packages/db-kit/package.json
+++ b/packages/db-kit/package.json
@@ -66,7 +66,7 @@
     "ts-jest": "29.0.3",
     "ts-node": "10.7.0",
     "tsconfig-paths": "^3.9.0",
-    "ttypescript": "1.5.13",
+    "ttypescript": "1.5.15",
     "typedoc": "0.22.18",
     "typescript": "^4.7.4",
     "typescript-transform-paths": "3.3.1",

--- a/packages/db-kit/package.json
+++ b/packages/db-kit/package.json
@@ -68,7 +68,7 @@
     "tsconfig-paths": "^3.9.0",
     "ttypescript": "1.5.15",
     "typedoc": "0.22.18",
-    "typescript": "^4.7.4",
+    "typescript": "^4.9.5",
     "typescript-transform-paths": "3.3.1",
     "web3-core": "1.10.0"
   },

--- a/packages/db-loader/package.json
+++ b/packages/db-loader/package.json
@@ -34,6 +34,6 @@
     "@truffle/db": "^2.0.26"
   },
   "devDependencies": {
-    "typescript": "^4.7.4"
+    "typescript": "^4.9.5"
   }
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -80,7 +80,7 @@
     "tsconfig-paths": "^3.9.0",
     "ttypescript": "1.5.15",
     "typedoc": "0.22.18",
-    "typescript": "^4.7.4",
+    "typescript": "^4.9.5",
     "typescript-transform-paths": "3.3.1",
     "web3": "1.10.0"
   },

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -78,7 +78,7 @@
     "ts-jest": "29.0.3",
     "ts-node": "10.7.0",
     "tsconfig-paths": "^3.9.0",
-    "ttypescript": "1.5.13",
+    "ttypescript": "1.5.15",
     "typedoc": "0.22.18",
     "typescript": "^4.7.4",
     "typescript-transform-paths": "3.3.1",

--- a/packages/decoder/package.json
+++ b/packages/decoder/package.json
@@ -50,7 +50,7 @@
     "lodash": "^4.17.21",
     "mocha": "10.1.0",
     "tmp": "^0.2.1",
-    "typescript": "^4.7.4",
+    "typescript": "^4.9.5",
     "web3": "1.10.0"
   },
   "keywords": [

--- a/packages/encoder/package.json
+++ b/packages/encoder/package.json
@@ -63,7 +63,7 @@
     "jest": "29.1.2",
     "jest-transform-stealthy-require": "^1.0.0",
     "ts-jest": "29.0.3",
-    "typescript": "^4.7.4",
+    "typescript": "^4.9.5",
     "utf8": "^3.0.0",
     "web3": "1.10.0"
   },

--- a/packages/error/package.json
+++ b/packages/error/package.json
@@ -32,6 +32,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "typescript": "^4.7.4"
+    "typescript": "^4.9.5"
   }
 }

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -32,7 +32,7 @@
     "mocha": "10.1.0",
     "tsd": "^0.25.0",
     "ttypescript": "1.5.15",
-    "typescript": "^4.7.4",
+    "typescript": "^4.9.5",
     "typescript-transform-paths": "3.3.1"
   },
   "keywords": [

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -31,7 +31,7 @@
     "@types/node": "~12.12.0",
     "mocha": "10.1.0",
     "tsd": "^0.25.0",
-    "ttypescript": "1.5.13",
+    "ttypescript": "1.5.15",
     "typescript": "^4.7.4",
     "typescript-transform-paths": "3.3.1"
   },

--- a/packages/fetch-and-compile/package.json
+++ b/packages/fetch-and-compile/package.json
@@ -46,7 +46,7 @@
     "mocha": "9.2.2",
     "sinon": "^9.0.2",
     "ts-node": "10.7.0",
-    "typescript": "^4.7.4"
+    "typescript": "^4.9.5"
   },
   "keywords": [
     "compile",

--- a/packages/from-hardhat/package.json
+++ b/packages/from-hardhat/package.json
@@ -33,7 +33,7 @@
     "hardhat": "^2.10.1",
     "jest": "29.1.2",
     "ttypescript": "1.5.15",
-    "typescript": "^4.3.5",
+    "typescript": "^4.9.5",
     "typescript-transform-paths": "3.3.1"
   },
   "keywords": [

--- a/packages/from-hardhat/package.json
+++ b/packages/from-hardhat/package.json
@@ -32,7 +32,7 @@
     "@types/node": "^18.6.5",
     "hardhat": "^2.10.1",
     "jest": "29.1.2",
-    "ttypescript": "1.5.13",
+    "ttypescript": "1.5.15",
     "typescript": "^4.3.5",
     "typescript-transform-paths": "3.3.1"
   },

--- a/packages/hdwallet-provider/package.json
+++ b/packages/hdwallet-provider/package.json
@@ -41,7 +41,7 @@
     "ganache": "7.8.0",
     "mocha": "10.1.0",
     "ts-node": "10.7.0",
-    "typescript": "^4.7.4"
+    "typescript": "^4.9.5"
   },
   "keywords": [
     "ethereum",

--- a/packages/hdwallet/package.json
+++ b/packages/hdwallet/package.json
@@ -29,7 +29,7 @@
     "bip39": "3.0.4",
     "mocha": "10.1.0",
     "ts-node": "10.7.0",
-    "typescript": "^4.7.4"
+    "typescript": "^4.9.5"
   },
   "keywords": [
     "ethereum",

--- a/packages/interface-adapter/package.json
+++ b/packages/interface-adapter/package.json
@@ -36,7 +36,7 @@
     "ganache": "7.8.0",
     "mocha": "10.1.0",
     "ts-node": "10.7.0",
-    "typescript": "^4.7.4"
+    "typescript": "^4.9.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -36,7 +36,7 @@
     "mocha": "10.1.0",
     "sinon": "^9.0.2",
     "ts-node": "10.7.0",
-    "typescript": "^4.7.4",
+    "typescript": "^4.9.5",
     "web3": "1.10.0"
   },
   "keywords": [

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -33,7 +33,7 @@
     "@types/node": "~12.12.0",
     "jest": "29.1.2",
     "ts-jest": "29.0.3",
-    "typescript": "^4.7.4"
+    "typescript": "^4.9.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/preserve/package.json
+++ b/packages/preserve/package.json
@@ -34,7 +34,7 @@
     "jest": "29.1.2",
     "ts-jest": "29.0.3",
     "typedoc": "0.22.18",
-    "typescript": "4.7.4"
+    "typescript": "^4.9.5"
   },
   "dependencies": {
     "@truffle/error": "^0.2.0",

--- a/packages/profiler/package.json
+++ b/packages/profiler/package.json
@@ -28,7 +28,7 @@
     "@truffle/config": "^1.3.56",
     "@types/node": "~12.12.0",
     "ts-node": "10.7.0",
-    "typescript": "^4.7.4"
+    "typescript": "^4.9.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/promise-tracker/package.json
+++ b/packages/promise-tracker/package.json
@@ -43,6 +43,6 @@
     "delay": "^5.0.0",
     "jest": "29.1.2",
     "ts-jest": "29.0.3",
-    "typescript": "^4.7.4"
+    "typescript": "^4.9.5"
   }
 }

--- a/packages/provisioner/package.json
+++ b/packages/provisioner/package.json
@@ -32,7 +32,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "typescript": "^4.7.4"
+    "typescript": "^4.9.5"
   },
   "dependencies": {
     "@truffle/config": "^1.3.56"

--- a/packages/require/package.json
+++ b/packages/require/package.json
@@ -43,7 +43,7 @@
     "mocha": "10.1.0",
     "npm-run-all": "^4.1.5",
     "ts-node": "10.7.0",
-    "typescript": "^4.7.4",
+    "typescript": "^4.9.5",
     "web3": "1.10.0"
   },
   "peerDependencies": {

--- a/packages/resolver/package.json
+++ b/packages/resolver/package.json
@@ -47,7 +47,7 @@
     "mocha": "10.1.0",
     "sinon": "^9.0.2",
     "ts-node": "10.7.0",
-    "typescript": "^4.7.4"
+    "typescript": "^4.9.5"
   },
   "keywords": [
     "dependencies",

--- a/packages/source-fetcher/package.json
+++ b/packages/source-fetcher/package.json
@@ -36,7 +36,7 @@
     "@types/async-retry": "^1.4.3",
     "@types/debug": "^4.1.5",
     "@types/node": "~12.12.0",
-    "typescript": "^4.7.4"
+    "typescript": "^4.9.5"
   },
   "keywords": [
     "ethereum",

--- a/packages/spinners/package.json
+++ b/packages/spinners/package.json
@@ -34,7 +34,7 @@
     "@types/semver": "^7.3.9",
     "mocha": "10.1.0",
     "ts-node": "10.7.0",
-    "typescript": "^4.7.4"
+    "typescript": "^4.9.5"
   },
   "keywords": [
     "compile",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -43,7 +43,7 @@
     "@types/bn.js": "^5.1.0",
     "@types/mocha": "^5.2.7",
     "ts-node": "10.7.0",
-    "typescript": "^4.7.4",
+    "typescript": "^4.9.5",
     "web3": "1.10.0"
   },
   "keywords": [

--- a/packages/workflow-compile/package.json
+++ b/packages/workflow-compile/package.json
@@ -35,7 +35,7 @@
     "debug": "^4.3.1",
     "mocha": "10.1.0",
     "ts-node": "10.7.0",
-    "typescript": "^4.7.4"
+    "typescript": "^4.9.5"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -24509,10 +24509,10 @@ tsutils@^3.21.0:
   dependencies:
     tslib "^1.8.1"
 
-ttypescript@1.5.13:
-  version "1.5.13"
-  resolved "https://registry.yarnpkg.com/ttypescript/-/ttypescript-1.5.13.tgz#c3bcb760599fe49157d30c5d5895a0023cbb7f30"
-  integrity sha512-KT/RBfGGlVJFqEI8cVvI3nMsmYcFvPSZh8bU0qX+pAwbi7/ABmYkzn7l/K8skw0xmYjVCoyaV6WLsBQxdadybQ==
+ttypescript@1.5.15:
+  version "1.5.15"
+  resolved "https://registry.yarnpkg.com/ttypescript/-/ttypescript-1.5.15.tgz#e45550ad69289d06d3bc3fd4a3c87e7c1ef3eba7"
+  integrity sha512-48ykDNHzFnPMnv4hYX1P8Q84TvCZyL1QlFxeuxsuZ48X2+ameBgPenvmCkHJtoOSxpoWTWi8NcgNrRnVDOmfSg==
   dependencies:
     resolve ">=1.9.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -24674,11 +24674,6 @@ typescript-tuple@^2.2.1:
   dependencies:
     typescript-compare "^0.0.2"
 
-typescript@4.7.4, typescript@^4.3.5, typescript@^4.7.4:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
-
 "typescript@^3 || ^4":
   version "4.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.3.tgz#d59344522c4bc464a65a730ac695007fdb66dd88"
@@ -24694,7 +24689,7 @@ typescript@^3.9.7:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
   integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
-typescript@^4.0.3:
+typescript@^4.9.5:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==


### PR DESCRIPTION
In trying to update typescript for all packages to 5.x I found out that the latest ttypescript [does not support typescript 5.x](https://github.com/cevek/ttypescript/issues/140), and it appears to be out of maintenance. We should consider forgoing the use of this package, or at least swapping it for an equivalent.

Here are the changes:
- Updated ttypescript to latest for all packages that use it (codec, compile-solidity, compile-solidity-tests, db, db-kit, expect, from-hardhat, hdwallet), so that they can use the latest typescript 4.x, which I then updated them to.
- Updated remaining packages to typescript 5.x.

Basically all ts packages use 5.x (^5.0.4) if they can, 4.x (^4.9.5) otherwise. Hopefully ci passes.

---

**Change of plans**: Only updating all to the latest 4.x ts, and we'll deal with ttypescript and updating ts to 5.x in the future. Still updating ttypescript.