### PR TITLE
Fix modifier argument detection by factoring out no-op handling

### DIFF
--- a/packages/debugger/lib/data/selectors/index.js
+++ b/packages/debugger/lib/data/selectors/index.js
@@ -10,7 +10,8 @@ import {
   stableKeccak256,
   makePath,
   topLevelNodeTypes,
-  isTopLevelNode
+  isTopLevelNode,
+  peelAwayPotentialEVMNoOp
 } from "lib/helpers";
 
 import trace from "lib/trace/selectors";
@@ -1336,18 +1337,17 @@ const data = createSelectorTree({
         }
 
         //now: are we on the node corresponding to an argument, or, if
-        //it's a type conversion, its nested argument?
+        //it's a potential EVM no-op, its nested argument?
         if (index === undefined) {
           return false;
         }
         let argument = invocation.arguments[index];
-        while (argument.kind === "typeConversion") {
+        do {
           if (node.id === argument.id) {
             return true;
           }
-          argument = argument.arguments[0];
-        }
-        return node.id === argument.id;
+        } while ((argument = peelAwayPotentialEVMNoOp(argument)));
+        return false;
       }
     ),
 


### PR DESCRIPTION
## PR description

This PR fixes an old bug regarding detection of arguments to modifiers, and factors some code in the process.

Both mapping key handling and modifier argument detection can require looking inside nodes that aren't sourcemapped because they're no-ops on the EVM level and so don't correspond to any instruction.  (Certain type conversions; unary plus in Solidity prior to 0.5.0; and `wrap`/`unwrap` for UDVTs.)  When dealing with these, we often need to peel away the node representing the no-op, to find the node inside representing an actual operation.

For mapping-key handling, this code has been kept up to date.  But for modifier argument detection, which had the logic separate, it was not.  I didn't notice this until going over the code with @cds-amal this past Friday.

This PR factors out the logic into a function in `helpers`, unifying the two places it's used.  So now the up-to-date logic from mapping key handling is applied to modifier argument detection as well.  And if there's ever any further need to update this, now the code will all be in one place so it won't desync like that again!

I used some fairly C-style loops in this one, hope you don't mind, it seemed the easiest way. :P

## Testing instructions

I didn't bother adding any tests for this one, I just did some brief manual testing.  I tested using the `modifier-test-8` project in the `solidity-test-cases` repo.