### PR TITLE
Display Dashboard Debugger variables in <ul>s with <NameValuePair>s

### DIFF
--- a/packages/dashboard/src/components/composed/Debugger/Variables.tsx
+++ b/packages/dashboard/src/components/composed/Debugger/Variables.tsx
@@ -41,9 +41,20 @@ const useStyles = createStyles(theme => ({
   variablesContent: {
     paddingLeft: 10
   },
+  variablesSection: {
+    listStyleType: "none",
+    marginBlockStart: "0em",
+    marginBlockEnd: "0em",
+    marginInlineStart: "0em",
+    marginInlineEnd: "0em",
+    paddingInlineStart: "0em",
+    marginBottom: "1em"
+  },
   variablesTypes: {
     fontSize: 12,
-    fontWeight: 800
+    fontWeight: 800,
+    textDecoration: "underline",
+    marginBottom: "0.5em"
   }
 }));
 
@@ -75,12 +86,14 @@ function Variables({
           .map((variableName: keyof typeof variables) => {
             if (variables) {
               return (
-                <>
-                  <dt>{"  " + variableName}</dt>
-                  <dd>
-                    <CodecComponents.Result data={variables[variableName]} />
-                  </dd>
-                </>
+                <li key={variableName}>
+                  <CodecComponents.NameValuePair
+                    data={{
+                      name: `${variableName}`,
+                      value: variables[variableName]
+                    }}
+                  />
+                </li>
               );
             } else {
               return undefined;
@@ -89,10 +102,10 @@ function Variables({
           .filter((item: JSX.Element | undefined) => item);
         if (variableValues.length > 0) {
           entries.push(
-            <dl key={section}>
+            <div key={section}>
               <div className={classes.variablesTypes}>{section}</div>
-              {...variableValues}
-            </dl>
+              <ul className={classes.variablesSection}>{...variableValues}</ul>
+            </div>
           );
         }
       }
@@ -101,7 +114,7 @@ function Variables({
     }
 
     getVariables();
-  }, [currentStep, session, classes.variablesTypes]);
+  }, [currentStep, session, classes.variablesTypes, classes.variablesSection]);
 
   return (
     <Flex direction="column" className={classes.variablesContainer}>


### PR DESCRIPTION
## PR description

Use `<ul>` instead of `<dl>` for variables in Dashboard Debugger and ensure the name/value is displayed via `<NameValuePair />`.

Here's what it looks like:

<img width="541" alt="Screenshot 2023-06-22 at 4 44 56 PM" src="https://github.com/trufflesuite/truffle/assets/151065/587c5dc9-5206-4a08-b3f3-a208710a627b">


## Testing instructions

Run the debugger and see it