### PR TITLE
Allow strings and bigints instead of numbers in decoder input fields

### DIFF
--- a/packages/decoder/lib/decoders.ts
+++ b/packages/decoder/lib/decoders.ts
@@ -455,7 +455,8 @@ export class ProjectDecoder {
     overrideContext?: Contexts.Context,
     isForSelectorBasedDecoding?: boolean
   ): Promise<CalldataDecoding> {
-    const block = transaction.blockNumber;
+    const block =
+      transaction.blockNumber !== null ? Number(transaction.blockNumber) : null;
     const blockNumber = await this.regularizeBlock(block);
     const isConstructor = transaction.to === null;
     const context =
@@ -615,7 +616,7 @@ export class ProjectDecoder {
     options: DecoderTypes.EventOptions = {},
     additionalContexts: Contexts.Contexts = {}
   ): Promise<LogDecoding[]> {
-    const block = log.blockNumber;
+    const block = log.blockNumber !== null ? Number(log.blockNumber) : null;
     const blockNumber = await this.regularizeBlock(block);
     const data = Conversion.toBytes(log.data);
     const topics = log.topics.map(Conversion.toBytes);

--- a/packages/decoder/lib/types.ts
+++ b/packages/decoder/lib/types.ts
@@ -125,11 +125,28 @@ export interface ContractState {
 
 /**
  * This type represents a web3 Log object that has been decoded.
- * Note that it extends the Log type and just adds an additional field
- * with the decoding.
+ * Note that it extends the Log type.   The differences are:
+ *
+ *   1. It adds an additional field with the decodings;
+ *   2. Some fields that in Log are allowed to be strings,
+ *     here are specified as numbers.  (Because this type is
+ *     for output and that type is for input.)
  * @category Results
  */
 export interface DecodedLog extends Log {
+  /**
+   * Index of the log within the block.
+   */
+  logIndex?: number;
+  /**
+   * Index within the block of the emitting transaction; null if
+   * block is pending.
+   */
+  transactionIndex?: number | null;
+  /**
+   * The block number.  Null if pending.
+   */
+  blockNumber: number | null;
   /**
    * An array of possible decodings of the given log -- it's an array because logs can be ambiguous.
    *
@@ -247,7 +264,7 @@ export interface ReturnOptions {
  *
  * Intended to work like Web3's
  * [Transaction](https://web3js.readthedocs.io/en/v1.2.1/web3-eth.html#eth-gettransaction-return)
- * type.
+ * type, but with strings allowed where it requires numbers.
  * @category Inputs
  */
 export interface Transaction {
@@ -258,7 +275,7 @@ export interface Transaction {
   /**
    * The nonce of the sender before this transaction was sent.
    */
-  nonce?: number;
+  nonce?: number | string | bigint;
   /**
    * Hash of this transaction's block as hex string; null if pending.
    */
@@ -266,11 +283,11 @@ export interface Transaction {
   /**
    * This transaction's block number; null if pending.
    */
-  blockNumber: number | null;
+  blockNumber: number | string | bigint | null;
   /**
    * Index of transaction in block; null if block is pending.
    */
-  transactionIndex?: number | null;
+  transactionIndex?: number | string | bigint | null;
   /**
    * Address of the sender (as checksummed hex string).
    */
@@ -299,7 +316,7 @@ export interface Transaction {
   /**
    * A positive unsigned 8-bit number between 0 and 0x7f that represents the type of the transaction.
    */
-  type?: number;
+  type?: number | string | bigint;
   /**
    * The maximum fee per gas that the transaction is willing to pay in total.
    */
@@ -317,7 +334,7 @@ export interface Transaction {
  *
  * Intended to work like Web3's
  * [Log](https://web3js.readthedocs.io/en/v1.2.1/web3-eth.html#eth-getpastlogs-return)
- * type.
+ * type, but with strings allowed where it requires numbers.
  * @category Inputs
  */
 export interface Log {
@@ -336,12 +353,12 @@ export interface Log {
   /**
    * Index of the log within the block.
    */
-  logIndex?: number;
+  logIndex?: number | string | bigint;
   /**
    * Index within the block of the emitting transaction; null if
    * block is pending.
    */
-  transactionIndex?: number | null;
+  transactionIndex?: number | string | bigint | null;
   /**
    * The emitting transaction's hash (as hex string).
    */
@@ -353,7 +370,7 @@ export interface Log {
   /**
    * The block number.  Null if pending.
    */
-  blockNumber: number | null;
+  blockNumber: number | string | bigint | null;
 }
 
 //HACK

--- a/packages/decoder/lib/types.ts
+++ b/packages/decoder/lib/types.ts
@@ -125,7 +125,7 @@ export interface ContractState {
 
 /**
  * This type represents a web3 Log object that has been decoded.
- * Note that it extends the Log type.   The differences are:
+ * Note that it has the same fields the Log type.   The differences are:
  *
  *   1. It adds an additional field with the decodings;
  *   2. Some fields that in Log are allowed to be strings,
@@ -133,16 +133,36 @@ export interface ContractState {
  *     for output and that type is for input.)
  * @category Results
  */
-export interface DecodedLog extends Log {
+export interface DecodedLog {
+  /**
+   * Address of the emitter (as checksummed hex string).
+   */
+  address: string;
+  /**
+   * The log's data section (as hex string).
+   */
+  data: string;
+  /**
+   * The log's topics; each is a hex string representing 32 bytes.
+   */
+  topics: string[];
   /**
    * Index of the log within the block.
    */
-  logIndex?: number;
+  logIndex: number;
   /**
    * Index within the block of the emitting transaction; null if
    * block is pending.
    */
-  transactionIndex?: number | null;
+  transactionIndex: number | null;
+  /**
+   * The emitting transaction's hash (as hex string).
+   */
+  transactionHash: string;
+  /**
+   * The block hash (as hex string).  Null if pending.
+   */
+  blockHash: string | null;
   /**
    * The block number.  Null if pending.
    */

--- a/packages/decoder/test/current/test/compatible-nativize.js
+++ b/packages/decoder/test/current/test/compatible-nativize.js
@@ -117,7 +117,8 @@ describe("nativize (ethers format)", function () {
           });
           const logs = receipt.logs;
           assert.lengthOf(logs, 1);
-          const log = logs[0];
+          let log = logs[0];
+          log.blockNumber = String(log.blockNumber); //while we're here, let's test the ability to take strings :P
           const decodings = await decoder.decodeLog(log);
           assert.lengthOf(decodings, 1);
           const decoding = decodings[0];

--- a/packages/decoder/test/current/test/wire-test.js
+++ b/packages/decoder/test/current/test/wire-test.js
@@ -126,6 +126,20 @@ describe("Over-the-wire decoding", function () {
       defaultConstructorHash
     );
 
+    for (let tx of [
+      constructorTx,
+      emitStuffTx,
+      moreStuffTx,
+      globalTestTx,
+      inheritedTx,
+      getterTx1,
+      getterTx2,
+      defaultConstructorTx
+    ]) {
+      //while we're here, let's test string input to the decoder
+      tx.blockNumber = String(tx.blockNumber);
+    }
+
     let constructorDecoding = await decoder.decodeTransaction(constructorTx);
     let emitStuffDecoding = await decoder.decodeTransaction(emitStuffTx);
     let moreStuffDecoding = await decoder.decodeTransaction(moreStuffTx);


### PR DESCRIPTION
## PR description

Addresses #6080.  This makes it so that fields in `Log` or `Transaction` that previously were `number` are now `number | string | bigint`, and fields that were `number | null` are now `number | string | bigint | null`.

Most of these fields are ignored, so the type is changed and that's all.

The one changed field that's actually used is `blockNumber`, so I just changed things so that if we get that and it's not null, we convert it to a number.

I do have to also discuss what happened to the `DecodedLog` type.  For simplicity, `DecodedLog` extends `Log`.  However, `Log` has just had its type broadened.  But while that's fine for `Log`, because it's an input type, `DecodedLog` is an output type.  So to broaden its type would be a breaking change.  So I re-narrowed the types of the appropriate fields to prevent that.

Anyway that's it (aside from tests); this is pretty simple.

## Testing instructions

I altered some decoder tests so that they pass in strings for the block number (the only part that matters), I think that should be sufficient.