### PR TITLE
Reject SolidityAST contracts verified on Etherscan

### DIFF
--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -255,7 +255,13 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
   private static processJsonResult(
     result: EtherscanResult,
     jsonInput: Types.SolcInput
-  ): Types.SourceInfo {
+  ): Types.SourceInfo | null {
+    if (jsonInput.language === "SolidityAST") {
+      //I don't know whether this is actually possible on Etherscan,
+      //but there's no way we can reasonably handle it, so let's
+      //just be defensive and refuse it
+      return null;
+    }
     return {
       contractName: result.ContractName,
       sources: this.processSources(jsonInput.sources),

--- a/packages/source-fetcher/lib/types.ts
+++ b/packages/source-fetcher/lib/types.ts
@@ -101,7 +101,7 @@ export interface SolcSources {
 }
 
 export interface SolcInput {
-  language: "Solidity";
+  language: "Solidity" | "Yul" | "SolidityAST";
   sources: SolcSources;
   settings: SolcSettings;
 }


### PR DESCRIPTION
As of Solidity 0.8.20, it's now possible to use the Solidity compiler in a mode where, instead of passing `language: "Solidity"` or `language: "Yul"`, you pass `language: "SolidityAST"`, and put in the AST of what you want compiled (it's the long-awaited companion to the stop-after-parsing option).

I got worried about the possibility that Etherscan might allow verifying input in this form.  I haven't actually yet tested whether it does, I intend to test that later.  But I thought it would be good to put in a bit of defensive coding against that possibility right now, since there's no way we can reasonably handle it (at least, not quickly right now).