### PR TITLE
Specify "magic" variables' type only in component tooltip, not via prefix

### DIFF
--- a/packages/codec-components/src/react/components/codec/format.values.magic-value.tsx
+++ b/packages/codec-components/src/react/components/codec/format.values.magic-value.tsx
@@ -4,23 +4,31 @@ import { createCodecComponent } from "../../utils/create-codec-component";
 import { Result } from "./format.values.result";
 import { NextBracketDepth } from "../providers/next-bracket-depth";
 import { InjectedNode } from "../providers/injected-node";
+import { useInjectedNode } from "../../contexts/injected-node";
 import { Container } from "../common/container";
 import { Code } from "../common/code";
 
 export const { MagicValue } = createCodecComponent(
   "MagicValue",
   ({ type, value }: Format.Values.MagicValue) => {
+    const { prefix, suffix } = useInjectedNode();
     const valueLength = Object.keys(value).length;
     return (
       <Container
         prefix={
           <>
+            {prefix?.prefix}
             <Code title={`type: ${type.variable}`} type="bracket">
               {"{"}
             </Code>
           </>
         }
-        suffix={<Code type="bracket">{"}"}</Code>}
+        suffix={
+          <>
+            <Code type="bracket">{"}"}</Code>
+            {suffix?.suffix}
+          </>
+        }
         empty={valueLength === 0}
       >
         <NextBracketDepth>

--- a/packages/codec-components/src/react/components/codec/format.values.magic-value.tsx
+++ b/packages/codec-components/src/react/components/codec/format.values.magic-value.tsx
@@ -15,9 +15,9 @@ export const { MagicValue } = createCodecComponent(
       <Container
         prefix={
           <>
-            <Code title="type: magic (debugger-only)">{type.variable}</Code>
-            <Code type="colon">:</Code>
-            <Code type="bracket">{"{"}</Code>
+            <Code title={`type: ${type.variable}`} type="bracket">
+              {"{"}
+            </Code>
           </>
         }
         suffix={<Code type="bracket">{"}"}</Code>}


### PR DESCRIPTION
## PR description

This updates the `MagicValue` component to omit the prefix specifying which kind of magic variable it is, instead putting that information in the tooltip.

See: 

<img width="481" alt="Screenshot 2023-06-21 at 11 06 17 PM" src="https://github.com/trufflesuite/truffle/assets/151065/5cf0d139-2c68-4385-873c-68a991620ee3">