### PR TITLE
Add support for multicall3 to decoder interpretations

### DIFF
--- a/packages/codec/lib/types.ts
+++ b/packages/codec/lib/types.ts
@@ -120,8 +120,8 @@ export interface FunctionDecoding {
     /**
      * If this interpretation is present, indicates that the transaction can be
      * understood as an `aggregate` (from multicallv2).  This also includes
-     * `blockAndAggregate`.  See [[CallInterpretationInfo]] for more
-     * information.
+     * `blockAndAggregate`, as well as `aggregate3` (from multicallv3), and
+     * `aggregate3Value`.  See [[CallInterpretationInfo]] for more information.
      */
     aggregate?: CallInterpretationInfo[];
     /**
@@ -952,6 +952,14 @@ export interface CallInterpretationInfo {
    * The decoding of the call; may be null in case of error.
    */
   decoding: CalldataDecoding | null;
+  /**
+   * Whether failure was allowed; may be null in case of error.
+   */
+  allowFailure: boolean | null;
+  /**
+   * The value sent with the call, in Wei.  May be null in case of error.
+   */
+  value: BN | null;
 }
 
 /**

--- a/packages/decoder/test/current/contracts/WireTest.sol
+++ b/packages/decoder/test/current/contracts/WireTest.sol
@@ -42,7 +42,7 @@ contract WireTest is WireTestParent, WireTestAbstract {
     emit Done();
   } //just a dummy function, not 
 
-  constructor(bool status, bytes memory info, Ternary whoknows) {
+  constructor(bool status, bytes memory info, Ternary whoknows) payable {
     deepStruct["blornst"].push();
     deepStruct["blornst"].push();
     deepString.push();
@@ -98,7 +98,7 @@ contract WireTest is WireTestParent, WireTestAbstract {
 
   event HasIndices(uint, uint indexed, string, string indexed, uint);
 
-  function indexTest(uint a, uint b, string memory c, string memory d, uint e) public {
+  function indexTest(uint a, uint b, string memory c, string memory d, uint e) public payable {
     emit HasIndices(a, b, c, d, e);
   }
 
@@ -241,12 +241,37 @@ contract WireTest is WireTestParent, WireTestAbstract {
     }
   }
 
-  event Result(bytes);
-
   function tryAggregate(bool requireSuccess, Call[] calldata calls) external {
     for (uint i = 0; i < calls.length; i++) {
       (bool success, bytes memory result) = calls[i].target.call(calls[i].data);
       if (requireSuccess) require(success);
+    }
+  }
+
+  struct Call3 {
+    address target;
+    bool allowFailure;
+    bytes data;
+  }
+
+  function aggregate3(Call3[] calldata calls) external {
+    for (uint i = 0; i < calls.length; i++) {
+      (bool success, bytes memory result) = calls[i].target.call(calls[i].data);
+      if (!calls[i].allowFailure) require(success);
+    }
+  }
+
+  struct Call3Value {
+    address target;
+    bool allowFailure;
+    uint value;
+    bytes data;
+  }
+
+  function aggregate3Value(Call3Value[] calldata calls) external {
+    for (uint i = 0; i < calls.length; i++) {
+      (bool success, bytes memory result) = calls[i].target.call{value: calls[i].value}(calls[i].data);
+      if (!calls[i].allowFailure) require(success);
     }
   }
 
@@ -297,7 +322,7 @@ contract WireTestRedHerring {
     emit NonAmbiguousEvent();
   }
 
-  function otherMethod(uint k) public {
+  function otherMethod(uint k) public payable {
     emit SemiAmbiguousEvent(k, 0);
   }
 }

--- a/packages/decoder/test/current/migrations/2_deploy_contracts.js
+++ b/packages/decoder/test/current/migrations/2_deploy_contracts.js
@@ -13,7 +13,7 @@ module.exports = function (deployer) {
   deployer.link(DecoyLibrary, DowngradeTest);
   deployer.deploy(WireTestLibrary);
   deployer.link(WireTestLibrary, WireTest);
-  deployer.deploy(WireTest, false, "0x", 0);
+  deployer.deploy(WireTest, false, "0x", 0, { value: 100 });
   deployer.deploy(ReceiveTest);
   deployer.deploy(FallbackTest);
   deployer.deploy(DecodingSample);

--- a/packages/decoder/test/current/test/wire-test.js
+++ b/packages/decoder/test/current/test/wire-test.js
@@ -1365,8 +1365,10 @@ describe("Over-the-wire decoding", function () {
       assert.isArray(calls);
       assert.lengthOf(calls, methods.length);
       for (let i = 0; i < methods.length; i++) {
-        const { address, decoding } = calls[i];
+        const { address, allowFailure, value, decoding } = calls[i];
         assert.strictEqual(address, contracts[i].address);
+        assert.isFalse(allowFailure);
+        assert(value.eqn(0));
         assert.strictEqual(decoding.kind, "function");
         assert.strictEqual(decoding.decodingMode, "full");
         assert.strictEqual(decoding.abi.name, methodNames[i]);
@@ -1425,8 +1427,138 @@ describe("Over-the-wire decoding", function () {
       assert.isArray(calls);
       assert.lengthOf(calls, methods.length);
       for (let i = 0; i < methods.length; i++) {
-        const { address, decoding } = calls[i];
+        const { address, allowFailure, value, decoding } = calls[i];
         assert.strictEqual(address, contracts[i].address);
+        assert.isTrue(allowFailure); //since we didn't require success
+        assert(value.eqn(0));
+        assert.strictEqual(decoding.kind, "function");
+        assert.strictEqual(decoding.decodingMode, "full");
+        assert.strictEqual(decoding.abi.name, methodNames[i]);
+        assert.strictEqual(
+          decoding.class.typeName,
+          contracts[i].constructor.contractName
+        );
+        const variablesByName = Object.fromEntries(
+          decoding.arguments.map(({ name, value }) => [name, value])
+        );
+        assert.deepEqual(
+          Codec.Format.Utils.Inspect.unsafeNativizeVariables(variablesByName),
+          argsNamed[i]
+        );
+      }
+    });
+
+    it("Decodes multicalls (v3 w/o value)", async function () {
+      const deployedContract = await abstractions.WireTest.deployed();
+      const otherContract = await abstractions.WireTestRedHerring.new();
+
+      const decoder = await Decoder.forProject({
+        provider: web3.currentProvider,
+        projectInfo: { artifacts: Contracts }
+      });
+
+      //first, let's encode some calls
+      const contracts = [otherContract, deployedContract];
+      const methodNames = ["otherMethod", "indexTest"];
+      const methods = [otherContract.otherMethod, deployedContract.indexTest];
+      const failureAllowed = [false, true];
+      const argsNamed = [
+        { k: 63 },
+        { a: 7, b: 89, c: "hello", d: "indecipherable", e: 62 }
+      ];
+      const args = argsNamed.map(argsObject => Object.values(argsObject));
+      let encodedTxs = [];
+      for (let i = 0; i < methods.length; i++) {
+        encodedTxs.push({
+          target: contracts[i].address,
+          allowFailure: failureAllowed[i],
+          data: (await methods[i].request(...args[i])).data
+        });
+      }
+
+      //now, let's perform a multicall
+      debug("encodedTxs: %O", encodedTxs);
+      const multicall = await deployedContract.aggregate3(encodedTxs);
+      const multicallHash = multicall.tx;
+      const multicallTx = await web3.eth.getTransaction(multicallHash);
+
+      //now let's decode it and check the result!
+      const multicallDecoding = await decoder.decodeTransaction(multicallTx);
+      assert.isDefined(multicallDecoding.interpretations);
+      const calls = multicallDecoding.interpretations.aggregate;
+      assert.isArray(calls);
+      assert.lengthOf(calls, methods.length);
+      for (let i = 0; i < methods.length; i++) {
+        const { address, allowFailure, value, decoding } = calls[i];
+        debug("calls[i]: %O", calls[i]);
+        assert.strictEqual(address, contracts[i].address);
+        assert.strictEqual(allowFailure, failureAllowed[i]);
+        assert(value.eqn(0));
+        assert.strictEqual(decoding.kind, "function");
+        assert.strictEqual(decoding.decodingMode, "full");
+        assert.strictEqual(decoding.abi.name, methodNames[i]);
+        assert.strictEqual(
+          decoding.class.typeName,
+          contracts[i].constructor.contractName
+        );
+        const variablesByName = Object.fromEntries(
+          decoding.arguments.map(({ name, value }) => [name, value])
+        );
+        assert.deepEqual(
+          Codec.Format.Utils.Inspect.unsafeNativizeVariables(variablesByName),
+          argsNamed[i]
+        );
+      }
+    });
+
+    it("Decodes multicalls (v3 w/value)", async function () {
+      const deployedContract = await abstractions.WireTest.deployed();
+      const otherContract = await abstractions.WireTestRedHerring.new();
+
+      const decoder = await Decoder.forProject({
+        provider: web3.currentProvider,
+        projectInfo: { artifacts: Contracts }
+      });
+
+      //first, let's encode some calls
+      const contracts = [otherContract, deployedContract];
+      const methodNames = ["otherMethod", "indexTest"];
+      const methods = [otherContract.otherMethod, deployedContract.indexTest];
+      const failureAllowed = [false, true];
+      const values = [1, 2];
+      const argsNamed = [
+        { k: 63 },
+        { a: 7, b: 89, c: "hello", d: "indecipherable", e: 62 }
+      ];
+      const args = argsNamed.map(argsObject => Object.values(argsObject));
+      let encodedTxs = [];
+      for (let i = 0; i < methods.length; i++) {
+        encodedTxs.push({
+          target: contracts[i].address,
+          allowFailure: failureAllowed[i],
+          value: values[i],
+          data: (await methods[i].request(...args[i])).data
+        });
+      }
+
+      //now, let's perform a multicall
+      debug("encodedTxs: %O", encodedTxs);
+      const multicall = await deployedContract.aggregate3Value(encodedTxs);
+      const multicallHash = multicall.tx;
+      const multicallTx = await web3.eth.getTransaction(multicallHash);
+
+      //now let's decode it and check the result!
+      const multicallDecoding = await decoder.decodeTransaction(multicallTx);
+      assert.isDefined(multicallDecoding.interpretations);
+      const calls = multicallDecoding.interpretations.aggregate;
+      assert.isArray(calls);
+      assert.lengthOf(calls, methods.length);
+      for (let i = 0; i < methods.length; i++) {
+        const { address, allowFailure, value, decoding } = calls[i];
+        debug("calls[i]: %O", calls[i]);
+        assert.strictEqual(address, contracts[i].address);
+        assert.strictEqual(allowFailure, failureAllowed[i]);
+        assert(value.eqn(values[i]));
         assert.strictEqual(decoding.kind, "function");
         assert.strictEqual(decoding.decodingMode, "full");
         assert.strictEqual(decoding.abi.name, methodNames[i]);


### PR DESCRIPTION
Addresses #6079.  This PR adds support for the new methods from Multicall v3 -- `aggregate3` and `aggregate3Value` -- to the decoder's multicall interpretation support.

The `aggregate3` method allows you to specify `allowFailure` for each call (in addition to the target and the data), and `aggregate3Value` allows both `allowFailure` and `value`.  So, I added two new fields to the `CallInterpretationInfo` type, `allowFailure` (a boolean) and `value` (a BN).

When a simple `aggregate` is detected, these fields will be included in the decoding, with `allowFailure` set to `false` and `value` set to zero.  When a `tryAggregate` is detected, `allowFailure` will be set to the negation of the `requireSuccess` field.

When `aggregate3` or `aggregate3Value` is detected, these will be set as appropriate (with `value` always being zero in the former case).  The thing to note here is that while I added fields to `CallInterpretationInfo`, I didn't add any new interpretations; I just had `aggregate3` and `aggregate3Value` continue to use the `aggregate` interpretation, just with non-default values potentially for `allowFailure` and `value`.  I think this should be fine, but let me know if it's not.  It's not like you can't distinguish if you don't want to (just check the ABI in the decoding!).  We already have other combined interpretations like this.

(I was originally going to make these changes in a breaking manner due to a misunderstanding on my part, but ultimately I did it in this non-breaking way instead.)

I also updated the inspectors to report this new information.  I did not update codec-components, as it turns out that codec-components doesn't currently handle this stuff at all, so there was nothing to update.

As for how it's done, there's not a lot to say here, it's basically the same as the existing multicall handling.  The one thing of note is that in order to avoid too much tedious repetition, I did factor some stuff into an `interpretCallInAggregate` method that is used for all of `aggregate`, `tryAggregate`, `aggregate3`, and `aggregate3Value`; although in the case of `tryAggregate`, the value of `allowFailure` is set separately afterward.

## Testing instructions

I added tests for the new interpretations and upgraded the existing tests to test the new fields.  I think that should suffice.