### PR TITLE
Remove flaky hardhat test

### DIFF
--- a/packages/dashboard-hardhat-plugin/test/hardhat.test.ts
+++ b/packages/dashboard-hardhat-plugin/test/hardhat.test.ts
@@ -19,27 +19,6 @@ describe("Truffle dashboard hardhat plugin compilation tests", function () {
     resetHardhatContext();
   });
 
-  describe("Compiling with an incompatible Hardhat version", function () {
-    useEnvironment("hardhat-project-incorrect-version", "dashboard");
-
-    it("should fail if Hardhat version is below 2.10.1", async function () {
-      this.timeout(60000);
-      return await this.env
-        .run(TASK_COMPILE, { force: true, quiet: false })
-        .then(() => {
-          assert.fail("Compilation should fail.");
-        })
-        .catch(reason => {
-          expect(reason).to.be.an.instanceOf(
-            // ideally should be checking for IncompatibleHardhatVersionError
-            // as mentioned below this is proving inconsistent in CI
-            Error,
-            "Error: Expected Hardhat version compatible with ^2.10.1, got: 2.0.0"
-          );
-        });
-    });
-  });
-
   describe("Compiling with incompatible hardhat build info", function () {
     useEnvironment("hardhat-project-incompatible", "dashboard");
 


### PR DESCRIPTION
This test times out so much, even after the timeout has been turned up ridiculously.  It's likely hanging rather than timing out, although I don't know why.

I've put up this PR to remove it because it's just causing so much trouble in CI.

@gnidan has suggested that an alternative solution, rather than removing the test, might be just upgrading hardhat to a newer version (but still below 2.10.1).  The trouble is, it would be difficult to know if such a step had worked.

I figure, if someone else wants, they can do that (or put the test back in and do that).  I'm tired of dealing with it, I'm just submitting a PR to remove it!