### PR TITLE
add new route in preparation for visual debugger PR

### DIFF
--- a/packages/dashboard/lib/DashboardServer.ts
+++ b/packages/dashboard/lib/DashboardServer.ts
@@ -106,12 +106,8 @@ export class DashboardServer {
       let config;
       try {
         config = Config.detect();
-      } catch (error) {
-        const notFound = "Could not find suitable configuration file.";
-        if (!error.message.includes(notFound)) {
-          throw error;
-        }
-      }
+        // we'll ignore errors as we only get the config for the api key
+      } catch {}
 
       // a key provided in the browser takes precedence over on in the config
       let etherscanKey: undefined | string;

--- a/packages/dashboard/lib/DashboardServer.ts
+++ b/packages/dashboard/lib/DashboardServer.ts
@@ -2,6 +2,8 @@ import express, { Application, NextFunction, Request, Response } from "express";
 import path from "path";
 import getPort from "get-port";
 import open from "open";
+import { fetchAndCompile } from "@truffle/fetch-and-compile";
+import { sha1 } from "object-hash";
 import { v4 as uuid } from "uuid";
 import Config from "@truffle/config";
 import {
@@ -9,6 +11,7 @@ import {
   LogMessage,
   logMessageType
 } from "@truffle/dashboard-message-bus-common";
+import type { Compilation } from "@truffle/compile-common";
 import { DashboardMessageBus } from "@truffle/dashboard-message-bus";
 import { DashboardMessageBusClient } from "@truffle/dashboard-message-bus-client";
 import cors from "cors";
@@ -94,6 +97,62 @@ export class DashboardServer {
       await this.connectToMessageBus();
       this.expressApp.post("/rpc", this.postRpc.bind(this));
     }
+
+    this.expressApp.get("/fetch-and-compile", async (req, res) => {
+      const { address, networkId, etherscanApiKey } = req.query as Record<
+        string,
+        string
+      >;
+      let config;
+      try {
+        config = Config.detect();
+      } catch (error) {
+        const notFound = "Could not find suitable configuration file.";
+        if (!error.message.includes(notFound)) {
+          throw error;
+        }
+      }
+
+      // a key provided in the browser takes precedence over on in the config
+      let etherscanKey: undefined | string;
+      if (etherscanApiKey) {
+        etherscanKey = etherscanApiKey;
+      } else if (config && config.etherscan !== undefined) {
+        etherscanKey = config.etherscan.apiKey;
+      }
+
+      config = Config.default().merge({
+        networks: {
+          custom: { network_id: networkId }
+        },
+        network: "custom",
+        etherscan: {
+          apiKey: etherscanKey
+        }
+      });
+
+      let result;
+      try {
+        result = (await fetchAndCompile(address, config)).compileResult;
+      } catch (error) {
+        if (!error.message.includes("No verified sources")) {
+          throw error;
+        }
+      }
+      if (result) {
+        // we calculate hashes on the server because it is at times too
+        // resource intensive for the browser and causes it to crash
+        const hashes = result.compilations.map((compilation: Compilation) => {
+          return sha1(compilation);
+        });
+        res.json({
+          hashes,
+          compilations: result.compilations
+        });
+      } else {
+        res.json({ compilations: [] });
+      }
+    });
 
     this.expressApp.get("/analytics", (_req, res) => {
       const userConfig = Config.getUserConfig();

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -39,6 +39,7 @@
     "@mantine/prism": "^5.0.0",
     "@truffle/codec": "^0.15.2",
     "@truffle/config": "^1.3.57",
+    "@truffle/fetch-and-compile": "^0.5.48",
     "@truffle/dashboard-message-bus": "^0.1.11",
     "@truffle/dashboard-message-bus-client": "^0.1.11",
     "@truffle/dashboard-message-bus-common": "^0.1.6",


### PR DESCRIPTION
This PR adds a route in preparation for getting https://github.com/trufflesuite/truffle/pull/6058 merged.

The visual debugger will be fetching verified sources externally in the case that it doesn't have compilations for some of the contracts the tx touches. In order to implement this, this route is added. It allows dashboard to give the server a list of addresses and a network to use to attempt to fetch the source material. This route fetches what it can, compiles everything, and then returns it to dashboard.