### PR TITLE
Add new sourcify networks; fix problem with beam testnet

### DIFF
--- a/packages/source-fetcher/lib/networks.ts
+++ b/packages/source-fetcher/lib/networks.ts
@@ -37,6 +37,12 @@ export const networkNamesById: { [id: number]: string } = {
   335: "testnet-dfk-avalance",
   432204: "dexalot-avalanche",
   432201: "testnet-dexalot-avalanche",
+  4337: "beam-avalanche",
+  13337: "testnet-beam-avalanche",
+  2037: "kiwi-avalanche",
+  78430: "amplify-avalanche",
+  78431: "bulletin-avalanche",
+  78432: "conduit-avalanche",
   40: "telos",
   41: "testnet-telos",
   8: "ubiq",
@@ -131,8 +137,8 @@ export const networkNamesById: { [id: number]: string } = {
   22776: "map",
   212: "makalu-map",
   2021: "edgeware",
-  //beam doesn't appear to have a mainnet yet?
-  13337: "testnet-beam"
+  333000333: "meld",
+  222000222: "kanazawa-meld"
   //I'm not including crystaleum as it has network ID different from chain ID
   //not including kekchain for the same reason
   //not including ethereum classic for same reason

--- a/packages/source-fetcher/lib/sourcify.ts
+++ b/packages/source-fetcher/lib/sourcify.ts
@@ -73,6 +73,12 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "testnet-dfk-avalanche",
     "dexalot-avalanche",
     "testnet-dexalot-avalanche",
+    "beam-avalanche",
+    "testnet-beam-avalanche",
+    "kiwi-avalanche",
+    "amplify-avalanche",
+    "bulletin-avalanche",
+    "conduit-avalanche",
     "telos",
     "testnet-telos",
     "ubiq",
@@ -154,8 +160,9 @@ const SourcifyFetcher: FetcherConstructor = class SourcifyFetcher
     "map",
     "makalu-map",
     "fantom",
-    "beam",
-    "edgeware"
+    "edgeware",
+    "meld",
+    "kanazawa-meld"
     //I'm excluding crystaleum as it has network ID different from chain ID
     //excluding kekchain for the same reason
     //excluding ethereum classic for same reason


### PR DESCRIPTION
There's a new Sourcify version out, so even though it doesn't matter anymore, I've updated the chains.

Also, I fixed a problem where I used an inconsistent name for the beam testnet.  Oops.  Probably there ought to be some type-level way of preventing this, but I figure now is not the time to worry about that.