### PR TITLE
Update sourcify networks for sourcify 2.5.0

### DIFF
--- a/packages/source-fetcher/lib/networks.ts
+++ b/packages/source-fetcher/lib/networks.ts
@@ -126,7 +126,9 @@ export const networkNamesById: { [id: number]: string } = {
   111111: "siberium", //not presently supported by either fetcher, but...
   111000: "testnet-siberium",
   59144: "linea",
-  59140: "goerli-linea"
+  59140: "goerli-linea",
+  22776: "map",
+  212: "makalu-map"
   //I'm not including crystaleum as it has network ID different from chain ID
   //not including kekchain for the same reason
   //not including ethereum classic for same reason

--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -123,7 +123,7 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "songbird-flare",
     //sourcify does *not* support stratos mainnet?
     "testnet-stratos",
-    //sourcify does *not* support base mainnet?
+    "base",
     "goerli-base",
     "bear",
     "wanchain",
@@ -147,9 +147,12 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "filecoin",
     "zilliqa",
     "testnet-zilliqa",
-    "testnet-siberium"
+    "testnet-siberium",
+    "map",
+    "makalu-map"
     //I'm excluding crystaleum as it has network ID different from chain ID
     //excluding kekchain for the same reason
+    //excluding ethereum classic for same reason
   ]);
 
   constructor(networkId: number) {


### PR DESCRIPTION
Updates Sourcify networks for Sourcify 2.5.0, adding Base Mainnet, MAP, and the MAP testnet Makalu.  Also updated a comment. :P

Addresses you can test with if you want:
Base: 0x5e357053DDa704D059D146444cCC81afC1B2a662
MAP: 0xAbdE047dD5861E163830Ad57e1E51990035E1F44
MAP Makalu: 0xAbdE047dD5861E163830Ad57e1E51990035E1F44