### PR TITLE
Remove ropsten, kovan, rinkeby support from Etherscan fetcher

### DIFF
--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -56,9 +56,6 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
   private static readonly apiDomainsByNetworkName: { [name: string]: string } =
     {
       "mainnet": "api.etherscan.io",
-      "ropsten": "api-ropsten.etherscan.io",
-      "kovan": "api-kovan.etherscan.io",
-      "rinkeby": "api-rinkeby.etherscan.io",
       "goerli": "api-goerli.etherscan.io",
       "sepolia": "api-sepolia.etherscan.io",
       "optimistic": "api-optimistic.etherscan.io",


### PR DESCRIPTION
It seems that Etherscan has removed all support for Ropsten, Kovan, and Rinkeby... you can't even go and browse what was once there.  It's just all gone.  So, time to remove it from the Etherscan fetcher...