### PR TITLE
Properly handle event decoding in Solidity 0.8.20

### DIFF
--- a/packages/codec/lib/abi-data/allocate/types.ts
+++ b/packages/codec/lib/abi-data/allocate/types.ts
@@ -135,7 +135,7 @@ export interface EventAllocations {
 export interface EventAllocation {
   abi: Abi.EventEntry;
   contextHash: string;
-  definedIn?: Format.Types.ContractType; //is omitted if we don't know
+  definedIn?: Format.Types.ContractType | null; //is omitted if we don't know
   id?: string; //is omitted if we don't know
   anonymous: boolean;
   arguments: EventArgumentAllocation[];
@@ -150,7 +150,8 @@ export interface EventArgumentAllocation {
 
 //now let's go back and fill in returndata
 export interface ReturndataAllocations {
-  [contextHash: string]: { //NOTE: contextHash here can also be "" to represent no context
+  [contextHash: string]: {
+    //NOTE: contextHash here can also be "" to represent no context
     [selector: string]: RevertReturndataAllocation[];
   };
 }

--- a/packages/codec/lib/ast/types.ts
+++ b/packages/codec/lib/ast/types.ts
@@ -55,6 +55,7 @@ export interface AstNode {
   contractKind?: Common.ContractKind;
   isConstructor?: boolean;
   usedErrors?: number[];
+  usedEvents?: number[];
   //Note: May need to add more in the future.
   //May also want to create a proper system of AstNode types
   //in the future, but sticking with this for now.

--- a/packages/codec/lib/export.ts
+++ b/packages/codec/lib/export.ts
@@ -448,11 +448,17 @@ export class LogDecodingInspector {
     return this[util.inspect.custom].bind(this)(depth, options);
   }
   [util.inspect.custom](depth: number | null, options: InspectOptions): string {
-    const className = this.decoding.definedIn
-      ? this.decoding.definedIn.typeName
-      : this.decoding.class.typeName;
     const eventName = this.decoding.abi.name;
-    const fullName = `${className}.${eventName}`;
+    let fullName: string;
+    if (this.decoding.definedIn) {
+      fullName = `${this.decoding.definedIn}.${eventName}`;
+    } else if (this.decoding.definedIn === null) {
+      //file-level event
+      fullName = eventName;
+    } else {
+      //event of unknown definition location
+      fullName = `${this.decoding.class.typeName}.${eventName}`;
+    }
     switch (this.decoding.kind) {
       case "event":
         return formatFunctionLike(fullName, this.decoding.arguments, options);

--- a/packages/codec/lib/types.ts
+++ b/packages/codec/lib/types.ts
@@ -304,9 +304,10 @@ export interface EventDecoding {
   class: Types.ContractType;
   /**
    * The class of the contract that (according to this decoding) defined the event, as a Format.Types.ContractType.
-   * May be omitted if we can't determine it, as may occur in ABI mode.
+   * May be omitted if we can't determine it, as may occur in ABI mode.  If null, this means that it's a file-level
+   * event (which as of right now is just future-proofing).
    */
-  definedIn?: Types.ContractType;
+  definedIn?: Types.ContractType | null;
   /**
    * The list of decoded arguments to the event.
    */

--- a/packages/debugger/test/helpers.js
+++ b/packages/debugger/test/helpers.js
@@ -34,10 +34,10 @@ export async function prepareContracts(
 
   config.compilers = {
     solc: {
-      version: "0.8.18",
+      version: "0.8.20",
       settings: {
         optimizer: { enabled: false, runs: 200 },
-        evmVersion: "paris"
+        evmVersion: "shanghai"
       }
     },
     vyper: {

--- a/packages/decoder/test/current/truffle-config.js
+++ b/packages/decoder/test/current/truffle-config.js
@@ -56,7 +56,7 @@ module.exports = {
   // Configure your compilers
   compilers: {
     solc: {
-      version: "0.8.9" // Fetch exact version from solc-bin (default: truffle's version)
+      version: "0.8.20" // Fetch exact version from solc-bin (default: truffle's version)
       // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
       // settings: {          // See the solidity docs for advice about optimization and evmVersion
       //  optimizer: {


### PR DESCRIPTION
So, Solidity 0.8.20 is out, and it changes which events get listed in a contract's ABI!  That means our existing event allocation code won't work with 0.8.20 contracts.  Fortunately, they also added the `usedEvents` property to contract nodes (much like the existing `usedErrors`), which lets us distinguish when we're in this case, and also helps us handle it.  So, now we have two event allocation pathways; one for pre-0.8.20, and one for post-0.8.20.

In addition to this, there's also one change to the event decoding return type; `definedIn` can now be `null`, as distinct from `undefined` (same as with errors).  The use of `null` here means that the event was defined at file level, as opposed to `undefined`, which means we don't know where it was defined.  Now you may say, but Solidity doesn't allow file-level events!  Sure, but it will soon, and as long as I was doing this, I thought it made sense to future-proof for that.  I've updated the event decoding inspector to account for this.

Anyway, back to the allocation changes -- let's break down how this affects each of the three event allocation functions.

For `getEventAllocations`, it basically just means that inheritance handling is bypassed if `usedEvents` is present.  Which is nice, because it means you get to skip the confusing part of the function!  Well, OK, one of the confusing parts of the function.

For `getEventAllocationsForContract`, it means we now have two separate allocation pathways... you'll notice this function now heavily parallels `getReturndataAllocationsForContract`, this is not a coincidence. :P  Note that the meaning of `undefined` differs between the two paths, though... in the old path cases of `undefined` are left in for inheritance processing, while in the new path they're filtered out since there won't be any.

Finally `getEventAllocation` is the function whose changes you might find the most confusing, so let's go over that.  First off, the function signature has changed; you can now pass in an `eventNode`, since now we might already know that going in.  We also introduce a new variable, `definedInNode`; previously there was no need for this since the defined-in node was always the contract node, but now this is no longer the case!  If `node` is defined but `definedInNode` is not, that's interpreted as a file-level event.

Anyway, you can see that if `eventNode` is not passed in, we run the old code, except that we set `definedInNode` equal to `contractNode`.  By contrast, if `eventNode` is passed in, then we run the new code, which thankfully is much simpler.  It sets `node` to `eventNode` (since we already know it, rather than having to find it like in the old case) and searches all the contracts to find the event we're looking for, setting `definedInNode` as appropriate (or leaving it undefined if nothing was found -- this indicates a file-level event).

(You may say, to determine if an event is file-level, shouldn't you search all the `SourceUnit` nodes to see if it's defined directly under one of them?  Ideally, yes, but we don't have that information in the current setup and I didn't want to deal with changing that right now.)

However, due to the special handling of library events, the new code does do one more check -- if it's a library event, and this contract isn't the library that defined it, we don't allocate it.  Library events are always considered to be "in play", so we leave the event alone so its defining library can allocate it; we don't want it to appear twice, after all.

But that's it!  Sorry, I know I'm modifying some confusing code here, but I hope you'll find that the code paths I've added are less confusing than the older existing code paths. :P

As for tests... I wanted to get this up quickly, so I didn't test it as thoroughly as I otherwise might have.  I just updated the debugger and decoder tests to 0.8.20 and checked that they still passed.  Hopefully that's enough!