### PR TITLE
move source range data into Sources

### DIFF
--- a/packages/dashboard/src/components/composed/Debugger/Stack.tsx
+++ b/packages/dashboard/src/components/composed/Debugger/Stack.tsx
@@ -40,11 +40,7 @@ const useStyles = createStyles(theme => ({
   }
 }));
 
-type StackArgs = {
-  currentStep: string;
-};
-
-function Stack({ currentStep }: StackArgs): JSX.Element | null {
+function Stack(): JSX.Element | null {
   const { classes } = useStyles();
   const {
     state: {
@@ -66,7 +62,7 @@ function Stack({ currentStep }: StackArgs): JSX.Element | null {
       setStackReport(report);
     }
     getStack();
-  }, [currentStep, session]);
+  }, [session!.view(session!.selectors.trace.index)]);
 
   const output = stackReport
     ? stackReport.map((reportItem: any, index: number) => {

--- a/packages/dashboard/src/components/composed/Debugger/Stack.tsx
+++ b/packages/dashboard/src/components/composed/Debugger/Stack.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
-import type { Session } from "src/components/composed/Debugger/utils";
 import { createStyles, Flex } from "@mantine/core";
+import { useDash } from "src/hooks";
 
 const useStyles = createStyles(theme => ({
   sectionHeader: {
@@ -41,17 +41,25 @@ const useStyles = createStyles(theme => ({
 }));
 
 type StackArgs = {
-  session: Session;
   currentStep: string;
 };
 
-function Stack({ session, currentStep }: StackArgs): JSX.Element | null {
+function Stack({ currentStep }: StackArgs): JSX.Element | null {
   const { classes } = useStyles();
+  const {
+    state: {
+      debugger: { session }
+    }
+  } = useDash()!;
+
   const [stackReport, setStackReport] = useState<JSX.Element[] | null>(null);
   // when the debugger step changes, update variables
   useEffect(() => {
     async function getStack() {
-      const report = session.view(session.selectors.stacktrace.current.report);
+      // we don't render this component until session is defined
+      const report = session!.view(
+        session!.selectors.stacktrace.current.report
+      );
       if (!report) return;
       // we need to display this information in the reverse order
       report.reverse();

--- a/packages/dashboard/src/components/composed/Debugger/Variables.tsx
+++ b/packages/dashboard/src/components/composed/Debugger/Variables.tsx
@@ -58,11 +58,7 @@ const useStyles = createStyles(theme => ({
   }
 }));
 
-type VariablesArgs = {
-  currentStep: string;
-};
-
-function Variables({ currentStep }: VariablesArgs): JSX.Element | null {
+function Variables(): JSX.Element | null {
   const { classes } = useStyles();
   const {
     state: {
@@ -99,7 +95,7 @@ function Variables({ currentStep }: VariablesArgs): JSX.Element | null {
     }
 
     getVariables();
-  }, [currentStep, session, classes.variablesTypes, classes.variablesSection]);
+  }, [session!.view(session!.selectors.trace.index)]);
 
   const output = variables
     ? Object.keys(variables).map(sectionName => {

--- a/packages/dashboard/src/components/composed/Debugger/Variables.tsx
+++ b/packages/dashboard/src/components/composed/Debugger/Variables.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
-import type { Session } from "src/components/composed/Debugger/utils";
 import * as CodecComponents from "@truffle/codec-components/react";
 import "@truffle/codec-components/react-styles";
 import { createStyles, Flex } from "@mantine/core";
+import { useDash } from "src/hooks";
 
 const useStyles = createStyles(theme => ({
   sectionHeader: {
@@ -59,24 +59,26 @@ const useStyles = createStyles(theme => ({
 }));
 
 type VariablesArgs = {
-  session: Session;
   currentStep: string;
 };
 
-function Variables({
-  session,
-  currentStep
-}: VariablesArgs): JSX.Element | null {
+function Variables({ currentStep }: VariablesArgs): JSX.Element | null {
   const { classes } = useStyles();
+  const {
+    state: {
+      debugger: { session }
+    }
+  } = useDash()!;
   const [variables, setVariables] = useState<any>(null);
 
   // when the debugger step changes, update variables
   useEffect(() => {
     async function getVariables() {
-      const sections = session.view(
-        session.selectors.data.current.identifiers.sections
+      // we don't render this component until session is defined
+      const sections = session!.view(
+        session!.selectors.data.current.identifiers.sections
       );
-      const vars = await session.variables();
+      const vars = await session!.variables();
       if (!vars || Object.keys(vars).length === 0) return;
 
       const variableValues: { [key: string]: any } = {};

--- a/packages/dashboard/src/components/composed/Debugger/index.tsx
+++ b/packages/dashboard/src/components/composed/Debugger/index.tsx
@@ -113,7 +113,6 @@ function Debugger(): JSX.Element {
     traceIndex: -1
   };
 
-  let currentStep;
   // wait until the debugger has been initialized and then get source info
   if (session) {
     currentSourceRange = getCurrentSourceRange(session);
@@ -129,7 +128,6 @@ function Debugger(): JSX.Element {
         setCurrentSourceId(currentContractAddress);
       }
     }
-    currentStep = session.view(session.selectors.trace.index);
   }
 
   const scrollToLine = ({
@@ -206,7 +204,7 @@ function Debugger(): JSX.Element {
       const { source, start } = currentSourceRange!;
       scrollToLine({ sourceId: source.id, line: start.line });
     }
-  }, [currentStep, currentSourceId]);
+  }, [session!.view(session!.selectors.trace.index), currentSourceId]);
 
   // check whether we need to scroll to a breakpoint
   // this is to ensure the source has fully rendered before scrolling
@@ -262,13 +260,13 @@ function Debugger(): JSX.Element {
             />
           </Grid.Col>
           <Grid.Col span={2} className={classes.fullHeight}>
-            <Variables currentStep={currentStep} />
+            <Variables />
             <Breakpoints
               sources={sources}
               handleBreakpointComponentClick={handleBreakpointComponentClick}
               handleBreakpointDeleteClick={handleBreakpointDeleteClick}
             />
-            <Stack currentStep={currentStep} />
+            <Stack />
           </Grid.Col>
         </Grid>
       </div>

--- a/packages/dashboard/src/components/composed/Debugger/index.tsx
+++ b/packages/dashboard/src/components/composed/Debugger/index.tsx
@@ -262,13 +262,13 @@ function Debugger(): JSX.Element {
             />
           </Grid.Col>
           <Grid.Col span={2} className={classes.fullHeight}>
-            <Variables currentStep={currentStep} session={session} />
+            <Variables currentStep={currentStep} />
             <Breakpoints
               sources={sources}
               handleBreakpointComponentClick={handleBreakpointComponentClick}
               handleBreakpointDeleteClick={handleBreakpointDeleteClick}
             />
-            <Stack session={session} currentStep={currentStep} />
+            <Stack currentStep={currentStep} />
           </Grid.Col>
         </Grid>
       </div>

--- a/packages/dashboard/src/components/composed/Debugger/index.tsx
+++ b/packages/dashboard/src/components/composed/Debugger/index.tsx
@@ -15,11 +15,7 @@ import {
   SessionStatus
 } from "src/components/composed/Debugger/utils";
 import { useDash } from "src/hooks";
-import { getCurrentSourceRange } from "src/components/composed/Debugger/utils";
-import type {
-  BreakpointType,
-  SourceRange
-} from "src/components/composed/Debugger/utils";
+import type { BreakpointType } from "src/components/composed/Debugger/utils";
 import { etherscanApiKeyName } from "src/utils/constants";
 
 const useStyles = createStyles(theme => ({
@@ -109,27 +105,6 @@ function Debugger(): JSX.Element {
     undefined
   );
 
-  let currentSourceRange: SourceRange | Partial<SourceRange> = {
-    traceIndex: -1
-  };
-
-  // wait until the debugger has been initialized and then get source info
-  if (session) {
-    currentSourceRange = getCurrentSourceRange(session);
-    // if the starting source is unknown, we may get `undefined` in the source
-    // range - in that case we'll initialize it manually from the stacktrace
-    if (!currentSourceRange.source?.id && !currentSourceId) {
-      const currentContractAddress = session.view(
-        session.selectors.stacktrace.current.report
-      )[0].address;
-      // when the contract is "unknown", the source id will be the address
-      // we need this if check so that no loop occurs when the value is falsy
-      if (currentContractAddress) {
-        setCurrentSourceId(currentContractAddress);
-      }
-    }
-  }
-
   const scrollToLine = ({
     sourceId,
     line
@@ -199,13 +174,6 @@ function Debugger(): JSX.Element {
     }
   };
 
-  useEffect(() => {
-    if (isSourceRange(currentSourceRange) && currentSourceRange.source.id) {
-      const { source, start } = currentSourceRange!;
-      scrollToLine({ sourceId: source.id, line: start.line });
-    }
-  }, [session!.view(session!.selectors.trace.index), currentSourceId]);
-
   // check whether we need to scroll to a breakpoint
   // this is to ensure the source has fully rendered before scrolling
   useEffect(() => {
@@ -231,13 +199,8 @@ function Debugger(): JSX.Element {
     });
   };
 
-  const isSourceRange = (item: any): item is SourceRange => {
-    // when source exists, that means it should be a full SourceRange
-    return item.source !== undefined;
-  };
-
   let content;
-  if (session && sources && isSourceRange(currentSourceRange)) {
+  if (session && sources) {
     content = (
       <div className={classes.mainContent}>
         <Grid
@@ -254,9 +217,9 @@ function Debugger(): JSX.Element {
               unknownAddresses={unknownAddresses}
               session={session}
               sessionUpdated={sessionUpdated}
-              currentSourceRange={currentSourceRange}
               currentSourceId={currentSourceId}
               setCurrentSourceId={setCurrentSourceId}
+              scrollToLine={scrollToLine}
             />
           </Grid.Col>
           <Grid.Col span={2} className={classes.fullHeight}>


### PR DESCRIPTION
The visual debugger currently stores data for the current source range at a high level of the component structure. It also relies on re-renders to set the data as it is not stored in the state. This PR creates a state variable for it and moves it into the `Sources` component. It now also updates the current source range data in a `useEffect` hook.