### PR TITLE
Put try/catch guard around ENS forward resolution in decoder/debugger

### DIFF
--- a/packages/debugger/lib/web3/adapter.js
+++ b/packages/debugger/lib/web3/adapter.js
@@ -143,6 +143,13 @@ export default class Web3Adapter {
     if (!this.ens) {
       return null;
     }
-    return await this.ens.name(name).getAddress();
+    try {
+      //unfortunately, ensjs will error if the name contains certain characters
+      //that aren't allowed in domain names.
+      //and again, we really don't want this erroring, so we swallow it, sorry :-/
+      return await this.ens.name(name).getAddress();
+    } catch {
+      return null;
+    }
   }
 }

--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -412,7 +412,15 @@ export class ProjectDecoder {
     }
     if (name !== null) {
       //do a forward resolution check to make sure it matches
-      const checkAddress = await this.ens.name(name).getAddress();
+      let checkAddress: string;
+      try {
+        checkAddress = await this.ens.name(name).getAddress();
+      } catch {
+        //why the try/catch?  because forward resolution will throw if the
+        //name contains certain characters that are illegal in a domain name,
+        //but this isn't in any way enforced on reverse resolution above. yay.
+        checkAddress = null;
+      }
       if (checkAddress !== address) {
         //if it doesn't, the name is no good!
         name = null;


### PR DESCRIPTION
## PR description

This PR fixes an issue noticed by @gnidan.  Turns out that ENSJS will throw an error if you try to resolve an ENS name which contains certain characters not permitted in URLs[0], such as 🪴 (but apparently 🍑 is fine).  This despite the fact that it has no problem with them on reverse resolution, and apparently it was possible to register these names in the first place (presumably by just not using ENSJS).

Since I don't really want to go tearing out ENSJS right now, I'm fixing this the crudest way possible, with a blunt try/catch.  I could check for the particular error message, but that's probably too brittle.

(Notionally I could use a library (ideally one we're already implicitly using) to check for the particular illegal characters, but that seems a bit too much work for something like this.)

[0] I'm a little unclear at this point, honestly.  Suffice it to say that there is apparently at least *one* convention under which they are illegal, and ENSJS is applying this convention.

## Testing instructions

Nick found this issue by attempting to use the decoder to decode the state variables (as of block `17445497`) of the mainnet contract at address `0xa39739ef8b0231dbfa0dcda07d7e29faabcf4bb2`, having obtained its source via fetch-and-compile.  The particular variable that causes the error is called "TroveOwners".  Try executing the following commands in `node --experimental-repl-await`: (or run this outside the repl I guess :P )

```
const { fetchAndCompile } = require("@truffle/fetch-and-compile")
Decoder = require("@truffle/decoder")
address = "0xa39739ef8b0231dbfa0dcda07d7e29faabcf4bb2"
networkId = 1
let { compileResult } = await fetchAndCompile(address, { network: { networkId } })
let projectInfo = { commonCompilations: compileResult.compilations }
let Web3 = require("web3")
let web3 = new Web3(<your preferred way of connecting to mainnet>)
let projectDecoder = await Decoder.forProject({ provider: web3.currentProvider, projectInfo })
let decoder = await projectDecoder.forAddress(address)
block = 17445497
await decoder.variable("TroveOwners", block)
```

That last line should not error.  (Without this fix, it does.)