### PR TITLE
chore(ci/tests): pin nodejs 20 to 20.5 due to regression in 20.6

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -32,7 +32,8 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        node-version: [16.x, 18.x, 20.x]
+        # TODO: unpin to 20.x once 20.7 has ben released
+        node-version: [16.x, 18.x, 20.5]
         env: [GETH=true, PACKAGES=true, INTEGRATION=true]
     runs-on: ${{ matrix.platform }}
 
@@ -47,9 +48,9 @@ jobs:
 
     - run: yarn install
     - run: test -z "$(git diff)" || (echo 'Did you check in a generated file to source control?  Please remove it if so'; false)
-    
+
     - run: yarn depcheck
-    
+
     - run: ${{ matrix.env }} yarn ci
       env:
         CI: true


### PR DESCRIPTION
## PR description

CI is currently failing due to a regression in Node.js v20. This temporarily pins to the penultimate version pending a fix.

- https://github.com/vitejs/vite/issues/14299#issuecomment-1706557322
  - https://github.com/babel/babel/issues/15927
    - https://github.com/nodejs/node/issues/49497
      - https://github.com/nodejs/node/pull/49500 

## Testing instructions


## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.

## Breaking changes and new features

- [x] I have added any needed `breaking-change` and `new-feature` labels for the appropriate packages.
