### PR TITLE
Add `parseSignature` functions to ABI utils

### DIFF
--- a/packages/abi-utils/README.md
+++ b/packages/abi-utils/README.md
@@ -9,6 +9,7 @@ This package contains a few different components:
 - [Normalize ABIs](#normalize-abis)
 - [TypeScript types](#typescript-types)
 - [Selector and signature computation](#selector-and-signature-computation)
+- [Signature parsing](#signature-parsing)
 - [Arbitrary random ABIs](#arbitrary-random-abis)
 
 ## Normalize ABIs
@@ -108,6 +109,27 @@ This package exports the following functions for computing signatures and select
 
 In addition, the package also exports the constant `ShortSelectorSize`, which
 is equal to 4 (the number of bytes in a function or event selector).
+
+## Signature parsing
+
+This package exports several functions for parsing signatures back to full ABI entries.
+Note that because signatures lose a lot of information, much of the result will
+be filled with default vales; functions will always be marked as having no outputs
+and as being nonpayable, events will always be marked as non-anonymous and their
+parameters marked as non-indexed.
+
+You can parse signatures with the `parseFunctionSignature`, `parseEventSignature`, and
+`parseErrorSignature` functions, depending on what type of ABI entry you want.
+
+There's also `parseSignature`, which will not produce a valid ABI entry, but will
+produce an object with `name` and `inputs`. The inputs will not have `indexed` fields.
+And there's also `parseParameterList`, which can be used on a signature with the name
+removed to get just the `inputs`.
+
+Note that these functions do not currently perform full validation of all the types
+used in the signature, so if you include invalid types in your signature, the parser
+may reproduce these in the output ABI. Stricter validation may be added at a later
+date.
 
 ## Arbitrary random ABIs
 

--- a/packages/abi-utils/lib/index.ts
+++ b/packages/abi-utils/lib/index.ts
@@ -1,5 +1,6 @@
 export * from "./types";
 export * from "./normalize";
 export * from "./signature";
+export * from "./parse";
 import * as Arbitrary from "./arbitrary";
 export { Arbitrary };

--- a/packages/abi-utils/lib/parse.test.ts
+++ b/packages/abi-utils/lib/parse.test.ts
@@ -1,0 +1,206 @@
+import "jest-extended";
+import { testProp } from "@fast-check/jest";
+import * as Arbitrary from "./arbitrary";
+import { FunctionEntry, EventEntry, ErrorEntry } from "./types";
+import assert from "assert";
+
+import * as Parse from "./parse";
+import * as Signature from "./signature";
+
+describe("Signature parsing (property-based tests)", () => {
+  testProp(
+    "abiSignature undoes parseFunctionSignature",
+    [Arbitrary.FunctionEntry()],
+    entry => {
+      const correctSignature = Signature.abiSignature(entry as FunctionEntry); //sorry
+      const reparsedEntry = Parse.parseFunctionSignature(correctSignature);
+      const regeneratedSignature = Signature.abiSignature(reparsedEntry);
+      assert.equal(regeneratedSignature, correctSignature);
+    }
+  );
+
+  testProp(
+    "abiSignature undoes parseErrorSignature",
+    [Arbitrary.ErrorEntry()],
+    entry => {
+      const correctSignature = Signature.abiSignature(entry as ErrorEntry); //sorry
+      const reparsedEntry = Parse.parseErrorSignature(correctSignature);
+      const regeneratedSignature = Signature.abiSignature(reparsedEntry);
+      assert.equal(regeneratedSignature, correctSignature);
+    }
+  );
+
+  testProp(
+    "abiSignature undoes parseEventSignature",
+    [Arbitrary.EventEntry()],
+    entry => {
+      const correctSignature = Signature.abiSignature(entry as EventEntry); //sorry
+      const reparsedEntry = Parse.parseEventSignature(correctSignature);
+      const regeneratedSignature = Signature.abiSignature(reparsedEntry);
+      assert.equal(regeneratedSignature, correctSignature);
+    }
+  );
+});
+
+describe("Signature parsing (manual tests)", () => {
+  it("Parses simple signature", () => {
+    const signature = "ThingsDone(uint256,bytes32,address)";
+    const computed = Parse.parseEventSignature(signature);
+    const expected: EventEntry = {
+      type: "event",
+      anonymous: false,
+      name: "ThingsDone",
+      inputs: [
+        {
+          name: "",
+          indexed: false,
+          type: "uint256"
+        },
+        {
+          name: "",
+          indexed: false,
+          type: "bytes32"
+        },
+        {
+          name: "",
+          indexed: false,
+          type: "address"
+        }
+      ]
+    };
+    assert.deepStrictEqual(computed, expected);
+  });
+
+  it("Parses signature with no inputs", () => {
+    const signature = "ThingsNotDone()";
+    const computed = Parse.parseErrorSignature(signature);
+    const expected: ErrorEntry = {
+      type: "error",
+      name: "ThingsNotDone",
+      inputs: []
+    };
+    assert.deepStrictEqual(computed, expected);
+  });
+
+  it("Parses signature with arrays", () => {
+    const signature = "doThings(uint256[2],bytes32[4][4],string[])";
+    const computed = Parse.parseFunctionSignature(signature);
+    const expected: FunctionEntry = {
+      type: "function",
+      stateMutability: "nonpayable",
+      outputs: [],
+      name: "doThings",
+      inputs: [
+        {
+          name: "",
+          type: "uint256[2]"
+        },
+        {
+          name: "",
+          type: "bytes32[4][4]"
+        },
+        {
+          name: "",
+          type: "string[]"
+        }
+      ]
+    };
+    assert.deepStrictEqual(computed, expected);
+  });
+
+  it("Parses signature with tuples", () => {
+    const signature =
+      "doSillyThings((bool,address[]),(function,(string,bytes[2])))";
+    const computed = Parse.parseFunctionSignature(signature);
+    const expected: FunctionEntry = {
+      type: "function",
+      stateMutability: "nonpayable",
+      outputs: [],
+      name: "doSillyThings",
+      inputs: [
+        {
+          name: "",
+          type: "tuple",
+          components: [
+            {
+              name: "",
+              type: "bool"
+            },
+            {
+              name: "",
+              type: "address[]"
+            }
+          ]
+        },
+        {
+          name: "",
+          type: "tuple",
+          components: [
+            {
+              name: "",
+              type: "function"
+            },
+            {
+              name: "",
+              type: "tuple",
+              components: [
+                {
+                  name: "",
+                  type: "string"
+                },
+                {
+                  name: "",
+                  type: "bytes[2]"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    };
+    assert.deepStrictEqual(computed, expected);
+  });
+
+  it("Parses signature with arrays of tuples", () => {
+    const signature =
+      "doVerySillyThings((bool,address[])[2][][2],(string,int256)[][2][])";
+    const computed = Parse.parseFunctionSignature(signature);
+    const expected: FunctionEntry = {
+      type: "function",
+      stateMutability: "nonpayable",
+      outputs: [],
+      name: "doVerySillyThings",
+      inputs: [
+        {
+          name: "",
+          type: "tuple[2][][2]",
+          components: [
+            {
+              name: "",
+              type: "bool"
+            },
+            {
+              name: "",
+              type: "address[]"
+            }
+          ]
+        },
+        {
+          name: "",
+          type: "tuple[][2][]",
+          components: [
+            {
+              name: "",
+              type: "string"
+            },
+            {
+              name: "",
+              type: "int256"
+            }
+          ]
+        }
+      ]
+    };
+    assert.deepStrictEqual(computed, expected);
+  });
+});

--- a/packages/abi-utils/lib/parse.ts
+++ b/packages/abi-utils/lib/parse.ts
@@ -1,0 +1,138 @@
+import { Parameter, FunctionEntry, ErrorEntry, EventEntry } from "./types";
+
+export function parseFunctionSignature(signature: string): FunctionEntry {
+  const { name, inputs } = parseSignature(signature);
+  return {
+    type: "function" as const,
+    name,
+    inputs,
+    outputs: [] as Parameter[],
+    stateMutability: "nonpayable" as const
+  };
+}
+
+export function parseErrorSignature(signature: string): ErrorEntry {
+  const { name, inputs } = parseSignature(signature);
+  return {
+    type: "error" as const,
+    name,
+    inputs
+  };
+}
+
+export function parseEventSignature(signature: string): EventEntry {
+  const { name, inputs } = parseSignature(signature);
+  return {
+    type: "event" as const,
+    name,
+    inputs: inputs.map(parameter => ({ ...parameter, indexed: false })),
+    anonymous: false
+  };
+}
+
+export function parseSignature(signature: string): {
+  name: string;
+  inputs: Parameter[];
+} {
+  let openParenIndex = signature.indexOf("(");
+  if (openParenIndex === -1) {
+    openParenIndex = signature.length; //set to end of string if not found
+  }
+  const parameterList = signature.slice(openParenIndex);
+  const name = signature.slice(0, openParenIndex);
+  const inputs = parseParameterList(parameterList);
+  return {
+    name,
+    inputs
+  };
+}
+
+export function parseParameterList(parameterList: string): Parameter[] {
+  const { parameters, remaining } =
+    parseParameterListWithRemainder(parameterList);
+  if (remaining !== "") {
+    throw new Error(`Parameter list had extra text ${remaining} afterwards`);
+  }
+  return parameters;
+}
+
+export function parseParameterListWithRemainder(parameterList: string): {
+  parameters: Parameter[];
+  remaining: string;
+} {
+  if (parameterList === "") {
+    throw new Error("Parameter list is missing");
+  }
+  if (parameterList[0] !== "(") {
+    throw new Error(
+      `Parameter list ${parameterList} doesn't begin with parenthesis"`
+    );
+  }
+  if (parameterList[1] === ")") {
+    //due to the appraoch we take below, we need to handle the case of an empty
+    //parameter list as a special case.  a more proper parser wouldn't need to do
+    //this, but, this is easier. :P
+    return { parameters: [], remaining: parameterList.slice(2) };
+  }
+  let remaining = parameterList.slice(1); //cut off opening parenthesis
+  let parameters: Parameter[] = [];
+  //now: we process parameters one by one.  note we CANNOT split on comma!!
+  //that approach will break down if there are any tuples.
+  while (true) {
+    if (remaining[0] === "(") {
+      //tuple or tuple array case
+      let components: Parameter[];
+      ({ parameters: components, remaining } =
+        parseParameterListWithRemainder(remaining));
+      //now we have the components, but there might be an array suffix
+      //copypaste warning, this is copypasted from the simple case below!
+      const match = remaining.match(/[,)]/); //find next comma or close paren
+      const nextTerminatorIndex = match?.index;
+      if (nextTerminatorIndex === undefined) {
+        //if there is none, throw
+        throw new Error("Unmatched open parenthesis");
+      }
+      const final = remaining[nextTerminatorIndex] === ")";
+      const arraySuffix = remaining.slice(0, nextTerminatorIndex);
+      if (!arraySuffix.match(/(\[\d*\])*/)) {
+        //here at least it's pretty straightforward to check whether the array
+        //suffix is valid or not
+        throw new Error(`Invalid array suffix ${arraySuffix}`);
+      }
+      parameters.push({
+        name: "",
+        type: "tuple" + arraySuffix,
+        components
+      });
+      remaining = remaining.slice(nextTerminatorIndex + 1);
+      if (final) {
+        //if we hit a ")", close this group
+        return { parameters, remaining };
+      }
+    } else {
+      //simple case (including arrays w/o tuples)
+      const match = remaining.match(/[,)]/); //find next comma or close paren
+      const nextTerminatorIndex = match?.index;
+      if (nextTerminatorIndex === undefined) {
+        //if there is none, throw
+        throw new Error("Unmatched open parenthesis");
+      }
+      const final = remaining[nextTerminatorIndex] === ")";
+      const parameterString = remaining.slice(0, nextTerminatorIndex);
+      if (!parameterString.match(/[a-zA-Z]([a-zA-Z\d])*(\[\d*\])*/)) {
+        //we're not going to try to fully validate the type here...
+        //we're just going to check that it looks vaguely correct, sorry
+        throw new Error(`Malformed type ${parameterString}`);
+      }
+      parameters.push({
+        name: "",
+        type: parameterString
+      });
+      remaining = remaining.slice(nextTerminatorIndex + 1);
+      if (final) {
+        //if we hit a ")", close this group
+        return { parameters, remaining };
+      }
+    }
+  }
+}

--- a/packages/abi-utils/lib/parse.ts
+++ b/packages/abi-utils/lib/parse.ts
@@ -56,7 +56,7 @@ export function parseParameterList(parameterList: string): Parameter[] {
   return parameters;
 }
 
-export function parseParameterListWithRemainder(parameterList: string): {
+function parseParameterListWithRemainder(parameterList: string): {
   parameters: Parameter[];
   remaining: string;
 } {

--- a/packages/abi-utils/lib/signature.test.ts
+++ b/packages/abi-utils/lib/signature.test.ts
@@ -173,7 +173,7 @@ describe("signature computation", () => {
             {
               name: "bb",
               type: "int256",
-              internalType: "address payable[]"
+              internalType: "int256"
             }
           ]
         }


### PR DESCRIPTION
## PR description

This PR adds functions to ABI utils for parsing signatures.  There's `parseFunctionSignature`, `parseEventSignature`, and `parseErrorSignature`, depending on the entry type you want out.  There's also just a bare-bones `parseSignature` that doesn't return a valid ABI entry, but which is used to back the other three.

This is intended as precursor work for our upcoming solution to #6029.

Note that the ABI entries generated by these functions will have default values for lots of fields... so e.g. `anonymous` will always be `false`, `outputs` will always be `[]`, etc.  Best we can do in the situation, seems to me.  It won't be relevant in the contexts we need this (#6029) anyway.

Also note that the parser doesn't fully validate the input... when it came to primitive types, I just checked that the types looked vaguely like primitive types, not that they're actual types.  (So e.g. `kafoo2e3` will pass validation.)  I could tighten this up if you think it's warranted.

(Also note that on the other hand, if you're dealing with a weird library signature that has like periods or spaces in it, that will *not* pass validation.  I'd consider that to be out of scope for this though... `abi-utils` deals in valid ABIs, not the weird stuff libraries sometimes do.  And of course for #6029 we should only need valid signatures.)

Anyway, I'm not going to bother trying to explain here how the parser works... just go read the code if you want to know that. :P

Also I just used ordinary `Error`s for when something went wrong, I didn't see any point in using like a custom `Error` class here, but again let me know if you think that should be changed.

## Testing instructions

I think the tests I added -- particularly the property-based tests -- should do the job pretty well! :)

Note: Turns out that TS doesn't recognize the arbitraries for `FunctionEntry`, `EventEntry`, etc, as being of the appropriate types. :-/  Maybe there's a way to fix that, but I don't really know much about arbitraries, so I just tossed in some coercions instead...