### PR TITLE
handle case when a user uses @truffle/test without core

### DIFF
--- a/packages/test/src/Test.ts
+++ b/packages/test/src/Test.ts
@@ -44,7 +44,7 @@ interface SetJSTestGlobalsInterface {
 export const Test = {
   run: async function (
     options: Config,
-    createInTestDebugFunction: CreateInTestDebugFunction
+    createInTestDebugFunction?: CreateInTestDebugFunction
   ) {
     expect.options(options, [
       "contracts_directory",
@@ -55,6 +55,20 @@ export const Test = {
       "network_id",
       "provider"
     ]);
+
+    // if test is used standalone, this function won't be setup like in core
+    if (createInTestDebugFunction === undefined) {
+      createInTestDebugFunction = () => {
+        return () => {
+          config.logger.log(
+            `${colors.bold(
+              "Warning:"
+            )} Use of in-test debugging is only available when running ` +
+              `truffle test --debug.`
+          );
+        };
+      };
+    }
 
     const config = Config.default().merge(options);
 


### PR DESCRIPTION
Consider Truffle's test flow. Normally we set up a `createInTestDebug` function which does what it says and pass it to test. A user reported [here](https://github.com/trufflesuite/truffle/issues/6105) that running test programmatically (without the CLI and core) is crashing. It turns out that we never handled the case where this function wasn't passed to @truffle/test. This PR inserts a value for this function that gives the user a helpful message if they try to use `debug` and it is not available.