### PR TITLE
Add missing codec component for new error type

### DIFF
--- a/packages/codec-components/src/react/components/codec/format.errors.internal-use-error.tsx
+++ b/packages/codec-components/src/react/components/codec/format.errors.internal-use-error.tsx
@@ -3,14 +3,20 @@ import type { Format } from "@truffle/codec";
 import { createCodecComponent } from "../../utils/create-codec-component";
 import { OverlongArrayOrStringStrictModeError } from "./format.errors.overlong-array-or-string-strict-mode-error";
 import { InternalFunctionInABIError } from "./format.errors.internal-function-in-abi-error";
-import { isOverlongArrayOrStringStrictModeError } from "../../../utils";
+import { ReEncodingMismatchError } from "./format.errors.re-encoding-mismatch-error";
+import {
+  isOverlongArrayOrStringStrictModeError,
+  isInternalFunctionInABIError
+} from "../../../utils";
 
 export const { InternalUseError } = createCodecComponent(
   "InternalUseError",
   (data: Format.Errors.InternalUseError) =>
     isOverlongArrayOrStringStrictModeError(data) ? (
       <OverlongArrayOrStringStrictModeError data={data} />
-    ) : (
+    ) : isInternalFunctionInABIError(data) ? (
       <InternalFunctionInABIError data={data} />
+    ) : (
+      <ReEncodingMismatchError data={data} />
     )
 );

--- a/packages/codec-components/src/react/components/codec/format.errors.re-encoding-mismatch-error.tsx
+++ b/packages/codec-components/src/react/components/codec/format.errors.re-encoding-mismatch-error.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import type { Format } from "@truffle/codec";
+import { createCodecComponent } from "../../utils/create-codec-component";
+import { CodecError } from "../common/codec-error";
+
+export const { ReEncodingMismatchError } = createCodecComponent(
+  "ReEncodingMismatchError",
+  ({ kind }: Format.Errors.ReEncodingMismatchError) => (
+    <CodecError kind={kind} />
+  )
+);

--- a/packages/codec-components/src/react/contexts/custom-components.ts
+++ b/packages/codec-components/src/react/contexts/custom-components.ts
@@ -86,6 +86,7 @@ export interface CustomComponentsContextValue {
       OverlargePointersNotImplementedError: Codec.Format.Errors.OverlargePointersNotImplementedError;
       OverlongArrayOrStringStrictModeError: Codec.Format.Errors.OverlongArrayOrStringStrictModeError;
       OverlongArraysAndStringsNotImplementedError: Codec.Format.Errors.OverlongArraysAndStringsNotImplementedError;
+      ReEncodingMismatchError: Codec.Format.Errors.ReEncodingMismatchError;
       ReadErrorBytes: Codec.Format.Errors.ReadErrorBytes;
       ReadErrorStack: Codec.Format.Errors.ReadErrorStack;
       ReadErrorStorage: Codec.Format.Errors.ReadErrorStorage;

--- a/packages/codec-components/src/react/index.ts
+++ b/packages/codec-components/src/react/index.ts
@@ -68,6 +68,7 @@ export * from "./components/codec/format.errors.options-error";
 export * from "./components/codec/format.errors.overlarge-pointers-not-implemented-error";
 export * from "./components/codec/format.errors.overlong-array-or-string-strict-mode-error";
 export * from "./components/codec/format.errors.overlong-arrays-and-strings-not-implemented-error";
+export * from "./components/codec/format.errors.re-encoding-mismatch-error";
 export * from "./components/codec/format.errors.read-error-bytes";
 export * from "./components/codec/format.errors.read-error-stack";
 export * from "./components/codec/format.errors.read-error-storage";

--- a/packages/codec-components/src/utils/index.ts
+++ b/packages/codec-components/src/utils/index.ts
@@ -39,6 +39,7 @@ export * from "./type-guards/decoder-error/options-error";
 export * from "./type-guards/decoder-error/overlarge-pointers-not-implemented-error";
 export * from "./type-guards/decoder-error/overlong-array-or-string-strict-mode-error";
 export * from "./type-guards/decoder-error/overlong-arrays-and-strings-not-implemented-error";
+export * from "./type-guards/decoder-error/re-encoding-mismatch-error";
 export * from "./type-guards/decoder-error/read-error";
 export * from "./type-guards/decoder-error/read-error-bytes";
 export * from "./type-guards/decoder-error/read-error-stack";

--- a/packages/codec-components/src/utils/type-guards/decoder-error/internal-use-error.ts
+++ b/packages/codec-components/src/utils/type-guards/decoder-error/internal-use-error.ts
@@ -2,9 +2,11 @@ import type { Format } from "@truffle/codec";
 import { decoderErrorTypeGuardHelper } from "./helper";
 import { overlongArrayOrStringStrictModeErrorKinds } from "./overlong-array-or-string-strict-mode-error";
 import { internalFunctionInABIErrorKinds } from "./internal-function-in-abi-error";
+import { reEncodingMismatchErrorKinds } from "./re-encoding-mismatch-error";
 
 export const [isInternalUseError, internalUseErrorKinds] =
   decoderErrorTypeGuardHelper<Format.Errors.InternalUseError>(
     ...overlongArrayOrStringStrictModeErrorKinds,
-    ...internalFunctionInABIErrorKinds
+    ...internalFunctionInABIErrorKinds,
+    ...reEncodingMismatchErrorKinds
   );

--- a/packages/codec-components/src/utils/type-guards/decoder-error/re-encoding-mismatch-error.ts
+++ b/packages/codec-components/src/utils/type-guards/decoder-error/re-encoding-mismatch-error.ts
@@ -1,0 +1,7 @@
+import type { Format } from "@truffle/codec";
+import { decoderErrorTypeGuardHelper } from "./helper";
+
+export const [isReEncodingMismatchError, reEncodingMismatchErrorKinds] =
+  decoderErrorTypeGuardHelper<Format.Errors.ReEncodingMismatchError>(
+    "ReEncodingMismatchError"
+  );


### PR DESCRIPTION
I merged #6057 while ignoring that it adds a new codec error type which needs a component, crap!  So uh I added that quickly.

I didn't actually test this component because this error should never actually appear onscreen and also I just want develop not broken.  It builds, that's good enough for me. :P  Next time I write a component, which will be something that could appear onscreen, I will bother to test it. :P