### PR TITLE
Add sourcify chains for sourcify 2.6.0

### DIFF
--- a/packages/source-fetcher/lib/networks.ts
+++ b/packages/source-fetcher/lib/networks.ts
@@ -110,8 +110,8 @@ export const networkNamesById: { [id: number]: string } = {
   1149: "symplexia",
   2000: "dogechain",
   1339: "elysium",
-  //taiko doesn't seem to have a mainnet yet
-  167005: "alpha3-taiko",
+  167005: "grimsvotn-taiko",
+  167006: "eldfell-taiko",
   96: "bitkub",
   25925: "testnet-bitkub",
   7777777: "zora",
@@ -121,6 +121,7 @@ export const networkNamesById: { [id: number]: string } = {
   2222: "kava",
   2221: "testnet-kava",
   314: "filecoin",
+  314159: "calibration-filecoin",
   32769: "zilliqa",
   33101: "testnet-zilliqa",
   111111: "siberium", //not presently supported by either fetcher, but...
@@ -128,7 +129,10 @@ export const networkNamesById: { [id: number]: string } = {
   59144: "linea",
   59140: "goerli-linea",
   22776: "map",
-  212: "makalu-map"
+  212: "makalu-map",
+  2021: "edgeware",
+  //beam doesn't appear to have a mainnet yet?
+  13337: "testnet-beam"
   //I'm not including crystaleum as it has network ID different from chain ID
   //not including kekchain for the same reason
   //not including ethereum classic for same reason

--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -51,6 +51,7 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "goerli-optimistic",
     "goerli-bedrock-optimistic",
     "arbitrum",
+    "nova-arbitrum",
     "rinkeby-arbitrum", //can no longer verify but can still fetch existing
     "goerli-arbitrum",
     "polygon",
@@ -135,7 +136,8 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "dogechain",
     "cronos",
     "elysium",
-    "alpha3-taiko",
+    "grimsvotn-taiko",
+    "eldfell-taiko",
     "bitkub",
     "testnet-bitkub",
     "zora",
@@ -145,11 +147,15 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "kava",
     "testnet-kava",
     "filecoin",
+    "calibration-filecoin",
     "zilliqa",
     "testnet-zilliqa",
     "testnet-siberium",
     "map",
-    "makalu-map"
+    "makalu-map",
+    "fantom",
+    "beam",
+    "edgeware"
     //I'm excluding crystaleum as it has network ID different from chain ID
     //excluding kekchain for the same reason
     //excluding ethereum classic for same reason


### PR DESCRIPTION
New networks for Sourcify.  They are: Edgeware; the Filecoin calibration testnet; Fantom (already supported by Etherscan, so doesn't need to be added to networks.ts); Arbitrum Nova (also already supported by Etherscan); the Beam testnet (doesn't appear to have a mainnet yet?); and Taiko Eldfell (also, I renamed Taiko Alpha 3 as it's now Taiko Grimsvotn).