### PR TITLE
Bug fix: correct resolver import in legacy workflow compile

### DIFF
--- a/packages/workflow-compile/legacy/index.js
+++ b/packages/workflow-compile/legacy/index.js
@@ -7,7 +7,7 @@ const { Shims } = require("@truffle/compile-common");
 const expect = require("@truffle/expect");
 const Config = require("@truffle/config");
 const Artifactor = require("@truffle/artifactor");
-const Resolver = require("@truffle/resolver");
+const Resolver = require("@truffle/resolver").default;
 
 const SUPPORTED_COMPILERS = {
   solc: solcCompile,


### PR DESCRIPTION
This PR was prompted by https://github.com/trufflesuite/truffle/issues/6066.

The resolver package exports were changed and the legacy workflow compile package imports for it were not updated which caused it to break. This PR corrects the import in legacy workflow-compile. 