### PR TITLE
Swap priority order of bools/strings if strictBooleans is on

### DIFF
--- a/packages/codec/lib/wrap/index.ts
+++ b/packages/codec/lib/wrap/index.ts
@@ -268,6 +268,7 @@ export function* resolveAndWrap(
         !isMoreSpecificMultiple(
           comparisonResolution.arguments,
           resolution.arguments,
+          strictBooleans,
           userDefinedTypes
         ) ||
         //because the comparison is nonstrict, this comparison is added to
@@ -278,6 +279,7 @@ export function* resolveAndWrap(
         isMoreSpecificMultiple(
           resolution.arguments,
           comparisonResolution.arguments,
+          strictBooleans,
           userDefinedTypes
         )
     )

--- a/packages/codec/lib/wrap/priority.ts
+++ b/packages/codec/lib/wrap/priority.ts
@@ -48,7 +48,7 @@ export function isMoreSpecific(
   if (type2.typeClass === "userDefinedValueType") {
     type2 = getUnderlyingType(type2, userDefinedTypes);
   }
-  let typeClasses = [
+  const typeClassesMinusStringAndBool = [
     ["options"],
     ["array"],
     ["struct", "tuple"],
@@ -56,17 +56,11 @@ export function isMoreSpecific(
     ["bytes"],
     ["function"],
     ["uint", "int", "fixed", "ufixed"],
-    ["enum"],
-    ["string"],
-    ["bool"]
+    ["enum"]
   ];
-  if (strictBooleans) {
-    //swap priority of strings and bools
-    typeClasses.pop();
-    typeClasses.pop();
-    typeClasses.push(["bool"]);
-    typeClasses.push(["string"]);
-  }
+  const typeClasses = typeClassesMinusStringAndBool.concat(
+    strictBooleans ? [["bool"], ["string"]] : [["string"], ["bool"]]
+  );
   //for each type, what's the first one it counts as?
   const index1 = typeClasses.findIndex(classes =>
     classes.includes(type1.typeClass)

--- a/packages/codec/lib/wrap/priority.ts
+++ b/packages/codec/lib/wrap/priority.ts
@@ -10,6 +10,7 @@ import { maxValue, minValue, places } from "./utils";
 export function isMoreSpecificMultiple(
   types1: Format.Types.OptionallyNamedType[],
   types2: Format.Types.OptionallyNamedType[],
+  strictBooleans: boolean,
   userDefinedTypes: Format.Types.TypesById
 ): boolean {
   //just wrap the types in tuples and defer to isMoreSpecific()
@@ -21,7 +22,13 @@ export function isMoreSpecificMultiple(
     typeClass: "tuple",
     memberTypes: types2
   };
-  return isMoreSpecific(combinedType1, combinedType2, userDefinedTypes, true);
+  return isMoreSpecific(
+    combinedType1,
+    combinedType2,
+    strictBooleans,
+    userDefinedTypes,
+    true
+  );
   //that last flag is so we ignore variable names at top level
 }
 
@@ -30,6 +37,7 @@ export function isMoreSpecificMultiple(
 export function isMoreSpecific(
   type1: Format.Types.Type,
   type2: Format.Types.Type,
+  strictBooleans: boolean,
   userDefinedTypes: Format.Types.TypesById,
   ignoreComponentNames: boolean = false //this flag is *not* applied recursively!
 ): boolean {
@@ -40,7 +48,7 @@ export function isMoreSpecific(
   if (type2.typeClass === "userDefinedValueType") {
     type2 = getUnderlyingType(type2, userDefinedTypes);
   }
-  const typeClasses = [
+  let typeClasses = [
     ["options"],
     ["array"],
     ["struct", "tuple"],
@@ -52,6 +60,13 @@ export function isMoreSpecific(
     ["string"],
     ["bool"]
   ];
+  if (strictBooleans) {
+    //swap priority of strings and bools
+    typeClasses.pop();
+    typeClasses.pop();
+    typeClasses.push(["bool"]);
+    typeClasses.push(["string"]);
+  }
   //for each type, what's the first one it counts as?
   const index1 = typeClasses.findIndex(classes =>
     classes.includes(type1.typeClass)
@@ -78,12 +93,14 @@ export function isMoreSpecific(
         //we haven't actually checked visibility, so we'll have to coerce
         <Format.Types.FunctionExternalType>type1,
         <Format.Types.FunctionExternalType>type2,
+        strictBooleans,
         userDefinedTypes
       );
     case "array":
       return isMoreSpecificArray(
         type1,
         <Format.Types.ArrayType>type2,
+        strictBooleans,
         userDefinedTypes
       );
     case "bytes":
@@ -102,6 +119,7 @@ export function isMoreSpecific(
       return isMoreSpecificTuple(
         type1,
         <Format.Types.TupleType>type2,
+        strictBooleans,
         userDefinedTypes,
         ignoreComponentNames
       );
@@ -192,6 +210,7 @@ function isMoreSpecificString(
 function isMoreSpecificArray(
   type1: Format.Types.ArrayType,
   type2: Format.Types.ArrayType,
+  strictBooleans: boolean,
   userDefinedTypes: Format.Types.TypesById
 ): boolean {
   //static is more specific than dynamic, but
@@ -205,13 +224,19 @@ function isMoreSpecificArray(
   //length and types must both be more specific
   return (
     moreSpecificLength &&
-    isMoreSpecific(type1.baseType, type2.baseType, userDefinedTypes)
+    isMoreSpecific(
+      type1.baseType,
+      type2.baseType,
+      strictBooleans,
+      userDefinedTypes
+    )
   );
 }
 
 function isMoreSpecificFunction(
   type1: Format.Types.FunctionExternalType,
   type2: Format.Types.FunctionExternalType,
+  strictBooleans: boolean,
   userDefinedTypes?: Format.Types.TypesById
 ): boolean {
   switch (type2.kind) {
@@ -238,6 +263,7 @@ function isMoreSpecificFunction(
               !isMoreSpecific(
                 type1.outputParameterTypes[i],
                 type2.outputParameterTypes[i],
+                strictBooleans,
                 userDefinedTypes
               )
             ) {
@@ -256,6 +282,7 @@ function isMoreSpecificFunction(
                 //swapped for contravariance, I guess...?
                 type2.inputParameterTypes[i],
                 type1.inputParameterTypes[i],
+                strictBooleans,
                 userDefinedTypes
               )
             ) {
@@ -282,23 +309,24 @@ function isMutabilityMoreSpecific(
 function isMoreSpecificTuple(
   type1: TupleLikeType,
   type2: TupleLikeType,
+  strictBooleans: boolean,
   userDefinedTypes: Format.Types.TypesById,
   ignoreComponentNames: boolean = false
 ): boolean {
   debug("type1: %O", type1);
   debug("type2: %O", type2);
-  const fullType1 = (<TupleLikeType>Format.Types.fullType(
-    type1,
-    userDefinedTypes
-  ));
-  const fullType2 = (<TupleLikeType>Format.Types.fullType(
-    type2,
-    userDefinedTypes
-  ));
+  const fullType1 = <TupleLikeType>(
+    Format.Types.fullType(type1, userDefinedTypes)
+  );
+  const fullType2 = <TupleLikeType>(
+    Format.Types.fullType(type2, userDefinedTypes)
+  );
   const types1: Format.Types.Type[] = (<Format.Types.OptionallyNamedType[]>(
-    fullType1.memberTypes)).map(member => member.type);
+    fullType1.memberTypes
+  )).map(member => member.type);
   const types2: Format.Types.Type[] = (<Format.Types.OptionallyNamedType[]>(
-    fullType2.memberTypes)).map(member => member.type);
+    fullType2.memberTypes
+  )).map(member => member.type);
   //lengths must match
   if (types1.length !== types2.length) {
     return false;
@@ -306,7 +334,9 @@ function isMoreSpecificTuple(
   //individual types must satisfy isMoreSpecific
   for (let i = 0; i < types1.length; i++) {
     //note we do *not* pass along the ignoreComponentNames flag
-    if (!isMoreSpecific(types1[i], types2[i], userDefinedTypes)) {
+    if (
+      !isMoreSpecific(types1[i], types2[i], strictBooleans, userDefinedTypes)
+    ) {
       return false;
     }
   }
@@ -316,9 +346,11 @@ function isMoreSpecificTuple(
     //(and all exist)
     //then compare by component names in addition to by position
     let names1: string[] = (<Format.Types.OptionallyNamedType[]>(
-      fullType1.memberTypes)).map(member => member.name);
+      fullType1.memberTypes
+    )).map(member => member.name);
     let names2: string[] = (<Format.Types.OptionallyNamedType[]>(
-      fullType2.memberTypes)).map(member => member.name);
+      fullType2.memberTypes
+    )).map(member => member.name);
     //we just created these via a map so it's OK to sort in-place
     names1.sort();
     names2.sort();
@@ -331,7 +363,7 @@ function isMoreSpecificTuple(
     }
     if (namesEqual) {
       debug("names equal");
-      for(let i = 0; i < types1.length; i++) {
+      for (let i = 0; i < types1.length; i++) {
         const type1 = types1[i];
         const name = fullType1.memberTypes[i].name;
         const type2 = fullType2.memberTypes.find(
@@ -340,7 +372,7 @@ function isMoreSpecificTuple(
         debug("name: %s", name);
         debug("type1: %O", type1);
         debug("type2: %O", type2);
-        if (!isMoreSpecific(type1, type2, userDefinedTypes)) {
+        if (!isMoreSpecific(type1, type2, strictBooleans, userDefinedTypes)) {
           debug("returning false");
           return false;
         }

--- a/packages/encoder/lib/encoders.ts
+++ b/packages/encoder/lib/encoders.ts
@@ -868,12 +868,15 @@ export class ContractEncoder {
    * 6. external function pointers
    * 7. numeric types
    * 8. `enum`s
-   * 9. `string`
-   * 10. `bool`
+   * 9. `string` [is #10 with `strictBooleans`]
+   * 10. `bool` [is #9 with `strictBooleans`]
    *
    * (Note that if the encoder does not know that a certain argument is
    * supposed to be an enum, it will of course just be treated as the
    * underlying numeric type.)
+   *
+   * (If the `strictBooleans` option is passed, the priority order of `string`
+   * and `bool` is swapped.)
    *
    * Moreover, within each category there is a priority ordering (which is
    * not always total).  Specifically:

--- a/packages/encoder/test/overload.test.ts
+++ b/packages/encoder/test/overload.test.ts
@@ -300,7 +300,8 @@ describe("Overload resolution", () => {
 
     it("Encodes as string as last resort with strict booleans on", async () => {
       const { abi, tx } = await encoder.encodeTransaction("overloaded", [""], {
-        allowOptions: true
+        allowOptions: true,
+        strictBooleans: true
       });
       assert.lengthOf(abi.inputs, 1);
       assert.strictEqual(abi.inputs[0].type, "string");

--- a/packages/encoder/test/overload.test.ts
+++ b/packages/encoder/test/overload.test.ts
@@ -279,6 +279,39 @@ describe("Overload resolution", () => {
       );
     });
 
+    it("Prefers bools to strings with strict booleans on", async () => {
+      const { abi, tx } = await encoder.encodeTransaction(
+        "overloaded",
+        ["true"],
+        {
+          allowOptions: true,
+          strictBooleans: true
+        }
+      );
+      assert.lengthOf(abi.inputs, 1);
+      assert.strictEqual(abi.inputs[0].type, "bool");
+      const selector = Codec.AbiData.Utils.abiSelector(abi);
+      assert.strictEqual(
+        tx.data,
+        selector +
+          "0000000000000000000000000000000000000000000000000000000000000001"
+      );
+    });
+
+    it("Encodes as string as last resort with strict booleans on", async () => {
+      const { abi, tx } = await encoder.encodeTransaction("overloaded", [""], {
+        allowOptions: true
+      });
+      assert.lengthOf(abi.inputs, 1);
+      assert.strictEqual(abi.inputs[0].type, "string");
+      const selector = Codec.AbiData.Utils.abiSelector(abi);
+      assert.strictEqual(
+        tx.data,
+        selector +
+          "00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000"
+      );
+    });
+
     it("Treats UDVT same as underlying type (bytes1)", async () => {
       const { abi, tx } = await encoder.encodeTransaction(
         "overloaded",


### PR DESCRIPTION
Addresses #6028.

The point of this is that, if there's an overloaded function with a bool overload and a string overload, then `truffle call Contract f true` ought to hit the bool overload, not the string overload.  Of course this only makes sense if we're restricted to string input, which is more or less what the `strictBooleans` flag means.

I added tests also.  You could also test it manually by making a function with a `string` overload and a `bool` overload and try calling it with `truffle call`.

*Arguably* this is a breaking change (to codec and encoder), but I'd consider it a bug fix.  Overload resolution is never guaranteed anyway! :)