### PR TITLE
Replace bootstrap with install in scripts/workflows

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -45,7 +45,7 @@ jobs:
 
     - run: npm install -g yarn
 
-    - run: yarn bootstrap
+    - run: yarn install
     - run: test -z "$(git diff)" || (echo 'Did you check in a generated file to source control?  Please remove it if so'; false)
     
     - run: yarn depcheck

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -12,7 +12,7 @@ git checkout develop
 git pull origin develop
 
 ## Build
-yarn bootstrap
+yarn install
 
 ## Get output of changes for release notes
 prs-merged-since --repo trufflesuite/truffle --tag v$LAST_PUBLISHED_TAG --format markdown


### PR DESCRIPTION
Since `yarn bootstrap` seems to be causing such problems, and I can't figure out the root cause, here's a simple workaround... replacing `yarn bootstrap` with `yarn install`.   There used to be a difference between these, but due to every package using `prepare` now, there no longer is.  Hopefully this is all OK and solves the problem?