### PR TITLE
Add `contractClass` interpretation to address values

### DIFF
--- a/packages/codec/lib/basic/decode/index.ts
+++ b/packages/codec/lib/basic/decode/index.ts
@@ -222,7 +222,7 @@ export function* decodeBasic(
       }
       bytes = removePadding(bytes, dataType, paddingMode);
       const address = Evm.Utils.toAddress(bytes);
-      let decoded = {
+      let decoded: Format.Values.AddressValue = {
         type: dataType,
         kind: "value" as const,
         value: {
@@ -234,7 +234,12 @@ export function* decodeBasic(
       //now: attach interpretations
       const ensName = yield* reverseEnsResolve(address);
       if (ensName !== null) {
-        decoded.interpretations = { ensName };
+        decoded.interpretations.ensName = ensName;
+      }
+      //yes, this makes the contract/address distinction a little silly
+      const contractValueInfo = yield* decodeContract(bytes, info);
+      if (contractValueInfo.kind === "known") {
+        decoded.interpretations.contractClass = contractValueInfo.class;
       }
       return decoded;
     }

--- a/packages/codec/lib/format/elementary.ts
+++ b/packages/codec/lib/format/elementary.ts
@@ -137,6 +137,7 @@ export interface AddressValue {
   };
   interpretations: {
     ensName?: StringValueInfo;
+    contractClass?: Types.ContractType;
   };
 }
 

--- a/packages/codec/lib/format/utils/inspect.ts
+++ b/packages/codec/lib/format/utils/inspect.ts
@@ -117,23 +117,28 @@ export class ResultInspector {
                 return options.stylize(`hex'${hex.slice(2)}'`, "string");
             }
           case "address": {
-            const coercedResult = this.result as Format.Values.AddressValue;
-            const addressString = options.stylize(
-              coercedResult.value.asAddress,
-              "number"
+            const coercedValue = this.result as Format.Values.AddressValue;
+            //the address/contract distinction has gotten pretty silly!
+            //so we're just going to convert to the contract case and
+            //use the existing code there.
+            const contractValueInfo = coercedValue.interpretations.contractClass
+              ? {
+                  kind: "known" as const,
+                  address: coercedValue.value.asAddress,
+                  class: coercedValue.interpretations.contractClass
+                }
+              : {
+                  kind: "unknown" as const,
+                  address: coercedValue.value.asAddress
+                };
+            return util.inspect(
+              new ContractInfoInspector(
+                contractValueInfo,
+                coercedValue.interpretations.ensName,
+                this.options
+              ),
+              options
             );
-            if (coercedResult.interpretations.ensName) {
-              const nameString = options.stylize(
-                stringValueInfoToStringLossy(
-                  coercedResult.interpretations.ensName
-                ),
-                "special"
-              );
-              return this.options.noHideAddress
-                ? `${nameString} [${addressString}]`
-                : nameString;
-            }
-            return options.stylize(coercedResult.value.asAddress, "number");
           }
           case "string":
             return util.inspect(

--- a/packages/debugger/test/data/more-decoding.js
+++ b/packages/debugger/test/data/more-decoding.js
@@ -446,9 +446,9 @@ describe("Further Decoding", function () {
 
     await bugger.continueUntilBreakpoint();
 
-    const variables = Codec.Format.Utils.Inspect.unsafeNativizeVariables(
-      await bugger.variables()
-    );
+    const rawVariables = await bugger.variables();
+    const variables =
+      Codec.Format.Utils.Inspect.unsafeNativizeVariables(rawVariables);
     debug("variables %O", variables);
 
     const expectedResult = {
@@ -457,7 +457,11 @@ describe("Further Decoding", function () {
       bytesMap: { "0x01": "0x01" },
       uintMap: { 1: 1, 2: 2 },
       intMap: { "-1": -1 },
-      stringMap: { "0xdeadbeef": "0xdeadbeef", 12345: "12345", hello: "hello" },
+      stringMap: {
+        "0xdeadbeef": "0xdeadbeef",
+        "12345": "12345",
+        "hello": "hello"
+      },
       addressMap: { [address]: address },
       contractMap: { [address]: address },
       enumMap: { "ElementaryTest.Ternary.Blue": "ElementaryTest.Ternary.Blue" },
@@ -476,6 +480,16 @@ describe("Further Decoding", function () {
     };
 
     assert.deepInclude(variables, expectedResult);
+
+    //while we're at it, let's also test the interpretation on addressMap[address]
+    const value = rawVariables.addressMap.value[0].value;
+    assert.equal(value.kind, "value");
+    assert.equal(value.type.typeClass, "address");
+    assert.isDefined(value.interpretations.contractClass);
+    assert.equal(
+      value.interpretations.contractClass.typeName,
+      "ElementaryTest"
+    );
   });
 
   it("Splices locations correctly", async function () {


### PR DESCRIPTION
## PR description

Addresses #5913.  Adds a `contractClass` interpretation to address values.  Basically, if we can identify what sort of contract a given address is, it will have this interpretation with more information; otherwise it won't.

Yes, this means that the address/contract distinction is now pretty silly -- they now contain the same information but formatted differently.  Oh well.  I don't want to make a breaking change to make them more unified.

The code is pretty straightforward, not much to explain.  I could have further eliminated some minor recomputation by just using `decodeContract` and then doing everything based on the results of that, but I decided it was clearer to do it this way, even if that means calling `Evm.Utils.toAddress` twice. :P

I also updated the inspector so that it now basically just treats addresses like contracts.  Could have distinguished them some but that would have been more work.

I did *not* update `codec-components`.  I figure I can worry about that later; there are likely multiple changes I want to make to address and contracts there.

## Testing instructions

I added a debugger test for it, I figured that should be enough.