### PR TITLE
Add zora network to Sourcify fetcher

### DIFF
--- a/packages/source-fetcher/lib/networks.ts
+++ b/packages/source-fetcher/lib/networks.ts
@@ -112,7 +112,8 @@ export const networkNamesById: { [id: number]: string } = {
   //taiko doesn't seem to have a mainnet yet
   167005: "alpha3-taiko",
   96: "bitkub",
-  25925: "testnet-bitkub"
+  25925: "testnet-bitkub",
+  7777777: "zora"
   //I'm not including crystaleum as it has network ID different from chain ID
   //not including kekchain for the same reason
 };

--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -137,7 +137,8 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "elysium",
     "alpha3-taiko",
     "bitkub",
-    "testnet-bitkub"
+    "testnet-bitkub",
+    "zora"
     //I'm excluding crystaleum as it has network ID different from chain ID
     //excluding kekchain for the same reason
   ]);


### PR DESCRIPTION
Adds the zora chain to the sourcify fetcher.

If you want to test it, you could try testing it with address 0x090734f94FA67590702421A9B61892509b7CE80A.