### PR TITLE
pass solc when available to profiler to avoid fetching the solc list again

### DIFF
--- a/packages/compile-solidity/src/index.ts
+++ b/packages/compile-solidity/src/index.ts
@@ -165,7 +165,8 @@ export const Compile = {
           name: "solc",
           version: solc.version()
         }
-      })
+      }),
+      solc
     );
     debug("compilationTargets: %O", compilationTargets);
 

--- a/packages/compile-solidity/src/profiler/index.ts
+++ b/packages/compile-solidity/src/profiler/index.ts
@@ -13,9 +13,9 @@ export const Profiler = {
 
   // Returns the minimal set of sources to pass to solc as compilations targets,
   // as well as the complete set of sources so solc can resolve the comp targets' imports.
-  requiredSources: async (options: Config) => {
+  requiredSources: async (options: Config, solc?: any) => {
     // get parser
-    const parseImports = await loadParser(options);
+    const parseImports = await loadParser(options, solc);
 
     // generate profiler
     const profiler = new TruffleProfiler({

--- a/packages/compile-solidity/src/profiler/loadParser.ts
+++ b/packages/compile-solidity/src/profiler/loadParser.ts
@@ -18,7 +18,7 @@ export async function loadParser(
   { events, compilers: { solc: solcConfig } }: Config,
   providedSolc?: any
 ) {
-  if (providedSolc) {
+  if (providedSolc && solcConfig.parser === undefined) {
     return makeParseImports(providedSolc);
   }
   const { parser } = solcConfig;

--- a/packages/compile-solidity/src/profiler/loadParser.ts
+++ b/packages/compile-solidity/src/profiler/loadParser.ts
@@ -14,10 +14,13 @@ import type Config from "@truffle/config";
  * up to twice: first time as usual, to get the specific version, then a second
  * time to get the solcjs of that version.
  */
-export async function loadParser({
-  events,
-  compilers: { solc: solcConfig }
-}: Config) {
+export async function loadParser(
+  { events, compilers: { solc: solcConfig } }: Config,
+  providedSolc?: any
+) {
+  if (providedSolc) {
+    return makeParseImports(providedSolc);
+  }
   const { parser } = solcConfig;
 
   const supplier = new CompilerSupplier({ events, solcConfig });


### PR DESCRIPTION
This PR is an optimization. In certain cases during the compilation flow, the CompilerSupplier is instantiated twice and it fetches the list of Solidity compiler versions twice. This is because it needs to see what compiler versions are available when making sure it has the right version and because we need the parser to determine what a sources dependencies are for compilation. So this PR passes the compiler to the Profiler when it has it so that it doesn't need to be fetched again.