### PR TITLE
add a tooltip for the debug button in the tx signer for dashboard

### DIFF
--- a/packages/dashboard/src/components/composed/RPCs/RPC/Overview.tsx
+++ b/packages/dashboard/src/components/composed/RPCs/RPC/Overview.tsx
@@ -1,4 +1,12 @@
-import { Group, Stack, Button, Badge, Text, createStyles } from "@mantine/core";
+import {
+  Group,
+  Stack,
+  Button,
+  Badge,
+  Text,
+  Tooltip,
+  createStyles
+} from "@mantine/core";
 import type { ReceivedMessageLifecycle } from "@truffle/dashboard-message-bus-client";
 import type { DashboardProviderMessage } from "@truffle/dashboard-message-bus-common";
 import { useDash } from "src/hooks";
@@ -151,6 +159,9 @@ function Overview({
     navigate("/debugger");
   };
 
+  const debugButtonTooltipMessage =
+    `Simulate transaction in Ganache and ` + `debug the result.`;
+
   return (
     <Stack
       onClick={onBackClick}
@@ -205,15 +216,17 @@ function Overview({
             Confirm
           </Button>
         </Group>
-        <Button
-          size="md"
-          onClick={onDebugButtonClick}
-          onMouseEnter={onDebugButtonEnter}
-          onMouseLeave={onDebugButtonLeave}
-          className={`${classes.button} ${classes.debugButton}`}
-        >
-          Debug
-        </Button>
+        <Tooltip label={debugButtonTooltipMessage}>
+          <Button
+            size="md"
+            onClick={onDebugButtonClick}
+            onMouseEnter={onDebugButtonEnter}
+            onMouseLeave={onDebugButtonLeave}
+            className={`${classes.button} ${classes.debugButton}`}
+          >
+            Debug
+          </Button>
+        </Tooltip>
       </Group>
     </Stack>
   );


### PR DESCRIPTION
This PR adds a tooltip to the Debug button in the transaction signer in Dashboard. See screenshot below:
<img width="894" alt="Screenshot 2023-07-18 at 11 42 41 AM" src="https://github.com/trufflesuite/truffle/assets/14827965/6d1d2257-c982-4d14-9461-4a246b09dafc">
