### PR TITLE
Allow decoding while debugging Yul sources in Solidity 0.8.21 (and related changes)

### DIFF
--- a/packages/codec/lib/ast/types.ts
+++ b/packages/codec/lib/ast/types.ts
@@ -59,6 +59,8 @@ export interface AstNode {
   isConstructor?: boolean;
   usedErrors?: number[];
   usedEvents?: number[];
+  code?: AstNode; //exists on YulObject
+  block?: AstNode; //exists on YulCode
   //Note: May need to add more in the future.
   //May also want to create a proper system of AstNode types
   //in the future, but sticking with this for now.

--- a/packages/codec/lib/compilations/utils.ts
+++ b/packages/codec/lib/compilations/utils.ts
@@ -286,6 +286,10 @@ function sourceIndexForAst(ast: AstNode): number | undefined {
   if (!ast) {
     return undefined;
   }
+  if (ast.nodeType === "YulObject") {
+    //Yul needs some special handling...
+    ast = ast.code.block;
+  }
   return parseInt(ast.src.split(":")[2]);
   //src is given as start:length:file.
   //we want just the file.

--- a/packages/compile-solidity/src/run.ts
+++ b/packages/compile-solidity/src/run.ts
@@ -207,6 +207,7 @@ function prepareOutputSelection({ targets = [] }: { targets: Targets }) {
     "": ["legacyAST", "ast"],
     "*": [
       "abi",
+      "ast", //necessary to get Yul ASTs
       "metadata",
       "evm.bytecode.object",
       "evm.bytecode.linkReferences",
@@ -341,7 +342,7 @@ function processAllSources({
   if (!compilerOutput.sources) {
     const entries = Object.entries(sources);
     if (entries.length === 1) {
-      //special case for handling Yul
+      //special case for handling old Yul versions
       const [sourcePath, contents] = entries[0];
       return [
         {
@@ -365,6 +366,15 @@ function processAllSources({
       legacyAST,
       language
     };
+  }
+  //HACK: special case for handling a Yul compilation bug that causes
+  //the ID to be returned as 1 rather than 0
+  if (
+    language === "Yul" &&
+    outputSources.length === 2 &&
+    outputSources[0] === undefined
+  ) {
+    return [outputSources[1]];
   }
   return outputSources;
 }

--- a/packages/debugger/lib/helpers/index.js
+++ b/packages/debugger/lib/helpers/index.js
@@ -12,6 +12,12 @@ export function isDeliberatelySkippedNodeType(node) {
   return skippedTypes.includes(node.nodeType);
 }
 
+export const topLevelNodeTypes = ["SourceUnit", "YulObject"];
+
+export function isTopLevelNode(node) {
+  return topLevelNodeTypes.includes(node.nodeType);
+}
+
 //HACK
 //these aren't the only types of skipped nodes, but determining all skipped
 //nodes would be too difficult

--- a/packages/debugger/test/data/more-decoding.js
+++ b/packages/debugger/test/data/more-decoding.js
@@ -739,6 +739,7 @@ describe("Further Decoding", function () {
 
   describe("Overflow", function () {
     it("Discards padding on unsigned integers", async function () {
+      this.timeout(6000);
       let instance = await abstractions.OverflowTest.deployed();
       let receipt = await instance.unsignedTest();
       let txHash = receipt.tx;
@@ -769,6 +770,7 @@ describe("Further Decoding", function () {
     });
 
     it("Discards padding on signed integers", async function () {
+      this.timeout(6000);
       let instance = await abstractions.OverflowTest.deployed();
       let receipt = await instance.signedTest();
       let txHash = receipt.tx;
@@ -799,6 +801,7 @@ describe("Further Decoding", function () {
     });
 
     it("Discards padding on static bytestrings", async function () {
+      this.timeout(6000);
       let instance = await abstractions.OverflowTest.deployed();
       let receipt = await instance.rawTest();
       let txHash = receipt.tx;

--- a/packages/debugger/test/data/yul-source.js
+++ b/packages/debugger/test/data/yul-source.js
@@ -1,0 +1,122 @@
+import debugModule from "debug";
+const debug = debugModule("debugger:test:data:yul");
+
+import { assert } from "chai";
+
+import Ganache from "ganache";
+
+import { prepareContracts, lineOf, testBlockGasLimit } from "../helpers";
+import Debugger from "lib/debugger";
+
+import sourcemapping from "lib/sourcemapping/selectors";
+
+import * as Codec from "@truffle/codec";
+
+const __YUL = `
+object "YulTest" {
+  code {
+    let size := datasize("runtime")
+    datacopy(0, dataoffset("runtime"), size)
+    return(0, size)
+  }
+  object "runtime" {
+    code {
+      let a := 1
+      let b := 2 //BREAK #1
+      mstore(0, add(b, a)) //BREAK #2
+      return(0, 0x20)
+    }
+  }
+}
+`;
+
+let sources = {
+  "YulTest.yul": __YUL
+};
+
+describe("Assembly decoding (Yul source)", function () {
+  let provider;
+  let abstractions;
+  let compilations;
+
+  before("Create Provider", async function () {
+    provider = Ganache.provider({
+      seed: "debugger",
+      miner: {
+        instamine: "strict",
+        blockGasLimit: testBlockGasLimit
+      },
+      logging: {
+        quiet: true
+      }
+    });
+  });
+
+  before("Prepare contracts and artifacts", async function () {
+    this.timeout(30000);
+
+    let prepared = await prepareContracts(provider, sources);
+    abstractions = prepared.abstractions;
+    compilations = prepared.compilations;
+  });
+
+  it("Decodes variables in Yul files", async function () {
+    this.timeout(12000);
+
+    let instance = await abstractions.YulTest.deployed();
+    let receipt = await instance.sendTransaction({});
+    let txHash = receipt.tx;
+
+    let bugger = await Debugger.forTx(txHash, { provider, compilations });
+
+    let sourceId = bugger.view(sourcemapping.current.source).id;
+    let source = bugger.view(sourcemapping.current.source).source;
+    await bugger.addBreakpoint({
+      sourceId,
+      line: lineOf("BREAK #1", source)
+    });
+    await bugger.addBreakpoint({
+      sourceId,
+      line: lineOf("BREAK #2", source)
+    });
+    await bugger.addBreakpoint({
+      sourceId,
+      line: lineOf("BREAK #3", source)
+    });
+
+    await bugger.continueUntilBreakpoint();
+
+    const numberize = obj =>
+      Object.assign(
+        {},
+        ...Object.entries(obj).map(([key, value]) => ({ [key]: Number(value) }))
+      );
+
+    let variables = numberize(
+      Codec.Format.Utils.Inspect.unsafeNativizeVariables(
+        await bugger.variables()
+      )
+    );
+
+    let expectedResult = {
+      a: 1
+    };
+
+    assert.deepEqual(variables, expectedResult);
+
+    await bugger.continueUntilBreakpoint();
+
+    variables = numberize(
+      Codec.Format.Utils.Inspect.unsafeNativizeVariables(
+        await bugger.variables()
+      )
+    );
+
+    expectedResult = {
+      a: 1,
+      b: 2
+    };
+
+    assert.deepEqual(variables, expectedResult);
+  });
+});

--- a/packages/debugger/test/helpers.js
+++ b/packages/debugger/test/helpers.js
@@ -34,7 +34,7 @@ export async function prepareContracts(
 
   config.compilers = {
     solc: {
-      version: "0.8.20",
+      version: "0.8.21",
       settings: {
         optimizer: { enabled: false, runs: 200 },
         evmVersion: "shanghai"


### PR DESCRIPTION
This PR allows decoding of variables while decoding Yul sources that were compiled with solc 0.8.21 or greater.  Note this PR does **not** address #3831, I figured that was better saved for later.

It was already possible to decode Yul variables in Solidity `assembly` blocks, but not in straight Yul files, because Solidity wouldn't give us ASTs for the latter.  But now it does!

Well, now it does if we ask for them right.  For some reason, Solidity makes us ask for the ast at the contract level when compiling Yul, instead of at the file level like normal; I've filed [an issue](https://github.com/ethereum/solidity/issues/14452) about that (although for 0.8.21 compatibility we'll have to leave this extra bit in anyway).  Also, there's another bug regarding these (which I've also [filed an issue about](https://github.com/ethereum/solidity/issues/14453)) -- it assigns the singular source an ID of 1 instead of 0.  So, I had to add in a workaround for that as well.

Once we have the ASTs, the debugger can do the rest, so not many more changes were needed!  But there are two.

First off, it turns out that the top-level node in a Yul AST, the `YulObject` node type, doesn't have an `src` field.  So the code in Codec that gets the source index from the top node of an AST needed some adjustment in that case.  Not only does the `YulObject` node lack this info, but so does the `YulCode` node below it; one has to go to the `YulBlock` node at `ast.code.block` to get it.  Fortunately these nodes *are* always present -- I tried.  (Of course we could also just always return 0, but hey, if the info is there let's use it, right? :P )

Second off, since an AST might now have `YulObject` rather than `SourceUnit` as its top-level node, a bunch of code in data that assumed that `SourceUnit` is the only type of top-level node has been updated to account for `YulObject` as well.  Some of this got factored out into `helpers`.

Finally, I added a test!  One caveat -- the test did not work right once I introduced mutation. O_o  I assume this is due to something with the optimizer or something?  I decided to just omit that from the test, which is not great, but I didn't see what else I could reasonably do.

Note that adding this test obviously involved increasing the Solidity version used in the debugger tests to 0.8.21, and for some reason that slowed down a few tests, so I increased the timeout on those few.

I also tested this manually using the `yul-test` project in the solidity-test-cases repo.