### PR TITLE
Fix build error at codec while upgrading web3.js to v4

### DIFF
--- a/packages/codec/docs/tsconfig.json
+++ b/packages/codec/docs/tsconfig.json
@@ -9,7 +9,8 @@
     "outDir": "dist",
     "baseUrl": "..",
     "lib": [
-      "es2017"
+      "es2017",
+      "dom"
     ],
     "paths": {
       "@truffle/codec": [


### PR DESCRIPTION
## PR description

Add "dom" to lib at packages/codec/docs/tsconfig.json
