### PR TITLE
Add chains for Sourcify 2.2.3

### DIFF
--- a/packages/source-fetcher/lib/networks.ts
+++ b/packages/source-fetcher/lib/networks.ts
@@ -107,7 +107,12 @@ export const networkNamesById: { [id: number]: string } = {
   7672: "porcini-root",
   295: "hedera",
   1149: "symplexia",
-  2000: "dogechain"
+  2000: "dogechain",
+  1339: "elysium",
+  //taiko doesn't seem to have a mainnet yet
+  167005: "alpha3-taiko",
+  96: "bitkub",
+  25925: "testnet-bitkub"
   //I'm not including crystaleum as it has network ID different from chain ID
   //not including kekchain for the same reason
 };

--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -132,7 +132,12 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "porcini-root",
     "hedera",
     "symplexia",
-    "dogechain"
+    "dogechain",
+    "cronos",
+    "elysium",
+    "alpha3-taiko",
+    "bitkub",
+    "testnet-bitkub"
     //I'm excluding crystaleum as it has network ID different from chain ID
     //excluding kekchain for the same reason
   ]);


### PR DESCRIPTION
Sourcify has added more chains!

Contracts you can test these with:

Cronos: 0xEdE2053329D203E8261B47A10540Ee4b7a596667
Elysium: 0x20563837F7423465699D7675BCB82f886a761c25
Bitkub: 0xC75f4D89A0DdA70Ad613908D9976E90dAb42035c
Bitkub testnet: 0x58909Ef2F2b167F52cF46575f1582500287cCE48
Taiko testnet alpha 3: 0x68107Fb54f5f29D8e0B3Ac44a99f4444D1F22a68