### PR TITLE
Bug fix: re-add event that seems like it was accidentally removed

### DIFF
--- a/packages/compile-solidity/src/compilerSupplier/loadingStrategies/VersionRange.ts
+++ b/packages/compile-solidity/src/compilerSupplier/loadingStrategies/VersionRange.ts
@@ -249,6 +249,7 @@ export class VersionRange {
     const url = `${urlRoot.replace(/\/+$/, "")}/list.json`;
     try {
       const response = await axios.get(url, { maxRedirects: 50 });
+      events.emit("fetchSolcList:succeed");
       return response.data;
     } catch (error) {
       events.emit("fetchSolcList:fail");


### PR DESCRIPTION
It seems like somewhere along the line the event declaring success for fetching the list of Solidity compilers got accidentally removed? This PR re-adds this event.