### PR TITLE
Add more networks to etherscan fetcher (including linea)

### DIFF
--- a/packages/source-fetcher/lib/etherscan.ts
+++ b/packages/source-fetcher/lib/etherscan.ts
@@ -69,6 +69,7 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
       "testnet-zkevm-polygon": "api-testnet-zkevm.polygonscan.com",
       "binance": "api.bscscan.com",
       "testnet-binance": "api-testnet.bscscan.com",
+      "testnet-opbnb-binance": "api-opbnb-testnet.bscscan.com",
       "fantom": "api.ftmscan.com",
       "testnet-fantom": "api-testnet.ftmscan.com",
       "avalanche": "api.snowtrace.io",
@@ -86,8 +87,10 @@ const EtherscanFetcher: FetcherConstructor = class EtherscanFetcher
       "boba": "api.bobascan.com",
       "goerli-boba": "api-testnet.bobascan.com",
       "gnosis": "api.gnosisscan.io",
-      //etherscan does *not* support base mainnet?
-      "goerli-base": "api-goerli.basescan.org"
+      "base": "api.basescan.org",
+      "goerli-base": "api-goerli.basescan.org",
+      "linea": "api.lineascan.build",
+      "goerli-linea": "api-goerli.lineascan.build"
     };
 
   constructor(networkId: number, apiKey: string = "") {

--- a/packages/source-fetcher/lib/networks.ts
+++ b/packages/source-fetcher/lib/networks.ts
@@ -26,6 +26,7 @@ export const networkNamesById: { [id: number]: string } = {
   77: "sokol-poa",
   56: "binance",
   97: "testnet-binance",
+  5611: "testnet-opbnb-binance",
   42220: "celo",
   44787: "alfajores-celo",
   62320: "baklava-celo",
@@ -98,7 +99,7 @@ export const networkNamesById: { [id: number]: string } = {
   19: "songbird-flare",
   2048: "stratos", //not presently supported by either fetcher, but...
   2047: "testnet-stratos",
-  8453: "base", //not presently supported by either fetcher, but...
+  8453: "base",
   84531: "goerli-base",
   641230: "bear",
   888: "wanchain",
@@ -123,7 +124,9 @@ export const networkNamesById: { [id: number]: string } = {
   32769: "zilliqa",
   33101: "testnet-zilliqa",
   111111: "siberium", //not presently supported by either fetcher, but...
-  111000: "testnet-siberium"
+  111000: "testnet-siberium",
+  59144: "linea",
+  59140: "goerli-linea"
   //I'm not including crystaleum as it has network ID different from chain ID
   //not including kekchain for the same reason
   //not including ethereum classic for same reason


### PR DESCRIPTION
Etherscan added four more networks!  This PR adds support for them.

These networks are Linea (yay!) and its Goerli testnet; Base mainnet (it already supported Base Goerli, but now here's the mainnet); and a testnet for some sort of optimistic Binance L2?  Idk.  That last one doesn't appear in commonly-used chains.json files (e.g. Sourcify's), but I was able to verify its chain ID and network ID (both equal to 5611), so I'm including it.

Addresses you can test this with if you want:

Base mainnet: 0x5c86d643Cca3762264711fD9c760BA8e7e6c44Da
Linea mainnet: 0x8CD6e29d3686d24d3C2018CEe54621eA0f89313B
Linea Goerli: 0x18D10e66D77E1b5aF072bB44c97de8b0a2eC96eE
This optimistic Binance thing: 0x9BcC6C79C164161A3D14e61f1290074Cdff57BC7