### PR TITLE
Add two more sourcify networks

### DIFF
--- a/packages/source-fetcher/lib/networks.ts
+++ b/packages/source-fetcher/lib/networks.ts
@@ -105,7 +105,9 @@ export const networkNamesById: { [id: number]: string } = {
   999: "testnet-wanchain",
   7668: "root",
   7672: "porcini-root",
-  295: "hedera"
+  295: "hedera",
+  1149: "symplexia",
+  2000: "dogechain"
   //I'm not including crystaleum as it has network ID different from chain ID
   //not including kekchain for the same reason
 };

--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -130,7 +130,9 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "testnet-wanchain",
     "root",
     "porcini-root",
-    "hedera"
+    "hedera",
+    "symplexia",
+    "dogechain"
     //I'm excluding crystaleum as it has network ID different from chain ID
     //excluding kekchain for the same reason
   ]);


### PR DESCRIPTION
Adding symplexia and dogechain.  Looks like Sourcify may have "shadow-dropped" these two, oy.

Note that Sourcify also removed a bunch of networks recently, but unlike Etherscan, when Sourcify removes a network, it still leaves up the verified contracts, so I don't typically remove support from the fetcher since there's still something for it to fetch.