### PR TITLE
Update sourcify networks for sourcify 2.4.0

### DIFF
--- a/packages/source-fetcher/lib/networks.ts
+++ b/packages/source-fetcher/lib/networks.ts
@@ -115,9 +115,18 @@ export const networkNamesById: { [id: number]: string } = {
   25925: "testnet-bitkub",
   7777777: "zora",
   570: "rollux",
-  57000: "tanenbaum-rollux"
+  57000: "tanenbaum-rollux",
+  6119: "uptn",
+  2222: "kava",
+  2221: "testnet-kava",
+  314: "filecoin",
+  32769: "zilliqa",
+  33101: "testnet-zilliqa",
+  111111: "siberium", //not presently supported by either fetcher, but...
+  111000: "testnet-siberium"
   //I'm not including crystaleum as it has network ID different from chain ID
   //not including kekchain for the same reason
+  //not including ethereum classic for same reason
 };
 
 export const networksByName: Types.SupportedNetworks = Object.fromEntries(

--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -140,7 +140,14 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "testnet-bitkub",
     "zora",
     "rollux",
-    "tanenbaum-rollux"
+    "tanenbaum-rollux",
+    "uptn",
+    "kava",
+    "testnet-kava",
+    "filecoin",
+    "zilliqa",
+    "testnet-zilliqa",
+    "testnet-siberium"
     //I'm excluding crystaleum as it has network ID different from chain ID
     //excluding kekchain for the same reason
   ]);


### PR DESCRIPTION
More Sourcify networks.  They also added support for Ethereum Classic, but we only handle networks with network ID = source ID, so I excluded that.

Addresses you can use for testing if you want:

6119: 0x212F6222fB4937978A806b14FB2725169825078F
33101: 0xeb6Ea260eDFb9837ed100B09c559081AfA5b0785
32769: 0x6F85669808e20b121980DE8E7a794a0cc90fDc77
314: 0x23396626F2C9c0b31cC6C2729172103961Ae2A26
111000: 0x60E9b3CD8C160Ce6408dD6E2Fa938895cfF7E087
2221: 0x40b4f95C3bafc8d690B4c3fDD1E8303c4817Cd9C
2222: 0xAdFa11e737ec8fA6e91091468aEF33a66Ae0044c