### PR TITLE
Have debugger skip anything called from a generated source while stepping

### DIFF
--- a/packages/debugger/lib/controller/sagas/index.js
+++ b/packages/debugger/lib/controller/sagas/index.js
@@ -80,7 +80,7 @@ function* stepNext() {
   const starting = yield select(controller.current.location);
   const allowInternal = yield select(controller.stepIntoInternalSources);
 
-  let upcoming, finished;
+  let upcoming, finished, isUpcomingInternal;
 
   do {
     // advance at least once step
@@ -88,6 +88,7 @@ function* stepNext() {
 
     // and check the next source range
     upcoming = yield select(controller.current.location);
+    isUpcomingInternal = yield select(controller.current.isAnyFrameInternal);
 
     finished = yield select(controller.current.trace.finished);
 
@@ -97,9 +98,7 @@ function* stepNext() {
     (!upcoming ||
       //don't stop on an internal source unless allowInternal is on or
       //we started in an internal source
-      (!allowInternal &&
-        upcoming.source.internal &&
-        !starting.source.internal) ||
+      (!allowInternal && isUpcomingInternal && !starting.source.internal) ||
       upcoming.sourceRange.length === 0 ||
       upcoming.source.id === undefined ||
       (upcoming.node && isDeliberatelySkippedNodeType(upcoming.node)) ||

--- a/packages/debugger/lib/controller/sagas/index.js
+++ b/packages/debugger/lib/controller/sagas/index.js
@@ -78,6 +78,9 @@ function* advance(action) {
  */
 function* stepNext() {
   const starting = yield select(controller.current.location);
+  const isStartingGenerated = yield select(
+    controller.current.isAnyFrameGenerated
+  );
   const allowInternal = yield select(controller.stepIntoInternalSources);
 
   let upcoming, finished, isUpcomingGenerated;
@@ -100,7 +103,7 @@ function* stepNext() {
       //we started in an internal source
       (!allowInternal &&
         (upcoming.source.internal || isUpcomingGenerated) &&
-        !starting.source.internal) ||
+        !(starting.source.internal || isStartingGenerated)) ||
       upcoming.sourceRange.length === 0 ||
       upcoming.source.id === undefined ||
       (upcoming.node && isDeliberatelySkippedNodeType(upcoming.node)) ||

--- a/packages/debugger/lib/controller/sagas/index.js
+++ b/packages/debugger/lib/controller/sagas/index.js
@@ -80,7 +80,7 @@ function* stepNext() {
   const starting = yield select(controller.current.location);
   const allowInternal = yield select(controller.stepIntoInternalSources);
 
-  let upcoming, finished, isUpcomingInternal;
+  let upcoming, finished, isUpcomingGenerated;
 
   do {
     // advance at least once step
@@ -88,7 +88,7 @@ function* stepNext() {
 
     // and check the next source range
     upcoming = yield select(controller.current.location);
-    isUpcomingInternal = yield select(controller.current.isAnyFrameInternal);
+    isUpcomingGenerated = yield select(controller.current.isAnyFrameGenerated);
 
     finished = yield select(controller.current.trace.finished);
 
@@ -98,7 +98,9 @@ function* stepNext() {
     (!upcoming ||
       //don't stop on an internal source unless allowInternal is on or
       //we started in an internal source
-      (!allowInternal && isUpcomingInternal && !starting.source.internal) ||
+      (!allowInternal &&
+        (upcoming.source.internal || isUpcomingGenerated) &&
+        !starting.source.internal) ||
       upcoming.sourceRange.length === 0 ||
       upcoming.source.id === undefined ||
       (upcoming.node && isDeliberatelySkippedNodeType(upcoming.node)) ||

--- a/packages/debugger/lib/controller/selectors/index.js
+++ b/packages/debugger/lib/controller/selectors/index.js
@@ -144,14 +144,16 @@ const controller = createSelectorTree({
     callstack: createLeaf([stacktrace.current.callstack.preupdated], identity),
 
     /**
-     * controller.current.isAnyFrameInternal
+     * controller.current.isAnyFrameGenerated
      *
-     * This selector checks whether there are any internal (unmapped or
-     * generated) stackframes on the callstack.  We should regard ourselves
+     * This selector checks whether there are any generated sources
+     * stackframes on the callstack.  We should regard ourselves
      * as still inside a generated source until there are none.
+     * (We only consider generated sources here, not other sorts of internal
+     * sources, to prevent potential problems.)
      */
-    isAnyFrameInternal: createLeaf(["./callstack"], callstack =>
-      callstack.some(frame => frame.sourceIsInternal)
+    isAnyFrameGenerated: createLeaf(["./callstack"], callstack =>
+      callstack.some(frame => frame.sourceIsGenerated)
     ),
 
     /**

--- a/packages/debugger/lib/controller/selectors/index.js
+++ b/packages/debugger/lib/controller/selectors/index.js
@@ -7,6 +7,7 @@ import * as Codec from "@truffle/codec";
 
 import evm from "lib/evm/selectors";
 import sourcemapping from "lib/sourcemapping/selectors";
+import stacktrace from "lib/stacktrace/selectors";
 import data from "lib/data/selectors";
 import trace from "lib/trace/selectors";
 
@@ -136,6 +137,22 @@ const controller = createSelectorTree({
         (raw, loaded) => (loaded ? raw : false)
       )
     },
+
+    /**
+     * controller.current.callstack
+     */
+    callstack: createLeaf([stacktrace.current.callstack.preupdated], identity),
+
+    /**
+     * controller.current.isAnyFrameInternal
+     *
+     * This selector checks whether there are any internal (unmapped or
+     * generated) stackframes on the callstack.  We should regard ourselves
+     * as still inside a generated source until there are none.
+     */
+    isAnyFrameInternal: createLeaf(["./callstack"], callstack =>
+      callstack.some(frame => frame.sourceIsInternal)
+    ),
 
     /**
      * controller.current.trace

--- a/packages/debugger/lib/stacktrace/actions/index.js
+++ b/packages/debugger/lib/stacktrace/actions/index.js
@@ -1,11 +1,18 @@
 export const JUMP_IN = "STACKTRACE_JUMP_IN";
-export function jumpIn(location, functionNode, contractNode, sourceIsInternal) {
+export function jumpIn(
+  location,
+  functionNode,
+  contractNode,
+  sourceIsInternal,
+  sourceIsGenerated
+) {
   return {
     type: JUMP_IN,
     location,
     functionNode,
     contractNode,
-    sourceIsInternal
+    sourceIsInternal,
+    sourceIsGenerated
   };
 }
 

--- a/packages/debugger/lib/stacktrace/reducers.js
+++ b/packages/debugger/lib/stacktrace/reducers.js
@@ -10,7 +10,13 @@ function callstack(state = [], action) {
   let newFrame;
   switch (action.type) {
     case actions.JUMP_IN:
-      const { location, functionNode, contractNode, sourceIsInternal } = action;
+      const {
+        location,
+        functionNode,
+        contractNode,
+        sourceIsInternal,
+        sourceIsGenerated
+      } = action;
       newFrame = {
         type: "internal",
         calledFromLocation: location,
@@ -27,7 +33,8 @@ function callstack(state = [], action) {
             ? contractNode.name
             : undefined,
         combineWithNextInternal: false,
-        sourceIsInternal
+        sourceIsInternal,
+        sourceIsGenerated
         //note we don't currently account for getters because currently
         //we can't; fallback, receive, constructors, & modifiers also remain
         //unaccounted for at present

--- a/packages/debugger/lib/stacktrace/sagas/index.js
+++ b/packages/debugger/lib/stacktrace/sagas/index.js
@@ -63,12 +63,16 @@ function* stacktraceSaga() {
     const nextLocation = yield select(stacktrace.next.location);
     const nextParent = yield select(stacktrace.next.contractNode);
     const nextSourceIsInternal = yield select(stacktrace.next.sourceIsInternal);
+    const nextSourceIsGenerated = yield select(
+      stacktrace.next.sourceIsGenerated
+    );
     yield put(
       actions.jumpIn(
         currentLocation,
         nextLocation.node,
         nextParent,
-        nextSourceIsInternal
+        nextSourceIsInternal,
+        nextSourceIsGenerated
       )
     );
     positionUpdated = true;

--- a/packages/debugger/lib/stacktrace/selectors/index.js
+++ b/packages/debugger/lib/stacktrace/selectors/index.js
@@ -175,6 +175,10 @@ let stacktrace = createSelectorTree({
 
       /**
        * stacktrace.current.callstack.preupdated
+       * This selector reflects the callstack as it actually is at the current
+       * moment, rather than carrying around additional error information on top
+       * in case it turns out to be relevant -- it's been "preupdated" assuming
+       * we don't want the error info on top, which in certain cases, we don't.
        */
       preupdated: createLeaf(
         ["./_", "/current/returnCounter"],

--- a/packages/debugger/lib/stacktrace/selectors/index.js
+++ b/packages/debugger/lib/stacktrace/selectors/index.js
@@ -156,9 +156,27 @@ let stacktrace = createSelectorTree({
    */
   current: {
     /**
-     * stacktrace.current.callstack
+     * stacktrace.current.callstack (namespace)
      */
-    callstack: createLeaf(["/state"], state => state.proc.callstack),
+    callstack: {
+      /**
+       * stacktrace.current.callstack (selector)
+       */
+      _: createLeaf(["/state"], state => state.proc.callstack),
+
+      /**
+       * stacktrace.current.callstack.preupdated
+       */
+      preupdated: createLeaf(
+        ["./_", "/current/returnCounter"],
+        (callstack, returnCounter) =>
+          popNWhere(
+            callstack,
+            returnCounter,
+            frame => frame.type === "external"
+          )
+      )
+    },
 
     /**
      * stacktrace.current.returnCounter
@@ -398,18 +416,14 @@ let stacktrace = createSelectorTree({
      */
     report: createLeaf(
       [
-        "./callstack",
+        "./callstack/preupdated",
         "./returnCounter",
         "./lastPosition",
         "/current/strippedLocation"
       ],
       (callstack, returnCounter, lastPosition, currentLocation) =>
         generateReport(
-          popNWhere(
-            callstack,
-            returnCounter,
-            frame => frame.type === "external"
-          ),
+          callstack,
           currentLocation || lastPosition,
           null,
           undefined

--- a/packages/debugger/lib/stacktrace/selectors/index.js
+++ b/packages/debugger/lib/stacktrace/selectors/index.js
@@ -112,6 +112,15 @@ function createMultistepSelectors(stepSelector) {
     ),
 
     /**
+     * .sourceIsGenerated
+     * only specifically generated sources, not unmapped code or anything!
+     */
+    sourceIsGenerated: createLeaf(
+      ["./location/source"],
+      source => source.internal
+    ),
+
+    /**
      * .strippedLocation
      */
     strippedLocation: createLeaf(


### PR DESCRIPTION
## PR description

@gnidan noticed a problem whereby a generated source could appear in a stacktrace even though generated sources were turned off.  What's up with that?

Well, turns out that in this case, a function in a generated source called another function in that generated source, and due to optimization part of the latter function ended up sourcemapped to a user source!  So when you stepped, you would hit that source range, and see that you were now inside a user source called from a generated source.  Yikes!

The fix for this is that, if generated sources are turned off, you shouldn't hit such a source range in the first place, as logically it should really be considered to be within a generated source.  So I changed it so that, while stepping, the debugger won't stop while there are generated sources anywhere on the callstack (unless you started in a generated source or generated sources are turned on).

Now, I wanted to restrict this new check specifically to *generated* sources.  Normally in the debugger we consider a source to be "internal" if it's either generated, or unmapped, or we just don't know what it is.  I was a little worried that this last case could cause some problems, though.  And while ideally maybe we'd do the first two but not the third, the thing is that distinguishing the second from the third would require making some changes to the debugger's internals that I didn't want to bother with.  (Although, now that I think about it, it actually wouldn't be that difficult, so I can go back and change that if you want.)  So this new check only checks specifically for generated sources.

(The existing check regarding the current location -- the top stackframe -- is left in as-is, it's just for the stackframes below that we only check for generated sources.)

Anyway, some changes you'll notice I made:

1. Because we want to distinguish specifically *generated* sources from other "internal" sources, I added a new `isSourceGenerated` field to the callstack state in `stacktrace`.
2. I added a new selector, `stacktrace.current.callstack.preupdated`.  This gives the callstack as it actually currently is, rather than with error information still left on top, much like is used in `stacktrace.current.report`; that bit of code is now factored out into this new selector.
3. Then there's the changes to the controller described above, sitting on top of these changes to `stacktrace`.

I think that basically covers everything important.

## Testing instructions

I didn't add any automated tets for this PR, I just tested in manually.

This issue was uncovered in Sepolia transaction 0x84f82b79b516aa64f38797f204e09a49e821f7f9353723545dfd600e99b60955.  Pressing `n` twice would land in the messed-up state described above, where pressing `s` would yield the bizarre callstack.

Now, if you debug this transaction with `-x` and press `n` twice, you will skip over that node, and if you press `s`, you will see a callstack without generated sources.