### PR TITLE
Allow Truffle Dashboard to run without launching a browser window automatically

### DIFF
--- a/packages/config/src/configDefaults.ts
+++ b/packages/config/src/configDefaults.ts
@@ -50,6 +50,7 @@ export const getInitialConfig = ({
     dashboard: {
       host: "localhost",
       port: 24012,
+      autoOpen: true,
       verbose: false
     },
     ens: {

--- a/packages/core/lib/commands/dashboard/meta.js
+++ b/packages/core/lib/commands/dashboard/meta.js
@@ -3,19 +3,19 @@ module.exports = {
   description:
     "Start Truffle Dashboard to sign development transactions using browser wallet",
   builder: {
-    port: {
+    "port": {
       describe: "Specify the port to start the dashboard and RPC endpoint on",
       type: "number"
     },
-    host: {
+    "host": {
       describe: "Specify the host to start the dashboard and RPC endpoint on",
       type: "string"
     },
-    autoOpen: {
-      describe: "Open dashboard in default browser on start",
+    "no-auto-open": {
+      describe: "Disable opening dashboard in default browser on start",
       type: "boolean"
     },
-    verbose: {
+    "verbose": {
       describe: "Display debug logs for the dashboard server and message bus",
       type: "boolean"
     }
@@ -32,8 +32,8 @@ module.exports = {
         description: "Start the dashboard and RPC endpoint on a specific host."
       },
       {
-        option: "--autoOpen <boolean>",
-        description: "Open dashboard in default browser on start"
+        option: "--no-auto-open",
+        description: "Disable opening dashboard in default browser on start"
       },
       {
         option: "--verbose",

--- a/packages/core/lib/commands/dashboard/meta.js
+++ b/packages/core/lib/commands/dashboard/meta.js
@@ -11,6 +11,10 @@ module.exports = {
       describe: "Specify the host to start the dashboard and RPC endpoint on",
       type: "string"
     },
+    autoOpen: {
+      describe: "Open dashboard in default browser on start",
+      type: "boolean"
+    },
     verbose: {
       describe: "Display debug logs for the dashboard server and message bus",
       type: "boolean"
@@ -26,6 +30,10 @@ module.exports = {
       {
         option: "--host <string>",
         description: "Start the dashboard and RPC endpoint on a specific host."
+      },
+      {
+        option: "--autoOpen <boolean>",
+        description: "Open dashboard in default browser on start"
       },
       {
         option: "--verbose",

--- a/packages/core/lib/commands/dashboard/run.js
+++ b/packages/core/lib/commands/dashboard/run.js
@@ -7,10 +7,11 @@ module.exports = async function (options) {
 
   const port = options.port || config.dashboard.port;
   const host = options.host || config.dashboard.host;
+  const autoOpen = options.autoOpen ?? config.dashboard.autoOpen;
   const verbose = options.verbose || config.dashboard.verbose;
   const rpc = true;
 
-  const dashboardServerOptions = { port, host, verbose, rpc };
+  const dashboardServerOptions = { port, host, autoOpen, verbose, rpc };
   const dashboardServer = new DashboardServer(dashboardServerOptions);
   await dashboardServer.start();
 


### PR DESCRIPTION
Addresses #6095

It can be useful in some environments to not want Dashboard to open in browser on start.

To test:
- `truffle dashboard --no-auto-open`
- `truffle dashboard` in a Truffle project with `dashboard.autoOpen` set in truffle-config.js

CLI value takes precedence.
