### PR TITLE
Increase time on various tests that were timing out

### DIFF
--- a/packages/dashboard-hardhat-plugin/test/hardhat.test.ts
+++ b/packages/dashboard-hardhat-plugin/test/hardhat.test.ts
@@ -23,6 +23,7 @@ describe("Truffle dashboard hardhat plugin compilation tests", function () {
     useEnvironment("hardhat-project-incorrect-version", "dashboard");
 
     it("should fail if Hardhat version is below 2.10.1", async function () {
+      this.timeout(15000);
       return await this.env
         .run(TASK_COMPILE, { force: true, quiet: false })
         .then(() => {

--- a/packages/debugger/test/step.js
+++ b/packages/debugger/test/step.js
@@ -70,7 +70,7 @@ describe("Stepping functions", function () {
   });
 
   it("Steps correctly with step next", async function () {
-    this.timeout(4000);
+    this.timeout(5000);
     let instance = await abstractions.Steppy.deployed();
     let receipt = await instance.run();
     let txHash = receipt.tx;
@@ -109,7 +109,7 @@ describe("Stepping functions", function () {
   });
 
   it("Steps correctly with step into", async function () {
-    this.timeout(4000);
+    this.timeout(5000);
     let instance = await abstractions.Steppy.deployed();
     let receipt = await instance.run();
     let txHash = receipt.tx;
@@ -148,7 +148,7 @@ describe("Stepping functions", function () {
   });
 
   it("Steps over a function from the call site", async function () {
-    this.timeout(4000);
+    this.timeout(5000);
     let instance = await abstractions.Steppy.deployed();
     let receipt = await instance.run();
     let txHash = receipt.tx;
@@ -175,7 +175,7 @@ describe("Stepping functions", function () {
   });
 
   it("Steps over a function from the definition", async function () {
-    this.timeout(4000);
+    this.timeout(5000);
     let instance = await abstractions.Steppy.deployed();
     let receipt = await instance.run();
     let txHash = receipt.tx;
@@ -202,7 +202,7 @@ describe("Stepping functions", function () {
   });
 
   it("Steps out of a function", async function () {
-    this.timeout(4000);
+    this.timeout(5000);
     let instance = await abstractions.Steppy.deployed();
     let receipt = await instance.run();
     let txHash = receipt.tx;
@@ -229,7 +229,7 @@ describe("Stepping functions", function () {
   });
 
   it("Steps out of a function from the definition", async function () {
-    this.timeout(4000);
+    this.timeout(5000);
     let instance = await abstractions.Steppy.deployed();
     let receipt = await instance.run();
     let txHash = receipt.tx;
@@ -256,7 +256,7 @@ describe("Stepping functions", function () {
   });
 
   it("Steps over a Yul function from the call site", async function () {
-    this.timeout(4000);
+    this.timeout(5000);
     let instance = await abstractions.Steppy.deployed();
     let receipt = await instance.yulTest();
     let txHash = receipt.tx;
@@ -283,7 +283,7 @@ describe("Stepping functions", function () {
   });
 
   it("Steps over a Yul function from the definition", async function () {
-    this.timeout(4000);
+    this.timeout(5000);
     let instance = await abstractions.Steppy.deployed();
     let receipt = await instance.yulTest();
     let txHash = receipt.tx;
@@ -319,7 +319,7 @@ describe("Stepping functions", function () {
   });
 
   it("Steps out of a Yul function", async function () {
-    this.timeout(4000);
+    this.timeout(5000);
     let instance = await abstractions.Steppy.deployed();
     let receipt = await instance.yulTest();
     let txHash = receipt.tx;
@@ -346,7 +346,7 @@ describe("Stepping functions", function () {
   });
 
   it("Steps out of a Yul function from the definition", async function () {
-    this.timeout(4000);
+    this.timeout(5000);
     let instance = await abstractions.Steppy.deployed();
     let receipt = await instance.yulTest();
     let txHash = receipt.tx;


### PR DESCRIPTION
This test keeps failing its 10-second timeout.  Increasing the time from 10 seconds to 15.

May add more timeout increases to this PR if I see more that we need to get.