### PR TITLE
Remove cronos testnet from etherscan fetcher

### DIFF
--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -79,7 +79,6 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
       "moonriver": "api-moonriver.moonscan.io",
       "moonbase-alpha": "api-moonbase.moonscan.io",
       "cronos": "api.cronoscan.com",
-      "testnet-cronos": "api-testnet.cronoscan.com",
       "bttc": "api.bttcscan.com",
       "donau-bttc": "api-testnet.bttcscan.com",
       "celo": "api.celoscan.io",

--- a/packages/source-fetcher/lib/networks.ts
+++ b/packages/source-fetcher/lib/networks.ts
@@ -63,7 +63,7 @@ export const networkNamesById: { [id: number]: string } = {
   11297108099: "testnet-palm",
   70: "hoo", //not presently supported by either fetcher, but formerly by etherscan
   25: "cronos",
-  338: "testnet-cronos",
+  338: "testnet-cronos", //not presently supported by either fetcher, but formerly by etherscan
   199: "bttc",
   1029: "donau-bttc",
   1024: "clover", //not presently supported by either fetcher, but formerly by etherscan


### PR DESCRIPTION
Etherscan no longer supports the Cronos Testnet (still the mainnet but no longer the testnet!) -- it's Blockscout now! -- so I'm removing it.